### PR TITLE
fix(table): restore migration_next_row_id on ManifestBuildConfig

### DIFF
--- a/rust/lance-table/src/format/manifest.rs
+++ b/rust/lance-table/src/format/manifest.rs
@@ -707,6 +707,10 @@ pub struct ManifestBuildConfig {
     pub storage_format: Option<DataStorageFormat>,
     /// Skip writing a detached transaction file for this commit.
     pub disable_transaction_file: bool,
+    /// When `Some`, this commit is the second step of `migrate_to_stable_row_ids`.
+    /// It bypasses the "cannot enable stable row ids on existing dataset" guard and
+    /// sets `manifest.next_row_id` to the provided value before activating the flag.
+    pub migration_next_row_id: Option<u64>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/rust/lance/src/dataset.rs
+++ b/rust/lance/src/dataset.rs
@@ -4052,6 +4052,7 @@ impl ManifestWriteConfig {
             use_legacy_format: self.use_legacy_format,
             storage_format: self.storage_format.clone(),
             disable_transaction_file: self.disable_transaction_file,
+            migration_next_row_id: self.migration_next_row_id,
         }
     }
 }


### PR DESCRIPTION
`main` does not compile, which fails the Rust, Python, and Java workflows on main and on every open PR.

Two PRs that were each green on their own collided semantically. #8521 added a `migration_next_row_id` option to `ManifestWriteConfig` and read it while building the manifest. #8053 then moved that config down into `lance-table` as the new `ManifestBuildConfig`; because it branched before #8521, the new struct had no such field. Git merged both cleanly, so the break only appeared once the second one landed:

```
error[E0609]: no field `migration_next_row_id` on type `&lance_table::format::ManifestBuildConfig`
    --> rust/lance/src/dataset/transaction.rs:2230:23
```

This PR adds the missing field to `ManifestBuildConfig` and passes it through `ManifestWriteConfig::to_build_config`. The code that reads it is already correct and is unchanged.

No new test: the five `migrate_to_stable_row_ids` tests added by #8521 already cover this behavior, and they pass again now that the crate compiles.
