### PR TITLE
fix(index): accumulate k-means centroids in a wider float

### DIFF
--- a/rust/lance-index/src/vector/kmeans.rs
+++ b/rust/lance-index/src/vector/kmeans.rs
@@ -10,7 +10,7 @@
 //!
 
 use core::f32;
-use std::cmp::Ordering;
+use std::cmp::{Ordering, Reverse};
 use std::collections::BinaryHeap;
 use std::ops::{AddAssign, DivAssign};
 use std::sync::Arc;
@@ -32,8 +32,7 @@ use lance_linalg::distance::hamming::{hamming, hamming_distance_batch};
 use lance_linalg::distance::{DistanceType, Normalize, dot_distance_batch};
 use lance_linalg::kernels::{argmin_value_float, argmin_value_float_with_bias};
 use log::{info, warn};
-use num_traits::One;
-use num_traits::{AsPrimitive, Float, FromPrimitive, Num, Zero};
+use num_traits::{AsPrimitive, Float, FromPrimitive, Num, NumCast, ToPrimitive};
 use rand::prelude::*;
 use rayon::prelude::*;
 use {
@@ -191,38 +190,48 @@ fn kmeans_random_init<T: ArrowPrimitiveType>(
     }
 }
 
-/// Split one big cluster into two smaller clusters. After split, each
-/// cluster has approximately half of the vectors.
-fn split_clusters<T: Float + MulAssign>(
-    n: usize,
-    cnts: &mut [usize],
-    centroids: &mut [T],
-    dim: usize,
-) {
+/// Reseed every empty cluster by splitting the largest cluster in two. After a split, each
+/// half holds approximately half of the donor's vectors, and the two centroids are pushed
+/// apart by `eps` so the next assignment step can separate them again.
+///
+/// Donors are taken largest-first, breaking ties on the smaller cluster id, so the result is
+/// reproducible. Splitting stops as soon as no cluster has more than one vector left to
+/// donate: the remaining empty clusters simply stay empty, which the caller already tolerates.
+fn split_clusters<T: Float + MulAssign>(cnts: &mut [usize], centroids: &mut [T], dim: usize) {
     let eps = T::from(1.0 / 1024.0).unwrap();
-    let mut rng = SmallRng::from_os_rng();
-    for i in 0..cnts.len() {
-        if cnts[i] == 0 {
-            let mut j = 0;
-            loop {
-                let p = (cnts[j] as f32 - 1.0) / (n - cnts.len()) as f32;
-                if rng.random::<f32>() < p {
-                    break;
-                }
-                j += 1;
-                j %= cnts.len();
-            }
 
-            cnts[i] = cnts[j] / 2;
-            cnts[j] -= cnts[i];
-            for k in 0..dim {
-                if k % 2 == 0 {
-                    centroids[i * dim + k] = centroids[j * dim + k] * (T::one() + eps);
-                    centroids[j * dim + k] *= T::one() - eps;
-                } else {
-                    centroids[i * dim + k] = centroids[j * dim + k] * (T::one() - eps);
-                    centroids[j * dim + k] *= T::one() + eps;
-                }
+    // Max-heap of (cluster size, cluster id). `Reverse` on the id makes the smaller id win a
+    // tie. Entries are only ever pushed with their current size, so the heap never goes stale.
+    let mut donors = cnts
+        .iter()
+        .enumerate()
+        .filter(|&(_, &cnt)| cnt > 1)
+        .map(|(id, &cnt)| (cnt, Reverse(id)))
+        .collect::<BinaryHeap<_>>();
+
+    for i in 0..cnts.len() {
+        if cnts[i] > 0 {
+            continue;
+        }
+        let Some((donor_size, Reverse(j))) = donors.pop() else {
+            return;
+        };
+
+        cnts[i] = donor_size / 2;
+        cnts[j] = donor_size - cnts[i];
+        for k in 0..dim {
+            if k % 2 == 0 {
+                centroids[i * dim + k] = centroids[j * dim + k] * (T::one() + eps);
+                centroids[j * dim + k] *= T::one() - eps;
+            } else {
+                centroids[i * dim + k] = centroids[j * dim + k] * (T::one() - eps);
+                centroids[j * dim + k] *= T::one() + eps;
+            }
+        }
+
+        for half in [i, j] {
+            if cnts[half] > 1 {
+                donors.push((cnts[half], Reverse(half)));
             }
         }
     }
@@ -324,6 +333,30 @@ pub trait KMeansAlgo<T: Num> {
     ) -> KMeans;
 }
 
+/// Narrow finished centroids from the `f64` accumulator back into the storage type.
+///
+/// The centroid update must not run in the storage type. An `f16` sum saturates at 65504, so a
+/// cluster holding a few hundred vectors of magnitude ~1000 sums to `inf`; an `f16` cluster
+/// size above 65504 saturates as well, turning the division into `inf * 0 = NaN`. Either way
+/// the centroid stops being finite, no vector can be assigned to it, and the model collapses.
+/// `f64` holds every sum an `f16`, `f32` or `f64` cluster can produce.
+fn narrow_centroids<T: ArrowNumericType>(centroids: Vec<f64>) -> Vec<T::Native>
+where
+    T::Native: Float,
+{
+    // `split_clusters` scales a donor centroid by `1 + 1/1024`, which can push a value sitting
+    // at the top of the storage range past its maximum. Clamp so a split never turns a finite
+    // centroid into an infinite one.
+    let max = T::Native::max_value().to_f64().unwrap();
+    centroids
+        .into_iter()
+        .map(|value| {
+            <T::Native as NumCast>::from(value.clamp(-max, max))
+                .expect("a centroid clamped to the storage range is representable")
+        })
+        .collect()
+}
+
 pub struct KMeansAlgoFloat<T: ArrowNumericType>
 where
     T::Native: Float + Num,
@@ -399,7 +432,9 @@ where
         distance_type: DistanceType,
         loss: f64,
     ) -> KMeans {
-        let mut centroids = vec![T::Native::zero(); k * dimension];
+        // Sums, division and the split perturbation all happen in f64; the centroids are
+        // narrowed back to the storage type once, at the end. See [`narrow_centroids`].
+        let mut centroids = vec![0f64; k * dimension];
 
         let mut num_cpus = get_num_compute_intensive_cpus();
         if k < num_cpus || k < 16 {
@@ -424,7 +459,10 @@ where
                             let local_id = cluster_id - start;
                             let centroid =
                                 &mut centroids[local_id * dimension..(local_id + 1) * dimension];
-                            centroid.iter_mut().zip(vector).for_each(|(c, v)| *c += *v);
+                            centroid
+                                .iter_mut()
+                                .zip(vector)
+                                .for_each(|(c, v)| *c += v.to_f64().unwrap());
                         }
                     });
             });
