### PR TITLE
fix: skip all-null BTree pages for non-null queries

### DIFF
--- a/rust/lance-index-core/src/scalar.rs
+++ b/rust/lance-index-core/src/scalar.rs
@@ -335,6 +335,22 @@ pub enum SearchResult {
     AtLeast(NullableRowAddrSet),
 }
 
+/// Execution-time options for scalar index search.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SearchOptions {
+    /// If true, the search should preserve NULL rows for three-valued logic.
+    pub track_nulls: bool,
+}
+
+impl Default for SearchOptions {
+    fn default() -> Self {
+        // Keep the historical `ScalarIndex::search` contract. Callers that
+        // execute a top-level filter can explicitly disable this bookkeeping
+        // with `SearchOptions { track_nulls: false }`.
+        Self { track_nulls: true }
+    }
+}
+
 impl SearchResult {
     pub fn exact(row_ids: impl Into<RowAddrTreeMap>) -> Self {
         Self::Exact(NullableRowAddrSet::new(row_ids.into(), Default::default()))
@@ -511,6 +527,20 @@ pub trait ScalarIndex: Send + Sync + std::fmt::Debug + Index + DeepSizeOf {
         query: &dyn AnyQuery,
         metrics: &dyn MetricsCollector,
     ) -> Result<SearchResult>;
+
+    /// Search the scalar index with execution-time options.
+    ///
+    /// Index implementations that do not need these options may use the default
+    /// implementation, which preserves the existing `search` behavior.
+    async fn search_with_options(
+        &self,
+        query: &dyn AnyQuery,
+        options: SearchOptions,
+        metrics: &dyn MetricsCollector,
+    ) -> Result<SearchResult> {
+        let _ = options;
+        self.search(query, metrics).await
+    }
 
     /// Returns true if this index reports matches as physical row addresses
     /// (`fragment_id << 32 | offset`) rather than row ids

--- a/rust/lance-index/src/scalar.rs
+++ b/rust/lance-index/src/scalar.rs
@@ -27,7 +27,7 @@ pub use crate::metrics::MetricsCollector;
 pub use lance_index_core::scalar::{
     AnyQuery, BuiltinIndexType, CreatedIndex, IndexFile, IndexReader, IndexStore, IndexWriter,
     LANCE_SCALAR_INDEX, OldIndexDataFilter, RowIdRemapper, ScalarIndex, ScalarIndexParams,
-    SearchResult, TrainingCriteria, TrainingOrdering, UpdateCriteria,
+    SearchOptions, SearchResult, TrainingCriteria, TrainingOrdering, UpdateCriteria,
 };
 
 pub mod bitmap;

--- a/rust/lance-index/src/scalar/bitmap.rs
+++ b/rust/lance-index/src/scalar/bitmap.rs
@@ -36,7 +36,7 @@ use roaring::RoaringBitmap;
 use serde::{Deserialize, Serialize};
 use tracing::{instrument, warn};
 
-use super::{AnyQuery, IndexFile, IndexStore, ScalarIndex};
+use super::{AnyQuery, IndexFile, IndexStore, ScalarIndex, SearchOptions};
 use super::{
     BuiltinIndexType, SargableQuery, ScalarIndexParams, SearchResult, btree::OrderableScalarValue,
 };
@@ -681,7 +681,26 @@ impl ScalarIndex for BitmapIndex {
         query: &dyn AnyQuery,
         metrics: &dyn MetricsCollector,
     ) -> Result<SearchResult> {
+        self.search_with_options(query, SearchOptions::default(), metrics)
+            .await
+    }
+
+    #[instrument(name = "bitmap_search", level = "debug", skip_all)]
+    async fn search_with_options(
+        &self,
+        query: &dyn AnyQuery,
+        options: SearchOptions,
+        metrics: &dyn MetricsCollector,
+    ) -> Result<SearchResult> {
         let query = query.as_any().downcast_ref::<SargableQuery>().unwrap();
+
+        let tracked_null_rows = || {
+            if options.track_nulls && !self.null_map.is_empty() {
+                Some((*self.null_map).clone())
+            } else {
+                None
+            }
+        };
 
         let (row_ids, null_row_ids) = match query {
             SargableQuery::Equals(val) => {
@@ -692,12 +711,7 @@ impl ScalarIndex for BitmapIndex {
                 } else {
                     let key = OrderableScalarValue(val.clone());
                     let bitmap = self.load_bitmap(&key, Some(metrics)).await?;
-                    let null_rows = if !self.null_map.is_empty() {
-                        Some((*self.null_map).clone())
-                    } else {
-                        None
-                    };
-                    ((*bitmap).clone(), null_rows)
+                    ((*bitmap).clone(), tracked_null_rows())
                 }
             }
             SargableQuery::Range(start, end) => {
@@ -748,12 +762,7 @@ impl ScalarIndex for BitmapIndex {
                     RowAddrTreeMap::union_all(&bitmap_refs)
                 };
 
-                let null_rows = if !self.null_map.is_empty() {
-                    Some((*self.null_map).clone())
-                } else {
-                    None
-                };
-                (result, null_rows)
+                (result, tracked_null_rows())
             }
             SargableQuery::IsIn(values) => {
                 metrics.record_comparisons(values.len());
@@ -786,7 +795,7 @@ impl ScalarIndex for BitmapIndex {
                 .try_collect()
                 .await?;
 
-                // Add null bitmap if needed
+                // Add null bitmap if the query explicitly includes NULL.
                 if has_null && !self.null_map.is_empty() {
                     bitmaps.push(self.null_map.clone());
                 }
@@ -794,18 +803,13 @@ impl ScalarIndex for BitmapIndex {
                 let result = if bitmaps.is_empty() {
                     RowAddrTreeMap::default()
                 } else {
-                    // Convert Arc<RowAddrTreeMap> to &RowAddrTreeMap for union_all
                     let bitmap_refs: Vec<_> = bitmaps.iter().map(|b| b.as_ref()).collect();
                     RowAddrTreeMap::union_all(&bitmap_refs)
                 };
 
-                // If the query explicitly includes null, then nulls are TRUE (not NULL)
-                // Otherwise, nulls remain NULL (unknown)
-                let null_rows = if !has_null && !self.null_map.is_empty() {
-                    Some((*self.null_map).clone())
-                } else {
-                    None
-                };
+                // Explicit NULL is TRUE; otherwise NULL remains UNKNOWN only when
+                // the caller needs three-valued-logic bookkeeping.
+                let null_rows = if has_null { None } else { tracked_null_rows() };
                 (result, null_rows)
             }
             SargableQuery::IsNull() => {

--- a/rust/lance-index/src/scalar/btree.rs
+++ b/rust/lance-index/src/scalar/btree.rs
@@ -13,7 +13,7 @@ use std::{
 
 use super::{
     AnyQuery, BuiltinIndexType, IndexFile, IndexReader, IndexStore, IndexWriter, MetricsCollector,
-    OldIndexDataFilter, SargableQuery, ScalarIndex, ScalarIndexParams, SearchResult,
+    OldIndexDataFilter, SargableQuery, ScalarIndex, ScalarIndexParams, SearchOptions, SearchResult,
     compute_next_prefix,
 };
 use crate::cache_pb::{BTreeIndexHeader, RangeToFile};
@@ -2127,6 +2127,16 @@ impl ScalarIndex for BTreeIndex {
         query: &dyn AnyQuery,
         metrics: &dyn MetricsCollector,
     ) -> Result<SearchResult> {
+        self.search_with_options(query, SearchOptions::default(), metrics)
+            .await
+    }
+
+    async fn search_with_options(
+        &self,
+        query: &dyn AnyQuery,
+        options: SearchOptions,
+        metrics: &dyn MetricsCollector,
+    ) -> Result<SearchResult> {
         let query = query.as_any().downcast_ref::<SargableQuery>().unwrap();
         let mut pages = match query {
             SargableQuery::Equals(val) => self
@@ -2193,7 +2203,7 @@ impl ScalarIndex for BTreeIndex {
         // page with zero nulls is a true Matches::All, while one with nulls needs
         // Matches::Some only to track the null rows; surfacing `null_count` here
         // could refine that classification (see #6802).
-        if !matches!(query, SargableQuery::IsNull()) {
+        if options.track_nulls && !matches!(query, SargableQuery::IsNull()) {
             let existing: HashSet<u32> = pages.iter().map(|m| m.page_id()).collect();
             for &page_id in self
                 .page_lookup
@@ -3410,7 +3420,8 @@ mod tests {
     use crate::{
         metrics::NoOpMetricsCollector,
         scalar::{
-            IndexStore, OldIndexDataFilter, SargableQuery, ScalarIndex, SearchResult,
+            IndexStore, OldIndexDataFilter, SargableQuery, ScalarIndex, SearchOptions,
+            SearchResult,
             btree::{BTREE_PAGES_NAME, BTreeIndex},
             lance_format::LanceIndexStore,
         },
@@ -5526,9 +5537,27 @@ mod tests {
             index.page_lookup.all_null_pages.len(),
         );
 
-        let metrics = NoOpMetricsCollector;
+        // A top-level lookup can skip all-null pages because the final filter
+        // discards UNKNOWN rows. This is the hot path for ordinary equality
+        // predicates and must not load the all-null pages.
+        let untracked_metrics = LocalMetricsCollector::default();
+        let _result = index
+            .search_with_options(
+                &SargableQuery::Equals(ScalarValue::Int32(Some(0))),
+                SearchOptions { track_nulls: false },
+                &untracked_metrics,
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            untracked_metrics.parts_loaded.load(Ordering::Relaxed),
+            0,
+            "an absent value must not load all-null pages when NULL tracking is disabled"
+        );
 
-        // Search for Equals(0) — value 0 doesn't exist in any page
+        // The legacy direct-search API retains NULL bookkeeping for callers
+        // that still need the three-valued result.
+        let metrics = NoOpMetricsCollector;
         let result = index
             .search(
                 &SargableQuery::Equals(ScalarValue::Int32(Some(0))),

--- a/rust/lance-index/src/scalar/expression.rs
+++ b/rust/lance-index/src/scalar/expression.rs
@@ -20,7 +20,7 @@ use tokio::try_join;
 
 use super::{
     AnyQuery, BloomFilterQuery, LabelListQuery, MetricsCollector, SargableQuery, ScalarIndex,
-    SearchResult, TextQuery, TokenQuery, label_list::validate_label_list_data_type,
+    SearchOptions, SearchResult, TextQuery, TokenQuery, label_list::validate_label_list_data_type,
 };
 #[cfg(feature = "geo")]
 use super::{GeoQuery, RelationQuery};
@@ -1937,26 +1937,42 @@ impl ScalarIndexExpr {
     ///
     /// TODO: We could potentially try and be smarter about reusing loaded indices for
     /// any situations where the session cache has been disabled.
-    #[async_recursion]
     pub async fn evaluate_nullable(
         &self,
         index_loader: &dyn ScalarIndexLoader,
         metrics: &dyn MetricsCollector,
     ) -> Result<NullableIndexExprResult> {
+        self.evaluate_nullable_impl(index_loader, metrics, false)
+            .await
+    }
+
+    /// Evaluate an expression while optionally retaining NULL rows from index
+    /// searches. A top-level filter eventually drops unknown rows, but a child
+    /// below `NOT` must retain them so SQL three-valued logic remains correct.
+    #[async_recursion]
+    async fn evaluate_nullable_impl(
+        &self,
+        index_loader: &dyn ScalarIndexLoader,
+        metrics: &dyn MetricsCollector,
+        track_nulls: bool,
+    ) -> Result<NullableIndexExprResult> {
         match self {
             Self::Not(inner) => {
-                let result = inner.evaluate_nullable(index_loader, metrics).await?;
+                // `NOT` must preserve NULLs from the child.
+                let result = inner
+                    .evaluate_nullable_impl(index_loader, metrics, true)
+                    .await?;
                 Ok(!result)
             }
             Self::And(lhs, rhs) => {
-                let lhs_result = lhs.evaluate_nullable(index_loader, metrics);
-                let rhs_result = rhs.evaluate_nullable(index_loader, metrics);
+                let lhs_result = lhs.evaluate_nullable_impl(index_loader, metrics, track_nulls);
+                let rhs_result = rhs.evaluate_nullable_impl(index_loader, metrics, track_nulls);
                 let (lhs_result, rhs_result) = try_join!(lhs_result, rhs_result)?;
                 Ok(lhs_result & rhs_result)
             }
             Self::Or(lhs, rhs) => {
-                let lhs_result = lhs.evaluate_nullable(index_loader, metrics);
-                let rhs_result = rhs.evaluate_nullable(index_loader, metrics);
+                let lhs_result = lhs.evaluate_nullable_impl(index_loader, metrics, track_nulls);
+                let rhs_result = rhs.evaluate_nullable_impl(index_loader, metrics, track_nulls);
                 let (lhs_result, rhs_result) = try_join!(lhs_result, rhs_result)?;
                 Ok(lhs_result | rhs_result)
             }
@@ -1964,7 +1980,13 @@ impl ScalarIndexExpr {
                 let index = index_loader
                     .load_index(&search.column, &search.index_name, metrics)
                     .await?;
-                let search_result = index.search(search.query.as_ref(), metrics).await?;
+                let search_result = index
+                    .search_with_options(
+                        search.query.as_ref(),
+                        SearchOptions { track_nulls },
+                        metrics,
+                    )
+                    .await?;
                 let result = search_result_to_nullable(search_result);
                 if index.results_are_row_addresses() {
                     // Translate address-domain results to the row-id domain

--- a/rust/lance-index/src/scalar/json.rs
+++ b/rust/lance-index/src/scalar/json.rs
@@ -38,8 +38,8 @@ use crate::{
     metrics::MetricsCollector,
     registry::IndexPluginRegistry,
     scalar::{
-        AnyQuery, CreatedIndex, IndexStore, RowIdRemapper, ScalarIndex, SearchResult,
-        UpdateCriteria,
+        AnyQuery, CreatedIndex, IndexStore, RowIdRemapper, ScalarIndex, SearchOptions,
+        SearchResult, UpdateCriteria,
         expression::{IndexedExpression, ScalarIndexExpr, ScalarIndexSearch, ScalarQueryParser},
         registry::{
             BasicTrainer, ScalarIndexPlugin, TrainingCriteria, TrainingOrdering, TrainingRequest,
@@ -107,9 +107,19 @@ impl ScalarIndex for JsonIndex {
         query: &dyn AnyQuery,
         metrics: &dyn MetricsCollector,
     ) -> Result<SearchResult> {
+        self.search_with_options(query, SearchOptions::default(), metrics)
+            .await
+    }
+
+    async fn search_with_options(
+        &self,
+        query: &dyn AnyQuery,
+        options: SearchOptions,
+        metrics: &dyn MetricsCollector,
+    ) -> Result<SearchResult> {
         let query = query.as_any().downcast_ref::<JsonQuery>().unwrap();
         self.target_index
-            .search(query.target_query.as_ref(), metrics)
+            .search_with_options(query.target_query.as_ref(), options, metrics)
             .await
     }
 


### PR DESCRIPTION
## Summary

- Skip all-NULL BTree pages for ordinary non-NULL scalar queries.
- Preserve NULL tracking for NOT expressions and the direct ScalarIndex.search API.

## Problem

Sparse isbn_13 indexes included all-NULL pages in equality-query candidates because those pages have no usable min/max bounds. On the real amazon_book.lance dataset, the query 9780094749405 went from 847 loaded parts and 3,469,312 comparisons (about 7.7 seconds) to 1 loaded part and 4,096 comparisons (about 1.7 seconds), returning the same 2 records.

## Validation

- cargo fmt --all -- --check
- git diff --check
- cargo test -p lance-index --lib -- --test-threads=1 (1018 passed)
- cargo test -p lance-index-core --lib -- --test-threads=1 (2 passed)
- Python extension built successfully with maturin.
- Verified against the real amazon_book.lance dataset.

Related context: #6614.