### PR TITLE
perf(rowids): count bitmap bits a word at a time

### DIFF
--- a/rust/lance-table/src/rowids/bitmap.rs
+++ b/rust/lance-table/src/rowids/bitmap.rs
@@ -9,6 +9,21 @@ pub struct Bitmap {
     pub len: usize,
 }
 
+/// Set bits in `data`, counted a word at a time.
+fn count_ones(data: &[u8]) -> usize {
+    let mut words = data.chunks_exact(8);
+    let full: usize = words
+        .by_ref()
+        .map(|word| u64::from_le_bytes(word.try_into().unwrap()).count_ones() as usize)
+        .sum();
+    let tail: usize = words
+        .remainder()
+        .iter()
+        .map(|byte| byte.count_ones() as usize)
+        .sum();
+    full + tail
+}
+
 impl std::fmt::Debug for Bitmap {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         write!(f, "Bitmap {{ data: ")?;
@@ -65,7 +80,7 @@ impl Bitmap {
     }
 
     pub fn count_ones(&self) -> usize {
-        self.data.iter().map(|&x| x.count_ones() as usize).sum()
+        count_ones(&self.data)
     }
 
     pub fn count_zeros(&self) -> usize {
@@ -132,10 +147,7 @@ impl BitmapSlice<'_> {
             }
 
             // Middle bytes can just use count_ones
-            count += self.bitmap.data[first_byte + 1..last_byte]
-                .iter()
-                .map(|&x| x.count_ones() as usize)
-                .sum::<usize>();
+            count += count_ones(&self.bitmap.data[first_byte + 1..last_byte]);
             count
         }
     }
@@ -189,6 +201,17 @@ mod tests {
 
         let bitmap_slice = bitmap.slice(5, 5);
         assert_eq!(bitmap_slice.count_ones(), 2);
+    }
+
+    #[test]
+    fn test_count_ones_spans_words_and_tail() {
+        for len in [1_usize, 7, 8, 63, 64, 65, 130] {
+            let mut bitmap = Bitmap::new_empty(len);
+            for i in (0..len).step_by(3) {
+                bitmap.set(i);
+            }
+            assert_eq!(bitmap.count_ones(), len.div_ceil(3), "len {len}");
+        }
     }
 
     #[test]


### PR DESCRIPTION
### Problem

`Bitmap::count_ones` walks the bitmap one byte at a time. A row id sequence
asks for that count on the hot paths:

- `U64Segment::len` counts the whole bitmap of a `RangeWithBitmap` segment, and
  `RowIdIndex::new` calls `len` on every segment of every fragment.
- `U64Segment::position` counts the bits up to the wanted offset, once per
  lookup.

On a 15.43B row / 17,601 fragment dataset whose sequences hold 3.36 GB of
bitmaps, that byte-at-a-time count is the whole cost of opening the index.

### Change

Count a `u64` at a time, and keep the byte loop for the trailing bytes and for
the two partial bytes at the ends of a slice.

### Measurement

Taking one row id from that dataset, release build, 96-core Linux x86-64. The
index here is the per-fragment index from #8624, which calls `len` per segment:

| | before | after |
|---|---|---|
| first `_take_rows`, 1 row id | 1.92 s | 1.41 s |
| second call, same dataset object | 1.10 s | 0.61 s |

`cargo test -p lance-table --lib rowids`: 98 passed.