@@ -434,7 +472,7 @@ where
             .zip(cluster_sizes.par_iter())
             .for_each(|(centroid, &cnt)| {
                 if cnt > 0 {
-                    let norm = T::Native::one() / T::Native::from_usize(cnt).unwrap();
+                    let norm = 1.0 / cnt as f64;
                     centroid.iter_mut().for_each(|v| *v *= norm);
                 }
             });
@@ -459,13 +497,9 @@ where
             }
         }
 
-        split_clusters(
-            data.len() / dimension,
-            cluster_sizes,
-            &mut centroids,
-            dimension,
-        );
+        split_clusters(cluster_sizes, &mut centroids, dimension);
 
+        let centroids = narrow_centroids::<T>(centroids);
         KMeans {
             centroids: Arc::new(PrimitiveArray::<T>::from(centroids)),
             dimension,
@@ -775,8 +809,11 @@ impl KMeans {
         // the data is `num_partitions * sample_rate` vectors,
         // but here `k` may be not `num_partitions` in the case of hierarchical kmeans,
         // so we need to sample the sampled data again here.
-        // we have to limit the number of data to avoid division underflow,
-        // the threshold 512 is chosen because the minimal normal f16 value will be 0 if divided by 1024.
+        // the 512 threshold was originally picked to keep f16 centroid updates from
+        // underflowing; that is now handled by [`narrow_centroids`]. What is left is a
+        // bound on training cost, and a crude one: it keeps the leading rows rather than
+        // sampling, so the hierarchical path (which trains with k=hierarchical_k) trains on a
+        // prefix of the data.
         let data = if data.len() >= k * 512 {
             data.slice(0, k * 512)
         } else {
@@ -846,6 +883,26 @@ impl KMeans {
                     Some(&cluster_sizes),
                     index.as_ref(),
                 );
+
+                // A vector is left unassigned when every distance to it is NaN or infinite.
+                // Every empty cluster is reseeded from a cluster with at least two members
+                // (see `split_clusters`), so below `k` assigned vectors the model can no
+                // longer be repaired -- and at that point the input is degenerate rather
+                // than merely hard to cluster.
+                let assigned = membership.iter().filter(|id| id.is_some()).count();
+                if assigned < k {
+                    return Err(ArrowError::InvalidArgumentError(format!(
+                        "KMeans: only {} of {} vectors could be assigned to a centroid, fewer \
+                         than k={}. The {} training data likely contains NaN or infinite \
+                         values, zero-length vectors under a normalizing metric, or values \
+                         large enough that {} distances overflow.",
+                        assigned,
+                        n,
+                        k,
+                        T::DATA_TYPE,
+                        params.distance_type,
+                    )));
+                }
 
                 adjusted_balance_factor =
                     compute_cluster_sizes(&membership, &radius, &losses, &mut cluster_sizes);
@@ -1772,13 +1829,169 @@ mod tests {
         );
     }
 
+    #[test]
+    fn test_split_clusters_reseeds_empty_clusters() {
+        const DIM: usize = 2;
+        let initial_cnts = [0_usize, 0, 8, 4];
+        let initial_centroids = [0.0_f32, 0.0, 0.0, 0.0, 10.0, 10.0, 20.0, 20.0];
+
+        let mut runs = Vec::new();
+        for _ in 0..2 {
+            let mut cnts = initial_cnts;
+            let mut centroids = initial_centroids;
+            split_clusters(&mut cnts, &mut centroids, DIM);
+            runs.push((cnts, centroids));
+        }
+
+        let (cnts, centroids) = runs[0];
+        assert!(
+            cnts.iter().all(|&cnt| cnt > 0),
+            "every cluster should be reseeded: {cnts:?}"
+        );
+        assert_eq!(
+            cnts.iter().sum::<usize>(),
+            initial_cnts.iter().sum::<usize>(),
+            "splitting must preserve the total number of vectors"
+        );
+        assert!(centroids.iter().all(|v| v.is_finite() && *v != 0.0));
+        assert_eq!(runs[0], runs[1], "donor selection must be deterministic");
+    }
+
+    #[test]
+    fn test_split_clusters_stops_when_donors_run_out() {
+        // Three vectors cannot seed five clusters. Splitting must fill what it can and leave
+        // the rest empty rather than looking for a donor that does not exist.
+        const DIM: usize = 2;
+        let mut cnts = [3_usize, 0, 0, 0, 0];
+        let mut centroids = [1.0_f32; 5 * DIM];
+
+        split_clusters(&mut cnts, &mut centroids, DIM);
+
+        assert_eq!(cnts, [1, 1, 1, 0, 0]);
+        assert!(centroids.iter().all(|v| v.is_finite()));
+    }
+
+    #[test]
+    fn test_split_clusters_stops_without_donor() {
+        // Every distance being non-finite leaves all clusters empty. There is nothing to
+        // split, and the old probabilistic donor search spun forever on this input.
+        const DIM: usize = 2;
+        let mut cnts = [0_usize; 4];
+        let mut centroids = [1.0_f32; 4 * DIM];
+
+        split_clusters(&mut cnts, &mut centroids, DIM);
+
+        assert_eq!(cnts, [0; 4]);
+        assert_eq!(centroids, [1.0; 4 * DIM]);
+    }
+
+    #[test]
+    fn test_narrow_centroids_clamps_to_finite() {
+        // `split_clusters` scales a donor centroid by `1 + 1/1024`, so a cluster whose mean
+        // sits at the top of the f16 range would otherwise be narrowed to +/-inf.
+        let over = f16::MAX.to_f64() * (1.0 + 1.0 / 1024.0);
+        assert_eq!(
+            narrow_centroids::<Float16Type>(vec![over, -over]),
+            vec![f16::MAX, f16::MIN]
+        );
+        // A type whose range already covers the accumulator is passed through untouched.
+        assert_eq!(narrow_centroids::<Float32Type>(vec![1.5]), vec![1.5f32]);
+    }
+
+    #[tokio::test]
+    async fn test_train_kmeans_rejects_unassignable_data() {
+        // NaN vectors make every distance non-finite, so argmin assigns nothing. This is not
+        // f16-specific: it reproduces on f32 and used to hang inside `split_clusters`.
+        const DIM: usize = 8;
+        const K: usize = 32;
+        const NUM_VALUES: usize = 8 * K;
+
+        let values = Float32Array::from_iter_values(repeat_n(f32::NAN, NUM_VALUES * DIM));
+        let fsl = FixedSizeListArray::try_new_from_values(values, DIM as i32).unwrap();
+
+        let err = KMeans::new_with_params(&fsl, K, &KMeansParams::default())
+            .expect_err("training on unassignable data should fail instead of hanging");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("could be assigned") && msg.contains(&K.to_string()),
+            "unexpected error message: {msg}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_train_kmeans_f16_large_values() {
+        // Regression test: 1024 vectors over 4 clusters means ~256 vectors per centroid, and
+        // summing 256 values of magnitude ~1000 in f16 saturates at 65504. The infinite
+        // centroids made every L2 distance +inf, which left every cluster empty.
+        const DIM: usize = 16;
+        const K: usize = 4;
+        const NUM_VALUES: usize = 1024;
+        const SCALE: f32 = 1000.0;
+
+        let mut rng = SmallRng::seed_from_u64(42);
+        let values = Float16Array::from_iter_values(
+            repeat_n((), NUM_VALUES * DIM).map(|_| f16::from_f32(rng.random::<f32>() * SCALE)),
+        );
+        let fsl = FixedSizeListArray::try_new_from_values(values, DIM as i32).unwrap();
+
+        let params = KMeansParams {
+            max_iters: 10,
+            ..Default::default()
+        };
+        let kmeans = KMeans::new_with_params(&fsl, K, &params).unwrap();
+
+        assert_eq!(kmeans.centroids.len(), K * DIM);
+        let centroids = kmeans.centroids.as_primitive::<Float16Type>().values();
+        for &value in centroids {
+            let value = value.to_f32();
+            assert!(
+                value.is_finite() && (0.0..=SCALE).contains(&value),
+                "centroid outside the range of the training data: {value}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn test_to_kmeans_f16_cluster_larger_than_f16_max() {
+        // A cluster can hold more vectors than f16 can count: `f16::from_usize(70_000)` is
+        // `inf`, so the old reciprocal was 0 and the centroid was zeroed out (and became NaN
+        // instead when the sum had already saturated to `inf`). PQ codebook training reaches
+        // cluster sizes like this with its default sample rate.
+        const DIM: usize = 2;
+        const K: usize = 2;
+        const BIG_CLUSTER: usize = 70_000;
+
+        let mut values = vec![f16::from_f32(3.0); BIG_CLUSTER * DIM];
+        values.extend(repeat_n(f16::from_f32(7.0), DIM));
+        let mut membership = vec![Some(0_u32); BIG_CLUSTER];
+        membership.push(Some(1));
+        let mut cluster_sizes = vec![BIG_CLUSTER, 1];
+
+        let kmeans = KMeansAlgoFloat::<Float16Type>::to_kmeans(
+            &values,
+            DIM,
+            K,
+            &membership,
+            &mut cluster_sizes,
+            DistanceType::L2,
+            0.0,
+        );
+
+        let centroids = kmeans.centroids.as_primitive::<Float16Type>().values();
+        assert_eq!(
+            centroids,
+            &[f16::from_f32(3.0); DIM]
+                .into_iter()
+                .chain([f16::from_f32(7.0); DIM])
+                .collect::<Vec<_>>()
+        );
+    }
+
     #[tokio::test]
     async fn test_float16_underflow_fix() {
-        // This test verifies the fix for float16 division underflow
-        // When training k-means on many float16 vectors with small k,
-        // without limiting the data size, dividing centroids by count
-        // can underflow to 0,
-        // The fix limits data to k * 512 to prevent this
+        // Training k-means on many float16 vectors with a small k puts a large number of
+        // vectors in every cluster. Dividing the centroid sum by that count used to underflow
+        // to 0 in f16; the centroid update now runs in f64 (see [`narrow_centroids`]).
         const DIM: usize = 2;
         const K: usize = 2;
         const NUM_VALUES: usize = K * 65536; // Many vectors to trigger the issue

--- a/rust/lance/src/index/vector/ivf.rs
+++ b/rust/lance/src/index/vector/ivf.rs
@@ -6328,12 +6328,45 @@ mod tests {
         );
     }
 
+    /// Build a deterministic float16 vector column whose values span `[0, scale)`.
+    fn f16_vectors(num_rows: usize, dim: usize, scale: f32) -> Float16Array {
+        let base = generate_random_array_with_seed::<Float32Type>(num_rows * dim, [22; 32]);
+        Float16Array::from_iter_values(base.values().iter().map(|&v| f16::from_f32(v * scale)))
+    }
+
+    /// Brute-force the `k` nearest row ids for `query` over a flat float16 column.
+    fn f16_ground_truth(
+        values: &Float16Array,
+        query: &Float16Array,
+        dim: usize,
+        k: usize,
+        distance_type: DistanceType,
+    ) -> HashSet<u64> {
+        let values = Float32Array::from_iter_values(values.values().iter().map(|v| v.to_f32()));
+        let fsl = FixedSizeListArray::try_new_from_values(values, dim as i32).unwrap();
+        let query = query.values().iter().map(|v| v.to_f32()).collect_vec();
+        ground_truth(&fsl, &query, k, distance_type)
+            .into_iter()
+            .map(|(_, row)| row as u64)
+            .collect()
+    }
+
+    /// A float16 sum saturates at 65504, so the magnitude of the vectors decides whether the
+    /// k-means centroid update overflows: with 2 partitions each centroid sums ~500 vectors,
+    /// and at `scale = 1000` that sum used to become `inf`, making every L2 distance `+inf`,
+    /// leaving every cluster empty and hanging the build in `split_clusters`.
+    #[rstest]
+    #[case::unit_scale(1.0)]
+    #[case::large_values(1000.0)]
     #[tokio::test]
-    async fn test_create_ivf_flat_f16() {
+    async fn test_create_ivf_flat_f16(#[case] scale: f32) {
         let test_dir = TempStrDir::default();
         let test_uri = test_dir.as_str();
 
         const DIM: usize = 32;
+        const NUM_ROWS: usize = 1000;
+        const NUM_PARTITIONS: usize = 2;
+        const K: usize = 10;
         let schema = Arc::new(Schema::new(vec![Field::new(
             "vector",
             DataType::FixedSizeList(
@@ -6343,23 +6376,27 @@ mod tests {
             true,
         )]));
 
-        let arr = generate_random_array_with_seed::<Float16Type>(1000 * DIM, [22; 32]);
-        let fsl = FixedSizeListArray::try_new_from_values(arr, DIM as i32).unwrap();
+        let arr = f16_vectors(NUM_ROWS, DIM, scale);
+        let fsl = FixedSizeListArray::try_new_from_values(arr.clone(), DIM as i32).unwrap();
         let batch = RecordBatch::try_new(schema.clone(), vec![Arc::new(fsl)]).unwrap();
         let batches = RecordBatchIterator::new(vec![batch].into_iter().map(Ok), schema.clone());
         let mut dataset = Dataset::write(batches, test_uri, None).await.unwrap();
 
-        let params = VectorIndexParams::ivf_flat(2, MetricType::L2);
+        let params = VectorIndexParams::ivf_flat(NUM_PARTITIONS, MetricType::L2);
         dataset
             .create_index(&["vector"], IndexType::Vector, None, &params, false)
             .await
             .unwrap();
 
-        let query = Float16Array::from_iter_values(repeat_n(f16::from_f32(0.5), DIM));
+        // Probing every partition makes the search exhaustive, so the recall check below is an
+        // assertion about the centroids being sane rather than about partitioning quality.
+        let query = Float16Array::from_iter_values(arr.values()[..DIM].iter().copied());
         let results = dataset
             .scan()
-            .nearest("vector", &query, 5)
+            .with_row_id()
+            .nearest("vector", &query, K)
             .unwrap()
+            .minimum_nprobes(NUM_PARTITIONS)
             .try_into_stream()
             .await
             .unwrap()
@@ -6367,13 +6404,174 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(results.len(), 1);
-        assert_eq!(results[0].num_rows(), 5);
+        assert_eq!(results[0].num_rows(), K);
         let schema = results[0].schema();
         let field = schema.field(0);
         let DataType::FixedSizeList(item, _) = field.data_type() else {
             panic!("vector column should remain fixed size list");
         };
         assert_eq!(item.data_type(), &DataType::Float16);
+
+        let dists = results[0]
+            .column_by_name("_distance")
+            .unwrap()
+            .as_primitive::<Float32Type>();
+        assert!(
+            dists.values().iter().all(|d| d.is_finite()),
+            "overflowed centroids leak into the distances: {:?}",
+            dists.values()
+        );
+
+        let row_ids = results[0]
+            .column_by_name(ROW_ID)
+            .unwrap()
+            .as_primitive::<UInt64Type>()
+            .values()
+            .iter()
+            .copied()
+            .collect::<HashSet<_>>();
+        let gt = f16_ground_truth(&arr, &query, DIM, K, DistanceType::L2);
+        let recall = row_ids.intersection(&gt).count() as f32 / K as f32;
+        assert!(recall >= 0.9, "recall: {recall}, scale: {scale}");
+    }
+
+    /// Training rejects data where fewer than `k` vectors can be assigned to a centroid, which
+    /// is safe only because every training entry point filters non-finite rows first (see
+    /// `filter_finite_training_data`). Without that filter the random centroid seeding could
+    /// draw an all-NaN set and fail a build that has plenty of usable vectors, so pin the
+    /// interaction here: a column that is almost entirely NaN still indexes off the rest.
+    #[rstest]
+    #[case::mostly_nan(0.9)]
+    #[case::almost_all_nan(0.99)]
+    #[tokio::test]
+    async fn test_create_ivf_flat_with_nan_rows(#[case] nan_fraction: f64) {
+        const DIM: usize = 16;
+        const NUM_ROWS: usize = 1000;
+        const NUM_PARTITIONS: usize = 4;
+
+        let nan_rows = (NUM_ROWS as f64 * nan_fraction) as usize;
+        let values = (0..NUM_ROWS).flat_map(|row| {
+            (0..DIM).map(move |dim| {
+                if row < nan_rows {
+                    f32::NAN
+                } else {
+                    ((row * DIM + dim) % 97) as f32 / 97.0
+                }
+            })
+        });
+        let arr = FixedSizeListArray::try_new_from_values(
+            Float32Array::from_iter_values(values),
+            DIM as i32,
+        )
+        .unwrap();
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "vector",
+            arr.data_type().clone(),
+            true,
+        )]));
+        let batch = RecordBatch::try_new(schema.clone(), vec![Arc::new(arr)]).unwrap();
+        let batches = RecordBatchIterator::new(vec![batch].into_iter().map(Ok), schema.clone());
+        let test_dir = TempStrDir::default();
+        let mut dataset = Dataset::write(batches, test_dir.as_str(), None)
+            .await
+            .unwrap();
+
+        // Centroid seeding is random, so build repeatedly: a single success proves little.
+        let params = VectorIndexParams::ivf_flat(NUM_PARTITIONS, MetricType::L2);
+        for attempt in 0..5 {
+            dataset
+                .create_index(&["vector"], IndexType::Vector, None, &params, true)
+                .await
+                .unwrap_or_else(|e| {
+                    panic!(
+                        "attempt {attempt} failed with {} of {NUM_ROWS} rows usable: {e}",
+                        NUM_ROWS - nan_rows
+                    )
+                });
+        }
+    }
+
+    /// The `dot` metric skips residuals, so the PQ codebook is trained on the raw vectors and
+    /// hits the same f16 centroid overflow one level below the IVF partitioning.
+    #[tokio::test]
+    async fn test_create_ivf_pq_f16_dot_large_values() {
+        let test_dir = TempStrDir::default();
+        let test_uri = test_dir.as_str();
+
+        const DIM: usize = 32;
+        const NUM_ROWS: usize = 1000;
+        const NUM_PARTITIONS: usize = 2;
+        const K: usize = 10;
+        // With 256 PQ centroids over 1000 rows a sub-quantizer cluster holds ~4 vectors, so
+        // the sub-vector sums overflow f16 once the values reach ~20000.
+        const SCALE: f32 = 40000.0;
+        // 8 sub-vectors, i.e. 4 dimensions each. Quantizing 8 dimensions into one code word
+        // leaves an error comparable to the spread of the dot products being ranked, which
+        // puts recall right at the assertion threshold; 4 dimensions clears it comfortably.
+        const NUM_SUB_VECTORS: usize = 8;
+
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "vector",
+            DataType::FixedSizeList(
+                Arc::new(Field::new("item", DataType::Float16, true)),
+                DIM as i32,
+            ),
+            true,
+        )]));
+
+        let arr = f16_vectors(NUM_ROWS, DIM, SCALE);
+        let fsl = FixedSizeListArray::try_new_from_values(arr.clone(), DIM as i32).unwrap();
+        let batch = RecordBatch::try_new(schema.clone(), vec![Arc::new(fsl)]).unwrap();
+        let batches = RecordBatchIterator::new(vec![batch].into_iter().map(Ok), schema.clone());
+        let mut dataset = Dataset::write(batches, test_uri, None).await.unwrap();
+
+        let params = VectorIndexParams::with_ivf_pq_params(
+            MetricType::Dot,
+            IvfBuildParams::new(NUM_PARTITIONS),
+            PQBuildParams::new(NUM_SUB_VECTORS, 8),
+        );
+        dataset
+            .create_index(&["vector"], IndexType::Vector, None, &params, false)
+            .await
+            .unwrap();
+
+        let query = Float16Array::from_iter_values(arr.values()[..DIM].iter().copied());
+        let results = dataset
+            .scan()
+            .with_row_id()
+            .nearest("vector", &query, K)
+            .unwrap()
+            .minimum_nprobes(NUM_PARTITIONS)
+            .try_into_stream()
+            .await
+            .unwrap()
+            .try_collect::<Vec<_>>()
+            .await
+            .unwrap();
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].num_rows(), K);
+
+        let dists = results[0]
+            .column_by_name("_distance")
+            .unwrap()
+            .as_primitive::<Float32Type>();
+        assert!(
+            dists.values().iter().all(|d| d.is_finite()),
+            "overflowed PQ codebook leaks into the distances: {:?}",
+            dists.values()
+        );
+
+        let row_ids = results[0]
+            .column_by_name(ROW_ID)
+            .unwrap()
+            .as_primitive::<UInt64Type>()
+            .values()
+            .iter()
+            .copied()
+            .collect::<HashSet<_>>();
+        let gt = f16_ground_truth(&arr, &query, DIM, K, DistanceType::Dot);
+        let recall = row_ids.intersection(&gt).count() as f32 / K as f32;
+        assert!(recall >= 0.5, "recall: {recall}");
     }
 
     #[tokio::test]


