### PR TITLE
fix(namespace): fence stale table deregistration

### DIFF
--- a/protos/table.proto
+++ b/protos/table.proto
@@ -603,16 +603,13 @@ message FragmentReuseIndexDetails {
 // ============================================================================
 
 // Lifecycle status of a WAL shard. Drives drop-table two-phase commit:
-// a SEALED shard refuses new writer claims while the outcome is unresolved.
-// A committed drop transitions to DROPPED and remains fenced until cleanup
-// removes the shard directory; a rollback transitions back to ACTIVE.
+// a SEALED shard refuses new writer claims while the outcome is unresolved;
+// a rollback transitions back to ACTIVE.
 enum ShardStatus {
   // Normal: the shard accepts writer claims.
   ACTIVE = 0;
   // A drop is in flight: claims are refused. Reversible to ACTIVE.
   SEALED = 1;
-  // The drop committed: claims are permanently refused for this generation.
-  DROPPED = 2;
 }
 
 // Shard manifest containing epoch-based fencing and WAL state.

--- a/protos/table.proto
+++ b/protos/table.proto
@@ -603,13 +603,16 @@ message FragmentReuseIndexDetails {
 // ============================================================================
 
 // Lifecycle status of a WAL shard. Drives drop-table two-phase commit:
-// a SEALED shard refuses new writer claims (reversible) until the drop
-// commits (the shard dir is deleted) or rolls back (status -> ACTIVE).
+// a SEALED shard refuses new writer claims while the outcome is unresolved.
+// A committed drop transitions to DROPPED and remains fenced until cleanup
+// removes the shard directory; a rollback transitions back to ACTIVE.
 enum ShardStatus {
   // Normal: the shard accepts writer claims.
   ACTIVE = 0;
   // A drop is in flight: claims are refused. Reversible to ACTIVE.
   SEALED = 1;
+  // The drop committed: claims are permanently refused for this generation.
+  DROPPED = 2;
 }
 
 // Shard manifest containing epoch-based fencing and WAL state.

--- a/rust/lance-namespace-impls/src/dir.rs
+++ b/rust/lance-namespace-impls/src/dir.rs
@@ -273,6 +273,7 @@ pub struct DirectoryNamespaceBuilder {
     dir_listing_enabled: bool,
     inline_optimization_enabled: bool,
     table_version_tracking_enabled: bool,
+    async_drop_enabled: bool,
     /// When true, enables migration mode where the namespace checks the manifest first
     /// before falling back to directory listing for root-level tables. When false (default),
     /// root-level tables use directory listing directly without checking the manifest,
@@ -344,6 +345,7 @@ impl DirectoryNamespaceBuilder {
             dir_listing_enabled: true, // Default to enabled for backwards compatibility
             inline_optimization_enabled: true,
             table_version_tracking_enabled: false, // Default to disabled
+            async_drop_enabled: false,
             dir_listing_to_manifest_migration_enabled: false, // Default to disabled
             credential_vendor_properties: HashMap::new(),
             context_provider: None,
@@ -404,6 +406,12 @@ impl DirectoryNamespaceBuilder {
         self
     }
 
+    /// Enable unique physical generations required by expected-location drop fencing.
+    pub fn async_drop_enabled(mut self, enabled: bool) -> Self {
+        self.async_drop_enabled = enabled;
+        self
+    }
+
     /// Create a DirectoryNamespaceBuilder from properties HashMap.
     ///
     /// This method parses a properties map into builder configuration.
@@ -412,6 +420,7 @@ impl DirectoryNamespaceBuilder {
     /// - `manifest_enabled`: Enable manifest-based table tracking (optional, default: true)
     /// - `dir_listing_enabled`: Enable directory listing for table discovery (optional, default: true)
     /// - `inline_optimization_enabled`: Enable replacement indices on __manifest rewrites (optional, default: true)
+    /// - `async_drop_enabled`: Enable unique physical generations for asynchronous drop fencing (optional, default: false)
     /// - `storage.*`: Storage options (optional, prefix will be stripped)
     ///
     /// Credential vendor properties (prefixed with `credential_vendor.`, prefix is stripped):
@@ -521,6 +530,11 @@ impl DirectoryNamespaceBuilder {
             .and_then(|v| v.parse::<bool>().ok())
             .unwrap_or(false);
 
+        let async_drop_enabled = properties
+            .get("async_drop_enabled")
+            .and_then(|v| v.parse::<bool>().ok())
+            .unwrap_or(false);
+
         // Extract dir_listing_to_manifest_migration_enabled (default: false)
         let dir_listing_to_manifest_migration_enabled = properties
             .get("dir_listing_to_manifest_migration_enabled")
@@ -567,6 +581,7 @@ impl DirectoryNamespaceBuilder {
             dir_listing_enabled,
             inline_optimization_enabled,
             table_version_tracking_enabled,
+            async_drop_enabled,
             dir_listing_to_manifest_migration_enabled,
             credential_vendor_properties,
             context_provider: None,
@@ -754,6 +769,7 @@ impl DirectoryNamespaceBuilder {
                 object_store.clone(),
                 base_path.clone(),
                 self.dir_listing_enabled,
+                self.async_drop_enabled,
                 self.inline_optimization_enabled,
                 self.commit_retries,
             )
@@ -811,6 +827,7 @@ impl DirectoryNamespaceBuilder {
             dir_listing_to_manifest_migration_enabled: self
                 .dir_listing_to_manifest_migration_enabled,
             table_version_tracking_enabled: self.table_version_tracking_enabled,
+            async_drop_enabled: self.async_drop_enabled,
             credential_vendor,
             context_provider: self.context_provider,
             vend_input_storage_options: self.vend_input_storage_options,
@@ -897,6 +914,7 @@ pub struct DirectoryNamespace {
     /// When true, `describe_table` returns `managed_versioning: true` to indicate
     /// commits should go through namespace table version APIs.
     table_version_tracking_enabled: bool,
+    async_drop_enabled: bool,
     /// Credential vendor created once during initialization.
     /// Used to vend temporary credentials for table access.
     credential_vendor: Option<Arc<dyn CredentialVendor>>,
@@ -1032,6 +1050,7 @@ impl DirectoryNamespace {
                     self.object_store.clone(),
                     self.base_path.clone(),
                     self.dir_listing_enabled,
+                    self.async_drop_enabled,
                     self.inline_optimization_enabled,
                     self.commit_retries,
                 )
@@ -1070,6 +1089,7 @@ impl DirectoryNamespace {
                     self.object_store.clone(),
                     self.base_path.clone(),
                     self.dir_listing_enabled,
+                    self.async_drop_enabled,
                     self.inline_optimization_enabled,
                     self.commit_retries,
                 )
@@ -9321,10 +9341,12 @@ mod tests {
         properties.insert("root".to_string(), temp_dir.to_str().unwrap().to_string());
         properties.insert("manifest_enabled".to_string(), "true".to_string());
         properties.insert("dir_listing_enabled".to_string(), "false".to_string());
+        properties.insert("async_drop_enabled".to_string(), "true".to_string());
 
         let builder = DirectoryNamespaceBuilder::from_properties(properties, None).unwrap();
         assert!(builder.manifest_enabled);
         assert!(!builder.dir_listing_enabled);
+        assert!(builder.async_drop_enabled);
 
         let namespace = builder.build().await.unwrap();
 
@@ -9386,6 +9408,7 @@ mod tests {
         // Both should default to true
         assert!(builder.manifest_enabled);
         assert!(builder.dir_listing_enabled);
+        assert!(!builder.async_drop_enabled);
     }
 
     #[tokio::test]

--- a/rust/lance-namespace-impls/src/dir.rs
+++ b/rust/lance-namespace-impls/src/dir.rs
@@ -10124,7 +10124,9 @@ mod tests {
 
     #[tokio::test]
     async fn test_register_table() {
-        use lance_namespace::models::{RegisterTableRequest, TableExistsRequest};
+        use lance_namespace::models::{
+            DeregisterTableRequest, RegisterTableRequest, TableExistsRequest,
+        };
 
         let temp_dir = TempStdDir::default();
         let temp_path = temp_dir.to_str().unwrap();
@@ -10169,6 +10171,22 @@ mod tests {
         list_req.id = Some(vec![]);
         let tables = namespace.list_tables(list_req).await.unwrap();
         assert!(tables.tables.contains(&"registered_table".to_string()));
+
+        let mut deregister_req = DeregisterTableRequest::new();
+        deregister_req.id = Some(vec!["registered_table".to_string()]);
+        deregister_req.context = Some(HashMap::from([(
+            EXPECTED_DEREGISTER_LOCATION_CONTEXT_KEY.to_string(),
+            table_uri,
+        )]));
+        let error = namespace
+            .deregister_table(deregister_req)
+            .await
+            .unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("was not generated as a unique table incarnation")
+        );
     }
 
     #[tokio::test]
@@ -10352,7 +10370,11 @@ mod tests {
             .deregister_table(deregister_req)
             .await
             .unwrap_err();
-        assert!(error.to_string().contains("location is deterministic"));
+        assert!(
+            error
+                .to_string()
+                .contains("was not generated as a unique table incarnation")
+        );
     }
 
     #[tokio::test]
@@ -10396,7 +10418,11 @@ mod tests {
             .deregister_table(deregister_req)
             .await
             .unwrap_err();
-        assert!(error.to_string().contains("location is deterministic"));
+        assert!(
+            error
+                .to_string()
+                .contains("was not generated as a unique table incarnation")
+        );
     }
 
     #[tokio::test]

--- a/rust/lance-namespace-impls/src/dir.rs
+++ b/rust/lance-namespace-impls/src/dir.rs
@@ -10320,6 +10320,7 @@ mod tests {
         let namespace = DirectoryNamespaceBuilder::new(temp_dir.to_str().unwrap())
             .manifest_enabled(true)
             .dir_listing_enabled(false)
+            .async_drop_enabled(true)
             .build()
             .await
             .unwrap();

--- a/rust/lance-namespace-impls/src/dir.rs
+++ b/rust/lance-namespace-impls/src/dir.rs
@@ -758,6 +758,13 @@ impl DirectoryNamespaceBuilder {
     /// - Connection to the storage backend fails
     /// - Storage options are invalid
     pub async fn build(self) -> Result<DirectoryNamespace> {
+        if self.async_drop_enabled && self.manifest_enabled && self.dir_listing_enabled {
+            return Err(NamespaceError::InvalidInput {
+                message: "async_drop_enabled requires dir_listing_enabled=false when the manifest is enabled"
+                    .to_string(),
+            }
+            .into());
+        }
         let (object_store, base_path) =
             Self::initialize_object_store(&self.root, &self.storage_options, &self.session).await?;
 
@@ -1059,6 +1066,19 @@ impl DirectoryNamespace {
             })
             .await?;
         Ok(Some(manifest_ns.clone()))
+    }
+
+    /// Retire a durable manifest drop intent after physical cleanup completes.
+    pub async fn complete_drop_tombstone(&self, object_id: &str, location: &str) -> Result<bool> {
+        let manifest_ns =
+            self.manifest_ns_for_write()
+                .await?
+                .ok_or_else(|| NamespaceError::InvalidInput {
+                    message: "drop tombstones require a manifest-enabled namespace".to_string(),
+                })?;
+        manifest_ns
+            .complete_drop_tombstone_at_uri(object_id, location)
+            .await
     }
 
     /// Lazily open the `__manifest` dataset (read-only) into the read cell.

--- a/rust/lance-namespace-impls/src/dir.rs
+++ b/rust/lance-namespace-impls/src/dir.rs
@@ -10258,6 +10258,90 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_deregister_table_expected_location_fence() {
+        use lance_namespace::models::{DeregisterTableRequest, DescribeTableRequest};
+
+        let temp_dir = TempStdDir::default();
+        let namespace = DirectoryNamespaceBuilder::new(temp_dir.to_str().unwrap())
+            .manifest_enabled(true)
+            .dir_listing_enabled(false)
+            .build()
+            .await
+            .unwrap();
+
+        let schema = create_test_schema();
+        let ipc_data = create_test_ipc_data(&schema);
+        let mut create_req = CreateTableRequest::new();
+        create_req.id = Some(vec!["test_table".to_string()]);
+        namespace
+            .create_table(create_req, bytes::Bytes::from(ipc_data))
+            .await
+            .unwrap();
+
+        let table_id = vec!["test_table".to_string()];
+        let location = namespace
+            .describe_table(DescribeTableRequest {
+                id: Some(table_id.clone()),
+                ..Default::default()
+            })
+            .await
+            .unwrap()
+            .location
+            .unwrap();
+
+        let mut stale_req = DeregisterTableRequest::new();
+        stale_req.id = Some(table_id.clone());
+        stale_req.context = Some(HashMap::from([(
+            "expected_location".to_string(),
+            format!("{location}-replacement"),
+        )]));
+        let error = namespace.deregister_table(stale_req).await.unwrap_err();
+        assert!(error.to_string().contains("instead of expected location"));
+
+        let mut matching_req = DeregisterTableRequest::new();
+        matching_req.id = Some(table_id);
+        matching_req.context = Some(HashMap::from([(
+            "expected_location".to_string(),
+            format!("{location}/"),
+        )]));
+        let response = namespace.deregister_table(matching_req).await.unwrap();
+        assert_eq!(response.location.as_deref(), Some(location.as_str()));
+    }
+
+    #[tokio::test]
+    async fn test_deregister_table_rejects_deterministic_location_fence() {
+        use lance_namespace::models::DeregisterTableRequest;
+
+        let temp_dir = TempStdDir::default();
+        let namespace = DirectoryNamespaceBuilder::new(temp_dir.to_str().unwrap())
+            .manifest_enabled(true)
+            .dir_listing_enabled(true)
+            .build()
+            .await
+            .unwrap();
+
+        let schema = create_test_schema();
+        let ipc_data = create_test_ipc_data(&schema);
+        let mut create_req = CreateTableRequest::new();
+        create_req.id = Some(vec!["test_table".to_string()]);
+        let location = namespace
+            .create_table(create_req, bytes::Bytes::from(ipc_data))
+            .await
+            .unwrap()
+            .location
+            .unwrap();
+
+        let mut deregister_req = DeregisterTableRequest::new();
+        deregister_req.id = Some(vec!["test_table".to_string()]);
+        deregister_req.context = Some(HashMap::from([("expected_location".to_string(), location)]));
+        let error = namespace
+            .deregister_table(deregister_req)
+            .await
+            .unwrap_err();
+        assert!(error.to_string().contains("location is deterministic"));
+    }
+
+    #[tokio::test]
     async fn test_deregister_table_in_child_namespace() {
         use lance_namespace::models::{
             CreateNamespaceRequest, DeregisterTableRequest, TableExistsRequest,

--- a/rust/lance-namespace-impls/src/dir.rs
+++ b/rust/lance-namespace-impls/src/dir.rs
@@ -92,6 +92,8 @@ use crate::credentials::{
     CredentialVendor, create_credential_vendor_for_location, has_credential_vendor_config,
 };
 
+const EXPECTED_DEREGISTER_LOCATION_CONTEXT_KEY: &str = "expected_location";
+
 /// Thread-safe metrics tracker for namespace operations.
 ///
 /// Tracks the count of each API operation when `ops_metrics_enabled` is true.
@@ -3685,6 +3687,18 @@ impl LanceNamespace for DirectoryNamespace {
         // If manifest is enabled, delegate to manifest namespace
         if let Some(manifest_ns) = self.manifest_ns_for_write().await? {
             return LanceNamespace::deregister_table(manifest_ns.as_ref(), request).await;
+        }
+
+        if request
+            .context
+            .as_ref()
+            .is_some_and(|context| context.contains_key(EXPECTED_DEREGISTER_LOCATION_CONTEXT_KEY))
+        {
+            return Err(NamespaceError::Unsupported {
+                message: "Expected-location fencing is unsupported when the manifest is disabled because table locations are deterministic"
+                    .to_string(),
+            }
+            .into());
         }
 
         // V1 mode: create a .lance-deregistered marker file in the table directory
@@ -10339,6 +10353,74 @@ mod tests {
             .await
             .unwrap_err();
         assert!(error.to_string().contains("location is deterministic"));
+    }
+
+    #[tokio::test]
+    async fn test_deregister_table_rejects_deterministic_location_after_config_change() {
+        use lance_namespace::models::DeregisterTableRequest;
+
+        let temp_dir = TempStdDir::default();
+        let root = temp_dir.to_str().unwrap();
+        let creating_namespace = DirectoryNamespaceBuilder::new(root)
+            .manifest_enabled(true)
+            .dir_listing_enabled(true)
+            .build()
+            .await
+            .unwrap();
+
+        let schema = create_test_schema();
+        let ipc_data = create_test_ipc_data(&schema);
+        let mut create_req = CreateTableRequest::new();
+        create_req.id = Some(vec!["test_table".to_string()]);
+        let location = creating_namespace
+            .create_table(create_req, bytes::Bytes::from(ipc_data))
+            .await
+            .unwrap()
+            .location
+            .unwrap();
+
+        let fencing_namespace = DirectoryNamespaceBuilder::new(root)
+            .manifest_enabled(true)
+            .dir_listing_enabled(false)
+            .build()
+            .await
+            .unwrap();
+        let mut deregister_req = DeregisterTableRequest::new();
+        deregister_req.id = Some(vec!["test_table".to_string()]);
+        deregister_req.context = Some(HashMap::from([(
+            EXPECTED_DEREGISTER_LOCATION_CONTEXT_KEY.to_string(),
+            location,
+        )]));
+
+        let error = fencing_namespace
+            .deregister_table(deregister_req)
+            .await
+            .unwrap_err();
+        assert!(error.to_string().contains("location is deterministic"));
+    }
+
+    #[tokio::test]
+    async fn test_deregister_table_rejects_location_fence_without_manifest() {
+        use lance_namespace::models::DeregisterTableRequest;
+
+        let temp_dir = TempStdDir::default();
+        let namespace = DirectoryNamespaceBuilder::new(temp_dir.to_str().unwrap())
+            .manifest_enabled(false)
+            .build()
+            .await
+            .unwrap();
+        let mut deregister_req = DeregisterTableRequest::new();
+        deregister_req.id = Some(vec!["test_table".to_string()]);
+        deregister_req.context = Some(HashMap::from([(
+            EXPECTED_DEREGISTER_LOCATION_CONTEXT_KEY.to_string(),
+            "file:///stale/test_table.lance".to_string(),
+        )]));
+
+        let error = namespace
+            .deregister_table(deregister_req)
+            .await
+            .unwrap_err();
+        assert!(error.to_string().contains("manifest is disabled"));
     }
 
     #[tokio::test]

--- a/rust/lance-namespace-impls/src/dir.rs
+++ b/rust/lance-namespace-impls/src/dir.rs
@@ -1069,16 +1069,14 @@ impl DirectoryNamespace {
     }
 
     /// Retire a durable manifest drop intent after physical cleanup completes.
-    pub async fn complete_drop_tombstone(&self, object_id: &str, location: &str) -> Result<bool> {
+    pub async fn complete_drop_tombstone(&self, tombstone_id: &str) -> Result<bool> {
         let manifest_ns =
             self.manifest_ns_for_write()
                 .await?
                 .ok_or_else(|| NamespaceError::InvalidInput {
                     message: "drop tombstones require a manifest-enabled namespace".to_string(),
                 })?;
-        manifest_ns
-            .complete_drop_tombstone_at_uri(object_id, location)
-            .await
+        manifest_ns.complete_drop_tombstone(tombstone_id).await
     }
 
     /// Lazily open the `__manifest` dataset (read-only) into the read cell.

--- a/rust/lance-namespace-impls/src/dir/manifest.rs
+++ b/rust/lance-namespace-impls/src/dir/manifest.rs
@@ -288,6 +288,7 @@ struct ManifestIndexAccumulator {
     base_objects_values: Vec<Option<Vec<String>>>,
     base_objects_row_ids: Vec<u64>,
     row_count: u64,
+    has_drop_tombstones: bool,
 }
 
 impl ManifestIndexAccumulator {
@@ -320,6 +321,7 @@ impl ManifestIndexAccumulator {
             .entry(row.object_type.as_str())
             .or_default()
             .insert(row_id as u32);
+        self.has_drop_tombstones |= row.object_type == ObjectType::DropTombstone;
         self.base_objects_values
             .push(row.base_objects.map(|objects| objects.to_vec()));
         self.base_objects_row_ids.push(row_id);
@@ -2501,9 +2503,10 @@ impl ManifestNamespace {
         manifest: &mut Manifest,
         indices: Option<Vec<IndexMetadata>>,
         transaction: Transaction,
+        has_drop_tombstones: bool,
     ) -> std::result::Result<(), CommitError> {
         apply_feature_flags(manifest, false, false).map_err(CommitError::from)?;
-        if self.async_drop_enabled {
+        if has_drop_tombstones {
             mark_drop_tombstone_rows(manifest.table_metadata_mut());
         }
         let timestamp_nanos = SystemTime::now()
@@ -2671,6 +2674,7 @@ impl ManifestNamespace {
             };
 
             let (mutation, index_data) = Self::take_manifest_rewrite_result(&shared)?;
+            let has_drop_tombstones = index_data.has_drop_tombstones;
 
             let Operation::Overwrite {
                 fragments, schema, ..
@@ -2731,6 +2735,7 @@ impl ManifestNamespace {
                     &mut manifest,
                     indices,
                     transaction,
+                    has_drop_tombstones,
                 )
                 .await;
 
@@ -3995,46 +4000,57 @@ impl LanceNamespace for ManifestNamespace {
                 metadata,
             };
             if replacing_generated_location {
-                let previous_location = &existing_table
+                let previous_location = existing_table
                     .as_ref()
                     .expect("an overwrite has an existing table")
-                    .location;
+                    .location
+                    .clone();
                 let tombstone_id = match self
-                    .replace_manifest_table_location(entry, previous_location)
+                    .replace_manifest_table_location(entry, &previous_location)
                     .await
                 {
                     Ok(tombstone_id) => tombstone_id,
                     Err(error) => {
-                        let new_table_path = self.table_path(&dir_name);
-                        if let Err(cleanup_error) =
-                            self.object_store.remove_dir_all(new_table_path).await
-                            && !cleanup_error.is_not_found()
-                        {
-                            log::warn!(
-                                "Failed to clean up replacement table location '{}' after manifest conflict: {}",
-                                dir_name,
-                                cleanup_error
-                            );
+                        let replacement_did_not_commit = self
+                            .query_manifest_for_table(&object_id)
+                            .await
+                            .is_ok_and(|current| {
+                                current.is_some_and(|current| {
+                                    manifest_locations_match(&current.location, &previous_location)
+                                })
+                            });
+                        if replacement_did_not_commit {
+                            let new_table_path = self.table_path(&dir_name);
+                            if let Err(cleanup_error) =
+                                self.object_store.remove_dir_all(new_table_path).await
+                                && !cleanup_error.is_not_found()
+                            {
+                                log::warn!(
+                                    "Failed to clean up replacement table location '{}' after manifest conflict: {}",
+                                    dir_name,
+                                    cleanup_error
+                                );
+                            }
                         }
                         return Err(error);
                     }
                 };
-                if let Err(error) = self.put_deregistered_table_marker(previous_location).await {
+                if let Err(error) = self.put_deregistered_table_marker(&previous_location).await {
                     log::warn!(
                         "Failed to write deregistration marker for overwritten table location '{}': {error:?}",
                         previous_location
                     );
                 }
-                let previous_table_path = self.table_path(previous_location);
+                let previous_table_path = self.table_path(&previous_location);
                 let cleanup_complete =
                     match self.object_store.remove_dir_all(previous_table_path).await {
                         Ok(()) => {
-                            self.remove_deregistered_table_marker(previous_location)
+                            self.remove_deregistered_table_marker(&previous_location)
                                 .await;
                             true
                         }
                         Err(error) if error.is_not_found() => {
-                            self.remove_deregistered_table_marker(previous_location)
+                            self.remove_deregistered_table_marker(&previous_location)
                                 .await;
                             true
                         }
@@ -4659,13 +4675,6 @@ impl LanceNamespace for ManifestNamespace {
             .context
             .as_ref()
             .and_then(|context| context.get(EXPECTED_DEREGISTER_LOCATION_CONTEXT_KEY));
-        if expected_location.is_some() && !self.async_drop_enabled {
-            return Err(NamespaceError::Unsupported {
-                message: "Expected-location fencing requires async_drop_enabled=true".to_string(),
-            }
-            .into());
-        }
-
         // Get table info before deleting
         let table_info = self.query_manifest_for_table(&object_id).await?;
 
@@ -4676,6 +4685,13 @@ impl LanceNamespace for ManifestNamespace {
             }
             None => {
                 if let Some(expected_location) = expected_location {
+                    if !self.async_drop_enabled {
+                        return Err(NamespaceError::Unsupported {
+                            message: "Expected-location fencing requires async_drop_enabled=true"
+                                .to_string(),
+                        }
+                        .into());
+                    }
                     let existing_tombstone =
                         self.list_drop_tombstones()
                             .await?
@@ -4725,6 +4741,12 @@ impl LanceNamespace for ManifestNamespace {
                     "Expected-location fencing is unsupported for table '{}' because location '{}' was not generated as a unique table incarnation",
                     object_id, manifest_location
                 ),
+            }
+            .into());
+        }
+        if expected_location.is_some() && !self.async_drop_enabled {
+            return Err(NamespaceError::Unsupported {
+                message: "Expected-location fencing requires async_drop_enabled=true".to_string(),
             }
             .into());
         }
@@ -5279,6 +5301,67 @@ mod tests {
         assert!(
             !ds.metadata()
                 .contains_key(crate::dir::manifest_feature_flags::WRITER_FEATURE_FLAGS_KEY)
+        );
+    }
+
+    #[tokio::test]
+    async fn test_async_drop_flags_start_with_first_tombstone() {
+        use lance::dataset::builder::DatasetBuilder;
+
+        let temp_dir = TempStdDir::default();
+        let temp_path = temp_dir.to_str().unwrap();
+        let namespace = DirectoryNamespaceBuilder::new(temp_path)
+            .manifest_enabled(true)
+            .dir_listing_enabled(false)
+            .async_drop_enabled(true)
+            .build()
+            .await
+            .unwrap();
+        let table_id = vec!["t1".to_string()];
+        let mut create_request = CreateTableRequest::new();
+        create_request.id = Some(table_id.clone());
+        namespace
+            .create_table(create_request, Bytes::from(create_test_ipc_data()))
+            .await
+            .unwrap();
+
+        let manifest_uri = format!("{temp_path}/{MANIFEST_TABLE_NAME}");
+        let dataset = DatasetBuilder::from_uri(&manifest_uri)
+            .load()
+            .await
+            .unwrap();
+        assert!(
+            !dataset
+                .metadata()
+                .contains_key(crate::dir::manifest_feature_flags::READER_FEATURE_FLAGS_KEY)
+        );
+
+        let location = namespace
+            .describe_table(DescribeTableRequest {
+                id: Some(table_id.clone()),
+                ..Default::default()
+            })
+            .await
+            .unwrap()
+            .location
+            .unwrap();
+        namespace
+            .deregister_table(DeregisterTableRequest {
+                id: Some(table_id),
+                context: Some(HashMap::from([(
+                    super::EXPECTED_DEREGISTER_LOCATION_CONTEXT_KEY.to_string(),
+                    location,
+                )])),
+                ..Default::default()
+            })
+            .await
+            .unwrap();
+
+        let dataset = DatasetBuilder::from_uri(manifest_uri).load().await.unwrap();
+        assert!(
+            dataset
+                .metadata()
+                .contains_key(crate::dir::manifest_feature_flags::READER_FEATURE_FLAGS_KEY)
         );
     }
 

--- a/rust/lance-namespace-impls/src/dir/manifest.rs
+++ b/rust/lance-namespace-impls/src/dir/manifest.rs
@@ -1124,7 +1124,14 @@ impl ManifestNamespace {
     }
 
     fn deregistered_table_marker_path(&self, location: &str) -> Path {
-        self.table_path(location).join(DEREGISTERED_TABLE_MARKER)
+        let table_path = self.table_path(location);
+        let filename = table_path
+            .filename()
+            .expect("a table location has a filename");
+        table_path
+            .parent()
+            .unwrap_or_else(|| self.base_path.clone())
+            .join(format!(".{filename}{DEREGISTERED_TABLE_MARKER}"))
     }
 
     async fn has_deregistered_table_marker(&self, location: &str) -> Result<bool> {
@@ -1134,11 +1141,14 @@ impl ManifestNamespace {
             .filter(|segment| !segment.is_empty() && *segment != ".")
         {
             path = path.join(segment);
-            if self
-                .object_store
-                .exists(&path.clone().join(DEREGISTERED_TABLE_MARKER))
-                .await?
-            {
+            let Some(filename) = path.filename() else {
+                continue;
+            };
+            let marker_path = path
+                .parent()
+                .unwrap_or_else(|| self.base_path.clone())
+                .join(format!(".{filename}{DEREGISTERED_TABLE_MARKER}"));
+            if self.object_store.exists(&marker_path).await? {
                 return Ok(true);
             }
         }
@@ -1168,7 +1178,7 @@ impl ManifestNamespace {
             && !error.is_not_found()
         {
             log::warn!(
-                "Failed to remove uncommitted deregistration marker at '{}': {error}",
+                "Failed to remove deregistration marker at '{}': {error}",
                 marker_path
             );
         }
@@ -3364,17 +3374,12 @@ impl LanceNamespace for ManifestNamespace {
                     .as_ref()
                     .expect("an overwrite has an existing table")
                     .location;
-                let marker_created = self
-                    .put_deregistered_table_marker(previous_location)
+                self.put_deregistered_table_marker(previous_location)
                     .await?;
                 if let Err(error) = self
                     .replace_manifest_table_location(entry, previous_location)
                     .await
                 {
-                    if marker_created {
-                        self.remove_deregistered_table_marker(previous_location)
-                            .await;
-                    }
                     let new_table_path = self.table_path(&dir_name);
                     if let Err(cleanup_error) =
                         self.object_store.remove_dir_all(new_table_path).await
@@ -3390,8 +3395,14 @@ impl LanceNamespace for ManifestNamespace {
                 }
                 let previous_table_path = self.table_path(previous_location);
                 match self.object_store.remove_dir_all(previous_table_path).await {
-                    Ok(()) => {}
-                    Err(error) if error.is_not_found() => {}
+                    Ok(()) => {
+                        self.remove_deregistered_table_marker(previous_location)
+                            .await;
+                    }
+                    Err(error) if error.is_not_found() => {
+                        self.remove_deregistered_table_marker(previous_location)
+                            .await;
+                    }
                     Err(error) => {
                         log::warn!(
                             "Failed to delete overwritten table location '{}': {error:?}",
@@ -3479,18 +3490,10 @@ impl LanceNamespace for ManifestNamespace {
                     .await;
                 let owns_manifest_deletion = match delete_result {
                     Ok(owns_manifest_deletion) => owns_manifest_deletion,
-                    Err(error) => {
-                        if marker_created {
-                            self.remove_deregistered_table_marker(&info.location).await;
-                        }
-                        return Err(error);
-                    }
+                    Err(error) => return Err(error),
                 };
 
-                if !owns_manifest_deletion {
-                    if marker_created {
-                        self.remove_deregistered_table_marker(&info.location).await;
-                    }
+                if !marker_created && !owns_manifest_deletion {
                     return Ok(DropTableResponse {
                         id: request.id.clone(),
                         location: Some(Self::construct_full_uri(&self.root, &info.location)?),
@@ -3512,6 +3515,7 @@ impl LanceNamespace for ManifestNamespace {
                             message: format!("Failed to delete table directory: {:?}", e),
                         })
                     })?;
+                self.remove_deregistered_table_marker(&info.location).await;
 
                 Ok(DropTableResponse {
                     id: request.id.clone(),
@@ -4019,40 +4023,21 @@ impl LanceNamespace for ManifestNamespace {
             .into());
         }
 
-        let marker_created = if expected_location.is_some() {
+        if expected_location.is_some() {
             self.ensure_manifest_writable().await?;
-            Some(
-                self.put_deregistered_table_marker(&manifest_location)
-                    .await?,
-            )
-        } else {
-            None
-        };
+            self.put_deregistered_table_marker(&manifest_location)
+                .await?;
+        }
 
         // Randomized table locations are checked again inside every rewrite attempt,
         // so a concurrent replacement cannot be deleted by a stale deregistration.
-        let delete_result = self
-            .delete_from_manifest_if_location(
-                &object_id,
-                Some(&manifest_location),
-                expected_location.is_some(),
-            )
-            .boxed()
-            .await;
-        let owns_manifest_deletion = match delete_result {
-            Ok(owns_manifest_deletion) => owns_manifest_deletion,
-            Err(error) => {
-                if marker_created == Some(true) {
-                    self.remove_deregistered_table_marker(&manifest_location)
-                        .await;
-                }
-                return Err(error);
-            }
-        };
-        if !owns_manifest_deletion && marker_created == Some(true) {
-            self.remove_deregistered_table_marker(&manifest_location)
-                .await;
-        }
+        self.delete_from_manifest_if_location(
+            &object_id,
+            Some(&manifest_location),
+            expected_location.is_some(),
+        )
+        .boxed()
+        .await?;
 
         Ok(DeregisterTableResponse {
             id: request.id.clone(),

--- a/rust/lance-namespace-impls/src/dir/manifest.rs
+++ b/rust/lance-namespace-impls/src/dir/manifest.rs
@@ -810,6 +810,7 @@ struct TombstoneTableMutation {
     next_drop_epoch: Option<String>,
 }
 
+#[derive(Clone)]
 enum TombstoneTableResult {
     Owned(String),
     Existing(String),
@@ -4975,11 +4976,12 @@ impl LanceNamespace for ManifestNamespace {
 #[cfg(test)]
 mod tests {
     use super::{
-        BASE_OBJECTS_INDEX_NAME, ConflictResolution, CopyOnWriteMutation, DeleteObjectMutation,
-        LANCE_DATA_DIR, LANCE_INDICES_DIR, MANIFEST_TABLE_NAME, ManifestBatchBuilder,
-        ManifestEntry, ManifestIndexAccumulator, ManifestNamespace, ManifestOutputRow,
-        ManifestRowValue, ManifestStreamMutation, OBJECT_ID_INDEX_NAME, OBJECT_TYPE_INDEX_NAME,
-        ObjectType,
+        BASE_OBJECTS_INDEX_NAME, ConflictResolution, CopyOnWriteMutation, DROP_EPOCH_OBJECT_ID,
+        DROP_TOMBSTONE_ID_PROPERTY, DeleteObjectMutation, DropTombstoneInfo, LANCE_DATA_DIR,
+        LANCE_INDICES_DIR, MANIFEST_TABLE_NAME, ManifestBatchBuilder, ManifestEntry,
+        ManifestIndexAccumulator, ManifestNamespace, ManifestOutputRow, ManifestRowValue,
+        ManifestStreamMutation, OBJECT_ID_INDEX_NAME, OBJECT_TYPE_INDEX_NAME, ObjectType,
+        TombstoneTableResult,
     };
     use crate::DirectoryNamespaceBuilder;
     use arrow::datatypes::DataType;

--- a/rust/lance-namespace-impls/src/dir/manifest.rs
+++ b/rust/lance-namespace-impls/src/dir/manifest.rs
@@ -4697,14 +4697,16 @@ mod tests {
             .await
             .unwrap();
 
-        let error = manifest_ns
-            .register_table(RegisterTableRequest {
+        let error = LanceNamespace::register_table(
+            &manifest_ns,
+            RegisterTableRequest {
                 id: Some(vec!["table".to_string()]),
                 location,
                 ..Default::default()
-            })
-            .await
-            .unwrap_err();
+            },
+        )
+        .await
+        .unwrap_err();
         assert!(error.to_string().contains("physically deleted"));
     }
 

--- a/rust/lance-namespace-impls/src/dir/manifest.rs
+++ b/rust/lance-namespace-impls/src/dir/manifest.rs
@@ -3057,25 +3057,6 @@ impl ManifestNamespace {
         Ok(epoch.unwrap_or_default())
     }
 
-    /// Insert an entry into the manifest table
-    async fn insert_into_manifest(
-        &self,
-        object_id: String,
-        object_type: ObjectType,
-        location: Option<String>,
-    ) -> Result<()> {
-        self.insert_into_manifest_with_metadata(
-            vec![ManifestEntry {
-                object_id,
-                object_type,
-                location,
-                metadata: None,
-            }],
-            None,
-        )
-        .await
-    }
-
     /// Insert one or more entries into the manifest table with metadata and base_objects.
     ///
     /// This is the unified entry point for both single and batch inserts.

--- a/rust/lance-namespace-impls/src/dir/manifest.rs
+++ b/rust/lance-namespace-impls/src/dir/manifest.rs
@@ -74,6 +74,7 @@ use tokio::sync::{Mutex, RwLock, RwLockReadGuard, RwLockWriteGuard};
 use uuid::Uuid;
 
 const MANIFEST_TABLE_NAME: &str = "__manifest";
+const DEREGISTERED_TABLE_MARKER: &str = ".lance-deregistered";
 const LANCE_DATA_DIR: &str = "data";
 const LANCE_INDICES_DIR: &str = "_indices";
 const DELIMITER: &str = "$";
@@ -1035,6 +1036,28 @@ impl ManifestNamespace {
                 .bytes()
                 .all(|byte| byte.is_ascii_hexdigit() && !byte.is_ascii_uppercase())
             && suffix == object_id
+    }
+
+    fn deregistered_table_marker_path(&self, location: &str) -> Path {
+        self.base_path
+            .clone()
+            .join(location.trim_matches('/'))
+            .join(DEREGISTERED_TABLE_MARKER)
+    }
+
+    fn table_locations_match(left: &str, right: &str) -> bool {
+        fn physical_location(location: &str) -> String {
+            let location = location.trim_end_matches('/');
+            location
+                .strip_prefix("s3+ddb://")
+                .map(|suffix| {
+                    let path = suffix.split_once('?').map_or(suffix, |(path, _)| path);
+                    format!("s3://{}", path.trim_end_matches('/'))
+                })
+                .unwrap_or_else(|| location.to_string())
+        }
+
+        physical_location(left) == physical_location(right)
     }
 
     /// Construct a full URI from root and relative location
@@ -3720,15 +3743,6 @@ impl LanceNamespace for ManifestNamespace {
         let (namespace, table_name) = Self::split_object_id(table_id);
         let object_id = Self::build_object_id(&namespace, &table_name);
 
-        if Self::is_generated_dir_name(&object_id, &location) {
-            return Err(NamespaceError::InvalidInput {
-                message: format!(
-                    "Location '{location}' uses the reserved namespace-generated table naming pattern"
-                ),
-            }
-            .into());
-        }
-
         // Validate that parent namespaces exist (if not root)
         if !namespace.is_empty() {
             self.validate_namespace_levels_exist(&namespace).await?;
@@ -3738,6 +3752,19 @@ impl LanceNamespace for ManifestNamespace {
         if self.manifest_contains_object(&object_id).await? {
             return Err(NamespaceError::TableAlreadyExists {
                 message: object_id.to_string(),
+            }
+            .into());
+        }
+
+        if self
+            .object_store
+            .exists(&self.deregistered_table_marker_path(&location))
+            .await?
+        {
+            return Err(NamespaceError::ConcurrentModification {
+                message: format!(
+                    "Location '{location}' is being physically deleted after deregistration"
+                ),
             }
             .into());
         }
@@ -3804,7 +3831,7 @@ impl LanceNamespace for ManifestNamespace {
             .into());
         }
         if let Some(expected_location) = expected_location
-            && expected_location.trim_end_matches('/') != table_uri.trim_end_matches('/')
+            && !Self::table_locations_match(expected_location, &table_uri)
         {
             return Err(NamespaceError::ConcurrentModification {
                 message: format!(
@@ -3813,6 +3840,15 @@ impl LanceNamespace for ManifestNamespace {
                 ),
             }
             .into());
+        }
+
+        if expected_location.is_some() {
+            self.object_store
+                .put(
+                    &self.deregistered_table_marker_path(&manifest_location),
+                    b"deregistered",
+                )
+                .await?;
         }
 
         // Randomized table locations are checked again inside every rewrite attempt,
@@ -4016,8 +4052,8 @@ mod tests {
     use lance_namespace::LanceNamespace;
     use lance_namespace::error::NamespaceError;
     use lance_namespace::models::{
-        CreateNamespaceRequest, CreateTableRequest, DescribeTableRequest, DropTableRequest,
-        ListTablesRequest, TableExistsRequest,
+        CreateNamespaceRequest, CreateTableRequest, DeregisterTableRequest, DescribeTableRequest,
+        DropTableRequest, ListTablesRequest, RegisterTableRequest, TableExistsRequest,
     };
     use lance_table::format::Fragment;
     use rstest::rstest;
@@ -4620,6 +4656,56 @@ mod tests {
                 .join(new_location)
                 .exists()
         );
+    }
+
+    #[test]
+    fn dynamodb_manifest_uri_matches_physical_s3_location() {
+        assert!(ManifestNamespace::table_locations_match(
+            "s3+ddb://bucket/db/table?ddbTableName=manifests",
+            "s3://bucket/db/table/",
+        ));
+    }
+
+    #[tokio::test]
+    async fn expected_deregister_blocks_reregistering_cleanup_location() {
+        let temp_dir = TempStdDir::default();
+        let manifest_ns = create_manifest_namespace(temp_dir.to_str().unwrap(), false).await;
+        let location = ManifestNamespace::generate_dir_name("table");
+        manifest_ns
+            .insert_into_manifest_with_metadata(
+                vec![ManifestEntry {
+                    object_id: "table".to_string(),
+                    object_type: ObjectType::Table,
+                    location: Some(location.clone()),
+                    metadata: None,
+                }],
+                None,
+            )
+            .await
+            .unwrap();
+        let full_location =
+            ManifestNamespace::construct_full_uri(temp_dir.to_str().unwrap(), &location).unwrap();
+        manifest_ns
+            .deregister_table(DeregisterTableRequest {
+                id: Some(vec!["table".to_string()]),
+                context: Some(HashMap::from([(
+                    super::EXPECTED_DEREGISTER_LOCATION_CONTEXT_KEY.to_string(),
+                    full_location,
+                )])),
+                ..Default::default()
+            })
+            .await
+            .unwrap();
+
+        let error = manifest_ns
+            .register_table(RegisterTableRequest {
+                id: Some(vec!["table".to_string()]),
+                location,
+                ..Default::default()
+            })
+            .await
+            .unwrap_err();
+        assert!(error.to_string().contains("physically deleted"));
     }
 
     #[tokio::test]

--- a/rust/lance-namespace-impls/src/dir/manifest.rs
+++ b/rust/lance-namespace-impls/src/dir/manifest.rs
@@ -4673,6 +4673,17 @@ impl LanceNamespace for ManifestNamespace {
         let (namespace, table_name) = Self::split_object_id(table_id);
         let object_id = Self::build_object_id(&namespace, &table_name);
 
+        let expected_location = request
+            .context
+            .as_ref()
+            .and_then(|context| context.get(EXPECTED_DEREGISTER_LOCATION_CONTEXT_KEY));
+        if expected_location.is_some() && !self.async_drop_enabled {
+            return Err(NamespaceError::Unsupported {
+                message: "Expected-location fencing requires async_drop_enabled=true".to_string(),
+            }
+            .into());
+        }
+
         // Get table info before deleting
         let table_info = self.query_manifest_for_table(&object_id).await?;
 
@@ -4682,6 +4693,41 @@ impl LanceNamespace for ManifestNamespace {
                 (table_uri, info.location)
             }
             None => {
+                if let Some(expected_location) = expected_location {
+                    let existing_tombstone =
+                        self.list_drop_tombstones()
+                            .await?
+                            .into_iter()
+                            .find(|tombstone| {
+                                tombstone.object_id == object_id
+                                    && Self::construct_full_uri(&self.root, &tombstone.location)
+                                        .is_ok_and(|location| {
+                                            Self::table_locations_match(
+                                                expected_location,
+                                                &location,
+                                            )
+                                        })
+                            });
+                    if let Some(tombstone) = existing_tombstone {
+                        let table_uri = Self::construct_full_uri(&self.root, &tombstone.location)?;
+                        return Ok(DeregisterTableResponse {
+                            id: request.id.clone(),
+                            location: Some(table_uri),
+                            properties: Some(HashMap::from([(
+                                DROP_TOMBSTONE_ID_PROPERTY.to_string(),
+                                tombstone.tombstone_id,
+                            )])),
+                            ..Default::default()
+                        });
+                    }
+                    return Err(NamespaceError::ConcurrentModification {
+                        message: format!(
+                            "Table '{}' was concurrently deregistered without a drop intent",
+                            object_id
+                        ),
+                    }
+                    .into());
+                }
                 return Err(NamespaceError::TableNotFound {
                     message: object_id.to_string(),
                 }
@@ -4689,10 +4735,6 @@ impl LanceNamespace for ManifestNamespace {
             }
         };
 
-        let expected_location = request
-            .context
-            .as_ref()
-            .and_then(|context| context.get(EXPECTED_DEREGISTER_LOCATION_CONTEXT_KEY));
         if expected_location.is_some()
             && !Self::is_generated_dir_name(&object_id, &manifest_location)
         {
@@ -4715,13 +4757,6 @@ impl LanceNamespace for ManifestNamespace {
             }
             .into());
         }
-        if expected_location.is_some() && !self.async_drop_enabled {
-            return Err(NamespaceError::Unsupported {
-                message: "Expected-location fencing requires async_drop_enabled=true".to_string(),
-            }
-            .into());
-        }
-
         let tombstone_id = if expected_location.is_some() {
             self.ensure_manifest_writable().await?;
             let tombstone_result = self
@@ -5593,17 +5628,26 @@ mod tests {
             .unwrap();
         let full_location =
             ManifestNamespace::construct_full_uri(temp_dir.to_str().unwrap(), &location).unwrap();
-        manifest_ns
-            .deregister_table(DeregisterTableRequest {
-                id: Some(vec!["table".to_string()]),
-                context: Some(HashMap::from([(
-                    super::EXPECTED_DEREGISTER_LOCATION_CONTEXT_KEY.to_string(),
-                    full_location,
-                )])),
-                ..Default::default()
-            })
-            .await
-            .unwrap();
+        let request = DeregisterTableRequest {
+            id: Some(vec!["table".to_string()]),
+            context: Some(HashMap::from([(
+                super::EXPECTED_DEREGISTER_LOCATION_CONTEXT_KEY.to_string(),
+                full_location,
+            )])),
+            ..Default::default()
+        };
+        let first_response = manifest_ns.deregister_table(request.clone()).await.unwrap();
+        let retry_response = manifest_ns.deregister_table(request).await.unwrap();
+        assert_eq!(
+            first_response
+                .properties
+                .as_ref()
+                .and_then(|properties| properties.get(DROP_TOMBSTONE_ID_PROPERTY)),
+            retry_response
+                .properties
+                .as_ref()
+                .and_then(|properties| properties.get(DROP_TOMBSTONE_ID_PROPERTY))
+        );
         manifest_ns
             .remove_deregistered_table_marker(&location)
             .await;

--- a/rust/lance-namespace-impls/src/dir/manifest.rs
+++ b/rust/lance-namespace-impls/src/dir/manifest.rs
@@ -3378,6 +3378,7 @@ impl LanceNamespace for ManifestNamespace {
 
         match table_info {
             Some(info) => {
+                self.ensure_manifest_writable().await?;
                 self.object_store
                     .put(
                         &self.deregistered_table_marker_path(&info.location),
@@ -3910,6 +3911,7 @@ impl LanceNamespace for ManifestNamespace {
         }
 
         if expected_location.is_some() {
+            self.ensure_manifest_writable().await?;
             self.object_store
                 .put(
                     &self.deregistered_table_marker_path(&manifest_location),

--- a/rust/lance-namespace-impls/src/dir/manifest.rs
+++ b/rust/lance-namespace-impls/src/dir/manifest.rs
@@ -288,7 +288,7 @@ struct ManifestIndexAccumulator {
     base_objects_values: Vec<Option<Vec<String>>>,
     base_objects_row_ids: Vec<u64>,
     row_count: u64,
-    has_drop_tombstones: bool,
+    has_drop_state_rows: bool,
 }
 
 impl ManifestIndexAccumulator {
@@ -321,7 +321,10 @@ impl ManifestIndexAccumulator {
             .entry(row.object_type.as_str())
             .or_default()
             .insert(row_id as u32);
-        self.has_drop_tombstones |= row.object_type == ObjectType::DropTombstone;
+        self.has_drop_state_rows |= matches!(
+            row.object_type,
+            ObjectType::DropTombstone | ObjectType::DropEpoch
+        );
         self.base_objects_values
             .push(row.base_objects.map(|objects| objects.to_vec()));
         self.base_objects_row_ids.push(row_id);
@@ -2503,10 +2506,10 @@ impl ManifestNamespace {
         manifest: &mut Manifest,
         indices: Option<Vec<IndexMetadata>>,
         transaction: Transaction,
-        has_drop_tombstones: bool,
+        has_drop_state_rows: bool,
     ) -> std::result::Result<(), CommitError> {
         apply_feature_flags(manifest, false, false).map_err(CommitError::from)?;
-        if has_drop_tombstones {
+        if has_drop_state_rows {
             mark_drop_tombstone_rows(manifest.table_metadata_mut());
         }
         let timestamp_nanos = SystemTime::now()
@@ -2674,7 +2677,7 @@ impl ManifestNamespace {
             };
 
             let (mutation, index_data) = Self::take_manifest_rewrite_result(&shared)?;
-            let has_drop_tombstones = index_data.has_drop_tombstones;
+            let has_drop_state_rows = index_data.has_drop_state_rows;
 
             let Operation::Overwrite {
                 fragments, schema, ..
@@ -2735,7 +2738,7 @@ impl ManifestNamespace {
                     &mut manifest,
                     indices,
                     transaction,
-                    has_drop_tombstones,
+                    has_drop_state_rows,
                 )
                 .await;
 
@@ -4148,7 +4151,16 @@ impl LanceNamespace for ManifestNamespace {
                         .await?
                     {
                         TombstoneTableResult::Owned(tombstone_id) => Some(tombstone_id),
-                        TombstoneTableResult::Existing(_) | TombstoneTableResult::Missing => None,
+                        TombstoneTableResult::Existing(_) => None,
+                        TombstoneTableResult::Missing => {
+                            return Err(NamespaceError::ConcurrentModification {
+                                message: format!(
+                                    "Table '{}' was concurrently deregistered without a drop intent",
+                                    object_id
+                                ),
+                            }
+                            .into());
+                        }
                     }
                 } else if self
                     .delete_from_manifest_if_location(&object_id, Some(&info.location), true)
@@ -4157,7 +4169,13 @@ impl LanceNamespace for ManifestNamespace {
                 {
                     Some(String::new())
                 } else {
-                    None
+                    return Err(NamespaceError::ConcurrentModification {
+                        message: format!(
+                            "Table '{}' was concurrently deregistered before drop cleanup was claimed",
+                            object_id
+                        ),
+                    }
+                    .into());
                 };
 
                 let Some(tombstone_id) = tombstone_id else {
@@ -5345,7 +5363,7 @@ mod tests {
             .unwrap()
             .location
             .unwrap();
-        namespace
+        let response = namespace
             .deregister_table(DeregisterTableRequest {
                 id: Some(table_id),
                 context: Some(HashMap::from([(
@@ -5356,12 +5374,43 @@ mod tests {
             })
             .await
             .unwrap();
+        let tombstone_id = response
+            .properties
+            .as_ref()
+            .and_then(|properties| properties.get(DROP_TOMBSTONE_ID_PROPERTY))
+            .expect("async deregistration returns its durable tombstone id");
 
+        let dataset = DatasetBuilder::from_uri(&manifest_uri)
+            .load()
+            .await
+            .unwrap();
+        assert!(
+            dataset
+                .metadata()
+                .contains_key(crate::dir::manifest_feature_flags::READER_FEATURE_FLAGS_KEY)
+        );
+        assert!(
+            dataset
+                .metadata()
+                .contains_key(crate::dir::manifest_feature_flags::WRITER_FEATURE_FLAGS_KEY)
+        );
+
+        assert!(
+            namespace
+                .complete_drop_tombstone(tombstone_id)
+                .await
+                .unwrap()
+        );
         let dataset = DatasetBuilder::from_uri(manifest_uri).load().await.unwrap();
         assert!(
             dataset
                 .metadata()
                 .contains_key(crate::dir::manifest_feature_flags::READER_FEATURE_FLAGS_KEY)
+        );
+        assert!(
+            dataset
+                .metadata()
+                .contains_key(crate::dir::manifest_feature_flags::WRITER_FEATURE_FLAGS_KEY)
         );
     }
 

--- a/rust/lance-namespace-impls/src/dir/manifest.rs
+++ b/rust/lance-namespace-impls/src/dir/manifest.rs
@@ -1013,6 +1013,15 @@ impl ManifestNamespace {
         format!("{:08x}_{}", (hash & 0xFFFFFFFF) as u32, object_id)
     }
 
+    fn is_generated_dir_name(object_id: &str, location: &str) -> bool {
+        let Some((prefix, suffix)) = location.trim_end_matches('/').split_once('_') else {
+            return false;
+        };
+        prefix.len() == 8
+            && prefix.bytes().all(|byte| byte.is_ascii_hexdigit())
+            && suffix == object_id
+    }
+
     /// Construct a full URI from root and relative location
     pub(crate) fn construct_full_uri(root: &str, relative_location: &str) -> Result<String> {
         let mut base_url = lance_io::object_store::uri_to_url(root)?;
@@ -3625,6 +3634,15 @@ impl LanceNamespace for ManifestNamespace {
         let (namespace, table_name) = Self::split_object_id(table_id);
         let object_id = Self::build_object_id(&namespace, &table_name);
 
+        if Self::is_generated_dir_name(&object_id, &location) {
+            return Err(NamespaceError::InvalidInput {
+                message: format!(
+                    "Location '{location}' uses the reserved namespace-generated table naming pattern"
+                ),
+            }
+            .into());
+        }
+
         // Validate that parent namespaces exist (if not root)
         if !namespace.is_empty() {
             self.validate_namespace_levels_exist(&namespace).await?;
@@ -3688,15 +3706,13 @@ impl LanceNamespace for ManifestNamespace {
             .context
             .as_ref()
             .and_then(|context| context.get(EXPECTED_DEREGISTER_LOCATION_CONTEXT_KEY));
-        let deterministic_location = format!("{table_name}.lance");
         if expected_location.is_some()
-            && namespace.is_empty()
-            && manifest_location.trim_end_matches('/') == deterministic_location
+            && !Self::is_generated_dir_name(&object_id, &manifest_location)
         {
             return Err(NamespaceError::Unsupported {
                 message: format!(
-                    "Expected-location fencing is unsupported for root table '{}' when directory listing is enabled because its location is deterministic",
-                    object_id
+                    "Expected-location fencing is unsupported for table '{}' because location '{}' was not generated as a unique table incarnation",
+                    object_id, manifest_location
                 ),
             }
             .into());

--- a/rust/lance-namespace-impls/src/dir/manifest.rs
+++ b/rust/lance-namespace-impls/src/dir/manifest.rs
@@ -804,8 +804,7 @@ struct TombstoneTableMutation {
     expected_location: String,
     tombstone_object_id: String,
     deleted: bool,
-    tombstone_exists: bool,
-    owns_existing_tombstone: bool,
+    existing_tombstone_id: Option<String>,
     drop_epoch: u64,
     saw_drop_epoch: bool,
     next_drop_epoch: Option<String>,
@@ -813,7 +812,7 @@ struct TombstoneTableMutation {
 
 enum TombstoneTableResult {
     Owned(String),
-    Existing,
+    Existing(String),
     Missing,
 }
 
@@ -884,8 +883,7 @@ impl ManifestStreamMutation for TombstoneTableMutation {
                 .as_deref()
                 .is_some_and(|location| manifest_locations_match(location, &self.expected_location))
         {
-            self.tombstone_exists = true;
-            self.owns_existing_tombstone = row.object_id == self.tombstone_object_id;
+            self.existing_tombstone_id = Some(row.object_id.clone());
         } else if row.object_type == ObjectType::Table
             && row.location.as_deref().is_some_and(|location| {
                 manifest_locations_overlap(location, &self.expected_location)
@@ -917,7 +915,7 @@ impl ManifestStreamMutation for TombstoneTableMutation {
         output: &mut ManifestBatchBuilder,
         index_data: &mut ManifestIndexAccumulator,
     ) -> Result<()> {
-        if self.deleted && !self.tombstone_exists {
+        if self.deleted && self.existing_tombstone_id.is_none() {
             output.append(index_data, self.tombstone_row())?;
         }
         if self.deleted {
@@ -952,12 +950,12 @@ impl ManifestStreamMutation for TombstoneTableMutation {
             CopyOnWriteMutation::updated(TombstoneTableResult::Owned(
                 self.tombstone_object_id.clone(),
             ))
-        } else if self.owns_existing_tombstone {
+        } else if self.existing_tombstone_id.as_deref() == Some(self.tombstone_object_id.as_str()) {
             CopyOnWriteMutation::unchanged(TombstoneTableResult::Owned(
                 self.tombstone_object_id.clone(),
             ))
-        } else if self.tombstone_exists {
-            CopyOnWriteMutation::unchanged(TombstoneTableResult::Existing)
+        } else if let Some(tombstone_id) = &self.existing_tombstone_id {
+            CopyOnWriteMutation::unchanged(TombstoneTableResult::Existing(tombstone_id.clone()))
         } else {
             CopyOnWriteMutation::unchanged(TombstoneTableResult::Missing)
         }
@@ -3195,8 +3193,7 @@ impl ManifestNamespace {
                 expected_location: expected_location.clone(),
                 tombstone_object_id: tombstone_object_id.clone(),
                 deleted: false,
-                tombstone_exists: false,
-                owns_existing_tombstone: false,
+                existing_tombstone_id: None,
                 drop_epoch: 0,
                 saw_drop_epoch: false,
                 next_drop_epoch: None,
@@ -4153,7 +4150,7 @@ impl LanceNamespace for ManifestNamespace {
                         .await?
                     {
                         TombstoneTableResult::Owned(tombstone_id) => Some(tombstone_id),
-                        TombstoneTableResult::Existing | TombstoneTableResult::Missing => None,
+                        TombstoneTableResult::Existing(_) | TombstoneTableResult::Missing => None,
                     }
                 } else if self
                     .delete_from_manifest_if_location(&object_id, Some(&info.location), true)
@@ -4733,7 +4730,7 @@ impl LanceNamespace for ManifestNamespace {
                 .await?;
             let tombstone_id = match tombstone_result {
                 TombstoneTableResult::Owned(tombstone_id) => Some(tombstone_id),
-                TombstoneTableResult::Existing => None,
+                TombstoneTableResult::Existing(tombstone_id) => Some(tombstone_id),
                 TombstoneTableResult::Missing => {
                     return Err(NamespaceError::ConcurrentModification {
                         message: format!(
@@ -6140,12 +6137,13 @@ mod tests {
         else {
             panic!("first tombstone must own cleanup");
         };
+        let retry = manifest_ns
+            .tombstone_table_in_manifest("table", "generation.lance")
+            .await
+            .unwrap();
         assert!(matches!(
-            manifest_ns
-                .tombstone_table_in_manifest("table", "generation.lance")
-                .await
-                .unwrap(),
-            TombstoneTableResult::Existing
+            &retry,
+            TombstoneTableResult::Existing(existing) if existing == &tombstone_id
         ));
         assert_eq!(
             manifest_ns.list_drop_tombstones().await.unwrap(),

--- a/rust/lance-namespace-impls/src/dir/manifest.rs
+++ b/rust/lance-namespace-impls/src/dir/manifest.rs
@@ -103,6 +103,14 @@ static BASE_OBJECTS_VALUE_FIELD: LazyLock<Field> = LazyLock::new(|| {
 const DEFAULT_MANIFEST_REWRITE_COMMIT_RETRIES: u32 = 20;
 const MANIFEST_INDEX_BATCH_SIZE: usize = 8192;
 
+fn manifest_locations_match(left: &str, right: &str) -> bool {
+    left.split('/')
+        .filter(|segment| !segment.is_empty() && *segment != ".")
+        .eq(right
+            .split('/')
+            .filter(|segment| !segment.is_empty() && *segment != "."))
+}
+
 /// Object types that can be stored in the manifest
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ObjectType {
@@ -512,7 +520,7 @@ impl ManifestStreamMutation for UpsertManifestMutation {
             && self
                 .expected_locations
                 .values()
-                .any(|expected_location| expected_location == location)
+                .any(|expected_location| manifest_locations_match(expected_location, location))
         {
             return Err(NamespaceError::ConcurrentModification {
                 message: format!(
@@ -584,11 +592,12 @@ impl ManifestStreamMutation for UpsertManifestMutation {
 struct DeleteObjectMutation {
     object_id: String,
     expected_location: Option<String>,
+    require_exclusive_location: bool,
     deleted: bool,
 }
 
 impl ManifestStreamMutation for DeleteObjectMutation {
-    type Output = ();
+    type Output = bool;
 
     fn process_existing_row(
         &mut self,
@@ -614,8 +623,12 @@ impl ManifestStreamMutation for DeleteObjectMutation {
             return Ok(());
         }
 
-        if let Some(expected_location) = self.expected_location.as_deref()
-            && row.location.as_deref() == Some(expected_location)
+        if self.require_exclusive_location
+            && let Some(expected_location) = self.expected_location.as_deref()
+            && row
+                .location
+                .as_deref()
+                .is_some_and(|location| manifest_locations_match(location, expected_location))
         {
             return Err(NamespaceError::ConcurrentModification {
                 message: format!(
@@ -648,20 +661,20 @@ impl ManifestStreamMutation for DeleteObjectMutation {
 
     fn finish(&self) -> CopyOnWriteMutation<Self::Output> {
         if self.deleted {
-            CopyOnWriteMutation::updated(())
+            CopyOnWriteMutation::updated(true)
         } else {
-            CopyOnWriteMutation::unchanged(())
+            CopyOnWriteMutation::unchanged(false)
         }
     }
 
     fn conflict_resolution(&self) -> ConflictResolution<Self::Output> {
-        if self.expected_location.is_some() {
+        if self.require_exclusive_location {
             ConflictResolution::Retry
         } else {
             // If a concurrent writer already removed the object, the delete is satisfied.
             ConflictResolution::SucceedIfAbsent {
                 object_id: self.object_id.clone(),
-                output: (),
+                output: false,
             }
         }
     }
@@ -1082,6 +1095,35 @@ impl ManifestNamespace {
             .clone()
             .join(location.trim_matches('/'))
             .join(DEREGISTERED_TABLE_MARKER)
+    }
+
+    async fn put_deregistered_table_marker(&self, location: &str) -> Result<bool> {
+        let marker_path = self.deregistered_table_marker_path(location);
+        match super::put_marker_file_atomic(
+            &self.object_store,
+            &marker_path,
+            &format!("deregistration marker at {location}"),
+        )
+        .await
+        {
+            Ok(()) => Ok(true),
+            Err(super::MarkerFileError::AlreadyExists { .. }) => Ok(false),
+            Err(super::MarkerFileError::Other { message }) => {
+                Err(NamespaceError::Internal { message }.into())
+            }
+        }
+    }
+
+    async fn remove_deregistered_table_marker(&self, location: &str) {
+        let marker_path = self.deregistered_table_marker_path(location);
+        if let Err(error) = self.object_store.delete(&marker_path).await
+            && !error.is_not_found()
+        {
+            log::warn!(
+                "Failed to remove uncommitted deregistration marker at '{}': {error}",
+                marker_path
+            );
+        }
     }
 
     fn table_locations_match(left: &str, right: &str) -> bool {
@@ -2503,19 +2545,23 @@ impl ManifestNamespace {
 
     /// Delete an entry from the manifest table
     pub async fn delete_from_manifest(&self, object_id: &str) -> Result<()> {
-        self.delete_from_manifest_if_location(object_id, None).await
+        self.delete_from_manifest_if_location(object_id, None, false)
+            .await
+            .map(|_| ())
     }
 
     async fn delete_from_manifest_if_location(
         &self,
         object_id: &str,
         expected_location: Option<&str>,
-    ) -> Result<()> {
+        require_exclusive_location: bool,
+    ) -> Result<bool> {
         let object_id = object_id.to_string();
         let expected_location = expected_location.map(str::to_string);
         self.rewrite_manifest("Failed to delete from manifest", || DeleteObjectMutation {
             object_id: object_id.clone(),
             expected_location: expected_location.clone(),
+            require_exclusive_location,
             deleted: false,
         })
         .await
@@ -3274,16 +3320,17 @@ impl LanceNamespace for ManifestNamespace {
                     .as_ref()
                     .expect("an overwrite has an existing table")
                     .location;
-                self.object_store
-                    .put(
-                        &self.deregistered_table_marker_path(previous_location),
-                        b"deregistered",
-                    )
+                let marker_created = self
+                    .put_deregistered_table_marker(previous_location)
                     .await?;
                 if let Err(error) = self
                     .replace_manifest_table_location(entry, previous_location)
                     .await
                 {
+                    if marker_created {
+                        self.remove_deregistered_table_marker(previous_location)
+                            .await;
+                    }
                     let new_table_path = self.base_path.clone().join(dir_name.as_str());
                     if let Err(cleanup_error) =
                         self.object_store.remove_dir_all(new_table_path).await
@@ -3379,17 +3426,24 @@ impl LanceNamespace for ManifestNamespace {
         match table_info {
             Some(info) => {
                 self.ensure_manifest_writable().await?;
-                self.object_store
-                    .put(
-                        &self.deregistered_table_marker_path(&info.location),
-                        b"deregistered",
-                    )
-                    .await?;
+                let marker_created = self.put_deregistered_table_marker(&info.location).await?;
 
                 // Delete from manifest first
-                self.delete_from_manifest_if_location(&object_id, Some(&info.location))
+                let owns_manifest_deletion = self
+                    .delete_from_manifest_if_location(&object_id, Some(&info.location), true)
                     .boxed()
                     .await?;
+
+                if !owns_manifest_deletion {
+                    if marker_created {
+                        self.remove_deregistered_table_marker(&info.location).await;
+                    }
+                    return Ok(DropTableResponse {
+                        id: request.id.clone(),
+                        location: Some(Self::construct_full_uri(&self.root, &info.location)?),
+                        ..Default::default()
+                    });
+                }
 
                 // Delete physical data directory using the dir_name from manifest
                 let table_path = self.base_path.clone().join(info.location.as_str());
@@ -3910,21 +3964,30 @@ impl LanceNamespace for ManifestNamespace {
             .into());
         }
 
-        if expected_location.is_some() {
+        let marker_created = if expected_location.is_some() {
             self.ensure_manifest_writable().await?;
-            self.object_store
-                .put(
-                    &self.deregistered_table_marker_path(&manifest_location),
-                    b"deregistered",
-                )
-                .await?;
-        }
+            Some(
+                self.put_deregistered_table_marker(&manifest_location)
+                    .await?,
+            )
+        } else {
+            None
+        };
 
         // Randomized table locations are checked again inside every rewrite attempt,
         // so a concurrent replacement cannot be deleted by a stale deregistration.
-        self.delete_from_manifest_if_location(&object_id, Some(&manifest_location))
+        let owns_manifest_deletion = self
+            .delete_from_manifest_if_location(
+                &object_id,
+                Some(&manifest_location),
+                expected_location.is_some(),
+            )
             .boxed()
             .await?;
+        if !owns_manifest_deletion && marker_created == Some(true) {
+            self.remove_deregistered_table_marker(&manifest_location)
+                .await;
+        }
 
         Ok(DeregisterTableResponse {
             id: request.id.clone(),
@@ -4264,7 +4327,7 @@ mod tests {
     }
 
     impl ManifestStreamMutation for ConcurrentDeleteBeforeCommitMutation {
-        type Output = ();
+        type Output = bool;
 
         fn process_existing_row(
             &mut self,
@@ -4301,7 +4364,7 @@ mod tests {
         fn conflict_resolution(&self) -> ConflictResolution<Self::Output> {
             ConflictResolution::SucceedIfAbsent {
                 object_id: self.target.clone(),
-                output: (),
+                output: false,
             }
         }
     }
@@ -4667,7 +4730,7 @@ mod tests {
             .unwrap();
 
         let error = manifest_ns
-            .delete_from_manifest_if_location("table", Some("old-generation.lance"))
+            .delete_from_manifest_if_location("table", Some("old-generation.lance"), true)
             .await
             .unwrap_err();
 
@@ -5069,6 +5132,7 @@ mod tests {
                     inner: DeleteObjectMutation {
                         object_id: "table".to_string(),
                         expected_location: None,
+                        require_exclusive_location: false,
                         deleted: false,
                     },
                     root: temp_path.to_string(),
@@ -5099,7 +5163,7 @@ mod tests {
                     ManifestEntry {
                         object_id: "alias".to_string(),
                         object_type: ObjectType::Table,
-                        location: Some("shared.lance".to_string()),
+                        location: Some("shared.lance/".to_string()),
                         metadata: None,
                     },
                 ],
@@ -5109,12 +5173,82 @@ mod tests {
             .unwrap();
 
         let result = manifest_ns
-            .delete_from_manifest_if_location("table", Some("shared.lance"))
+            .delete_from_manifest_if_location("table", Some("shared.lance"), true)
             .await;
 
         assert!(result.is_err(), "shared location must not be deregistered");
         assert!(manifest_ns.manifest_contains_object("table").await.unwrap());
         assert!(manifest_ns.manifest_contains_object("alias").await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn test_manifest_nonexclusive_deregister_allows_alias() {
+        let temp_dir = TempStdDir::default();
+        let temp_path = temp_dir.to_str().unwrap();
+        let manifest_ns = create_manifest_namespace_with_retries(temp_path, false, Some(0)).await;
+
+        manifest_ns
+            .insert_into_manifest_with_metadata(
+                vec![
+                    ManifestEntry {
+                        object_id: "table".to_string(),
+                        object_type: ObjectType::Table,
+                        location: Some("shared.lance".to_string()),
+                        metadata: None,
+                    },
+                    ManifestEntry {
+                        object_id: "alias".to_string(),
+                        object_type: ObjectType::Table,
+                        location: Some("shared.lance/".to_string()),
+                        metadata: None,
+                    },
+                ],
+                None,
+            )
+            .await
+            .unwrap();
+
+        let deleted = manifest_ns
+            .delete_from_manifest_if_location("table", Some("shared.lance"), false)
+            .await
+            .unwrap();
+
+        assert!(deleted);
+        assert!(!manifest_ns.manifest_contains_object("table").await.unwrap());
+        assert!(manifest_ns.manifest_contains_object("alias").await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn test_manifest_conditional_delete_reports_ownership() {
+        let temp_dir = TempStdDir::default();
+        let temp_path = temp_dir.to_str().unwrap();
+        let manifest_ns = create_manifest_namespace_with_retries(temp_path, false, Some(0)).await;
+
+        manifest_ns
+            .insert_into_manifest_with_metadata(
+                vec![ManifestEntry {
+                    object_id: "table".to_string(),
+                    object_type: ObjectType::Table,
+                    location: Some("table.lance".to_string()),
+                    metadata: None,
+                }],
+                None,
+            )
+            .await
+            .unwrap();
+
+        assert!(
+            manifest_ns
+                .delete_from_manifest_if_location("table", Some("table.lance"), true)
+                .await
+                .unwrap()
+        );
+        assert!(
+            !manifest_ns
+                .delete_from_manifest_if_location("table", Some("table.lance"), true)
+                .await
+                .unwrap()
+        );
     }
 
     #[tokio::test]
@@ -5135,7 +5269,7 @@ mod tests {
                     ManifestEntry {
                         object_id: "alias".to_string(),
                         object_type: ObjectType::Table,
-                        location: Some("shared.lance".to_string()),
+                        location: Some("shared.lance/".to_string()),
                         metadata: None,
                     },
                 ],

--- a/rust/lance-namespace-impls/src/dir/manifest.rs
+++ b/rust/lance-namespace-impls/src/dir/manifest.rs
@@ -111,6 +111,18 @@ fn manifest_locations_match(left: &str, right: &str) -> bool {
             .filter(|segment| !segment.is_empty() && *segment != "."))
 }
 
+fn manifest_locations_overlap(left: &str, right: &str) -> bool {
+    let left = left
+        .split('/')
+        .filter(|segment| !segment.is_empty() && *segment != ".")
+        .collect::<Vec<_>>();
+    let right = right
+        .split('/')
+        .filter(|segment| !segment.is_empty() && *segment != ".")
+        .collect::<Vec<_>>();
+    left.starts_with(&right) || right.starts_with(&left)
+}
+
 /// Object types that can be stored in the manifest
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ObjectType {
@@ -520,7 +532,7 @@ impl ManifestStreamMutation for UpsertManifestMutation {
             && self
                 .expected_locations
                 .values()
-                .any(|expected_location| manifest_locations_match(expected_location, location))
+                .any(|expected_location| manifest_locations_overlap(expected_location, location))
         {
             return Err(NamespaceError::ConcurrentModification {
                 message: format!(
@@ -607,7 +619,10 @@ impl ManifestStreamMutation for DeleteObjectMutation {
     ) -> Result<()> {
         if row.object_id == self.object_id {
             if let Some(expected_location) = self.expected_location.as_deref()
-                && row.location.as_deref() != Some(expected_location)
+                && !row
+                    .location
+                    .as_deref()
+                    .is_some_and(|location| manifest_locations_match(location, expected_location))
             {
                 return Err(NamespaceError::ConcurrentModification {
                     message: format!(
@@ -628,7 +643,7 @@ impl ManifestStreamMutation for DeleteObjectMutation {
             && row
                 .location
                 .as_deref()
-                .is_some_and(|location| manifest_locations_match(location, expected_location))
+                .is_some_and(|location| manifest_locations_overlap(location, expected_location))
         {
             return Err(NamespaceError::ConcurrentModification {
                 message: format!(
@@ -857,6 +872,7 @@ pub struct ManifestNamespace {
     /// If true, root namespace tables use {table_name}.lance naming
     /// If false, they use namespace-prefixed names
     dir_listing_enabled: bool,
+    async_drop_enabled: bool,
     /// Whether copy-on-write manifest rewrites should build replacement indices.
     /// Defaults to true.
     inline_optimization_enabled: bool,
@@ -950,6 +966,7 @@ impl ManifestNamespace {
         object_store: Arc<ObjectStore>,
         base_path: Path,
         dir_listing_enabled: bool,
+        async_drop_enabled: bool,
         inline_optimization_enabled: bool,
         commit_retries: Option<u32>,
     ) -> Result<Self> {
@@ -965,6 +982,7 @@ impl ManifestNamespace {
             base_path,
             manifest_dataset,
             dir_listing_enabled,
+            async_drop_enabled,
             inline_optimization_enabled,
             commit_retries,
         ))
@@ -979,6 +997,7 @@ impl ManifestNamespace {
         object_store: Arc<ObjectStore>,
         base_path: Path,
         dir_listing_enabled: bool,
+        async_drop_enabled: bool,
         inline_optimization_enabled: bool,
         commit_retries: Option<u32>,
     ) -> Result<Self> {
@@ -993,6 +1012,7 @@ impl ManifestNamespace {
             base_path,
             manifest_dataset,
             dir_listing_enabled,
+            async_drop_enabled,
             inline_optimization_enabled,
             commit_retries,
         ))
@@ -1007,6 +1027,7 @@ impl ManifestNamespace {
         base_path: Path,
         manifest_dataset: DatasetConsistencyWrapper,
         dir_listing_enabled: bool,
+        async_drop_enabled: bool,
         inline_optimization_enabled: bool,
         commit_retries: Option<u32>,
     ) -> Self {
@@ -1018,6 +1039,7 @@ impl ManifestNamespace {
             base_path,
             manifest_dataset,
             dir_listing_enabled,
+            async_drop_enabled,
             inline_optimization_enabled,
             commit_retries,
             manifest_mutation_lock: Arc::new(Mutex::new(())),
@@ -1090,11 +1112,37 @@ impl ManifestNamespace {
             && suffix == object_id
     }
 
+    fn table_path(&self, location: &str) -> Path {
+        let mut path = self.base_path.clone();
+        for segment in location
+            .split('/')
+            .filter(|segment| !segment.is_empty() && *segment != ".")
+        {
+            path = path.join(segment);
+        }
+        path
+    }
+
     fn deregistered_table_marker_path(&self, location: &str) -> Path {
-        self.base_path
-            .clone()
-            .join(location.trim_matches('/'))
-            .join(DEREGISTERED_TABLE_MARKER)
+        self.table_path(location).join(DEREGISTERED_TABLE_MARKER)
+    }
+
+    async fn has_deregistered_table_marker(&self, location: &str) -> Result<bool> {
+        let mut path = self.base_path.clone();
+        for segment in location
+            .split('/')
+            .filter(|segment| !segment.is_empty() && *segment != ".")
+        {
+            path = path.join(segment);
+            if self
+                .object_store
+                .exists(&path.clone().join(DEREGISTERED_TABLE_MARKER))
+                .await?
+            {
+                return Ok(true);
+            }
+        }
+        Ok(false)
     }
 
     async fn put_deregistered_table_marker(&self, location: &str) -> Result<bool> {
@@ -2059,11 +2107,7 @@ impl ManifestNamespace {
                     }
                 }
                 for location in locations {
-                    if self
-                        .object_store
-                        .exists(&self.deregistered_table_marker_path(location))
-                        .await?
-                    {
+                    if self.has_deregistered_table_marker(location).await? {
                         return Err(NamespaceError::ConcurrentModification {
                             message: format!(
                                 "Location '{location}' is being physically deleted after deregistration"
@@ -2408,8 +2452,7 @@ impl ManifestNamespace {
     }
 
     async fn location_has_actual_manifests(&self, location: &str) -> Result<bool> {
-        Self::path_has_actual_manifests(&self.object_store, &self.base_path.clone().join(location))
-            .await
+        Self::path_has_actual_manifests(&self.object_store, &self.table_path(location)).await
     }
 
     pub(crate) fn is_not_found_load_error(err: &LanceError) -> bool {
@@ -3198,7 +3241,8 @@ impl LanceNamespace for ManifestNamespace {
         };
         let overwriting_existing_table =
             existing_has_manifests == Some(true) && create_mode == CreateTableMode::Overwrite;
-        let replacing_generated_location = overwriting_existing_table
+        let replacing_generated_location = self.async_drop_enabled
+            && overwriting_existing_table
             && existing_table
                 .as_ref()
                 .is_some_and(|table| Self::is_generated_dir_name(&object_id, &table.location));
@@ -3331,7 +3375,7 @@ impl LanceNamespace for ManifestNamespace {
                         self.remove_deregistered_table_marker(previous_location)
                             .await;
                     }
-                    let new_table_path = self.base_path.clone().join(dir_name.as_str());
+                    let new_table_path = self.table_path(&dir_name);
                     if let Err(cleanup_error) =
                         self.object_store.remove_dir_all(new_table_path).await
                         && !cleanup_error.is_not_found()
@@ -3344,7 +3388,7 @@ impl LanceNamespace for ManifestNamespace {
                     }
                     return Err(error);
                 }
-                let previous_table_path = self.base_path.clone().join(previous_location.as_str());
+                let previous_table_path = self.table_path(previous_location);
                 match self.object_store.remove_dir_all(previous_table_path).await {
                     Ok(()) => {}
                     Err(error) if error.is_not_found() => {}
@@ -3429,10 +3473,19 @@ impl LanceNamespace for ManifestNamespace {
                 let marker_created = self.put_deregistered_table_marker(&info.location).await?;
 
                 // Delete from manifest first
-                let owns_manifest_deletion = self
+                let delete_result = self
                     .delete_from_manifest_if_location(&object_id, Some(&info.location), true)
                     .boxed()
-                    .await?;
+                    .await;
+                let owns_manifest_deletion = match delete_result {
+                    Ok(owns_manifest_deletion) => owns_manifest_deletion,
+                    Err(error) => {
+                        if marker_created {
+                            self.remove_deregistered_table_marker(&info.location).await;
+                        }
+                        return Err(error);
+                    }
+                };
 
                 if !owns_manifest_deletion {
                     if marker_created {
@@ -3446,7 +3499,7 @@ impl LanceNamespace for ManifestNamespace {
                 }
 
                 // Delete physical data directory using the dir_name from manifest
-                let table_path = self.base_path.clone().join(info.location.as_str());
+                let table_path = self.table_path(&info.location);
                 let table_uri = Self::construct_full_uri(&self.root, &info.location)?;
 
                 // Remove the table directory
@@ -3739,7 +3792,7 @@ impl LanceNamespace for ManifestNamespace {
             // Child namespace table or dir listing disabled: use hash-based naming
             Self::generate_dir_name(&object_id)
         };
-        let table_path = self.base_path.clone().join(dir_name.as_str());
+        let table_path = self.table_path(&dir_name);
         let table_uri = Self::construct_full_uri(&self.root, &dir_name)?;
 
         // Validate location if provided
@@ -3878,11 +3931,7 @@ impl LanceNamespace for ManifestNamespace {
             .into());
         }
 
-        if self
-            .object_store
-            .exists(&self.deregistered_table_marker_path(&location))
-            .await?
-        {
+        if self.has_deregistered_table_marker(&location).await? {
             return Err(NamespaceError::ConcurrentModification {
                 message: format!(
                     "Location '{location}' is being physically deleted after deregistration"
@@ -3941,6 +3990,12 @@ impl LanceNamespace for ManifestNamespace {
             .context
             .as_ref()
             .and_then(|context| context.get(EXPECTED_DEREGISTER_LOCATION_CONTEXT_KEY));
+        if expected_location.is_some() && !self.async_drop_enabled {
+            return Err(NamespaceError::Unsupported {
+                message: "Expected-location fencing requires async_drop_enabled=true".to_string(),
+            }
+            .into());
+        }
         if expected_location.is_some()
             && !Self::is_generated_dir_name(&object_id, &manifest_location)
         {
@@ -3976,14 +4031,24 @@ impl LanceNamespace for ManifestNamespace {
 
         // Randomized table locations are checked again inside every rewrite attempt,
         // so a concurrent replacement cannot be deleted by a stale deregistration.
-        let owns_manifest_deletion = self
+        let delete_result = self
             .delete_from_manifest_if_location(
                 &object_id,
                 Some(&manifest_location),
                 expected_location.is_some(),
             )
             .boxed()
-            .await?;
+            .await;
+        let owns_manifest_deletion = match delete_result {
+            Ok(owns_manifest_deletion) => owns_manifest_deletion,
+            Err(error) => {
+                if marker_created == Some(true) {
+                    self.remove_deregistered_table_marker(&manifest_location)
+                        .await;
+                }
+                return Err(error);
+            }
+        };
         if !owns_manifest_deletion && marker_created == Some(true) {
             self.remove_deregistered_table_marker(&manifest_location)
                 .await;
@@ -4215,6 +4280,7 @@ mod tests {
             base_path,
             false,
             false,
+            false,
             None,
         )
         .await
@@ -4240,6 +4306,7 @@ mod tests {
             object_store,
             base_path,
             true,
+            false,
             inline_optimization_enabled,
             commit_retries,
         )
@@ -4748,8 +4815,9 @@ mod tests {
     #[tokio::test]
     async fn overwrite_moves_generated_table_to_a_new_location() {
         let temp_dir = TempStdDir::default();
-        let manifest_ns =
+        let mut manifest_ns =
             create_manifest_namespace_without_directory_listing(temp_dir.to_str().unwrap()).await;
+        manifest_ns.async_drop_enabled = true;
         let mut request = CreateTableRequest::new();
         request.id = Some(vec!["table".to_string()]);
         manifest_ns
@@ -4801,7 +4869,8 @@ mod tests {
     #[tokio::test]
     async fn expected_deregister_blocks_reregistering_cleanup_location() {
         let temp_dir = TempStdDir::default();
-        let manifest_ns = create_manifest_namespace(temp_dir.to_str().unwrap(), false).await;
+        let mut manifest_ns = create_manifest_namespace(temp_dir.to_str().unwrap(), false).await;
+        manifest_ns.async_drop_enabled = true;
         let location = ManifestNamespace::generate_dir_name("table");
         manifest_ns
             .insert_into_manifest_with_metadata(
@@ -4839,6 +4908,29 @@ mod tests {
         )
         .await
         .unwrap_err();
+        assert!(error.to_string().contains("physically deleted"));
+    }
+
+    #[tokio::test]
+    async fn register_rejects_location_beneath_drop_marker() {
+        let temp_dir = TempStdDir::default();
+        let manifest_ns = create_manifest_namespace(temp_dir.to_str().unwrap(), false).await;
+        manifest_ns
+            .put_deregistered_table_marker("dropped-generation")
+            .await
+            .unwrap();
+
+        let error = LanceNamespace::register_table(
+            &manifest_ns,
+            RegisterTableRequest {
+                id: Some(vec!["table".to_string()]),
+                location: "dropped-generation/nested".to_string(),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap_err();
+
         assert!(error.to_string().contains("physically deleted"));
     }
 
@@ -5163,7 +5255,7 @@ mod tests {
                     ManifestEntry {
                         object_id: "alias".to_string(),
                         object_type: ObjectType::Table,
-                        location: Some("shared.lance/".to_string()),
+                        location: Some("shared.lance/nested".to_string()),
                         metadata: None,
                     },
                 ],

--- a/rust/lance-namespace-impls/src/dir/manifest.rs
+++ b/rust/lance-namespace-impls/src/dir/manifest.rs
@@ -67,7 +67,6 @@ use std::io::Cursor;
 use std::time::{SystemTime, UNIX_EPOCH};
 use std::{
     collections::{BTreeMap, HashMap, HashSet},
-    hash::{DefaultHasher, Hash, Hasher},
     ops::{Deref, DerefMut},
     sync::{Arc, LazyLock, Mutex as StdMutex, MutexGuard as StdMutexGuard},
 };
@@ -413,6 +412,7 @@ struct UpsertManifestMutation {
     entry_positions: HashMap<String, usize>,
     matched: Vec<bool>,
     when_matched: WhenMatched,
+    expected_locations: HashMap<String, String>,
 }
 
 impl UpsertManifestMutation {
@@ -420,6 +420,7 @@ impl UpsertManifestMutation {
         entries: Vec<ManifestEntry>,
         base_objects: Option<Vec<String>>,
         when_matched: WhenMatched,
+        expected_locations: HashMap<String, String>,
     ) -> Self {
         let entry_positions = entries
             .iter()
@@ -437,6 +438,7 @@ impl UpsertManifestMutation {
             entry_positions,
             matched,
             when_matched,
+            expected_locations,
         }
     }
 
@@ -462,6 +464,19 @@ impl ManifestStreamMutation for UpsertManifestMutation {
         index_data: &mut ManifestIndexAccumulator,
     ) -> Result<()> {
         if let Some(index) = self.entry_positions.get(&row.object_id).copied() {
+            if let Some(expected_location) = self.expected_locations.get(&row.object_id)
+                && row.location.as_deref() != Some(expected_location.as_str())
+            {
+                return Err(NamespaceError::ConcurrentModification {
+                    message: format!(
+                        "Table '{}' moved from expected location '{}' to '{}'",
+                        row.object_id,
+                        expected_location,
+                        row.location.as_deref().unwrap_or("<missing>")
+                    ),
+                }
+                .into());
+            }
             match self.when_matched {
                 WhenMatched::Fail => {
                     return Err(NamespaceError::ConcurrentModification {
@@ -508,6 +523,17 @@ impl ManifestStreamMutation for UpsertManifestMutation {
     ) -> Result<()> {
         for index in 0..self.entries.len() {
             if !self.matched[index] {
+                if let Some(expected_location) =
+                    self.expected_locations.get(&self.entries[index].object_id)
+                {
+                    return Err(NamespaceError::ConcurrentModification {
+                        message: format!(
+                            "Table '{}' was removed from expected location '{}'",
+                            self.entries[index].object_id, expected_location
+                        ),
+                    }
+                    .into());
+                }
                 output.append(index_data, self.entry_row(index))?;
             }
         }
@@ -993,32 +1019,21 @@ impl ManifestNamespace {
         format!("table id '{}'", Self::str_object_id(table_id))
     }
 
-    /// Generate a new directory name in format: `<hash>_<object_id>`
-    /// The hash is used to (1) optimize object store throughput,
-    /// (2) have high enough entropy in a short period of time to prevent issues like
-    /// failed table creation, delete and create new table of the same name, etc.
-    /// The object_id is added after the hash to ensure
+    /// Generate a new directory name in format: `<uuid>_<object_id>`.
+    /// The object_id is added after the UUID to ensure
     /// dir name uniqueness and make debugging easier.
     pub fn generate_dir_name(object_id: &str) -> String {
-        // Generate a random number for uniqueness
-        let random_num: u64 = rand::random();
-
-        // Create hash from random number + object_id
-        let mut hasher = DefaultHasher::new();
-        random_num.hash(&mut hasher);
-        object_id.hash(&mut hasher);
-        let hash = hasher.finish();
-
-        // Format as lowercase hex (8 characters - sufficient entropy for uniqueness)
-        format!("{:08x}_{}", (hash & 0xFFFFFFFF) as u32, object_id)
+        format!("{}_{}", Uuid::new_v4().simple(), object_id)
     }
 
     fn is_generated_dir_name(object_id: &str, location: &str) -> bool {
         let Some((prefix, suffix)) = location.trim_end_matches('/').split_once('_') else {
             return false;
         };
-        prefix.len() == 8
-            && prefix.bytes().all(|byte| byte.is_ascii_hexdigit())
+        matches!(prefix.len(), 8 | 32)
+            && prefix
+                .bytes()
+                .all(|byte| byte.is_ascii_hexdigit() && !byte.is_ascii_uppercase())
             && suffix == object_id
     }
 
@@ -2378,7 +2393,31 @@ impl ManifestNamespace {
         }
 
         self.rewrite_manifest("Failed to overwrite manifest", || {
-            UpsertManifestMutation::new(entries.clone(), base_objects.clone(), when_matched.clone())
+            UpsertManifestMutation::new(
+                entries.clone(),
+                base_objects.clone(),
+                when_matched.clone(),
+                HashMap::new(),
+            )
+        })
+        .await
+    }
+
+    async fn replace_manifest_table_location(
+        &self,
+        entry: ManifestEntry,
+        expected_location: &str,
+    ) -> Result<()> {
+        let object_id = entry.object_id.clone();
+        let expected_locations =
+            HashMap::from([(object_id.clone(), expected_location.to_string())]);
+        self.rewrite_manifest("Failed to replace manifest table location", || {
+            UpsertManifestMutation::new(
+                vec![entry.clone()],
+                None,
+                WhenMatched::UpdateAll,
+                expected_locations.clone(),
+            )
         })
         .await
     }
@@ -3032,7 +3071,15 @@ impl LanceNamespace for ManifestNamespace {
         } else {
             CreateTableMode::parse(request.mode.as_deref())?
         };
-        let dir_name = if let Some(existing_table) = &existing_table {
+        let overwriting_existing_table =
+            existing_has_manifests == Some(true) && create_mode == CreateTableMode::Overwrite;
+        let replacing_generated_location = overwriting_existing_table
+            && existing_table
+                .as_ref()
+                .is_some_and(|table| Self::is_generated_dir_name(&object_id, &table.location));
+        let dir_name = if replacing_generated_location {
+            Self::generate_dir_name(&object_id)
+        } else if let Some(existing_table) = &existing_table {
             existing_table.location.clone()
         } else if namespace.is_empty() && self.dir_listing_enabled {
             format!("{}.lance", table_name)
@@ -3040,8 +3087,6 @@ impl LanceNamespace for ManifestNamespace {
             Self::generate_dir_name(&object_id)
         };
         let table_uri = Self::construct_full_uri(&self.root, &dir_name)?;
-        let overwriting_existing_table =
-            existing_has_manifests == Some(true) && create_mode == CreateTableMode::Overwrite;
 
         if existing_has_manifests == Some(true) {
             match create_mode {
@@ -3118,7 +3163,11 @@ impl LanceNamespace for ManifestNamespace {
             ..Default::default()
         };
         let write_params = WriteParams {
-            mode: create_mode.write_mode(),
+            mode: if replacing_generated_location {
+                WriteMode::Create
+            } else {
+                create_mode.write_mode()
+            },
             session: self.session.clone(),
             store_params: Some(store_params),
             ..Default::default()
@@ -3135,16 +3184,51 @@ impl LanceNamespace for ManifestNamespace {
         if overwriting_existing_table {
             let metadata =
                 Self::serialize_metadata(request.properties.as_ref(), "table", &object_id)?;
-            self.upsert_into_manifest_with_metadata(
-                vec![ManifestEntry {
-                    object_id,
-                    object_type: ObjectType::Table,
-                    location: Some(dir_name),
-                    metadata,
-                }],
-                None,
-            )
-            .await?;
+            let entry = ManifestEntry {
+                object_id,
+                object_type: ObjectType::Table,
+                location: Some(dir_name.clone()),
+                metadata,
+            };
+            if replacing_generated_location {
+                let previous_location = &existing_table
+                    .as_ref()
+                    .expect("an overwrite has an existing table")
+                    .location;
+                if let Err(error) = self
+                    .replace_manifest_table_location(entry, previous_location)
+                    .await
+                {
+                    let new_table_path = self.base_path.clone().join(dir_name.as_str());
+                    if let Err(cleanup_error) =
+                        self.object_store.remove_dir_all(new_table_path).await
+                        && !cleanup_error.is_not_found()
+                    {
+                        log::warn!(
+                            "Failed to clean up replacement table location '{}' after manifest conflict: {}",
+                            dir_name,
+                            cleanup_error
+                        );
+                    }
+                    return Err(error);
+                }
+                let previous_table_path = self.base_path.clone().join(previous_location.as_str());
+                match self.object_store.remove_dir_all(previous_table_path).await {
+                    Ok(()) => {}
+                    Err(error) if error.is_not_found() => {}
+                    Err(error) => {
+                        return Err(lance_core::Error::from(NamespaceError::Internal {
+                            message: format!(
+                                "Failed to delete overwritten table location '{}': {error:?}",
+                                previous_location
+                            ),
+                        }));
+                    }
+                }
+            } else {
+                self.upsert_into_manifest_with_metadata(vec![entry], None)
+                    .await?;
+            }
 
             Ok(CreateTableResponse {
                 version: Some(version),
@@ -3947,6 +4031,28 @@ mod tests {
         create_manifest_namespace_with_retries(root, inline_optimization_enabled, None).await
     }
 
+    async fn create_manifest_namespace_without_directory_listing(root: &str) -> ManifestNamespace {
+        let (object_store, base_path) = ObjectStore::from_uri_and_params(
+            Arc::new(ObjectStoreRegistry::default()),
+            root,
+            &ObjectStoreParams::default(),
+        )
+        .await
+        .unwrap();
+        ManifestNamespace::from_directory(
+            root.to_string(),
+            None,
+            None,
+            object_store,
+            base_path,
+            false,
+            false,
+            None,
+        )
+        .await
+        .unwrap()
+    }
+
     async fn create_manifest_namespace_with_retries(
         root: &str,
         inline_optimization_enabled: bool,
@@ -4469,6 +4575,51 @@ mod tests {
         ));
         assert!(error.to_string().contains("moved from expected location"));
         assert!(manifest_ns.manifest_contains_object("table").await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn overwrite_moves_generated_table_to_a_new_location() {
+        let temp_dir = TempStdDir::default();
+        let manifest_ns =
+            create_manifest_namespace_without_directory_listing(temp_dir.to_str().unwrap()).await;
+        let mut request = CreateTableRequest::new();
+        request.id = Some(vec!["table".to_string()]);
+        manifest_ns
+            .create_table(request, Bytes::from(create_test_ipc_data()))
+            .await
+            .unwrap();
+        let old_location = manifest_ns
+            .query_manifest_for_table("table")
+            .await
+            .unwrap()
+            .unwrap()
+            .location;
+
+        let mut request = CreateTableRequest::new();
+        request.id = Some(vec!["table".to_string()]);
+        request.mode = Some("overwrite".to_string());
+        manifest_ns
+            .create_table(request, Bytes::from(create_test_ipc_data()))
+            .await
+            .unwrap();
+        let new_location = manifest_ns
+            .query_manifest_for_table("table")
+            .await
+            .unwrap()
+            .unwrap()
+            .location;
+
+        assert_ne!(old_location, new_location);
+        assert!(
+            !std::path::Path::new(temp_dir.to_str().unwrap())
+                .join(old_location)
+                .exists()
+        );
+        assert!(
+            std::path::Path::new(temp_dir.to_str().unwrap())
+                .join(new_location)
+                .exists()
+        );
     }
 
     #[tokio::test]

--- a/rust/lance-namespace-impls/src/dir/manifest.rs
+++ b/rust/lance-namespace-impls/src/dir/manifest.rs
@@ -358,7 +358,10 @@ enum ConflictResolution<O> {
     /// Creating these object ids with fail-on-conflict semantics. If any of them now
     /// exists in the latest manifest, the create lost the race and must fail with a
     /// concurrent-modification error; otherwise retry the rewrite.
-    FailIfExists(Vec<String>),
+    FailIfExists {
+        object_ids: Vec<String>,
+        locations: Vec<String>,
+    },
     /// Deleting `object_id`. If it is already absent from the latest manifest the delete
     /// has effectively happened, so return `output` as success; otherwise retry.
     SucceedIfAbsent { object_id: String, output: O },
@@ -505,6 +508,21 @@ impl ManifestStreamMutation for UpsertManifestMutation {
             }
         }
 
+        if let Some(location) = row.location.as_deref()
+            && self
+                .expected_locations
+                .values()
+                .any(|expected_location| expected_location == location)
+        {
+            return Err(NamespaceError::ConcurrentModification {
+                message: format!(
+                    "Location '{}' is also registered to object '{}'",
+                    location, row.object_id
+                ),
+            }
+            .into());
+        }
+
         output.append(
             index_data,
             ManifestOutputRow {
@@ -549,9 +567,14 @@ impl ManifestStreamMutation for UpsertManifestMutation {
         match self.when_matched {
             // Fail-on-conflict create: a concurrent writer may have created one of these
             // ids. Re-applying would still fail, so check directly instead of re-staging.
-            WhenMatched::Fail => ConflictResolution::FailIfExists(
-                self.entries.iter().map(|e| e.object_id.clone()).collect(),
-            ),
+            WhenMatched::Fail => ConflictResolution::FailIfExists {
+                object_ids: self.entries.iter().map(|e| e.object_id.clone()).collect(),
+                locations: self
+                    .entries
+                    .iter()
+                    .filter_map(|e| e.location.clone())
+                    .collect(),
+            },
             // Metadata upsert is last-writer-wins: re-read and re-apply.
             _ => ConflictResolution::Retry,
         }
@@ -591,6 +614,18 @@ impl ManifestStreamMutation for DeleteObjectMutation {
             return Ok(());
         }
 
+        if let Some(expected_location) = self.expected_location.as_deref()
+            && row.location.as_deref() == Some(expected_location)
+        {
+            return Err(NamespaceError::ConcurrentModification {
+                message: format!(
+                    "Location '{}' is also registered to object '{}'",
+                    expected_location, row.object_id
+                ),
+            }
+            .into());
+        }
+
         output.append(
             index_data,
             ManifestOutputRow {
@@ -620,10 +655,14 @@ impl ManifestStreamMutation for DeleteObjectMutation {
     }
 
     fn conflict_resolution(&self) -> ConflictResolution<Self::Output> {
-        // If a concurrent writer already removed the object, the delete is satisfied.
-        ConflictResolution::SucceedIfAbsent {
-            object_id: self.object_id.clone(),
-            output: (),
+        if self.expected_location.is_some() {
+            ConflictResolution::Retry
+        } else {
+            // If a concurrent writer already removed the object, the delete is satisfied.
+            ConflictResolution::SucceedIfAbsent {
+                object_id: self.object_id.clone(),
+                output: (),
+            }
         }
     }
 }
@@ -1962,13 +2001,30 @@ impl ManifestNamespace {
     ) -> Result<Option<O>> {
         match resolution {
             ConflictResolution::Retry => Ok(None),
-            ConflictResolution::FailIfExists(object_ids) => {
+            ConflictResolution::FailIfExists {
+                object_ids,
+                locations,
+            } => {
                 for object_id in object_ids {
                     if self.manifest_contains_object(object_id).await? {
                         return Err(NamespaceError::ConcurrentModification {
                             message: format!(
                                 "Object '{}' was concurrently created by another operation",
                                 object_id
+                            ),
+                        }
+                        .into());
+                    }
+                }
+                for location in locations {
+                    if self
+                        .object_store
+                        .exists(&self.deregistered_table_marker_path(location))
+                        .await?
+                    {
+                        return Err(NamespaceError::ConcurrentModification {
+                            message: format!(
+                                "Location '{location}' is being physically deleted after deregistration"
                             ),
                         }
                         .into());
@@ -3218,6 +3274,12 @@ impl LanceNamespace for ManifestNamespace {
                     .as_ref()
                     .expect("an overwrite has an existing table")
                     .location;
+                self.object_store
+                    .put(
+                        &self.deregistered_table_marker_path(previous_location),
+                        b"deregistered",
+                    )
+                    .await?;
                 if let Err(error) = self
                     .replace_manifest_table_location(entry, previous_location)
                     .await
@@ -3240,12 +3302,10 @@ impl LanceNamespace for ManifestNamespace {
                     Ok(()) => {}
                     Err(error) if error.is_not_found() => {}
                     Err(error) => {
-                        return Err(lance_core::Error::from(NamespaceError::Internal {
-                            message: format!(
-                                "Failed to delete overwritten table location '{}': {error:?}",
-                                previous_location
-                            ),
-                        }));
+                        log::warn!(
+                            "Failed to delete overwritten table location '{}': {error:?}",
+                            previous_location
+                        );
                     }
                 }
             } else {
@@ -3318,6 +3378,13 @@ impl LanceNamespace for ManifestNamespace {
 
         match table_info {
             Some(info) => {
+                self.object_store
+                    .put(
+                        &self.deregistered_table_marker_path(&info.location),
+                        b"deregistered",
+                    )
+                    .await?;
+
                 // Delete from manifest first
                 self.delete_from_manifest_if_location(&object_id, Some(&info.location))
                     .boxed()
@@ -5010,6 +5077,93 @@ mod tests {
 
         assert!(result.is_ok(), "delete should succeed: {result:?}");
         assert!(!manifest_ns.manifest_contains_object("table").await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn test_manifest_expected_location_delete_rejects_alias() {
+        let temp_dir = TempStdDir::default();
+        let temp_path = temp_dir.to_str().unwrap();
+        let manifest_ns = create_manifest_namespace_with_retries(temp_path, false, Some(0)).await;
+
+        manifest_ns
+            .insert_into_manifest_with_metadata(
+                vec![
+                    ManifestEntry {
+                        object_id: "table".to_string(),
+                        object_type: ObjectType::Table,
+                        location: Some("shared.lance".to_string()),
+                        metadata: None,
+                    },
+                    ManifestEntry {
+                        object_id: "alias".to_string(),
+                        object_type: ObjectType::Table,
+                        location: Some("shared.lance".to_string()),
+                        metadata: None,
+                    },
+                ],
+                None,
+            )
+            .await
+            .unwrap();
+
+        let result = manifest_ns
+            .delete_from_manifest_if_location("table", Some("shared.lance"))
+            .await;
+
+        assert!(result.is_err(), "shared location must not be deregistered");
+        assert!(manifest_ns.manifest_contains_object("table").await.unwrap());
+        assert!(manifest_ns.manifest_contains_object("alias").await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn test_manifest_expected_location_replace_rejects_alias() {
+        let temp_dir = TempStdDir::default();
+        let temp_path = temp_dir.to_str().unwrap();
+        let manifest_ns = create_manifest_namespace_with_retries(temp_path, false, Some(0)).await;
+
+        manifest_ns
+            .insert_into_manifest_with_metadata(
+                vec![
+                    ManifestEntry {
+                        object_id: "table".to_string(),
+                        object_type: ObjectType::Table,
+                        location: Some("shared.lance".to_string()),
+                        metadata: None,
+                    },
+                    ManifestEntry {
+                        object_id: "alias".to_string(),
+                        object_type: ObjectType::Table,
+                        location: Some("shared.lance".to_string()),
+                        metadata: None,
+                    },
+                ],
+                None,
+            )
+            .await
+            .unwrap();
+
+        let result = manifest_ns
+            .replace_manifest_table_location(
+                ManifestEntry {
+                    object_id: "table".to_string(),
+                    object_type: ObjectType::Table,
+                    location: Some("replacement.lance".to_string()),
+                    metadata: None,
+                },
+                "shared.lance",
+            )
+            .await;
+
+        assert!(result.is_err(), "shared location must not be replaced");
+        assert_eq!(
+            manifest_ns
+                .query_manifest_for_table("table")
+                .await
+                .unwrap()
+                .unwrap()
+                .location,
+            "shared.lance"
+        );
     }
 
     #[rstest]

--- a/rust/lance-namespace-impls/src/dir/manifest.rs
+++ b/rust/lance-namespace-impls/src/dir/manifest.rs
@@ -75,6 +75,7 @@ use uuid::Uuid;
 
 const MANIFEST_TABLE_NAME: &str = "__manifest";
 const DEREGISTERED_TABLE_MARKER: &str = ".lance-deregistered";
+const DROP_TOMBSTONE_OBJECT_ID_PREFIX: &str = "__drop_tombstone$";
 const LANCE_DATA_DIR: &str = "data";
 const LANCE_INDICES_DIR: &str = "_indices";
 const DELIMITER: &str = "$";
@@ -128,6 +129,7 @@ fn manifest_locations_overlap(left: &str, right: &str) -> bool {
 pub enum ObjectType {
     Namespace,
     Table,
+    DropTombstone,
 }
 
 impl ObjectType {
@@ -135,6 +137,7 @@ impl ObjectType {
         match self {
             Self::Namespace => "namespace",
             Self::Table => "table",
+            Self::DropTombstone => "drop_tombstone",
         }
     }
 
@@ -142,6 +145,7 @@ impl ObjectType {
         match s {
             "namespace" => Ok(Self::Namespace),
             "table" => Ok(Self::Table),
+            "drop_tombstone" => Ok(Self::DropTombstone),
             _ => Err(NamespaceError::Internal {
                 message: format!("Invalid object type: {}", s),
             }
@@ -437,6 +441,7 @@ struct UpsertManifestMutation {
     matched: Vec<bool>,
     when_matched: WhenMatched,
     expected_locations: HashMap<String, String>,
+    reject_drop_tombstone_overlaps: bool,
 }
 
 impl UpsertManifestMutation {
@@ -445,6 +450,7 @@ impl UpsertManifestMutation {
         base_objects: Option<Vec<String>>,
         when_matched: WhenMatched,
         expected_locations: HashMap<String, String>,
+        reject_drop_tombstone_overlaps: bool,
     ) -> Self {
         let entry_positions = entries
             .iter()
@@ -463,6 +469,7 @@ impl UpsertManifestMutation {
             matched,
             when_matched,
             expected_locations,
+            reject_drop_tombstone_overlaps,
         }
     }
 
@@ -487,6 +494,24 @@ impl ManifestStreamMutation for UpsertManifestMutation {
         output: &mut ManifestBatchBuilder,
         index_data: &mut ManifestIndexAccumulator,
     ) -> Result<()> {
+        if self.reject_drop_tombstone_overlaps
+            && row.object_type == ObjectType::DropTombstone
+            && let Some(tombstoned_location) = row.location.as_deref()
+            && self.entries.iter().any(|entry| {
+                entry.location.as_deref().is_some_and(|location| {
+                    manifest_locations_overlap(location, tombstoned_location)
+                })
+            })
+        {
+            return Err(NamespaceError::ConcurrentModification {
+                message: format!(
+                    "Location '{}' overlaps a durably deregistered table location",
+                    tombstoned_location
+                ),
+            }
+            .into());
+        }
+
         if let Some(index) = self.entry_positions.get(&row.object_id).copied() {
             if let Some(expected_location) = self.expected_locations.get(&row.object_id)
                 && row.location.as_deref() != Some(expected_location.as_str())
@@ -692,6 +717,206 @@ impl ManifestStreamMutation for DeleteObjectMutation {
                 output: false,
             }
         }
+    }
+}
+
+struct TombstoneTableMutation {
+    object_id: String,
+    expected_location: String,
+    tombstone_object_id: String,
+    deleted: bool,
+    tombstone_exists: bool,
+}
+
+impl TombstoneTableMutation {
+    fn tombstone_row(&self) -> ManifestOutputRow<'_> {
+        ManifestOutputRow {
+            object_id: &self.tombstone_object_id,
+            object_type: ObjectType::DropTombstone,
+            location: Some(&self.expected_location),
+            metadata: None,
+            base_objects: None,
+        }
+    }
+}
+
+impl ManifestStreamMutation for TombstoneTableMutation {
+    type Output = bool;
+
+    fn process_existing_row(
+        &mut self,
+        row: ManifestRowValue,
+        output: &mut ManifestBatchBuilder,
+        index_data: &mut ManifestIndexAccumulator,
+    ) -> Result<()> {
+        if row.object_id == self.object_id {
+            if !row
+                .location
+                .as_deref()
+                .is_some_and(|location| manifest_locations_match(location, &self.expected_location))
+            {
+                return Err(NamespaceError::ConcurrentModification {
+                    message: format!(
+                        "Table '{}' moved from expected location '{}' to '{}'",
+                        self.object_id,
+                        self.expected_location,
+                        row.location.as_deref().unwrap_or("<missing>")
+                    ),
+                }
+                .into());
+            }
+            self.deleted = true;
+            return Ok(());
+        }
+
+        if row.object_type == ObjectType::DropTombstone
+            && row
+                .location
+                .as_deref()
+                .is_some_and(|location| manifest_locations_match(location, &self.expected_location))
+        {
+            self.tombstone_exists = true;
+        } else if row.object_type == ObjectType::Table
+            && row.location.as_deref().is_some_and(|location| {
+                manifest_locations_overlap(location, &self.expected_location)
+            })
+        {
+            return Err(NamespaceError::ConcurrentModification {
+                message: format!(
+                    "Location '{}' is also registered to object '{}'",
+                    self.expected_location, row.object_id
+                ),
+            }
+            .into());
+        }
+
+        output.append(
+            index_data,
+            ManifestOutputRow {
+                object_id: &row.object_id,
+                object_type: row.object_type,
+                location: row.location.as_deref(),
+                metadata: row.metadata.as_deref(),
+                base_objects: row.base_objects.as_deref(),
+            },
+        )
+    }
+
+    fn append_rows(
+        &mut self,
+        output: &mut ManifestBatchBuilder,
+        index_data: &mut ManifestIndexAccumulator,
+    ) -> Result<()> {
+        if self.deleted && !self.tombstone_exists {
+            output.append(index_data, self.tombstone_row())?;
+        }
+        Ok(())
+    }
+
+    fn finish(&self) -> CopyOnWriteMutation<Self::Output> {
+        if self.deleted {
+            CopyOnWriteMutation::updated(true)
+        } else {
+            CopyOnWriteMutation::unchanged(false)
+        }
+    }
+}
+
+struct ReplaceTableLocationMutation {
+    entry: ManifestEntry,
+    expected_location: String,
+    tombstone_object_id: String,
+    replaced: bool,
+}
+
+impl ManifestStreamMutation for ReplaceTableLocationMutation {
+    type Output = ();
+
+    fn process_existing_row(
+        &mut self,
+        row: ManifestRowValue,
+        output: &mut ManifestBatchBuilder,
+        index_data: &mut ManifestIndexAccumulator,
+    ) -> Result<()> {
+        if row.object_id == self.entry.object_id {
+            if row.location.as_deref() != Some(self.expected_location.as_str()) {
+                return Err(NamespaceError::ConcurrentModification {
+                    message: format!(
+                        "Table '{}' moved from expected location '{}' to '{}'",
+                        self.entry.object_id,
+                        self.expected_location,
+                        row.location.as_deref().unwrap_or("<missing>")
+                    ),
+                }
+                .into());
+            }
+            self.replaced = true;
+            return output.append(
+                index_data,
+                ManifestOutputRow {
+                    object_id: &self.entry.object_id,
+                    object_type: self.entry.object_type,
+                    location: self.entry.location.as_deref(),
+                    metadata: self.entry.metadata.as_deref(),
+                    base_objects: None,
+                },
+            );
+        }
+
+        if row.object_type == ObjectType::Table
+            && row.location.as_deref().is_some_and(|location| {
+                manifest_locations_overlap(location, &self.expected_location)
+            })
+        {
+            return Err(NamespaceError::ConcurrentModification {
+                message: format!(
+                    "Location '{}' is also registered to object '{}'",
+                    self.expected_location, row.object_id
+                ),
+            }
+            .into());
+        }
+
+        output.append(
+            index_data,
+            ManifestOutputRow {
+                object_id: &row.object_id,
+                object_type: row.object_type,
+                location: row.location.as_deref(),
+                metadata: row.metadata.as_deref(),
+                base_objects: row.base_objects.as_deref(),
+            },
+        )
+    }
+
+    fn append_rows(
+        &mut self,
+        output: &mut ManifestBatchBuilder,
+        index_data: &mut ManifestIndexAccumulator,
+    ) -> Result<()> {
+        if !self.replaced {
+            return Err(NamespaceError::ConcurrentModification {
+                message: format!(
+                    "Table '{}' was removed from expected location '{}'",
+                    self.entry.object_id, self.expected_location
+                ),
+            }
+            .into());
+        }
+        output.append(
+            index_data,
+            ManifestOutputRow {
+                object_id: &self.tombstone_object_id,
+                object_type: ObjectType::DropTombstone,
+                location: Some(&self.expected_location),
+                metadata: None,
+                base_objects: None,
+            },
+        )
+    }
+
+    fn finish(&self) -> CopyOnWriteMutation<Self::Output> {
+        CopyOnWriteMutation::updated(())
     }
 }
 
@@ -2515,6 +2740,35 @@ impl ManifestNamespace {
         Ok(locations)
     }
 
+    /// List physical locations retained as durable drop intents.
+    pub async fn list_drop_tombstone_locations(&self) -> Result<std::collections::HashSet<String>> {
+        let mut scanner = self.manifest_scanner().await?;
+        scanner
+            .filter("object_type = 'drop_tombstone'")
+            .map_err(|e| {
+                lance_core::Error::from(NamespaceError::Internal {
+                    message: format!("Failed to filter drop tombstones: {e:?}"),
+                })
+            })?;
+        scanner.project(&["location"]).map_err(|e| {
+            lance_core::Error::from(NamespaceError::Internal {
+                message: format!("Failed to project drop tombstones: {e:?}"),
+            })
+        })?;
+
+        let batches = Self::execute_scanner(scanner).await?;
+        let mut locations = std::collections::HashSet::new();
+        for batch in batches {
+            let location_array = Self::get_string_column(&batch, "location")?;
+            for index in 0..location_array.len() {
+                if !location_array.is_null(index) {
+                    locations.insert(location_array.value(index).to_string());
+                }
+            }
+        }
+        Ok(locations)
+    }
+
     /// Insert an entry into the manifest table
     async fn insert_into_manifest(
         &self,
@@ -2572,6 +2826,20 @@ impl ManifestNamespace {
                 base_objects.clone(),
                 when_matched.clone(),
                 HashMap::new(),
+                false,
+            )
+        })
+        .await
+    }
+
+    async fn register_table_in_manifest(&self, entry: ManifestEntry) -> Result<()> {
+        self.rewrite_manifest("Failed to register table in manifest", || {
+            UpsertManifestMutation::new(
+                vec![entry.clone()],
+                None,
+                WhenMatched::Fail,
+                HashMap::new(),
+                true,
             )
         })
         .await
@@ -2582,16 +2850,40 @@ impl ManifestNamespace {
         entry: ManifestEntry,
         expected_location: &str,
     ) -> Result<()> {
-        let object_id = entry.object_id.clone();
-        let expected_locations =
-            HashMap::from([(object_id.clone(), expected_location.to_string())]);
         self.rewrite_manifest("Failed to replace manifest table location", || {
-            UpsertManifestMutation::new(
-                vec![entry.clone()],
-                None,
-                WhenMatched::UpdateAll,
-                expected_locations.clone(),
-            )
+            ReplaceTableLocationMutation {
+                entry: entry.clone(),
+                expected_location: expected_location.to_string(),
+                tombstone_object_id: Self::drop_tombstone_object_id(),
+                replaced: false,
+            }
+        })
+        .await
+    }
+
+    fn drop_tombstone_object_id() -> String {
+        format!(
+            "{DROP_TOMBSTONE_OBJECT_ID_PREFIX}{}",
+            Uuid::new_v4().simple()
+        )
+    }
+
+    async fn tombstone_table_in_manifest(
+        &self,
+        object_id: &str,
+        expected_location: &str,
+    ) -> Result<bool> {
+        let object_id = object_id.to_string();
+        let expected_location = expected_location.to_string();
+        let tombstone_object_id = Self::drop_tombstone_object_id();
+        self.rewrite_manifest("Failed to tombstone table in manifest", || {
+            TombstoneTableMutation {
+                object_id: object_id.clone(),
+                expected_location: expected_location.clone(),
+                tombstone_object_id: tombstone_object_id.clone(),
+                deleted: false,
+                tombstone_exists: false,
+            }
         })
         .await
     }
@@ -2630,8 +2922,13 @@ impl ManifestNamespace {
             .into());
         }
 
-        self.insert_into_manifest(object_id, ObjectType::Table, Some(location))
-            .await
+        self.register_table_in_manifest(ManifestEntry {
+            object_id,
+            object_type: ObjectType::Table,
+            location: Some(location),
+            metadata: None,
+        })
+        .await
     }
 
     /// Validate that all levels of a namespace path exist
@@ -3374,8 +3671,6 @@ impl LanceNamespace for ManifestNamespace {
                     .as_ref()
                     .expect("an overwrite has an existing table")
                     .location;
-                self.put_deregistered_table_marker(previous_location)
-                    .await?;
                 if let Err(error) = self
                     .replace_manifest_table_location(entry, previous_location)
                     .await
@@ -3392,6 +3687,12 @@ impl LanceNamespace for ManifestNamespace {
                         );
                     }
                     return Err(error);
+                }
+                if let Err(error) = self.put_deregistered_table_marker(previous_location).await {
+                    log::warn!(
+                        "Failed to write deregistration marker for overwritten table location '{}': {error:?}",
+                        previous_location
+                    );
                 }
                 let previous_table_path = self.table_path(previous_location);
                 match self.object_store.remove_dir_all(previous_table_path).await {
@@ -3481,24 +3782,23 @@ impl LanceNamespace for ManifestNamespace {
         match table_info {
             Some(info) => {
                 self.ensure_manifest_writable().await?;
-                let marker_created = self.put_deregistered_table_marker(&info.location).await?;
-
-                // Delete from manifest first
-                let delete_result = self
-                    .delete_from_manifest_if_location(&object_id, Some(&info.location), true)
+                let owns_manifest_deletion = self
+                    .tombstone_table_in_manifest(&object_id, &info.location)
                     .boxed()
-                    .await;
-                let owns_manifest_deletion = match delete_result {
-                    Ok(owns_manifest_deletion) => owns_manifest_deletion,
-                    Err(error) => return Err(error),
-                };
+                    .await?;
 
-                if !marker_created && !owns_manifest_deletion {
+                if !owns_manifest_deletion {
                     return Ok(DropTableResponse {
                         id: request.id.clone(),
                         location: Some(Self::construct_full_uri(&self.root, &info.location)?),
                         ..Default::default()
                     });
+                }
+                if let Err(error) = self.put_deregistered_table_marker(&info.location).await {
+                    log::warn!(
+                        "Failed to write deregistration marker for table location '{}': {error:?}",
+                        info.location
+                    );
                 }
 
                 // Delete physical data directory using the dir_name from manifest
@@ -3886,6 +4186,16 @@ impl LanceNamespace for ManifestNamespace {
 
         let location = request.location.clone();
 
+        if location
+            .split('/')
+            .all(|segment| segment.is_empty() || segment == ".")
+        {
+            return Err(NamespaceError::InvalidInput {
+                message: "Location must not be empty".to_string(),
+            }
+            .into());
+        }
+
         // Validate that location is a relative path within the root directory
         // We don't allow absolute URIs or paths that escape the root
         if location.contains("://") {
@@ -3944,9 +4254,13 @@ impl LanceNamespace for ManifestNamespace {
             .into());
         }
 
-        // Register the table with its location in the manifest
-        self.insert_into_manifest(object_id, ObjectType::Table, Some(location.clone()))
-            .await?;
+        self.register_table_in_manifest(ManifestEntry {
+            object_id,
+            object_type: ObjectType::Table,
+            location: Some(location.clone()),
+            metadata: None,
+        })
+        .await?;
 
         Ok(RegisterTableResponse {
             location: Some(location),
@@ -4025,19 +4339,23 @@ impl LanceNamespace for ManifestNamespace {
 
         if expected_location.is_some() {
             self.ensure_manifest_writable().await?;
-            self.put_deregistered_table_marker(&manifest_location)
+            let owns_manifest_deletion = self
+                .tombstone_table_in_manifest(&object_id, &manifest_location)
+                .boxed()
+                .await?;
+            if owns_manifest_deletion
+                && let Err(error) = self.put_deregistered_table_marker(&manifest_location).await
+            {
+                log::warn!(
+                    "Failed to write deregistration marker for table location '{}': {error:?}",
+                    manifest_location
+                );
+            }
+        } else {
+            self.delete_from_manifest_if_location(&object_id, Some(&manifest_location), false)
+                .boxed()
                 .await?;
         }
-
-        // Randomized table locations are checked again inside every rewrite attempt,
-        // so a concurrent replacement cannot be deleted by a stale deregistration.
-        self.delete_from_manifest_if_location(
-            &object_id,
-            Some(&manifest_location),
-            expected_location.is_some(),
-        )
-        .boxed()
-        .await?;
 
         Ok(DeregisterTableResponse {
             id: request.id.clone(),
@@ -4882,6 +5200,16 @@ mod tests {
             })
             .await
             .unwrap();
+        manifest_ns
+            .remove_deregistered_table_marker(&location)
+            .await;
+        assert!(
+            manifest_ns
+                .list_drop_tombstone_locations()
+                .await
+                .unwrap()
+                .contains(&location)
+        );
 
         let error = LanceNamespace::register_table(
             &manifest_ns,
@@ -4893,7 +5221,7 @@ mod tests {
         )
         .await
         .unwrap_err();
-        assert!(error.to_string().contains("physically deleted"));
+        assert!(error.to_string().contains("durably deregistered"));
     }
 
     #[tokio::test]
@@ -4917,6 +5245,56 @@ mod tests {
         .unwrap_err();
 
         assert!(error.to_string().contains("physically deleted"));
+    }
+
+    #[tokio::test]
+    async fn register_rejects_location_above_drop_tombstone() {
+        let temp_dir = TempStdDir::default();
+        let manifest_ns = create_manifest_namespace(temp_dir.to_str().unwrap(), false).await;
+        manifest_ns
+            .insert_into_manifest_with_metadata(
+                vec![ManifestEntry {
+                    object_id: ManifestNamespace::drop_tombstone_object_id(),
+                    object_type: ObjectType::DropTombstone,
+                    location: Some("ancestor/dropped-generation".to_string()),
+                    metadata: None,
+                }],
+                None,
+            )
+            .await
+            .unwrap();
+
+        let error = LanceNamespace::register_table(
+            &manifest_ns,
+            RegisterTableRequest {
+                id: Some(vec!["table".to_string()]),
+                location: "ancestor".to_string(),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap_err();
+
+        assert!(error.to_string().contains("durably deregistered"));
+    }
+
+    #[tokio::test]
+    async fn register_rejects_empty_location() {
+        let temp_dir = TempStdDir::default();
+        let manifest_ns = create_manifest_namespace(temp_dir.to_str().unwrap(), false).await;
+
+        let error = LanceNamespace::register_table(
+            &manifest_ns,
+            RegisterTableRequest {
+                id: Some(vec!["table".to_string()]),
+                location: "/./".to_string(),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap_err();
+
+        assert!(error.to_string().contains("must not be empty"));
     }
 
     #[tokio::test]
@@ -5325,6 +5703,43 @@ mod tests {
                 .delete_from_manifest_if_location("table", Some("table.lance"), true)
                 .await
                 .unwrap()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_manifest_tombstone_has_single_cleanup_owner() {
+        let temp_dir = TempStdDir::default();
+        let manifest_ns =
+            create_manifest_namespace_with_retries(temp_dir.to_str().unwrap(), false, Some(0))
+                .await;
+        manifest_ns
+            .insert_into_manifest_with_metadata(
+                vec![ManifestEntry {
+                    object_id: "table".to_string(),
+                    object_type: ObjectType::Table,
+                    location: Some("generation.lance".to_string()),
+                    metadata: None,
+                }],
+                None,
+            )
+            .await
+            .unwrap();
+
+        assert!(
+            manifest_ns
+                .tombstone_table_in_manifest("table", "generation.lance")
+                .await
+                .unwrap()
+        );
+        assert!(
+            !manifest_ns
+                .tombstone_table_in_manifest("table", "generation.lance")
+                .await
+                .unwrap()
+        );
+        assert_eq!(
+            manifest_ns.list_drop_tombstone_locations().await.unwrap(),
+            HashSet::from(["generation.lance".to_string()])
         );
     }
 

--- a/rust/lance-namespace-impls/src/dir/manifest.rs
+++ b/rust/lance-namespace-impls/src/dir/manifest.rs
@@ -806,10 +806,15 @@ struct TombstoneTableMutation {
     deleted: bool,
     tombstone_exists: bool,
     owns_existing_tombstone: bool,
-    claimed_missing: bool,
     drop_epoch: u64,
     saw_drop_epoch: bool,
     next_drop_epoch: Option<String>,
+}
+
+enum TombstoneTableResult {
+    Owned(String),
+    Existing,
+    Missing,
 }
 
 impl TombstoneTableMutation {
@@ -825,7 +830,7 @@ impl TombstoneTableMutation {
 }
 
 impl ManifestStreamMutation for TombstoneTableMutation {
-    type Output = Option<String>;
+    type Output = TombstoneTableResult;
 
     fn process_existing_row(
         &mut self,
@@ -912,13 +917,10 @@ impl ManifestStreamMutation for TombstoneTableMutation {
         output: &mut ManifestBatchBuilder,
         index_data: &mut ManifestIndexAccumulator,
     ) -> Result<()> {
-        if !self.deleted && !self.tombstone_exists {
-            self.claimed_missing = true;
-        }
-        if (self.deleted || self.claimed_missing) && !self.tombstone_exists {
+        if self.deleted && !self.tombstone_exists {
             output.append(index_data, self.tombstone_row())?;
         }
-        if self.deleted || self.claimed_missing {
+        if self.deleted {
             self.next_drop_epoch = Some(
                 self.drop_epoch
                     .checked_add(1)
@@ -946,12 +948,18 @@ impl ManifestStreamMutation for TombstoneTableMutation {
     }
 
     fn finish(&self) -> CopyOnWriteMutation<Self::Output> {
-        if self.deleted || self.claimed_missing {
-            CopyOnWriteMutation::updated(Some(self.tombstone_object_id.clone()))
+        if self.deleted {
+            CopyOnWriteMutation::updated(TombstoneTableResult::Owned(
+                self.tombstone_object_id.clone(),
+            ))
         } else if self.owns_existing_tombstone {
-            CopyOnWriteMutation::unchanged(Some(self.tombstone_object_id.clone()))
+            CopyOnWriteMutation::unchanged(TombstoneTableResult::Owned(
+                self.tombstone_object_id.clone(),
+            ))
+        } else if self.tombstone_exists {
+            CopyOnWriteMutation::unchanged(TombstoneTableResult::Existing)
         } else {
-            CopyOnWriteMutation::unchanged(None)
+            CopyOnWriteMutation::unchanged(TombstoneTableResult::Missing)
         }
     }
 }
@@ -3162,7 +3170,7 @@ impl ManifestNamespace {
         &self,
         object_id: &str,
         expected_location: &str,
-    ) -> Result<Option<String>> {
+    ) -> Result<TombstoneTableResult> {
         let object_id = object_id.to_string();
         let expected_location = expected_location.to_string();
         let tombstone_object_id = Self::drop_tombstone_object_id(&object_id);
@@ -3174,7 +3182,6 @@ impl ManifestNamespace {
                 deleted: false,
                 tombstone_exists: false,
                 owns_existing_tombstone: false,
-                claimed_missing: false,
                 drop_epoch: 0,
                 saw_drop_epoch: false,
                 next_drop_epoch: None,
@@ -3185,14 +3192,25 @@ impl ManifestNamespace {
 
     /// Retire a durable drop intent after its physical location is fully removed.
     pub async fn complete_drop_tombstone(&self, tombstone_id: &str) -> Result<bool> {
+        let location = self
+            .list_drop_tombstones()
+            .await?
+            .into_iter()
+            .find(|tombstone| tombstone.tombstone_id == tombstone_id)
+            .map(|tombstone| tombstone.location);
         let tombstone_id = tombstone_id.to_string();
-        self.rewrite_manifest("Failed to complete table drop tombstone", || {
-            DeleteDropTombstoneMutation {
-                tombstone_id: tombstone_id.clone(),
-                deleted: false,
-            }
-        })
-        .await
+        let deleted = self
+            .rewrite_manifest("Failed to complete table drop tombstone", || {
+                DeleteDropTombstoneMutation {
+                    tombstone_id: tombstone_id.clone(),
+                    deleted: false,
+                }
+            })
+            .await?;
+        if deleted && let Some(location) = location {
+            self.remove_deregistered_table_marker(&location).await;
+        }
+        Ok(deleted)
     }
 
     /// Delete an entry from the manifest table
@@ -4114,9 +4132,14 @@ impl LanceNamespace for ManifestNamespace {
             Some(info) => {
                 self.ensure_manifest_writable().await?;
                 let tombstone_id = if self.async_drop_enabled {
-                    self.tombstone_table_in_manifest(&object_id, &info.location)
+                    match self
+                        .tombstone_table_in_manifest(&object_id, &info.location)
                         .boxed()
                         .await?
+                    {
+                        TombstoneTableResult::Owned(tombstone_id) => Some(tombstone_id),
+                        TombstoneTableResult::Existing | TombstoneTableResult::Missing => None,
+                    }
                 } else if self
                     .delete_from_manifest_if_location(&object_id, Some(&info.location), true)
                     .boxed()
@@ -4689,10 +4712,23 @@ impl LanceNamespace for ManifestNamespace {
 
         let tombstone_id = if expected_location.is_some() {
             self.ensure_manifest_writable().await?;
-            let tombstone_id = self
+            let tombstone_result = self
                 .tombstone_table_in_manifest(&object_id, &manifest_location)
                 .boxed()
                 .await?;
+            let tombstone_id = match tombstone_result {
+                TombstoneTableResult::Owned(tombstone_id) => Some(tombstone_id),
+                TombstoneTableResult::Existing => None,
+                TombstoneTableResult::Missing => {
+                    return Err(NamespaceError::ConcurrentModification {
+                        message: format!(
+                            "Table '{}' was concurrently deregistered without a drop intent",
+                            object_id
+                        ),
+                    }
+                    .into());
+                }
+            };
             if tombstone_id.is_some()
                 && let Err(error) = self.put_deregistered_table_marker(&manifest_location).await
             {
@@ -6082,18 +6118,20 @@ mod tests {
             .await
             .unwrap();
 
-        let tombstone_id = manifest_ns
+        let TombstoneTableResult::Owned(tombstone_id) = manifest_ns
             .tombstone_table_in_manifest("table", "generation.lance")
             .await
             .unwrap()
-            .unwrap();
-        assert!(
+        else {
+            panic!("first tombstone must own cleanup");
+        };
+        assert!(matches!(
             manifest_ns
                 .tombstone_table_in_manifest("table", "generation.lance")
                 .await
-                .unwrap()
-                .is_none()
-        );
+                .unwrap(),
+            TombstoneTableResult::Existing
+        ));
         assert_eq!(
             manifest_ns.list_drop_tombstones().await.unwrap(),
             vec![DropTombstoneInfo {
@@ -6105,7 +6143,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_manifest_tombstone_claims_location_after_ordinary_deregister() {
+    async fn test_manifest_tombstone_does_not_claim_ordinary_deregister() {
         let temp_dir = TempStdDir::default();
         let manifest_ns =
             create_manifest_namespace_with_retries(temp_dir.to_str().unwrap(), false, Some(0))
@@ -6129,51 +6167,15 @@ mod tests {
                 .unwrap()
         );
 
-        let tombstone_id = manifest_ns
-            .tombstone_table_in_manifest("table", "generation.lance")
-            .await
-            .unwrap()
-            .unwrap();
-        assert!(
+        assert!(matches!(
             manifest_ns
                 .tombstone_table_in_manifest("table", "generation.lance")
                 .await
-                .unwrap()
-                .is_none()
-        );
-        assert_eq!(manifest_ns.current_drop_epoch().await.unwrap(), 1);
-        assert!(
-            manifest_ns
-                .complete_drop_tombstone(&tombstone_id)
-                .await
-                .unwrap()
-        );
-        let newer_tombstone_id = manifest_ns
-            .tombstone_table_in_manifest("table", "generation.lance")
-            .await
-            .unwrap()
-            .unwrap();
-        assert_ne!(tombstone_id, newer_tombstone_id);
-        assert!(
-            !manifest_ns
-                .complete_drop_tombstone(&tombstone_id)
-                .await
-                .unwrap()
-        );
-        assert_eq!(
-            manifest_ns.list_drop_tombstones().await.unwrap(),
-            vec![DropTombstoneInfo {
-                tombstone_id: newer_tombstone_id.clone(),
-                object_id: "table".to_string(),
-                location: "generation.lance".to_string(),
-            }]
-        );
-        assert!(
-            manifest_ns
-                .complete_drop_tombstone(&newer_tombstone_id)
-                .await
-                .unwrap()
-        );
+                .unwrap(),
+            TombstoneTableResult::Missing
+        ));
+        assert_eq!(manifest_ns.current_drop_epoch().await.unwrap(), 0);
+        assert!(manifest_ns.list_drop_tombstones().await.unwrap().is_empty());
 
         let stale_registration = ManifestEntry {
             object_id: "stale".to_string(),
@@ -6224,11 +6226,13 @@ mod tests {
             )
             .await
             .unwrap();
-        manifest_ns
-            .tombstone_table_in_manifest("table", "generation.lance")
-            .await
-            .unwrap()
-            .unwrap();
+        assert!(matches!(
+            manifest_ns
+                .tombstone_table_in_manifest("table", "generation.lance")
+                .await
+                .unwrap(),
+            TombstoneTableResult::Owned(_)
+        ));
 
         assert!(
             !manifest_ns

--- a/rust/lance-namespace-impls/src/dir/manifest.rs
+++ b/rust/lance-namespace-impls/src/dir/manifest.rs
@@ -77,6 +77,7 @@ const MANIFEST_TABLE_NAME: &str = "__manifest";
 const LANCE_DATA_DIR: &str = "data";
 const LANCE_INDICES_DIR: &str = "_indices";
 const DELIMITER: &str = "$";
+const EXPECTED_DEREGISTER_LOCATION_CONTEXT_KEY: &str = "expected_location";
 /// Bounded concurrency for per-table `_versions/` probes when filtering declared tables.
 /// Higher values reduce latency but increase burst load against the object store.
 pub(crate) const DECLARED_FILTER_CONCURRENCY: usize = 16;
@@ -3683,10 +3684,20 @@ impl LanceNamespace for ManifestNamespace {
             }
         };
 
-        if let Some(expected_location) = request
+        let expected_location = request
             .context
             .as_ref()
-            .and_then(|context| context.get("expected_location"))
+            .and_then(|context| context.get(EXPECTED_DEREGISTER_LOCATION_CONTEXT_KEY));
+        if expected_location.is_some() && namespace.is_empty() && self.dir_listing_enabled {
+            return Err(NamespaceError::Unsupported {
+                message: format!(
+                    "Expected-location fencing is unsupported for root table '{}' when directory listing is enabled because its location is deterministic",
+                    object_id
+                ),
+            }
+            .into());
+        }
+        if let Some(expected_location) = expected_location
             && expected_location.trim_end_matches('/') != table_uri.trim_end_matches('/')
         {
             return Err(NamespaceError::ConcurrentModification {
@@ -3698,9 +3709,8 @@ impl LanceNamespace for ManifestNamespace {
             .into());
         }
 
-        // The expected manifest location is checked again inside every rewrite
-        // attempt, so a concurrent drop-and-recreate cannot be deleted by a
-        // stale deregistration request.
+        // Randomized table locations are checked again inside every rewrite attempt,
+        // so a concurrent replacement cannot be deleted by a stale deregistration.
         self.delete_from_manifest_if_location(&object_id, Some(&manifest_location))
             .boxed()
             .await?;
@@ -3898,6 +3908,7 @@ mod tests {
     use lance_core::utils::tempfile::TempStdDir;
     use lance_io::object_store::{ObjectStore, ObjectStoreParams, ObjectStoreRegistry};
     use lance_namespace::LanceNamespace;
+    use lance_namespace::error::NamespaceError;
     use lance_namespace::models::{
         CreateNamespaceRequest, CreateTableRequest, DescribeTableRequest, DropTableRequest,
         ListTablesRequest, TableExistsRequest,

--- a/rust/lance-namespace-impls/src/dir/manifest.rs
+++ b/rust/lance-namespace-impls/src/dir/manifest.rs
@@ -7,7 +7,7 @@
 //! to track tables and nested namespaces.
 
 use super::EXPECTED_DEREGISTER_LOCATION_CONTEXT_KEY;
-use super::manifest_feature_flags::{ensure_readable, ensure_writable};
+use super::manifest_feature_flags::{ensure_readable, ensure_writable, mark_drop_tombstone_rows};
 use arrow::array::builder::{ListBuilder, StringBuilder};
 use arrow::array::{Array, ListArray, RecordBatch, RecordBatchIterator, StringArray, UInt64Array};
 use arrow::datatypes::{DataType, Field, Schema as ArrowSchema, SchemaRef};
@@ -1348,15 +1348,17 @@ impl ManifestNamespace {
         path
     }
 
-    fn deregistered_table_marker_path(&self, location: &str) -> Path {
+    fn deregistered_table_marker_path(&self, location: &str) -> Result<Path> {
         let table_path = self.table_path(location);
         let filename = table_path
             .filename()
-            .expect("a table location has a filename");
-        table_path
+            .ok_or_else(|| NamespaceError::InvalidInput {
+                message: format!("Table location '{location}' has no filename"),
+            })?;
+        Ok(table_path
             .parent()
             .unwrap_or_else(|| self.base_path.clone())
-            .join(format!(".{filename}{DEREGISTERED_TABLE_MARKER}"))
+            .join(format!(".{filename}{DEREGISTERED_TABLE_MARKER}")))
     }
 
     async fn has_deregistered_table_marker(&self, location: &str) -> Result<bool> {
@@ -1381,7 +1383,7 @@ impl ManifestNamespace {
     }
 
     async fn put_deregistered_table_marker(&self, location: &str) -> Result<bool> {
-        let marker_path = self.deregistered_table_marker_path(location);
+        let marker_path = self.deregistered_table_marker_path(location)?;
         match super::put_marker_file_atomic(
             &self.object_store,
             &marker_path,
@@ -1398,7 +1400,13 @@ impl ManifestNamespace {
     }
 
     async fn remove_deregistered_table_marker(&self, location: &str) {
-        let marker_path = self.deregistered_table_marker_path(location);
+        let marker_path = match self.deregistered_table_marker_path(location) {
+            Ok(marker_path) => marker_path,
+            Err(error) => {
+                log::warn!("Failed to resolve deregistration marker for '{location}': {error}");
+                return;
+            }
+        };
         if let Err(error) = self.object_store.delete(&marker_path).await
             && !error.is_not_found()
         {
@@ -2266,6 +2274,9 @@ impl ManifestNamespace {
         transaction: Transaction,
     ) -> std::result::Result<(), CommitError> {
         apply_feature_flags(manifest, false, false).map_err(CommitError::from)?;
+        if self.async_drop_enabled {
+            mark_drop_tombstone_rows(manifest.table_metadata_mut());
+        }
         let timestamp_nanos = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .map(|d| d.as_nanos())
@@ -2914,6 +2925,15 @@ impl ManifestNamespace {
 
     /// Register a table in the manifest without creating the physical table (internal helper for migration)
     pub async fn register_table(&self, name: &str, location: String) -> Result<()> {
+        if location
+            .split('/')
+            .all(|segment| segment.is_empty() || segment == ".")
+        {
+            return Err(NamespaceError::InvalidInput {
+                message: "Location must not be empty".to_string(),
+            }
+            .into());
+        }
         let object_id = Self::build_object_id(&[], name);
         if self.manifest_contains_object(&object_id).await? {
             return Err(NamespaceError::Internal {
@@ -3782,10 +3802,15 @@ impl LanceNamespace for ManifestNamespace {
         match table_info {
             Some(info) => {
                 self.ensure_manifest_writable().await?;
-                let owns_manifest_deletion = self
-                    .tombstone_table_in_manifest(&object_id, &info.location)
-                    .boxed()
-                    .await?;
+                let owns_manifest_deletion = if self.async_drop_enabled {
+                    self.tombstone_table_in_manifest(&object_id, &info.location)
+                        .boxed()
+                        .await?
+                } else {
+                    self.delete_from_manifest_if_location(&object_id, Some(&info.location), true)
+                        .boxed()
+                        .await?
+                };
 
                 if !owns_manifest_deletion {
                     return Ok(DropTableResponse {
@@ -3794,7 +3819,9 @@ impl LanceNamespace for ManifestNamespace {
                         ..Default::default()
                     });
                 }
-                if let Err(error) = self.put_deregistered_table_marker(&info.location).await {
+                if self.async_drop_enabled
+                    && let Err(error) = self.put_deregistered_table_marker(&info.location).await
+                {
                     log::warn!(
                         "Failed to write deregistration marker for table location '{}': {error:?}",
                         info.location
@@ -3815,7 +3842,9 @@ impl LanceNamespace for ManifestNamespace {
                             message: format!("Failed to delete table directory: {:?}", e),
                         })
                     })?;
-                self.remove_deregistered_table_marker(&info.location).await;
+                if self.async_drop_enabled {
+                    self.remove_deregistered_table_marker(&info.location).await;
+                }
 
                 Ok(DropTableResponse {
                     id: request.id.clone(),
@@ -4308,12 +4337,6 @@ impl LanceNamespace for ManifestNamespace {
             .context
             .as_ref()
             .and_then(|context| context.get(EXPECTED_DEREGISTER_LOCATION_CONTEXT_KEY));
-        if expected_location.is_some() && !self.async_drop_enabled {
-            return Err(NamespaceError::Unsupported {
-                message: "Expected-location fencing requires async_drop_enabled=true".to_string(),
-            }
-            .into());
-        }
         if expected_location.is_some()
             && !Self::is_generated_dir_name(&object_id, &manifest_location)
         {
@@ -4333,6 +4356,12 @@ impl LanceNamespace for ManifestNamespace {
                     "Table '{}' is at '{}' instead of expected location '{}'",
                     object_id, table_uri, expected_location
                 ),
+            }
+            .into());
+        }
+        if expected_location.is_some() && !self.async_drop_enabled {
+            return Err(NamespaceError::Unsupported {
+                message: "Expected-location fencing requires async_drop_enabled=true".to_string(),
             }
             .into());
         }
@@ -4870,7 +4899,7 @@ mod tests {
         set_manifest_table_metadata(
             temp_path,
             crate::dir::manifest_feature_flags::READER_FEATURE_FLAGS_KEY,
-            "1",
+            "2",
         )
         .await;
 
@@ -4893,7 +4922,7 @@ mod tests {
         set_manifest_table_metadata(
             temp_path,
             crate::dir::manifest_feature_flags::WRITER_FEATURE_FLAGS_KEY,
-            "1",
+            "2",
         )
         .await;
 

--- a/rust/lance-namespace-impls/src/dir/manifest.rs
+++ b/rust/lance-namespace-impls/src/dir/manifest.rs
@@ -1631,21 +1631,19 @@ impl ManifestNamespace {
         }
     }
 
-    async fn remove_deregistered_table_marker(&self, location: &str) {
-        let marker_path = match self.deregistered_table_marker_path(location) {
-            Ok(marker_path) => marker_path,
-            Err(error) => {
-                log::warn!("Failed to resolve deregistration marker for '{location}': {error}");
-                return;
-            }
-        };
+    async fn delete_deregistered_table_marker(&self, location: &str) -> Result<()> {
+        let marker_path = self.deregistered_table_marker_path(location)?;
         if let Err(error) = self.object_store.delete(&marker_path).await
             && !error.is_not_found()
         {
-            log::warn!(
-                "Failed to remove deregistration marker at '{}': {error}",
-                marker_path
-            );
+            return Err(error);
+        }
+        Ok(())
+    }
+
+    async fn remove_deregistered_table_marker(&self, location: &str) {
+        if let Err(error) = self.delete_deregistered_table_marker(location).await {
+            log::warn!("Failed to remove deregistration marker for '{location}': {error}");
         }
     }
 
@@ -3110,6 +3108,7 @@ impl ManifestNamespace {
         if entries.is_empty() {
             return Ok(());
         }
+        Self::ensure_drop_epoch_id_not_user_entries(&entries)?;
 
         self.rewrite_manifest("Failed to overwrite manifest", || {
             UpsertManifestMutation::new(
@@ -3125,6 +3124,7 @@ impl ManifestNamespace {
     }
 
     async fn register_table_in_manifest(&self, entry: ManifestEntry) -> Result<()> {
+        Self::ensure_drop_epoch_id_not_user_entries(std::slice::from_ref(&entry))?;
         let expected_drop_epoch = self.current_drop_epoch().await?;
         self.rewrite_manifest("Failed to register table in manifest", || {
             UpsertManifestMutation::new(
@@ -3144,6 +3144,7 @@ impl ManifestNamespace {
         entry: ManifestEntry,
         expected_location: &str,
     ) -> Result<String> {
+        Self::ensure_drop_epoch_id_not_user_entries(std::slice::from_ref(&entry))?;
         let tombstone_object_id = Self::drop_tombstone_object_id(&entry.object_id);
         self.rewrite_manifest("Failed to replace manifest table location", || {
             ReplaceTableLocationMutation {
@@ -3157,6 +3158,20 @@ impl ManifestNamespace {
         })
         .await?;
         Ok(tombstone_object_id)
+    }
+
+    fn ensure_drop_epoch_id_not_user_entries(entries: &[ManifestEntry]) -> Result<()> {
+        if entries.iter().any(|entry| {
+            entry.object_id == DROP_EPOCH_OBJECT_ID && entry.object_type != ObjectType::DropEpoch
+        }) {
+            return Err(NamespaceError::InvalidInput {
+                message: format!(
+                    "Object id '{DROP_EPOCH_OBJECT_ID}' is reserved for manifest drop fencing"
+                ),
+            }
+            .into());
+        }
+        Ok(())
     }
 
     fn drop_tombstone_object_id(object_id: &str) -> String {
@@ -3198,6 +3213,9 @@ impl ManifestNamespace {
             .into_iter()
             .find(|tombstone| tombstone.tombstone_id == tombstone_id)
             .map(|tombstone| tombstone.location);
+        if let Some(location) = location.as_deref() {
+            self.delete_deregistered_table_marker(location).await?;
+        }
         let tombstone_id = tombstone_id.to_string();
         let deleted = self
             .rewrite_manifest("Failed to complete table drop tombstone", || {
@@ -3207,9 +3225,6 @@ impl ManifestNamespace {
                 }
             })
             .await?;
-        if deleted && let Some(location) = location {
-            self.remove_deregistered_table_marker(&location).await;
-        }
         Ok(deleted)
     }
 
@@ -6226,29 +6241,17 @@ mod tests {
         let legacy =
             create_manifest_namespace_with_retries(legacy_dir.to_str().unwrap(), false, Some(0))
                 .await;
-        legacy
-            .insert_into_manifest_with_metadata(
-                vec![
-                    ManifestEntry {
+        assert!(
+            legacy
+                .insert_into_manifest_with_metadata(
+                    vec![ManifestEntry {
                         object_id: DROP_EPOCH_OBJECT_ID.to_string(),
                         object_type: ObjectType::Table,
                         location: Some("legacy.lance".to_string()),
                         metadata: None,
-                    },
-                    ManifestEntry {
-                        object_id: "table".to_string(),
-                        object_type: ObjectType::Table,
-                        location: Some("generation.lance".to_string()),
-                        metadata: None,
-                    },
-                ],
-                None,
-            )
-            .await
-            .unwrap();
-        assert!(
-            legacy
-                .tombstone_table_in_manifest("table", "generation.lance")
+                    }],
+                    None,
+                )
                 .await
                 .is_err()
         );

--- a/rust/lance-namespace-impls/src/dir/manifest.rs
+++ b/rust/lance-namespace-impls/src/dir/manifest.rs
@@ -532,6 +532,7 @@ impl ManifestStreamMutation for UpsertManifestMutation {
 
 struct DeleteObjectMutation {
     object_id: String,
+    expected_location: Option<String>,
     deleted: bool,
 }
 
@@ -545,6 +546,19 @@ impl ManifestStreamMutation for DeleteObjectMutation {
         index_data: &mut ManifestIndexAccumulator,
     ) -> Result<()> {
         if row.object_id == self.object_id {
+            if let Some(expected_location) = self.expected_location.as_deref()
+                && row.location.as_deref() != Some(expected_location)
+            {
+                return Err(NamespaceError::ConcurrentModification {
+                    message: format!(
+                        "Table '{}' moved from expected location '{}' to '{}'",
+                        self.object_id,
+                        expected_location,
+                        row.location.as_deref().unwrap_or("<missing>")
+                    ),
+                }
+                .into());
+            }
             self.deleted = true;
             return Ok(());
         }
@@ -2361,9 +2375,19 @@ impl ManifestNamespace {
 
     /// Delete an entry from the manifest table
     pub async fn delete_from_manifest(&self, object_id: &str) -> Result<()> {
+        self.delete_from_manifest_if_location(object_id, None).await
+    }
+
+    async fn delete_from_manifest_if_location(
+        &self,
+        object_id: &str,
+        expected_location: Option<&str>,
+    ) -> Result<()> {
         let object_id = object_id.to_string();
+        let expected_location = expected_location.map(str::to_string);
         self.rewrite_manifest("Failed to delete from manifest", || DeleteObjectMutation {
             object_id: object_id.clone(),
+            expected_location: expected_location.clone(),
             deleted: false,
         })
         .await
@@ -3646,11 +3670,10 @@ impl LanceNamespace for ManifestNamespace {
         // Get table info before deleting
         let table_info = self.query_manifest_for_table(&object_id).await?;
 
-        let table_uri = match table_info {
+        let (table_uri, manifest_location) = match table_info {
             Some(info) => {
-                // Delete from manifest only (leave physical data intact)
-                self.delete_from_manifest(&object_id).boxed().await?;
-                Self::construct_full_uri(&self.root, &info.location)?
+                let table_uri = Self::construct_full_uri(&self.root, &info.location)?;
+                (table_uri, info.location)
             }
             None => {
                 return Err(NamespaceError::TableNotFound {
@@ -3659,6 +3682,28 @@ impl LanceNamespace for ManifestNamespace {
                 .into());
             }
         };
+
+        if let Some(expected_location) = request
+            .context
+            .as_ref()
+            .and_then(|context| context.get("expected_location"))
+            && expected_location.trim_end_matches('/') != table_uri.trim_end_matches('/')
+        {
+            return Err(NamespaceError::ConcurrentModification {
+                message: format!(
+                    "Table '{}' is at '{}' instead of expected location '{}'",
+                    object_id, table_uri, expected_location
+                ),
+            }
+            .into());
+        }
+
+        // The expected manifest location is checked again inside every rewrite
+        // attempt, so a concurrent drop-and-recreate cannot be deleted by a
+        // stale deregistration request.
+        self.delete_from_manifest_if_location(&object_id, Some(&manifest_location))
+            .boxed()
+            .await?;
 
         Ok(DeregisterTableResponse {
             id: request.id.clone(),
@@ -4361,6 +4406,39 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_manifest_delete_rejects_replacement_location() {
+        let temp_dir = TempStdDir::default();
+        let manifest_ns = create_manifest_namespace(temp_dir.to_str().unwrap(), false).await;
+        manifest_ns
+            .insert_into_manifest_with_metadata(
+                vec![ManifestEntry {
+                    object_id: "table".to_string(),
+                    object_type: ObjectType::Table,
+                    location: Some("new-generation.lance".to_string()),
+                    metadata: None,
+                }],
+                None,
+            )
+            .await
+            .unwrap();
+
+        let error = manifest_ns
+            .delete_from_manifest_if_location("table", Some("old-generation.lance"))
+            .await
+            .unwrap_err();
+
+        let lance_core::Error::Namespace { source, .. } = &error else {
+            panic!("expected namespace error, got {error}");
+        };
+        assert!(matches!(
+            source.downcast_ref::<NamespaceError>(),
+            Some(NamespaceError::ConcurrentModification { .. })
+        ));
+        assert!(error.to_string().contains("moved from expected location"));
+        assert!(manifest_ns.manifest_contains_object("table").await.unwrap());
+    }
+
+    #[tokio::test]
     async fn test_manifest_rewrite_fragment_bitmap_uses_overwrite_fragment_ids() {
         let temp_dir = TempStdDir::default();
         let temp_path = temp_dir.to_str().unwrap();
@@ -4649,6 +4727,7 @@ mod tests {
                 ConcurrentDeleteBeforeCommitMutation {
                     inner: DeleteObjectMutation {
                         object_id: "table".to_string(),
+                        expected_location: None,
                         deleted: false,
                     },
                     root: temp_path.to_string(),

--- a/rust/lance-namespace-impls/src/dir/manifest.rs
+++ b/rust/lance-namespace-impls/src/dir/manifest.rs
@@ -76,6 +76,7 @@ use uuid::Uuid;
 const MANIFEST_TABLE_NAME: &str = "__manifest";
 const DEREGISTERED_TABLE_MARKER: &str = ".lance-deregistered";
 const DROP_TOMBSTONE_OBJECT_ID_PREFIX: &str = "__drop_tombstone$";
+const DROP_EPOCH_OBJECT_ID: &str = "__drop_epoch";
 const LANCE_DATA_DIR: &str = "data";
 const LANCE_INDICES_DIR: &str = "_indices";
 const DELIMITER: &str = "$";
@@ -130,6 +131,7 @@ pub enum ObjectType {
     Namespace,
     Table,
     DropTombstone,
+    DropEpoch,
 }
 
 impl ObjectType {
@@ -138,6 +140,7 @@ impl ObjectType {
             Self::Namespace => "namespace",
             Self::Table => "table",
             Self::DropTombstone => "drop_tombstone",
+            Self::DropEpoch => "drop_epoch",
         }
     }
 
@@ -146,6 +149,7 @@ impl ObjectType {
             "namespace" => Ok(Self::Namespace),
             "table" => Ok(Self::Table),
             "drop_tombstone" => Ok(Self::DropTombstone),
+            "drop_epoch" => Ok(Self::DropEpoch),
             _ => Err(NamespaceError::Internal {
                 message: format!("Invalid object type: {}", s),
             }
@@ -198,6 +202,12 @@ pub struct TableInfo {
     pub name: String,
     pub location: String,
     pub metadata: Option<HashMap<String, String>>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct DropTombstoneInfo {
+    pub object_id: String,
+    pub location: String,
 }
 
 /// An entry to be inserted into the manifest table.
@@ -442,6 +452,8 @@ struct UpsertManifestMutation {
     when_matched: WhenMatched,
     expected_locations: HashMap<String, String>,
     reject_drop_tombstone_overlaps: bool,
+    expected_drop_epoch: Option<u64>,
+    saw_drop_epoch: bool,
 }
 
 impl UpsertManifestMutation {
@@ -451,6 +463,7 @@ impl UpsertManifestMutation {
         when_matched: WhenMatched,
         expected_locations: HashMap<String, String>,
         reject_drop_tombstone_overlaps: bool,
+        expected_drop_epoch: Option<u64>,
     ) -> Self {
         let entry_positions = entries
             .iter()
@@ -470,6 +483,8 @@ impl UpsertManifestMutation {
             when_matched,
             expected_locations,
             reject_drop_tombstone_overlaps,
+            expected_drop_epoch,
+            saw_drop_epoch: false,
         }
     }
 
@@ -494,6 +509,28 @@ impl ManifestStreamMutation for UpsertManifestMutation {
         output: &mut ManifestBatchBuilder,
         index_data: &mut ManifestIndexAccumulator,
     ) -> Result<()> {
+        if row.object_type == ObjectType::DropEpoch {
+            let epoch = row
+                .metadata
+                .as_deref()
+                .unwrap_or("0")
+                .parse::<u64>()
+                .map_err(|error| NamespaceError::Internal {
+                    message: format!("Invalid manifest drop epoch: {error}"),
+                })?;
+            self.saw_drop_epoch = true;
+            if self
+                .expected_drop_epoch
+                .is_some_and(|expected| expected != epoch)
+            {
+                return Err(NamespaceError::ConcurrentModification {
+                    message: "A table drop committed while this registration was in progress"
+                        .to_string(),
+                }
+                .into());
+            }
+        }
+
         if self.reject_drop_tombstone_overlaps
             && row.object_type == ObjectType::DropTombstone
             && let Some(tombstoned_location) = row.location.as_deref()
@@ -585,6 +622,16 @@ impl ManifestStreamMutation for UpsertManifestMutation {
         output: &mut ManifestBatchBuilder,
         index_data: &mut ManifestIndexAccumulator,
     ) -> Result<()> {
+        if self
+            .expected_drop_epoch
+            .is_some_and(|expected| expected != 0 && !self.saw_drop_epoch)
+        {
+            return Err(NamespaceError::ConcurrentModification {
+                message: "The manifest drop epoch changed while this registration was in progress"
+                    .to_string(),
+            }
+            .into());
+        }
         for index in 0..self.entries.len() {
             if !self.matched[index] {
                 if let Some(expected_location) =
@@ -609,6 +656,12 @@ impl ManifestStreamMutation for UpsertManifestMutation {
     }
 
     fn conflict_resolution(&self) -> ConflictResolution<Self::Output> {
+        if self.expected_drop_epoch.is_some() {
+            // Re-apply registrations after a catalog conflict so the captured
+            // epoch is checked even when the matching tombstone was already
+            // retired by physical cleanup.
+            return ConflictResolution::Retry;
+        }
         match self.when_matched {
             // Fail-on-conflict create: a concurrent writer may have created one of these
             // ids. Re-applying would still fail, so check directly instead of re-staging.
@@ -726,6 +779,10 @@ struct TombstoneTableMutation {
     tombstone_object_id: String,
     deleted: bool,
     tombstone_exists: bool,
+    claimed_missing: bool,
+    drop_epoch: u64,
+    saw_drop_epoch: bool,
+    next_drop_epoch: Option<String>,
 }
 
 impl TombstoneTableMutation {
@@ -749,6 +806,18 @@ impl ManifestStreamMutation for TombstoneTableMutation {
         output: &mut ManifestBatchBuilder,
         index_data: &mut ManifestIndexAccumulator,
     ) -> Result<()> {
+        if row.object_type == ObjectType::DropEpoch {
+            self.drop_epoch = row
+                .metadata
+                .as_deref()
+                .unwrap_or("0")
+                .parse::<u64>()
+                .map_err(|error| NamespaceError::Internal {
+                    message: format!("Invalid manifest drop epoch: {error}"),
+                })?;
+            self.saw_drop_epoch = true;
+            return Ok(());
+        }
         if row.object_id == self.object_id {
             if !row
                 .location
@@ -807,14 +876,41 @@ impl ManifestStreamMutation for TombstoneTableMutation {
         output: &mut ManifestBatchBuilder,
         index_data: &mut ManifestIndexAccumulator,
     ) -> Result<()> {
-        if self.deleted && !self.tombstone_exists {
+        if !self.deleted && !self.tombstone_exists {
+            self.claimed_missing = true;
+        }
+        if (self.deleted || self.claimed_missing) && !self.tombstone_exists {
             output.append(index_data, self.tombstone_row())?;
+        }
+        if self.deleted || self.claimed_missing {
+            self.next_drop_epoch = Some(
+                self.drop_epoch
+                    .checked_add(1)
+                    .ok_or_else(|| NamespaceError::Internal {
+                        message: "Manifest drop epoch overflowed".to_string(),
+                    })?
+                    .to_string(),
+            );
+        } else if self.saw_drop_epoch {
+            self.next_drop_epoch = Some(self.drop_epoch.to_string());
+        }
+        if let Some(epoch) = self.next_drop_epoch.as_deref() {
+            output.append(
+                index_data,
+                ManifestOutputRow {
+                    object_id: DROP_EPOCH_OBJECT_ID,
+                    object_type: ObjectType::DropEpoch,
+                    location: None,
+                    metadata: Some(epoch),
+                    base_objects: None,
+                },
+            )?;
         }
         Ok(())
     }
 
     fn finish(&self) -> CopyOnWriteMutation<Self::Output> {
-        if self.deleted {
+        if self.deleted || self.claimed_missing {
             CopyOnWriteMutation::updated(true)
         } else {
             CopyOnWriteMutation::unchanged(false)
@@ -827,6 +923,8 @@ struct ReplaceTableLocationMutation {
     expected_location: String,
     tombstone_object_id: String,
     replaced: bool,
+    drop_epoch: u64,
+    next_drop_epoch: Option<String>,
 }
 
 impl ManifestStreamMutation for ReplaceTableLocationMutation {
@@ -838,8 +936,23 @@ impl ManifestStreamMutation for ReplaceTableLocationMutation {
         output: &mut ManifestBatchBuilder,
         index_data: &mut ManifestIndexAccumulator,
     ) -> Result<()> {
+        if row.object_type == ObjectType::DropEpoch {
+            self.drop_epoch = row
+                .metadata
+                .as_deref()
+                .unwrap_or("0")
+                .parse::<u64>()
+                .map_err(|error| NamespaceError::Internal {
+                    message: format!("Invalid manifest drop epoch: {error}"),
+                })?;
+            return Ok(());
+        }
         if row.object_id == self.entry.object_id {
-            if row.location.as_deref() != Some(self.expected_location.as_str()) {
+            if !row
+                .location
+                .as_deref()
+                .is_some_and(|location| manifest_locations_match(location, &self.expected_location))
+            {
                 return Err(NamespaceError::ConcurrentModification {
                     message: format!(
                         "Table '{}' moved from expected location '{}' to '{}'",
@@ -912,11 +1025,88 @@ impl ManifestStreamMutation for ReplaceTableLocationMutation {
                 metadata: None,
                 base_objects: None,
             },
+        )?;
+        self.next_drop_epoch = Some(
+            self.drop_epoch
+                .checked_add(1)
+                .ok_or_else(|| NamespaceError::Internal {
+                    message: "Manifest drop epoch overflowed".to_string(),
+                })?
+                .to_string(),
+        );
+        output.append(
+            index_data,
+            ManifestOutputRow {
+                object_id: DROP_EPOCH_OBJECT_ID,
+                object_type: ObjectType::DropEpoch,
+                location: None,
+                metadata: self.next_drop_epoch.as_deref(),
+                base_objects: None,
+            },
         )
     }
 
     fn finish(&self) -> CopyOnWriteMutation<Self::Output> {
         CopyOnWriteMutation::updated(())
+    }
+}
+
+struct DeleteDropTombstoneMutation {
+    object_id: String,
+    location: String,
+    deleted: bool,
+}
+
+impl ManifestStreamMutation for DeleteDropTombstoneMutation {
+    type Output = bool;
+
+    fn process_existing_row(
+        &mut self,
+        row: ManifestRowValue,
+        output: &mut ManifestBatchBuilder,
+        index_data: &mut ManifestIndexAccumulator,
+    ) -> Result<()> {
+        let tombstoned_object_id = row
+            .object_id
+            .strip_prefix(DROP_TOMBSTONE_OBJECT_ID_PREFIX)
+            .and_then(|value| value.split_once('$'))
+            .map(|(_, object_id)| object_id);
+        if row.object_type == ObjectType::DropTombstone
+            && tombstoned_object_id == Some(self.object_id.as_str())
+            && row
+                .location
+                .as_deref()
+                .is_some_and(|location| manifest_locations_match(location, &self.location))
+        {
+            self.deleted = true;
+            return Ok(());
+        }
+        output.append(
+            index_data,
+            ManifestOutputRow {
+                object_id: &row.object_id,
+                object_type: row.object_type,
+                location: row.location.as_deref(),
+                metadata: row.metadata.as_deref(),
+                base_objects: row.base_objects.as_deref(),
+            },
+        )
+    }
+
+    fn append_rows(
+        &mut self,
+        _output: &mut ManifestBatchBuilder,
+        _index_data: &mut ManifestIndexAccumulator,
+    ) -> Result<()> {
+        Ok(())
+    }
+
+    fn finish(&self) -> CopyOnWriteMutation<Self::Output> {
+        if self.deleted {
+            CopyOnWriteMutation::updated(true)
+        } else {
+            CopyOnWriteMutation::unchanged(false)
+        }
     }
 }
 
@@ -2751,8 +2941,8 @@ impl ManifestNamespace {
         Ok(locations)
     }
 
-    /// List physical locations retained as durable drop intents.
-    pub async fn list_drop_tombstone_locations(&self) -> Result<std::collections::HashSet<String>> {
+    /// List durable drop intents retained until physical cleanup completes.
+    pub async fn list_drop_tombstones(&self) -> Result<Vec<DropTombstoneInfo>> {
         let mut scanner = self.manifest_scanner().await?;
         scanner
             .filter("object_type = 'drop_tombstone'")
@@ -2761,23 +2951,70 @@ impl ManifestNamespace {
                     message: format!("Failed to filter drop tombstones: {e:?}"),
                 })
             })?;
-        scanner.project(&["location"]).map_err(|e| {
+        scanner.project(&["object_id", "location"]).map_err(|e| {
             lance_core::Error::from(NamespaceError::Internal {
                 message: format!("Failed to project drop tombstones: {e:?}"),
             })
         })?;
 
         let batches = Self::execute_scanner(scanner).await?;
-        let mut locations = std::collections::HashSet::new();
+        let mut tombstones = Vec::new();
         for batch in batches {
+            let object_id_array = Self::get_string_column(&batch, "object_id")?;
             let location_array = Self::get_string_column(&batch, "location")?;
             for index in 0..location_array.len() {
-                if !location_array.is_null(index) {
-                    locations.insert(location_array.value(index).to_string());
+                let Some((_, object_id)) = object_id_array
+                    .value(index)
+                    .strip_prefix(DROP_TOMBSTONE_OBJECT_ID_PREFIX)
+                    .and_then(|value| value.split_once('$'))
+                else {
+                    continue;
+                };
+                if location_array.is_null(index) {
+                    continue;
                 }
+                tombstones.push(DropTombstoneInfo {
+                    object_id: object_id.to_string(),
+                    location: location_array.value(index).to_string(),
+                });
             }
         }
-        Ok(locations)
+        Ok(tombstones)
+    }
+
+    async fn current_drop_epoch(&self) -> Result<u64> {
+        let mut scanner = self.manifest_scanner().await?;
+        scanner
+            .filter(&format!(
+                "object_id = '{DROP_EPOCH_OBJECT_ID}' AND object_type = 'drop_epoch'"
+            ))
+            .map_err(|error| NamespaceError::Internal {
+                message: format!("Failed to filter manifest drop epoch: {error:?}"),
+            })?;
+        scanner
+            .project(&["metadata"])
+            .map_err(|error| NamespaceError::Internal {
+                message: format!("Failed to project manifest drop epoch: {error:?}"),
+            })?;
+        let batches = Self::execute_scanner(scanner).await?;
+        let mut epoch = None;
+        for batch in batches {
+            let metadata = Self::get_string_column(&batch, "metadata")?;
+            for index in 0..metadata.len() {
+                if metadata.is_null(index) || epoch.is_some() {
+                    return Err(NamespaceError::Internal {
+                        message: "Manifest drop epoch row is invalid or duplicated".to_string(),
+                    }
+                    .into());
+                }
+                epoch = Some(metadata.value(index).parse::<u64>().map_err(|error| {
+                    NamespaceError::Internal {
+                        message: format!("Invalid manifest drop epoch: {error}"),
+                    }
+                })?);
+            }
+        }
+        Ok(epoch.unwrap_or_default())
     }
 
     /// Insert an entry into the manifest table
@@ -2838,12 +3075,14 @@ impl ManifestNamespace {
                 when_matched.clone(),
                 HashMap::new(),
                 false,
+                None,
             )
         })
         .await
     }
 
     async fn register_table_in_manifest(&self, entry: ManifestEntry) -> Result<()> {
+        let expected_drop_epoch = self.current_drop_epoch().await?;
         self.rewrite_manifest("Failed to register table in manifest", || {
             UpsertManifestMutation::new(
                 vec![entry.clone()],
@@ -2851,6 +3090,7 @@ impl ManifestNamespace {
                 WhenMatched::Fail,
                 HashMap::new(),
                 true,
+                Some(expected_drop_epoch),
             )
         })
         .await
@@ -2867,6 +3107,8 @@ impl ManifestNamespace {
                 expected_location: expected_location.to_string(),
                 tombstone_object_id: Self::drop_tombstone_object_id(&entry.object_id),
                 replaced: false,
+                drop_epoch: 0,
+                next_drop_epoch: None,
             }
         })
         .await
@@ -2894,9 +3136,47 @@ impl ManifestNamespace {
                 tombstone_object_id: tombstone_object_id.clone(),
                 deleted: false,
                 tombstone_exists: false,
+                claimed_missing: false,
+                drop_epoch: 0,
+                saw_drop_epoch: false,
+                next_drop_epoch: None,
             }
         })
         .await
+    }
+
+    /// Retire a durable drop intent after its physical location is fully removed.
+    pub async fn complete_drop_tombstone(&self, object_id: &str, location: &str) -> Result<bool> {
+        let object_id = object_id.to_string();
+        let location = location.to_string();
+        self.rewrite_manifest("Failed to complete table drop tombstone", || {
+            DeleteDropTombstoneMutation {
+                object_id: object_id.clone(),
+                location: location.clone(),
+                deleted: false,
+            }
+        })
+        .await
+    }
+
+    /// Retire the matching durable drop intent using its externally visible URI.
+    pub async fn complete_drop_tombstone_at_uri(
+        &self,
+        object_id: &str,
+        location: &str,
+    ) -> Result<bool> {
+        let tombstones = self.list_drop_tombstones().await?;
+        for tombstone in tombstones {
+            if tombstone.object_id == object_id {
+                let tombstone_uri = Self::construct_full_uri(&self.root, &tombstone.location)?;
+                if Self::table_locations_match(&tombstone_uri, location) {
+                    return self
+                        .complete_drop_tombstone(object_id, &tombstone.location)
+                        .await;
+                }
+            }
+        }
+        Ok(false)
     }
 
     /// Delete an entry from the manifest table
@@ -3681,7 +3961,7 @@ impl LanceNamespace for ManifestNamespace {
             let metadata =
                 Self::serialize_metadata(request.properties.as_ref(), "table", &object_id)?;
             let entry = ManifestEntry {
-                object_id,
+                object_id: object_id.clone(),
                 object_type: ObjectType::Table,
                 location: Some(dir_name.clone()),
                 metadata,
@@ -3715,21 +3995,35 @@ impl LanceNamespace for ManifestNamespace {
                     );
                 }
                 let previous_table_path = self.table_path(previous_location);
-                match self.object_store.remove_dir_all(previous_table_path).await {
-                    Ok(()) => {
-                        self.remove_deregistered_table_marker(previous_location)
-                            .await;
-                    }
-                    Err(error) if error.is_not_found() => {
-                        self.remove_deregistered_table_marker(previous_location)
-                            .await;
-                    }
-                    Err(error) => {
-                        log::warn!(
-                            "Failed to delete overwritten table location '{}': {error:?}",
-                            previous_location
-                        );
-                    }
+                let cleanup_complete =
+                    match self.object_store.remove_dir_all(previous_table_path).await {
+                        Ok(()) => {
+                            self.remove_deregistered_table_marker(previous_location)
+                                .await;
+                            true
+                        }
+                        Err(error) if error.is_not_found() => {
+                            self.remove_deregistered_table_marker(previous_location)
+                                .await;
+                            true
+                        }
+                        Err(error) => {
+                            log::warn!(
+                                "Failed to delete overwritten table location '{}': {error:?}",
+                                previous_location
+                            );
+                            false
+                        }
+                    };
+                if cleanup_complete
+                    && let Err(error) = self
+                        .complete_drop_tombstone(&object_id, previous_location)
+                        .await
+                {
+                    log::warn!(
+                        "Failed to retire overwritten table tombstone for '{}': {error:?}",
+                        previous_location
+                    );
                 }
             } else {
                 self.upsert_into_manifest_with_metadata(vec![entry], None)
@@ -3843,6 +4137,15 @@ impl LanceNamespace for ManifestNamespace {
                         })
                     })?;
                 if self.async_drop_enabled {
+                    if let Err(error) = self
+                        .complete_drop_tombstone(&object_id, &info.location)
+                        .await
+                    {
+                        log::warn!(
+                            "Failed to retire table drop tombstone for '{}': {error:?}",
+                            info.location
+                        );
+                    }
                     self.remove_deregistered_table_marker(&info.location).await;
                 }
 
@@ -5234,10 +5537,11 @@ mod tests {
             .await;
         assert!(
             manifest_ns
-                .list_drop_tombstone_locations()
+                .list_drop_tombstones()
                 .await
                 .unwrap()
-                .contains(&location)
+                .iter()
+                .any(|tombstone| tombstone.location == location)
         );
 
         let error = LanceNamespace::register_table(
@@ -5767,9 +6071,89 @@ mod tests {
                 .unwrap()
         );
         assert_eq!(
-            manifest_ns.list_drop_tombstone_locations().await.unwrap(),
-            HashSet::from(["generation.lance".to_string()])
+            manifest_ns.list_drop_tombstones().await.unwrap(),
+            vec![DropTombstoneInfo {
+                object_id: "table".to_string(),
+                location: "generation.lance".to_string(),
+            }]
         );
+    }
+
+    #[tokio::test]
+    async fn test_manifest_tombstone_claims_location_after_ordinary_deregister() {
+        let temp_dir = TempStdDir::default();
+        let manifest_ns =
+            create_manifest_namespace_with_retries(temp_dir.to_str().unwrap(), false, Some(0))
+                .await;
+        manifest_ns
+            .insert_into_manifest_with_metadata(
+                vec![ManifestEntry {
+                    object_id: "table".to_string(),
+                    object_type: ObjectType::Table,
+                    location: Some("generation.lance".to_string()),
+                    metadata: None,
+                }],
+                None,
+            )
+            .await
+            .unwrap();
+        assert!(
+            manifest_ns
+                .delete_from_manifest_if_location("table", Some("generation.lance"), false)
+                .await
+                .unwrap()
+        );
+
+        assert!(
+            manifest_ns
+                .tombstone_table_in_manifest("table", "generation.lance")
+                .await
+                .unwrap()
+        );
+        assert!(
+            !manifest_ns
+                .tombstone_table_in_manifest("table", "generation.lance")
+                .await
+                .unwrap()
+        );
+        assert_eq!(manifest_ns.current_drop_epoch().await.unwrap(), 1);
+        assert!(
+            manifest_ns
+                .complete_drop_tombstone("table", "generation.lance")
+                .await
+                .unwrap()
+        );
+        assert!(manifest_ns.list_drop_tombstones().await.unwrap().is_empty());
+
+        let stale_registration = ManifestEntry {
+            object_id: "stale".to_string(),
+            object_type: ObjectType::Table,
+            location: Some("generation.lance".to_string()),
+            metadata: None,
+        };
+        let stale_result = manifest_ns
+            .rewrite_manifest("stale registration", || {
+                UpsertManifestMutation::new(
+                    vec![stale_registration.clone()],
+                    None,
+                    WhenMatched::Fail,
+                    HashMap::new(),
+                    true,
+                    Some(0),
+                )
+            })
+            .await;
+        assert!(stale_result.is_err());
+
+        manifest_ns
+            .register_table_in_manifest(ManifestEntry {
+                object_id: "replacement".to_string(),
+                object_type: ObjectType::Table,
+                location: Some("generation.lance".to_string()),
+                metadata: None,
+            })
+            .await
+            .unwrap();
     }
 
     #[tokio::test]

--- a/rust/lance-namespace-impls/src/dir/manifest.rs
+++ b/rust/lance-namespace-impls/src/dir/manifest.rs
@@ -2854,17 +2854,17 @@ impl ManifestNamespace {
             ReplaceTableLocationMutation {
                 entry: entry.clone(),
                 expected_location: expected_location.to_string(),
-                tombstone_object_id: Self::drop_tombstone_object_id(),
+                tombstone_object_id: Self::drop_tombstone_object_id(&entry.object_id),
                 replaced: false,
             }
         })
         .await
     }
 
-    fn drop_tombstone_object_id() -> String {
+    fn drop_tombstone_object_id(object_id: &str) -> String {
         format!(
-            "{DROP_TOMBSTONE_OBJECT_ID_PREFIX}{}",
-            Uuid::new_v4().simple()
+            "{DROP_TOMBSTONE_OBJECT_ID_PREFIX}{}${object_id}",
+            Uuid::new_v4().simple(),
         )
     }
 
@@ -2875,7 +2875,7 @@ impl ManifestNamespace {
     ) -> Result<bool> {
         let object_id = object_id.to_string();
         let expected_location = expected_location.to_string();
-        let tombstone_object_id = Self::drop_tombstone_object_id();
+        let tombstone_object_id = Self::drop_tombstone_object_id(&object_id);
         self.rewrite_manifest("Failed to tombstone table in manifest", || {
             TombstoneTableMutation {
                 object_id: object_id.clone(),
@@ -5254,7 +5254,7 @@ mod tests {
         manifest_ns
             .insert_into_manifest_with_metadata(
                 vec![ManifestEntry {
-                    object_id: ManifestNamespace::drop_tombstone_object_id(),
+                    object_id: ManifestNamespace::drop_tombstone_object_id("table"),
                     object_type: ObjectType::DropTombstone,
                     location: Some("ancestor/dropped-generation".to_string()),
                     metadata: None,

--- a/rust/lance-namespace-impls/src/dir/manifest.rs
+++ b/rust/lance-namespace-impls/src/dir/manifest.rs
@@ -6177,26 +6177,6 @@ mod tests {
         assert_eq!(manifest_ns.current_drop_epoch().await.unwrap(), 0);
         assert!(manifest_ns.list_drop_tombstones().await.unwrap().is_empty());
 
-        let stale_registration = ManifestEntry {
-            object_id: "stale".to_string(),
-            object_type: ObjectType::Table,
-            location: Some("generation.lance".to_string()),
-            metadata: None,
-        };
-        let stale_result = manifest_ns
-            .rewrite_manifest("stale registration", || {
-                UpsertManifestMutation::new(
-                    vec![stale_registration.clone()],
-                    None,
-                    WhenMatched::Fail,
-                    HashMap::new(),
-                    true,
-                    Some(0),
-                )
-            })
-            .await;
-        assert!(stale_result.is_err());
-
         manifest_ns
             .register_table_in_manifest(ManifestEntry {
                 object_id: "replacement".to_string(),

--- a/rust/lance-namespace-impls/src/dir/manifest.rs
+++ b/rust/lance-namespace-impls/src/dir/manifest.rs
@@ -77,6 +77,8 @@ const MANIFEST_TABLE_NAME: &str = "__manifest";
 const DEREGISTERED_TABLE_MARKER: &str = ".lance-deregistered";
 const DROP_TOMBSTONE_OBJECT_ID_PREFIX: &str = "__drop_tombstone$";
 const DROP_EPOCH_OBJECT_ID: &str = "__drop_epoch";
+/// Deregistration response property containing the exact durable drop claim token.
+pub const DROP_TOMBSTONE_ID_PROPERTY: &str = "__drop_tombstone_id";
 const LANCE_DATA_DIR: &str = "data";
 const LANCE_INDICES_DIR: &str = "_indices";
 const DELIMITER: &str = "$";
@@ -206,6 +208,7 @@ pub struct TableInfo {
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct DropTombstoneInfo {
+    pub tombstone_id: String,
     pub object_id: String,
     pub location: String,
 }
@@ -509,6 +512,17 @@ impl ManifestStreamMutation for UpsertManifestMutation {
         output: &mut ManifestBatchBuilder,
         index_data: &mut ManifestIndexAccumulator,
     ) -> Result<()> {
+        if self.expected_drop_epoch.is_some()
+            && row.object_id == DROP_EPOCH_OBJECT_ID
+            && row.object_type != ObjectType::DropEpoch
+        {
+            return Err(NamespaceError::InvalidInput {
+                message: format!(
+                    "Object id '{DROP_EPOCH_OBJECT_ID}' is reserved for manifest drop fencing"
+                ),
+            }
+            .into());
+        }
         if row.object_type == ObjectType::DropEpoch {
             let epoch = row
                 .metadata
@@ -695,6 +709,18 @@ impl ManifestStreamMutation for DeleteObjectMutation {
         output: &mut ManifestBatchBuilder,
         index_data: &mut ManifestIndexAccumulator,
     ) -> Result<()> {
+        if row.object_type == ObjectType::DropEpoch {
+            return output.append(
+                index_data,
+                ManifestOutputRow {
+                    object_id: &row.object_id,
+                    object_type: row.object_type,
+                    location: row.location.as_deref(),
+                    metadata: row.metadata.as_deref(),
+                    base_objects: row.base_objects.as_deref(),
+                },
+            );
+        }
         if row.object_id == self.object_id {
             if let Some(expected_location) = self.expected_location.as_deref()
                 && !row
@@ -779,6 +805,7 @@ struct TombstoneTableMutation {
     tombstone_object_id: String,
     deleted: bool,
     tombstone_exists: bool,
+    owns_existing_tombstone: bool,
     claimed_missing: bool,
     drop_epoch: u64,
     saw_drop_epoch: bool,
@@ -798,7 +825,7 @@ impl TombstoneTableMutation {
 }
 
 impl ManifestStreamMutation for TombstoneTableMutation {
-    type Output = bool;
+    type Output = Option<String>;
 
     fn process_existing_row(
         &mut self,
@@ -806,6 +833,14 @@ impl ManifestStreamMutation for TombstoneTableMutation {
         output: &mut ManifestBatchBuilder,
         index_data: &mut ManifestIndexAccumulator,
     ) -> Result<()> {
+        if row.object_id == DROP_EPOCH_OBJECT_ID && row.object_type != ObjectType::DropEpoch {
+            return Err(NamespaceError::InvalidInput {
+                message: format!(
+                    "Object id '{DROP_EPOCH_OBJECT_ID}' is reserved for manifest drop fencing"
+                ),
+            }
+            .into());
+        }
         if row.object_type == ObjectType::DropEpoch {
             self.drop_epoch = row
                 .metadata
@@ -845,6 +880,7 @@ impl ManifestStreamMutation for TombstoneTableMutation {
                 .is_some_and(|location| manifest_locations_match(location, &self.expected_location))
         {
             self.tombstone_exists = true;
+            self.owns_existing_tombstone = row.object_id == self.tombstone_object_id;
         } else if row.object_type == ObjectType::Table
             && row.location.as_deref().is_some_and(|location| {
                 manifest_locations_overlap(location, &self.expected_location)
@@ -911,9 +947,11 @@ impl ManifestStreamMutation for TombstoneTableMutation {
 
     fn finish(&self) -> CopyOnWriteMutation<Self::Output> {
         if self.deleted || self.claimed_missing {
-            CopyOnWriteMutation::updated(true)
+            CopyOnWriteMutation::updated(Some(self.tombstone_object_id.clone()))
+        } else if self.owns_existing_tombstone {
+            CopyOnWriteMutation::unchanged(Some(self.tombstone_object_id.clone()))
         } else {
-            CopyOnWriteMutation::unchanged(false)
+            CopyOnWriteMutation::unchanged(None)
         }
     }
 }
@@ -936,6 +974,14 @@ impl ManifestStreamMutation for ReplaceTableLocationMutation {
         output: &mut ManifestBatchBuilder,
         index_data: &mut ManifestIndexAccumulator,
     ) -> Result<()> {
+        if row.object_id == DROP_EPOCH_OBJECT_ID && row.object_type != ObjectType::DropEpoch {
+            return Err(NamespaceError::InvalidInput {
+                message: format!(
+                    "Object id '{DROP_EPOCH_OBJECT_ID}' is reserved for manifest drop fencing"
+                ),
+            }
+            .into());
+        }
         if row.object_type == ObjectType::DropEpoch {
             self.drop_epoch = row
                 .metadata
@@ -1052,8 +1098,7 @@ impl ManifestStreamMutation for ReplaceTableLocationMutation {
 }
 
 struct DeleteDropTombstoneMutation {
-    object_id: String,
-    location: String,
+    tombstone_id: String,
     deleted: bool,
 }
 
@@ -1066,18 +1111,7 @@ impl ManifestStreamMutation for DeleteDropTombstoneMutation {
         output: &mut ManifestBatchBuilder,
         index_data: &mut ManifestIndexAccumulator,
     ) -> Result<()> {
-        let tombstoned_object_id = row
-            .object_id
-            .strip_prefix(DROP_TOMBSTONE_OBJECT_ID_PREFIX)
-            .and_then(|value| value.split_once('$'))
-            .map(|(_, object_id)| object_id);
-        if row.object_type == ObjectType::DropTombstone
-            && tombstoned_object_id == Some(self.object_id.as_str())
-            && row
-                .location
-                .as_deref()
-                .is_some_and(|location| manifest_locations_match(location, &self.location))
-        {
+        if row.object_type == ObjectType::DropTombstone && row.object_id == self.tombstone_id {
             self.deleted = true;
             return Ok(());
         }
@@ -2974,6 +3008,7 @@ impl ManifestNamespace {
                     continue;
                 }
                 tombstones.push(DropTombstoneInfo {
+                    tombstone_id: object_id_array.value(index).to_string(),
                     object_id: object_id.to_string(),
                     location: location_array.value(index).to_string(),
                 });
@@ -3100,18 +3135,20 @@ impl ManifestNamespace {
         &self,
         entry: ManifestEntry,
         expected_location: &str,
-    ) -> Result<()> {
+    ) -> Result<String> {
+        let tombstone_object_id = Self::drop_tombstone_object_id(&entry.object_id);
         self.rewrite_manifest("Failed to replace manifest table location", || {
             ReplaceTableLocationMutation {
                 entry: entry.clone(),
                 expected_location: expected_location.to_string(),
-                tombstone_object_id: Self::drop_tombstone_object_id(&entry.object_id),
+                tombstone_object_id: tombstone_object_id.clone(),
                 replaced: false,
                 drop_epoch: 0,
                 next_drop_epoch: None,
             }
         })
-        .await
+        .await?;
+        Ok(tombstone_object_id)
     }
 
     fn drop_tombstone_object_id(object_id: &str) -> String {
@@ -3125,7 +3162,7 @@ impl ManifestNamespace {
         &self,
         object_id: &str,
         expected_location: &str,
-    ) -> Result<bool> {
+    ) -> Result<Option<String>> {
         let object_id = object_id.to_string();
         let expected_location = expected_location.to_string();
         let tombstone_object_id = Self::drop_tombstone_object_id(&object_id);
@@ -3136,6 +3173,7 @@ impl ManifestNamespace {
                 tombstone_object_id: tombstone_object_id.clone(),
                 deleted: false,
                 tombstone_exists: false,
+                owns_existing_tombstone: false,
                 claimed_missing: false,
                 drop_epoch: 0,
                 saw_drop_epoch: false,
@@ -3146,37 +3184,15 @@ impl ManifestNamespace {
     }
 
     /// Retire a durable drop intent after its physical location is fully removed.
-    pub async fn complete_drop_tombstone(&self, object_id: &str, location: &str) -> Result<bool> {
-        let object_id = object_id.to_string();
-        let location = location.to_string();
+    pub async fn complete_drop_tombstone(&self, tombstone_id: &str) -> Result<bool> {
+        let tombstone_id = tombstone_id.to_string();
         self.rewrite_manifest("Failed to complete table drop tombstone", || {
             DeleteDropTombstoneMutation {
-                object_id: object_id.clone(),
-                location: location.clone(),
+                tombstone_id: tombstone_id.clone(),
                 deleted: false,
             }
         })
         .await
-    }
-
-    /// Retire the matching durable drop intent using its externally visible URI.
-    pub async fn complete_drop_tombstone_at_uri(
-        &self,
-        object_id: &str,
-        location: &str,
-    ) -> Result<bool> {
-        let tombstones = self.list_drop_tombstones().await?;
-        for tombstone in tombstones {
-            if tombstone.object_id == object_id {
-                let tombstone_uri = Self::construct_full_uri(&self.root, &tombstone.location)?;
-                if Self::table_locations_match(&tombstone_uri, location) {
-                    return self
-                        .complete_drop_tombstone(object_id, &tombstone.location)
-                        .await;
-                }
-            }
-        }
-        Ok(false)
     }
 
     /// Delete an entry from the manifest table
@@ -3971,23 +3987,26 @@ impl LanceNamespace for ManifestNamespace {
                     .as_ref()
                     .expect("an overwrite has an existing table")
                     .location;
-                if let Err(error) = self
+                let tombstone_id = match self
                     .replace_manifest_table_location(entry, previous_location)
                     .await
                 {
-                    let new_table_path = self.table_path(&dir_name);
-                    if let Err(cleanup_error) =
-                        self.object_store.remove_dir_all(new_table_path).await
-                        && !cleanup_error.is_not_found()
-                    {
-                        log::warn!(
-                            "Failed to clean up replacement table location '{}' after manifest conflict: {}",
-                            dir_name,
-                            cleanup_error
-                        );
+                    Ok(tombstone_id) => tombstone_id,
+                    Err(error) => {
+                        let new_table_path = self.table_path(&dir_name);
+                        if let Err(cleanup_error) =
+                            self.object_store.remove_dir_all(new_table_path).await
+                            && !cleanup_error.is_not_found()
+                        {
+                            log::warn!(
+                                "Failed to clean up replacement table location '{}' after manifest conflict: {}",
+                                dir_name,
+                                cleanup_error
+                            );
+                        }
+                        return Err(error);
                     }
-                    return Err(error);
-                }
+                };
                 if let Err(error) = self.put_deregistered_table_marker(previous_location).await {
                     log::warn!(
                         "Failed to write deregistration marker for overwritten table location '{}': {error:?}",
@@ -4016,9 +4035,7 @@ impl LanceNamespace for ManifestNamespace {
                         }
                     };
                 if cleanup_complete
-                    && let Err(error) = self
-                        .complete_drop_tombstone(&object_id, previous_location)
-                        .await
+                    && let Err(error) = self.complete_drop_tombstone(&tombstone_id).await
                 {
                     log::warn!(
                         "Failed to retire overwritten table tombstone for '{}': {error:?}",
@@ -4096,23 +4113,27 @@ impl LanceNamespace for ManifestNamespace {
         match table_info {
             Some(info) => {
                 self.ensure_manifest_writable().await?;
-                let owns_manifest_deletion = if self.async_drop_enabled {
+                let tombstone_id = if self.async_drop_enabled {
                     self.tombstone_table_in_manifest(&object_id, &info.location)
                         .boxed()
                         .await?
+                } else if self
+                    .delete_from_manifest_if_location(&object_id, Some(&info.location), true)
+                    .boxed()
+                    .await?
+                {
+                    Some(String::new())
                 } else {
-                    self.delete_from_manifest_if_location(&object_id, Some(&info.location), true)
-                        .boxed()
-                        .await?
+                    None
                 };
 
-                if !owns_manifest_deletion {
+                let Some(tombstone_id) = tombstone_id else {
                     return Ok(DropTableResponse {
                         id: request.id.clone(),
                         location: Some(Self::construct_full_uri(&self.root, &info.location)?),
                         ..Default::default()
                     });
-                }
+                };
                 if self.async_drop_enabled
                     && let Err(error) = self.put_deregistered_table_marker(&info.location).await
                 {
@@ -4137,10 +4158,7 @@ impl LanceNamespace for ManifestNamespace {
                         })
                     })?;
                 if self.async_drop_enabled {
-                    if let Err(error) = self
-                        .complete_drop_tombstone(&object_id, &info.location)
-                        .await
-                    {
+                    if let Err(error) = self.complete_drop_tombstone(&tombstone_id).await {
                         log::warn!(
                             "Failed to retire table drop tombstone for '{}': {error:?}",
                             info.location
@@ -4669,13 +4687,13 @@ impl LanceNamespace for ManifestNamespace {
             .into());
         }
 
-        if expected_location.is_some() {
+        let tombstone_id = if expected_location.is_some() {
             self.ensure_manifest_writable().await?;
-            let owns_manifest_deletion = self
+            let tombstone_id = self
                 .tombstone_table_in_manifest(&object_id, &manifest_location)
                 .boxed()
                 .await?;
-            if owns_manifest_deletion
+            if tombstone_id.is_some()
                 && let Err(error) = self.put_deregistered_table_marker(&manifest_location).await
             {
                 log::warn!(
@@ -4683,15 +4701,21 @@ impl LanceNamespace for ManifestNamespace {
                     manifest_location
                 );
             }
+            tombstone_id
         } else {
             self.delete_from_manifest_if_location(&object_id, Some(&manifest_location), false)
                 .boxed()
                 .await?;
-        }
+            None
+        };
 
+        let properties = tombstone_id.map(|tombstone_id| {
+            HashMap::from([(DROP_TOMBSTONE_ID_PROPERTY.to_string(), tombstone_id)])
+        });
         Ok(DeregisterTableResponse {
             id: request.id.clone(),
             location: Some(table_uri),
+            properties,
             ..Default::default()
         })
     }
@@ -6058,21 +6082,22 @@ mod tests {
             .await
             .unwrap();
 
+        let tombstone_id = manifest_ns
+            .tombstone_table_in_manifest("table", "generation.lance")
+            .await
+            .unwrap()
+            .unwrap();
         assert!(
             manifest_ns
                 .tombstone_table_in_manifest("table", "generation.lance")
                 .await
                 .unwrap()
-        );
-        assert!(
-            !manifest_ns
-                .tombstone_table_in_manifest("table", "generation.lance")
-                .await
-                .unwrap()
+                .is_none()
         );
         assert_eq!(
             manifest_ns.list_drop_tombstones().await.unwrap(),
             vec![DropTombstoneInfo {
+                tombstone_id,
                 object_id: "table".to_string(),
                 location: "generation.lance".to_string(),
             }]
@@ -6104,26 +6129,51 @@ mod tests {
                 .unwrap()
         );
 
+        let tombstone_id = manifest_ns
+            .tombstone_table_in_manifest("table", "generation.lance")
+            .await
+            .unwrap()
+            .unwrap();
         assert!(
             manifest_ns
                 .tombstone_table_in_manifest("table", "generation.lance")
                 .await
                 .unwrap()
-        );
-        assert!(
-            !manifest_ns
-                .tombstone_table_in_manifest("table", "generation.lance")
-                .await
-                .unwrap()
+                .is_none()
         );
         assert_eq!(manifest_ns.current_drop_epoch().await.unwrap(), 1);
         assert!(
             manifest_ns
-                .complete_drop_tombstone("table", "generation.lance")
+                .complete_drop_tombstone(&tombstone_id)
                 .await
                 .unwrap()
         );
-        assert!(manifest_ns.list_drop_tombstones().await.unwrap().is_empty());
+        let newer_tombstone_id = manifest_ns
+            .tombstone_table_in_manifest("table", "generation.lance")
+            .await
+            .unwrap()
+            .unwrap();
+        assert_ne!(tombstone_id, newer_tombstone_id);
+        assert!(
+            !manifest_ns
+                .complete_drop_tombstone(&tombstone_id)
+                .await
+                .unwrap()
+        );
+        assert_eq!(
+            manifest_ns.list_drop_tombstones().await.unwrap(),
+            vec![DropTombstoneInfo {
+                tombstone_id: newer_tombstone_id.clone(),
+                object_id: "table".to_string(),
+                location: "generation.lance".to_string(),
+            }]
+        );
+        assert!(
+            manifest_ns
+                .complete_drop_tombstone(&newer_tombstone_id)
+                .await
+                .unwrap()
+        );
 
         let stale_registration = ManifestEntry {
             object_id: "stale".to_string(),
@@ -6154,6 +6204,70 @@ mod tests {
             })
             .await
             .unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_manifest_drop_epoch_id_is_reserved_and_not_deleted_as_user_object() {
+        let temp_dir = TempStdDir::default();
+        let manifest_ns =
+            create_manifest_namespace_with_retries(temp_dir.to_str().unwrap(), false, Some(0))
+                .await;
+        manifest_ns
+            .insert_into_manifest_with_metadata(
+                vec![ManifestEntry {
+                    object_id: "table".to_string(),
+                    object_type: ObjectType::Table,
+                    location: Some("generation.lance".to_string()),
+                    metadata: None,
+                }],
+                None,
+            )
+            .await
+            .unwrap();
+        manifest_ns
+            .tombstone_table_in_manifest("table", "generation.lance")
+            .await
+            .unwrap()
+            .unwrap();
+
+        assert!(
+            !manifest_ns
+                .delete_from_manifest_if_location(DROP_EPOCH_OBJECT_ID, None, false)
+                .await
+                .unwrap()
+        );
+        assert_eq!(manifest_ns.current_drop_epoch().await.unwrap(), 1);
+
+        let legacy_dir = TempStdDir::default();
+        let legacy =
+            create_manifest_namespace_with_retries(legacy_dir.to_str().unwrap(), false, Some(0))
+                .await;
+        legacy
+            .insert_into_manifest_with_metadata(
+                vec![
+                    ManifestEntry {
+                        object_id: DROP_EPOCH_OBJECT_ID.to_string(),
+                        object_type: ObjectType::Table,
+                        location: Some("legacy.lance".to_string()),
+                        metadata: None,
+                    },
+                    ManifestEntry {
+                        object_id: "table".to_string(),
+                        object_type: ObjectType::Table,
+                        location: Some("generation.lance".to_string()),
+                        metadata: None,
+                    },
+                ],
+                None,
+            )
+            .await
+            .unwrap();
+        assert!(
+            legacy
+                .tombstone_table_in_manifest("table", "generation.lance")
+                .await
+                .is_err()
+        );
     }
 
     #[tokio::test]

--- a/rust/lance-namespace-impls/src/dir/manifest.rs
+++ b/rust/lance-namespace-impls/src/dir/manifest.rs
@@ -3212,7 +3212,9 @@ impl LanceNamespace for ManifestNamespace {
         match table_info {
             Some(info) => {
                 // Delete from manifest first
-                self.delete_from_manifest(&object_id).boxed().await?;
+                self.delete_from_manifest_if_location(&object_id, Some(&info.location))
+                    .boxed()
+                    .await?;
 
                 // Delete physical data directory using the dir_name from manifest
                 let table_path = self.base_path.clone().join(info.location.as_str());

--- a/rust/lance-namespace-impls/src/dir/manifest.rs
+++ b/rust/lance-namespace-impls/src/dir/manifest.rs
@@ -6,6 +6,7 @@
 //! This module provides a namespace implementation that uses a manifest table
 //! to track tables and nested namespaces.
 
+use super::EXPECTED_DEREGISTER_LOCATION_CONTEXT_KEY;
 use super::manifest_feature_flags::{ensure_readable, ensure_writable};
 use arrow::array::builder::{ListBuilder, StringBuilder};
 use arrow::array::{Array, ListArray, RecordBatch, RecordBatchIterator, StringArray, UInt64Array};
@@ -77,7 +78,6 @@ const MANIFEST_TABLE_NAME: &str = "__manifest";
 const LANCE_DATA_DIR: &str = "data";
 const LANCE_INDICES_DIR: &str = "_indices";
 const DELIMITER: &str = "$";
-const EXPECTED_DEREGISTER_LOCATION_CONTEXT_KEY: &str = "expected_location";
 /// Bounded concurrency for per-table `_versions/` probes when filtering declared tables.
 /// Higher values reduce latency but increase burst load against the object store.
 pub(crate) const DECLARED_FILTER_CONCURRENCY: usize = 16;
@@ -3688,7 +3688,11 @@ impl LanceNamespace for ManifestNamespace {
             .context
             .as_ref()
             .and_then(|context| context.get(EXPECTED_DEREGISTER_LOCATION_CONTEXT_KEY));
-        if expected_location.is_some() && namespace.is_empty() && self.dir_listing_enabled {
+        let deterministic_location = format!("{table_name}.lance");
+        if expected_location.is_some()
+            && namespace.is_empty()
+            && manifest_location.trim_end_matches('/') == deterministic_location
+        {
             return Err(NamespaceError::Unsupported {
                 message: format!(
                     "Expected-location fencing is unsupported for root table '{}' when directory listing is enabled because its location is deterministic",

--- a/rust/lance-namespace-impls/src/dir/manifest_feature_flags.rs
+++ b/rust/lance-namespace-impls/src/dir/manifest_feature_flags.rs
@@ -15,11 +15,9 @@
 //! with a clear "please upgrade" error instead of silently misreading data. The
 //! set of bits a build understands is `READER_KNOWN_FLAGS` / `WRITER_KNOWN_FLAGS`.
 //!
-//! This is the mechanism only: no manifest feature is defined yet, so the known
-//! masks are `0` and nothing is ever set — every current manifest reads and
-//! writes unchanged. The first format change that needs forward-compatibility
-//! protection adds its bit to the known masks and stamps it on write; from then
-//! on, builds without that bit refuse the new format rather than misreading it.
+//! The durable drop-tombstone row type is the first protected format feature.
+//! It is stamped only when asynchronous drop support is enabled, so catalogs
+//! that do not opt in remain readable and writable by older Lance versions.
 //! Manifests written before this mechanism carry no flag keys, which parse as
 //! `0` and stay compatible with every build.
 
@@ -33,12 +31,23 @@ pub const READER_FEATURE_FLAGS_KEY: &str = "lance.namespace.manifest.reader_feat
 /// `table_metadata` key holding the writer feature-flag bitmask (decimal `u64`).
 pub const WRITER_FEATURE_FLAGS_KEY: &str = "lance.namespace.manifest.writer_feature_flags";
 
-/// Reader feature-flag bits this build understands. No manifest feature is
-/// defined yet, so this build understands none and refuses any non-zero reader
-/// flag. A future format change adds its bit here.
-const READER_KNOWN_FLAGS: u64 = 0;
+const DROP_TOMBSTONE_ROWS_FLAG: u64 = 1;
+/// Reader feature-flag bits this build understands.
+const READER_KNOWN_FLAGS: u64 = DROP_TOMBSTONE_ROWS_FLAG;
 /// Writer feature-flag bits this build understands.
-const WRITER_KNOWN_FLAGS: u64 = 0;
+const WRITER_KNOWN_FLAGS: u64 = DROP_TOMBSTONE_ROWS_FLAG;
+
+/// Mark a manifest as containing durable drop-tombstone rows.
+pub fn mark_drop_tombstone_rows(table_metadata: &mut HashMap<String, String>) {
+    for key in [READER_FEATURE_FLAGS_KEY, WRITER_FEATURE_FLAGS_KEY] {
+        let flags = table_metadata
+            .get(key)
+            .and_then(|raw| raw.parse::<u64>().ok())
+            .unwrap_or_default()
+            | DROP_TOMBSTONE_ROWS_FLAG;
+        table_metadata.insert(key.to_string(), flags.to_string());
+    }
+}
 
 /// Whether this build can read a `__manifest` whose persisted reader feature
 /// flags are `reader_flags` — i.e. it understands every set bit.
@@ -158,13 +167,12 @@ mod tests {
 
     #[test]
     fn any_unknown_flag_is_refused() {
-        // This build understands no feature flags, so any non-zero bit is refused.
-        assert!(!can_read_manifest(1));
-        assert!(!can_write_manifest(1));
+        assert!(can_read_manifest(DROP_TOMBSTONE_ROWS_FLAG));
+        assert!(can_write_manifest(DROP_TOMBSTONE_ROWS_FLAG));
         assert!(!can_read_manifest(1 << 30));
         assert!(!can_write_manifest(1 << 63));
 
-        let reader = meta(&[(READER_FEATURE_FLAGS_KEY, "1")]);
+        let reader = meta(&[(READER_FEATURE_FLAGS_KEY, "2")]);
         let err = ensure_readable(&reader).unwrap_err();
         assert!(err.to_string().to_lowercase().contains("upgrade"));
         assert!(is_incompatible_manifest_error(&err));

--- a/rust/lance-table/src/io/commit/dynamodb.rs
+++ b/rust/lance-table/src/io/commit/dynamodb.rs
@@ -465,27 +465,39 @@ impl ExternalManifestStore for DynamoDBExternalManifestStore {
 
     /// Delete the manifest information for the given base_uri in dynamodb
     async fn delete(&self, base_uri: &str) -> Result<()> {
-        let query_result = self
-            .ddb_query()
-            .key_condition_expression(format!("{} = :{}", base_uri!(), base_uri!()))
-            .expression_attribute_values(
-                format!(":{}", base_uri!()),
-                AttributeValue::S(base_uri.into()),
-            )
-            .send()
-            .await
-            .wrap_err()?;
+        let mut exclusive_start_key = None;
+        loop {
+            let query_result = self
+                .ddb_query()
+                .key_condition_expression(format!("{} = :{}", base_uri!(), base_uri!()))
+                .expression_attribute_values(
+                    format!(":{}", base_uri!()),
+                    AttributeValue::S(base_uri.into()),
+                )
+                .set_exclusive_start_key(exclusive_start_key)
+                .send()
+                .await
+                .wrap_err()?;
 
-        if let Some(items) = query_result.items {
-            for item in items {
-                if let Some(AttributeValue::N(version)) = item.get("version") {
-                    self.ddb_delete()
-                        .key(base_uri!(), AttributeValue::S(base_uri.to_string()))
-                        .key(version!(), AttributeValue::N(version.clone()))
-                        .send()
-                        .await
-                        .wrap_err()?;
+            if let Some(items) = query_result.items {
+                for item in items {
+                    if let Some(AttributeValue::N(version)) = item.get("version") {
+                        self.ddb_delete()
+                            .key(base_uri!(), AttributeValue::S(base_uri.to_string()))
+                            .key(version!(), AttributeValue::N(version.clone()))
+                            .send()
+                            .await
+                            .wrap_err()?;
+                    }
                 }
+            }
+
+            exclusive_start_key = query_result.last_evaluated_key;
+            if exclusive_start_key
+                .as_ref()
+                .is_none_or(|key| key.is_empty())
+            {
+                break;
             }
         }
         Ok(())

--- a/rust/lance-table/src/system_index/mem_wal.rs
+++ b/rust/lance-table/src/system_index/mem_wal.rs
@@ -163,7 +163,10 @@ impl ShardStatus {
         match self {
             Self::Active => 0,
             Self::Sealed => 1,
-            Self::Dropped => 2,
+            // Committed drops use a fail-closed envelope around a SEALED
+            // protobuf; see ShardManifestStore. Never emit a new enum value
+            // that an older reader would interpret as Active.
+            Self::Dropped => 1,
         }
     }
 
@@ -172,8 +175,8 @@ impl ShardStatus {
     fn from_i32(v: i32) -> Self {
         match v {
             1 => Self::Sealed,
-            2 => Self::Dropped,
-            _ => Self::Active,
+            // Unknown non-zero values are lifecycle fences, never Active.
+            _ => Self::Sealed,
         }
     }
 }

--- a/rust/lance-table/src/system_index/mem_wal.rs
+++ b/rust/lance-table/src/system_index/mem_wal.rs
@@ -143,9 +143,9 @@ impl TryFrom<pb::IndexCatchupProgress> for IndexCatchupProgress {
 
 /// Lifecycle status of a WAL shard, persisted in [`ShardManifest`].
 ///
-/// `Sealed` is the durable in-doubt record for drop-table two-phase
-/// commit: a sealed shard refuses new writer claims (enforced in
-/// `claim_epoch`) but is reversible back to `Active` on rollback.
+/// `Sealed` is the durable in-doubt record for drop-table two-phase commit.
+/// `Dropped` records a committed drop and remains fenced until cleanup removes
+/// the old generation.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub enum ShardStatus {
     /// Normal: the shard accepts writer claims.
@@ -153,6 +153,8 @@ pub enum ShardStatus {
     Active,
     /// A drop is in flight: claims are refused. Reversible.
     Sealed,
+    /// The drop committed: claims are permanently refused for this generation.
+    Dropped,
 }
 
 impl ShardStatus {
@@ -161,6 +163,7 @@ impl ShardStatus {
         match self {
             Self::Active => 0,
             Self::Sealed => 1,
+            Self::Dropped => 2,
         }
     }
 
@@ -169,6 +172,7 @@ impl ShardStatus {
     fn from_i32(v: i32) -> Self {
         match v {
             1 => Self::Sealed,
+            2 => Self::Dropped,
             _ => Self::Active,
         }
     }

--- a/rust/lance-table/src/system_index/mem_wal.rs
+++ b/rust/lance-table/src/system_index/mem_wal.rs
@@ -170,10 +170,11 @@ impl ShardStatus {
         }
     }
 
-    /// Map from the protobuf enum discriminant; unknown values decode as
-    /// `Active` (forward-compatible default).
+    /// Map from the protobuf enum discriminant; unknown non-zero values fail
+    /// closed as lifecycle fences.
     fn from_i32(v: i32) -> Self {
         match v {
+            0 => Self::Active,
             1 => Self::Sealed,
             // Unknown non-zero values are lifecycle fences, never Active.
             _ => Self::Sealed,

--- a/rust/lance/src/dataset/mem_wal/manifest.rs
+++ b/rust/lance/src/dataset/mem_wal/manifest.rs
@@ -382,18 +382,15 @@ impl ShardManifestStore {
         for _ in 0..MAX_CLAIM_RETRIES {
             let current = self.read_latest().await?;
 
-            // A sealed shard is mid-drop (drop-table 2PC). Refuse the claim
-            // with a distinguishable error rather than minting a new epoch,
-            // so a caller that skips its own status check still cannot
-            // resurrect a shard being dropped. Sophon's reconcile keys on
-            // the "sealed" marker in this message to tell it apart from an
-            // ordinary epoch fence.
+            // A non-active shard is either mid-drop or durably dropped. Refuse
+            // the claim rather than minting a new epoch, so cleanup remains the
+            // only operation that can make the physical generation reusable.
             if let Some(m) = &current
-                && m.status == ShardStatus::Sealed
+                && m.status != ShardStatus::Active
             {
                 return Err(Error::invalid_input(format!(
-                    "shard {} is sealed; refusing claim (drop in flight)",
-                    self.shard_id
+                    "shard {} is {:?}; refusing claim (drop fence)",
+                    self.shard_id, m.status
                 )));
             }
 

--- a/rust/lance/src/dataset/mem_wal/manifest.rs
+++ b/rust/lance/src/dataset/mem_wal/manifest.rs
@@ -388,9 +388,14 @@ impl ShardManifestStore {
             if let Some(m) = &current
                 && m.status != ShardStatus::Active
             {
+                let status = match m.status {
+                    ShardStatus::Active => unreachable!(),
+                    ShardStatus::Sealed => "sealed",
+                    ShardStatus::Dropped => "dropped",
+                };
                 return Err(Error::invalid_input(format!(
-                    "shard {} is {:?}; refusing claim (drop fence)",
-                    self.shard_id, m.status
+                    "shard {} is {status}; refusing claim (drop fence)",
+                    self.shard_id
                 )));
             }
 
@@ -766,6 +771,21 @@ mod tests {
         let (next_epoch, reclaimed) = manifest_store.claim_epoch(0).await.unwrap();
         assert!(next_epoch > epoch, "rolled-back shard mints the next epoch");
         assert_eq!(reclaimed.status, ShardStatus::Active);
+
+        let dropped = ShardManifest {
+            version: reclaimed.version + 1,
+            status: ShardStatus::Dropped,
+            ..reclaimed
+        };
+        manifest_store.write(&dropped).await.unwrap();
+        let err = manifest_store.claim_epoch(0).await.unwrap_err();
+        assert!(
+            err.to_string().contains("dropped"),
+            "expected a distinguishable dropped-refusal error, got: {err}"
+        );
+        let after = manifest_store.read_latest().await.unwrap().unwrap();
+        assert_eq!(after.writer_epoch, dropped.writer_epoch, "no epoch minted");
+        assert_eq!(after.status, ShardStatus::Dropped);
     }
 
     #[tokio::test]

--- a/rust/lance/src/dataset/mem_wal/manifest.rs
+++ b/rust/lance/src/dataset/mem_wal/manifest.rs
@@ -47,10 +47,11 @@ use uuid::Uuid;
 
 use super::util::{manifest_filename, parse_bit_reversed_filename, shard_manifest_path};
 
-// Prefixing the protobuf with field tag zero makes the record undecodable by
-// older readers, which fail closed instead of mapping a new enum value to
-// Active. New readers strip the envelope and restore `Dropped` explicitly.
-const DROPPED_MANIFEST_PREFIX: &[u8] = b"\0LANCE_DROPPED\0";
+// Committed drops remain wire-compatible with older readers: they see the
+// known `Sealed` status and refuse claims. New readers recognize and remove
+// this reserved entry before exposing shard field values.
+const DROPPED_MANIFEST_FIELD_ID: &str = "__lance_internal_drop_committed_v1";
+const DROPPED_MANIFEST_MAGIC: &[u8] = b"LANCE_DROPPED_V1";
 
 /// Version hint file structure.
 #[derive(Debug, Serialize, Deserialize)]
@@ -124,12 +125,18 @@ impl ShardManifestStore {
             .await
             .map_err(|e| Error::io(format!("Failed to read manifest bytes: {}", e)))?;
 
-        let (bytes, dropped) = match bytes.strip_prefix(DROPPED_MANIFEST_PREFIX) {
-            Some(bytes) => (bytes, true),
-            None => (bytes.as_ref(), false),
-        };
-        let pb_manifest = pb::ShardManifest::decode(bytes)
+        let mut pb_manifest = pb::ShardManifest::decode(bytes)
             .map_err(|e| Error::io(format!("Failed to decode manifest protobuf: {}", e)))?;
+        let dropped = pb_manifest.shard_field_entries.iter().any(|entry| {
+            entry.field_id == DROPPED_MANIFEST_FIELD_ID
+                && entry.value.as_slice() == DROPPED_MANIFEST_MAGIC
+        });
+        if dropped {
+            pb_manifest.shard_field_entries.retain(|entry| {
+                !(entry.field_id == DROPPED_MANIFEST_FIELD_ID
+                    && entry.value.as_slice() == DROPPED_MANIFEST_MAGIC)
+            });
+        }
 
         let mut manifest = ShardManifest::try_from(pb_manifest)?;
         if dropped {
@@ -188,20 +195,26 @@ impl ShardManifestStore {
     /// Returns `Error::AlreadyExists` if another writer already wrote this version.
     #[instrument(name = "manifest_write", level = "debug", skip_all, fields(shard_id = %self.shard_id, version = manifest.version, epoch = manifest.writer_epoch))]
     pub async fn write(&self, manifest: &ShardManifest) -> Result<u64> {
+        if manifest
+            .shard_field_values
+            .contains_key(DROPPED_MANIFEST_FIELD_ID)
+        {
+            return Err(Error::invalid_input(format!(
+                "shard field id '{DROPPED_MANIFEST_FIELD_ID}' is reserved"
+            )));
+        }
         let version = manifest.version;
         let filename = manifest_filename(version);
         let path = self.manifest_dir.clone().join(filename.as_str());
 
-        let pb_manifest = pb::ShardManifest::from(manifest);
+        let mut pb_manifest = pb::ShardManifest::from(manifest);
+        if manifest.status == ShardStatus::Dropped {
+            pb_manifest.shard_field_entries.push(pb::ShardFieldEntry {
+                field_id: DROPPED_MANIFEST_FIELD_ID.to_string(),
+                value: DROPPED_MANIFEST_MAGIC.to_vec(),
+            });
+        }
         let bytes = pb_manifest.encode_to_vec();
-        let bytes = if manifest.status == ShardStatus::Dropped {
-            let mut enveloped = Vec::with_capacity(DROPPED_MANIFEST_PREFIX.len() + bytes.len());
-            enveloped.extend_from_slice(DROPPED_MANIFEST_PREFIX);
-            enveloped.extend_from_slice(&bytes);
-            enveloped
-        } else {
-            bytes
-        };
 
         self.object_store
             .put_if_absent(&path, Bytes::from(bytes).into())
@@ -812,9 +825,10 @@ mod tests {
             .bytes()
             .await
             .unwrap();
-        assert!(
-            pb::ShardManifest::decode(raw).is_err(),
-            "an older protobuf-only reader must fail closed on a dropped fence"
+        let old_reader = pb::ShardManifest::decode(raw).unwrap();
+        assert_eq!(
+            old_reader.status, 1,
+            "an older reader must observe the known sealed status"
         );
         let err = manifest_store.claim_epoch(0).await.unwrap_err();
         assert!(

--- a/rust/lance/src/dataset/mem_wal/manifest.rs
+++ b/rust/lance/src/dataset/mem_wal/manifest.rs
@@ -47,11 +47,10 @@ use uuid::Uuid;
 
 use super::util::{manifest_filename, parse_bit_reversed_filename, shard_manifest_path};
 
-// Committed drops remain wire-compatible with older readers: they see the
-// known `Sealed` status and refuse claims. New readers recognize and remove
-// this reserved entry before exposing shard field values.
-const DROPPED_MANIFEST_FIELD_ID: &str = "__lance_internal_drop_committed_v1";
-const DROPPED_MANIFEST_MAGIC: &[u8] = b"LANCE_DROPPED_V1";
+// The leading invalid protobuf tag makes committed-drop records unreadable to
+// older lifecycle writers, so their claim and abort paths both fail closed.
+// New readers strip the versioned envelope and restore `Dropped` explicitly.
+const DROPPED_MANIFEST_PREFIX: &[u8] = b"\0LANCE_DROPPED\0";
 
 /// Version hint file structure.
 #[derive(Debug, Serialize, Deserialize)]
@@ -125,18 +124,12 @@ impl ShardManifestStore {
             .await
             .map_err(|e| Error::io(format!("Failed to read manifest bytes: {}", e)))?;
 
-        let mut pb_manifest = pb::ShardManifest::decode(bytes)
+        let (bytes, dropped) = match bytes.strip_prefix(DROPPED_MANIFEST_PREFIX) {
+            Some(bytes) => (bytes, true),
+            None => (bytes.as_ref(), false),
+        };
+        let pb_manifest = pb::ShardManifest::decode(bytes)
             .map_err(|e| Error::io(format!("Failed to decode manifest protobuf: {}", e)))?;
-        let dropped = pb_manifest.shard_field_entries.iter().any(|entry| {
-            entry.field_id == DROPPED_MANIFEST_FIELD_ID
-                && entry.value.as_slice() == DROPPED_MANIFEST_MAGIC
-        });
-        if dropped {
-            pb_manifest.shard_field_entries.retain(|entry| {
-                !(entry.field_id == DROPPED_MANIFEST_FIELD_ID
-                    && entry.value.as_slice() == DROPPED_MANIFEST_MAGIC)
-            });
-        }
 
         let mut manifest = ShardManifest::try_from(pb_manifest)?;
         if dropped {
@@ -195,26 +188,20 @@ impl ShardManifestStore {
     /// Returns `Error::AlreadyExists` if another writer already wrote this version.
     #[instrument(name = "manifest_write", level = "debug", skip_all, fields(shard_id = %self.shard_id, version = manifest.version, epoch = manifest.writer_epoch))]
     pub async fn write(&self, manifest: &ShardManifest) -> Result<u64> {
-        if manifest
-            .shard_field_values
-            .contains_key(DROPPED_MANIFEST_FIELD_ID)
-        {
-            return Err(Error::invalid_input(format!(
-                "shard field id '{DROPPED_MANIFEST_FIELD_ID}' is reserved"
-            )));
-        }
         let version = manifest.version;
         let filename = manifest_filename(version);
         let path = self.manifest_dir.clone().join(filename.as_str());
 
-        let mut pb_manifest = pb::ShardManifest::from(manifest);
-        if manifest.status == ShardStatus::Dropped {
-            pb_manifest.shard_field_entries.push(pb::ShardFieldEntry {
-                field_id: DROPPED_MANIFEST_FIELD_ID.to_string(),
-                value: DROPPED_MANIFEST_MAGIC.to_vec(),
-            });
-        }
+        let pb_manifest = pb::ShardManifest::from(manifest);
         let bytes = pb_manifest.encode_to_vec();
+        let bytes = if manifest.status == ShardStatus::Dropped {
+            let mut enveloped = Vec::with_capacity(DROPPED_MANIFEST_PREFIX.len() + bytes.len());
+            enveloped.extend_from_slice(DROPPED_MANIFEST_PREFIX);
+            enveloped.extend_from_slice(&bytes);
+            enveloped
+        } else {
+            bytes
+        };
 
         self.object_store
             .put_if_absent(&path, Bytes::from(bytes).into())
@@ -825,10 +812,9 @@ mod tests {
             .bytes()
             .await
             .unwrap();
-        let old_reader = pb::ShardManifest::decode(raw).unwrap();
-        assert_eq!(
-            old_reader.status, 1,
-            "an older reader must observe the known sealed status"
+        assert!(
+            pb::ShardManifest::decode(raw).is_err(),
+            "an older lifecycle writer must fail closed on a committed drop"
         );
         let err = manifest_store.claim_epoch(0).await.unwrap_err();
         assert!(

--- a/rust/lance/src/dataset/mem_wal/manifest.rs
+++ b/rust/lance/src/dataset/mem_wal/manifest.rs
@@ -47,6 +47,11 @@ use uuid::Uuid;
 
 use super::util::{manifest_filename, parse_bit_reversed_filename, shard_manifest_path};
 
+// Prefixing the protobuf with field tag zero makes the record undecodable by
+// older readers, which fail closed instead of mapping a new enum value to
+// Active. New readers strip the envelope and restore `Dropped` explicitly.
+const DROPPED_MANIFEST_PREFIX: &[u8] = b"\0LANCE_DROPPED\0";
+
 /// Version hint file structure.
 #[derive(Debug, Serialize, Deserialize)]
 struct VersionHint {
@@ -119,10 +124,18 @@ impl ShardManifestStore {
             .await
             .map_err(|e| Error::io(format!("Failed to read manifest bytes: {}", e)))?;
 
+        let (bytes, dropped) = match bytes.strip_prefix(DROPPED_MANIFEST_PREFIX) {
+            Some(bytes) => (bytes, true),
+            None => (bytes.as_ref(), false),
+        };
         let pb_manifest = pb::ShardManifest::decode(bytes)
             .map_err(|e| Error::io(format!("Failed to decode manifest protobuf: {}", e)))?;
 
-        ShardManifest::try_from(pb_manifest)
+        let mut manifest = ShardManifest::try_from(pb_manifest)?;
+        if dropped {
+            manifest.status = ShardStatus::Dropped;
+        }
+        Ok(manifest)
     }
 
     /// Write an initial manifest for a newly-created shard.
@@ -181,6 +194,14 @@ impl ShardManifestStore {
 
         let pb_manifest = pb::ShardManifest::from(manifest);
         let bytes = pb_manifest.encode_to_vec();
+        let bytes = if manifest.status == ShardStatus::Dropped {
+            let mut enveloped = Vec::with_capacity(DROPPED_MANIFEST_PREFIX.len() + bytes.len());
+            enveloped.extend_from_slice(DROPPED_MANIFEST_PREFIX);
+            enveloped.extend_from_slice(&bytes);
+            enveloped
+        } else {
+            bytes
+        };
 
         self.object_store
             .put_if_absent(&path, Bytes::from(bytes).into())
@@ -778,6 +799,23 @@ mod tests {
             ..reclaimed
         };
         manifest_store.write(&dropped).await.unwrap();
+        let raw_path = manifest_store
+            .manifest_dir
+            .clone()
+            .join(manifest_filename(dropped.version).as_str());
+        let raw = manifest_store
+            .object_store
+            .inner
+            .get(&raw_path)
+            .await
+            .unwrap()
+            .bytes()
+            .await
+            .unwrap();
+        assert!(
+            pb::ShardManifest::decode(raw).is_err(),
+            "an older protobuf-only reader must fail closed on a dropped fence"
+        );
         let err = manifest_store.claim_epoch(0).await.unwrap_err();
         assert!(
             err.to_string().contains("dropped"),


### PR DESCRIPTION
Make manifest-backed deregistration conditional on the physical location observed by the caller and re-check that generation inside every manifest rewrite attempt. Expected-generation deregistration writes an out-of-prefix sibling tombstone so the old location cannot be re-registered until physical cleanup finishes.

With `async_drop_enabled=true`, generated table paths use UUID-sized incarnation IDs and overwrite publishes a fresh physical generation with a conditional manifest swap. The default overwrite path retains its existing version-history semantics.

Also paginate DynamoDB external-manifest deletion so asynchronous physical cleanup removes every manifest entry for the dropped table.