### PR TITLE
fix(dataset): isolate wrapped additional base stores

### DIFF
--- a/rust/lance-io/src/object_store.rs
+++ b/rust/lance-io/src/object_store.rs
@@ -498,6 +498,28 @@ impl ObjectStore {
         uri: &str,
         params: &ObjectStoreParams,
     ) -> Result<(Arc<Self>, Path)> {
+        Self::from_uri_and_params_impl(registry, uri, params, true).await
+    }
+
+    /// Parse a URI and build a fresh object store outside the registry cache.
+    ///
+    /// The caller must retain the returned store for as long as its
+    /// provider-local state should be reused.
+    #[doc(hidden)]
+    pub async fn from_uri_and_params_uncached(
+        registry: Arc<ObjectStoreRegistry>,
+        uri: &str,
+        params: &ObjectStoreParams,
+    ) -> Result<(Arc<Self>, Path)> {
+        Self::from_uri_and_params_impl(registry, uri, params, false).await
+    }
+
+    async fn from_uri_and_params_impl(
+        registry: Arc<ObjectStoreRegistry>,
+        uri: &str,
+        params: &ObjectStoreParams,
+        use_registry_cache: bool,
+    ) -> Result<(Arc<Self>, Path)> {
         #[allow(deprecated)]
         if let Some((store, path)) = params.object_store.as_ref() {
             let mut inner = store.clone();
@@ -531,7 +553,11 @@ impl ObjectStore {
         }
         let url = uri_to_url(uri)?;
 
-        let store = registry.get_store(url.clone(), params).await?;
+        let store = if use_registry_cache {
+            registry.get_store(url.clone(), params).await?
+        } else {
+            registry.new_store(url.clone(), params).await?
+        };
         // We know the scheme is valid if we got a store back.
         let provider = registry.get_provider(url.scheme()).expect_ok()?;
         let path = provider.extract_path(&url)?;

--- a/rust/lance-io/src/object_store/providers.rs
+++ b/rust/lance-io/src/object_store/providers.rs
@@ -205,6 +205,57 @@ impl ObjectStoreRegistry {
         Error::invalid_input(message)
     }
 
+    async fn build_store(
+        &self,
+        provider: Arc<dyn ObjectStoreProvider>,
+        base_path: Url,
+        params: &ObjectStoreParams,
+        store_prefix: &str,
+    ) -> Result<Arc<ObjectStore>> {
+        let mut store = provider.new_store(base_path, params).await?;
+
+        store.inner = store.inner.traced();
+
+        // Label metrics by the store's unique prefix (e.g. `s3$bucket`,
+        // `az$container@account`) so multiple stores on one cloud differ.
+        crate::object_store::meter_store(&mut store.inner, &mut store.io_tracker, store_prefix);
+
+        if let Some(wrapper) = &params.object_store_wrapper {
+            store.inner = wrapper.wrap(store_prefix, store.inner);
+        }
+
+        // Always wrap with IO tracking
+        store.inner = store.io_tracker.wrap("", store.inner);
+
+        Ok(Arc::new(store))
+    }
+
+    /// Build a fresh object store without consulting or populating the cache.
+    ///
+    /// Callers should retain the returned [`Arc`] for as long as they want to
+    /// reuse provider-local state such as HTTP clients and rate limiters.
+    #[doc(hidden)]
+    pub async fn new_store(
+        &self,
+        base_path: Url,
+        params: &ObjectStoreParams,
+    ) -> Result<Arc<ObjectStore>> {
+        // Base-scoped storage options (`base_<id>.<key>`) are directives for
+        // other registered base paths; resolve them away before building a
+        // store for this location.
+        let params = params.scoped_to_base(None);
+        let params = params.as_ref();
+        let scheme = base_path.scheme();
+        let Some(provider) = self.get_provider(scheme) else {
+            return Err(self.scheme_not_found_error(scheme));
+        };
+        let store_prefix =
+            provider.calculate_object_store_prefix(&base_path, params.storage_options())?;
+
+        self.build_store(provider, base_path, params, &store_prefix)
+            .await
+    }
+
     /// Get an object store for a given base path and parameters.
     ///
     /// If the object store is already in use, it will return a strong reference
@@ -261,22 +312,9 @@ impl ObjectStoreRegistry {
 
         self.misses.fetch_add(1, Ordering::Relaxed);
 
-        let mut store = provider.new_store(base_path, params).await?;
-
-        store.inner = store.inner.traced();
-
-        // Label metrics by the store's unique prefix (e.g. `s3$bucket`,
-        // `az$container@account`) so multiple stores on one cloud differ.
-        crate::object_store::meter_store(&mut store.inner, &mut store.io_tracker, &cache_path);
-
-        if let Some(wrapper) = &params.object_store_wrapper {
-            store.inner = wrapper.wrap(&cache_path, store.inner);
-        }
-
-        // Always wrap with IO tracking
-        store.inner = store.io_tracker.wrap("", store.inner);
-
-        let store = Arc::new(store);
+        let store = self
+            .build_store(provider, base_path, params, &cache_path)
+            .await?;
 
         {
             // Insert the store into the cache
@@ -516,5 +554,19 @@ mod tests {
 
         // Same params returns same instance
         assert!(Arc::ptr_eq(&stores[0], &stores[1]));
+    }
+
+    #[tokio::test]
+    async fn test_new_store_bypasses_cache() {
+        let registry = ObjectStoreRegistry::default();
+        let url = Url::parse("memory://test").unwrap();
+        let params = ObjectStoreParams::default();
+
+        let first = registry.new_store(url.clone(), &params).await.unwrap();
+        let second = registry.new_store(url, &params).await.unwrap();
+
+        assert!(!Arc::ptr_eq(&first, &second));
+        let stats = registry.stats();
+        assert_eq!((stats.hits, stats.misses, stats.active_stores), (0, 0, 0));
     }
 }

--- a/rust/lance/src/dataset.rs
+++ b/rust/lance/src/dataset.rs
@@ -197,7 +197,8 @@ pub struct Dataset {
     pub(crate) store_params: Option<Box<ObjectStoreParams>>,
     /// Optional runtime-only object store parameters keyed by base path URI.
     pub(crate) base_store_params: Option<Arc<HashMap<String, ObjectStoreParams>>>,
-    /// Object stores for additional base paths, shared across clones.
+    /// Object stores for additional base paths, normally shared across clones.
+    /// Applying new object store wrappers starts a fresh cache scope.
     pub(crate) base_object_stores: BaseObjectStores,
 }
 
@@ -2052,6 +2053,10 @@ impl Dataset {
         }
 
         let mut cloned = self.clone();
+        // Each wrapper application defines a new store lifetime. Keep base
+        // stores alive within the derived dataset without sharing stateful
+        // provider layers (such as an AIMD throttle) with other scopes.
+        cloned.base_object_stores = Default::default();
         let mut object_store = self.object_store.as_ref().clone();
         for wrapper in &wrappers {
             object_store.inner =
@@ -2423,35 +2428,37 @@ impl Dataset {
         let base_path = self.manifest.base_paths.get(&base_id).ok_or_else(|| {
             Error::invalid_input(format!("Dataset base path with ID {} not found", base_id))
         })?;
-        // Cores are cached without wrappers; each resolution decorates the
-        // shared core with the caller's wrapper.
-        let mut core_params = self.store_params_for_base(Some(base_path));
-        let wrapper = core_params.object_store_wrapper.take();
+        let store_params = self.store_params_for_base(Some(base_path));
 
         let cell = {
             let mut stores = self.base_object_stores.lock().unwrap();
             stores.entry(base_id).or_default().clone()
         };
-        let core = cell
+        let store = cell
             .get_or_try_init(|| async {
-                let (store, _) = ObjectStore::from_uri_and_params(
-                    self.session.store_registry(),
-                    &base_path.path,
-                    &core_params,
-                )
-                .await?;
+                // Wrappers define a request or execution scope. Keep the
+                // fully resolved store in this dataset's OnceCell, but do not
+                // also put it in the global registry: provider-local state
+                // such as GCS AIMD token buckets must not cross that scope.
+                let (store, _) = if store_params.object_store_wrapper.is_some() {
+                    ObjectStore::from_uri_and_params_uncached(
+                        self.session.store_registry(),
+                        &base_path.path,
+                        &store_params,
+                    )
+                    .await?
+                } else {
+                    ObjectStore::from_uri_and_params(
+                        self.session.store_registry(),
+                        &base_path.path,
+                        &store_params,
+                    )
+                    .await?
+                };
                 Ok::<_, Error>(store)
             })
             .await?;
-
-        match wrapper {
-            Some(wrapper) => {
-                let mut store = core.as_ref().clone();
-                store.inner = wrapper.wrap(&store.store_prefix, store.inner.clone());
-                Ok(Arc::new(store))
-            }
-            None => Ok(core.clone()),
-        }
+        Ok(store.clone())
     }
 
     /// Resolve the object store for the primary dataset or an additional base.

--- a/rust/lance/src/dataset/tests/dataset_io.rs
+++ b/rust/lance/src/dataset/tests/dataset_io.rs
@@ -2,7 +2,10 @@
 // SPDX-FileCopyrightText: Copyright The Lance Authors
 
 use std::collections::HashMap;
-use std::sync::Arc;
+use std::sync::{
+    Arc,
+    atomic::{AtomicUsize, Ordering},
+};
 use std::vec;
 
 use super::dataset_common::{create_file, require_send};
@@ -530,6 +533,28 @@ fn registry_attempts(dataset: &Dataset) -> u64 {
     stats.hits + stats.misses
 }
 
+#[derive(Debug, Default)]
+struct CountingObjectStoreWrapper {
+    wraps: AtomicUsize,
+}
+
+impl WrappingObjectStore for CountingObjectStoreWrapper {
+    fn wrap(
+        &self,
+        _store_prefix: &str,
+        original: Arc<dyn object_store::ObjectStore>,
+    ) -> Arc<dyn object_store::ObjectStore> {
+        self.wraps.fetch_add(1, Ordering::Relaxed);
+        original
+    }
+}
+
+impl CountingObjectStoreWrapper {
+    fn wraps(&self) -> usize {
+        self.wraps.load(Ordering::Relaxed)
+    }
+}
+
 fn first_base_id(dataset: &Dataset) -> u32 {
     dataset.get_fragments()[0].metadata().files[0]
         .base_id
@@ -655,6 +680,49 @@ async fn test_shallow_clone_reuses_base_object_store() {
         registry_attempts(&fresh) - attempts_before,
         1,
         "concurrent resolutions must resolve the store exactly once"
+    );
+
+    // A caller can derive wrapper-scoped datasets by applying the same shared
+    // wrapper to a cached dataset. Each derived dataset must retain one base
+    // store for its own lifetime without sharing it with another scope.
+    let shared_wrapper = Arc::new(CountingObjectStoreWrapper::default());
+    let scope_a =
+        fresh.with_object_store_wrappers([shared_wrapper.clone() as Arc<dyn WrappingObjectStore>]);
+    let scope_b =
+        fresh.with_object_store_wrappers([shared_wrapper.clone() as Arc<dyn WrappingObjectStore>]);
+    let wraps_before = shared_wrapper.wraps();
+    let attempts_before = registry_attempts(&fresh);
+
+    let scope_a_first = scope_a.object_store(Some(base_id)).await.unwrap();
+    let scope_a_second = scope_a.object_store(Some(base_id)).await.unwrap();
+    assert!(
+        Arc::ptr_eq(&scope_a_first, &scope_a_second),
+        "one wrapper scope must reuse its resolved base store"
+    );
+
+    let scope_b_first = scope_b.object_store(Some(base_id)).await.unwrap();
+    let scope_b_second = scope_b.object_store(Some(base_id)).await.unwrap();
+    assert!(
+        Arc::ptr_eq(&scope_b_first, &scope_b_second),
+        "one wrapper scope must reuse its resolved base store"
+    );
+    assert!(
+        !Arc::ptr_eq(&scope_a_first, &scope_b_first),
+        "separate wrapper scopes must not share a stateful base store"
+    );
+    assert!(
+        !Arc::ptr_eq(&scope_a_first.inner, &scope_b_first.inner),
+        "separate wrapper scopes must not share provider-local layers"
+    );
+    assert_eq!(
+        registry_attempts(&fresh) - attempts_before,
+        0,
+        "wrapper-scoped base stores must bypass the global registry cache"
+    );
+    assert_eq!(
+        shared_wrapper.wraps() - wraps_before,
+        2,
+        "each wrapper scope must build its base store exactly once"
     );
 
     let read = cloned.scan().try_into_batch().await.unwrap();


### PR DESCRIPTION
Follow-up to #8530.

## What is the bug?

Additional-base object stores are cached as wrapper-free cores and shared across `Dataset` clones. Applying a new object-store wrapper decorates that same core instead of giving the derived dataset its own store lifetime.

This also shares provider-local state inside the core. For example, the GCS provider installs an AIMD token bucket below the Lance wrapper layer, so independently wrapped datasets can unexpectedly use the same limiter and wait queue.

The issue is limited to files that resolve through an additional base path (`base_id`), such as shallow-cloned datasets. The primary object-store path is unchanged.

## What issues does this cause?

Concurrent wrapper scopes can interfere through a shared rate limiter. One scope can add waiters or reduce the available rate for another scope even though their Lance wrappers are independent.

Simply assigning a unique registry cache key per wrapper scope is not sufficient: the registry key owns the wrapper `Arc`, so request-unique keys could accumulate. Wrapped stores need a bounded owner outside the global registry.

## How does this PR fix the problem?

- Applying object-store wrappers starts a fresh additional-base store cache scope.
- Wrapped base stores bypass the global `ObjectStoreRegistry` cache and are retained by the derived dataset's per-base `OnceCell`.
- Repeated and concurrent resolutions within one scope still reuse exactly one store, so this does not return to rebuilding a store for every fragment open.
- Unwrapped datasets continue to use the shared registry and retain the caching benefit from #8530.
- Object-store construction is factored so cached and uncached creation use the same tracing, metrics, wrapping, and I/O tracking layers.

## Validation

- `cargo test -p lance-io --lib` (200 passed)
- `cargo test -p lance --lib base_object_store` (4 passed)
- `cargo test -p lance --lib with_object_store_wrappers` (3 passed)
- `cargo test -p lance --lib object_store_uses_runtime_base_store_params` (1 passed)
- `cargo clippy --all --tests --benches -- -D warnings`
- `cargo fmt --all`

The regression test verifies that one wrapper scope reuses its resolved store, separate scopes do not share the store or provider-local layers, and wrapper-scoped stores do not populate the global registry cache.

## Performance

Performance recovery has not yet been measured on this PR head. This change deliberately trades one additional-base store construction per wrapper scope (not per fragment) for isolation of provider-local state. A comparable GCS concurrency canary on a dataset with `base_id` references is still required before claiming a performance improvement.
