### PR TITLE
fix(linalg): reject short slices in SIMD register conversions

### DIFF
--- a/rust/lance-linalg/src/simd.rs
+++ b/rust/lance-linalg/src/simd.rs
@@ -27,6 +27,9 @@ use u8::u8x16;
 
 /// Lance SIMD lib
 ///
+/// The `From<&[T]>` supertrait bound means every register type converts from a
+/// slice. That conversion reads the first `N` elements and ignores the rest, and
+/// panics if the slice is shorter than `N` -- see each impl's `# Panics`.
 pub trait SIMD<T: Num + Copy, const N: usize>:
     std::fmt::Debug
     + AddAssign<Self>
@@ -57,6 +60,11 @@ pub trait SIMD<T: Num + Copy, const N: usize>:
     /// Load unaligned data from memory.
     ///
     /// # Safety
+    ///
+    /// `ptr` must be valid for reads of `N` contiguous `T`. The implementations
+    /// read a whole register with no bounds check, so a pointer derived from a
+    /// slice shorter than `N` reads beyond the slice, and past the end of the
+    /// allocation when the slice reaches its end.
     unsafe fn load_unaligned(ptr: *const T) -> Self;
 
     /// Store the values to aligned memory.
@@ -69,6 +77,8 @@ pub trait SIMD<T: Num + Copy, const N: usize>:
     /// Store the values to unaligned memory.
     ///
     /// # Safety
+    ///
+    /// `ptr` must be valid for writes of `N` contiguous `T`.
     unsafe fn store_unaligned(&self, ptr: *mut T);
 
     /// Return the values as an array.

--- a/rust/lance-linalg/src/simd/f32.rs
+++ b/rust/lance-linalg/src/simd/f32.rs
@@ -146,8 +146,21 @@ fn gather_scalar_x86(slice: &[f32], indices: &[i32; 8]) -> f32x8 {
     unsafe { f32x8::load_unaligned(values.as_ptr()) }
 }
 
+/// Reads the first 8 elements and ignores the rest.
+///
+/// # Panics
+///
+/// If `value` has fewer than 8 elements.
 impl From<&[f32]> for f32x8 {
     fn from(value: &[f32]) -> Self {
+        // `load_unaligned` reads 8 lanes with no bounds check, and this is safe
+        // code reachable from outside the crate, so the check has to survive
+        // release builds -- `debug_assert!` would reinstate the out-of-bounds read.
+        assert!(
+            value.len() >= 8,
+            "f32x8 conversion requires at least 8 elements, got {}",
+            value.len()
+        );
         unsafe { Self::load_unaligned(value.as_ptr()) }
     }
 }
@@ -526,8 +539,21 @@ impl std::fmt::Debug for f32x16 {
     }
 }
 
+/// Reads the first 16 elements and ignores the rest.
+///
+/// # Panics
+///
+/// If `value` has fewer than 16 elements.
 impl From<&[f32]> for f32x16 {
     fn from(value: &[f32]) -> Self {
+        // `load_unaligned` reads 16 lanes with no bounds check, and this is safe
+        // code reachable from outside the crate, so the check has to survive
+        // release builds -- `debug_assert!` would reinstate the out-of-bounds read.
+        assert!(
+            value.len() >= 16,
+            "f32x16 conversion requires at least 16 elements, got {}",
+            value.len()
+        );
         unsafe { Self::load_unaligned(value.as_ptr()) }
     }
 }