### PR DESCRIPTION
Fixes #8607.

Building any IVF index over a float16 vector column hangs forever at 100% CPU once a cluster's values sum past the f16 range. The issue has the reproduction and the full chain; the short version is that the centroid update accumulated in the storage type, non-finite centroids made `argmin` assign nothing, and `split_clusters` then spun in an unbounded loop that could never satisfy its exit condition.

## Changes

Three changes, each sufficient on its own to prevent the hang. They are kept together because the first is the root cause and the other two make the failure mode unreachable rather than merely unlikely.

**`to_kmeans` accumulates in `f64`.** Summing, dividing and the split perturbation all happen there, and the centroids are narrowed back to the storage type once, at the end. `f64` holds every sum an f16, f32 or f64 cluster can produce, so this closes the f32 overflow path as well as the f16 one. Narrowing clamps to the storage type's maximum, because the split perturbation scales a centroid by `1 + 1/1024`, which would otherwise round a top-of-range value to `inf`.

**`split_clusters` takes donors largest-first** from a `BinaryHeap` instead of by unbounded probabilistic search, breaking ties on the smaller cluster id, and returns once no cluster has more than one vector to donate. This replaces the direct port of faiss's `Clustering.cpp` donor selection, so donor choice is now deterministic and the routine terminates regardless of its input — it no longer relies on a precondition held by its only caller. The `n` parameter is gone with the probability denominator.

