### PR TITLE
feat(io)!: paginated directory listing on ObjectStore

### DIFF
--- a/rust/lance-io/src/object_store.rs
+++ b/rust/lance-io/src/object_store.rs
@@ -24,6 +24,7 @@ use object_store::DynObjectStore;
 use object_store::ObjectStoreExt as OSObjectStoreExt;
 #[cfg(feature = "aws")]
 use object_store::aws::AwsCredentialProvider;
+use object_store::list::PaginatedListStore;
 #[cfg(any(feature = "aws", feature = "azure", feature = "gcp"))]
 use object_store::{ClientOptions, HeaderMap, HeaderValue};
 use object_store::{
@@ -57,6 +58,7 @@ pub mod metrics;
 ))]
 pub(crate) mod opendal_store;
 pub mod providers;
+pub(crate) mod read_dir;
 pub mod storage_options;
 #[cfg(test)]
 pub(crate) mod test_utils;
@@ -99,6 +101,7 @@ pub static DEFAULT_MAX_IOP_SIZE: std::sync::LazyLock<u64> = std::sync::LazyLock:
 pub const DEFAULT_DOWNLOAD_RETRY_COUNT: usize = 3;
 
 pub use providers::{ObjectStoreProvider, ObjectStoreRegistry};
+pub use read_dir::ReadDirOptions;
 pub use storage_options::{
     BASE_SCOPED_OPTION_PREFIX, BaseScopedStorageOptionsProvider, EXPIRES_AT_MILLIS_KEY,
     LanceNamespaceStorageOptionsProvider, REFRESH_OFFSET_MILLIS_KEY, StorageOptionsAccessor,
@@ -153,7 +156,7 @@ impl<O: OSObjectStore + ?Sized> ObjectStoreExt for O {
 }
 
 /// Wraps [ObjectStore](object_store::ObjectStore)
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct ObjectStore {
     // Inner object store
     pub inner: Arc<dyn OSObjectStore>,
@@ -177,6 +180,31 @@ pub struct ObjectStore {
     /// which usually cannot be found in the URL such as Azure account name. The prefix plus the
     /// path uniquely identifies any object inside the store.
     pub store_prefix: String,
+    /// The backend's paginated listing API, when it has one. `None` means
+    /// [`Self::read_dir_page`] has to list a directory in full to page through it.
+    pub(crate) paginated_lister: Option<Arc<dyn PaginatedListStore>>,
+}
+
+// Hand-written because `PaginatedListStore` is not `Debug`.
+impl std::fmt::Debug for ObjectStore {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ObjectStore")
+            .field("inner", &self.inner)
+            .field("scheme", &self.scheme)
+            .field("block_size", &self.block_size)
+            .field("max_iop_size", &self.max_iop_size)
+            .field(
+                "use_constant_size_upload_parts",
+                &self.use_constant_size_upload_parts,
+            )
+            .field("list_is_lexically_ordered", &self.list_is_lexically_ordered)
+            .field("io_parallelism", &self.io_parallelism)
+            .field("download_retry_count", &self.download_retry_count)
+            .field("io_tracker", &self.io_tracker)
+            .field("store_prefix", &self.store_prefix)
+            .field("paginated_lister", &self.paginated_lister.is_some())
+            .finish()
+    }
 }
 
 impl DeepSizeOf for ObjectStore {
@@ -201,6 +229,34 @@ pub trait WrappingObjectStore: std::fmt::Debug + Send + Sync {
     /// The store_prefix is a string which uniquely identifies the object
     /// store being wrapped.
     fn wrap(&self, store_prefix: &str, original: Arc<dyn OSObjectStore>) -> Arc<dyn OSObjectStore>;
+
+    /// Wrap the paginated listing API that goes with the store, if it has one.
+    ///
+    /// [`ObjectStore::read_dir_page`] pushes the page size and the resume position into
+    /// [`PaginatedListStore`], which is a separate trait from [`OSObjectStore`] and so cannot
+    /// be reached through the store [`Self::wrap`] returns. A listing that is pushed down
+    /// therefore does not pass through [`Self::wrap`], and this is where a wrapper says what
+    /// should happen instead:
+    ///
+    /// - `Some(lister)` keeps the pushdown, wrapping the lister or handing back the one
+    ///   given. Right for a wrapper that observes rather than intercepts — metering, caching,
+    ///   mirroring writes.
+    /// - `None` gives up the pushdown, so listings go through [`Self::wrap`] as a full
+    ///   directory read. Right for a wrapper that hides, rewrites or fails paths, which a
+    ///   pushed-down listing would otherwise walk straight past.
+    ///
+    /// A wrapper that keeps the pushdown must leave the listing itself alone: setting
+    /// [`offset`](object_store::list::PaginatedListOptions::offset) or changing the delimiter
+    /// breaks paging, since `read_dir_page` reads one directory level and resumes by the token
+    /// it got back.
+    ///
+    /// There is deliberately no default: getting this wrong is either a silent loss of speed
+    /// or a silent loss of the wrapper, and neither announces itself.
+    fn wrap_paginated(
+        &self,
+        store_prefix: &str,
+        original: Arc<dyn PaginatedListStore>,
+    ) -> Option<Arc<dyn PaginatedListStore>>;
 }
 
 #[derive(Debug, Clone)]
@@ -223,6 +279,18 @@ impl WrappingObjectStore for ChainedWrappingObjectStore {
         self.wrappers
             .iter()
             .fold(original, |acc, wrapper| wrapper.wrap(store_prefix, acc))
+    }
+
+    // One wrapper giving up the pushdown gives it up for the chain: the listing has to go
+    // through `wrap`, which is every wrapper in the chain at once.
+    fn wrap_paginated(
+        &self,
+        store_prefix: &str,
+        original: Arc<dyn PaginatedListStore>,
+    ) -> Option<Arc<dyn PaginatedListStore>> {
+        self.wrappers.iter().try_fold(original, |acc, wrapper| {
+            wrapper.wrap_paginated(store_prefix, acc)
+        })
     }
 }
 
@@ -566,6 +634,8 @@ impl ObjectStore {
                 download_retry_count: DEFAULT_DOWNLOAD_RETRY_COUNT,
                 io_tracker,
                 store_prefix,
+                // Type-erased on the way in, so there is no telling if it can paginate.
+                paginated_lister: None,
             };
             let path = Path::parse(path.path())?;
             return Ok((Arc::new(store), path));
@@ -712,6 +782,19 @@ impl ObjectStore {
     /// different stages of processing.
     pub fn io_stats_incremental(&self) -> IoStats {
         self.io_tracker.incremental_stats()
+    }
+
+    /// Apply a [`WrappingObjectStore`] to both `inner` and `paginated_lister` together.
+    ///
+    /// Keeps both halves in sync: a wrapper returning `None` from
+    /// [`WrappingObjectStore::wrap_paginated`] clears the lister so that
+    /// [`Self::read_dir_page`] falls back through the (already-wrapped) `inner`.
+    pub fn apply_wrapper(&mut self, wrapper: &dyn WrappingObjectStore) {
+        self.inner = wrapper.wrap(&self.store_prefix, self.inner.clone());
+        self.paginated_lister = self
+            .paginated_lister
+            .take()
+            .and_then(|lister| wrapper.wrap_paginated(&self.store_prefix, lister));
     }
 
     /// Open a file for path.
@@ -989,6 +1072,9 @@ impl ObjectStore {
     }
 
     /// Read a directory (start from base directory) and returns all sub-paths in the directory.
+    ///
+    /// This enumerates the whole prefix before it returns, however many children it holds.
+    /// Use [`Self::read_dir_page`] to page through a directory instead.
     pub async fn read_dir(&self, dir_path: impl Into<Path>) -> Result<Vec<String>> {
         let path = dir_path.into();
         let path = Path::parse(&path)?;
@@ -1340,6 +1426,8 @@ impl ObjectStore {
             download_retry_count,
             io_tracker,
             store_prefix,
+            // Type-erased on the way in, so there is no telling if it can paginate.
+            paginated_lister: None,
         }
     }
 }
@@ -1778,12 +1866,138 @@ mod tests {
             // return a mocked value so we can check if the final store is the one we expect
             self.return_value.clone()
         }
+
+        // This one swaps the store out entirely, so a listing that went around it would be
+        // listing something else.
+        fn wrap_paginated(
+            &self,
+            _store_prefix: &str,
+            _original: Arc<dyn PaginatedListStore>,
+        ) -> Option<Arc<dyn PaginatedListStore>> {
+            None
+        }
     }
 
     impl TestWrapper {
         fn called(&self) -> bool {
             self.called.load(Ordering::Relaxed)
         }
+    }
+
+    /// A lister that exists only to be wrapped.
+    #[derive(Debug)]
+    struct StubLister;
+
+    #[async_trait]
+    impl PaginatedListStore for StubLister {
+        async fn list_paginated(
+            &self,
+            _prefix: Option<&str>,
+            _opts: object_store::list::PaginatedListOptions,
+        ) -> object_store::Result<object_store::list::PaginatedListResult> {
+            unimplemented!("this lister exists to be wrapped, not to list")
+        }
+    }
+
+    /// Records the listers it was handed, and leaves the store alone.
+    #[derive(Debug)]
+    struct PaginatedTestWrapper {
+        name: &'static str,
+        log: Arc<std::sync::Mutex<Vec<String>>>,
+    }
+
+    impl WrappingObjectStore for PaginatedTestWrapper {
+        fn wrap(
+            &self,
+            _store_prefix: &str,
+            original: Arc<dyn OSObjectStore>,
+        ) -> Arc<dyn OSObjectStore> {
+            original
+        }
+
+        fn wrap_paginated(
+            &self,
+            store_prefix: &str,
+            original: Arc<dyn PaginatedListStore>,
+        ) -> Option<Arc<dyn PaginatedListStore>> {
+            self.log
+                .lock()
+                .unwrap()
+                .push(format!("{}@{store_prefix}", self.name));
+            Some(original)
+        }
+    }
+
+    /// A chain hands the lister to each of its wrappers in turn. One wrapper giving up the
+    /// pushdown gives it up for the chain, and the wrappers after it are never asked: the
+    /// listing is going through `wrap` either way, which is every wrapper at once.
+    #[rstest]
+    #[case::every_wrapper_keeps_it(false, vec!["first@memory", "second@memory"])]
+    #[case::one_wrapper_gives_it_up(true, vec!["first@memory"])]
+    fn test_a_chain_wraps_the_lister_until_one_gives_it_up(
+        #[case] gives_up: bool,
+        #[case] expected_log: Vec<&str>,
+    ) {
+        let log = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let mut wrappers: Vec<Arc<dyn WrappingObjectStore>> =
+            vec![Arc::new(PaginatedTestWrapper {
+                name: "first",
+                log: log.clone(),
+            })];
+        if gives_up {
+            wrappers.push(Arc::new(TestWrapper {
+                called: AtomicBool::new(false),
+                return_value: Arc::new(InMemory::new()),
+            }));
+        }
+        wrappers.push(Arc::new(PaginatedTestWrapper {
+            name: "second",
+            log: log.clone(),
+        }));
+
+        let wrapped = ChainedWrappingObjectStore::new(wrappers)
+            .wrap_paginated("memory", Arc::new(StubLister));
+
+        assert_eq!(wrapped.is_none(), gives_up);
+        assert_eq!(*log.lock().unwrap(), expected_log);
+    }
+
+    /// `apply_wrapper` keeps both halves of the store in sync. A wrapper that gives up the
+    /// pushdown has to clear the lister too, or `read_dir_page` would keep talking to the
+    /// backend behind the wrapper's back.
+    #[rstest]
+    #[case::gives_up_the_pushdown(true)]
+    #[case::keeps_the_pushdown(false)]
+    fn test_apply_wrapper_keeps_inner_and_the_lister_in_sync(#[case] gives_up: bool) {
+        let replacement = Arc::new(InMemory::new());
+        let giving_up = TestWrapper {
+            called: AtomicBool::new(false),
+            return_value: replacement.clone(),
+        };
+        let keeping = PaginatedTestWrapper {
+            name: "passthrough",
+            log: Arc::new(std::sync::Mutex::new(Vec::new())),
+        };
+        let wrapper: &dyn WrappingObjectStore = match gives_up {
+            true => &giving_up,
+            false => &keeping,
+        };
+
+        let mut store = ObjectStore::memory();
+        store.paginated_lister = Some(Arc::new(StubLister) as Arc<dyn PaginatedListStore>);
+        store.apply_wrapper(wrapper);
+
+        assert_eq!(
+            store.paginated_lister.is_some(),
+            !gives_up,
+            "the lister has to follow what the wrapper said"
+        );
+        // The wrapper that gives up the pushdown is also the one that swaps the store out, so
+        // whether `inner` was replaced says that `wrap` ran on the same wrapper.
+        assert_eq!(
+            Arc::ptr_eq(&store.inner, &(replacement as Arc<dyn OSObjectStore>)),
+            gives_up
+        );
     }
 
     #[tokio::test]