@@ -934,6 +960,56 @@ mod tests {
 
     use super::*;
     use rstest::rstest;
+
+    #[test]
+    #[should_panic(expected = "f32x8 conversion requires at least 8 elements")]
+    fn f32x8_from_slice_rejects_short_slice() {
+        // No feature guard: the assert precedes `load_unaligned`, so the panic
+        // happens on every host. An early `return` here would fail the test.
+        let _ = f32x8::from(&[0.0; 7][..]);
+    }
+
+    #[test]
+    #[should_panic(expected = "f32x16 conversion requires at least 16 elements")]
+    fn f32x16_from_slice_rejects_short_slice() {
+        let _ = f32x16::from(&[0.0; 15][..]);
+    }
+
+    #[rstest]
+    #[case::exact_length(8)]
+    #[case::over_length(12)]
+    fn f32x8_from_slice_reads_the_first_eight_lanes(#[case] len: usize) {
+        // `load_unaligned` / `store_unaligned` lower to `_mm256_loadu_ps` and
+        // `_mm256_storeu_ps`, which need AVX. FMA is not involved.
+        #[cfg(target_arch = "x86_64")]
+        if !std::is_x86_feature_detected!("avx") {
+            return;
+        }
+        // Ascending values so a wrong-offset load cannot pass; slicing an
+        // over-long fixture is how the exact-length case is produced.
+        let values: Vec<f32> = (1..=12).map(|v| v as f32).collect();
+
+        let reg = f32x8::from(&values[..len]);
+
+        assert_eq!(reg.as_array().as_slice(), &values[..8]);
+    }
+
+    #[rstest]
+    #[case::exact_length(16)]
+    #[case::over_length(24)]
+    fn f32x16_from_slice_reads_the_first_sixteen_lanes(#[case] len: usize) {
+        #[cfg(target_arch = "x86_64")]
+        if !std::is_x86_feature_detected!("avx") {
+            return;
+        }
+        // Ascending values so a wrong-offset load cannot pass; slicing an
+        // over-long fixture is how the exact-length case is produced.
+        let values: Vec<f32> = (1..=24).map(|v| v as f32).collect();
+
+        let reg = f32x16::from(&values[..len]);
+
+        assert_eq!(reg.as_array().as_slice(), &values[..16]);
+    }
 
     #[test]
     fn test_basic_ops() {

--- a/rust/lance-linalg/src/simd/f64.rs
+++ b/rust/lance-linalg/src/simd/f64.rs
@@ -43,8 +43,21 @@ impl std::fmt::Debug for f64x4 {
     }
 }
 
+/// Reads the first 4 elements and ignores the rest.
+///
+/// # Panics
+///
+/// If `value` has fewer than 4 elements.
 impl From<&[f64]> for f64x4 {
     fn from(value: &[f64]) -> Self {
+        // `load_unaligned` reads 4 lanes with no bounds check, and this is safe
+        // code reachable from outside the crate, so the check has to survive
+        // release builds -- `debug_assert!` would reinstate the out-of-bounds read.
+        assert!(
+            value.len() >= 4,
+            "f64x4 conversion requires at least 4 elements, got {}",
+            value.len()
+        );
         unsafe { Self::load_unaligned(value.as_ptr()) }
     }
 }
@@ -387,8 +400,21 @@ impl std::fmt::Debug for f64x8 {
     }
 }
 
+/// Reads the first 8 elements and ignores the rest.
+///
+/// # Panics
+///
+/// If `value` has fewer than 8 elements.
 impl From<&[f64]> for f64x8 {
     fn from(value: &[f64]) -> Self {
+        // `load_unaligned` reads 8 lanes with no bounds check, and this is safe
+        // code reachable from outside the crate, so the check has to survive
+        // release builds -- `debug_assert!` would reinstate the out-of-bounds read.
+        assert!(
+            value.len() >= 8,
+            "f64x8 conversion requires at least 8 elements, got {}",
+            value.len()
+        );
         unsafe { Self::load_unaligned(value.as_ptr()) }
     }
 }
@@ -733,6 +759,57 @@ impl SubAssign for f64x8 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use rstest::rstest;
+
+    #[test]
+    #[should_panic(expected = "f64x4 conversion requires at least 4 elements")]
+    fn f64x4_from_slice_rejects_short_slice() {
+        // No feature guard: the assert precedes `load_unaligned`, so the panic
+        // happens on every host. An early `return` here would fail the test.
+        let _ = f64x4::from(&[0.0; 3][..]);
+    }
+
+    #[test]
+    #[should_panic(expected = "f64x8 conversion requires at least 8 elements")]
+    fn f64x8_from_slice_rejects_short_slice() {
+        let _ = f64x8::from(&[0.0; 7][..]);
+    }
+
+    #[rstest]
+    #[case::exact_length(4)]
+    #[case::over_length(6)]
+    fn f64x4_from_slice_reads_the_first_four_lanes(#[case] len: usize) {
+        // `load_unaligned` / `store_unaligned` lower to `_mm256_loadu_pd` and
+        // `_mm256_storeu_pd`, which need AVX.
+        #[cfg(target_arch = "x86_64")]
+        if !std::is_x86_feature_detected!("avx") {
+            return;
+        }
+        // Ascending values so a wrong-offset load cannot pass; slicing an
+        // over-long fixture is how the exact-length case is produced.
+        let values: Vec<f64> = (1..=6).map(|v| v as f64).collect();
+
+        let reg = f64x4::from(&values[..len]);
+
+        assert_eq!(reg.as_array().as_slice(), &values[..4]);
+    }
+
+    #[rstest]
+    #[case::exact_length(8)]
+    #[case::over_length(12)]
+    fn f64x8_from_slice_reads_the_first_eight_lanes(#[case] len: usize) {
+        #[cfg(target_arch = "x86_64")]
+        if !std::is_x86_feature_detected!("avx") {
+            return;
+        }
+        // Ascending values so a wrong-offset load cannot pass; slicing an
+        // over-long fixture is how the exact-length case is produced.
+        let values: Vec<f64> = (1..=12).map(|v| v as f64).collect();
+
+        let reg = f64x8::from(&values[..len]);
+
+        assert_eq!(reg.as_array().as_slice(), &values[..8]);
+    }
 
     #[test]
     fn test_f64x4_basic_ops() {

--- a/rust/lance-linalg/src/simd/i32.rs
+++ b/rust/lance-linalg/src/simd/i32.rs
@@ -40,8 +40,21 @@ impl std::fmt::Debug for i32x8 {
     }
 }
 