**`train_kmeans` rejects training data where fewer than `k` vectors could be assigned** to any centroid. That threshold is exact rather than conservative: with at least `k` vectors assigned, pigeonhole guarantees that whenever an empty cluster exists some cluster has two or more members and can donate, so `split_clusters` always fills every cluster; below `k`, the old loop was guaranteed to reach a state with an empty cluster and all counts at most one, which is precisely where it hung. Small datasets, heavy duplication and the hierarchical path are unaffected.

Non-finite rows cannot trip it from the index-building path, because every training entry point runs `filter_finite_training_data` first (`ivf.rs`, `builder.rs`), so k-means never sees a NaN or infinite vector and `kmeans_random_init` cannot seed a centroid from one. `test_create_ivf_flat_with_nan_rows` pins that interaction — a column that is 99% NaN still indexes off the remaining rows, repeatedly, since the seeding is random. A caller reaching `KMeans::new_with_params` directly with unfiltered data and drawing an all-non-finite seed set now gets this error where it previously hung.

PQ codebook training reaches the same `to_kmeans`, so `IVF_PQ` with the `dot` metric — which skips residuals and therefore quantizes the raw vectors — was hanging for the same reason and is fixed by the same change.

## Compatibility

No public signature changes. The accumulator is a private helper, the `KMeansAlgo for KMeansAlgoFloat<T>` bound stays at `T: ArrowNumericType`, and the update uses only bounds that implementation already required, so downstream code generic over `T` keeps compiling untouched.