--- a/rust/lance-io/src/object_store/providers.rs
+++ b/rust/lance-io/src/object_store/providers.rs
@@ -221,7 +221,7 @@ impl ObjectStoreRegistry {
         crate::object_store::meter_store(&mut store.inner, &mut store.io_tracker, store_prefix);
 
         if let Some(wrapper) = &params.object_store_wrapper {
-            store.inner = wrapper.wrap(store_prefix, store.inner);
+            store.apply_wrapper(wrapper.as_ref());
         }
 
         // Always wrap with IO tracking
@@ -415,8 +415,14 @@ impl ObjectStoreRegistry {
 #[cfg(test)]
 mod tests {
     use std::collections::HashMap;
+    use std::sync::Mutex;
 
     use super::*;
+    use object_store::ObjectStore as OSObjectStore;
+
+    use crate::object_store::providers::memory::MemoryStoreProvider;
+    use object_store::list::{PaginatedListOptions, PaginatedListResult, PaginatedListStore};
+    use rstest::rstest;
 
     #[derive(Debug)]
     struct DummyProvider;
@@ -429,6 +435,125 @@ mod tests {
             _params: &ObjectStoreParams,
         ) -> Result<ObjectStore> {
             unreachable!("This test doesn't create stores")
+        }
+    }
+
+    /// A lister that exists only to be handed to a wrapper.
+    struct StubLister;
+
+    #[async_trait::async_trait]
+    impl PaginatedListStore for StubLister {
+        async fn list_paginated(
+            &self,
+            _prefix: Option<&str>,
+            _opts: PaginatedListOptions,
+        ) -> object_store::Result<PaginatedListResult> {
+            unimplemented!("this lister exists to be wrapped, not to list")
+        }
+    }
+
+    /// A provider whose stores come with a paginated lister, which the memory store does not.
+    #[derive(Debug)]
+    struct PaginatedProvider;
+
+    #[async_trait::async_trait]
+    impl ObjectStoreProvider for PaginatedProvider {
+        async fn new_store(
+            &self,
+            base_path: Url,
+            params: &ObjectStoreParams,
+        ) -> Result<ObjectStore> {
+            let mut store = MemoryStoreProvider.new_store(base_path, params).await?;
+            store.paginated_lister = Some(Arc::new(StubLister));
+            Ok(store)
+        }
+
+        fn calculate_object_store_prefix(
+            &self,
+            _url: &Url,
+            _storage_options: Option<&HashMap<String, String>>,
+        ) -> Result<String> {
+            Ok("memory".to_string())
+        }
+    }
+
+    /// Swaps the store out for an empty one, the way a wrapper enforcing visibility would, and
+    /// records the prefix each call was labelled with. `keep_pushdown` is what it answers when
+    /// asked about the lister.
+    #[derive(Debug)]
+    struct RecordingWrapper {
+        keep_pushdown: bool,
+        prefixes: Mutex<Vec<String>>,
+    }
+
+    impl WrappingObjectStore for RecordingWrapper {
+        fn wrap(
+            &self,
+            store_prefix: &str,
+            _original: Arc<dyn OSObjectStore>,
+        ) -> Arc<dyn OSObjectStore> {
+            self.prefixes
+                .lock()
+                .unwrap()
+                .push(format!("wrap@{store_prefix}"));
+            Arc::new(object_store::memory::InMemory::new())
+        }
+
+        fn wrap_paginated(
+            &self,
+            store_prefix: &str,
+            original: Arc<dyn PaginatedListStore>,
+        ) -> Option<Arc<dyn PaginatedListStore>> {
+            self.prefixes
+                .lock()
+                .unwrap()
+                .push(format!("wrap_paginated@{store_prefix}"));
+            self.keep_pushdown.then_some(original)
+        }
+    }
+
+    /// A decorator supplied through [`ObjectStoreParams`] has to reach the paginated lister
+    /// too, or `read_dir_page` would talk to the backend behind its back — and a decorator
+    /// that gives the pushdown up gets a store with no lister, so its listings go through the
+    /// wrapped `inner` and see what the wrapper allows rather than what the backend holds.
+    #[rstest]
+    #[case::keeps_the_pushdown(true)]
+    #[case::gives_up_the_pushdown(false)]
+    #[tokio::test]
+    async fn test_the_registry_hands_the_lister_to_the_wrapper(#[case] keep_pushdown: bool) {
+        let wrapper = Arc::new(RecordingWrapper {
+            keep_pushdown,
+            prefixes: Mutex::new(Vec::new()),
+        });
+        let registry = ObjectStoreRegistry::default();
+        registry.insert("pagmem", Arc::new(PaginatedProvider));
+
+        let store = registry
+            .get_store(
+                Url::parse("pagmem:///").unwrap(),
+                &ObjectStoreParams {
+                    object_store_wrapper: Some(wrapper.clone()),
+                    ..Default::default()
+                },
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(store.paginated_lister.is_some(), keep_pushdown);
+        // Both halves of the store are labelled with the same prefix.
+        assert_eq!(
+            *wrapper.prefixes.lock().unwrap(),
+            vec!["wrap@memory", "wrap_paginated@memory"]
+        );
+        if !keep_pushdown {
+            // `StubLister` panics if it is ever asked to list, so reaching a page at all is
+            // the other half of the assertion.
+            let page = store
+                .read_dir_page(Path::from(""), Default::default())
+                .await
+                .unwrap();
+            assert!(page.result.common_prefixes.is_empty());
+            assert!(page.result.objects.is_empty());
         }
     }
 

--- a/rust/lance-io/src/object_store/providers/aws.rs
+++ b/rust/lance-io/src/object_store/providers/aws.rs
@@ -10,6 +10,7 @@ use mock_instant::thread_local::{SystemTime, UNIX_EPOCH};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use object_store::ObjectStore as OSObjectStore;
+use object_store::list::PaginatedListStore;
 use opendal::{Operator, services::S3};
 
 use aws_config::default_provider::credentials::DefaultCredentialsChain;
@@ -22,7 +23,7 @@ use object_store::{
     ClientOptions, CredentialProvider, Result as ObjectStoreResult, RetryConfig,
     StaticCredentialProvider,
     aws::{
-        AmazonS3Builder, AmazonS3ConfigKey, AwsCredential as ObjectStoreAwsCredential,
+        AmazonS3, AmazonS3Builder, AmazonS3ConfigKey, AwsCredential as ObjectStoreAwsCredential,
         AwsCredentialProvider,
     },
 };
@@ -34,7 +35,7 @@ use crate::object_store::{
     DEFAULT_CLOUD_BLOCK_SIZE, DEFAULT_CLOUD_IO_PARALLELISM, DEFAULT_MAX_IOP_SIZE, ObjectStore,
     ObjectStoreParams, ObjectStoreProvider, StorageOptions, StorageOptionsAccessor,
     dynamic_credentials::{NamespaceCredentialsProvider, build_dynamic_credential_provider},
-    throttle::{AimdThrottleConfig, AimdThrottleState, AimdThrottledStore, cloud_http_connector},
+    throttle::{AimdThrottleConfig, AimdThrottleState, cloud_http_connector, with_throttling},
 };
 use lance_core::error::{Error, Result};
 
@@ -84,7 +85,9 @@ impl AwsStoreProvider {
         mut resolved_s3_options: ResolvedS3StorageOptions,
         is_s3_express: bool,
         throttle_state: Option<&AimdThrottleState>,
-    ) -> Result<Arc<dyn OSObjectStore>> {
+        // Concrete rather than `dyn`, so the caller keeps the handle a paginated listing
+        // needs: `PaginatedListStore` is a separate trait from `ObjectStore`.
+    ) -> Result<Arc<AmazonS3>> {
         // Use a low retry count since the AIMD throttle layer handles
         // throttle recovery with its own retry loop.
         let retry_config = RetryConfig {
@@ -140,7 +143,7 @@ impl AwsStoreProvider {
 
         builder = builder.with_http_connector(cloud_http_connector(throttle_state, store_prefix));
 
-        Ok(Arc::new(builder.build()?) as Arc<dyn OSObjectStore>)
+        Ok(Arc::new(builder.build()?))
     }
 
     async fn build_opendal_s3_store(
@@ -220,31 +223,33 @@ impl ObjectStoreProvider for AwsStoreProvider {
             Some(AimdThrottleState::new(throttle_config)?)
         };
 
-        let inner = if use_opendal {
+        let (inner, paginated_lister) = if use_opendal {
             // Use OpenDAL implementation
-            self.build_opendal_s3_store(&base_path, &storage_options)
-                .await?
+            // Listed in full: no paginated lister covers OpenDAL yet.
+            (
+                self.build_opendal_s3_store(&base_path, &storage_options)
+                    .await?,
+                None,
+            )
         } else {
             // Use default Amazon S3 implementation
-            self.build_amazon_s3_store(
-                &mut base_path,
-                params,
-                &storage_options,
-                resolved_s3_options,
-                is_s3_express,
-                throttle_state.as_ref(),
+            let store = self
+                .build_amazon_s3_store(
+                    &mut base_path,
+                    params,
+                    &storage_options,
+                    resolved_s3_options,
+                    is_s3_express,
+                    throttle_state.as_ref(),
+                )
+                .await?;
+            (
+                store.clone() as Arc<dyn OSObjectStore>,
+                Some(store as Arc<dyn PaginatedListStore>),
             )
-            .await?
         };
-        let inner = if let Some(throttle_state) = throttle_state {
-            Arc::new(AimdThrottledStore::new_with_state(
-                inner,
-                throttle_state,
-                !use_opendal,
-            )) as Arc<dyn OSObjectStore>
-        } else {
-            inner
-        };
+        let (inner, paginated_lister) =
+            with_throttling(throttle_state, !use_opendal, inner, paginated_lister);
 
         Ok(ObjectStore {
             inner,
@@ -259,6 +264,7 @@ impl ObjectStoreProvider for AwsStoreProvider {
             io_tracker: Default::default(),
             store_prefix: self
                 .calculate_object_store_prefix(&base_path, params.storage_options())?,
+            paginated_lister,
         })
     }
 }
@@ -918,6 +924,36 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(store.scheme, "s3");
+    }
+
+    /// S3 Express ignores `start-after` and does not list in key order, but it does hand back
+    /// continuation tokens, which is all the native store resumes from — so an Express bucket
+    /// pages like any other. The OpenDAL arm has no lister to page with at all.
+    #[rstest::rstest]
+    #[case::native("false", true)]
+    #[case::opendal("true", false)]
+    #[tokio::test]
+    async fn test_s3_express_is_paged_by_continuation_token(
+        #[case] use_opendal: &str,
+        #[case] paginated: bool,
+    ) {
+        let provider = AwsStoreProvider;
+        // Express bucket names carry their availability zone, which the S3 client validates.
+        let url = Url::parse("s3://test-bucket--use1-az4--x-s3/path").unwrap();
+        let params = ObjectStoreParams {
+            storage_options_accessor: Some(Arc::new(StorageOptionsAccessor::with_static_options(
+                HashMap::from([
+                    ("use_opendal".to_string(), use_opendal.to_string()),
+                    ("region".to_string(), "us-west-2".to_string()),
+                ]),
+            ))),
+            ..Default::default()
+        };
+
+        let store = provider.new_store(url, &params).await.unwrap();
+
+        assert!(!store.list_is_lexically_ordered);
+        assert_eq!(store.paginated_lister.is_some(), paginated);
     }
 
     #[derive(Debug)]

--- a/rust/lance-io/src/object_store/providers/azure.rs
+++ b/rust/lance-io/src/object_store/providers/azure.rs
@@ -9,11 +9,12 @@ use std::{
 };
 
 use object_store::ObjectStore as OSObjectStore;
+use object_store::list::PaginatedListStore;
 use opendal::{Operator, services::Azblob, services::Azdls};
 
 use object_store::{
     RetryConfig,
-    azure::{AzureConfigKey, AzureCredential, MicrosoftAzureBuilder},
+    azure::{AzureConfigKey, AzureCredential, MicrosoftAzure, MicrosoftAzureBuilder},
 };
 use url::Url;
 
@@ -22,7 +23,7 @@ use crate::object_store::{
     DEFAULT_CLOUD_BLOCK_SIZE, DEFAULT_CLOUD_IO_PARALLELISM, DEFAULT_MAX_IOP_SIZE, ObjectStore,
     ObjectStoreParams, ObjectStoreProvider, StorageOptions, StorageOptionsAccessor,
     dynamic_credentials::build_dynamic_credential_provider,
-    throttle::{AimdThrottleConfig, AimdThrottleState, AimdThrottledStore, cloud_http_connector},
+    throttle::{AimdThrottleConfig, AimdThrottleState, cloud_http_connector, with_throttling},
 };
 use lance_core::error::{Error, Result};
 
@@ -163,7 +164,9 @@ impl AzureBlobStoreProvider {
         storage_options: &StorageOptions,
         accessor: Option<Arc<StorageOptionsAccessor>>,
         throttle_state: Option<&AimdThrottleState>,
-    ) -> Result<Arc<dyn OSObjectStore>> {
+        // Concrete rather than `dyn`, so the caller keeps the handle a paginated listing
+        // needs: `PaginatedListStore` is a separate trait from `ObjectStore`.
+    ) -> Result<Arc<MicrosoftAzure>> {
         // Use a low retry count since the AIMD throttle layer handles
         // throttle recovery with its own retry loop.
         let retry_config = RetryConfig {
@@ -190,7 +193,7 @@ impl AzureBlobStoreProvider {
             self.calculate_object_store_prefix(base_path, Some(&storage_options.0))?;
         builder = builder.with_http_connector(cloud_http_connector(throttle_state, store_prefix));
 
-        Ok(Arc::new(builder.build()?) as Arc<dyn OSObjectStore>)
+        Ok(Arc::new(builder.build()?))
     }
 
     fn calculate_object_store_prefix_with_env(
@@ -262,29 +265,31 @@ impl ObjectStoreProvider for AzureBlobStoreProvider {
             Some(AimdThrottleState::new(throttle_config)?)
         };
 
-        let inner: Arc<dyn OSObjectStore> = if use_opendal {
+        let (inner, paginated_lister) = if use_opendal {
             // OpenDAL Azure intentionally uses static/environment-backed configuration only.
             // Namespace-vended dynamic credentials are supported on the native object_store path.
-            self.build_opendal_azure_store(&base_path, &storage_options)
-                .await?
-        } else {
-            self.build_microsoft_azure_store(
-                &base_path,
-                &storage_options,
-                accessor,
-                throttle_state.as_ref(),
+            // Listed in full: no paginated lister covers OpenDAL yet.
+            (
+                self.build_opendal_azure_store(&base_path, &storage_options)
+                    .await?,
+                None,
             )
-            .await?
-        };
-        let inner = if let Some(throttle_state) = throttle_state {
-            Arc::new(AimdThrottledStore::new_with_state(
-                inner,
-                throttle_state,
-                !use_opendal,
-            )) as Arc<dyn OSObjectStore>
         } else {
-            inner
+            let store = self
+                .build_microsoft_azure_store(
+                    &base_path,
+                    &storage_options,
+                    accessor,
+                    throttle_state.as_ref(),
+                )
+                .await?;
+            (
+                store.clone() as Arc<dyn OSObjectStore>,
+                Some(store as Arc<dyn PaginatedListStore>),
+            )
         };
+        let (inner, paginated_lister) =
+            with_throttling(throttle_state, !use_opendal, inner, paginated_lister);
 
         Ok(ObjectStore {
             inner,
@@ -299,6 +304,7 @@ impl ObjectStoreProvider for AzureBlobStoreProvider {
             io_tracker: Default::default(),
             store_prefix: self
                 .calculate_object_store_prefix(&base_path, params.storage_options())?,
+            paginated_lister,
         })
     }
 
@@ -579,6 +585,29 @@ mod tests {
             "abfss:// without use_opendal should use MicrosoftAzureBuilder, got: {}",
             inner_desc
         );
+        assert!(
+            store.paginated_lister.is_some(),
+            "the native store pages an ADLS Gen2 account by continuation token"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_a_blob_container_is_paged() {
+        use crate::object_store::StorageOptionsAccessor;
+        let provider = AzureBlobStoreProvider;
+        let url = Url::parse("az://container@testaccount.blob.core.windows.net/data").unwrap();
+        let params = ObjectStoreParams {
+            storage_options_accessor: Some(Arc::new(StorageOptionsAccessor::with_static_options(
+                HashMap::from([
+                    ("account_name".to_string(), "testaccount".to_string()),
+                    ("account_key".to_string(), "dGVzdA==".to_string()),
+                ]),
+            ))),
+            ..Default::default()
+        };
+
+        let store = provider.new_store(url, &params).await.unwrap();
+        assert!(store.paginated_lister.is_some());
     }
 
     #[tokio::test]

--- a/rust/lance-io/src/object_store/providers/gcp.rs
+++ b/rust/lance-io/src/object_store/providers/gcp.rs
@@ -3,6 +3,7 @@
 
 use std::{collections::HashMap, str::FromStr, sync::Arc, time::Duration};
 
+use object_store::list::PaginatedListStore;
 use object_store::{
     ClientOptions, CredentialProvider, ObjectStore as OSObjectStore, Result as ObjectStoreResult,
     client::{HttpClient, HttpConnector, HttpRequestBody, ReqwestConnector},
@@ -15,7 +16,7 @@ use tokio::sync::RwLock;
 
 use object_store::{
     RetryConfig, StaticCredentialProvider,
-    gcp::{GcpCredential, GoogleCloudStorageBuilder, GoogleConfigKey},
+    gcp::{GcpCredential, GoogleCloudStorage, GoogleCloudStorageBuilder, GoogleConfigKey},
 };
 use url::Url;
 
@@ -24,7 +25,7 @@ use crate::object_store::{
     DEFAULT_CLOUD_BLOCK_SIZE, DEFAULT_CLOUD_IO_PARALLELISM, DEFAULT_MAX_IOP_SIZE, ObjectStore,
     ObjectStoreParams, ObjectStoreProvider, StorageOptions, StorageOptionsAccessor,
     dynamic_credentials::build_dynamic_credential_provider,
-    throttle::{AimdThrottleConfig, AimdThrottleState, AimdThrottledStore, cloud_http_connector},
+    throttle::{AimdThrottleConfig, AimdThrottleState, cloud_http_connector, with_throttling},
 };
 use lance_core::error::{Error, Result};
 
@@ -237,7 +238,9 @@ impl GcsStoreProvider {
         storage_options: &StorageOptions,
         accessor: Option<Arc<StorageOptionsAccessor>>,
         throttle_state: Option<&AimdThrottleState>,
-    ) -> Result<Arc<dyn OSObjectStore>> {
+        // Concrete rather than `dyn`, so the caller keeps the handle a paginated listing
+        // needs: `PaginatedListStore` is a separate trait from `ObjectStore`.
+    ) -> Result<Arc<GoogleCloudStorage>> {
         // Use a low retry count since the AIMD throttle layer handles
         // throttle recovery with its own retry loop.
         let retry_config = RetryConfig {
@@ -279,7 +282,7 @@ impl GcsStoreProvider {
             self.calculate_object_store_prefix(base_path, Some(&storage_options.0))?;
         builder = builder.with_http_connector(cloud_http_connector(throttle_state, store_prefix));
 
-        Ok(Arc::new(builder.build()?) as Arc<dyn OSObjectStore>)
+        Ok(Arc::new(builder.build()?))
     }
 }
 
@@ -307,29 +310,31 @@ impl ObjectStoreProvider for GcsStoreProvider {
             Some(AimdThrottleState::new(throttle_config)?)
         };
 
-        let inner = if use_opendal {
+        let (inner, paginated_lister) = if use_opendal {
             // OpenDAL GCS intentionally uses static/environment-backed configuration only.
             // Namespace-vended dynamic credentials are supported on the native object_store path.
-            self.build_opendal_gcs_store(&base_path, &storage_options)
-                .await?
-        } else {
-            self.build_google_cloud_store(
-                &base_path,
-                &storage_options,
-                accessor,
-                throttle_state.as_ref(),
+            // Listed in full: no paginated lister covers OpenDAL yet.
+            (
+                self.build_opendal_gcs_store(&base_path, &storage_options)
+                    .await?,
+                None,
             )
-            .await?
-        };
-        let inner = if let Some(throttle_state) = throttle_state {
-            Arc::new(AimdThrottledStore::new_with_state(
-                inner,
-                throttle_state,
-                !use_opendal,
-            )) as Arc<dyn OSObjectStore>
         } else {
-            inner
+            let store = self
+                .build_google_cloud_store(
+                    &base_path,
+                    &storage_options,
+                    accessor,
+                    throttle_state.as_ref(),
+                )
+                .await?;
+            (
+                store.clone() as Arc<dyn OSObjectStore>,
+                Some(store as Arc<dyn PaginatedListStore>),
+            )
         };
+        let (inner, paginated_lister) =
+            with_throttling(throttle_state, !use_opendal, inner, paginated_lister);
 
         Ok(ObjectStore {
             inner,
@@ -344,6 +349,7 @@ impl ObjectStoreProvider for GcsStoreProvider {
             io_tracker: Default::default(),
             store_prefix: self
                 .calculate_object_store_prefix(&base_path, params.storage_options())?,
+            paginated_lister,
         })
     }
 }

--- a/rust/lance-io/src/object_store/providers/goosefs.rs
+++ b/rust/lance-io/src/object_store/providers/goosefs.rs
@@ -191,6 +191,8 @@ impl ObjectStoreProvider for GooseFsStoreProvider {
             io_tracker: Default::default(),
             store_prefix: self
                 .calculate_object_store_prefix(&base_path, params.storage_options())?,
+            // Listed in full: no paginated lister covers OpenDAL yet.
+            paginated_lister: None,
         })
     }
 

--- a/rust/lance-io/src/object_store/providers/huggingface.rs
+++ b/rust/lance-io/src/object_store/providers/huggingface.rs
@@ -217,6 +217,8 @@ impl ObjectStoreProvider for HuggingfaceStoreProvider {
             io_tracker: Default::default(),
             store_prefix: self
                 .calculate_object_store_prefix(&base_path, params.storage_options())?,
+            // Listed in full: no paginated lister covers OpenDAL yet.
+            paginated_lister: None,
         })
     }
 

--- a/rust/lance-io/src/object_store/providers/local.rs
+++ b/rust/lance-io/src/object_store/providers/local.rs
@@ -138,6 +138,9 @@ impl ObjectStoreProvider for FileStoreProvider {
             io_tracker: Default::default(),
             store_prefix: self
                 .calculate_object_store_prefix(&base_path, params.storage_options())?,
+            // Listed in full: reading a directory is one local walk whatever the page size,
+            // so there is no request for a page to be pushed into.
+            paginated_lister: None,
         })
     }
 
@@ -200,6 +203,7 @@ mod tests {
             download_retry_count: 0,
             io_tracker: Default::default(),
             store_prefix: "file$rooted-test".to_owned(),
+            paginated_lister: None,
         }
     }
 

--- a/rust/lance-io/src/object_store/providers/memory.rs
+++ b/rust/lance-io/src/object_store/providers/memory.rs
@@ -34,6 +34,9 @@ impl ObjectStoreProvider for MemoryStoreProvider {
             io_tracker: Default::default(),
             store_prefix: self
                 .calculate_object_store_prefix(&base_path, params.storage_options())?,
+            // Listed in full: the store is already in memory, so a page costs no less than
+            // the directory does.
+            paginated_lister: None,
         })
     }
 

--- a/rust/lance-io/src/object_store/providers/oss.rs
+++ b/rust/lance-io/src/object_store/providers/oss.rs
@@ -145,6 +145,8 @@ impl ObjectStoreProvider for OssStoreProvider {
             download_retry_count: storage_options.download_retry_count(),
             io_tracker: Default::default(),
             store_prefix: self.calculate_object_store_prefix(&url, params.storage_options())?,
+            // Listed in full: no paginated lister covers OpenDAL yet.
+            paginated_lister: None,
         })
     }
 }

--- a/rust/lance-io/src/object_store/providers/tencent.rs
+++ b/rust/lance-io/src/object_store/providers/tencent.rs
@@ -101,6 +101,8 @@ impl ObjectStoreProvider for TencentStoreProvider {
             download_retry_count: storage_options.download_retry_count(),
             io_tracker: Default::default(),
             store_prefix: self.calculate_object_store_prefix(&url, params.storage_options())?,
+            // Listed in full: no paginated lister covers OpenDAL yet.
+            paginated_lister: None,
         })
     }
 }