+/// Reads the first 8 elements and ignores the rest.
+///
+/// # Panics
+///
+/// If `value` has fewer than 8 elements.
 impl From<&[i32]> for i32x8 {
     fn from(value: &[i32]) -> Self {
+        // `load_unaligned` reads 8 lanes with no bounds check, and this is safe
+        // code reachable from outside the crate, so the check has to survive
+        // release builds -- `debug_assert!` would reinstate the out-of-bounds read.
+        assert!(
+            value.len() >= 8,
+            "i32x8 conversion requires at least 8 elements, got {}",
+            value.len()
+        );
         unsafe { Self::load_unaligned(value.as_ptr()) }
     }
 }
@@ -318,4 +331,34 @@ impl Mul for i32x8 {
 }
 
 #[cfg(test)]
-mod tests {}
+mod tests {
+    use super::*;
+    use rstest::rstest;
+
+    #[test]
+    #[should_panic(expected = "i32x8 conversion requires at least 8 elements")]
+    fn from_slice_rejects_short_slice() {
+        // No feature guard: the assert precedes `load_unaligned`, so the panic
+        // happens on every host. An early `return` here would fail the test.
+        let _ = i32x8::from(&[0; 7][..]);
+    }
+
+    #[rstest]
+    #[case::exact_length(8)]
+    #[case::over_length(12)]
+    fn from_slice_reads_the_first_eight_lanes(#[case] len: usize) {
+        // `load_unaligned` / `store_unaligned` are `_mm256_loadu_si256` and
+        // `_mm256_storeu_si256`, both AVX.
+        #[cfg(target_arch = "x86_64")]
+        if !std::is_x86_feature_detected!("avx") {
+            return;
+        }
+        // Ascending values so a wrong-offset load cannot pass; slicing an
+        // over-long fixture is how the exact-length case is produced.
+        let values: Vec<i32> = (1..=12).collect();
+
+        let reg = i32x8::from(&values[..len]);
+
+        assert_eq!(reg.as_array().as_slice(), &values[..8]);
+    }
+}

--- a/rust/lance-linalg/src/simd/u8.rs
+++ b/rust/lance-linalg/src/simd/u8.rs
@@ -83,8 +83,21 @@ impl std::fmt::Debug for u8x16 {
     }
 }
 
+/// Reads the first 16 elements and ignores the rest.
+///
+/// # Panics
+///
+/// If `value` has fewer than 16 elements.
 impl From<&[u8]> for u8x16 {
     fn from(value: &[u8]) -> Self {
+        // `load_unaligned` reads 16 lanes with no bounds check, and this is safe
+        // code reachable from outside the crate, so the check has to survive
+        // release builds -- `debug_assert!` would reinstate the out-of-bounds read.
+        assert!(
+            value.len() >= 16,
+            "u8x16 conversion requires at least 16 elements, got {}",
+            value.len()
+        );
         unsafe { Self::load_unaligned(value.as_ptr()) }
     }
 }
