### PR TITLE
feat(index): support Hamming distance in streaming coreset k-means

### DIFF
--- a/rust/lance-index/src/vector/kmeans.rs
+++ b/rust/lance-index/src/vector/kmeans.rs
@@ -305,6 +305,14 @@ fn compute_balance_loss(cluster_sizes: &[usize], n: usize, balance_factor: f32) 
     balance_factor * (size_loss - n.pow(2) as f32 / cluster_sizes.len() as f32)
 }
 
+fn kmeans_has_converged(previous_loss: f64, loss: f64, tolerance: f64) -> bool {
+    if loss == 0.0 {
+        previous_loss == 0.0
+    } else {
+        (previous_loss - loss).abs() < tolerance * loss.abs()
+    }
+}
+
 pub trait KMeansAlgo<T: Num> {
     /// Recompute the membership of each vector.
     ///
@@ -336,7 +344,7 @@ pub trait KMeansAlgo<T: Num> {
         );
 
         let k = centroids.len() / dimension;
-        let mut cluster_radius = vec![0.0; k];
+        let mut cluster_radius = vec![f32::NEG_INFINITY; k];
         let mut losses = vec![0.0; k];
         for (cluster_id, dist) in membership.iter().zip(dists.iter()) {
             if let (Some(cluster_id), Some(dist)) = (cluster_id, dist) {
@@ -345,6 +353,11 @@ pub trait KMeansAlgo<T: Num> {
                 losses[cluster_id] += *dist as f64;
             }
         }
+        cluster_radius.iter_mut().for_each(|radius| {
+            if *radius == f32::NEG_INFINITY {
+                *radius = 0.0;
+            }
+        });
 
         (membership, cluster_radius, losses)
     }
@@ -881,7 +894,7 @@ impl KMeans {
     ) -> arrow::error::Result<KMeansMembershipAndLoss> {
         let (membership, distances) = self.compute_membership_and_distances(data)?;
         let k = self.centroids.len() / self.dimension;
-        let mut cluster_radius: Vec<f32> = vec![0.0_f32; k];
+        let mut cluster_radius = vec![f32::NEG_INFINITY; k];
         let mut losses = vec![0.0; k];
         for (cluster_id, dist) in membership.iter().zip(distances.iter()) {
             if let (Some(cluster_id), Some(dist)) = (cluster_id, dist) {
@@ -890,6 +903,11 @@ impl KMeans {
                 losses[cluster_id] += *dist as f64;
             }
         }
+        cluster_radius.iter_mut().for_each(|radius| {
+            if *radius == f32::NEG_INFINITY {
+                *radius = 0.0;
+            }
+        });
         Ok((membership, cluster_radius, losses))
     }
 
@@ -1080,15 +1098,15 @@ impl KMeans {
                     params.distance_type,
                     last_loss,
                 );
-                if (loss - last_loss).abs() < params.tolerance * last_loss {
+                let relative_loss_diff = if last_loss == 0.0 {
+                    if loss == 0.0 { 0.0 } else { f64::INFINITY }
+                } else {
+                    (loss - last_loss).abs() / last_loss.abs()
+                };
+                if kmeans_has_converged(loss, last_loss, params.tolerance) {
                     info!(
                         "KMeans training: converged at iteration {} / {}, redo={}, loss={}, last_loss={}, loss_diff={}",
-                        i,
-                        params.max_iters,
-                        redo,
-                        loss,
-                        last_loss,
-                        (loss - last_loss).abs() / last_loss
+                        i, params.max_iters, redo, loss, last_loss, relative_loss_diff
                     );
                     break;
                 }
@@ -2077,6 +2095,64 @@ mod tests {
         membership.iter().for_each(|cd| {
             assert!(cd.is_some());
         });
+    }
+
+    #[test]
+    fn test_dot_membership_preserves_negative_distances_and_radius() {
+        let centroids = Float32Array::from(vec![2.0, 1.0]);
+        let kmeans = KMeans::with_centroids(Arc::new(centroids), 1, DistanceType::Dot, f64::MAX);
+        let data =
+            FixedSizeListArray::try_new_from_values(Float32Array::from(vec![2.0, 3.0]), 1).unwrap();
+
+        let (membership, radii, losses) = kmeans.compute_membership_and_loss(&data).unwrap();
+
+        assert_eq!(membership, vec![Some(0), Some(0)]);
+        assert_eq!(radii, vec![-3.0, 0.0]);
+        assert_eq!(losses, vec![-8.0, 0.0]);
+    }
+
+    #[test]
+    fn test_l2_membership_preserves_positive_radii() {
+        let centroids = Float32Array::from(vec![0.0, 10.0]);
+        let kmeans = KMeans::with_centroids(Arc::new(centroids), 1, DistanceType::L2, f64::MAX);
+        let data = FixedSizeListArray::try_new_from_values(Float32Array::from(vec![1.0, 12.0]), 1)
+            .unwrap();
+
+        let (membership, radii, losses) = kmeans.compute_membership_and_loss(&data).unwrap();
+
+        assert_eq!(membership, vec![Some(0), Some(1)]);
+        assert_eq!(radii, vec![1.0, 4.0]);
+        assert_eq!(losses, vec![1.0, 4.0]);
+    }
+
+    #[test]
+    fn test_convergence_scale_is_sign_independent() {
+        assert!(kmeans_has_converged(-10.0, -10.0005, 1e-4));
+        assert!(kmeans_has_converged(10.0, 10.0005, 1e-4));
+        assert!(!kmeans_has_converged(-10.0, -10.01, 1e-4));
+        assert!(!kmeans_has_converged(10.0, 10.01, 1e-4));
+        assert!(kmeans_has_converged(0.0, 0.0, 1e-4));
+        assert!(!kmeans_has_converged(1.0, 0.0, 1e-4));
+    }
+
+    #[test]
+    fn scaled_l2_does_not_stop_early() {
+        let scale = 1e-5_f32;
+        let data = FixedSizeListArray::try_new_from_values(
+            Float32Array::from_iter_values((0..=100).map(|value| value as f32 * scale)),
+            1,
+        )
+        .unwrap();
+        let initial =
+            FixedSizeListArray::try_new_from_values(Float32Array::from(vec![0.0, scale]), 1)
+                .unwrap();
+        let params = KMeansParams::new(Some(Arc::new(initial)), 50, 1, DistanceType::L2);
+
+        let model = KMeans::new_with_params(&data, 2, &params).unwrap();
+        let centroids = model.centroids.as_primitive::<Float32Type>().values();
+
+        assert!((centroids[0] - 24.5 * scale).abs() < 1e-7, "{centroids:?}");
+        assert!((centroids[1] - 75.0 * scale).abs() < 1e-7, "{centroids:?}");
     }
 
     #[tokio::test]

--- a/rust/lance-index/src/vector/kmeans.rs
+++ b/rust/lance-index/src/vector/kmeans.rs
@@ -1098,12 +1098,14 @@ impl KMeans {
                     params.distance_type,
                     last_loss,
                 );
-                let relative_loss_diff = if last_loss == 0.0 {
-                    if loss == 0.0 { 0.0 } else { f64::INFINITY }
-                } else {
-                    (loss - last_loss).abs() / last_loss.abs()
-                };
+                // Keep `last_loss` as the scale reference to preserve the legacy
+                // convergence threshold.
                 if kmeans_has_converged(loss, last_loss, params.tolerance) {
+                    let relative_loss_diff = if last_loss == 0.0 {
+                        if loss == 0.0 { 0.0 } else { f64::INFINITY }
+                    } else {
+                        (loss - last_loss).abs() / last_loss.abs()
+                    };
                     info!(
                         "KMeans training: converged at iteration {} / {}, redo={}, loss={}, last_loss={}, loss_diff={}",
                         i, params.max_iters, redo, loss, last_loss, relative_loss_diff

--- a/rust/lance/Cargo.toml
+++ b/rust/lance/Cargo.toml
@@ -327,5 +327,9 @@ harness = false
 name = "hamming"
 harness = false
 
+[[bench]]
+name = "hamming_ivf_training"
+harness = false
+
 [lints]
 workspace = true

--- a/rust/lance/benches/hamming_ivf_training.rs
+++ b/rust/lance/benches/hamming_ivf_training.rs
@@ -1,0 +1,398 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+//! One-shot benchmark for batch and streaming Hamming IVF training.
+//!
+//! The benchmark intentionally runs one operation per process so `/usr/bin/time -v`
+//! can measure peak RSS without Criterion or dataset generation in the process.
+
+#![allow(clippy::print_stdout)]
+#![recursion_limit = "256"]
+
+use std::error::Error;
+use std::fs;
+use std::path::Path;
+use std::sync::Arc;
+use std::time::Instant;
+
+use arrow_array::cast::AsArray;
+use arrow_array::types::UInt8Type;
+use arrow_array::{Array, FixedSizeListArray, RecordBatch, RecordBatchIterator, UInt8Array};
+use arrow_schema::{ArrowError, DataType, Field, FieldRef, Schema};
+use lance::Dataset;
+use lance::dataset::WriteParams;
+use lance::index::vector::ivf::build_ivf_model;
+use lance_arrow::FixedSizeListArrayExt;
+use lance_index::progress::noop_progress;
+use lance_index::vector::ivf::IvfBuildParams;
+use lance_linalg::distance::MetricType;
+use lance_linalg::distance::hamming::hamming;
+use rand::rngs::SmallRng;
+use rand::{Rng, SeedableRng};
+use rayon::prelude::*;
+
+const DEFAULT_DIMENSION_BITS: usize = 256;
+const SAMPLE_RATE: usize = 256;
+const STREAMING_SAMPLE_RATE: usize = 64;
+const STREAMING_CORESET_RATE: usize = 16;
+const BATCH_ROWS: usize = 65_536;
+const MAX_ROWS_PER_FILE: usize = 10_000_000;
+
+fn dimension_bytes(dimension_bits: usize) -> Result<usize, Box<dyn Error>> {
+    if dimension_bits == 0 || !dimension_bits.is_multiple_of(8) {
+        return Err(format!(
+            "dimension_bits must be a positive multiple of 8, got {dimension_bits}"
+        )
+        .into());
+    }
+    let dimension_bytes = dimension_bits / 8;
+    if i32::try_from(dimension_bytes).is_err() {
+        return Err(
+            format!("dimension_bits is too large for FixedSizeList: {dimension_bits}").into(),
+        );
+    }
+    Ok(dimension_bytes)
+}
+
+fn schema(dimension_bytes: usize) -> Arc<Schema> {
+    Arc::new(Schema::new(vec![Field::new(
+        "vector",
+        DataType::FixedSizeList(
+            FieldRef::new(Field::new("item", DataType::UInt8, true)),
+            dimension_bytes as i32,
+        ),
+        false,
+    )]))
+}
+
+fn validate_dataset_dimension(
+    dataset: &Dataset,
+    expected_dimension_bytes: usize,
+) -> Result<(), Box<dyn Error>> {
+    let field = dataset
+        .schema()
+        .field("vector")
+        .ok_or("dataset does not contain a vector column")?;
+    match field.data_type() {
+        DataType::FixedSizeList(item, dimension)
+            if item.data_type() == &DataType::UInt8
+                && usize::try_from(dimension) == Ok(expected_dimension_bytes) =>
+        {
+            Ok(())
+        }
+        data_type => Err(format!(
+            "vector column must be FixedSizeList<UInt8, {expected_dimension_bytes}>, got {data_type}"
+        )
+        .into()),
+    }
+}
+
+fn generate_batch(
+    prototypes: &[u8],
+    num_prototypes: usize,
+    dimension_bytes: usize,
+    flip_probability: f64,
+    num_rows: usize,
+    rng: &mut SmallRng,
+    schema: &Arc<Schema>,
+) -> Result<RecordBatch, ArrowError> {
+    let value_capacity = num_rows.checked_mul(dimension_bytes).ok_or_else(|| {
+        ArrowError::InvalidArgumentError(format!(
+            "num_rows * dimension_bytes overflow: {num_rows} * {dimension_bytes}"
+        ))
+    })?;
+    let mut values = Vec::with_capacity(value_capacity);
+    for _ in 0..num_rows {
+        let prototype = rng.random_range(0..num_prototypes);
+        let start = prototype * dimension_bytes;
+        for &prototype_byte in &prototypes[start..start + dimension_bytes] {
+            let mut flip_mask = 0_u8;
+            for bit in 0..8 {
+                if rng.random_bool(flip_probability) {
+                    flip_mask |= 1 << bit;
+                }
+            }
+            values.push(prototype_byte ^ flip_mask);
+        }
+    }
+    let vectors =
+        FixedSizeListArray::try_new_from_values(UInt8Array::from(values), dimension_bytes as i32)?;
+    RecordBatch::try_new(schema.clone(), vec![Arc::new(vectors)])
+}
+
+async fn generate_dataset(
+    uri: &str,
+    num_rows: usize,
+    num_prototypes: usize,
+    flip_probability: f64,
+    seed: u64,
+    dimension_bytes: usize,
+) -> Result<(), Box<dyn Error>> {
+    if Path::new(uri).exists() {
+        return Err(format!("dataset path already exists: {uri}").into());
+    }
+    if num_rows == 0 {
+        return Err("num_rows must be greater than zero".into());
+    }
+    if num_prototypes == 0 {
+        return Err("num_prototypes must be greater than zero".into());
+    }
+    if !(0.0..=1.0).contains(&flip_probability) || !flip_probability.is_finite() {
+        return Err(format!(
+            "flip_probability must be finite and in [0, 1], got {flip_probability}"
+        )
+        .into());
+    }
+
+    let prototype_values = num_prototypes.checked_mul(dimension_bytes).ok_or_else(|| {
+        format!("num_prototypes * dimension_bytes overflow: {num_prototypes} * {dimension_bytes}")
+    })?;
+    let mut rng = SmallRng::seed_from_u64(seed);
+    let prototypes = (0..prototype_values)
+        .map(|_| rng.random::<u8>())
+        .collect::<Vec<_>>();
+    let schema = schema(dimension_bytes);
+    let batch_schema = schema.clone();
+    let mut remaining_rows = num_rows;
+    let batches = std::iter::from_fn(move || {
+        if remaining_rows == 0 {
+            return None;
+        }
+        let rows = remaining_rows.min(BATCH_ROWS);
+        remaining_rows -= rows;
+        Some(generate_batch(
+            &prototypes,
+            num_prototypes,
+            dimension_bytes,
+            flip_probability,
+            rows,
+            &mut rng,
+            &batch_schema,
+        ))
+    });
+
+    let reader = RecordBatchIterator::new(batches, schema);
+    let dataset = Dataset::write(
+        reader,
+        uri,
+        Some(WriteParams {
+            max_rows_per_file: num_rows.min(MAX_ROWS_PER_FILE),
+            max_rows_per_group: BATCH_ROWS,
+            ..Default::default()
+        }),
+    )
+    .await?;
+    let written_rows = dataset.count_rows(None).await?;
+    if written_rows != num_rows {
+        return Err(format!(
+            "generated row count mismatch: expected {num_rows}, got {written_rows}"
+        )
+        .into());
+    }
+    println!(
+        "generated uri={uri} rows={num_rows} dimension_bytes={dimension_bytes} prototypes={num_prototypes} flip_probability={flip_probability} seed={seed}"
+    );
+    Ok(())
+}
+
+async fn train(
+    uri: &str,
+    mode: &str,
+    num_partitions: usize,
+    refine_passes: usize,
+    centroids_path: &str,
+    dimension_bytes: usize,
+) -> Result<(), Box<dyn Error>> {
+    if num_partitions == 0 {
+        return Err("num_partitions must be greater than zero".into());
+    }
+    let dataset = Dataset::open(uri).await?;
+    validate_dataset_dimension(&dataset, dimension_bytes)?;
+    let mut params = IvfBuildParams::new(num_partitions);
+    params.sample_rate = SAMPLE_RATE;
+    if mode == "stream" {
+        params.streaming_sample_rate = Some(STREAMING_SAMPLE_RATE);
+        params.streaming_coreset_rate = Some(STREAMING_CORESET_RATE);
+        params.streaming_refine_passes = refine_passes;
+    } else if mode != "batch" {
+        return Err(format!("unknown training mode: {mode}").into());
+    } else if refine_passes != 0 {
+        return Err("batch mode does not support streaming refinement passes".into());
+    }
+
+    let start = Instant::now();
+    let model = build_ivf_model(
+        &dataset,
+        "vector",
+        dimension_bytes,
+        MetricType::Hamming,
+        &params,
+        None,
+        noop_progress(),
+    )
+    .await?;
+    let train_seconds = start.elapsed().as_secs_f64();
+    let centroids = model
+        .centroids_array()
+        .ok_or("trained IVF model has no centroids")?;
+    let values = centroids.values().as_primitive::<UInt8Type>();
+    fs::write(centroids_path, values.values())?;
+    println!(
+        "mode={mode} k={num_partitions} refine_passes={refine_passes} status=ok train_seconds={train_seconds:.6} centroids={} dimension_bytes={}",
+        centroids.len(),
+        centroids.value_length()
+    );
+    Ok(())
+}
+
+async fn exact_loss(
+    uri: &str,
+    num_partitions: usize,
+    evaluation_rows: usize,
+    centroids_path: &str,
+    dimension_bytes: usize,
+) -> Result<(), Box<dyn Error>> {
+    if num_partitions == 0 {
+        return Err("num_partitions must be greater than zero".into());
+    }
+    if evaluation_rows == 0 {
+        return Err("evaluation_rows must be greater than zero".into());
+    }
+    let dataset = Dataset::open(uri).await?;
+    validate_dataset_dimension(&dataset, dimension_bytes)?;
+    let mut scanner = dataset.scan();
+    scanner.project(&["vector"])?;
+    scanner.limit(Some(i64::try_from(evaluation_rows)?), None)?;
+    let batch = scanner.try_into_batch().await?;
+    let vectors = batch["vector"].as_fixed_size_list();
+    let vector_values = vectors.values().as_primitive::<UInt8Type>();
+    let centroids = fs::read(centroids_path)?;
+    let expected_centroid_bytes = num_partitions.checked_mul(dimension_bytes).ok_or_else(|| {
+        format!("num_partitions * dimension_bytes overflow: {num_partitions} * {dimension_bytes}")
+    })?;
+    if centroids.len() != expected_centroid_bytes {
+        return Err(format!(
+            "centroid file has {} bytes, expected {}",
+            centroids.len(),
+            expected_centroid_bytes
+        )
+        .into());
+    }
+
+    let start = Instant::now();
+    let loss = vector_values
+        .values()
+        .par_chunks_exact(dimension_bytes)
+        .map(|vector| {
+            centroids
+                .chunks_exact(dimension_bytes)
+                .fold(u64::MAX, |nearest, centroid| {
+                    nearest.min(hamming(vector, centroid) as u64)
+                })
+        })
+        .sum::<u64>();
+    println!(
+        "status=ok k={num_partitions} rows={} exact_loss={loss} mean_loss={:.6} eval_seconds={:.6}",
+        vectors.len(),
+        loss as f64 / vectors.len() as f64,
+        start.elapsed().as_secs_f64()
+    );
+    Ok(())
+}
+
+fn usage() -> &'static str {
+    "usage: hamming_ivf_training generate <dataset> <rows> <prototypes> <flip_probability> <seed> [dimension_bits] | train <dataset> <stream|batch> <k> <refine_passes> <centroids> [dimension_bits] | loss <dataset> <k> <evaluation_rows> <centroids> [dimension_bits]"
+}
+
+fn main() -> Result<(), Box<dyn Error>> {
+    let args = std::env::args().collect::<Vec<_>>();
+    let runtime = tokio::runtime::Runtime::new()?;
+    let default_dimension_bytes = dimension_bytes(DEFAULT_DIMENSION_BITS)?;
+    match args.as_slice() {
+        [_, command, uri, rows, prototypes, flip_probability, seed] if command == "generate" => {
+            runtime.block_on(generate_dataset(
+                uri,
+                rows.parse()?,
+                prototypes.parse()?,
+                flip_probability.parse()?,
+                seed.parse()?,
+                default_dimension_bytes,
+            ))
+        }
+        [
+            _,
+            command,
+            uri,
+            rows,
+            prototypes,
+            flip_probability,
+            seed,
+            dimension_bits,
+        ] if command == "generate" => runtime.block_on(generate_dataset(
+            uri,
+            rows.parse()?,
+            prototypes.parse()?,
+            flip_probability.parse()?,
+            seed.parse()?,
+            dimension_bytes(dimension_bits.parse()?)?,
+        )),
+        [
+            _,
+            command,
+            uri,
+            mode,
+            num_partitions,
+            refine_passes,
+            centroids,
+        ] if command == "train" => runtime.block_on(train(
+            uri,
+            mode,
+            num_partitions.parse()?,
+            refine_passes.parse()?,
+            centroids,
+            default_dimension_bytes,
+        )),
+        [
+            _,
+            command,
+            uri,
+            mode,
+            num_partitions,
+            refine_passes,
+            centroids,
+            dimension_bits,
+        ] if command == "train" => runtime.block_on(train(
+            uri,
+            mode,
+            num_partitions.parse()?,
+            refine_passes.parse()?,
+            centroids,
+            dimension_bytes(dimension_bits.parse()?)?,
+        )),
+        [_, command, uri, num_partitions, evaluation_rows, centroids] if command == "loss" => {
+            runtime.block_on(exact_loss(
+                uri,
+                num_partitions.parse()?,
+                evaluation_rows.parse()?,
+                centroids,
+                default_dimension_bytes,
+            ))
+        }
+        [
+            _,
+            command,
+            uri,
+            num_partitions,
+            evaluation_rows,
+            centroids,
+            dimension_bits,
+        ] if command == "loss" => runtime.block_on(exact_loss(
+            uri,
+            num_partitions.parse()?,
+            evaluation_rows.parse()?,
+            centroids,
+            dimension_bytes(dimension_bits.parse()?)?,
+        )),
+        _ => Err(usage().into()),
+    }
+}

--- a/rust/lance/benches/streaming_ivf_training.rs
+++ b/rust/lance/benches/streaming_ivf_training.rs
@@ -82,28 +82,30 @@ fn bench_streaming_ivf_training(c: &mut Criterion) {
     params.streaming_sample_rate = Some(STREAMING_SAMPLE_RATE);
     params.max_iters = MAX_ITERS;
 
-    c.bench_function(
-        &format!(
-            "streaming_ivf_training_{}d_{}p_sample_{}_stream_{}",
-            DIM, NUM_PARTITIONS, SAMPLE_RATE, STREAMING_SAMPLE_RATE
-        ),
-        |b| {
-            b.to_async(&rt).iter(|| async {
-                let ivf_model = build_ivf_model(
-                    &dataset,
-                    "vector",
-                    DIM,
-                    MetricType::L2,
-                    &params,
-                    None,
-                    noop_progress(),
-                )
-                .await
-                .unwrap();
-                black_box(ivf_model.num_partitions());
-            });
-        },
-    );
+    for metric_type in [MetricType::L2, MetricType::Dot] {
+        c.bench_function(
+            &format!(
+                "streaming_ivf_training_{}_{}d_{}p_sample_{}_stream_{}",
+                metric_type, DIM, NUM_PARTITIONS, SAMPLE_RATE, STREAMING_SAMPLE_RATE
+            ),
+            |b| {
+                b.to_async(&rt).iter(|| async {
+                    let ivf_model = build_ivf_model(
+                        &dataset,
+                        "vector",
+                        DIM,
+                        metric_type,
+                        &params,
+                        None,
+                        noop_progress(),
+                    )
+                    .await
+                    .unwrap();
+                    black_box(ivf_model.num_partitions());
+                });
+            },
+        );
+    }
 }
 
 criterion_group!(

--- a/rust/lance/src/index/vector/ivf.rs
+++ b/rust/lance/src/index/vector/ivf.rs
@@ -3520,12 +3520,219 @@ impl<'a> FixedIvfTrainingSampler<'a> {
 
 type KMeansProgressCallback = Arc<dyn Fn(u32, u32) + Send + Sync>;
 
+/// Metric-specific behavior for floating-point streaming coreset training.
+///
+/// Cosine input is normalized by the sampler and therefore uses the L2 policy.
+trait StreamingKMeansMetricPolicy: Send + Sync {
+    fn metric_type(&self) -> MetricType;
+
+    fn validate_sample_metric(&self, metric_type: MetricType) -> Result<()> {
+        if metric_type == self.metric_type() {
+            Ok(())
+        } else {
+            Err(Error::invalid_input(format!(
+                "streaming sampler returned metric {}, expected {}",
+                metric_type,
+                self.metric_type()
+            )))
+        }
+    }
+
+    fn disable_local_hierarchical(&self) -> bool {
+        false
+    }
+
+    fn local_coreset_k(
+        &self,
+        num_partitions: usize,
+        num_rows: usize,
+        coreset_rate: usize,
+        total_steps: usize,
+        has_decoupled_budget: bool,
+    ) -> usize {
+        streaming_local_coreset_k(
+            num_partitions,
+            num_rows,
+            coreset_rate,
+            total_steps,
+            has_decoupled_budget,
+        )
+    }
+
+    fn local_summary_loss(&self, distance: f32) -> f64;
+
+    fn merge_residual(&self, vector: &[f32], centroid: &[f32]) -> f64;
+
+    fn split_priority(
+        &self,
+        data_values: &[f32],
+        weights: &[f64],
+        indices: &[usize],
+        centroid: &[f32],
+        dimension: usize,
+        loss: f64,
+    ) -> f64;
+
+    fn has_converged(&self, previous_loss: f64, loss: f64) -> bool {
+        if loss == 0.0 {
+            previous_loss == 0.0
+        } else {
+            (previous_loss - loss).abs() < 1e-4 * loss.abs()
+        }
+    }
+
+    fn initialize_centroids(
+        &self,
+        data_values: &[f32],
+        dimension: usize,
+        k: usize,
+        n: usize,
+        weights: &[f64],
+    ) -> Vec<f32> {
+        initialize_weighted_centroids(data_values, dimension, k, n, weights)
+    }
+}
+
+struct L2MetricPolicy;
+
+impl StreamingKMeansMetricPolicy for L2MetricPolicy {
+    fn metric_type(&self) -> MetricType {
+        DistanceType::L2
+    }
+
+    fn local_summary_loss(&self, distance: f32) -> f64 {
+        distance as f64
+    }
+
+    fn merge_residual(&self, vector: &[f32], centroid: &[f32]) -> f64 {
+        squared_l2(vector, centroid)
+    }
+
+    fn split_priority(
+        &self,
+        _data_values: &[f32],
+        _weights: &[f64],
+        _indices: &[usize],
+        _centroid: &[f32],
+        _dimension: usize,
+        loss: f64,
+    ) -> f64 {
+        loss
+    }
+}
+
+struct DotMetricPolicy;
+
+impl StreamingKMeansMetricPolicy for DotMetricPolicy {
+    fn metric_type(&self) -> MetricType {
+        DistanceType::Dot
+    }
+
+    fn disable_local_hierarchical(&self) -> bool {
+        true
+    }
+
+    fn local_coreset_k(
+        &self,
+        num_partitions: usize,
+        num_rows: usize,
+        coreset_rate: usize,
+        total_steps: usize,
+        has_decoupled_budget: bool,
+    ) -> usize {
+        let local_k = streaming_local_coreset_k(
+            num_partitions,
+            num_rows,
+            coreset_rate,
+            total_steps,
+            has_decoupled_budget,
+        );
+        // Dot summaries merge without residual loss, so distribute the final
+        // representative count across chunks. This also keeps flat local
+        // k-means below the number of rows.
+        local_k
+            .min(num_partitions.div_ceil(total_steps.max(1)))
+            .min(num_rows.saturating_sub(1))
+    }
+
+    fn local_summary_loss(&self, _distance: f32) -> f64 {
+        0.0
+    }
+
+    fn merge_residual(&self, _vector: &[f32], _centroid: &[f32]) -> f64 {
+        0.0
+    }
+
+    fn split_priority(
+        &self,
+        data_values: &[f32],
+        weights: &[f64],
+        indices: &[usize],
+        centroid: &[f32],
+        dimension: usize,
+        _loss: f64,
+    ) -> f64 {
+        indices
+            .iter()
+            .map(|&idx| {
+                let vector = &data_values[idx * dimension..(idx + 1) * dimension];
+                weights[idx] * squared_l2(vector, centroid)
+            })
+            .sum()
+    }
+}
+
+static L2_METRIC_POLICY: L2MetricPolicy = L2MetricPolicy;
+static DOT_METRIC_POLICY: DotMetricPolicy = DotMetricPolicy;
+
+fn streaming_kmeans_metric_policy(
+    metric_type: MetricType,
+) -> Result<&'static dyn StreamingKMeansMetricPolicy> {
+    match metric_type {
+        DistanceType::L2 | DistanceType::Cosine => Ok(&L2_METRIC_POLICY),
+        DistanceType::Dot => Ok(&DOT_METRIC_POLICY),
+        _ => Err(Error::invalid_input(format!(
+            "streaming coreset IVF supports L2, Cosine, and Dot training, got {}",
+            metric_type
+        ))),
+    }
+}
+
+fn squared_l2(left: &[f32], right: &[f32]) -> f64 {
+    left.iter()
+        .zip(right)
+        .map(|(left, right)| {
+            let diff = left - right;
+            diff * diff
+        })
+        .sum::<f32>() as f64
+}
+
+fn validate_finite_kmeans_distance(
+    distance: f32,
+    row_idx: usize,
+    metric_type: MetricType,
+    operation: &str,
+) -> Result<()> {
+    if distance.is_finite() {
+        Ok(())
+    } else {
+        Err(Error::invalid_input(format!(
+            "{operation} produced a nonfinite distance at row {row_idx} \
+            for metric {metric_type}. Input vector magnitudes may exceed \
+            the numeric range used during streaming k-means training. \
+            Consider uniformly scaling the vectors to smaller magnitudes."
+        )))
+    }
+}
+
 struct KMeansStepOptions {
     dimension: usize,
     metric_type: MetricType,
     num_partitions: usize,
     sample_rate: usize,
     max_iters: usize,
+    disable_hierarchical: bool,
     on_progress: KMeansProgressCallback,
 }
 
@@ -3543,10 +3750,9 @@ where
         KMeansParams::new(centroids, options.max_iters as u32, 1, options.metric_type)
             .with_balance_factor(1.0)
             .with_on_progress(options.on_progress.clone());
-    if has_centroids {
-        // Incremental refinement already has the full centroid set.  The
-        // hierarchical trainer bootstraps a smaller tree and is only suitable
-        // for the initial training pass.
+    if has_centroids || options.disable_hierarchical {
+        // Incremental refinement already has the full centroid set. Streaming
+        // metric policy can also require flat local training.
         kmeans_params = kmeans_params.with_hierarchical_k(1);
     }
     lance_index::vector::kmeans::train_kmeans::<T>(
@@ -3561,37 +3767,24 @@ where
 fn train_ivf_kmeans_step_arrow_array_no_loss(
     centroids: Option<Arc<FixedSizeListArray>>,
     data: &FixedSizeListArray,
-    metric_type: MetricType,
-    num_partitions: usize,
-    sample_rate: usize,
-    max_iters: usize,
-    on_progress: Arc<dyn Fn(u32, u32) + Send + Sync>,
+    options: KMeansStepOptions,
 ) -> Result<KMeans> {
-    let dimension = data.value_length() as usize;
     let values = data.values();
-    let step_options = KMeansStepOptions {
-        dimension,
-        metric_type,
-        num_partitions,
-        sample_rate,
-        max_iters,
-        on_progress,
-    };
-    let kmeans = match (values.data_type(), metric_type) {
+    let kmeans = match (values.data_type(), options.metric_type) {
         (DataType::Float16, _) => train_ivf_kmeans_step::<Float16Type>(
             centroids,
             values.as_primitive::<Float16Type>(),
-            &step_options,
+            &options,
         )?,
         (DataType::Float32, _) => train_ivf_kmeans_step::<Float32Type>(
             centroids,
             values.as_primitive::<Float32Type>(),
-            &step_options,
+            &options,
         )?,
         (DataType::Float64, _) => train_ivf_kmeans_step::<Float64Type>(
             centroids,
             values.as_primitive::<Float64Type>(),
-            &step_options,
+            &options,
         )?,
         (DataType::Int8, DistanceType::L2)
         | (DataType::Int8, DistanceType::Dot)
@@ -3600,18 +3793,18 @@ fn train_ivf_kmeans_step_arrow_array_no_loss(
             train_ivf_kmeans_step::<Float32Type>(
                 centroids,
                 data.values().as_primitive::<Float32Type>(),
-                &step_options,
+                &options,
             )?
         }
         (DataType::UInt8, DistanceType::Hamming) => train_ivf_kmeans_step::<UInt8Type>(
             centroids,
             values.as_primitive::<UInt8Type>(),
-            &step_options,
+            &options,
         )?,
         _ => Err(Error::index(format!(
             "KMeans: can not train data type {} with distance type: {}",
             values.data_type(),
-            metric_type
+            options.metric_type
         )))?,
     };
     Ok(kmeans)
@@ -3620,6 +3813,7 @@ fn train_ivf_kmeans_step_arrow_array_no_loss(
 fn accumulate_refine_assignments(
     data: &FixedSizeListArray,
     centroids: &FixedSizeListArray,
+    metric_policy: &dyn StreamingKMeansMetricPolicy,
     cluster_sums: &mut [f32],
     cluster_weights: &mut [f64],
 ) -> Result<f64> {
@@ -3627,7 +3821,7 @@ fn accumulate_refine_assignments(
     let kmeans = KMeans::with_centroids(
         centroids.values().clone(),
         dimension,
-        DistanceType::L2,
+        metric_policy.metric_type(),
         f64::MAX,
     );
     let (membership, distances) = kmeans.compute_membership_and_distances(data)?;
@@ -3638,6 +3832,12 @@ fn accumulate_refine_assignments(
         let (Some(cluster_id), Some(distance)) = (membership[row_idx], distances[row_idx]) else {
             continue;
         };
+        validate_finite_kmeans_distance(
+            distance,
+            row_idx,
+            metric_policy.metric_type(),
+            "streaming kmeans refinement",
+        )?;
         let cluster_id = cluster_id as usize;
         cluster_weights[cluster_id] += 1.0;
         loss += distance as f64;
@@ -3685,6 +3885,7 @@ async fn refine_streaming_f32_kmeans_with_sampler(
     passes: usize,
     on_progress: Arc<dyn Fn(u32, u32) + Send + Sync>,
 ) -> Result<FixedSizeListArray> {
+    let metric_policy = streaming_kmeans_metric_policy(metric_type)?;
     let dimension = initial_centroids.value_length() as usize;
     let mut centroids = initial_centroids.clone();
     for pass in 1..=passes {
@@ -3701,15 +3902,11 @@ async fn refine_streaming_f32_kmeans_with_sampler(
             } else {
                 training_data.convert_to_floating_point()?
             };
-            if mt != DistanceType::L2 {
-                return Err(Error::invalid_input(format!(
-                    "streaming IVF refinement currently supports L2/Cosine training, got {}",
-                    metric_type
-                )));
-            }
+            metric_policy.validate_sample_metric(mt)?;
             loss += accumulate_refine_assignments(
                 &training_data,
                 &centroids,
+                metric_policy,
                 &mut cluster_sums,
                 &mut cluster_weights,
             )?;
@@ -3740,6 +3937,7 @@ async fn refine_streaming_f32_kmeans_with_resampling(
     passes: usize,
     on_progress: Arc<dyn Fn(u32, u32) + Send + Sync>,
 ) -> Result<FixedSizeListArray> {
+    let metric_policy = streaming_kmeans_metric_policy(metric_type)?;
     let dimension = initial_centroids.value_length() as usize;
     let mut centroids = initial_centroids.clone();
     for pass in 1..=passes {
@@ -3763,15 +3961,11 @@ async fn refine_streaming_f32_kmeans_with_resampling(
             } else {
                 training_data.convert_to_floating_point()?
             };
-            if mt != DistanceType::L2 {
-                return Err(Error::invalid_input(format!(
-                    "streaming IVF refinement currently supports L2/Cosine training, got {}",
-                    metric_type
-                )));
-            }
+            metric_policy.validate_sample_metric(mt)?;
             loss += accumulate_refine_assignments(
                 &training_data,
                 &centroids,
+                metric_policy,
                 &mut cluster_sums,
                 &mut cluster_weights,
             )?;
@@ -3839,14 +4033,19 @@ impl WeightedCoreset {
         ))
     }
 
-    fn reduce_to_budget(&mut self, dimension: usize, budget: usize) {
+    fn reduce_to_budget(
+        &mut self,
+        dimension: usize,
+        budget: usize,
+        metric_policy: &dyn StreamingKMeansMetricPolicy,
+    ) -> Result<()> {
         if self.len() <= budget {
-            return;
+            return Ok(());
         }
         let total_weight = self.weights.iter().sum::<f64>();
         if total_weight <= 0.0 {
             *self = Self::new(dimension, budget);
-            return;
+            return Ok(());
         }
 
         let mut weighted_sums = vec![0.0_f64; dimension];
@@ -3911,28 +4110,32 @@ impl WeightedCoreset {
                     *value /= weight_sum as f32;
                 }
             }
+            if reduced.values[centroid_start..centroid_start + dimension]
+                .iter()
+                .any(|value| !value.is_finite())
+            {
+                return Err(Error::invalid_input(format!(
+                    "streaming coreset reduction produced nonfinite centroid for metric {}",
+                    metric_policy.metric_type()
+                )));
+            }
 
             let mut loss = 0.0;
             let centroid = &reduced.values[centroid_start..centroid_start + dimension];
             for &idx in &indices[group_start..group_end] {
                 let vector = &self.values[idx * dimension..(idx + 1) * dimension];
-                let dist = vector
-                    .iter()
-                    .zip(centroid)
-                    .map(|(left, right)| {
-                        let diff = left - right;
-                        diff * diff
-                    })
-                    .sum::<f32>() as f64;
-                loss += self.losses[idx] + self.weights[idx] * dist;
+                let merge_residual = metric_policy.merge_residual(vector, centroid);
+                loss += self.losses[idx] + self.weights[idx] * merge_residual;
             }
             reduced.weights.push(weight_sum);
             reduced.losses.push(loss);
         }
         *self = reduced;
+        Ok(())
     }
 }
 
+#[derive(Debug)]
 struct WeightedKMeansResult {
     centroids: Vec<f32>,
     membership: Vec<Option<u32>>,
@@ -3978,14 +4181,7 @@ fn initialize_weighted_centroids(
                 continue;
             }
             let vector = &data_values[row_idx * dimension..(row_idx + 1) * dimension];
-            let distance = vector
-                .iter()
-                .zip(last_centroid)
-                .map(|(left, right)| {
-                    let diff = left - right;
-                    diff * diff
-                })
-                .sum::<f32>() as f64;
+            let distance = squared_l2(vector, last_centroid);
             min_distances[row_idx] = min_distances[row_idx].min(distance);
         }
 
@@ -4032,12 +4228,13 @@ fn assign_weighted_f32_points(
     weights: &[f64],
     base_losses: &[f64],
     centroid_values: &[f32],
-    metric_type: MetricType,
+    metric_policy: &dyn StreamingKMeansMetricPolicy,
 ) -> Result<WeightedKMeansResult> {
     let dimension = data.value_length() as usize;
     let k = centroid_values.len() / dimension;
     let centroids = Arc::new(Float32Array::from(centroid_values.to_vec())) as ArrayRef;
-    let kmeans = KMeans::with_centroids(centroids, dimension, metric_type, f64::MAX);
+    let kmeans =
+        KMeans::with_centroids(centroids, dimension, metric_policy.metric_type(), f64::MAX);
     let (membership, distances) = kmeans.compute_membership_and_distances(data)?;
     let data_values = data.values().as_primitive::<Float32Type>().values();
     let mut centroid_sums = vec![0.0_f32; k * dimension];
@@ -4051,6 +4248,12 @@ fn assign_weighted_f32_points(
         let Some(distance) = distances[row_idx] else {
             continue;
         };
+        validate_finite_kmeans_distance(
+            distance,
+            row_idx,
+            metric_policy.metric_type(),
+            "weighted kmeans",
+        )?;
         let cluster_id = cluster_id as usize;
         let weight = weights[row_idx];
         cluster_weights[cluster_id] += weight;
@@ -4077,6 +4280,12 @@ fn assign_weighted_f32_points(
             );
         }
     }
+    if next_centroids.iter().any(|value| !value.is_finite()) {
+        return Err(Error::invalid_input(format!(
+            "weighted kmeans produced nonfinite centroid for metric {}",
+            metric_policy.metric_type()
+        )));
+    }
 
     let loss = cluster_losses.iter().sum();
     Ok(WeightedKMeansResult {
@@ -4093,7 +4302,7 @@ fn train_weighted_f32_kmeans(
     weights: &[f64],
     base_losses: &[f64],
     k: usize,
-    metric_type: MetricType,
+    metric_policy: &dyn StreamingKMeansMetricPolicy,
     max_iters: usize,
     on_progress: Arc<dyn Fn(u32, u32) + Send + Sync>,
 ) -> Result<WeightedKMeansResult> {
@@ -4115,14 +4324,14 @@ fn train_weighted_f32_kmeans(
     let dimension = data.value_length() as usize;
     let data_values = data.values().as_primitive::<Float32Type>().values();
     let mut centroids =
-        initialize_weighted_centroids(data_values, dimension, k, data.len(), weights);
+        metric_policy.initialize_centroids(data_values, dimension, k, data.len(), weights);
     let mut previous_loss = f64::MAX;
     let max_iters = max_iters.max(1);
     for iter in 1..=max_iters {
         on_progress(iter as u32, max_iters as u32);
         let mut result =
-            assign_weighted_f32_points(data, weights, base_losses, &centroids, metric_type)?;
-        let converged = (previous_loss - result.loss).abs() < 1e-4 * result.loss.max(1.0);
+            assign_weighted_f32_points(data, weights, base_losses, &centroids, metric_policy)?;
+        let converged = metric_policy.has_converged(previous_loss, result.loss);
         previous_loss = result.loss;
         if converged || iter == max_iters {
             return Ok(result);
@@ -4137,7 +4346,7 @@ fn refine_weighted_f32_kmeans(
     weights: &[f64],
     base_losses: &[f64],
     initial_centroids: &FixedSizeListArray,
-    metric_type: MetricType,
+    metric_policy: &dyn StreamingKMeansMetricPolicy,
     max_iters: usize,
     on_progress: Arc<dyn Fn(u32, u32) + Send + Sync>,
 ) -> Result<WeightedKMeansResult> {
@@ -4151,8 +4360,8 @@ fn refine_weighted_f32_kmeans(
     for iter in 1..=max_iters {
         on_progress(iter as u32, max_iters as u32);
         let mut result =
-            assign_weighted_f32_points(data, weights, base_losses, &centroids, metric_type)?;
-        let converged = (previous_loss - result.loss).abs() < 1e-4 * result.loss.max(1.0);
+            assign_weighted_f32_points(data, weights, base_losses, &centroids, metric_policy)?;
+        let converged = metric_policy.has_converged(previous_loss, result.loss);
         previous_loss = result.loss;
         if converged || iter == max_iters {
             return Ok(result);
@@ -4165,7 +4374,7 @@ fn refine_weighted_f32_kmeans(
 fn append_local_coreset(
     coreset: &mut WeightedCoreset,
     data: &FixedSizeListArray,
-    metric_type: MetricType,
+    metric_policy: &dyn StreamingKMeansMetricPolicy,
     local_k: usize,
     max_iters: usize,
     on_progress: Arc<dyn Fn(u32, u32) + Send + Sync>,
@@ -4175,24 +4384,50 @@ fn append_local_coreset(
     let kmeans = train_ivf_kmeans_step_arrow_array_no_loss(
         None,
         data,
-        metric_type,
-        local_k,
-        sample_rate,
-        max_iters,
-        on_progress,
+        KMeansStepOptions {
+            dimension,
+            metric_type: metric_policy.metric_type(),
+            num_partitions: local_k,
+            sample_rate,
+            max_iters,
+            disable_hierarchical: metric_policy.disable_local_hierarchical(),
+            on_progress,
+        },
     )?;
     let centroids = FixedSizeListArray::try_new_from_values(kmeans.centroids, dimension as i32)?;
-    let kmeans =
-        KMeans::with_centroids(centroids.values().clone(), dimension, metric_type, f64::MAX);
+    if centroids
+        .values()
+        .as_primitive::<Float32Type>()
+        .values()
+        .iter()
+        .any(|value| !value.is_finite())
+    {
+        return Err(Error::invalid_input(format!(
+            "local streaming kmeans produced nonfinite centroid for metric {}",
+            metric_policy.metric_type()
+        )));
+    }
+    let kmeans = KMeans::with_centroids(
+        centroids.values().clone(),
+        dimension,
+        metric_policy.metric_type(),
+        f64::MAX,
+    );
     let (membership, distances) = kmeans.compute_membership_and_distances(data)?;
     let mut weights = vec![0.0; centroids.len()];
     let mut losses = vec![0.0; centroids.len()];
-    for (member, distance) in membership.into_iter().zip(distances) {
+    for (row_idx, (member, distance)) in membership.into_iter().zip(distances).enumerate() {
         let (Some(member), Some(distance)) = (member, distance) else {
             continue;
         };
+        validate_finite_kmeans_distance(
+            distance,
+            row_idx,
+            metric_policy.metric_type(),
+            "local streaming kmeans",
+        )?;
         weights[member as usize] += 1.0;
-        losses[member as usize] += distance as f64;
+        losses[member as usize] += metric_policy.local_summary_loss(distance);
     }
 
     let centroid_values = centroids.values().as_primitive::<Float32Type>().values();
@@ -4212,7 +4447,7 @@ struct WeightedCluster {
     indices: Vec<usize>,
     centroid: Vec<f32>,
     weight: f64,
-    loss: f64,
+    split_priority: f64,
     finalized: bool,
 }
 
@@ -4220,7 +4455,9 @@ impl Eq for WeightedCluster {}
 
 impl PartialEq for WeightedCluster {
     fn eq(&self, other: &Self) -> bool {
-        self.loss == other.loss && self.weight == other.weight
+        self.finalized == other.finalized
+            && self.split_priority == other.split_priority
+            && self.weight == other.weight
     }
 }
 
@@ -4230,8 +4467,8 @@ impl Ord for WeightedCluster {
             (false, true) => std::cmp::Ordering::Greater,
             (true, false) => std::cmp::Ordering::Less,
             _ => self
-                .loss
-                .partial_cmp(&other.loss)
+                .split_priority
+                .partial_cmp(&other.split_priority)
                 .unwrap_or(std::cmp::Ordering::Equal)
                 .then_with(|| {
                     self.weight
@@ -4248,10 +4485,10 @@ impl PartialOrd for WeightedCluster {
     }
 }
 
-struct WeightedHierarchicalKMeansParams {
+struct WeightedHierarchicalKMeansParams<'a> {
     dimension: usize,
     target_k: usize,
-    metric_type: MetricType,
+    metric_policy: &'a dyn StreamingKMeansMetricPolicy,
     max_iters: usize,
     on_progress: Arc<dyn Fn(u32, u32) + Send + Sync>,
 }
@@ -4282,7 +4519,7 @@ fn train_weighted_hierarchical_f32_kmeans(
     data: &FixedSizeListArray,
     weights: &[f64],
     losses: &[f64],
-    params: &WeightedHierarchicalKMeansParams,
+    params: &WeightedHierarchicalKMeansParams<'_>,
 ) -> Result<FixedSizeListArray> {
     if data.len() == 0 {
         return Err(Error::index("empty weighted coreset"));
@@ -4298,7 +4535,7 @@ fn train_weighted_hierarchical_f32_kmeans(
 
     let dimension = params.dimension;
     let target_k = params.target_k;
-    let metric_type = params.metric_type;
+    let metric_policy = params.metric_policy;
     let max_iters = params.max_iters;
     let initial_k = 16_usize.min(target_k).min(data.len()).max(1);
     let initial = train_weighted_f32_kmeans(
@@ -4306,12 +4543,13 @@ fn train_weighted_hierarchical_f32_kmeans(
         weights,
         losses,
         initial_k,
-        metric_type,
+        metric_policy,
         max_iters,
         params.on_progress.clone(),
     )?;
 
     let centroids = initial.centroids;
+    let data_values = data.values().as_primitive::<Float32Type>().values();
     let mut heap = std::collections::BinaryHeap::new();
     let mut next_cluster_id = 0;
     for cluster_id in 0..initial_k {
@@ -4322,19 +4560,27 @@ fn train_weighted_hierarchical_f32_kmeans(
             }
         }
         if !indices.is_empty() {
+            let centroid = centroids[cluster_id * dimension..(cluster_id + 1) * dimension].to_vec();
+            let split_priority = metric_policy.split_priority(
+                data_values,
+                weights,
+                &indices,
+                &centroid,
+                dimension,
+                initial.cluster_losses[cluster_id],
+            );
             heap.push(WeightedCluster {
                 id: next_cluster_id,
                 indices,
-                centroid: centroids[cluster_id * dimension..(cluster_id + 1) * dimension].to_vec(),
+                centroid,
                 weight: initial.cluster_weights[cluster_id],
-                loss: initial.cluster_losses[cluster_id],
+                split_priority,
                 finalized: false,
             });
             next_cluster_id += 1;
         }
     }
 
-    let data_values = data.values().as_primitive::<Float32Type>().values();
     while heap.len() < target_k {
         let mut cluster = heap
             .pop()
@@ -4358,7 +4604,7 @@ fn train_weighted_hierarchical_f32_kmeans(
             &sub_weights,
             &sub_losses,
             cluster_k,
-            metric_type,
+            metric_policy,
             max_iters.min(20),
             params.on_progress.clone(),
         )?;
@@ -4387,13 +4633,22 @@ fn train_weighted_hierarchical_f32_kmeans(
             if child_indices.is_empty() {
                 continue;
             }
+            let centroid =
+                split.centroids[child_id * dimension..(child_id + 1) * dimension].to_vec();
+            let split_priority = metric_policy.split_priority(
+                data_values,
+                weights,
+                &child_indices,
+                &centroid,
+                dimension,
+                split.cluster_losses[child_id],
+            );
             heap.push(WeightedCluster {
                 id: next_cluster_id,
                 indices: child_indices,
-                centroid: split.centroids[child_id * dimension..(child_id + 1) * dimension]
-                    .to_vec(),
+                centroid,
                 weight: split.cluster_weights[child_id],
-                loss: split.cluster_losses[child_id],
+                split_priority,
                 finalized: false,
             });
             next_cluster_id += 1;
@@ -4466,6 +4721,7 @@ async fn train_streaming_coreset_ivf_model(
     fragment_ids: Option<&[u32]>,
     progress: std::sync::Arc<dyn lance_index::progress::IndexBuildProgress>,
 ) -> Result<IvfModel> {
+    let metric_policy = streaming_kmeans_metric_policy(metric_type)?;
     let num_partitions = params.num_partitions.unwrap_or(32);
     let streaming_sample_rate = params.streaming_sample_rate.unwrap();
     let total_sample_rate = params.sample_rate;
@@ -4557,12 +4813,7 @@ async fn train_streaming_coreset_ivf_model(
             } else {
                 training_data.convert_to_floating_point()?
             };
-            if mt != DistanceType::L2 {
-                return Err(Error::invalid_input(format!(
-                    "streaming coreset IVF currently supports L2/Cosine training, got {}",
-                    metric_type
-                )));
-            }
+            metric_policy.validate_sample_metric(mt)?;
             if training_data.len() < num_partitions {
                 return Err(Error::index(format!(
                     "Not enough training vectors for streaming coreset IVF. Requires at least {} rows but sampled {} rows",
@@ -4573,7 +4824,7 @@ async fn train_streaming_coreset_ivf_model(
 
             max_training_vectors = max_training_vectors.max(training_data.len());
             total_training_vectors += training_data.len();
-            let local_k = streaming_local_coreset_k(
+            let local_k = metric_policy.local_coreset_k(
                 num_partitions,
                 training_data.len(),
                 coreset_rate,
@@ -4584,13 +4835,13 @@ async fn train_streaming_coreset_ivf_model(
             append_local_coreset(
                 &mut chunk_coreset,
                 &training_data,
-                mt,
+                metric_policy,
                 local_k,
                 params.max_iters,
                 on_progress.clone(),
             )?;
             coreset.append(chunk_coreset);
-            coreset.reduce_to_budget(dimension, coreset_budget);
+            coreset.reduce_to_budget(dimension, coreset_budget, metric_policy)?;
             info!(
                 "Streaming coreset IVF step {} compressed {} vectors into {} weighted centroids",
                 step,
@@ -4609,7 +4860,7 @@ async fn train_streaming_coreset_ivf_model(
             let weighted_hierarchical_params = WeightedHierarchicalKMeansParams {
                 dimension,
                 target_k: num_partitions,
-                metric_type: DistanceType::L2,
+                metric_policy,
                 max_iters: params.max_iters,
                 on_progress: on_progress.clone(),
             };
@@ -4627,7 +4878,7 @@ async fn train_streaming_coreset_ivf_model(
                 &coreset_weights,
                 &coreset_losses,
                 &centroids,
-                DistanceType::L2,
+                metric_policy,
                 refine_iters,
                 on_progress.clone(),
             )?;
@@ -4777,11 +5028,15 @@ async fn train_streaming_ivf_model(
             let kmeans = train_ivf_kmeans_step_arrow_array_no_loss(
                 centroids.clone(),
                 &training_data,
-                mt,
+                KMeansStepOptions {
+                dimension,
+                metric_type: mt,
                 num_partitions,
-                step_sample_rate,
-                params.max_iters,
-                on_progress.clone(),
+                sample_rate: step_sample_rate,
+                max_iters: params.max_iters,
+                disable_hierarchical: false,
+                on_progress: on_progress.clone(),
+            },
             )?;
             let trained_centroids = Arc::new(FixedSizeListArray::try_new_from_values(
                 kmeans.centroids,
@@ -4901,6 +5156,7 @@ mod tests {
     use super::*;
 
     use std::collections::HashSet;
+    use std::f32::consts::TAU;
     use std::iter::repeat_n;
     use std::ops::Range;
     use std::sync::atomic::{AtomicBool, Ordering};
@@ -4908,8 +5164,8 @@ mod tests {
 
     use arrow_array::types::UInt64Type;
     use arrow_array::{
-        FixedSizeListArray, Float16Array, Float32Array, RecordBatch, RecordBatchIterator,
-        RecordBatchReader, UInt64Array, make_array,
+        FixedSizeListArray, Float16Array, Float32Array, Float64Array, Int8Array, RecordBatch,
+        RecordBatchIterator, RecordBatchReader, UInt64Array, make_array,
     };
     use arrow_buffer::{BooleanBuffer, NullBuffer};
     use arrow_schema::{DataType, Field, Schema};
@@ -6319,6 +6575,66 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn test_build_ivf_model_streaming_dot_coreset_training() {
+        const DIMENSION: usize = 4;
+        const NUM_PARTITIONS: usize = 257;
+
+        let test_dir = TempStrDir::default();
+        let uri = format!("{}/ds", test_dir.as_str());
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "vector",
+            DataType::FixedSizeList(
+                Arc::new(Field::new("item", DataType::Float32, true)),
+                DIMENSION as i32,
+            ),
+            false,
+        )]));
+        let values = Float32Array::from_iter_values((0..1_024).flat_map(|row| {
+            let angle = TAU * row as f32 / 1_024.0;
+            [
+                angle.cos(),
+                angle.sin(),
+                (3.0 * angle).cos(),
+                (3.0 * angle).sin(),
+            ]
+        }));
+        let vectors = FixedSizeListArray::try_new_from_values(values, DIMENSION as i32).unwrap();
+        let batch = RecordBatch::try_new(schema.clone(), vec![Arc::new(vectors)]).unwrap();
+        let reader = RecordBatchIterator::new(vec![Ok(batch)], schema);
+        let dataset = Dataset::write(reader, &uri, None).await.unwrap();
+
+        let mut params = IvfBuildParams::new(NUM_PARTITIONS);
+        params.sample_rate = 2;
+        params.streaming_sample_rate = Some(1);
+        params.max_iters = 1;
+
+        let ivf_model = build_ivf_model(
+            &dataset,
+            "vector",
+            DIMENSION,
+            MetricType::Dot,
+            &params,
+            None,
+            lance_index::progress::noop_progress(),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(ivf_model.num_partitions(), NUM_PARTITIONS);
+        assert_eq!(ivf_model.dimension(), DIMENSION);
+        assert!(
+            ivf_model
+                .centroids
+                .unwrap()
+                .values()
+                .as_primitive::<Float32Type>()
+                .values()
+                .iter()
+                .all(|value| value.is_finite())
+        );
+    }
+
     /// Regression test for a hang in the streaming *coreset* trainer
     /// (`train_streaming_coreset_ivf_model`, taken when `num_partitions > 256`).
     ///
@@ -6476,6 +6792,26 @@ mod tests {
     }
 
     #[test]
+    fn test_streaming_metric_policy_maps_cosine_and_sizes_local_coresets() {
+        assert_eq!(
+            streaming_kmeans_metric_policy(DistanceType::Cosine)
+                .unwrap()
+                .metric_type(),
+            DistanceType::L2
+        );
+        assert_eq!(
+            L2_METRIC_POLICY.local_coreset_k(1024, 1024 * 128, 16, 2, true),
+            1024 * 8
+        );
+        assert_eq!(
+            DOT_METRIC_POLICY.local_coreset_k(1024, 1024 * 128, 16, 2, true),
+            512
+        );
+        assert!(!L2_METRIC_POLICY.disable_local_hierarchical());
+        assert!(DOT_METRIC_POLICY.disable_local_hierarchical());
+    }
+
+    #[test]
     fn test_weighted_coreset_reduction_groups_nearby_centroids() {
         let mut coreset = WeightedCoreset::new(1, 4);
         coreset.push(&[0.0], 1.0, 0.0);
@@ -6483,13 +6819,131 @@ mod tests {
         coreset.push(&[1.0], 1.0, 0.0);
         coreset.push(&[101.0], 1.0, 0.0);
 
-        coreset.reduce_to_budget(1, 2);
+        coreset.reduce_to_budget(1, 2, &L2_METRIC_POLICY).unwrap();
 
         assert_eq!(coreset.len(), 2);
         assert!((coreset.values[0] - 0.5).abs() < 1e-6);
         assert!((coreset.values[1] - 100.5).abs() < 1e-6);
         assert_eq!(coreset.weights, vec![2.0, 2.0]);
         assert!((coreset.losses.iter().sum::<f64>() - 1.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn test_dot_coreset_reduction_has_zero_merge_residual() {
+        let mut coreset = WeightedCoreset::new(1, 2);
+        coreset.push(&[2.0], 2.0, 0.0);
+        coreset.push(&[4.0], 1.0, 0.0);
+
+        coreset.reduce_to_budget(1, 1, &DOT_METRIC_POLICY).unwrap();
+
+        assert_eq!(coreset.len(), 1);
+        assert!((coreset.values[0] - 8.0 / 3.0).abs() < 1e-6);
+        assert_eq!(coreset.weights, vec![3.0]);
+        assert_eq!(coreset.losses, vec![0.0]);
+    }
+
+    #[test]
+    fn test_weighted_dot_summary_preserves_assignment_loss() {
+        let data = f32_fsl_from_values(vec![2.0, 4.0], 1).unwrap();
+        let weights = vec![2.0, 1.0];
+        let losses = vec![0.0, 0.0];
+
+        let result =
+            assign_weighted_f32_points(&data, &weights, &losses, &[3.0], &DOT_METRIC_POLICY)
+                .unwrap();
+
+        let raw_loss = 2.0 * (1.0 - 2.0 * 3.0) + (1.0 - 4.0 * 3.0);
+        assert!((result.loss - raw_loss).abs() < 1e-6);
+        assert!((result.centroids[0] - 8.0 / 3.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn test_weighted_convergence_scale_is_sign_independent() {
+        let metric_policy = &DOT_METRIC_POLICY;
+        assert!(metric_policy.has_converged(-10.0, -10.0005));
+        assert!(metric_policy.has_converged(10.0, 10.0005));
+        assert!(!metric_policy.has_converged(-10.0, -10.01));
+        assert!(!metric_policy.has_converged(10.0, 10.01));
+        assert!(metric_policy.has_converged(0.0, 0.0));
+        assert!(!metric_policy.has_converged(1.0, 0.0));
+    }
+
+    #[test]
+    fn test_streaming_dot_training_dispatches_supported_types() {
+        let f16_data = FixedSizeListArray::try_new_from_values(
+            Float16Array::from_iter_values([1.0, 2.0, -1.0, -2.0].into_iter().map(f16::from_f32)),
+            1,
+        )
+        .unwrap();
+        let f32_data = f32_fsl_from_values(vec![1.0, 2.0, -1.0, -2.0], 1).unwrap();
+        let f64_data = FixedSizeListArray::try_new_from_values(
+            Float64Array::from(vec![1.0, 2.0, -1.0, -2.0]),
+            1,
+        )
+        .unwrap();
+        let int8_data =
+            FixedSizeListArray::try_new_from_values(Int8Array::from(vec![1, 2, -1, -2]), 1)
+                .unwrap();
+
+        for data in [&f16_data, &f32_data, &f64_data, &int8_data] {
+            let model = train_ivf_kmeans_step_arrow_array_no_loss(
+                None,
+                data,
+                KMeansStepOptions {
+                    dimension: 1,
+                    metric_type: DistanceType::Dot,
+                    num_partitions: 2,
+                    sample_rate: 2,
+                    max_iters: 1,
+                    disable_hierarchical: true,
+                    on_progress: Arc::new(|_, _| {}),
+                },
+            )
+            .unwrap();
+            assert_eq!(model.centroids.len(), 2);
+        }
+    }
+
+    #[test]
+    fn test_dot_raw_refinement_uses_dot_assignments() {
+        let data = f32_fsl_from_values(vec![2.0, -2.0], 1).unwrap();
+        let centroids = f32_fsl_from_values(vec![1.0, -1.0], 1).unwrap();
+        let mut cluster_sums = vec![0.0; 2];
+        let mut cluster_weights = vec![0.0; 2];
+
+        let loss = accumulate_refine_assignments(
+            &data,
+            &centroids,
+            &DOT_METRIC_POLICY,
+            &mut cluster_sums,
+            &mut cluster_weights,
+        )
+        .unwrap();
+
+        assert_eq!(cluster_sums, vec![2.0, -2.0]);
+        assert_eq!(cluster_weights, vec![1.0, 1.0]);
+        assert_eq!(loss, -2.0);
+    }
+
+    #[test]
+    fn test_weighted_dot_rejects_nonfinite_distance() {
+        let data = f32_fsl_from_values(vec![f32::MAX], 1).unwrap();
+        let error =
+            assign_weighted_f32_points(&data, &[1.0], &[0.0], &[f32::MAX], &DOT_METRIC_POLICY)
+                .unwrap_err();
+
+        assert!(matches!(error, Error::InvalidInput { .. }));
+        assert!(error.to_string().contains("nonfinite distance"));
+        assert!(error.to_string().contains(&DistanceType::Dot.to_string()));
+    }
+
+    #[test]
+    fn test_dot_split_priority_is_nonnegative_dispersion() {
+        let data = vec![1.0, 3.0];
+        let priority =
+            DOT_METRIC_POLICY.split_priority(&data, &[1.0, 1.0], &[0, 1], &[2.0], 1, -100.0);
+
+        assert_eq!(priority, 2.0);
     }
 
     #[test]

--- a/rust/lance/src/index/vector/ivf.rs
+++ b/rust/lance/src/index/vector/ivf.rs
@@ -6947,6 +6947,254 @@ mod tests {
     }
 
     #[test]
+    fn test_weighted_assignment_ignores_zero_weight_rows() {
+        let data = f32_fsl_from_values(vec![0.0, 10.0], 1).unwrap();
+        let result = assign_weighted_f32_points(
+            &data,
+            &[1.0, 0.0],
+            &[0.0, 0.0],
+            &[0.0, 10.0],
+            &L2_METRIC_POLICY,
+        )
+        .unwrap();
+        assert_eq!(result.cluster_weights, vec![1.0, 0.0]);
+        assert_eq!(result.centroids, vec![0.0, 10.0]);
+        assert_eq!(result.loss, 0.0);
+    }
+
+    #[test]
+    fn test_weighted_hierarchical_rejects_empty_and_mismatched_inputs() {
+        let progress = Arc::new(|_: u32, _: u32| {});
+        let params = WeightedHierarchicalKMeansParams {
+            dimension: 1,
+            target_k: 2,
+            metric_policy: &L2_METRIC_POLICY,
+            max_iters: 1,
+            on_progress: progress,
+        };
+        let empty = f32_fsl_from_values(Vec::new(), 1).unwrap();
+        assert!(train_weighted_hierarchical_f32_kmeans(&empty, &[], &[], &params).is_err());
+        let data = f32_fsl_from_values(vec![0.0, 1.0], 1).unwrap();
+        let error = train_weighted_hierarchical_f32_kmeans(&data, &[1.0], &[0.0, 0.0], &params)
+            .unwrap_err();
+        assert!(error.to_string().contains("input lengths do not match"));
+    }
+
+    #[test]
+    fn test_weighted_hierarchical_splits_until_target_k() {
+        let values = (0..16)
+            .flat_map(|value| [value as f32, value as f32 + 0.1])
+            .collect::<Vec<_>>();
+        let data = f32_fsl_from_values(values, 1).unwrap();
+        let progress = Arc::new(|_: u32, _: u32| {});
+        let params = WeightedHierarchicalKMeansParams {
+            dimension: 1,
+            target_k: 17,
+            metric_policy: &L2_METRIC_POLICY,
+            max_iters: 3,
+            on_progress: progress,
+        };
+        let result = train_weighted_hierarchical_f32_kmeans(
+            &data,
+            &vec![1.0; 32],
+            &vec![0.0; 32],
+            &params,
+        )
+        .unwrap();
+        assert_eq!(result.len(), 17);
+        let values = result.values().as_primitive::<Float32Type>().values();
+        let mut sorted = values.to_vec();
+        sorted.sort_by(|left, right| left.total_cmp(right));
+        assert!(sorted.windows(2).filter(|pair| (pair[0] - pair[1]).abs() > 0.001).count() >= 16);
+    }
+
+    #[test]
+    fn test_weighted_update_all_points_single_cluster_and_duplicates() {
+        let data = f32_fsl_from_values(vec![3.0, 3.0, 3.0], 1).unwrap();
+        let result = assign_weighted_f32_points(
+            &data,
+            &[1.0, 2.0, 3.0],
+            &[0.0, 0.0, 0.0],
+            &[0.0, 10.0],
+            &L2_METRIC_POLICY,
+        )
+        .unwrap();
+        assert_eq!(result.cluster_weights, vec![6.0, 0.0]);
+        assert_eq!(result.centroids, vec![3.0, 10.0]);
+        assert_eq!(result.membership, vec![Some(0), Some(0), Some(0)]);
+    }
+
+    #[test]
+    fn test_weighted_update_tie_breaks_to_first_centroid() {
+        let data = f32_fsl_from_values(vec![0.0], 1).unwrap();
+        let result = assign_weighted_f32_points(
+            &data,
+            &[1.0],
+            &[0.0],
+            &[-1.0, 1.0],
+            &L2_METRIC_POLICY,
+        )
+        .unwrap();
+        assert_eq!(result.membership, vec![Some(0)]);
+        assert_eq!(result.cluster_weights, vec![1.0, 0.0]);
+    }
+
+    #[test]
+    fn test_streaming_partition_boundary_and_sample_rate_helpers() {
+        assert_eq!(streaming_local_coreset_k(256, 256, 16, 1, false), 256);
+        assert_eq!(streaming_local_coreset_k(257, 257, 16, 1, false), 257);
+        assert_eq!(streaming_coreset_rate(256, 1, None), 1);
+        assert_eq!(streaming_coreset_rate(256, 256, None), 64);
+        assert_eq!(streaming_coreset_rate(256, 256, Some(16)), 16);
+        assert_eq!(streaming_coreset_rate(1, 256, None), 1);
+    }
+
+    #[tokio::test]
+    async fn test_streaming_coreset_rejects_insufficient_sample() {
+        let test_dir = TempStrDir::default();
+        let uri = format!("{}/insufficient", test_dir.as_str());
+        let reader = gen_batch()
+            .col("id", array::step::<UInt64Type>())
+            .col("vector", array::rand_vec::<Float32Type>(2.into()))
+            .into_reader_rows(RowCount::from(8), BatchCount::from(1));
+        let dataset = Dataset::write(reader, &uri, None).await.unwrap();
+        let mut params = IvfBuildParams::new(257);
+        params.sample_rate = 1;
+        params.streaming_sample_rate = Some(1);
+        params.max_iters = 1;
+        let error = build_ivf_model(
+            &dataset,
+            "vector",
+            2,
+            MetricType::L2,
+            &params,
+            None,
+            lance_index::progress::noop_progress(),
+        )
+        .await
+        .unwrap_err();
+        assert!(error.to_string().contains("cannot train 257 centroids"), "{error}");
+    }
+
+    #[rstest]
+    #[case::fixed_no_refine(false, 0)]
+    #[case::fixed_refine(false, 1)]
+    #[case::fragments_no_refine(true, 0)]
+    #[case::fragments_refine(true, 1)]
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_streaming_coreset_fixed_and_fragment_refinement(
+        #[case] use_fragments: bool,
+        #[case] refine_passes: usize,
+    ) {
+        const DIMENSION: usize = 1;
+        const NUM_PARTITIONS: usize = 257;
+        let test_dir = TempStrDir::default();
+        let uri = format!("{}/streaming", test_dir.as_str());
+        let reader = gen_batch()
+            .col("id", array::step::<UInt64Type>())
+            .col("vector", array::rand_vec::<Float32Type>((DIMENSION as u32).into()))
+            .into_reader_rows(RowCount::from(1024), BatchCount::from(2));
+        let dataset = Dataset::write(reader, &uri, None).await.unwrap();
+        let fragment_ids = use_fragments.then(|| {
+            dataset
+                .get_fragments()
+                .iter()
+                .map(|fragment| fragment.id() as u32)
+                .collect::<Vec<_>>()
+        });
+        let mut params = IvfBuildParams::new(NUM_PARTITIONS);
+        params.sample_rate = 4;
+        params.streaming_sample_rate = Some(2);
+        params.streaming_refine_passes = refine_passes;
+        params.max_iters = 1;
+        let model = tokio::time::timeout(
+            std::time::Duration::from_secs(120),
+            build_ivf_model(
+                &dataset,
+                "vector",
+                DIMENSION,
+                MetricType::L2,
+                &params,
+                fragment_ids.as_deref(),
+                lance_index::progress::noop_progress(),
+            ),
+        )
+        .await
+        .expect("streaming refinement timed out")
+        .unwrap();
+        assert_eq!(model.num_partitions(), NUM_PARTITIONS);
+        assert_eq!(model.dimension(), DIMENSION);
+        let centroids = model.centroids.unwrap();
+        assert_eq!(centroids.len(), NUM_PARTITIONS);
+        assert!(centroids
+            .values()
+            .as_primitive::<Float32Type>()
+            .values()
+            .iter()
+            .all(|value| value.is_finite()));
+    }
+
+    #[tokio::test]
+    async fn test_streaming_coreset_dimension_one_and_empty_dataset_errors() {
+        let test_dir = TempStrDir::default();
+        let empty_uri = format!("{}/empty", test_dir.as_str());
+        let empty_reader = gen_batch()
+            .col("id", array::step::<UInt64Type>())
+            .col("vector", array::rand_vec::<Float32Type>(1.into()))
+            .into_reader_rows(RowCount::from(0), BatchCount::from(1));
+        let empty = Dataset::write(empty_reader, &empty_uri, None).await.unwrap();
+        let mut params = IvfBuildParams::new(257);
+        params.sample_rate = 1;
+        params.streaming_sample_rate = Some(1);
+        let error = build_ivf_model(
+            &empty,
+            "vector",
+            1,
+            MetricType::L2,
+            &params,
+            None,
+            lance_index::progress::noop_progress(),
+        )
+        .await
+        .unwrap_err();
+        assert!(!error.to_string().is_empty());
+    }
+
+    #[test]
+    fn test_dot_assignment_accepts_negative_distances() {
+        let data = f32_fsl_from_values(vec![2.0, -2.0], 1).unwrap();
+        let result = assign_weighted_f32_points(
+            &data,
+            &[1.0, 1.0],
+            &[0.0, 0.0],
+            &[1.0, -1.0],
+            &DOT_METRIC_POLICY,
+        )
+        .unwrap();
+        assert_eq!(result.membership, vec![Some(0), Some(1)]);
+        assert!(result.loss < 0.0);
+        assert_eq!(result.centroids, vec![2.0, -2.0]);
+    }
+
+    #[test]
+    fn test_dot_refinement_preserves_empty_centroid() {
+        let data = f32_fsl_from_values(vec![2.0, 2.0], 1).unwrap();
+        let initial = f32_fsl_from_values(vec![10.0, -10.0], 1).unwrap();
+        let result = refine_weighted_f32_kmeans(
+            &data,
+            &[1.0, 1.0],
+            &[0.0, 0.0],
+            &initial,
+            &DOT_METRIC_POLICY,
+            1,
+            Arc::new(|_, _| {}),
+        )
+        .unwrap();
+        assert_eq!(result.centroids, vec![2.0, -10.0]);
+        assert_eq!(result.cluster_weights, vec![2.0, 0.0]);
+    }
+
+    #[test]
     fn test_weighted_kmeanspp_initialization_selects_distant_centroids() {
         let values = vec![0.0, 0.1, 100.0, 101.0];
         let weights = vec![1.0; 4];

--- a/rust/lance/src/index/vector/ivf.rs
+++ b/rust/lance/src/index/vector/ivf.rs
@@ -134,9 +134,13 @@ use tracing::instrument;
 use uuid::Uuid;
 
 pub mod builder;
+mod coreset_algo;
 pub mod io;
 mod partition_serde;
+mod streaming_hamming;
 pub mod v2;
+
+use coreset_algo::{FloatCoresetAlgorithm, HammingCoresetAlgorithm, StreamingCoresetAlgorithm};
 
 // Cache wrapper for vector index trait objects
 // Cache key for IVF partitions in the legacy IVF index
@@ -3520,11 +3524,27 @@ impl<'a> FixedIvfTrainingSampler<'a> {
 
 type KMeansProgressCallback = Arc<dyn Fn(u32, u32) + Send + Sync>;
 
-/// Metric-specific behavior for floating-point streaming coreset training.
+struct StreamingCoresetTrainingRequest<'a> {
+    dataset: &'a Dataset,
+    column: &'a str,
+    dimension: usize,
+    metric_type: MetricType,
+    params: &'a IvfBuildParams,
+    fragment_ids: Option<&'a [u32]>,
+    progress: Arc<dyn lance_index::progress::IndexBuildProgress>,
+}
+
+/// Metric-specific behavior for streaming coreset training.
 ///
 /// Cosine input is normalized by the sampler and therefore uses the L2 policy.
+#[async_trait]
 trait StreamingKMeansMetricPolicy: Send + Sync {
     fn metric_type(&self) -> MetricType;
+
+    async fn train_coreset_ivf_model(
+        &self,
+        request: StreamingCoresetTrainingRequest<'_>,
+    ) -> Result<IvfModel>;
 
     fn validate_sample_metric(&self, metric_type: MetricType) -> Result<()> {
         if metric_type == self.metric_type() {
@@ -3559,6 +3579,17 @@ trait StreamingKMeansMetricPolicy: Send + Sync {
         )
     }
 
+    fn has_converged(&self, previous_loss: f64, loss: f64) -> bool {
+        if loss == 0.0 {
+            previous_loss == 0.0
+        } else {
+            (previous_loss - loss).abs() < 1e-4 * loss.abs()
+        }
+    }
+}
+
+/// Operations specific to floating-point coreset summaries.
+trait StreamingFloatKMeansMetricPolicy: StreamingKMeansMetricPolicy {
     fn local_summary_loss(&self, distance: f32) -> f64;
 
     fn merge_residual(&self, vector: &[f32], centroid: &[f32]) -> f64;
@@ -3572,14 +3603,6 @@ trait StreamingKMeansMetricPolicy: Send + Sync {
         dimension: usize,
         loss: f64,
     ) -> f64;
-
-    fn has_converged(&self, previous_loss: f64, loss: f64) -> bool {
-        if loss == 0.0 {
-            previous_loss == 0.0
-        } else {
-            (previous_loss - loss).abs() < 1e-4 * loss.abs()
-        }
-    }
 
     fn initialize_centroids(
         &self,
@@ -3595,11 +3618,22 @@ trait StreamingKMeansMetricPolicy: Send + Sync {
 
 struct L2MetricPolicy;
 
+#[async_trait]
 impl StreamingKMeansMetricPolicy for L2MetricPolicy {
     fn metric_type(&self) -> MetricType {
         DistanceType::L2
     }
 
+    async fn train_coreset_ivf_model(
+        &self,
+        request: StreamingCoresetTrainingRequest<'_>,
+    ) -> Result<IvfModel> {
+        train_streaming_coreset_ivf_model_with_algorithm(request, &FloatCoresetAlgorithm::new(self))
+            .await
+    }
+}
+
+impl StreamingFloatKMeansMetricPolicy for L2MetricPolicy {
     fn local_summary_loss(&self, distance: f32) -> f64 {
         distance as f64
     }
@@ -3623,9 +3657,18 @@ impl StreamingKMeansMetricPolicy for L2MetricPolicy {
 
 struct DotMetricPolicy;
 
+#[async_trait]
 impl StreamingKMeansMetricPolicy for DotMetricPolicy {
     fn metric_type(&self) -> MetricType {
         DistanceType::Dot
+    }
+
+    async fn train_coreset_ivf_model(
+        &self,
+        request: StreamingCoresetTrainingRequest<'_>,
+    ) -> Result<IvfModel> {
+        train_streaming_coreset_ivf_model_with_algorithm(request, &FloatCoresetAlgorithm::new(self))
+            .await
     }
 
     fn disable_local_hierarchical(&self) -> bool {
@@ -3654,7 +3697,9 @@ impl StreamingKMeansMetricPolicy for DotMetricPolicy {
             .min(num_partitions.div_ceil(total_steps.max(1)))
             .min(num_rows.saturating_sub(1))
     }
+}
 
+impl StreamingFloatKMeansMetricPolicy for DotMetricPolicy {
     fn local_summary_loss(&self, _distance: f32) -> f64 {
         0.0
     }
@@ -3682,8 +3727,25 @@ impl StreamingKMeansMetricPolicy for DotMetricPolicy {
     }
 }
 
+struct HammingMetricPolicy;
+
+#[async_trait]
+impl StreamingKMeansMetricPolicy for HammingMetricPolicy {
+    fn metric_type(&self) -> MetricType {
+        DistanceType::Hamming
+    }
+
+    async fn train_coreset_ivf_model(
+        &self,
+        request: StreamingCoresetTrainingRequest<'_>,
+    ) -> Result<IvfModel> {
+        train_streaming_coreset_ivf_model_with_algorithm(request, &HammingCoresetAlgorithm).await
+    }
+}
+
 static L2_METRIC_POLICY: L2MetricPolicy = L2MetricPolicy;
 static DOT_METRIC_POLICY: DotMetricPolicy = DotMetricPolicy;
+static HAMMING_METRIC_POLICY: HammingMetricPolicy = HammingMetricPolicy;
 
 fn streaming_kmeans_metric_policy(
     metric_type: MetricType,
@@ -3691,8 +3753,18 @@ fn streaming_kmeans_metric_policy(
     match metric_type {
         DistanceType::L2 | DistanceType::Cosine => Ok(&L2_METRIC_POLICY),
         DistanceType::Dot => Ok(&DOT_METRIC_POLICY),
+        DistanceType::Hamming => Ok(&HAMMING_METRIC_POLICY),
+    }
+}
+
+fn streaming_float_kmeans_metric_policy(
+    metric_type: MetricType,
+) -> Result<&'static dyn StreamingFloatKMeansMetricPolicy> {
+    match metric_type {
+        DistanceType::L2 | DistanceType::Cosine => Ok(&L2_METRIC_POLICY),
+        DistanceType::Dot => Ok(&DOT_METRIC_POLICY),
         _ => Err(Error::invalid_input(format!(
-            "streaming coreset IVF supports L2, Cosine, and Dot training, got {}",
+            "floating-point streaming coreset IVF supports L2, Cosine, and Dot training, got {}",
             metric_type
         ))),
     }
@@ -3702,10 +3774,10 @@ fn squared_l2(left: &[f32], right: &[f32]) -> f64 {
     left.iter()
         .zip(right)
         .map(|(left, right)| {
-            let diff = left - right;
+            let diff = f64::from(*left) - f64::from(*right);
             diff * diff
         })
-        .sum::<f32>() as f64
+        .sum()
 }
 
 fn validate_finite_kmeans_distance(
@@ -3813,7 +3885,7 @@ fn train_ivf_kmeans_step_arrow_array_no_loss(
 fn accumulate_refine_assignments(
     data: &FixedSizeListArray,
     centroids: &FixedSizeListArray,
-    metric_policy: &dyn StreamingKMeansMetricPolicy,
+    metric_policy: &dyn StreamingFloatKMeansMetricPolicy,
     cluster_sums: &mut [f32],
     cluster_weights: &mut [f64],
 ) -> Result<f64> {
@@ -3885,7 +3957,7 @@ async fn refine_streaming_f32_kmeans_with_sampler(
     passes: usize,
     on_progress: Arc<dyn Fn(u32, u32) + Send + Sync>,
 ) -> Result<FixedSizeListArray> {
-    let metric_policy = streaming_kmeans_metric_policy(metric_type)?;
+    let metric_policy = streaming_float_kmeans_metric_policy(metric_type)?;
     let dimension = initial_centroids.value_length() as usize;
     let mut centroids = initial_centroids.clone();
     for pass in 1..=passes {
@@ -3937,7 +4009,7 @@ async fn refine_streaming_f32_kmeans_with_resampling(
     passes: usize,
     on_progress: Arc<dyn Fn(u32, u32) + Send + Sync>,
 ) -> Result<FixedSizeListArray> {
-    let metric_policy = streaming_kmeans_metric_policy(metric_type)?;
+    let metric_policy = streaming_float_kmeans_metric_policy(metric_type)?;
     let dimension = initial_centroids.value_length() as usize;
     let mut centroids = initial_centroids.clone();
     for pass in 1..=passes {
@@ -3978,6 +4050,98 @@ async fn refine_streaming_f32_kmeans_with_resampling(
             pass,
             passes,
             cluster_weights.iter().sum::<f64>() as usize,
+            loss
+        );
+    }
+    Ok(centroids)
+}
+
+async fn refine_streaming_hamming_kmodes_with_sampler(
+    sampler: &FixedIvfTrainingSampler<'_>,
+    streaming_sample_size: usize,
+    sample_ranges: &FixedIvfTrainingRanges,
+    initial_centroids: &FixedSizeListArray,
+    passes: usize,
+    on_progress: KMeansProgressCallback,
+) -> Result<FixedSizeListArray> {
+    let dimension = initial_centroids.value_length() as usize;
+    let mut centroids = initial_centroids.clone();
+    for pass in 1..=passes {
+        let mut accumulator =
+            streaming_hamming::HammingAccumulator::try_new(centroids.len(), dimension)?;
+        let mut loss = 0.0;
+        let mut row_offset = 0;
+        while row_offset < sample_ranges.num_rows() {
+            let ranges = sample_ranges.chunk(row_offset, streaming_sample_size.max(1));
+            row_offset += ranges.iter().map(range_len).sum::<usize>();
+            let (training_data, metric_type) = sampler
+                .sample_ranges(&ranges, DistanceType::Hamming)
+                .await?;
+            HAMMING_METRIC_POLICY.validate_sample_metric(metric_type)?;
+            loss += streaming_hamming::accumulate_raw_assignments(
+                &training_data,
+                &centroids,
+                &mut accumulator,
+            )?;
+        }
+        centroids = streaming_hamming::update_raw_centroids(&centroids, &accumulator)?;
+        on_progress(pass as u32, passes as u32);
+        info!(
+            "Streaming IVF Hamming refinement pass {} / {} assigned {} vectors; pre-update loss={}",
+            pass,
+            passes,
+            accumulator.total_count()?,
+            loss
+        );
+    }
+    Ok(centroids)
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn refine_streaming_hamming_kmodes_with_resampling(
+    dataset: &Dataset,
+    column: &str,
+    total_sample_rate: usize,
+    streaming_sample_rate: usize,
+    num_partitions: usize,
+    initial_centroids: &FixedSizeListArray,
+    fragment_ids: Option<&[u32]>,
+    passes: usize,
+    on_progress: KMeansProgressCallback,
+) -> Result<FixedSizeListArray> {
+    let dimension = initial_centroids.value_length() as usize;
+    let mut centroids = initial_centroids.clone();
+    for pass in 1..=passes {
+        let mut accumulator =
+            streaming_hamming::HammingAccumulator::try_new(centroids.len(), dimension)?;
+        let mut remaining_sample_rate = total_sample_rate;
+        let mut loss = 0.0;
+        while remaining_sample_rate > 0 {
+            let step_sample_rate = remaining_sample_rate.min(streaming_sample_rate);
+            let step_sample_size = num_partitions * step_sample_rate;
+            let (training_data, metric_type) = sample_ivf_training_chunk(
+                dataset,
+                column,
+                step_sample_size,
+                DistanceType::Hamming,
+                fragment_ids,
+            )
+            .await?;
+            HAMMING_METRIC_POLICY.validate_sample_metric(metric_type)?;
+            loss += streaming_hamming::accumulate_raw_assignments(
+                &training_data,
+                &centroids,
+                &mut accumulator,
+            )?;
+            remaining_sample_rate -= step_sample_rate;
+        }
+        centroids = streaming_hamming::update_raw_centroids(&centroids, &accumulator)?;
+        on_progress(pass as u32, passes as u32);
+        info!(
+            "Streaming IVF resampled Hamming refinement pass {} / {} assigned {} vectors; pre-update loss={}",
+            pass,
+            passes,
+            accumulator.total_count()?,
             loss
         );
     }
@@ -4037,7 +4201,7 @@ impl WeightedCoreset {
         &mut self,
         dimension: usize,
         budget: usize,
-        metric_policy: &dyn StreamingKMeansMetricPolicy,
+        metric_policy: &dyn StreamingFloatKMeansMetricPolicy,
     ) -> Result<()> {
         if self.len() <= budget {
             return Ok(());
@@ -4228,7 +4392,7 @@ fn assign_weighted_f32_points(
     weights: &[f64],
     base_losses: &[f64],
     centroid_values: &[f32],
-    metric_policy: &dyn StreamingKMeansMetricPolicy,
+    metric_policy: &dyn StreamingFloatKMeansMetricPolicy,
 ) -> Result<WeightedKMeansResult> {
     let dimension = data.value_length() as usize;
     let k = centroid_values.len() / dimension;
@@ -4302,7 +4466,7 @@ fn train_weighted_f32_kmeans(
     weights: &[f64],
     base_losses: &[f64],
     k: usize,
-    metric_policy: &dyn StreamingKMeansMetricPolicy,
+    metric_policy: &dyn StreamingFloatKMeansMetricPolicy,
     max_iters: usize,
     on_progress: Arc<dyn Fn(u32, u32) + Send + Sync>,
 ) -> Result<WeightedKMeansResult> {
@@ -4346,7 +4510,7 @@ fn refine_weighted_f32_kmeans(
     weights: &[f64],
     base_losses: &[f64],
     initial_centroids: &FixedSizeListArray,
-    metric_policy: &dyn StreamingKMeansMetricPolicy,
+    metric_policy: &dyn StreamingFloatKMeansMetricPolicy,
     max_iters: usize,
     on_progress: Arc<dyn Fn(u32, u32) + Send + Sync>,
 ) -> Result<WeightedKMeansResult> {
@@ -4374,7 +4538,7 @@ fn refine_weighted_f32_kmeans(
 fn append_local_coreset(
     coreset: &mut WeightedCoreset,
     data: &FixedSizeListArray,
-    metric_policy: &dyn StreamingKMeansMetricPolicy,
+    metric_policy: &dyn StreamingFloatKMeansMetricPolicy,
     local_k: usize,
     max_iters: usize,
     on_progress: Arc<dyn Fn(u32, u32) + Send + Sync>,
@@ -4488,7 +4652,7 @@ impl PartialOrd for WeightedCluster {
 struct WeightedHierarchicalKMeansParams<'a> {
     dimension: usize,
     target_k: usize,
-    metric_policy: &'a dyn StreamingKMeansMetricPolicy,
+    metric_policy: &'a dyn StreamingFloatKMeansMetricPolicy,
     max_iters: usize,
     on_progress: Arc<dyn Fn(u32, u32) + Send + Sync>,
 }
@@ -4721,7 +4885,33 @@ async fn train_streaming_coreset_ivf_model(
     fragment_ids: Option<&[u32]>,
     progress: std::sync::Arc<dyn lance_index::progress::IndexBuildProgress>,
 ) -> Result<IvfModel> {
-    let metric_policy = streaming_kmeans_metric_policy(metric_type)?;
+    streaming_kmeans_metric_policy(metric_type)?
+        .train_coreset_ivf_model(StreamingCoresetTrainingRequest {
+            dataset,
+            column,
+            dimension,
+            metric_type,
+            params,
+            fragment_ids,
+            progress,
+        })
+        .await
+}
+
+async fn train_streaming_coreset_ivf_model_with_algorithm<A: StreamingCoresetAlgorithm>(
+    request: StreamingCoresetTrainingRequest<'_>,
+    algorithm: &A,
+) -> Result<IvfModel> {
+    let StreamingCoresetTrainingRequest {
+        dataset,
+        column,
+        dimension,
+        metric_type,
+        params,
+        fragment_ids,
+        progress,
+    } = request;
+    let metric_policy = algorithm.metric_policy();
     let num_partitions = params.num_partitions.unwrap_or(32);
     let streaming_sample_rate = params.streaming_sample_rate.unwrap();
     let total_sample_rate = params.sample_rate;
@@ -4780,19 +4970,20 @@ async fn train_streaming_coreset_ivf_model(
             .saturating_mul(coreset_rate)
             .max(num_partitions);
         let total_steps = total_sample_rate.div_ceil(streaming_sample_rate);
-        let decoupled_coreset_budget = params.streaming_coreset_rate.is_some();
-        let mut coreset = WeightedCoreset::new(dimension, coreset_budget.min(num_partitions * 16));
+        let has_decoupled_budget = params.streaming_coreset_rate.is_some();
+        let initial_capacity = coreset_budget.min(num_partitions.saturating_mul(16));
+        let mut coreset = algorithm.new_coreset(dimension, initial_capacity);
         let mut step = 0;
         while remaining_sample_rate > 0 {
             let step_sample_rate = remaining_sample_rate.min(streaming_sample_rate);
             let step_sample_size = num_partitions * step_sample_rate;
             step += 1;
             info!(
-                "Streaming coreset IVF training: step {}, sample_rate={}, sample_size={}",
-                step, step_sample_rate, step_sample_size
+                "Streaming coreset IVF training for metric {}: step {}, sample_rate={}, sample_size={}",
+                metric_type, step, step_sample_rate, step_sample_size
             );
 
-            let (training_data, mt) = if let (Some(sample_ranges), Some(sampler)) =
+            let (training_data, sampled_metric) = if let (Some(sample_ranges), Some(sampler)) =
                 (&fixed_sample_ranges, &fixed_sampler)
             {
                 let ranges = sample_ranges.chunk(sample_offset, step_sample_size);
@@ -4808,15 +4999,11 @@ async fn train_streaming_coreset_ivf_model(
                 )
                 .await?
             };
-            let training_data = if training_data.value_type() == DataType::Float32 {
-                training_data
-            } else {
-                training_data.convert_to_floating_point()?
-            };
-            metric_policy.validate_sample_metric(mt)?;
+            let training_data = algorithm.prepare_sample(training_data, sampled_metric)?;
             if training_data.len() < num_partitions {
                 return Err(Error::index(format!(
-                    "Not enough training vectors for streaming coreset IVF. Requires at least {} rows but sampled {} rows",
+                    "Not enough training vectors for streaming coreset IVF with metric {}. Requires at least {} rows but sampled {} rows",
+                    metric_type,
                     num_partitions,
                     training_data.len()
                 )));
@@ -4829,94 +5016,69 @@ async fn train_streaming_coreset_ivf_model(
                 training_data.len(),
                 coreset_rate,
                 total_steps,
-                decoupled_coreset_budget,
+                has_decoupled_budget,
             );
-            let mut chunk_coreset = WeightedCoreset::new(dimension, local_k);
-            append_local_coreset(
+            let mut chunk_coreset = algorithm.new_coreset(dimension, local_k);
+            algorithm.append_local_coreset(
                 &mut chunk_coreset,
                 &training_data,
-                metric_policy,
                 local_k,
                 params.max_iters,
                 on_progress.clone(),
             )?;
-            coreset.append(chunk_coreset);
-            coreset.reduce_to_budget(dimension, coreset_budget, metric_policy)?;
+            algorithm.append_coreset(&mut coreset, chunk_coreset)?;
+            algorithm.reduce_coreset(&mut coreset, dimension, coreset_budget)?;
             info!(
-                "Streaming coreset IVF step {} compressed {} vectors into {} weighted centroids",
+                "Streaming coreset IVF step {} compressed {} vectors into {} summaries for metric {}",
                 step,
                 total_training_vectors,
-                coreset.len()
+                algorithm.coreset_len(&coreset),
+                metric_type
             );
             remaining_sample_rate -= step_sample_rate;
         }
 
-        let coreset_len = coreset.len();
-        let (coreset_data, coreset_weights, coreset_losses) =
-            coreset.into_fsl_parts(dimension)?;
-        // Scope `weighted_hierarchical_params` so the `on_progress` clone it holds
-        // is dropped before the progress producer is closed below.
-        let mut centroids = {
-            let weighted_hierarchical_params = WeightedHierarchicalKMeansParams {
-                dimension,
-                target_k: num_partitions,
-                metric_policy,
-                max_iters: params.max_iters,
-                on_progress: on_progress.clone(),
-            };
-            train_weighted_hierarchical_f32_kmeans(
-                &coreset_data,
-                &coreset_weights,
-                &coreset_losses,
-                &weighted_hierarchical_params,
-            )?
-        };
-        let refine_iters = 3;
-        if refine_iters > 0 {
-            let refined = refine_weighted_f32_kmeans(
-                &coreset_data,
-                &coreset_weights,
-                &coreset_losses,
-                &centroids,
-                metric_policy,
-                refine_iters,
-                on_progress.clone(),
-            )?;
-            centroids = f32_fsl_from_values(refined.centroids, dimension)?;
-        }
+        let coreset_len = algorithm.coreset_len(&coreset);
+        let mut centroids = algorithm.train_centroids(
+            coreset,
+            dimension,
+            num_partitions,
+            params.max_iters,
+            on_progress.clone(),
+        )?;
         if params.streaming_refine_passes > 0 {
             info!(
-                "Running {} streaming raw-vector refinement pass(es)",
-                params.streaming_refine_passes
+                "Running {} streaming raw-vector refinement pass(es) for metric {}",
+                params.streaming_refine_passes, metric_type
             );
-            centroids = if let (Some(sample_ranges), Some(sampler)) =
-                (&fixed_sample_ranges, &fixed_sampler)
-            {
-                refine_streaming_f32_kmeans_with_sampler(
-                    sampler,
-                    metric_type,
-                    num_partitions * streaming_sample_rate,
-                    sample_ranges,
-                    &centroids,
-                    params.streaming_refine_passes,
-                    on_progress.clone(),
-                )
-                .await?
-            } else {
-                refine_streaming_f32_kmeans_with_resampling(
-                    dataset,
-                    column,
-                    metric_type,
-                    total_sample_rate,
-                    streaming_sample_rate,
-                    num_partitions,
-                    &centroids,
-                    fragment_ids,
-                    params.streaming_refine_passes,
-                    on_progress.clone(),
-                )
-                .await?
-            };
+            centroids =
+                if let (Some(sample_ranges), Some(sampler)) = (&fixed_sample_ranges, &fixed_sampler)
+                {
+                    algorithm
+                        .refine_with_sampler(
+                            sampler,
+                            num_partitions * streaming_sample_rate,
+                            sample_ranges,
+                            &centroids,
+                            params.streaming_refine_passes,
+                            on_progress.clone(),
+                        )
+                        .await?
+                } else {
+                    algorithm
+                        .refine_with_resampling(
+                            dataset,
+                            column,
+                            total_sample_rate,
+                            streaming_sample_rate,
+                            num_partitions,
+                            &centroids,
+                            fragment_ids,
+                            params.streaming_refine_passes,
+                            on_progress.clone(),
+                        )
+                        .await?
+                };
         }
 
         Ok((IvfModel::new(centroids, None), coreset_len))
@@ -4933,8 +5095,8 @@ async fn train_streaming_coreset_ivf_model(
     .await?;
 
     info!(
-        "Streaming coreset IVF sampled {} vectors total; max in-memory training vectors per step: {}; coreset vectors: {}",
-        total_training_vectors, max_training_vectors, coreset_len
+        "Streaming coreset IVF for metric {} sampled {} vectors total; max in-memory training vectors per step: {}; coreset summaries: {}",
+        metric_type, total_training_vectors, max_training_vectors, coreset_len
     );
 
     Ok(ivf_model)
@@ -5029,8 +5191,8 @@ async fn train_streaming_ivf_model(
                 centroids.clone(),
                 &training_data,
                 KMeansStepOptions {
-                dimension,
-                metric_type: mt,
+                    dimension: training_data.value_length() as usize,
+                    metric_type: mt,
                 num_partitions,
                 sample_rate: step_sample_rate,
                 max_iters: params.max_iters,
@@ -6723,6 +6885,68 @@ mod tests {
         );
     }
 
+    #[rstest]
+    #[case::without_raw_refinement(0)]
+    #[case::with_raw_refinement(1)]
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_streaming_hamming_coreset_ivf_training(#[case] refine_passes: usize) {
+        const DIMENSION: usize = 2;
+        const NUM_PARTITIONS: usize = 257;
+
+        let test_dir = TempStrDir::default();
+        let uri = format!("{}/hamming", test_dir.as_str());
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "vector",
+            DataType::FixedSizeList(
+                Arc::new(Field::new("item", DataType::UInt8, true)),
+                DIMENSION as i32,
+            ),
+            false,
+        )]));
+        let values = arrow_array::UInt8Array::from(
+            (0..600_u16).flat_map(u16::to_le_bytes).collect::<Vec<_>>(),
+        );
+        let vectors = FixedSizeListArray::try_new_from_values(values, DIMENSION as i32).unwrap();
+        let batch = RecordBatch::try_new(schema.clone(), vec![Arc::new(vectors)]).unwrap();
+        let reader = RecordBatchIterator::new(vec![Ok(batch)], schema);
+        let dataset = Dataset::write(reader, &uri, None).await.unwrap();
+
+        let mut params = IvfBuildParams::new(NUM_PARTITIONS);
+        params.sample_rate = 2;
+        params.streaming_sample_rate = Some(1);
+        params.streaming_refine_passes = refine_passes;
+        params.max_iters = 2;
+
+        let fragment_ids = dataset
+            .get_fragments()
+            .iter()
+            .map(|fragment| fragment.id() as u32)
+            .collect::<Vec<_>>();
+        for selected_fragments in [None, Some(fragment_ids.as_slice())] {
+            let model = build_ivf_model(
+                &dataset,
+                "vector",
+                DIMENSION,
+                MetricType::Hamming,
+                &params,
+                selected_fragments,
+                lance_index::progress::noop_progress(),
+            )
+            .await
+            .unwrap();
+
+            let centroids = model.centroids.unwrap();
+            assert_eq!(centroids.len(), NUM_PARTITIONS);
+            assert_eq!(centroids.value_length(), DIMENSION as i32);
+            assert_eq!(centroids.value_type(), DataType::UInt8);
+            let values = centroids.values().as_primitive::<UInt8Type>().values();
+            assert_eq!(
+                values.chunks_exact(DIMENSION).collect::<HashSet<_>>().len(),
+                NUM_PARTITIONS
+            );
+        }
+    }
+
     #[test]
     fn test_fixed_training_ranges_are_sorted_and_bounded() {
         let ranges = generate_fixed_training_ranges(10_000, 1_234, 1_024, 16);
@@ -6798,6 +7022,12 @@ mod tests {
                 .unwrap()
                 .metric_type(),
             DistanceType::L2
+        );
+        assert_eq!(
+            streaming_kmeans_metric_policy(DistanceType::Hamming)
+                .unwrap()
+                .metric_type(),
+            DistanceType::Hamming
         );
         assert_eq!(
             L2_METRIC_POLICY.local_coreset_k(1024, 1024 * 128, 16, 2, true),
@@ -6947,6 +7177,14 @@ mod tests {
     }
 
     #[test]
+    fn test_squared_l2_accumulates_in_f64() {
+        let distance = squared_l2(&[f32::MAX, f32::MAX], &[0.0, 0.0]);
+
+        assert!(distance.is_finite());
+        assert!(distance > f64::from(f32::MAX));
+    }
+
+    #[test]
     fn test_weighted_assignment_ignores_zero_weight_rows() {
         let data = f32_fsl_from_values(vec![0.0, 10.0], 1).unwrap();
         let result = assign_weighted_f32_points(
@@ -6994,18 +7232,20 @@ mod tests {
             max_iters: 3,
             on_progress: progress,
         };
-        let result = train_weighted_hierarchical_f32_kmeans(
-            &data,
-            &vec![1.0; 32],
-            &vec![0.0; 32],
-            &params,
-        )
-        .unwrap();
+        let result =
+            train_weighted_hierarchical_f32_kmeans(&data, &vec![1.0; 32], &vec![0.0; 32], &params)
+                .unwrap();
         assert_eq!(result.len(), 17);
         let values = result.values().as_primitive::<Float32Type>().values();
         let mut sorted = values.to_vec();
         sorted.sort_by(|left, right| left.total_cmp(right));
-        assert!(sorted.windows(2).filter(|pair| (pair[0] - pair[1]).abs() > 0.001).count() >= 16);
+        assert!(
+            sorted
+                .windows(2)
+                .filter(|pair| (pair[0] - pair[1]).abs() > 0.001)
+                .count()
+                >= 16
+        );
     }
 
     #[test]
@@ -7027,14 +7267,9 @@ mod tests {
     #[test]
     fn test_weighted_update_tie_breaks_to_first_centroid() {
         let data = f32_fsl_from_values(vec![0.0], 1).unwrap();
-        let result = assign_weighted_f32_points(
-            &data,
-            &[1.0],
-            &[0.0],
-            &[-1.0, 1.0],
-            &L2_METRIC_POLICY,
-        )
-        .unwrap();
+        let result =
+            assign_weighted_f32_points(&data, &[1.0], &[0.0], &[-1.0, 1.0], &L2_METRIC_POLICY)
+                .unwrap();
         assert_eq!(result.membership, vec![Some(0)]);
         assert_eq!(result.cluster_weights, vec![1.0, 0.0]);
     }
@@ -7073,7 +7308,10 @@ mod tests {
         )
         .await
         .unwrap_err();
-        assert!(error.to_string().contains("cannot train 257 centroids"), "{error}");
+        assert!(
+            error.to_string().contains("cannot train 257 centroids"),
+            "{error}"
+        );
     }
 
     #[rstest]
@@ -7092,7 +7330,10 @@ mod tests {
         let uri = format!("{}/streaming", test_dir.as_str());
         let reader = gen_batch()
             .col("id", array::step::<UInt64Type>())
-            .col("vector", array::rand_vec::<Float32Type>((DIMENSION as u32).into()))
+            .col(
+                "vector",
+                array::rand_vec::<Float32Type>((DIMENSION as u32).into()),
+            )
             .into_reader_rows(RowCount::from(1024), BatchCount::from(2));
         let dataset = Dataset::write(reader, &uri, None).await.unwrap();
         let fragment_ids = use_fragments.then(|| {
@@ -7126,12 +7367,14 @@ mod tests {
         assert_eq!(model.dimension(), DIMENSION);
         let centroids = model.centroids.unwrap();
         assert_eq!(centroids.len(), NUM_PARTITIONS);
-        assert!(centroids
-            .values()
-            .as_primitive::<Float32Type>()
-            .values()
-            .iter()
-            .all(|value| value.is_finite()));
+        assert!(
+            centroids
+                .values()
+                .as_primitive::<Float32Type>()
+                .values()
+                .iter()
+                .all(|value| value.is_finite())
+        );
     }
 
     #[tokio::test]
@@ -7142,7 +7385,9 @@ mod tests {
             .col("id", array::step::<UInt64Type>())
             .col("vector", array::rand_vec::<Float32Type>(1.into()))
             .into_reader_rows(RowCount::from(0), BatchCount::from(1));
-        let empty = Dataset::write(empty_reader, &empty_uri, None).await.unwrap();
+        let empty = Dataset::write(empty_reader, &empty_uri, None)
+            .await
+            .unwrap();
         let mut params = IvfBuildParams::new(257);
         params.sample_rate = 1;
         params.streaming_sample_rate = Some(1);

--- a/rust/lance/src/index/vector/ivf/coreset_algo/float_coreset.rs
+++ b/rust/lance/src/index/vector/ivf/coreset_algo/float_coreset.rs
@@ -1,0 +1,179 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+use arrow_array::FixedSizeListArray;
+use arrow_schema::DataType;
+use async_trait::async_trait;
+use lance_arrow::FixedSizeListArrayExt;
+use lance_core::Result;
+use lance_linalg::distance::MetricType;
+
+use crate::dataset::Dataset;
+
+use super::super::{
+    FixedIvfTrainingRanges, FixedIvfTrainingSampler, KMeansProgressCallback,
+    StreamingFloatKMeansMetricPolicy, StreamingKMeansMetricPolicy, WeightedCoreset,
+    WeightedHierarchicalKMeansParams, append_local_coreset, f32_fsl_from_values,
+    refine_streaming_f32_kmeans_with_resampling, refine_streaming_f32_kmeans_with_sampler,
+    refine_weighted_f32_kmeans, train_weighted_hierarchical_f32_kmeans,
+};
+use super::StreamingCoresetAlgorithm;
+
+pub(in crate::index::vector::ivf) struct FloatCoresetAlgorithm<'a> {
+    metric_policy: &'a dyn StreamingFloatKMeansMetricPolicy,
+}
+
+impl<'a> FloatCoresetAlgorithm<'a> {
+    pub(in crate::index::vector::ivf) fn new(
+        metric_policy: &'a dyn StreamingFloatKMeansMetricPolicy,
+    ) -> Self {
+        Self { metric_policy }
+    }
+}
+
+#[async_trait]
+impl StreamingCoresetAlgorithm for FloatCoresetAlgorithm<'_> {
+    type Coreset = WeightedCoreset;
+
+    fn metric_policy(&self) -> &dyn StreamingKMeansMetricPolicy {
+        self.metric_policy
+    }
+
+    fn prepare_sample(
+        &self,
+        training_data: FixedSizeListArray,
+        sampled_metric: MetricType,
+    ) -> Result<FixedSizeListArray> {
+        self.metric_policy.validate_sample_metric(sampled_metric)?;
+        if training_data.value_type() == DataType::Float32 {
+            Ok(training_data)
+        } else {
+            Ok(training_data.convert_to_floating_point()?)
+        }
+    }
+
+    fn new_coreset(&self, dimension: usize, capacity: usize) -> Self::Coreset {
+        WeightedCoreset::new(dimension, capacity)
+    }
+
+    fn append_local_coreset(
+        &self,
+        coreset: &mut Self::Coreset,
+        data: &FixedSizeListArray,
+        local_k: usize,
+        max_iters: usize,
+        on_progress: KMeansProgressCallback,
+    ) -> Result<()> {
+        append_local_coreset(
+            coreset,
+            data,
+            self.metric_policy,
+            local_k,
+            max_iters,
+            on_progress,
+        )
+    }
+
+    fn append_coreset(&self, coreset: &mut Self::Coreset, other: Self::Coreset) -> Result<()> {
+        coreset.append(other);
+        Ok(())
+    }
+
+    fn reduce_coreset(
+        &self,
+        coreset: &mut Self::Coreset,
+        dimension: usize,
+        budget: usize,
+    ) -> Result<()> {
+        coreset.reduce_to_budget(dimension, budget, self.metric_policy)
+    }
+
+    fn coreset_len(&self, coreset: &Self::Coreset) -> usize {
+        coreset.len()
+    }
+
+    fn train_centroids(
+        &self,
+        coreset: Self::Coreset,
+        dimension: usize,
+        num_partitions: usize,
+        max_iters: usize,
+        on_progress: KMeansProgressCallback,
+    ) -> Result<FixedSizeListArray> {
+        let (coreset_data, coreset_weights, coreset_losses) = coreset.into_fsl_parts(dimension)?;
+        let mut centroids = {
+            let params = WeightedHierarchicalKMeansParams {
+                dimension,
+                target_k: num_partitions,
+                metric_policy: self.metric_policy,
+                max_iters,
+                on_progress: on_progress.clone(),
+            };
+            train_weighted_hierarchical_f32_kmeans(
+                &coreset_data,
+                &coreset_weights,
+                &coreset_losses,
+                &params,
+            )?
+        };
+        let refined = refine_weighted_f32_kmeans(
+            &coreset_data,
+            &coreset_weights,
+            &coreset_losses,
+            &centroids,
+            self.metric_policy,
+            3,
+            on_progress,
+        )?;
+        centroids = f32_fsl_from_values(refined.centroids, dimension)?;
+        Ok(centroids)
+    }
+
+    async fn refine_with_sampler(
+        &self,
+        sampler: &FixedIvfTrainingSampler<'_>,
+        streaming_sample_size: usize,
+        sample_ranges: &FixedIvfTrainingRanges,
+        initial_centroids: &FixedSizeListArray,
+        passes: usize,
+        on_progress: KMeansProgressCallback,
+    ) -> Result<FixedSizeListArray> {
+        refine_streaming_f32_kmeans_with_sampler(
+            sampler,
+            self.metric_policy.metric_type(),
+            streaming_sample_size,
+            sample_ranges,
+            initial_centroids,
+            passes,
+            on_progress,
+        )
+        .await
+    }
+
+    async fn refine_with_resampling(
+        &self,
+        dataset: &Dataset,
+        column: &str,
+        total_sample_rate: usize,
+        streaming_sample_rate: usize,
+        num_partitions: usize,
+        initial_centroids: &FixedSizeListArray,
+        fragment_ids: Option<&[u32]>,
+        passes: usize,
+        on_progress: KMeansProgressCallback,
+    ) -> Result<FixedSizeListArray> {
+        refine_streaming_f32_kmeans_with_resampling(
+            dataset,
+            column,
+            self.metric_policy.metric_type(),
+            total_sample_rate,
+            streaming_sample_rate,
+            num_partitions,
+            initial_centroids,
+            fragment_ids,
+            passes,
+            on_progress,
+        )
+        .await
+    }
+}

--- a/rust/lance/src/index/vector/ivf/coreset_algo/hamming_coreset.rs
+++ b/rust/lance/src/index/vector/ivf/coreset_algo/hamming_coreset.rs
@@ -1,0 +1,140 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+use arrow_array::FixedSizeListArray;
+use arrow_schema::DataType;
+use async_trait::async_trait;
+use lance_core::{Error, Result};
+use lance_linalg::distance::MetricType;
+
+use crate::dataset::Dataset;
+
+use super::super::{
+    FixedIvfTrainingRanges, FixedIvfTrainingSampler, HAMMING_METRIC_POLICY, KMeansProgressCallback,
+    StreamingKMeansMetricPolicy, refine_streaming_hamming_kmodes_with_resampling,
+    refine_streaming_hamming_kmodes_with_sampler, streaming_hamming,
+};
+use super::StreamingCoresetAlgorithm;
+
+pub(in crate::index::vector::ivf) struct HammingCoresetAlgorithm;
+
+#[async_trait]
+impl StreamingCoresetAlgorithm for HammingCoresetAlgorithm {
+    type Coreset = streaming_hamming::HammingCoreset;
+
+    fn metric_policy(&self) -> &dyn StreamingKMeansMetricPolicy {
+        &HAMMING_METRIC_POLICY
+    }
+
+    fn prepare_sample(
+        &self,
+        training_data: FixedSizeListArray,
+        sampled_metric: MetricType,
+    ) -> Result<FixedSizeListArray> {
+        self.metric_policy()
+            .validate_sample_metric(sampled_metric)?;
+        if training_data.value_type() == DataType::UInt8 {
+            Ok(training_data)
+        } else {
+            Err(Error::invalid_input(format!(
+                "streaming Hamming k-modes requires UInt8 vectors, got {}",
+                training_data.value_type()
+            )))
+        }
+    }
+
+    fn new_coreset(&self, dimension: usize, capacity: usize) -> Self::Coreset {
+        streaming_hamming::HammingCoreset::new(dimension, capacity)
+    }
+
+    fn append_local_coreset(
+        &self,
+        coreset: &mut Self::Coreset,
+        data: &FixedSizeListArray,
+        local_k: usize,
+        max_iters: usize,
+        on_progress: KMeansProgressCallback,
+    ) -> Result<()> {
+        streaming_hamming::append_local_coreset(coreset, data, local_k, max_iters, on_progress)
+    }
+
+    fn append_coreset(&self, coreset: &mut Self::Coreset, other: Self::Coreset) -> Result<()> {
+        coreset.append(other)
+    }
+
+    fn reduce_coreset(
+        &self,
+        coreset: &mut Self::Coreset,
+        _dimension: usize,
+        budget: usize,
+    ) -> Result<()> {
+        coreset.reduce_to_budget(budget)
+    }
+
+    fn coreset_len(&self, coreset: &Self::Coreset) -> usize {
+        coreset.len()
+    }
+
+    fn train_centroids(
+        &self,
+        coreset: Self::Coreset,
+        _dimension: usize,
+        num_partitions: usize,
+        max_iters: usize,
+        on_progress: KMeansProgressCallback,
+    ) -> Result<FixedSizeListArray> {
+        let centroids = streaming_hamming::train_hierarchical(
+            &coreset,
+            num_partitions,
+            max_iters,
+            on_progress.clone(),
+        )?;
+        streaming_hamming::refine_weighted(&coreset, &centroids, 3, on_progress)
+    }
+
+    async fn refine_with_sampler(
+        &self,
+        sampler: &FixedIvfTrainingSampler<'_>,
+        streaming_sample_size: usize,
+        sample_ranges: &FixedIvfTrainingRanges,
+        initial_centroids: &FixedSizeListArray,
+        passes: usize,
+        on_progress: KMeansProgressCallback,
+    ) -> Result<FixedSizeListArray> {
+        refine_streaming_hamming_kmodes_with_sampler(
+            sampler,
+            streaming_sample_size,
+            sample_ranges,
+            initial_centroids,
+            passes,
+            on_progress,
+        )
+        .await
+    }
+
+    async fn refine_with_resampling(
+        &self,
+        dataset: &Dataset,
+        column: &str,
+        total_sample_rate: usize,
+        streaming_sample_rate: usize,
+        num_partitions: usize,
+        initial_centroids: &FixedSizeListArray,
+        fragment_ids: Option<&[u32]>,
+        passes: usize,
+        on_progress: KMeansProgressCallback,
+    ) -> Result<FixedSizeListArray> {
+        refine_streaming_hamming_kmodes_with_resampling(
+            dataset,
+            column,
+            total_sample_rate,
+            streaming_sample_rate,
+            num_partitions,
+            initial_centroids,
+            fragment_ids,
+            passes,
+            on_progress,
+        )
+        .await
+    }
+}

--- a/rust/lance/src/index/vector/ivf/coreset_algo/mod.rs
+++ b/rust/lance/src/index/vector/ivf/coreset_algo/mod.rs
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+//! Metric-specific adapters for streaming coreset IVF training.
+
+mod float_coreset;
+mod hamming_coreset;
+
+use arrow_array::FixedSizeListArray;
+use async_trait::async_trait;
+use lance_core::Result;
+use lance_linalg::distance::MetricType;
+
+use crate::dataset::Dataset;
+
+use super::{
+    FixedIvfTrainingRanges, FixedIvfTrainingSampler, KMeansProgressCallback,
+    StreamingKMeansMetricPolicy,
+};
+
+pub(in crate::index::vector::ivf) use float_coreset::FloatCoresetAlgorithm;
+pub(in crate::index::vector::ivf) use hamming_coreset::HammingCoresetAlgorithm;
+
+#[async_trait]
+pub(in crate::index::vector::ivf) trait StreamingCoresetAlgorithm:
+    Sync
+{
+    type Coreset;
+
+    fn metric_policy(&self) -> &dyn StreamingKMeansMetricPolicy;
+
+    fn prepare_sample(
+        &self,
+        training_data: FixedSizeListArray,
+        sampled_metric: MetricType,
+    ) -> Result<FixedSizeListArray>;
+
+    fn new_coreset(&self, dimension: usize, capacity: usize) -> Self::Coreset;
+
+    fn append_local_coreset(
+        &self,
+        coreset: &mut Self::Coreset,
+        data: &FixedSizeListArray,
+        local_k: usize,
+        max_iters: usize,
+        on_progress: KMeansProgressCallback,
+    ) -> Result<()>;
+
+    fn append_coreset(&self, coreset: &mut Self::Coreset, other: Self::Coreset) -> Result<()>;
+
+    fn reduce_coreset(
+        &self,
+        coreset: &mut Self::Coreset,
+        dimension: usize,
+        budget: usize,
+    ) -> Result<()>;
+
+    fn coreset_len(&self, coreset: &Self::Coreset) -> usize;
+
+    fn train_centroids(
+        &self,
+        coreset: Self::Coreset,
+        dimension: usize,
+        num_partitions: usize,
+        max_iters: usize,
+        on_progress: KMeansProgressCallback,
+    ) -> Result<FixedSizeListArray>;
+
+    async fn refine_with_sampler(
+        &self,
+        sampler: &FixedIvfTrainingSampler<'_>,
+        streaming_sample_size: usize,
+        sample_ranges: &FixedIvfTrainingRanges,
+        initial_centroids: &FixedSizeListArray,
+        passes: usize,
+        on_progress: KMeansProgressCallback,
+    ) -> Result<FixedSizeListArray>;
+
+    #[allow(clippy::too_many_arguments)]
+    async fn refine_with_resampling(
+        &self,
+        dataset: &Dataset,
+        column: &str,
+        total_sample_rate: usize,
+        streaming_sample_rate: usize,
+        num_partitions: usize,
+        initial_centroids: &FixedSizeListArray,
+        fragment_ids: Option<&[u32]>,
+        passes: usize,
+        on_progress: KMeansProgressCallback,
+    ) -> Result<FixedSizeListArray>;
+}

--- a/rust/lance/src/index/vector/ivf/streaming_hamming.rs
+++ b/rust/lance/src/index/vector/ivf/streaming_hamming.rs
@@ -988,6 +988,65 @@ mod tests {
     }
 
     #[test]
+    fn summary_cost_matches_bruteforce_for_multiple_candidates() {
+        let vectors = [[0b0000_0000], [0b0000_0011], [0b0000_1111], [0b1111_1111]];
+        let mut ones = vec![0_u64; 8];
+        for vector in vectors {
+            add_vector_bits(&mut ones, &vector).unwrap();
+        }
+        for centroid in [[0_u8], [0b0000_0011], [0b1111_1111]] {
+            let expected = vectors
+                .iter()
+                .map(|vector| (vector[0] ^ centroid[0]).count_ones() as u64)
+                .sum::<u64>();
+            assert_eq!(summary_cost(4, &ones, &centroid, 1).unwrap(), expected);
+        }
+    }
+
+    #[test]
+    fn hamming_summary_rejects_invalid_dimensions_and_counts() {
+        let mut coreset = HammingCoreset::new(2, 2);
+        assert!(coreset.push(1, &[1; 8]).is_err());
+        assert!(coreset.push(1, &[2; 16]).is_err());
+        let mut accumulator = HammingAccumulator::try_new(1, 2).unwrap();
+        assert!(accumulator.add_vector(0, &[1]).is_err());
+        assert!(accumulator.add_vector(1, &[1, 2]).is_err());
+    }
+
+    #[test]
+    fn hamming_reduction_is_deterministic_for_equal_bit_fractions() {
+        let mut first = HammingCoreset::new(1, 6);
+        let mut second = HammingCoreset::new(1, 6);
+        for coreset in [&mut first, &mut second] {
+            coreset.push(1, &[0, 0, 0, 0, 0, 0, 0, 0]).unwrap();
+            coreset.push(1, &[0, 1, 0, 0, 0, 0, 0, 0]).unwrap();
+            coreset.push(1, &[0, 0, 0, 0, 0, 0, 0, 0]).unwrap();
+            coreset.push(1, &[0, 1, 0, 0, 0, 0, 0, 0]).unwrap();
+            coreset.push(1, &[0, 0, 0, 0, 0, 0, 0, 0]).unwrap();
+            coreset.push(1, &[1, 1, 0, 0, 0, 0, 0, 0]).unwrap();
+        }
+        first.reduce_to_budget(2).unwrap();
+        second.reduce_to_budget(2).unwrap();
+        assert_eq!(first.counts, second.counts);
+        assert_eq!(first.ones, second.ones);
+        assert_eq!(first.counts, vec![3, 3]);
+        assert_eq!(
+            first.ones.to_u64_vec(),
+            vec![0, 0, 0, 0, 0, 0, 0, 0, 1, 3, 0, 0, 0, 0, 0, 0]
+        );
+    }
+
+    #[test]
+    fn hamming_empty_and_duplicate_summaries_are_safe() {
+        let mut coreset = HammingCoreset::new(1, 3);
+        coreset.push(3, &[3, 3, 0, 0, 0, 0, 0, 0]).unwrap();
+        coreset.push(3, &[3, 3, 0, 0, 0, 0, 0, 0]).unwrap();
+        assert!(coreset.reduce_to_budget(0).is_err());
+        assert_eq!(coreset.mode(0), vec![3]);
+        assert_eq!(coreset.cost(0, &[3]).unwrap(), 0);
+    }
+
+    #[test]
     fn majority_ties_resolve_to_zero() {
         let mut ones = vec![0_u64; 8];
         add_vector_bits(&mut ones, &[0b1010_1010]).unwrap();

--- a/rust/lance/src/index/vector/ivf/streaming_hamming.rs
+++ b/rust/lance/src/index/vector/ivf/streaming_hamming.rs
@@ -1,0 +1,1163 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+//! Hamming sufficient statistics and weighted k-modes for streaming IVF training.
+
+use std::{
+    cmp::Ordering,
+    collections::{BTreeSet, BinaryHeap},
+};
+
+use arrow_array::{Array, FixedSizeListArray, UInt8Array, cast::AsArray};
+use arrow_schema::DataType;
+use lance_arrow::FixedSizeListArrayExt;
+use lance_core::{Error, Result};
+use lance_index::vector::kmeans::KMeans;
+use lance_linalg::distance::DistanceType;
+use rand::{Rng, SeedableRng, rngs::SmallRng};
+
+use super::{KMeansProgressCallback, KMeansStepOptions, train_ivf_kmeans_step_arrow_array_no_loss};
+
+mod counter;
+
+use counter::CompactCounters;
+#[cfg(test)]
+use counter::{CounterWidth, add_vector_bits, mode_from_counts, summary_cost};
+
+#[derive(Clone, Debug)]
+pub(super) struct HammingCoreset {
+    dimension: usize,
+    counts: Vec<u64>,
+    ones: CompactCounters,
+    representatives: BTreeSet<Vec<u8>>,
+    representative_capacity: usize,
+}
+
+impl HammingCoreset {
+    pub(super) fn new(dimension: usize, capacity: usize) -> Self {
+        Self {
+            dimension,
+            counts: Vec::with_capacity(capacity),
+            ones: CompactCounters::with_capacity(
+                capacity.saturating_mul(dimension).saturating_mul(8),
+            ),
+            representatives: BTreeSet::new(),
+            representative_capacity: capacity,
+        }
+    }
+
+    pub(super) fn len(&self) -> usize {
+        self.counts.len()
+    }
+
+    fn bit_dimension(&self) -> usize {
+        self.dimension * 8
+    }
+
+    fn summary_start(&self, index: usize) -> usize {
+        index * self.bit_dimension()
+    }
+
+    fn insert_representative(&mut self, vector: &[u8]) -> Result<()> {
+        if vector.len() != self.dimension {
+            return Err(Error::invalid_input(format!(
+                "Hamming representative dimension {}, expected {}",
+                vector.len(),
+                self.dimension
+            )));
+        }
+        if self.representative_capacity == 0 {
+            return Ok(());
+        }
+        self.representatives.insert(vector.to_vec());
+        if self.representatives.len() > self.representative_capacity {
+            let _ = self.representatives.pop_last();
+        }
+        Ok(())
+    }
+
+    fn extend_representatives(
+        &mut self,
+        representatives: impl IntoIterator<Item = Vec<u8>>,
+    ) -> Result<()> {
+        for representative in representatives {
+            self.insert_representative(&representative)?;
+        }
+        Ok(())
+    }
+
+    fn validate_distinct_representatives(&self, target_k: usize) -> Result<()> {
+        if self.representative_capacity < target_k {
+            return Err(Error::invalid_input(format!(
+                "Hamming coreset representative capacity {} is smaller than the requested {target_k} partitions",
+                self.representative_capacity
+            )));
+        }
+        if self.representatives.len() < target_k {
+            return Err(Error::invalid_input(format!(
+                "weighted Hamming training requires at least {target_k} distinct training vectors, but sampled only {}",
+                self.representatives.len()
+            )));
+        }
+        Ok(())
+    }
+
+    #[cfg(test)]
+    fn push(&mut self, count: u64, ones: &[u64]) -> Result<()> {
+        if count == 0 {
+            return Ok(());
+        }
+        if ones.len() != self.bit_dimension() {
+            return Err(Error::invalid_input(format!(
+                "Hamming coreset summary has {} bit counters, expected {}",
+                ones.len(),
+                self.bit_dimension()
+            )));
+        }
+        if let Some((bit, value)) = ones
+            .iter()
+            .copied()
+            .enumerate()
+            .find(|(_, value)| *value > count)
+        {
+            return Err(Error::invalid_input(format!(
+                "Hamming coreset one-count at bit {bit} is {value}, greater than row count {count}"
+            )));
+        }
+        self.insert_representative(&mode_from_counts(count, ones, self.dimension))?;
+        self.counts.push(count);
+        self.ones.extend_u64(ones, count)?;
+        Ok(())
+    }
+
+    fn push_compact(&mut self, count: u64, ones: &CompactCounters, start: usize) -> Result<()> {
+        if count == 0 {
+            return Ok(());
+        }
+        let bit_dimension = self.bit_dimension();
+        let end = start.checked_add(bit_dimension).ok_or_else(|| {
+            Error::invalid_input("Hamming summary counter range overflow while appending")
+        })?;
+        if end > ones.len() {
+            return Err(Error::invalid_input(format!(
+                "Hamming summary counter range {start}..{end} exceeds length {}",
+                ones.len()
+            )));
+        }
+        if let Some((bit, value)) = (start..end)
+            .map(|index| ones.value(index))
+            .enumerate()
+            .find(|(_, value)| *value > count)
+        {
+            return Err(Error::invalid_input(format!(
+                "Hamming coreset one-count at bit {bit} is {value}, greater than row count {count}"
+            )));
+        }
+        self.counts.push(count);
+        self.ones.extend_from(ones, start, bit_dimension, count)?;
+        Ok(())
+    }
+
+    pub(super) fn append(&mut self, other: Self) -> Result<()> {
+        if self.dimension != other.dimension {
+            return Err(Error::invalid_input(format!(
+                "cannot append Hamming coreset dimension {} to dimension {}",
+                other.dimension, self.dimension
+            )));
+        }
+        let Self {
+            counts,
+            ones,
+            representatives,
+            ..
+        } = other;
+        self.extend_representatives(representatives)?;
+        self.counts.extend(counts);
+        self.ones.append(ones)?;
+        Ok(())
+    }
+
+    pub(super) fn reduce_to_budget(&mut self, budget: usize) -> Result<()> {
+        if self.len() <= budget {
+            return Ok(());
+        }
+        if budget == 0 {
+            return Err(Error::invalid_input(
+                "Hamming coreset budget must be greater than zero",
+            ));
+        }
+
+        let total_count = self.counts.iter().try_fold(0_u64, |total, count| {
+            total.checked_add(*count).ok_or_else(|| {
+                Error::invalid_input("Hamming coreset row count overflow during reduction")
+            })
+        })?;
+        if total_count == 0 {
+            let mut reduced = Self::new(self.dimension, budget);
+            reduced.extend_representatives(self.representatives.iter().cloned())?;
+            *self = reduced;
+            return Ok(());
+        }
+
+        let bit_dimension = self.bit_dimension();
+        let mut weighted_sums = vec![0.0; bit_dimension];
+        let mut weighted_square_sums = vec![0.0; bit_dimension];
+        for row in 0..self.len() {
+            let count = self.counts[row] as f64;
+            let summary_start = self.summary_start(row);
+            for bit in 0..bit_dimension {
+                let fraction = self.ones.value(summary_start + bit) as f64 / count;
+                weighted_sums[bit] += count * fraction;
+                weighted_square_sums[bit] += count * fraction * fraction;
+            }
+        }
+        let total_count = total_count as f64;
+        let variances = weighted_sums
+            .into_iter()
+            .zip(weighted_square_sums)
+            .map(|(weighted_sum, weighted_square_sum)| {
+                let mean = weighted_sum / total_count;
+                weighted_square_sum / total_count - mean * mean
+            })
+            .collect::<Vec<_>>();
+        let split_bit = variances
+            .iter()
+            .enumerate()
+            .max_by(|(_, left), (_, right)| left.partial_cmp(right).unwrap_or(Ordering::Equal))
+            .map(|(bit, _)| bit)
+            .unwrap_or(0);
+
+        let mut indices = (0..self.len()).collect::<Vec<_>>();
+        indices.sort_unstable_by(|left, right| {
+            let left_count = self.counts[*left] as u128;
+            let right_count = self.counts[*right] as u128;
+            let left_ones = self.ones.value(self.summary_start(*left) + split_bit) as u128;
+            let right_ones = self.ones.value(self.summary_start(*right) + split_bit) as u128;
+            (left_ones * right_count)
+                .cmp(&(right_ones * left_count))
+                .then_with(|| left.cmp(right))
+        });
+
+        let mut reduced = Self::new(self.dimension, budget);
+        for group_index in 0..budget {
+            let group_start = group_index * indices.len() / budget;
+            let group_end = (group_index + 1) * indices.len() / budget;
+            if group_start == group_end {
+                continue;
+            }
+            let group_indices = &indices[group_start..group_end];
+            let count = group_indices.iter().try_fold(0_u64, |count, index| {
+                count.checked_add(self.counts[*index]).ok_or_else(|| {
+                    Error::invalid_input("Hamming coreset row count overflow during merge")
+                })
+            })?;
+            let mut ones = CompactCounters::zeros(bit_dimension);
+            for &index in group_indices {
+                ones.add_from(
+                    0,
+                    &self.ones,
+                    self.summary_start(index),
+                    bit_dimension,
+                    count,
+                )?;
+            }
+            reduced.push_compact(count, &ones, 0)?;
+        }
+        reduced.extend_representatives(self.representatives.iter().cloned())?;
+        *self = reduced;
+        Ok(())
+    }
+
+    fn subset(&self, indices: &[usize]) -> Result<Self> {
+        let mut subset = Self::new(self.dimension, indices.len());
+        for &index in indices {
+            subset.push_compact(self.counts[index], &self.ones, self.summary_start(index))?;
+        }
+        Ok(subset)
+    }
+
+    fn mode(&self, index: usize) -> Vec<u8> {
+        self.ones.mode(
+            self.summary_start(index),
+            self.counts[index],
+            self.dimension,
+        )
+    }
+
+    fn cost(&self, index: usize, centroid: &[u8]) -> Result<u64> {
+        self.ones.cost(
+            self.summary_start(index),
+            self.counts[index],
+            centroid,
+            self.dimension,
+        )
+    }
+}
+
+#[derive(Debug)]
+pub(super) struct HammingAccumulator {
+    dimension: usize,
+    counts: Vec<u64>,
+    ones: CompactCounters,
+}
+
+impl HammingAccumulator {
+    pub(super) fn try_new(num_clusters: usize, dimension: usize) -> Result<Self> {
+        let bit_dimension = dimension.checked_mul(8).ok_or_else(|| {
+            Error::invalid_input(format!(
+                "Hamming accumulator bit dimension overflow for dimension {dimension}"
+            ))
+        })?;
+        let num_counters = num_clusters.checked_mul(bit_dimension).ok_or_else(|| {
+            Error::invalid_input(format!(
+                "Hamming accumulator size overflow for {num_clusters} clusters and dimension {dimension}"
+            ))
+        })?;
+        Ok(Self {
+            dimension,
+            counts: vec![0; num_clusters],
+            ones: CompactCounters::zeros(num_counters),
+        })
+    }
+
+    fn bit_dimension(&self) -> usize {
+        self.dimension * 8
+    }
+
+    fn add_vector(&mut self, cluster_id: usize, vector: &[u8]) -> Result<()> {
+        if vector.len() != self.dimension {
+            return Err(Error::invalid_input(format!(
+                "Hamming accumulator vector dimension {}, expected {}",
+                vector.len(),
+                self.dimension
+            )));
+        }
+        let count = self
+            .counts
+            .get(cluster_id)
+            .copied()
+            .ok_or_else(|| {
+                Error::invalid_input(format!(
+                    "Hamming accumulator cluster {cluster_id} is outside 0..{}",
+                    self.counts.len()
+                ))
+            })?
+            .checked_add(1)
+            .ok_or_else(|| {
+                Error::invalid_input(format!(
+                    "Hamming accumulator row count overflow for cluster {cluster_id}"
+                ))
+            })?;
+        self.ones
+            .add_vector(cluster_id * self.bit_dimension(), vector, count)?;
+        self.counts[cluster_id] = count;
+        Ok(())
+    }
+
+    fn add_summary(
+        &mut self,
+        cluster_id: usize,
+        coreset: &HammingCoreset,
+        summary_index: usize,
+    ) -> Result<()> {
+        if self.dimension != coreset.dimension {
+            return Err(Error::invalid_input(format!(
+                "Hamming accumulator dimension {} does not match coreset dimension {}",
+                self.dimension, coreset.dimension
+            )));
+        }
+        let summary_count = coreset.counts.get(summary_index).copied().ok_or_else(|| {
+            Error::invalid_input(format!(
+                "Hamming coreset summary {summary_index} is outside 0..{}",
+                coreset.len()
+            ))
+        })?;
+        let count = self
+            .counts
+            .get(cluster_id)
+            .copied()
+            .ok_or_else(|| {
+                Error::invalid_input(format!(
+                    "Hamming accumulator cluster {cluster_id} is outside 0..{}",
+                    self.counts.len()
+                ))
+            })?
+            .checked_add(summary_count)
+            .ok_or_else(|| {
+                Error::invalid_input(format!(
+                    "Hamming accumulator row count overflow for cluster {cluster_id}"
+                ))
+            })?;
+        self.ones.add_from(
+            cluster_id * self.bit_dimension(),
+            &coreset.ones,
+            coreset.summary_start(summary_index),
+            self.bit_dimension(),
+            count,
+        )?;
+        self.counts[cluster_id] = count;
+        Ok(())
+    }
+
+    fn count(&self, cluster_id: usize) -> u64 {
+        self.counts[cluster_id]
+    }
+
+    fn mode(&self, cluster_id: usize) -> Vec<u8> {
+        self.ones.mode(
+            cluster_id * self.bit_dimension(),
+            self.counts[cluster_id],
+            self.dimension,
+        )
+    }
+
+    pub(super) fn total_count(&self) -> Result<u64> {
+        self.counts.iter().try_fold(0_u64, |total, count| {
+            total
+                .checked_add(*count)
+                .ok_or_else(|| Error::invalid_input("Hamming accumulator total row count overflow"))
+        })
+    }
+}
+
+pub(super) fn append_local_coreset(
+    coreset: &mut HammingCoreset,
+    data: &FixedSizeListArray,
+    local_k: usize,
+    max_iters: usize,
+    on_progress: KMeansProgressCallback,
+) -> Result<()> {
+    if data.value_type() != DataType::UInt8 {
+        return Err(Error::invalid_input(format!(
+            "streaming Hamming k-modes requires UInt8 vectors, got {}",
+            data.value_type()
+        )));
+    }
+    let dimension = data.value_length() as usize;
+    let local_k = local_k.max(1);
+    let sample_rate = data.len().div_ceil(local_k).max(1);
+    let kmeans = train_ivf_kmeans_step_arrow_array_no_loss(
+        None,
+        data,
+        KMeansStepOptions {
+            dimension,
+            metric_type: DistanceType::Hamming,
+            num_partitions: local_k,
+            sample_rate,
+            max_iters,
+            disable_hierarchical: false,
+            on_progress,
+        },
+    )?;
+    let centroids = FixedSizeListArray::try_new_from_values(kmeans.centroids, dimension as i32)?;
+    let assignment_model = KMeans::with_centroids(
+        centroids.values().clone(),
+        dimension,
+        DistanceType::Hamming,
+        f64::MAX,
+    );
+    let (membership, _) = assignment_model.compute_membership_and_distances(data)?;
+    let values = data
+        .values()
+        .as_primitive::<arrow_array::types::UInt8Type>()
+        .values();
+    let mut summaries = HammingAccumulator::try_new(centroids.len(), dimension)?;
+    for (row_index, member) in membership.into_iter().enumerate() {
+        let Some(cluster_id) = member.map(|value| value as usize) else {
+            continue;
+        };
+        let vector = &values[row_index * dimension..(row_index + 1) * dimension];
+        coreset.insert_representative(vector)?;
+        summaries.add_vector(cluster_id, vector)?;
+    }
+    for cluster_id in 0..centroids.len() {
+        coreset.push_compact(
+            summaries.count(cluster_id),
+            &summaries.ones,
+            cluster_id * summaries.bit_dimension(),
+        )?;
+    }
+    Ok(())
+}
+
+#[derive(Debug)]
+struct WeightedKModesResult {
+    centroids: Vec<u8>,
+    membership: Vec<u32>,
+    cluster_counts: Vec<u64>,
+    cluster_losses: Vec<f64>,
+    loss: f64,
+}
+
+fn initialize_centroids(coreset: &HammingCoreset, k: usize) -> Result<Vec<u8>> {
+    let mut rng = SmallRng::seed_from_u64(0x1f17_5eed);
+    let mut selected = vec![false; coreset.len()];
+    let total_count = coreset.counts.iter().try_fold(0_u64, |total, count| {
+        total
+            .checked_add(*count)
+            .ok_or_else(|| Error::invalid_input("Hamming initialization row count overflow"))
+    })?;
+    let first = if total_count > 0 {
+        let mut threshold = rng.random_range(0..total_count);
+        let mut row_index = 0;
+        for (index, count) in coreset.counts.iter().copied().enumerate() {
+            if threshold < count {
+                row_index = index;
+                break;
+            }
+            threshold -= count;
+        }
+        row_index
+    } else {
+        0
+    };
+    selected[first] = true;
+    let mut centroids = coreset.mode(first);
+    let mut min_costs = vec![u64::MAX; coreset.len()];
+
+    while centroids.len() / coreset.dimension < k {
+        let last = &centroids[centroids.len() - coreset.dimension..];
+        for row_index in 0..coreset.len() {
+            if selected[row_index] {
+                min_costs[row_index] = 0;
+            } else {
+                min_costs[row_index] = min_costs[row_index].min(coreset.cost(row_index, last)?);
+            }
+        }
+        let total_cost = min_costs.iter().try_fold(0_u64, |total, cost| {
+            total
+                .checked_add(*cost)
+                .ok_or_else(|| Error::invalid_input("Hamming initialization distance sum overflow"))
+        })?;
+        let next = if total_cost > 0 {
+            let mut threshold = rng.random_range(0..total_cost);
+            let mut choice = None;
+            for (index, cost) in min_costs.iter().copied().enumerate() {
+                if selected[index] {
+                    continue;
+                }
+                if threshold < cost {
+                    choice = Some(index);
+                    break;
+                }
+                threshold -= cost;
+            }
+            choice
+        } else {
+            None
+        }
+        .or_else(|| (0..coreset.len()).find(|index| !selected[*index]));
+        let Some(next) = next else {
+            break;
+        };
+        selected[next] = true;
+        centroids.extend(coreset.mode(next));
+    }
+    while centroids.len() / coreset.dimension < k {
+        let row_index = (centroids.len() / coreset.dimension) * coreset.len() / k;
+        centroids.extend(coreset.mode(row_index));
+    }
+    Ok(centroids)
+}
+
+fn assign_summaries(coreset: &HammingCoreset, centroids: &[u8]) -> Result<WeightedKModesResult> {
+    let k = centroids.len() / coreset.dimension;
+    let mut membership = Vec::with_capacity(coreset.len());
+    let mut accumulator = HammingAccumulator::try_new(k, coreset.dimension)?;
+    let mut cluster_losses = vec![0.0_f64; k];
+
+    for row_index in 0..coreset.len() {
+        let mut best_assignment = None;
+        for cluster_id in 0..k {
+            let centroid =
+                &centroids[cluster_id * coreset.dimension..(cluster_id + 1) * coreset.dimension];
+            let cost = coreset.cost(row_index, centroid)?;
+            if best_assignment
+                .as_ref()
+                .is_none_or(|(_, best_cost)| cost < *best_cost)
+            {
+                best_assignment = Some((cluster_id, cost));
+            }
+        }
+        let (cluster_id, cost) = best_assignment
+            .ok_or_else(|| Error::index("weighted Hamming training has no centroids"))?;
+        membership.push(cluster_id as u32);
+        accumulator.add_summary(cluster_id, coreset, row_index)?;
+        cluster_losses[cluster_id] += cost as f64;
+    }
+
+    let mut next_centroids = Vec::with_capacity(centroids.len());
+    for cluster_id in 0..k {
+        if accumulator.count(cluster_id) == 0 {
+            next_centroids.extend_from_slice(
+                &centroids[cluster_id * coreset.dimension..(cluster_id + 1) * coreset.dimension],
+            );
+        } else {
+            next_centroids.extend(accumulator.mode(cluster_id));
+        }
+    }
+    let loss = cluster_losses.iter().sum();
+    Ok(WeightedKModesResult {
+        centroids: next_centroids,
+        membership,
+        cluster_counts: accumulator.counts,
+        cluster_losses,
+        loss,
+    })
+}
+
+fn has_converged(previous_loss: f64, loss: f64) -> bool {
+    if loss == 0.0 {
+        previous_loss == 0.0
+    } else {
+        (previous_loss - loss).abs() < 1e-4 * loss.abs()
+    }
+}
+
+fn train_weighted_kmodes(
+    coreset: &HammingCoreset,
+    k: usize,
+    max_iters: usize,
+    on_progress: KMeansProgressCallback,
+) -> Result<WeightedKModesResult> {
+    if coreset.len() < k {
+        return Err(Error::invalid_input(format!(
+            "weighted Hamming training requires at least {k} summaries, got {}",
+            coreset.len()
+        )));
+    }
+    let mut centroids = initialize_centroids(coreset, k)?;
+    let mut previous_loss = f64::MAX;
+    let max_iters = max_iters.max(1);
+    for iteration in 1..=max_iters {
+        on_progress(iteration as u32, max_iters as u32);
+        let mut result = assign_summaries(coreset, &centroids)?;
+        let converged = has_converged(previous_loss, result.loss);
+        previous_loss = result.loss;
+        if converged || iteration == max_iters {
+            return Ok(result);
+        }
+        centroids = std::mem::take(&mut result.centroids);
+    }
+    unreachable!("weighted Hamming training runs at least one iteration")
+}
+
+#[derive(Clone, Debug)]
+struct WeightedCluster {
+    id: usize,
+    indices: Vec<usize>,
+    centroid: Vec<u8>,
+    count: u64,
+    loss: f64,
+    finalized: bool,
+}
+
+impl Eq for WeightedCluster {}
+
+impl PartialEq for WeightedCluster {
+    fn eq(&self, other: &Self) -> bool {
+        self.finalized == other.finalized && self.loss == other.loss && self.count == other.count
+    }
+}
+
+impl Ord for WeightedCluster {
+    fn cmp(&self, other: &Self) -> Ordering {
+        match (self.finalized, other.finalized) {
+            (false, true) => Ordering::Greater,
+            (true, false) => Ordering::Less,
+            _ => self
+                .loss
+                .partial_cmp(&other.loss)
+                .unwrap_or(Ordering::Equal)
+                .then_with(|| self.count.cmp(&other.count)),
+        }
+    }
+}
+
+impl PartialOrd for WeightedCluster {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+fn complete_distinct_centroids(
+    candidates: impl IntoIterator<Item = Vec<u8>>,
+    fallbacks: impl IntoIterator<Item = Vec<u8>>,
+    target_k: usize,
+    dimension: usize,
+) -> Result<Vec<u8>> {
+    if target_k == 0 {
+        return Ok(Vec::new());
+    }
+    let mut distinct = BTreeSet::new();
+    let mut values = Vec::with_capacity(target_k.saturating_mul(dimension));
+    for centroid in candidates.into_iter().chain(fallbacks) {
+        if centroid.len() != dimension {
+            return Err(Error::invalid_input(format!(
+                "Hamming centroid dimension {}, expected {dimension}",
+                centroid.len()
+            )));
+        }
+        if distinct.insert(centroid.clone()) {
+            values.extend(centroid);
+            if distinct.len() == target_k {
+                return Ok(values);
+            }
+        }
+    }
+    Err(Error::index(format!(
+        "Hamming centroid completion produced only {} distinct centroids for {target_k} partitions",
+        distinct.len()
+    )))
+}
+
+pub(super) fn train_hierarchical(
+    coreset: &HammingCoreset,
+    target_k: usize,
+    max_iters: usize,
+    on_progress: KMeansProgressCallback,
+) -> Result<FixedSizeListArray> {
+    if coreset.len() == 0 {
+        return Err(Error::index("empty Hamming coreset"));
+    }
+    coreset.validate_distinct_representatives(target_k)?;
+    let initial_k = 16_usize.min(target_k).min(coreset.len()).max(1);
+    let initial = train_weighted_kmodes(coreset, initial_k, max_iters, on_progress.clone())?;
+    let mut heap = BinaryHeap::new();
+    let mut next_cluster_id = 0;
+    for cluster_id in 0..initial_k {
+        let indices = initial
+            .membership
+            .iter()
+            .enumerate()
+            .filter_map(|(index, member)| (*member as usize == cluster_id).then_some(index))
+            .collect::<Vec<_>>();
+        if !indices.is_empty() {
+            heap.push(WeightedCluster {
+                id: next_cluster_id,
+                indices,
+                centroid: initial.centroids
+                    [cluster_id * coreset.dimension..(cluster_id + 1) * coreset.dimension]
+                    .to_vec(),
+                count: initial.cluster_counts[cluster_id],
+                loss: initial.cluster_losses[cluster_id],
+                finalized: false,
+            });
+            next_cluster_id += 1;
+        }
+    }
+
+    while heap.len() < target_k {
+        let mut cluster = heap
+            .pop()
+            .ok_or_else(|| Error::index("No weighted Hamming cluster can be further split"))?;
+        if cluster.finalized {
+            heap.push(cluster);
+            break;
+        }
+        if cluster.indices.len() <= 1 {
+            cluster.finalized = true;
+            heap.push(cluster);
+            continue;
+        }
+        let remaining_k = target_k - heap.len();
+        let cluster_k = if cluster.indices.len() <= 16 {
+            2.min(remaining_k).min(cluster.indices.len())
+        } else {
+            (cluster.indices.len() / 16).min(remaining_k).clamp(2, 16)
+        };
+        let subset = coreset.subset(&cluster.indices)?;
+        let split =
+            train_weighted_kmodes(&subset, cluster_k, max_iters.min(20), on_progress.clone())?;
+        let mut assignments = vec![Vec::new(); cluster_k];
+        for (local_index, member) in split.membership.iter().copied().enumerate() {
+            assignments[member as usize].push(cluster.indices[local_index]);
+        }
+        let nonempty = assignments
+            .iter()
+            .filter(|indices| !indices.is_empty())
+            .count();
+        if nonempty <= 1 {
+            cluster.finalized = true;
+            heap.push(cluster);
+            continue;
+        }
+        for (child_id, child_indices) in assignments.into_iter().enumerate() {
+            if child_indices.is_empty() {
+                continue;
+            }
+            heap.push(WeightedCluster {
+                id: next_cluster_id,
+                indices: child_indices,
+                centroid: split.centroids
+                    [child_id * coreset.dimension..(child_id + 1) * coreset.dimension]
+                    .to_vec(),
+                count: split.cluster_counts[child_id],
+                loss: split.cluster_losses[child_id],
+                finalized: false,
+            });
+            next_cluster_id += 1;
+        }
+    }
+
+    let mut clusters = heap.into_vec();
+    clusters.sort_by_key(|cluster| cluster.id);
+    let values = complete_distinct_centroids(
+        clusters.into_iter().map(|cluster| cluster.centroid),
+        coreset.representatives.iter().cloned(),
+        target_k,
+        coreset.dimension,
+    )?;
+    Ok(FixedSizeListArray::try_new_from_values(
+        UInt8Array::from(values),
+        coreset.dimension as i32,
+    )?)
+}
+
+pub(super) fn refine_weighted(
+    coreset: &HammingCoreset,
+    initial_centroids: &FixedSizeListArray,
+    max_iters: usize,
+    on_progress: KMeansProgressCallback,
+) -> Result<FixedSizeListArray> {
+    let target_k = initial_centroids.len();
+    let mut centroids = initial_centroids
+        .values()
+        .as_primitive::<arrow_array::types::UInt8Type>()
+        .values()
+        .to_vec();
+    let mut previous_loss = f64::MAX;
+    for iteration in 1..=max_iters.max(1) {
+        on_progress(iteration as u32, max_iters.max(1) as u32);
+        let result = assign_summaries(coreset, &centroids)?;
+        let converged = has_converged(previous_loss, result.loss);
+        previous_loss = result.loss;
+        centroids = result.centroids;
+        if converged {
+            break;
+        }
+    }
+    let centroids = complete_distinct_centroids(
+        centroids
+            .chunks_exact(coreset.dimension)
+            .map(|centroid| centroid.to_vec()),
+        coreset.representatives.iter().cloned(),
+        target_k,
+        coreset.dimension,
+    )?;
+    Ok(FixedSizeListArray::try_new_from_values(
+        UInt8Array::from(centroids),
+        coreset.dimension as i32,
+    )?)
+}
+
+pub(super) fn accumulate_raw_assignments(
+    data: &FixedSizeListArray,
+    centroids: &FixedSizeListArray,
+    accumulator: &mut HammingAccumulator,
+) -> Result<f64> {
+    let dimension = data.value_length() as usize;
+    if accumulator.dimension != dimension || accumulator.counts.len() != centroids.len() {
+        return Err(Error::invalid_input(format!(
+            "Hamming refinement accumulator has {} clusters of dimension {}, expected {} clusters of dimension {dimension}",
+            accumulator.counts.len(),
+            accumulator.dimension,
+            centroids.len()
+        )));
+    }
+    let model = KMeans::with_centroids(
+        centroids.values().clone(),
+        dimension,
+        DistanceType::Hamming,
+        f64::MAX,
+    );
+    let (membership, distances) = model.compute_membership_and_distances(data)?;
+    let values = data
+        .values()
+        .as_primitive::<arrow_array::types::UInt8Type>()
+        .values();
+    let mut loss = 0.0;
+    for row_index in 0..data.len() {
+        let (Some(cluster_id), Some(distance)) = (membership[row_index], distances[row_index])
+        else {
+            continue;
+        };
+        let cluster_id = cluster_id as usize;
+        accumulator.add_vector(
+            cluster_id,
+            &values[row_index * dimension..(row_index + 1) * dimension],
+        )?;
+        loss += distance as f64;
+    }
+    Ok(loss)
+}
+
+pub(super) fn update_raw_centroids(
+    centroids: &FixedSizeListArray,
+    accumulator: &HammingAccumulator,
+) -> Result<FixedSizeListArray> {
+    let dimension = centroids.value_length() as usize;
+    if accumulator.dimension != dimension || accumulator.counts.len() != centroids.len() {
+        return Err(Error::invalid_input(format!(
+            "Hamming refinement accumulator has {} clusters of dimension {}, expected {} clusters of dimension {dimension}",
+            accumulator.counts.len(),
+            accumulator.dimension,
+            centroids.len()
+        )));
+    }
+    let current = centroids
+        .values()
+        .as_primitive::<arrow_array::types::UInt8Type>()
+        .values();
+    let mut candidates = Vec::with_capacity(centroids.len());
+    for cluster_id in 0..centroids.len() {
+        if accumulator.count(cluster_id) == 0 {
+            candidates.push(current[cluster_id * dimension..(cluster_id + 1) * dimension].to_vec());
+        } else {
+            candidates.push(accumulator.mode(cluster_id));
+        }
+    }
+    let next = complete_distinct_centroids(
+        candidates,
+        current
+            .chunks_exact(dimension)
+            .map(|centroid| centroid.to_vec()),
+        centroids.len(),
+        dimension,
+    )?;
+    Ok(FixedSizeListArray::try_new_from_values(
+        UInt8Array::from(next),
+        dimension as i32,
+    )?)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rstest::rstest;
+
+    #[rstest]
+    #[case::u8_max(u8::MAX as u64, CounterWidth::U8)]
+    #[case::u16_min(u8::MAX as u64 + 1, CounterWidth::U16)]
+    #[case::u16_max(u16::MAX as u64, CounterWidth::U16)]
+    #[case::u32_min(u16::MAX as u64 + 1, CounterWidth::U32)]
+    #[case::u32_max(u32::MAX as u64, CounterWidth::U32)]
+    #[case::u64_min(u32::MAX as u64 + 1, CounterWidth::U64)]
+    fn compact_counter_selects_narrowest_exact_width(
+        #[case] count: u64,
+        #[case] expected_width: CounterWidth,
+    ) {
+        let mut counters = CompactCounters::with_capacity(1);
+        counters.extend_u64(&[count], count).unwrap();
+        assert_eq!(counters.width(), expected_width);
+        assert_eq!(counters.to_u64_vec(), vec![count]);
+    }
+
+    #[test]
+    fn compact_counter_promotion_preserves_existing_values() {
+        let mut counters = CompactCounters::with_capacity(4);
+        counters
+            .extend_u64(&[1, u8::MAX as u64], u8::MAX as u64)
+            .unwrap();
+        counters.ensure_width_for(u8::MAX as u64 + 1);
+        counters
+            .extend_u64(&[u16::MAX as u64], u16::MAX as u64)
+            .unwrap();
+        counters.ensure_width_for(u16::MAX as u64 + 1);
+        counters
+            .extend_u64(&[u32::MAX as u64], u32::MAX as u64)
+            .unwrap();
+        counters.ensure_width_for(u32::MAX as u64 + 1);
+
+        assert_eq!(counters.width(), CounterWidth::U64);
+        assert_eq!(
+            counters.to_u64_vec(),
+            vec![1, u8::MAX as u64, u16::MAX as u64, u32::MAX as u64]
+        );
+    }
+
+    #[test]
+    fn summary_cost_and_mode_preserve_raw_hamming_statistics() {
+        let mut ones = vec![0_u64; 8];
+        for value in [0b0000_0001, 0b0000_0011, 0b0000_0010] {
+            add_vector_bits(&mut ones, &[value]).unwrap();
+        }
+        assert_eq!(mode_from_counts(3, &ones, 1), vec![0b0000_0011]);
+        assert_eq!(summary_cost(3, &ones, &[0], 1).unwrap(), 4);
+        assert_eq!(summary_cost(3, &ones, &[0b11], 1).unwrap(), 2);
+    }
+
+    #[test]
+    fn majority_ties_resolve_to_zero() {
+        let mut ones = vec![0_u64; 8];
+        add_vector_bits(&mut ones, &[0b1010_1010]).unwrap();
+        assert_eq!(mode_from_counts(2, &ones, 1), vec![0]);
+    }
+
+    #[test]
+    fn coreset_merge_is_associative() {
+        let mut coreset = HammingCoreset::new(1, 3);
+        coreset.push(2, &[1, 0, 0, 0, 0, 0, 0, 0]).unwrap();
+        coreset.push(3, &[2, 1, 0, 0, 0, 0, 0, 0]).unwrap();
+        coreset.push(1, &[1, 1, 0, 0, 0, 0, 0, 0]).unwrap();
+        coreset.reduce_to_budget(1).unwrap();
+        assert_eq!(coreset.counts, vec![6]);
+        assert_eq!(coreset.ones.width(), CounterWidth::U8);
+        assert_eq!(coreset.ones.to_u64_vec(), vec![4, 2, 0, 0, 0, 0, 0, 0]);
+    }
+
+    #[test]
+    fn coreset_append_promotes_mixed_widths_without_losing_counts() {
+        let mut left = HammingCoreset::new(1, 2);
+        left.push(2, &[1, 0, 0, 0, 0, 0, 0, 0]).unwrap();
+        let mut right = HammingCoreset::new(1, 1);
+        right.push(300, &[299, 1, 0, 0, 0, 0, 0, 0]).unwrap();
+
+        left.append(right).unwrap();
+
+        assert_eq!(left.counts, vec![2, 300]);
+        assert_eq!(left.ones.width(), CounterWidth::U16);
+        assert_eq!(
+            left.ones.to_u64_vec(),
+            vec![1, 0, 0, 0, 0, 0, 0, 0, 299, 1, 0, 0, 0, 0, 0, 0]
+        );
+    }
+
+    #[test]
+    fn compact_accumulator_matches_u64_reference_across_promotion() {
+        const DIMENSION: usize = 2;
+        const CLUSTERS: usize = 3;
+        let mut rng = SmallRng::seed_from_u64(0xacca_5510);
+        let mut accumulator = HammingAccumulator::try_new(CLUSTERS, DIMENSION).unwrap();
+        let mut reference_counts = vec![0_u64; CLUSTERS];
+        let mut reference_ones = vec![0_u64; CLUSTERS * DIMENSION * 8];
+
+        for _ in 0..1_000 {
+            let cluster_id = rng.random_range(0..CLUSTERS);
+            let vector = [rng.random::<u8>(), rng.random::<u8>()];
+            accumulator.add_vector(cluster_id, &vector).unwrap();
+            reference_counts[cluster_id] += 1;
+            add_vector_bits(
+                &mut reference_ones[cluster_id * DIMENSION * 8..(cluster_id + 1) * DIMENSION * 8],
+                &vector,
+            )
+            .unwrap();
+        }
+
+        assert_eq!(accumulator.ones.width(), CounterWidth::U16);
+        assert_eq!(accumulator.counts, reference_counts);
+        assert_eq!(accumulator.ones.to_u64_vec(), reference_ones);
+        for (cluster_id, count) in reference_counts.into_iter().enumerate() {
+            assert_eq!(
+                accumulator.mode(cluster_id),
+                mode_from_counts(
+                    count,
+                    &reference_ones[cluster_id * DIMENSION * 8..(cluster_id + 1) * DIMENSION * 8],
+                    DIMENSION,
+                )
+            );
+        }
+    }
+
+    #[test]
+    fn raw_centroid_update_promotes_and_preserves_empty_centroids() {
+        let centroids =
+            FixedSizeListArray::try_new_from_values(UInt8Array::from(vec![0_u8, 0b0101_0101]), 1)
+                .unwrap();
+        let mut accumulator = HammingAccumulator::try_new(2, 1).unwrap();
+        for _ in 0..256 {
+            accumulator.add_vector(0, &[u8::MAX]).unwrap();
+        }
+
+        assert_eq!(accumulator.ones.width(), CounterWidth::U16);
+        let updated = update_raw_centroids(&centroids, &accumulator).unwrap();
+        assert_eq!(
+            updated
+                .values()
+                .as_primitive::<arrow_array::types::UInt8Type>(),
+            &UInt8Array::from(vec![u8::MAX, 0b0101_0101])
+        );
+    }
+
+    #[test]
+    fn raw_centroid_update_preserves_distinct_centroids() {
+        let centroids =
+            FixedSizeListArray::try_new_from_values(UInt8Array::from(vec![0_u8, 1, 2]), 1).unwrap();
+        let mut accumulator = HammingAccumulator::try_new(3, 1).unwrap();
+        accumulator.add_vector(0, &[0]).unwrap();
+        accumulator.add_vector(1, &[0]).unwrap();
+
+        let updated = update_raw_centroids(&centroids, &accumulator).unwrap();
+        let values = updated
+            .values()
+            .as_primitive::<arrow_array::types::UInt8Type>()
+            .values();
+
+        assert_eq!(values.iter().copied().collect::<BTreeSet<_>>().len(), 3);
+    }
+
+    #[test]
+    fn local_coreset_clamps_zero_cluster_count() {
+        let data =
+            FixedSizeListArray::try_new_from_values(UInt8Array::from(vec![0_u8, u8::MAX]), 1)
+                .unwrap();
+        let mut coreset = HammingCoreset::new(1, 1);
+
+        append_local_coreset(&mut coreset, &data, 0, 2, std::sync::Arc::new(|_, _| {})).unwrap();
+
+        assert_eq!(coreset.counts, vec![2]);
+    }
+
+    #[test]
+    fn hierarchical_training_rejects_unsplittable_summaries() {
+        let mut coreset = HammingCoreset::new(1, 2);
+        coreset.push(1, &[0; 8]).unwrap();
+        coreset.push(1, &[0; 8]).unwrap();
+
+        let error = train_hierarchical(&coreset, 2, 2, std::sync::Arc::new(|_, _| {})).unwrap_err();
+
+        assert!(matches!(error, Error::InvalidInput { .. }));
+        assert!(
+            error
+                .to_string()
+                .contains("requires at least 2 distinct training vectors, but sampled only 1")
+        );
+    }
+
+    #[test]
+    fn hierarchical_training_completes_from_distinct_representatives() {
+        let mut coreset = HammingCoreset::new(1, 4);
+        coreset.push(4, &[2, 2, 0, 0, 0, 0, 0, 0]).unwrap();
+        for representative in 1_u8..4 {
+            coreset.insert_representative(&[representative]).unwrap();
+        }
+
+        let centroids = train_hierarchical(&coreset, 4, 2, std::sync::Arc::new(|_, _| {})).unwrap();
+        let values = centroids
+            .values()
+            .as_primitive::<arrow_array::types::UInt8Type>()
+            .values();
+
+        assert_eq!(values, &[0, 1, 2, 3]);
+    }
+
+    #[test]
+    fn hierarchical_training_keeps_splitting_after_a_high_loss_singleton() {
+        let mut coreset = HammingCoreset::new(1, 18);
+        coreset.push(1_000_000, &[500_001; 8]).unwrap();
+        for value in 0_u8..17 {
+            let mut ones = vec![0_u64; 8];
+            add_vector_bits(&mut ones, &[value]).unwrap();
+            coreset.push(1, &ones).unwrap();
+        }
+
+        let centroids =
+            train_hierarchical(&coreset, 17, 5, std::sync::Arc::new(|_, _| {})).unwrap();
+        let values = centroids
+            .values()
+            .as_primitive::<arrow_array::types::UInt8Type>()
+            .values();
+
+        assert_eq!(values.iter().filter(|&&value| value == u8::MAX).count(), 1);
+    }
+}

--- a/rust/lance/src/index/vector/ivf/streaming_hamming/counter.rs
+++ b/rust/lance/src/index/vector/ivf/streaming_hamming/counter.rs
@@ -1,0 +1,430 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+//! Compact per-bit counters for Hamming coreset summaries.
+
+use lance_core::{Error, Result};
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub(super) enum CounterWidth {
+    U8,
+    U16,
+    U32,
+    U64,
+}
+
+impl CounterWidth {
+    fn for_count(count: u64) -> Self {
+        if u8::try_from(count).is_ok() {
+            Self::U8
+        } else if u16::try_from(count).is_ok() {
+            Self::U16
+        } else if u32::try_from(count).is_ok() {
+            Self::U32
+        } else {
+            Self::U64
+        }
+    }
+}
+
+pub(super) trait CompactCounter: Copy {
+    fn from_u64(value: u64) -> Option<Self>;
+
+    fn to_u64(self) -> u64;
+}
+
+macro_rules! impl_compact_counter {
+    ($type:ty) => {
+        impl CompactCounter for $type {
+            fn from_u64(value: u64) -> Option<Self> {
+                Self::try_from(value).ok()
+            }
+
+            fn to_u64(self) -> u64 {
+                u64::from(self)
+            }
+        }
+    };
+}
+
+impl_compact_counter!(u8);
+impl_compact_counter!(u16);
+impl_compact_counter!(u32);
+
+impl CompactCounter for u64 {
+    fn from_u64(value: u64) -> Option<Self> {
+        Some(value)
+    }
+
+    fn to_u64(self) -> u64 {
+        self
+    }
+}
+
+fn widen_vec<T, U>(values: Vec<T>, convert: impl Fn(T) -> U) -> Vec<U> {
+    let mut widened = Vec::with_capacity(values.capacity());
+    widened.extend(values.into_iter().map(convert));
+    widened
+}
+
+fn add_counter_slices<T: CompactCounter, U: CompactCounter>(
+    destination: &mut [T],
+    source: &[U],
+) -> Result<()> {
+    debug_assert_eq!(destination.len(), source.len());
+    for (bit_index, (sum, value)) in destination.iter_mut().zip(source).enumerate() {
+        let next = sum.to_u64().checked_add(value.to_u64()).ok_or_else(|| {
+            Error::invalid_input(format!(
+                "Hamming one-count overflow while merging bit {bit_index}"
+            ))
+        })?;
+        *sum = T::from_u64(next).ok_or_else(|| {
+            Error::invalid_input(format!(
+                "Hamming one-count {next} does not fit destination counter at bit {bit_index}"
+            ))
+        })?;
+    }
+    Ok(())
+}
+
+fn extend_counter_slice<T: CompactCounter, U: CompactCounter>(
+    destination: &mut Vec<T>,
+    source: &[U],
+) -> Result<()> {
+    for (bit_index, value) in source.iter().copied().enumerate() {
+        let value = value.to_u64();
+        destination.push(T::from_u64(value).ok_or_else(|| {
+            Error::invalid_input(format!(
+                "Hamming one-count {value} does not fit destination counter at bit {bit_index}"
+            ))
+        })?);
+    }
+    Ok(())
+}
+
+pub(super) fn add_vector_bits<T: CompactCounter>(ones: &mut [T], vector: &[u8]) -> Result<()> {
+    debug_assert_eq!(ones.len(), vector.len() * 8);
+    for (byte_index, byte) in vector.iter().copied().enumerate() {
+        for bit in 0..8 {
+            if byte & (1 << bit) != 0 {
+                let bit_index = byte_index * 8 + bit;
+                let next = ones[bit_index].to_u64().checked_add(1).ok_or_else(|| {
+                    Error::invalid_input(format!("Hamming one-count overflow at bit {bit_index}"))
+                })?;
+                ones[bit_index] = T::from_u64(next).ok_or_else(|| {
+                    Error::invalid_input(format!(
+                        "Hamming one-count {next} does not fit counter at bit {bit_index}"
+                    ))
+                })?;
+            }
+        }
+    }
+    Ok(())
+}
+
+pub(super) fn mode_from_counts<T: CompactCounter>(
+    count: u64,
+    ones: &[T],
+    dimension: usize,
+) -> Vec<u8> {
+    let mut mode = vec![0_u8; dimension];
+    for (bit_index, one_count) in ones.iter().copied().enumerate() {
+        let one_count = one_count.to_u64();
+        if one_count > count - one_count {
+            mode[bit_index / 8] |= 1 << (bit_index % 8);
+        }
+    }
+    mode
+}
+
+pub(super) fn summary_cost<T: CompactCounter>(
+    count: u64,
+    ones: &[T],
+    centroid: &[u8],
+    dimension: usize,
+) -> Result<u64> {
+    if centroid.len() != dimension || ones.len() != dimension * 8 {
+        return Err(Error::invalid_input(format!(
+            "invalid Hamming summary dimensions: centroid={}, bit_counts={}, dimension={dimension}",
+            centroid.len(),
+            ones.len()
+        )));
+    }
+    let mut cost = 0_u64;
+    for (bit_index, one_count) in ones.iter().copied().enumerate() {
+        let one_count = one_count.to_u64();
+        let mismatch = if centroid[bit_index / 8] & (1 << (bit_index % 8)) == 0 {
+            one_count
+        } else {
+            count - one_count
+        };
+        cost = cost.checked_add(mismatch).ok_or_else(|| {
+            Error::invalid_input("Hamming coreset distance overflow during assignment")
+        })?;
+    }
+    Ok(cost)
+}
+
+/// Contiguous per-bit counters that use the narrowest exact integer width.
+///
+/// One width is shared by the whole buffer so hot loops dispatch once instead
+/// of storing and inspecting a tag for every counter.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(super) enum CompactCounters {
+    U8(Vec<u8>),
+    U16(Vec<u16>),
+    U32(Vec<u32>),
+    U64(Vec<u64>),
+}
+
+impl CompactCounters {
+    pub(super) fn with_capacity(capacity: usize) -> Self {
+        Self::U8(Vec::with_capacity(capacity))
+    }
+
+    pub(super) fn zeros(len: usize) -> Self {
+        Self::U8(vec![0; len])
+    }
+
+    pub(super) fn len(&self) -> usize {
+        match self {
+            Self::U8(values) => values.len(),
+            Self::U16(values) => values.len(),
+            Self::U32(values) => values.len(),
+            Self::U64(values) => values.len(),
+        }
+    }
+
+    pub(super) fn width(&self) -> CounterWidth {
+        match self {
+            Self::U8(_) => CounterWidth::U8,
+            Self::U16(_) => CounterWidth::U16,
+            Self::U32(_) => CounterWidth::U32,
+            Self::U64(_) => CounterWidth::U64,
+        }
+    }
+
+    pub(super) fn ensure_width_for(&mut self, count: u64) {
+        self.promote_to(CounterWidth::for_count(count));
+    }
+
+    pub(super) fn promote_to(&mut self, width: CounterWidth) {
+        while self.width() < width {
+            let current = std::mem::replace(self, Self::U8(Vec::new()));
+            *self = match current {
+                Self::U8(values) => Self::U16(widen_vec(values, u16::from)),
+                Self::U16(values) => Self::U32(widen_vec(values, u32::from)),
+                Self::U32(values) => Self::U64(widen_vec(values, u64::from)),
+                Self::U64(values) => Self::U64(values),
+            };
+        }
+    }
+
+    pub(super) fn value(&self, index: usize) -> u64 {
+        match self {
+            Self::U8(values) => u64::from(values[index]),
+            Self::U16(values) => u64::from(values[index]),
+            Self::U32(values) => u64::from(values[index]),
+            Self::U64(values) => values[index],
+        }
+    }
+
+    #[cfg(test)]
+    pub(super) fn extend_u64(&mut self, source: &[u64], max_count: u64) -> Result<()> {
+        self.ensure_width_for(max_count);
+        match self {
+            Self::U8(destination) => extend_counter_slice(destination, source),
+            Self::U16(destination) => extend_counter_slice(destination, source),
+            Self::U32(destination) => extend_counter_slice(destination, source),
+            Self::U64(destination) => extend_counter_slice(destination, source),
+        }
+    }
+
+    pub(super) fn extend_from(
+        &mut self,
+        source: &Self,
+        source_start: usize,
+        len: usize,
+        max_count: u64,
+    ) -> Result<()> {
+        self.ensure_width_for(max_count);
+        let source_end = source_start.checked_add(len).ok_or_else(|| {
+            Error::invalid_input("Hamming counter source range overflow while appending")
+        })?;
+        if source_end > source.len() {
+            return Err(Error::invalid_input(format!(
+                "Hamming counter source range {source_start}..{source_end} exceeds length {}",
+                source.len()
+            )));
+        }
+
+        macro_rules! extend {
+            ($destination:expr, $source:expr) => {
+                extend_counter_slice($destination, &$source[source_start..source_end])
+            };
+        }
+        match (self, source) {
+            (Self::U8(destination), Self::U8(source)) => extend!(destination, source),
+            (Self::U8(destination), Self::U16(source)) => extend!(destination, source),
+            (Self::U8(destination), Self::U32(source)) => extend!(destination, source),
+            (Self::U8(destination), Self::U64(source)) => extend!(destination, source),
+            (Self::U16(destination), Self::U8(source)) => extend!(destination, source),
+            (Self::U16(destination), Self::U16(source)) => extend!(destination, source),
+            (Self::U16(destination), Self::U32(source)) => extend!(destination, source),
+            (Self::U16(destination), Self::U64(source)) => extend!(destination, source),
+            (Self::U32(destination), Self::U8(source)) => extend!(destination, source),
+            (Self::U32(destination), Self::U16(source)) => extend!(destination, source),
+            (Self::U32(destination), Self::U32(source)) => extend!(destination, source),
+            (Self::U32(destination), Self::U64(source)) => extend!(destination, source),
+            (Self::U64(destination), Self::U8(source)) => extend!(destination, source),
+            (Self::U64(destination), Self::U16(source)) => extend!(destination, source),
+            (Self::U64(destination), Self::U32(source)) => extend!(destination, source),
+            (Self::U64(destination), Self::U64(source)) => extend!(destination, source),
+        }
+    }
+
+    pub(super) fn append(&mut self, mut other: Self) -> Result<()> {
+        let width = self.width().max(other.width());
+        self.promote_to(width);
+        other.promote_to(width);
+        match (self, other) {
+            (Self::U8(destination), Self::U8(mut source)) => destination.append(&mut source),
+            (Self::U16(destination), Self::U16(mut source)) => destination.append(&mut source),
+            (Self::U32(destination), Self::U32(mut source)) => destination.append(&mut source),
+            (Self::U64(destination), Self::U64(mut source)) => destination.append(&mut source),
+            _ => {
+                return Err(Error::invalid_input(
+                    "Hamming counter widths differ after promotion",
+                ));
+            }
+        }
+        Ok(())
+    }
+
+    pub(super) fn add_from(
+        &mut self,
+        destination_start: usize,
+        source: &Self,
+        source_start: usize,
+        len: usize,
+        max_count: u64,
+    ) -> Result<()> {
+        self.ensure_width_for(max_count);
+        let destination_end = destination_start.checked_add(len).ok_or_else(|| {
+            Error::invalid_input("Hamming counter destination range overflow while merging")
+        })?;
+        let source_end = source_start.checked_add(len).ok_or_else(|| {
+            Error::invalid_input("Hamming counter source range overflow while merging")
+        })?;
+        if destination_end > self.len() || source_end > source.len() {
+            return Err(Error::invalid_input(format!(
+                "invalid Hamming counter merge ranges: destination={destination_start}..{destination_end} of {}, source={source_start}..{source_end} of {}",
+                self.len(),
+                source.len()
+            )));
+        }
+
+        macro_rules! add {
+            ($destination:expr, $source:expr) => {
+                add_counter_slices(
+                    &mut $destination[destination_start..destination_end],
+                    &$source[source_start..source_end],
+                )
+            };
+        }
+        match (self, source) {
+            (Self::U8(destination), Self::U8(source)) => add!(destination, source),
+            (Self::U8(destination), Self::U16(source)) => add!(destination, source),
+            (Self::U8(destination), Self::U32(source)) => add!(destination, source),
+            (Self::U8(destination), Self::U64(source)) => add!(destination, source),
+            (Self::U16(destination), Self::U8(source)) => add!(destination, source),
+            (Self::U16(destination), Self::U16(source)) => add!(destination, source),
+            (Self::U16(destination), Self::U32(source)) => add!(destination, source),
+            (Self::U16(destination), Self::U64(source)) => add!(destination, source),
+            (Self::U32(destination), Self::U8(source)) => add!(destination, source),
+            (Self::U32(destination), Self::U16(source)) => add!(destination, source),
+            (Self::U32(destination), Self::U32(source)) => add!(destination, source),
+            (Self::U32(destination), Self::U64(source)) => add!(destination, source),
+            (Self::U64(destination), Self::U8(source)) => add!(destination, source),
+            (Self::U64(destination), Self::U16(source)) => add!(destination, source),
+            (Self::U64(destination), Self::U32(source)) => add!(destination, source),
+            (Self::U64(destination), Self::U64(source)) => add!(destination, source),
+        }
+    }
+
+    pub(super) fn add_vector(
+        &mut self,
+        destination_start: usize,
+        vector: &[u8],
+        max_count: u64,
+    ) -> Result<()> {
+        self.ensure_width_for(max_count);
+        let len = vector.len().checked_mul(8).ok_or_else(|| {
+            Error::invalid_input("Hamming vector bit dimension overflow while accumulating")
+        })?;
+        let destination_end = destination_start.checked_add(len).ok_or_else(|| {
+            Error::invalid_input("Hamming counter destination range overflow while accumulating")
+        })?;
+        if destination_end > self.len() {
+            return Err(Error::invalid_input(format!(
+                "Hamming vector counter range {destination_start}..{destination_end} exceeds length {}",
+                self.len()
+            )));
+        }
+        match self {
+            Self::U8(values) => {
+                add_vector_bits(&mut values[destination_start..destination_end], vector)
+            }
+            Self::U16(values) => {
+                add_vector_bits(&mut values[destination_start..destination_end], vector)
+            }
+            Self::U32(values) => {
+                add_vector_bits(&mut values[destination_start..destination_end], vector)
+            }
+            Self::U64(values) => {
+                add_vector_bits(&mut values[destination_start..destination_end], vector)
+            }
+        }
+    }
+
+    pub(super) fn mode(&self, start: usize, count: u64, dimension: usize) -> Vec<u8> {
+        let end = start + dimension * 8;
+        match self {
+            Self::U8(values) => mode_from_counts(count, &values[start..end], dimension),
+            Self::U16(values) => mode_from_counts(count, &values[start..end], dimension),
+            Self::U32(values) => mode_from_counts(count, &values[start..end], dimension),
+            Self::U64(values) => mode_from_counts(count, &values[start..end], dimension),
+        }
+    }
+
+    pub(super) fn cost(
+        &self,
+        start: usize,
+        count: u64,
+        centroid: &[u8],
+        dimension: usize,
+    ) -> Result<u64> {
+        let end = start
+            .checked_add(dimension.saturating_mul(8))
+            .ok_or_else(|| {
+                Error::invalid_input("Hamming counter range overflow while computing cost")
+            })?;
+        if end > self.len() {
+            return Err(Error::invalid_input(format!(
+                "Hamming counter cost range {start}..{end} exceeds length {}",
+                self.len()
+            )));
+        }
+        match self {
+            Self::U8(values) => summary_cost(count, &values[start..end], centroid, dimension),
+            Self::U16(values) => summary_cost(count, &values[start..end], centroid, dimension),
+            Self::U32(values) => summary_cost(count, &values[start..end], centroid, dimension),
+            Self::U64(values) => summary_cost(count, &values[start..end], centroid, dimension),
+        }
+    }
+
+    #[cfg(test)]
+    pub(super) fn to_u64_vec(&self) -> Vec<u64> {
+        (0..self.len()).map(|index| self.value(index)).collect()
+    }
+}


### PR DESCRIPTION
**Added support of Hamming distance in streaming coreset k-means.**
This PR depends on PR #8463

Benchmark report.
For k=1024 i used generated binary vector dataset with 1M 256bit vectors, not random but with clusters simulation (generate 1024 random vectors (prototypes), for every new vector - take protorype, copy it, flip every bit with probability p=0.05)
For k=16384 i used generated binary vector dataset with 100M 256bit vectors (16384 prototypes)
Percentages are relative to LanceStream stream=64, coreset=16, prefetch=1, refine=0

| k | algorithm | status | train | time delta | RSS | RSS delta | exact loss | loss delta |
| ---: | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: |
| 1,024 | LanceStream, Hamming distance, refine=0 | ok | 15.70s | baseline | 0.078 GiB | baseline | 3,556,818 | baseline |
| 1,024 | LanceStream non-stream, Hamming distance | ok | 1.17s | -92.5% | 0.085 GiB | +9.3% | 10,256,338 | +188.4% |
| 4,096 | LanceStream, Hamming distance | ok | 218.71s | baseline | 0.120 GiB | baseline | 84,229,200 | baseline |
| 4,096 | LanceStream non-stream, Hamming distance | ok | 13.76s | -93.7% | 0.215 GiB | +78.3% | 93,532,349 | +11.0% |
| 16,384 | LanceStream, Hamming distance | ok | 1,670.87s | baseline | 0.238 GiB | baseline | 120,927,252 | baseline |
| 16,384 | LanceStream non-stream, Hamming distance | ok | 117.20s | -93.0% | 0.476 GiB | +100.2% | 257,908,251 | +113.3% |


Exact loss was evaluated over 262,144 vectors as:

```text
sum_x min_c popcount(x XOR c)
```

Host:
- CPU: Intel Core i7-9700K at 3.60 GHz, 8 physical cores / 8 threads.
- Memory: 31 GiB.
- Architecture: x86-64.
   
In these tests we got only 2 times less memory consumption (in better case), this because of coreset for Hamming distance consumes more memory comparing to Dot/L2
As an option to decrease memory consumption we can decrease streaming_coreset_rate.