--- a/rust/lance-io/src/object_store/providers/tos.rs
+++ b/rust/lance-io/src/object_store/providers/tos.rs
@@ -151,6 +151,8 @@ impl ObjectStoreProvider for TosStoreProvider {
             download_retry_count: storage_options.download_retry_count(),
             io_tracker: Default::default(),
             store_prefix: self.calculate_object_store_prefix(&url, params.storage_options())?,
+            // Listed in full: no paginated lister covers OpenDAL yet.
+            paginated_lister: None,
         })
     }
 }

--- a/rust/lance-io/src/object_store/read_dir.rs
+++ b/rust/lance-io/src/object_store/read_dir.rs
@@ -1,0 +1,643 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+//! Paginated listing of a single directory level.
+//!
+//! [`ObjectStore::read_dir_page`] returns one page of the immediate children of a prefix, plus
+//! a token that resumes after it. Where the backend implements `object_store`'s paginated list
+//! API — S3, GCS and Azure do — the page size and the resume position are pushed into the list
+//! request, so a caller that wants the first few children pays for the first few children
+//! rather than for the whole prefix. Everything else lists the level in full and pages
+//! locally, which is correct but costs what the whole directory costs.
+//!
+//! The token is opaque, and a caller only ever hands it back: it is the backend's own
+//! continuation token where there is one, and the last key of the page where there is not.
+//! That is what lets a store without key-ordered listings, such as S3 Express, be paged at
+//! all — nothing outside this module compares one token to another.
+
+use object_store::list::{PaginatedListOptions, PaginatedListResult, PaginatedListStore};
+use object_store::{ListResult, ObjectMeta, ObjectStore as OSObjectStore, path::Path};
+use tracing::instrument;
+
+use lance_core::{Error, Result};
+
+use super::ObjectStore;
+
+#[cfg(feature = "metrics")]
+use crate::object_store::metrics::{InFlightGuard, record_outcome};
+#[cfg(feature = "metrics")]
+use std::time::Instant;
+
+/// The path delimiter that separates directory levels.
+const DELIMITER: &str = "/";
+
+/// Operation label for the metrics and IO statistics a paginated listing records.
+const LIST_OP: &str = "list_paginated";
+
+/// Options for [`ObjectStore::read_dir_page`].
+#[derive(Debug, Clone, Default)]
+pub struct ReadDirOptions {
+    /// Resume after the page a previous call returned, using the token it handed back.
+    ///
+    /// A token means something only to the store that minted it, and only for the directory
+    /// it was minted over. Handing one to a different store resumes from the wrong place
+    /// rather than failing.
+    pub page_token: Option<String>,
+    /// The page size to ask the backend for. Must be at least one. `None` lets the backend
+    /// return as much as it will.
+    pub limit: Option<usize>,
+}
+
+impl ObjectStore {
+    /// One page of the immediate children of `dir`, one directory level deep.
+    ///
+    /// On backends with a paginated list API — S3, GCS and Azure — the resume position and the
+    /// page size are pushed into the list request, so the page costs what the page holds.
+    /// Elsewhere the directory is listed in full and paged locally, which is correct but no
+    /// cheaper than [`Self::read_dir`].
+    ///
+    /// Child directories come back as [`ListResult::common_prefixes`] and child objects as
+    /// [`ListResult::objects`], the same split [`Self::list_with_delimiter`] returns.
+    ///
+    /// One page is one request, so a page can hold fewer children than `limit` asked for and
+    /// still be followed by more: with a delimiter a backend spends its page budget on keys it
+    /// collapses away, and it has a cap of its own besides. Walk until
+    /// [`PaginatedListResult::page_token`] is `None` rather than until a page comes back short.
+    ///
+    /// ```
+    /// # use lance_io::object_store::{ObjectStore, ReadDirOptions};
+    /// # async fn example(store: &ObjectStore) -> lance_core::Result<Vec<String>> {
+    /// let mut tables = Vec::new();
+    /// let mut page_token = None;
+    /// loop {
+    ///     let page = store
+    ///         .read_dir_page("my_db", ReadDirOptions { page_token, limit: Some(10) })
+    ///         .await?;
+    ///     // A table is a directory, so a loose object that happens to be named like one is not
+    ///     // a table.
+    ///     tables.extend(page.result.common_prefixes.iter().filter_map(|table| {
+    ///         Some(table.filename()?.strip_suffix(".lance")?.to_string())
+    ///     }));
+    ///     page_token = page.page_token;
+    ///     if page_token.is_none() || tables.len() >= 10 {
+    ///         break;
+    ///     }
+    /// }
+    /// # Ok(tables)
+    /// # }
+    /// ```
+    pub async fn read_dir_page(
+        &self,
+        dir: impl Into<Path>,
+        options: ReadDirOptions,
+    ) -> Result<PaginatedListResult> {
+        let dir = dir.into();
+        // A page of nothing cannot advance a listing, and the two paths below would disagree
+        // about what it means: the pushdown path would report an empty directory while the
+        // full listing ignored the limit and returned everything.
+        if options.limit == Some(0) {
+            return Err(Error::invalid_input(
+                "read_dir_page limit must be at least 1, got 0",
+            ));
+        }
+        match &self.paginated_lister {
+            Some(lister) => self.pushdown_page(lister.as_ref(), &dir, options).await,
+            // Goes through `inner`, so the wrappers around it instrument the request. The
+            // pushdown path talks to the backend directly and instruments itself.
+            None => full_listing_page(self.inner.as_ref(), &dir, options).await,
+        }
+    }
+
+    /// One page from the backend's own paginated list API.
+    ///
+    /// The pushdown path holds the backend directly, so its request never passes through the
+    /// wrappers around [`Self::inner`] that would otherwise record it, and it records itself.
+    #[instrument(level = "debug", skip_all, fields(dir = %dir))]
+    async fn pushdown_page(
+        &self,
+        lister: &dyn PaginatedListStore,
+        dir: &Path,
+        options: ReadDirOptions,
+    ) -> Result<PaginatedListResult> {
+        let prefix = list_prefix(dir);
+        self.io_tracker.record_read(LIST_OP, dir.clone(), 0, None);
+        #[cfg(feature = "metrics")]
+        let _in_flight = InFlightGuard::new(&self.store_prefix, LIST_OP);
+        #[cfg(feature = "metrics")]
+        let start = Instant::now();
+
+        let page = lister
+            .list_paginated(
+                prefix.as_deref(),
+                PaginatedListOptions {
+                    delimiter: Some(DELIMITER.into()),
+                    max_keys: options.limit,
+                    page_token: options.page_token,
+                    // `offset` is left unset: a continuation token is a position of its own,
+                    // and a caller-supplied key means something different on every store —
+                    // S3 excludes it, Azure includes it.
+                    ..Default::default()
+                },
+            )
+            .await;
+
+        #[cfg(feature = "metrics")]
+        record_outcome(&self.store_prefix, LIST_OP, start, 0, page.is_err());
+        let mut page = page?;
+
+        retain_children(&mut page.result, prefix.as_deref());
+        Ok(page)
+    }
+}
+
+/// The prefix to list under, carrying the trailing delimiter that the paginated API expects.
+/// `None` for the root of the store, which has no prefix at all.
+fn list_prefix(dir: &Path) -> Option<String> {
+    let dir = dir.as_ref();
+    (!dir.is_empty()).then(|| format!("{dir}{DELIMITER}"))
+}
+
+/// One page of a directory on a store with no paginated list API: list the level in full and
+/// page it locally.
+///
+/// The page has to be the smallest `limit` children past the token rather than any `limit` of
+/// them, since the next call lists the same directory again and keeps only what sorts after
+/// the key this page hands back. That means putting the listing in key order, which
+/// `list_with_delimiter` does not promise — a sort over children already in memory, costing no
+/// extra request.
+async fn full_listing_page(
+    store: &dyn OSObjectStore,
+    dir: &Path,
+    options: ReadDirOptions,
+) -> Result<PaginatedListResult> {
+    let listed = store.list_with_delimiter(Some(dir)).await?;
+    let mut children = keyed_children(listed, list_prefix(dir).as_deref());
+    if let Some(resume) = &options.page_token {
+        children.retain(|child| child.key > *resume);
+    }
+    let total = children.len();
+    children.truncate(options.limit.unwrap_or(total).min(total));
+    // The last key this page took, so a page that took nothing ends the listing rather than
+    // resuming from a position no page ever reached.
+    let page_token = match children.last() {
+        Some(last) if children.len() < total => Some(last.key.clone()),
+        _ => None,
+    };
+
+    let mut result = ListResult {
+        common_prefixes: Vec::new(),
+        objects: Vec::new(),
+    };
+    for child in children {
+        match child.child {
+            Child::Directory(location) => result.common_prefixes.push(location),
+            Child::File(meta) => result.objects.push(meta),
+        }
+    }
+    Ok(PaginatedListResult { result, page_token })
+}
+
+/// Drop everything in `listed` that is not a child of the level being listed.
+///
+/// This covers the marker object some stores keep for a directory: it lists as an object whose
+/// location is the directory's own prefix.
+fn retain_children(listed: &mut ListResult, prefix: Option<&str>) {
+    listed
+        .common_prefixes
+        .retain(|location| relative_key(prefix, location).is_some());
+    listed
+        .objects
+        .retain(|object| relative_key(prefix, &object.location).is_some());
+}
+
+/// A child of the directory being listed, with the key the backend listed it under.
+struct KeyedChild {
+    /// The key relative to the directory, which is what a full-listing token names. A child
+    /// directory keeps its trailing delimiter, since that is the prefix its keys share and so
+    /// where it sits in the listing; a child file is its name.
+    key: String,
+    child: Child,
+}
+
+enum Child {
+    Directory(Path),
+    File(ObjectMeta),
+}
+
+/// The children of `prefix` in `listed`, in key order, each with the key it was listed under.
+///
+/// Stores report common prefixes and objects as two separate lists, so the two are put back
+/// into one order here — the order a full-listing token pages through. Anything that is not a
+/// child of this level is dropped, as in [`retain_children`].
+fn keyed_children(listed: ListResult, prefix: Option<&str>) -> Vec<KeyedChild> {
+    let ListResult {
+        common_prefixes,
+        objects,
+    } = listed;
+    let directories = common_prefixes.into_iter().filter_map(|location| {
+        let key = format!("{}{DELIMITER}", relative_key(prefix, &location)?);
+        Some(KeyedChild {
+            key,
+            child: Child::Directory(location),
+        })
+    });
+    let files = objects.into_iter().filter_map(|meta| {
+        let key = relative_key(prefix, &meta.location)?.to_string();
+        Some(KeyedChild {
+            key,
+            child: Child::File(meta),
+        })
+    });
+    let mut children: Vec<KeyedChild> = directories.chain(files).collect();
+    children.sort_unstable_by(|left, right| left.key.cmp(&right.key));
+    children
+}
+
+/// Where a listed location sits inside the directory being listed, which is the space
+/// full-listing tokens live in, or `None` if it is not a child of that directory at all.
+fn relative_key<'a>(prefix: Option<&str>, location: &'a Path) -> Option<&'a str> {
+    let location = location.as_ref();
+    let relative = match prefix {
+        // Both halves of the prefix, so a location that merely starts with the directory's
+        // name — `dbx/y` against `db/` — is reported as not being under it, and so is the
+        // directory's own marker, whose location is `db`.
+        Some(prefix) => location.strip_prefix(prefix)?,
+        None => location,
+    };
+    (!relative.is_empty()).then_some(relative)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{Arc, Mutex};
+
+    use super::*;
+    use crate::object_store::{ObjectStoreParams, ObjectStoreRegistry};
+    use chrono::Utc;
+    use object_store::memory::InMemory;
+    use object_store::{ObjectStoreExt, PutPayload};
+    use rstest::rstest;
+
+    /// How the store under test resolves a listing.
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    enum Backend {
+        /// No paginated API: list the whole directory and page it locally.
+        FullListing,
+        /// A paginated API, as the native S3, GCS and Azure stores have.
+        Pushdown,
+    }
+    use Backend::{FullListing, Pushdown};
+
+    /// One list request, as the backend saw it.
+    #[derive(Debug, Clone)]
+    struct ListRequest {
+        prefix: Option<String>,
+        opts: PaginatedListOptions,
+    }
+
+    /// A stand-in for a store with a paginated list API.
+    ///
+    /// Keys are listed in the order they were given, a delimiter collapses each level, and the
+    /// continuation token is a position in that listing order — which is what a real token is:
+    /// exact, and never compared against a key. `page_bound` is the store's own cap, which is
+    /// why a page can come back holding less than it was asked for.
+    #[derive(Debug)]
+    struct FakeListStore {
+        keys: Vec<String>,
+        page_bound: usize,
+        requests: Arc<Mutex<Vec<ListRequest>>>,
+    }
+
+    #[async_trait::async_trait]
+    impl PaginatedListStore for FakeListStore {
+        async fn list_paginated(
+            &self,
+            prefix: Option<&str>,
+            opts: PaginatedListOptions,
+        ) -> object_store::Result<PaginatedListResult> {
+            self.requests.lock().unwrap().push(ListRequest {
+                prefix: prefix.map(String::from),
+                opts: opts.clone(),
+            });
+            let prefix = prefix.unwrap_or("");
+            let budget = opts
+                .max_keys
+                .unwrap_or(self.page_bound)
+                .min(self.page_bound);
+            let mut result = ListResult {
+                common_prefixes: Vec::new(),
+                objects: Vec::new(),
+            };
+            let mut idx: usize = match &opts.page_token {
+                Some(token) => token.parse().expect("a token this store minted"),
+                None => 0,
+            };
+
+            while idx < self.keys.len() {
+                if result.common_prefixes.len() + result.objects.len() >= budget {
+                    return Ok(PaginatedListResult {
+                        result,
+                        page_token: Some(idx.to_string()),
+                    });
+                }
+                // `Path::parse`, so that a key holding a character `Path::from` would encode
+                // is reported under the name it was stored with. This is what the S3, GCS and
+                // Azure clients do.
+                let key = self.keys[idx].clone();
+                idx += 1;
+                let Some(rest) = key.strip_prefix(prefix) else {
+                    continue;
+                };
+                match rest.find(DELIMITER) {
+                    // A collapsed prefix, and everything behind it: a store reports the child
+                    // directory once and skips the keys it stands for.
+                    Some(end) => {
+                        let child = format!("{prefix}{}", &rest[..=end]);
+                        result.common_prefixes.push(Path::parse(&child).unwrap());
+                        while idx < self.keys.len() && self.keys[idx].starts_with(&child) {
+                            idx += 1;
+                        }
+                    }
+                    None => result.objects.push(ObjectMeta {
+                        location: Path::parse(&key).unwrap(),
+                        last_modified: Utc::now(),
+                        size: 1,
+                        e_tag: None,
+                        version: None,
+                    }),
+                }
+            }
+
+            Ok(PaginatedListResult {
+                result,
+                page_token: None,
+            })
+        }
+    }
+
+    struct TestStore {
+        store: ObjectStore,
+        requests: Arc<Mutex<Vec<ListRequest>>>,
+    }
+
+    impl TestStore {
+        /// Every child of `dir`, taken a page at a time, which is how a caller walks a
+        /// directory: the token ends the walk, never a short page.
+        async fn walk(&self, dir: &str, limit: Option<usize>) -> Result<Vec<String>> {
+            let mut names = Vec::new();
+            let mut page_token = None;
+            for _ in 0..100 {
+                let page = self
+                    .store
+                    .read_dir_page(Path::from(dir), ReadDirOptions { page_token, limit })
+                    .await?;
+                names.extend(page_names(&page));
+                page_token = page.page_token;
+                if page_token.is_none() {
+                    return Ok(names);
+                }
+            }
+            panic!("the walk is not making progress: {names:?}")
+        }
+
+        async fn names(&self, dir: &str, limit: Option<usize>) -> Vec<String> {
+            self.walk(dir, limit).await.unwrap()
+        }
+
+        /// The first page only, as a caller wanting a bounded number of children would take it.
+        async fn first_page(&self, dir: &str, limit: Option<usize>) -> PaginatedListResult {
+            self.store
+                .read_dir_page(
+                    Path::from(dir),
+                    ReadDirOptions {
+                        page_token: None,
+                        limit,
+                    },
+                )
+                .await
+                .unwrap()
+        }
+    }
+
+    /// The names of every child in a page, directories and files alike.
+    fn page_names(page: &PaginatedListResult) -> Vec<String> {
+        page.result
+            .common_prefixes
+            .iter()
+            .chain(page.result.objects.iter().map(|object| &object.location))
+            .map(|location| location.filename().unwrap().to_string())
+            .collect()
+    }
+
+    async fn test_store(backend: Backend, keys: &[&str]) -> TestStore {
+        paged_test_store(backend, keys, usize::MAX).await
+    }
+
+    /// A store over `keys`, listing them in the order given. `page_bound` is the store's own
+    /// cap on a page, which only the pushdown backend has.
+    async fn paged_test_store(backend: Backend, keys: &[&str], page_bound: usize) -> TestStore {
+        let inner = Arc::new(InMemory::new());
+        for key in keys {
+            // `Path::parse`, so that a key holding a character `Path::from` would encode is
+            // stored under the name it was given.
+            inner
+                .put(&Path::parse(key).unwrap(), PutPayload::from_static(b"x"))
+                .await
+                .unwrap();
+        }
+        #[allow(deprecated)]
+        let params = ObjectStoreParams {
+            object_store: Some((inner, url::Url::parse("memory:///").unwrap())),
+            // Set because the deprecated hand-built path assumes nothing about the store it
+            // was given, and set conservatively: nothing on the `read_dir_page` path reads it,
+            // since the fallback sorts what it listed and the pushdown never compares keys.
+            list_is_lexically_ordered: Some(false),
+            ..Default::default()
+        };
+        let (store, _) = ObjectStore::from_uri_and_params(
+            Arc::new(ObjectStoreRegistry::default()),
+            "memory:///",
+            &params,
+        )
+        .await
+        .unwrap();
+        let mut store = Arc::try_unwrap(store).unwrap();
+
+        let requests = Arc::new(Mutex::new(Vec::new()));
+        if backend == Pushdown {
+            store.paginated_lister = Some(Arc::new(FakeListStore {
+                keys: keys.iter().map(|key| key.to_string()).collect(),
+                page_bound,
+                requests: requests.clone(),
+            }));
+        }
+        TestStore { store, requests }
+    }
+
+    const TABLES: &[&str] = &[
+        "db/a.lance/_versions/1.manifest",
+        "db/a.lance/data/1.lance",
+        "db/b.lance/data/1.lance",
+        "db/c.lance/data/1.lance",
+        "db/loose.txt",
+        "other/d.lance/data/1.lance",
+    ];
+
+    /// Walking a directory hands back every child exactly once, however the store resolves the
+    /// listing and however small the pages are. That it holds whatever order the store lists
+    /// in is [`test_an_unordered_store_is_still_paged`].
+    #[rstest]
+    #[case::whole_directory(TABLES, "db", vec!["a.lance", "b.lance", "c.lance", "loose.txt"])]
+    #[case::empty_directory(TABLES, "nonexistent", vec![])]
+    // A directory and the sibling that follows it: `foo/` and `foo0` are adjacent in key order
+    // with nothing between them, so resuming past `foo`'s contents must not swallow `foo0`.
+    #[case::the_sibling_after_a_directory(&["db/foo/inside", "db/foo0"], "db", vec!["foo", "foo0"])]
+    // Siblings where one name is a prefix of another, which is where a page boundary is easiest
+    // to get wrong: `foo/` and `foo-bar/` differ at `/` against `-`.
+    #[case::a_prefix_shaped_sibling(&["db/foo/inside", "db/foo-bar/inside", "db/zzz.txt"], "db", vec!["foo", "foo-bar", "zzz.txt"])]
+    // A store that keeps a marker object for a directory reports the directory itself when
+    // that directory is listed. Dropping the marker must not also drop the progress the page
+    // made, or a page holding nothing but the marker reads as the end of the listing.
+    #[case::a_directory_marker(&["db/marked/", "db/marked/a.txt", "db/marked/b.txt"], "db/marked", vec!["a.txt", "b.txt"])]
+    // A name holding a character `Path::from` would percent-encode is still reported, and
+    // sorted, under the name it was stored with.
+    #[case::an_encodable_name(&["db/az", "db/a~"], "db", vec!["az", "a~"])]
+    #[tokio::test]
+    async fn test_walking_a_directory_is_complete(
+        #[values(FullListing, Pushdown)] backend: Backend,
+        #[values(None, Some(1), Some(2), Some(3))] limit: Option<usize>,
+        #[case] keys: &[&str],
+        #[case] dir: &str,
+        #[case] expected: Vec<&str>,
+    ) {
+        let store = test_store(backend, keys).await;
+
+        // The order children come back in is the store's, so the walk is checked for holding
+        // every child once rather than for holding them in one particular order.
+        let mut listed = store.names(dir, limit).await;
+        let seen = listed.clone();
+        listed.sort();
+        assert_eq!(listed, expected, "from {seen:?}");
+    }
+
+    /// A store that lists in no particular order — S3 Express — is still paged, because a
+    /// continuation token is never compared to anything. This is the case a token spelled as a
+    /// key could not serve.
+    #[tokio::test]
+    async fn test_an_unordered_store_is_still_paged() {
+        let reversed: Vec<&str> = TABLES.iter().rev().copied().collect();
+        let store = test_store(Pushdown, &reversed).await;
+
+        let mut names = store.names("db", Some(1)).await;
+        names.sort();
+
+        assert_eq!(names, vec!["a.lance", "b.lance", "c.lance", "loose.txt"]);
+        assert!(
+            !store.requests.lock().unwrap().is_empty(),
+            "the paginated lister should have been used"
+        );
+    }
+
+    /// The point of the pushdown: a caller that wants one child of a directory makes one
+    /// request, for one child, one level deep. A listing that quietly fell back to reading the
+    /// whole directory would answer the same thing, so what tells the two apart is the request.
+    #[tokio::test]
+    async fn test_a_bounded_page_is_one_request_for_that_page() {
+        let store = test_store(Pushdown, TABLES).await;
+
+        let page = store.first_page("db", Some(1)).await;
+
+        assert_eq!(page_names(&page).len(), 1);
+        assert!(page.page_token.is_some());
+        let requests = store.requests.lock().unwrap();
+        assert_eq!(requests.len(), 1);
+        assert_eq!(requests[0].prefix.as_deref(), Some("db/"));
+        assert_eq!(requests[0].opts.max_keys, Some(1));
+        // Without a delimiter the listing would be recursive rather than one level deep.
+        assert_eq!(requests[0].opts.delimiter.as_deref(), Some(DELIMITER));
+        // A continuation token is a position of its own, so no offset goes with it.
+        assert_eq!(requests[0].opts.offset, None);
+    }
+
+    /// A backend that caps its pages below what was asked for hands back a short page with
+    /// more to come. Only the token ends a walk, so a caller that stopped at a short page
+    /// would report a directory as smaller than it is.
+    #[tokio::test]
+    async fn test_a_short_page_is_not_the_end_of_the_listing() {
+        let store = paged_test_store(Pushdown, TABLES, 1).await;
+
+        let page = store.first_page("db", Some(3)).await;
+
+        assert_eq!(page_names(&page).len(), 1);
+        assert!(
+            page.page_token.is_some(),
+            "the directory holds four children"
+        );
+        assert_eq!(
+            store.names("db", Some(3)).await.len(),
+            4,
+            "the walk should still reach every child"
+        );
+    }
+
+    /// A page of nothing is rejected rather than left to mean whatever the backend makes of it:
+    /// pushing it down reports an empty directory, and a full listing ignores it. The rejection
+    /// comes before the store is consulted, so one backend covers it.
+    #[tokio::test]
+    async fn test_zero_limit_is_rejected() {
+        let store = test_store(Pushdown, TABLES).await;
+
+        let err = store.walk("db", Some(0)).await.unwrap_err();
+
+        assert!(matches!(err, Error::InvalidInput { .. }), "{err:?}");
+        assert!(err.to_string().contains("limit must be at least 1"));
+        assert!(store.requests.lock().unwrap().is_empty());
+    }
+
+    /// Child directories and child objects stay in the two lists a listing reports them in, so
+    /// a caller that wants only one of the two — tables are directories — can take it.
+    #[rstest]
+    #[tokio::test]
+    async fn test_directories_and_files_stay_apart(
+        #[values(FullListing, Pushdown)] backend: Backend,
+    ) {
+        let store = test_store(backend, TABLES).await;
+
+        let page = store.first_page("db", None).await;
+
+        let mut directories: Vec<&str> = page
+            .result
+            .common_prefixes
+            .iter()
+            .map(|location| location.filename().unwrap())
+            .collect();
+        directories.sort();
+        assert_eq!(directories, vec!["a.lance", "b.lance", "c.lance"]);
+        let files: Vec<&str> = page
+            .result
+            .objects
+            .iter()
+            .map(|object| object.location.filename().unwrap())
+            .collect();
+        assert_eq!(files, vec!["loose.txt"]);
+        // The metadata a listing reports for a child object survives the page.
+        assert_eq!(page.result.objects[0].size, 1);
+    }
+
+    /// The pushdown path holds the backend directly, so it has to record its own IO. A listing
+    /// invisible to `io_tracker` would also be invisible to the metrics and tracing layers that
+    /// sit in the same chain.
+    #[rstest]
+    #[tokio::test]
+    async fn test_listing_is_recorded_in_io_stats(
+        #[values(FullListing, Pushdown)] backend: Backend,
+    ) {
+        let store = test_store(backend, TABLES).await;
+        assert_eq!(store.store.io_tracker().stats().read_iops, 0);
+
+        let _ = store.first_page("db", Some(2)).await;
+
+        // The full listing reaches the store through its wrappers, which record it there.
+        assert_eq!(store.store.io_tracker().stats().read_iops, 1);
+    }
+}

