### PR TITLE
fix(encoding): reject zero fixed-size-list dimension in repdef decimation

### DIFF
--- a/rust/lance-encoding/src/encodings/logical/struct.rs
+++ b/rust/lance-encoding/src/encodings/logical/struct.rs
@@ -31,7 +31,7 @@ use futures::{
 use itertools::Itertools;
 use lance_arrow::FieldExt;
 use lance_arrow::{deepcopy::deep_copy_nulls, r#struct::StructArrayExt};
-use lance_core::{Error, Result};
+use lance_core::{Error, Result, datatypes::validate_fixed_size_list_dimensions};
 use log::trace;
 
 #[derive(Debug)]
@@ -276,6 +276,12 @@ impl StructuralStructDecoder {
             DataType::FixedSizeList(child_field, _)
                 if matches!(child_field.data_type(), DataType::Struct(_)) =>
             {
+                // The scheduler factories run the same guard, but the decoder tree can be
+                // built independently (e.g. `create_decode_stream`) so a zero dimension from
+                // a malformed schema must be rejected here as well.  Draining and unraveling
+                // validity both scale by the dimension and a zero would make that math
+                // degenerate.
+                validate_fixed_size_list_dimensions(field.name(), field.data_type())?;
                 // FixedSizeList containing Struct needs structural decoding
                 let child_decoder = Self::field_to_decoder(child_field, should_validate)?;
                 Ok(Box::new(StructuralFixedSizeListDecoder::new(
@@ -632,7 +638,33 @@ mod tests {
     use arrow_buffer::{BooleanBuffer, NullBuffer, OffsetBuffer, ScalarBuffer};
     use arrow_schema::{DataType, Field, Fields};
 
+    use super::StructuralStructDecoder;
     use crate::testing::{TestCases, check_basic_random, check_round_trip_encoding_of_data};
+
+    #[test]
+    fn test_zero_dimension_fsl_decoder_errors() {
+        // Simulates a stored schema declaring a zero-dimension FixedSizeList (writers reject
+        // it but old files may contain one).  Building the decoder must fail cleanly instead
+        // of letting the zero dimension reach the rep/def decimation.
+        let item_fields = Fields::from(vec![Field::new("x", DataType::Int32, true)]);
+        let fields = Fields::from(vec![Field::new(
+            "vecs",
+            DataType::FixedSizeList(
+                Arc::new(Field::new("item", DataType::Struct(item_fields), true)),
+                0,
+            ),
+            true,
+        )]);
+
+        let err = StructuralStructDecoder::new(fields, false, /*is_root=*/ true).unwrap_err();
+        assert!(matches!(err, lance_core::Error::Schema { .. }));
+        assert!(
+            err.to_string()
+                .contains("dimension must be a positive integer"),
+            "unexpected error: {}",
+            err
+        );
+    }
 
     #[test_log::test(tokio::test)]
     async fn test_simple_struct() {

--- a/rust/lance-encoding/src/repdef.rs
+++ b/rust/lance-encoding/src/repdef.rs
@@ -1899,7 +1899,22 @@ impl RepDefUnraveler {
         Ok(())
     }
 
+    /// Removes all but the first definition level of each fixed-size-list slot
+    ///
+    /// The definition levels arrive with one entry per item.  A fixed-size-list
+    /// layer has a single definition level per slot (all `dimension` items in a
+    /// slot share it) so we keep every `dimension`-th level and drop the rest.
+    ///
+    /// `dimension` must be non-zero.  A zero dimension can only come from a
+    /// malformed schema (writers reject it, see
+    /// [`lance_core::datatypes::validate_fixed_size_list_dimensions`]) and is
+    /// rejected here rather than allowed to run off the end of the buffer.
     pub fn decimate(&mut self, dimension: usize) -> Result<()> {
+        if dimension == 0 {
+            return Err(Error::invalid_input(
+                "Cannot decimate repetition/definition levels with a fixed-size-list dimension of 0; dimension must be a positive integer",
+            ));
+        }
         if let Some(sparse) = self.sparse.as_mut() {
             return sparse.decimate(dimension);
         }
@@ -1923,6 +1938,9 @@ impl RepDefUnraveler {
         let mut read_idx = 0;
         let mut write_idx = 0;
         while read_idx < def_levels.len() {
+            // SAFETY: `read_idx` is checked against the length by the loop condition and
+            // `dimension >= 1` (checked above) means `write_idx <= read_idx`, so both
+            // indices are in bounds.
             unsafe {
                 *def_levels.get_unchecked_mut(write_idx) = *def_levels.get_unchecked(read_idx);
             }
@@ -3041,6 +3059,36 @@ mod tests {
         assert_eq!(
             unraveler.unravel_fsl_validity(2, 2).unwrap(),
             Some(validity(&[true, false]))
+        );
+    }
+
+    #[test]
+    fn test_repdef_fsl_zero_dimension_is_invalid_input() {
+        // A zero dimension can only reach us from a malformed schema.  Decimating with it
+        // used to loop forever, writing past the end of the definition levels buffer.
+        let mut builder = RepDefBuilder::default();
+        builder.add_fsl(Some(validity(&[true, false])), 2, 2);
+        builder.add_validity_bitmap(validity(&[true, false, true, false]));
+
+        let repdefs = RepDefBuilder::serialize(vec![builder]);
+        let def = repdefs.definition_levels.unwrap();
+
+        let mut unraveler = CompositeRepDefUnraveler::new(vec![RepDefUnraveler::new(
+            None,
+            Some(def.as_ref().to_vec()),
+            repdefs.def_meaning.into(),
+            4,
+        )]);
+        // Consume the item layer so the fixed-size-list layer is next
+        unraveler.unravel_validity(4).unwrap();
+
+        let err = unraveler.unravel_fsl_validity(2, 0).unwrap_err();
+        assert!(matches!(err, lance_core::Error::InvalidInput { .. }));
+        assert!(
+            err.to_string()
+                .contains("dimension must be a positive integer"),
+            "unexpected error: {}",
+            err
         );
     }
 


### PR DESCRIPTION
`RepDefUnraveler::decimate` steps through the definition levels with `read_idx += dimension` and copies with `get_unchecked_mut`. A dimension of 0 never advances the read index, so the loop runs forever and writes past the end of the buffer (SIGSEGV in release; the `get_unchecked_mut` precondition check aborts in debug).

A zero dimension can only come from a malformed schema. #7247 added guards on the write path (`Schema::validate`) and in the field-scheduler factories, but nothing protected the unsafe loop itself, and the decoder tree (`StructuralStructDecoder::field_to_decoder`) can be built without going through those factories.

Reject dimension 0 in `decimate` before the unsafe loop, document the invariant the loop relies on, and run the existing dimension guard when building a fixed-size-list decoder.