Two behavior changes worth calling out:

- **Donor selection is no longer faiss-compatible.** Reseeding an empty cluster now always splits the current largest cluster rather than sampling one with probability proportional to its size. This is the same heuristic `train_hierarchical_kmeans` already uses, and it is also asymptotically cheaper — the old search made roughly `n / mean_cluster_size` random draws per empty cluster.
- **Some previously-hanging builds now return an error** instead. That is the intended outcome, and the message names the likely causes (non-finite values, zero-length vectors under a normalizing metric, distances that overflow).

f32 centroids shift in the last few bits, since their sums are now exact rather than rounded at every step. Nothing depends on the previous values: `kmeans_random_init` seeds from `SmallRng::from_os_rng()`, so training is already non-deterministic between runs.

## Tests

New in `lance-index`: `split_clusters` filling empty clusters deterministically while preserving the vector count, stopping when donors run out (`[3,0,0,0,0] -> [1,1,1,0,0]`) and when there is no donor at all, the narrowing clamp in both directions, a `to_kmeans` case with a cluster larger than 65504, f16 training at magnitude 1000, and an all-NaN float32 case that must error rather than hang — the last one pins the unbounded loop without involving f16 at all.

`test_create_ivf_flat_f16` is now parameterized over vector magnitude and checks distance finiteness and recall; a new `test_create_ivf_pq_f16_dot_large_values` covers the PQ codebook path. Both hang on the unfixed build and pass in about a second with the fix, verified by running them against a build with only `kmeans.rs` reverted.

The stale comment on the `k * 512` training cap is updated: it existed to keep f16 centroid updates from underflowing, which the accumulator now handles, and what is left is a crude cost bound that keeps a prefix of the data rather than sampling.

`cargo clippy -p lance-index -p lance --tests --benches -- -D warnings` is clean; `cargo test -p lance-index --lib vector::` is 370 passed and `cargo test -p lance --lib index::vector` is 265 passed.

https://claude.ai/code/session_01HkgaggGvsdGuUGgnwEgKke