--- a/rust/lance-io/src/object_store/throttle.rs
+++ b/rust/lance-io/src/object_store/throttle.rs
@@ -48,6 +48,8 @@ use rand::Rng;
 use tokio::sync::Mutex;
 use tracing::{debug, warn};
 
+use object_store::list::{PaginatedListOptions, PaginatedListResult, PaginatedListStore};
+
 /// Check whether an `object_store::Error` represents a throttle response
 /// (HTTP 429 / 503) from a cloud object store.
 ///
@@ -873,6 +875,68 @@ impl AimdThrottledStore {
             multipart_parts_throttled_at_http,
         }
     }
+
+    /// Put a paginated lister on the same list budget as this store.
+    pub fn wrap_paginated(
+        &self,
+        inner: Arc<dyn PaginatedListStore>,
+    ) -> Arc<dyn PaginatedListStore> {
+        Arc::new(ThrottledListStore {
+            inner,
+            throttle: self.list.clone(),
+        })
+    }
+}
+
+/// A store paired with the paginated lister that shares its rate limits.
+#[cfg(any(feature = "aws", feature = "azure", feature = "gcp"))]
+type StoreWithLister = (Arc<dyn ObjectStore>, Option<Arc<dyn PaginatedListStore>>);
+
+/// Apply AIMD throttling to a store and to the lister that shares its list budget.
+///
+/// [`crate::object_store::ObjectStore::read_dir_page`] goes to the lister rather than
+/// through the store, so both have to be wrapped for list requests to be counted once
+/// against one rate.
+#[cfg(any(feature = "aws", feature = "azure", feature = "gcp"))]
+pub(crate) fn with_throttling(
+    state: Option<AimdThrottleState>,
+    multipart_parts_throttled_at_http: bool,
+    store: Arc<dyn ObjectStore>,
+    lister: Option<Arc<dyn PaginatedListStore>>,
+) -> StoreWithLister {
+    let Some(state) = state else {
+        return (store, lister);
+    };
+    let store = Arc::new(AimdThrottledStore::new_with_state(
+        store,
+        state,
+        multipart_parts_throttled_at_http,
+    ));
+    let lister = lister.map(|lister| store.wrap_paginated(lister));
+    (store, lister)
+}
+
+/// A [`PaginatedListStore`] whose requests draw on a store's list token bucket.
+struct ThrottledListStore {
+    inner: Arc<dyn PaginatedListStore>,
+    throttle: Arc<OperationThrottle>,
+}
+
+// Throttling only adds waiting, so every semantic of the store it wraps has to reach the
+// listing unchanged; the lint keeps a method added to the trait from silently falling back to
+// its default here.
+#[async_trait]
+#[deny(clippy::missing_trait_methods)]
+impl PaginatedListStore for ThrottledListStore {
+    async fn list_paginated(
+        &self,
+        prefix: Option<&str>,
+        opts: PaginatedListOptions,
+    ) -> OSResult<PaginatedListResult> {
+        self.throttle
+            .throttled(|| self.inner.list_paginated(prefix, opts.clone()))
+            .await
+    }
 }
 
 #[async_trait]
