### PR TITLE
fix(linalg): enforce the hamming_batch_u64 length contract in release

### DIFF
--- a/rust/lance-linalg/src/distance/hamming.rs
+++ b/rust/lance-linalg/src/distance/hamming.rs
@@ -385,10 +385,13 @@ impl Default for PairwiseResult {
 /// Panics if `results` is not the same length as `targets`.
 #[inline]
 pub fn hamming_batch_u64(query: u64, targets: &[u64], results: &mut [u32]) {
-    // The SIMD kernels below write through raw pointers with no bounds check, so
-    // this check has to survive release builds. As a `debug_assert_eq!` it let
-    // both x86 kernels write past the end of `results` in release, while the
-    // scalar fallback panicked on its indexed store.
+    // Rejected in either direction, and before the dispatch. A shorter `results` the
+    // dispatcher's reslice would refuse on its own, and that reslice is what keeps the
+    // kernels' raw stores in bounds; this check just gets there first, with a message
+    // that names both lengths. An over-long one the reslice would instead truncate,
+    // handing the surplus tail back unwritten for the caller to read as distances.
+    // That is wrong output rather than a crash, which is why this is an `assert_eq!`
+    // and not a `debug_assert_eq!`.
     let num_targets = targets.len();
     let num_slots = results.len();
     assert_eq!(
@@ -396,33 +399,37 @@ pub fn hamming_batch_u64(query: u64, targets: &[u64], results: &mut [u32]) {
         "hamming_batch_u64 needs one result slot per target, \
          got {num_targets} target(s) and {num_slots} slot(s)"
     );
-    // SAFETY: the assert above establishes `results.len() == targets.len()`, which
-    // satisfies `hamming_batch_simd`'s `results.len() >= targets.len()` requirement.
-    unsafe { hamming_batch_simd(query, targets, results) };
+    hamming_batch_simd(query, targets, results);
 }
 
 /// SIMD-accelerated batch hamming distance computation.
 ///
-/// # Safety
+/// # Panics
 ///
-/// `results.len()` must be at least `targets.len()`. The x86 kernels this
-/// dispatches to store through raw pointers with no bounds check, so a shorter
-/// `results` is an out-of-bounds write rather than a panic.
+/// Panics if `results` is shorter than `targets`. `results.len()` is required to equal
+/// `targets.len()`: an over-long `results` is truncated here rather than rejected, and
+/// the surplus tail goes back to the caller unwritten. `hamming_batch_u64` asserts the
+/// equality before dispatching.
 #[inline]
-unsafe fn hamming_batch_simd(query: u64, targets: &[u64], results: &mut [u32]) {
+fn hamming_batch_simd(query: u64, targets: &[u64], results: &mut [u32]) {
+    // Both x86 kernels store through raw pointers over a range bounded by
+    // `targets.len()`, and this reslice makes `results` exactly that long, so it has to
+    // stay above the dispatch.
+    let results = &mut results[..targets.len()];
+
     #[cfg(target_arch = "x86_64")]
     {
         if is_x86_feature_detected!("avx512vpopcntdq") && is_x86_feature_detected!("avx512f") {
-            // SAFETY: both required features were just detected, and
-            // `results.len() >= targets.len()` is this function's own requirement.
+            // SAFETY: both required features were just detected, and the reslice
+            // above makes `results.len() == targets.len()`.
             unsafe {
                 hamming_batch_avx512(query, targets, results);
             }
             return;
         }
         if is_x86_feature_detected!("avx2") {
-            // SAFETY: AVX2 was just detected, and `results.len() >= targets.len()`
-            // is this function's own requirement.
+            // SAFETY: AVX2 was just detected, and the reslice above makes
+            // `results.len() == targets.len()`.
             unsafe {
                 hamming_batch_avx2(query, targets, results);
             }
@@ -463,10 +470,14 @@ fn hamming_batch_scalar(query: u64, targets: &[u64], results: &mut [u32]) {
 
 /// AVX-512 VPOPCNTDQ: Process 8 x 64-bit values at once.
 ///
+/// The chunk loop reaches only the first `targets.len() / 8 * 8` slots through a
+/// raw pointer, 8 x u32 per chunk with no bounds check; the trailing slots go
+/// through bounds-checked indexing.
+///
 /// # Safety
+///
 /// The host must support AVX-512F and AVX512VPOPCNTDQ, and `results.len()` must
-/// be at least `targets.len()`: each chunk stores 8 x u32 through a raw pointer
-/// with no bounds check.
+/// be at least `targets.len()`.
 #[cfg(target_arch = "x86_64")]
 #[target_feature(enable = "avx512f", enable = "avx512vpopcntdq")]
 unsafe fn hamming_batch_avx512(query: u64, targets: &[u64], results: &mut [u32]) {
@@ -503,10 +514,14 @@ unsafe fn hamming_batch_avx512(query: u64, targets: &[u64], results: &mut [u32])
 
 /// AVX2 popcount using lookup table (Harley-Seal / PSHUFB method).
 ///
+/// The chunk loop reaches only the first `targets.len() / 4 * 4` slots through a
+/// raw pointer, 4 x u32 per chunk with no bounds check; the trailing slots go
+/// through bounds-checked indexing.
+///
 /// # Safety
+///
 /// The host must support AVX2, and `results.len()` must be at least
-/// `targets.len()`: each chunk stores 4 x u32 through a raw pointer with no
-/// bounds check.
+/// `targets.len()`.
 #[cfg(target_arch = "x86_64")]
 #[target_feature(enable = "avx2")]
 unsafe fn hamming_batch_avx2(query: u64, targets: &[u64], results: &mut [u32]) {
@@ -1149,30 +1164,82 @@ mod tests {
     }
 
     #[rstest]
-    // Fewer slots than targets is the case that used to write out of bounds: on
-    // an AVX2 host `hamming_batch_avx2` wrote 28 bytes past a 4-byte `results`.
-    #[case::one_slot_eight_targets(1)]
-    // A short final chunk still overruns, just by less.
-    #[case::seven_slots_eight_targets(7)]
-    // More slots than targets would leave the tail unwritten rather than
-    // overrun, but the contract is one slot per target either way.
-    #[case::nine_slots_eight_targets(9)]
-    // The `8` is the target count every case shares, so this one literal also
-    // pins which length the message reports first. A fourth case with a
-    // different target count has to move it out of the literal.
-    #[should_panic(expected = "needs one result slot per target, got 8 target(s) and ")]
-    fn test_hamming_batch_u64_rejects_mismatched_lengths(#[case] num_slots: usize) {
-        // No CPU feature gate: the assert precedes every kernel, so the panic
-        // happens on each host. An early return here would fail the test.
+    // Fewer slots than targets is the case that used to write out of bounds: on a
+    // host that takes the AVX2 path, `hamming_batch_avx2` wrote 28 bytes past a
+    // one-slot `results`.
+    #[case::eight_targets_one_slot(8, 1)]
+    // On the same path this one overran by 4 bytes instead of 28.
+    #[case::eight_targets_seven_slots(8, 7)]
+    // More slots than targets left the tail unwritten rather than overrunning, but
+    // the contract is one slot per target either way. This and the zero-target case
+    // below are the two that catch a guard weakened to a one-sided
+    // `results.len() >= targets.len()`.
+    #[case::eight_targets_nine_slots(8, 9)]
+    // The target count varies too, so that the two shortcuts most likely to appear
+    // here cannot slip past every case: an `if targets.is_empty() { return; }` above
+    // the check, or a `targets.len() < 8` fast path, would otherwise leave every
+    // eight-target case green. Four is the smallest target count that still reaches
+    // the AVX2 chunk loop.
+    #[case::four_targets_one_slot(4, 1)]
+    #[case::no_targets_one_slot(0, 1)]
+    // Zero slots is the case with no in-bounds slot at all, and the only one here
+    // that a `results.is_empty()` early return above the check would not survive.
+    // Its sentinel assertion is vacuous, so it pins the message and nothing else.
+    #[case::eight_targets_no_slots(8, 0)]
+    fn test_hamming_batch_u64_rejects_mismatched_lengths(
+        #[case] num_targets: usize,
+        #[case] num_slots: usize,
+    ) {
+        // No CPU feature gate: the length check precedes every kernel, so the panic
+        // happens on each host and no case reaches a kernel at all. Every case here is
+        // a mismatch; matching lengths are covered by `test_hamming_batch_u64` above,
+        // which calls `hamming_batch_u64` directly, and by
+        // `test_pairwise_correctness_1000_deterministic` below, which reaches it
+        // through `pairwise_hamming_distance_parallel`'s chunked path and checks the
+        // result against `reference_pairwise`.
+        //
+        // `catch_unwind` rather than `#[should_panic]`, because the property worth
+        // protecting is that the check runs before the dispatch, and
+        // `#[should_panic]` cannot observe order: a check moved below it can still
+        // panic with this same message, after a kernel has already written through
+        // `results`. The sentinel assertion at the end is what rules that out. It is
+        // also why the nine-slot case is here: a kernel's writes all land in bounds
+        // there, so nothing else would notice that it ran.
         //
         // A `debug_assert_eq!` carrying the same message still passes here when
         // debug assertions are on, which is the profile `--profile ci` gives this
         // crate; `cargo test --release -p lance-linalg --lib` (rust.yml) is what
         // catches that revert.
-        let targets = vec![u64::MAX; 8];
-        let mut results = vec![0u32; num_slots];
+        const SENTINEL: u32 = 0xDEAD_BEEF;
+        let targets = vec![u64::MAX; num_targets];
+        let mut results = vec![SENTINEL; num_slots];
 
-        hamming_batch_u64(0, &targets, &mut results);
+        let payload = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            hamming_batch_u64(0, &targets, &mut results);
+        }))
+        .expect_err("a length mismatch must panic");
+
+        let message = payload
+            .downcast_ref::<String>()
+            .map(String::as_str)
+            .or_else(|| payload.downcast_ref::<&'static str>().copied())
+            .expect("panic payload should be a string");
+        // Matching the whole message, not the two numbers separately, is deliberate:
+        // it pins the function name and the order the two lengths are reported in,
+        // which is what a message copied from a sibling guard would get wrong.
+        let expected = format!(
+            "hamming_batch_u64 needs one result slot per target, \
+             got {num_targets} target(s) and {num_slots} slot(s)"
+        );
+        assert!(
+            message.contains(&expected),
+            "expected {expected:?} in panic message, got {message:?}"
+        );
+        assert_eq!(
+            results.iter().position(|&slot| slot != SENTINEL),
+            None,
+            "a kernel reached `results`, so the length check no longer precedes it"
+        );
     }
 
     #[test]

--- a/rust/lance-linalg/src/distance/hamming.rs
+++ b/rust/lance-linalg/src/distance/hamming.rs
@@ -396,25 +396,33 @@ pub fn hamming_batch_u64(query: u64, targets: &[u64], results: &mut [u32]) {
         "hamming_batch_u64 needs one result slot per target, \
          got {num_targets} target(s) and {num_slots} slot(s)"
     );
-    hamming_batch_simd(query, targets, results);
+    // SAFETY: the assert above establishes `results.len() == targets.len()`, which
+    // satisfies `hamming_batch_simd`'s `results.len() >= targets.len()` requirement.
+    unsafe { hamming_batch_simd(query, targets, results) };
 }
 
 /// SIMD-accelerated batch hamming distance computation.
 ///
-/// `results.len()` must be at least `targets.len()`: the x86 kernels this
-/// dispatches to store through raw pointers with no bounds check. The only
-/// caller, `hamming_batch_u64`, asserts equality first.
+/// # Safety
+///
+/// `results.len()` must be at least `targets.len()`. The x86 kernels this
+/// dispatches to store through raw pointers with no bounds check, so a shorter
+/// `results` is an out-of-bounds write rather than a panic.
 #[inline]
-fn hamming_batch_simd(query: u64, targets: &[u64], results: &mut [u32]) {
+unsafe fn hamming_batch_simd(query: u64, targets: &[u64], results: &mut [u32]) {
     #[cfg(target_arch = "x86_64")]
     {
         if is_x86_feature_detected!("avx512vpopcntdq") && is_x86_feature_detected!("avx512f") {
+            // SAFETY: both required features were just detected, and
+            // `results.len() >= targets.len()` is this function's own requirement.
             unsafe {
                 hamming_batch_avx512(query, targets, results);
             }
             return;
         }
         if is_x86_feature_detected!("avx2") {
+            // SAFETY: AVX2 was just detected, and `results.len() >= targets.len()`
+            // is this function's own requirement.
             unsafe {
                 hamming_batch_avx2(query, targets, results);
             }

--- a/rust/lance-linalg/src/distance/hamming.rs
+++ b/rust/lance-linalg/src/distance/hamming.rs
@@ -379,13 +379,31 @@ impl Default for PairwiseResult {
 
 /// Compute hamming distances for a query against multiple targets.
 /// Uses SIMD acceleration when available.
+///
+/// # Panics
+///
+/// Panics if `results` is not the same length as `targets`.
 #[inline]
 pub fn hamming_batch_u64(query: u64, targets: &[u64], results: &mut [u32]) {
-    debug_assert_eq!(targets.len(), results.len());
+    // The SIMD kernels below write through raw pointers with no bounds check, so
+    // this check has to survive release builds. As a `debug_assert_eq!` it let
+    // both x86 kernels write past the end of `results` in release, while the
+    // scalar fallback panicked on its indexed store.
+    let num_targets = targets.len();
+    let num_slots = results.len();
+    assert_eq!(
+        num_targets, num_slots,
+        "hamming_batch_u64 needs one result slot per target, \
+         got {num_targets} target(s) and {num_slots} slot(s)"
+    );
     hamming_batch_simd(query, targets, results);
 }
 
 /// SIMD-accelerated batch hamming distance computation.
+///
+/// `results.len()` must be at least `targets.len()`: the x86 kernels this
+/// dispatches to store through raw pointers with no bounds check. The only
+/// caller, `hamming_batch_u64`, asserts equality first.
 #[inline]
 fn hamming_batch_simd(query: u64, targets: &[u64], results: &mut [u32]) {
     #[cfg(target_arch = "x86_64")]
@@ -436,6 +454,11 @@ fn hamming_batch_scalar(query: u64, targets: &[u64], results: &mut [u32]) {
 }
 
 /// AVX-512 VPOPCNTDQ: Process 8 x 64-bit values at once.
+///
+/// # Safety
+/// The host must support AVX-512F and AVX512VPOPCNTDQ, and `results.len()` must
+/// be at least `targets.len()`: each chunk stores 8 x u32 through a raw pointer
+/// with no bounds check.
 #[cfg(target_arch = "x86_64")]
 #[target_feature(enable = "avx512f", enable = "avx512vpopcntdq")]
 unsafe fn hamming_batch_avx512(query: u64, targets: &[u64], results: &mut [u32]) {
@@ -471,6 +494,11 @@ unsafe fn hamming_batch_avx512(query: u64, targets: &[u64], results: &mut [u32])
 }
 
 /// AVX2 popcount using lookup table (Harley-Seal / PSHUFB method).
+///
+/// # Safety
+/// The host must support AVX2, and `results.len()` must be at least
+/// `targets.len()`: each chunk stores 4 x u32 through a raw pointer with no
+/// bounds check.
 #[cfg(target_arch = "x86_64")]
 #[target_feature(enable = "avx2")]
 unsafe fn hamming_batch_avx2(query: u64, targets: &[u64], results: &mut [u32]) {
@@ -1060,6 +1088,7 @@ pub fn cluster_pairwise_result(result: &PairwiseResult) -> ClusteringResult {
 mod tests {
     use super::*;
     use lance_arrow::FixedSizeListArrayExt;
+    use rstest::rstest;
 
     #[test]
     fn test_result_schemas_are_initialized_once() {
@@ -1109,6 +1138,33 @@ mod tests {
         assert_eq!(results[1], 1);
         assert_eq!(results[3], 2); // 0b11 has 2 bits set
         assert_eq!(results[7], 3); // 0b111 has 3 bits set
+    }
+
+    #[rstest]
+    // Fewer slots than targets is the case that used to write out of bounds: on
+    // an AVX2 host `hamming_batch_avx2` wrote 28 bytes past a 4-byte `results`.
+    #[case::one_slot_eight_targets(1)]
+    // A short final chunk still overruns, just by less.
+    #[case::seven_slots_eight_targets(7)]
+    // More slots than targets would leave the tail unwritten rather than
+    // overrun, but the contract is one slot per target either way.
+    #[case::nine_slots_eight_targets(9)]
+    // The `8` is the target count every case shares, so this one literal also
+    // pins which length the message reports first. A fourth case with a
+    // different target count has to move it out of the literal.
+    #[should_panic(expected = "needs one result slot per target, got 8 target(s) and ")]
+    fn test_hamming_batch_u64_rejects_mismatched_lengths(#[case] num_slots: usize) {
+        // No CPU feature gate: the assert precedes every kernel, so the panic
+        // happens on each host. An early return here would fail the test.
+        //
+        // A `debug_assert_eq!` carrying the same message still passes here when
+        // debug assertions are on, which is the profile `--profile ci` gives this
+        // crate; `cargo test --release -p lance-linalg --lib` (rust.yml) is what
+        // catches that revert.
+        let targets = vec![u64::MAX; 8];
+        let mut results = vec![0u32; num_slots];
+
+        hamming_batch_u64(0, &targets, &mut results);
     }
 
     #[test]


### PR DESCRIPTION
## What was wrong

`hamming_batch_u64` is a safe public function. It dispatches to two x86 kernels that write results through raw pointers with no bounds check, and its only guard on `targets.len() == results.len()` was a `debug_assert_eq!`, which is compiled out of release builds. A caller passing a `results` shorter than `targets` therefore got a different outcome depending on the host:

| path | release behaviour before this change |
|---|---|
| `hamming_batch_avx2` | silent out-of-bounds write; with 8 targets and 1 slot, 32 bytes stored into a 4-byte allocation, 28 past the end |
| `hamming_batch_avx512` | same shape, one 32-byte `_mm256_storeu_si256` per 8-target chunk |
| scalar fallback | panics on its indexed store |

The AVX2 figure is measured: the kernel was ported intrinsic-for-intrinsic to C with a canary array around `results` and run under `qemu-x86_64 -cpu max`, which reported seven clobbered canary slots. The AVX-512 path could not be executed here, because the available QEMU build does not implement `avx512vpopcntdq` even when the feature is requested, so that row is read from the code rather than measured.

## The fix has two parts, and they cover different failures

`hamming_batch_simd`, the private dispatcher, now reslices `results` down to `targets.len()` before dispatching. That one line is what keeps the kernels' raw stores in bounds, and it does so structurally rather than by assertion: a `results` too short to reslice cannot reach a kernel at all, in any profile. This replaces the earlier revision of this PR, which marked the dispatcher `unsafe fn` and pushed the obligation onto the caller. @wjones127 asked for the smaller shape; the reslice is it.

The always-on `assert_eq!` at the public entry point covers the other direction. An over-long `results` is not an out-of-bounds write, so the reslice does not object to it: it truncates, and the surplus tail stays as the caller left it, to be read back as distances. That is wrong output, not a crash, which is why the check is `assert_eq!` and not `debug_assert_eq!`.

The exactness check lives once, at the public entry point. The private dispatcher has one caller and cannot be reached from outside the module, so a second always-on check there would only re-test what the entry already established. Its `# Panics` states the requirement rather than blessing the truncation. An earlier revision of this PR did put a `debug_assert_eq!` there, and dropping it costs one row of the mutation table below: with it, moving the entry assert below the dispatch failed all six cases instead of five. If you would rather have the belt and braces, promoting it costs nothing at runtime either: both functions are `#[inline]`, and LLVM folds the second compare.

## Why `assert_eq!` rather than returning `Result`

`rust/AGENTS.md` bans `assert!` in library code "for fallible operations" but reserves it for "conditions preventing data corruption", which is what reading a stale buffer tail back as a distance produces.

Returning `Result` is possible here, since the function returns `()` today, but it costs more than it buys. `hamming_batch_u64` is reachable as `lance_linalg::distance::hamming::hamming_batch_u64`, and `lance-index` already imports siblings through that path, so changing the signature means a `#[deprecated]` shim plus a new function, and the deprecated one would still need this same check.

This also follows a pattern the crate settled on recently: `assert_equal_lengths` and `assert_batch_layout` in `distance.rs` were added by #8594, and `l2`, `dot`, `l2_u8` and `dot_u8` route their length checks through them. Public boundary gets `assert!`. The message here is written inline rather than calling the shared helper because the helper's wording describes two inputs of equal length, while this contract is one output slot per input target.

## Behaviour change worth stating plainly

For an undersized `results` this is not a new failure mode. For an oversized one it is: the surplus tail was previously left unwritten and harmless, and now panics, because `assert_eq!` is strict equality. No in-repo caller does this; all three pass a buffer whose length is literally the same `remaining` expression as the target count. A downstream caller reusing one long scratch buffer across calls would newly panic in release, where it previously got a correct prefix. `#[case::eight_targets_nine_slots]` pins the tightening as deliberate.

## Callers

The three in-crate callers are unaffected, and more strongly than "they both derive from the same value": in all three, `targets.len()` and `results.len()` are both literally `remaining` (`n - i - 1`), with no branch or reassignment between them. The `remaining == 0` guard precedes both the allocation and the call. For the multi-lane caller, `BinaryHashValues::lane(k)` is a fixed-stride view into one flat `Vec<u64>`, so lanes of differing length are not expressible.

No callers exist in `python/`, `java/`, the benches, or other crates.

## Tests

Six `#[rstest]` cases drive `hamming_batch_u64` with mismatched lengths: `(8,1)`, `(8,7)`, `(8,9)`, `(4,1)`, `(0,1)`, `(8,0)`. Both the target count and the slot count vary, which is what the earlier three-case version got wrong. With the target count fixed at 8, any shortcut conditioned on it would have left every case green: an `if targets.is_empty() { return; }` above the check, or a `targets.len() < 8` fast path.

The cases use `catch_unwind` rather than `#[should_panic]`, because the property worth protecting is that the check runs *before* the dispatch, and `#[should_panic]` cannot observe order: a check moved below the dispatch still panics with the same message, after a kernel has written through `results`. Each case pre-fills `results` with a sentinel and asserts afterwards that no slot changed. That is also why `(8,9)` is in the set: a kernel's writes all land in bounds there, so nothing but the sentinel would notice it ran.

Two limits are documented in the test rather than papered over. A revert to `debug_assert_eq!` that keeps the message still passes under `--profile ci`, because that profile inherits `dev` and the `[profile.ci.package."*"]` override only reaches non-workspace members; `cargo test --release -p lance-linalg --lib` is what catches it. And the reslice itself is not test-visible: the entry assert makes it unreachable in the failure direction, so deleting the reslice leaves all six cases green. It is there for its structural effect on the kernels, not because a test pins it.

## Documentation

`hamming_batch_u64` and the private dispatcher each gained a `# Panics` section. The two kernels gained `# Safety` sections stating the required CPU features and the `results.len() >= targets.len()` bound; every other `unsafe fn` in the crate documents its contract, and these two were the exception. The dispatcher between them is a safe `fn`, so the `unsafe` in the non-test part of the file is the two kernels and the two call sites that dispatch to them.

## Test plan

- `cargo test -p lance-linalg --lib`: 166 passed on aarch64-apple-darwin in both dev and release, 224 on x86_64-apple-darwin in both
- `cargo clippy -p lance-linalg --all-targets -- -D warnings` on both targets, `cargo fmt --all -- --check`, `cargo doc -p lance-linalg --no-deps`: clean
- Mutation testing, all nine against the six cases, on aarch64 in both dev and release:

| mutation | cases that fail |
|---|---|
| entry assert reverted to `debug_assert_eq!` | 0 in dev, all 6 in release |
| entry assert moved below the dispatch | 5. The survivor is `(0,1)`: with no targets no kernel writes anything, so nothing distinguishes before from after |
| entry assert weakened to a one-sided `>=` | 2, exactly `(8,9)` and `(0,1)` |
| `results.is_empty()` early return above the assert | 1, only `(8,0)` |
| `targets.is_empty()` early return above the assert | 1, only `(0,1)` |
| `targets.len() < 8` fast path above the assert | 2, `(4,1)` and `(0,1)` |
| message names a sibling function | all 6 |
| the two interpolated lengths swapped | all 6 |
| reslice deleted | 0. See the note in Tests |

## Out of scope

`cosine_u8` has the same shape of defect with a different consequence: its AVX2 and AVX-512 kernels carry only `debug_assert_eq!(a.len(), b.len())` and then read `b.as_ptr().add(i)` bounded by `a.len()`, so a short `b` is an out-of-bounds read in release. Its peers `dot_u8` and `l2_u8` both call `assert_equal_lengths` at the public entry; `cosine_u8` is the one that does not. Filed as #8638.