@@ -402,6 +415,30 @@ impl SubAssign for u8x16 {
 mod tests {
 
     use super::*;
+    use rstest::rstest;
+
+    #[test]
+    #[should_panic(expected = "u8x16 conversion requires at least 16 elements")]
+    fn from_slice_rejects_short_slice() {
+        // No feature guard: the assert precedes `load_unaligned`, so the panic
+        // happens on every host. An early `return` here would fail the test.
+        let _ = u8x16::from(&[0; 15][..]);
+    }
+
+    #[rstest]
+    #[case::exact_length(16)]
+    #[case::over_length(24)]
+    fn from_slice_reads_the_first_sixteen_lanes(#[case] len: usize) {
+        // No feature guard needed: `_mm_loadu_si128` / `_mm_storeu_si128` are
+        // SSE2, which is baseline on x86_64.
+        // Ascending values so a wrong-offset load cannot pass; slicing an
+        // over-long fixture is how the exact-length case is produced.
+        let values: Vec<u8> = (1..=24).collect();
+
+        let reg = u8x16::from(&values[..len]);
+
+        assert_eq!(reg.as_array().as_slice(), &values[..16]);
+    }
 
     #[test]
     fn test_basic_u8x16_ops() {


### PR DESCRIPTION
## What was wrong

The six SIMD register types (`f32x8`, `f32x16`, `f64x4`, `f64x8`, `i32x8`, `u8x16`) each convert from a slice via `impl From<&[T]>`, and each body handed `value.as_ptr()` straight to `load_unaligned`, which reads a whole register with no bounds check. A slice shorter than the lane count read past the end of the slice, and past the end of the allocation when the slice reached its end.

This is safe code, reachable from outside the crate, so nothing stopped a caller from triggering it. It is also structural rather than one careless impl: `SIMD`'s supertrait bound `for<'a> From<&'a [T]>` requires every register type to offer the conversion, so all six had the same hole.

Each impl now asserts its lane count, naming the type, the requirement and the length received.

## Why `assert!` and not `debug_assert!`

`rust/AGENTS.md` prefers `debug_assert!` for non-safety invariants, but this one guards an out-of-bounds read, which is exactly where release builds matter. `debug_assert!` compiles out and would reinstate the read in the builds that ship. Returning `Result` is not available either: `From` is infallible by definition, and the supertrait bound fixes that signature, so a `TryFrom` redesign would change the trait and every caller. `f32x8::gather` in the same file already solved the same problem the same way, with an `assert!` and a `# Panics` section.

The rationale is now a comment on each impl, so a later pass that wants to trim a hot loop can see why the check has to stay.

## Effect on the one production caller

`copy_subtract_f32` in `lance-index` is the only place outside tests that reaches these impls, at `f32x16::from(&lhs[idx..])` and `f32x16::from(&rhs[idx..])`.

The `lhs` side is unaffected: `simd_len = input_len / 16 * 16` and `input_len <= lhs.len()`, so the slice is at least 16 long on every iteration.

The `rhs` side is a real behavior change and worth being explicit about. `input_len` is derived from `lhs` and `output` only; `rhs.len() >= input_len` is guarded by a `debug_assert!`. So in a release build with a residual centroid shorter than the query, `&rhs[idx..]` could be shorter than 16 and previously read out of bounds, producing wrong distances. It now panics. Debug builds are unchanged, since the existing `debug_assert!` fires first. That panic names the lane count rather than the dimension mismatch that caused it; tightening the `debug_assert!` at the call site belongs in its own change.

## Tests

Each type gets two tests, in its own file's `mod tests` next to the impl:

- the guard rejects `N-1` elements, with no CPU feature gate. The assert precedes `load_unaligned`, so the panic happens on every host; adding a feature check would make the test fail via its early `return` rather than skip.
- exactly `N` and more than `N` both load the first `N` lanes, as `#[rstest]` cases. The over-length case is the one that matters most: it pins the "reads the first N, ignores the rest" contract that `copy_subtract_f32` depends on, and without it tightening the guard to `== N` would pass everything here while breaking production.

The positive tests pass `&values[..len]` from a `Vec`, not an array reference, because `f32x8::from(&arr)` where `arr: [f32; 8]` binds the separate `From<&[f32; 8]>` impl and would test the wrong code. Fixtures ascend from 1 so a wrong-offset load cannot pass. The float and `i32` positive tests gate on `avx` since their loads are `_mm256_loadu_*`; the `u8x16` one does not, because `_mm_loadu_si128` is SSE2.

Three mutation rounds, each killing six tests: all six `>=` to `>`, all six to `==`, and all six guards deleted.

## Documentation

`SIMD::load_unaligned` and `store_unaligned` had `# Safety` headings with empty bodies, which satisfied `clippy::missing_safety_doc` while leaving the actual requirement unwritten. That requirement is what the six missing checks violated, so both now state it. The `SIMD` trait doc says what the `From<&[T]>` bound means for implementors and callers, and each impl carries its own `# Panics`.

## Test plan

- `cargo test -p lance-linalg --lib`: 167 passed on aarch64-apple-darwin, 225 on x86_64-apple-darwin
- `cargo test -p lance-index --lib vector::bq`: 222 passed (covers the production caller)
- `cargo clippy -p lance-linalg --all-targets -- -D warnings` on both targets: clean
- `cargo fmt --all -- --check` and `cargo doc -p lance-linalg --no-deps`: clean