@@ -1052,6 +1116,96 @@ mod tests {
             .body(object_store::client::HttpRequestBody::empty())
             .unwrap();
         assert_eq!(is_multipart_part_request(&request), expected);
+    }
+
+    /// One page of a fixed directory, counting the requests that reached it.
+    #[derive(Default)]
+    struct CountingListStore {
+        calls: AtomicUsize,
+        fail_with: Option<String>,
+    }
+
+    #[async_trait]
+    impl PaginatedListStore for CountingListStore {
+        async fn list_paginated(
+            &self,
+            _prefix: Option<&str>,
+            _opts: PaginatedListOptions,
+        ) -> OSResult<PaginatedListResult> {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            match &self.fail_with {
+                Some(message) => Err(make_generic_error(message)),
+                None => Ok(PaginatedListResult {
+                    result: ListResult {
+                        common_prefixes: vec![Path::from("prefix/child")],
+                        objects: Vec::new(),
+                    },
+                    page_token: None,
+                }),
+            }
+        }
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn test_paginated_lister_acquires_a_token_before_listing() {
+        let lister = Arc::new(CountingListStore::default());
+        let throttled = AimdThrottledStore::new(
+            Arc::new(InMemory::new()) as Arc<dyn ObjectStore>,
+            list_start_throttle_config(),
+        )
+        .unwrap();
+        let throttled_lister = throttled.wrap_paginated(lister.clone());
+
+        let mut page = Box::pin(
+            throttled_lister.list_paginated(Some("prefix/"), PaginatedListOptions::default()),
+        );
+        // With rate=10 tokens/s and burst_capacity=0, the token acquisition sleeps for
+        // 100 ms. A 50 ms timeout must expire before that.
+        assert!(
+            tokio::time::timeout(std::time::Duration::from_millis(50), &mut page)
+                .await
+                .is_err()
+        );
+        assert_eq!(lister.calls.load(Ordering::SeqCst), 0);
+
+        let page = tokio::time::timeout(std::time::Duration::from_millis(300), page)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(page.result.common_prefixes.len(), 1);
+        assert_eq!(lister.calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn test_paginated_lister_throttle_errors_decrease_rate() {
+        let lister = Arc::new(CountingListStore {
+            calls: AtomicUsize::new(0),
+            fail_with: Some(THROTTLE_ERROR_RESPONSE.to_string()),
+        });
+        let mut config = AimdThrottleConfig::default().with_list_aimd(
+            AimdConfig::default()
+                .with_initial_rate(100.0)
+                .with_decrease_factor(0.5)
+                .with_window_duration(std::time::Duration::from_millis(1)),
+        );
+        config.max_retries = 1;
+        config.min_backoff_ms = 0;
+        config.max_backoff_ms = 0;
+        let throttled =
+            AimdThrottledStore::new(Arc::new(InMemory::new()) as Arc<dyn ObjectStore>, config)
+                .unwrap();
+        let throttled_lister = throttled.wrap_paginated(lister.clone());
+
+        assert!(
+            throttled_lister
+                .list_paginated(Some("prefix/"), PaginatedListOptions::default())
+                .await
+                .is_err()
+        );
+
+        // The request was retried once, and the throttle response pushed the rate down.
+        assert_eq!(lister.calls.load(Ordering::SeqCst), 2);
+        assert!(throttled.list.controller.current_rate() < 100.0);
     }
 
     #[tokio::test]

--- a/rust/lance-io/src/utils/tracking_store.rs
+++ b/rust/lance-io/src/utils/tracking_store.rs
@@ -30,6 +30,7 @@ use object_store::{
 use crate::object_store::WrappingObjectStore;
 #[cfg(feature = "metrics")]
 use crate::object_store::metrics::{InFlightGuard, record_outcome};
+use object_store::list::PaginatedListStore;
 
 #[derive(Debug, Default, Clone)]
 pub struct IOTracker {
@@ -182,6 +183,16 @@ impl IoMetricsGuard {
 impl WrappingObjectStore for IOTracker {
     fn wrap(&self, _store_prefix: &str, target: Arc<dyn ObjectStore>) -> Arc<dyn ObjectStore> {
         Arc::new(IoTrackingStore::new(target, self.stats.clone()))
+    }
+
+    // A pushed-down listing records itself against the store's tracker, so it is already
+    // counted without passing through here.
+    fn wrap_paginated(
+        &self,
+        _store_prefix: &str,
+        original: Arc<dyn PaginatedListStore>,
+    ) -> Option<Arc<dyn PaginatedListStore>> {
+        Some(original)
     }
 }
 

--- a/rust/lance/src/dataset.rs
+++ b/rust/lance/src/dataset.rs
@@ -2077,8 +2077,7 @@ impl Dataset {
         cloned.base_object_stores = Default::default();
         let mut object_store = self.object_store.as_ref().clone();
         for wrapper in &wrappers {
-            object_store.inner =
-                wrapper.wrap(&object_store.store_prefix, object_store.inner.clone());
+            object_store.apply_wrapper(wrapper.as_ref());
         }
         cloned.object_store = Arc::new(object_store);
         cloned.refs = Refs::new(

--- a/rust/lance/src/dataset/cleanup.rs
+++ b/rust/lance/src/dataset/cleanup.rs
@@ -1679,6 +1679,15 @@ mod tests {
         ) -> Arc<dyn object_store::ObjectStore> {
             Arc::new(ProxyObjectStore::new(original, self.policy.clone()))
         }
+
+        // Injects behaviour into every request, so a listing must not go around it.
+        fn wrap_paginated(
+            &self,
+            _store_prefix: &str,
+            _original: Arc<dyn object_store::list::PaginatedListStore>,
+        ) -> Option<Arc<dyn object_store::list::PaginatedListStore>> {
+            None
+        }
     }
 
     impl MockObjectStore {

--- a/rust/lance/src/dataset/mem_wal/test_util.rs
+++ b/rust/lance/src/dataset/mem_wal/test_util.rs
@@ -89,6 +89,15 @@ impl WrappingObjectStore for FailingWrapper {
             controls: self.controls.clone(),
         })
     }
+
+    // Injects behaviour into every request, so a listing must not go around it.
+    fn wrap_paginated(
+        &self,
+        _store_prefix: &str,
+        _original: Arc<dyn object_store::list::PaginatedListStore>,
+    ) -> Option<Arc<dyn object_store::list::PaginatedListStore>> {
+        None
+    }
 }
 
 /// Delegates everything to `inner`, failing WAL-entry PUTs per [`FailControls`].

--- a/rust/lance/src/dataset/tests/dataset_io.rs
+++ b/rust/lance/src/dataset/tests/dataset_io.rs
@@ -547,6 +547,16 @@ impl WrappingObjectStore for CountingObjectStoreWrapper {
         self.wraps.fetch_add(1, Ordering::Relaxed);
         original
     }
+
+    // Passes requests straight through, so a listing may keep going around it. Only `wrap` is
+    // counted, since the count is what the caching assertions are written against.
+    fn wrap_paginated(
+        &self,
+        _store_prefix: &str,
+        original: Arc<dyn object_store::list::PaginatedListStore>,
+    ) -> Option<Arc<dyn object_store::list::PaginatedListStore>> {
+        Some(original)
+    }
 }
 
 impl CountingObjectStoreWrapper {

--- a/rust/lance/src/io/exec/pushdown_scan.rs
+++ b/rust/lance/src/io/exec/pushdown_scan.rs
@@ -719,6 +719,7 @@ mod test {
     use lance_datagen::{array, gen_batch};
     use lance_file::version::LanceFileVersion;
     use lance_io::object_store::WrappingObjectStore;
+    use object_store::list::PaginatedListStore;
     use object_store::{
         CopyOptions, GetOptions, GetResult, ListResult, MultipartUpload, ObjectMeta, ObjectStore,
         PutMultipartOptions, PutOptions, PutPayload, PutResult, RenameOptions,
@@ -771,6 +772,15 @@ mod test {
                 target,
                 reads: self.reads.clone(),
             })
+        }
+
+        // Only data file reads are blocked, so a listing can keep the pushdown.
+        fn wrap_paginated(
+            &self,
+            _store_prefix: &str,
+            original: Arc<dyn PaginatedListStore>,
+        ) -> Option<Arc<dyn PaginatedListStore>> {
+            Some(original)
         }
     }
 

--- a/rust/lance/src/utils/test/failing_store.rs
+++ b/rust/lance/src/utils/test/failing_store.rs
@@ -105,4 +105,13 @@ impl WrappingObjectStore for FailingProxyStore {
     ) -> Arc<dyn object_store::ObjectStore> {
         Arc::new(ProxyObjectStore::new(original, self.policy.clone()))
     }
+
+    // Injects behaviour into every request, so a listing must not go around it.
+    fn wrap_paginated(
+        &self,
+        _store_prefix: &str,
+        _original: Arc<dyn object_store::list::PaginatedListStore>,
+    ) -> Option<Arc<dyn object_store::list::PaginatedListStore>> {
+        None
+    }
 }

--- a/rust/lance/src/utils/test/throttle_store.rs
+++ b/rust/lance/src/utils/test/throttle_store.rs
@@ -19,4 +19,13 @@ impl WrappingObjectStore for ThrottledStoreWrapper {
         let throttle_store = ThrottledStore::new(original, self.config);
         Arc::new(throttle_store)
     }
+
+    // Injects behaviour into every request, so a listing must not go around it.
+    fn wrap_paginated(
+        &self,
+        _store_prefix: &str,
+        _original: Arc<dyn object_store::list::PaginatedListStore>,
+    ) -> Option<Arc<dyn object_store::list::PaginatedListStore>> {
+        None
+    }
 }


### PR DESCRIPTION
BREAKING CHANGE: `WrappingObjectStore` implementors must add `wrap_paginated`. There is no default, so the compiler points at every one of them.

`ObjectStore::read_dir` enumerates a whole prefix before it returns, so a caller that wants the first few children of a directory pays for all of them. Showing the first page of tables in a namespace costs a listing of every table in it.

This adds `read_dir_page`, which returns one page of the immediate children of a prefix plus an opaque token that resumes after it. Child directories come back as `common_prefixes` and child objects as `objects`, the same split `list_with_delimiter` already returns.

```rust
let page = store
    .read_dir_page("my_db", ReadDirOptions { page_token: None, limit: Some(10) })
    .await?;
```

On S3, GCS and Azure the page size and the resume position are pushed into the list request, so the page costs what the page holds. Every other store lists the level in full and pages locally, which is correct but no cheaper than `read_dir`.

One page is one request, so a page can hold fewer children than `limit` asked for and still be followed by more — with a delimiter a backend can spend its page budget on keys it collapses away. Callers walk until the returned token is `None`, not until a page comes back short.

A page token is whatever the backend handed back, verbatim; on the fallback path it is the last key of the page. Tokens are therefore opaque and scoped to the store and directory that minted them, and one fed elsewhere resumes from the wrong place rather than failing. This is documented on `ReadDirOptions::page_token`.

## The pushdown handle and `wrap_paginated`

`PaginatedListStore` is a separate `object_store` trait from `ObjectStore` and cannot be reached through a `dyn ObjectStore`, so the pushdown handle is a field of its own alongside `inner`. A pushed-down listing consequently does not pass through `WrappingObjectStore::wrap`, and would walk straight past a decorator that hides or rewrites paths.

`WrappingObjectStore` therefore gains `wrap_paginated`, where a wrapper takes the handle and says whether the pushdown survives it: `Some` to keep pushing listings down, `None` to give the pushdown up and have them fall back through the wrapped `inner`. There is deliberately no default implementation — a wrapper that enforces visibility has to make that call explicitly.

## Tests

A fake `PaginatedListStore` covers both paths: walk completeness over four page sizes and six key shapes (adjacent siblings, prefix-shaped names, directory markers, names needing percent-encoding), short pages, unordered stores, request-level pushdown of the page size and delimiter, and the wrapper contract.
