### PR TITLE
feat(compaction): add soft source budget mode

### DIFF
--- a/java/lance-jni/src/blocking_dataset.rs
+++ b/java/lance-jni/src/blocking_dataset.rs
@@ -3593,6 +3593,14 @@ fn convert_java_compaction_options_to_rust(
             &[],
         )?
         .l()?;
+    let source_budget_mode = env
+        .call_method(
+            &java_options,
+            "getSourceBudgetMode",
+            "()Ljava/util/Optional;",
+            &[],
+        )?
+        .l()?;
 
     build_compaction_options(
         env,
@@ -3610,6 +3618,7 @@ fn convert_java_compaction_options_to_rust(
         &max_source_rows,
         &max_source_bytes,
         &excluded_fragment_ids,
+        Some(&source_budget_mode),
         config,
     )
 }

--- a/java/lance-jni/src/optimize.rs
+++ b/java/lance-jni/src/optimize.rs
@@ -12,7 +12,8 @@ use lance::dataset::{
     index::DatasetIndexRemapperOptions,
     optimize::{
         CompactionMetrics, CompactionMode, CompactionOptions, CompactionPlan, CompactionTask,
-        IndexRemapperOptions, RewriteResult, TaskData, commit_compaction, plan_compaction,
+        IndexRemapperOptions, RewriteResult, SourceBudgetMode, TaskData, commit_compaction,
+        plan_compaction,
     },
 };
 
@@ -49,6 +50,7 @@ pub extern "system" fn Java_org_lance_compaction_Compaction_nativePlanCompaction
     max_source_rows: JObject,                 // Optional<Long>
     max_source_bytes: JObject,                // Optional<Long>
     excluded_fragment_ids: JObject,           // List<Long>
+    source_budget_mode: JObject,              // Optional<String>
 ) -> JObject<'local> {
     ok_or_throw_with_return!(
         env,
@@ -68,7 +70,8 @@ pub extern "system" fn Java_org_lance_compaction_Compaction_nativePlanCompaction
             max_source_fragments,
             max_source_rows,
             max_source_bytes,
-            excluded_fragment_ids
+            excluded_fragment_ids,
+            source_budget_mode
         ),
         JObject::null()
     )
@@ -92,6 +95,7 @@ fn inner_plan_compaction<'local>(
     max_source_rows: JObject,                 // Optional<Long>
     max_source_bytes: JObject,                // Optional<Long>
     excluded_fragment_ids: JObject,           // List<Long>
+    source_budget_mode: JObject,              // Optional<String>
 ) -> Result<JObject<'local>> {
     let config = {
         let dataset =
@@ -114,6 +118,7 @@ fn inner_plan_compaction<'local>(
         &max_source_rows,
         &max_source_bytes,
         &excluded_fragment_ids,
+        Some(&source_budget_mode),
         &config,
     )?;
 
@@ -212,6 +217,7 @@ fn inner_commit_compaction<'local>(
         &max_source_rows,
         &max_source_bytes,
         &excluded_fragment_ids,
+        None,
         &config,
     )?;
     let completed_tasks = import_vec_to_rust(env, &rewrite_results, |env, rewrite_result| {
@@ -322,6 +328,7 @@ fn inner_execute_task<'local>(
         &max_source_rows,
         &max_source_bytes,
         &excluded_fragment_ids,
+        None,
         &config,
     )?;
     let compaction_task = CompactionTask {
@@ -349,7 +356,8 @@ const REWRITE_RESULT_CONSTRUCTOR_SIG: &str =
     "(Lorg/lance/compaction/CompactionMetrics;Ljava/util/List;Ljava/util/List;J[B)V";
 const COMPACTION_OPTIONS_CLASS: &str = "org/lance/compaction/CompactionOptions";
 const COMPACTION_MODE_CLASS: &str = "org/lance/compaction/CompactionMode";
-const COMPACTION_OPTIONS_CONSTRUCTOR_SIG: &str = "(Ljava/util/Optional;Ljava/util/Optional;Ljava/util/Optional;Ljava/util/Optional;Ljava/util/Optional;Ljava/util/Optional;Ljava/util/Optional;Ljava/util/Optional;Ljava/util/Optional;Ljava/util/Optional;Ljava/util/Optional;Ljava/util/Optional;Ljava/util/Optional;Ljava/util/List;)V";
+const SOURCE_BUDGET_MODE_CLASS: &str = "org/lance/compaction/SourceBudgetMode";
+const COMPACTION_OPTIONS_CONSTRUCTOR_SIG: &str = "(Ljava/util/Optional;Ljava/util/Optional;Ljava/util/Optional;Ljava/util/Optional;Ljava/util/Optional;Ljava/util/Optional;Ljava/util/Optional;Ljava/util/Optional;Ljava/util/Optional;Ljava/util/Optional;Ljava/util/Optional;Ljava/util/Optional;Ljava/util/Optional;Ljava/util/List;Ljava/util/Optional;)V";
 
 impl IntoJava for &TaskData {
     fn into_java<'a>(self, env: &mut JNIEnv<'a>) -> Result<JObject<'a>> {
@@ -431,6 +439,18 @@ impl IntoJava for &CompactionOptions {
             .map(|fragment_id| to_java_long_obj(env, Some(*fragment_id as i64)))
             .collect::<Result<Vec<_>>>()?;
         let excluded_fragment_ids = to_java_list(env, &excluded_fragment_ids)?;
+        let source_budget_mode_name = match self.source_budget_mode {
+            SourceBudgetMode::Hard => "HARD",
+            SourceBudgetMode::Soft => "SOFT",
+        };
+        let source_budget_mode = env
+            .get_static_field(
+                SOURCE_BUDGET_MODE_CLASS,
+                source_budget_mode_name,
+                format!("L{};", SOURCE_BUDGET_MODE_CLASS),
+            )?
+            .l()?;
+        let source_budget_mode_opt = to_java_optional(env, source_budget_mode)?;
 
         Ok(env.new_object(
             COMPACTION_OPTIONS_CLASS,
@@ -450,6 +470,7 @@ impl IntoJava for &CompactionOptions {
                 JValueGen::Object(&max_source_rows_opt),
                 JValueGen::Object(&max_source_bytes_opt),
                 JValueGen::Object(&excluded_fragment_ids),
+                JValueGen::Object(&source_budget_mode_opt),
             ],
         )?)
     }

--- a/java/lance-jni/src/utils.rs
+++ b/java/lance-jni/src/utils.rs
@@ -8,7 +8,7 @@ use arrow_schema::{DataType, Field};
 use jni::JNIEnv;
 use jni::objects::{JFloatArray, JMap, JObject, JString, JValue, JValueGen};
 use jni::sys::{jboolean, jfloat, jlong};
-use lance::dataset::optimize::{CompactionMode, CompactionOptions};
+use lance::dataset::optimize::{CompactionMode, CompactionOptions, SourceBudgetMode};
 use lance::dataset::{WriteMode, WriteParams};
 use lance::index::vector::{IndexFileVersion, StageParams, VectorIndexParams};
 use lance::io::ObjectStoreParams;
@@ -194,6 +194,7 @@ pub fn build_compaction_options(
     max_source_rows: &JObject,                 // Optional<Long>
     max_source_bytes: &JObject,                // Optional<Long>
     excluded_fragment_ids: &JObject,           // List<Long>
+    source_budget_mode: Option<&JObject>,      // Optional<String>
     config: &std::collections::HashMap<String, String>,
 ) -> Result<CompactionOptions> {
     let mut compaction_options = CompactionOptions::from_dataset_config(config)?;
@@ -256,6 +257,12 @@ pub fn build_compaction_options(
             })
         })
         .collect::<Result<Vec<_>>>()?;
+    if let Some(source_budget_mode) = source_budget_mode
+        && let Some(source_budget_mode_val) = env.get_string_opt(source_budget_mode)?
+    {
+        compaction_options.source_budget_mode =
+            SourceBudgetMode::try_from(source_budget_mode_val.as_str())?;
+    }
 
     Ok(compaction_options)
 }

--- a/java/src/main/java/org/lance/compaction/Compaction.java
+++ b/java/src/main/java/org/lance/compaction/Compaction.java
@@ -49,7 +49,8 @@ public class Compaction {
           compactionOptions.getMaxSourceFragments(),
           compactionOptions.getMaxSourceRows(),
           compactionOptions.getMaxSourceBytes(),
-          compactionOptions.getExcludedFragmentIds());
+          compactionOptions.getExcludedFragmentIds(),
+          compactionOptions.getSourceBudgetMode());
     }
   }
 
@@ -153,5 +154,6 @@ public class Compaction {
       Optional<Long> maxSourceFragments,
       Optional<Long> maxSourceRows,
       Optional<Long> maxSourceBytes,
-      List<Long> excludedFragmentIds);
+      List<Long> excludedFragmentIds,
+      Optional<String> sourceBudgetMode);
 }

--- a/java/src/main/java/org/lance/compaction/CompactionOptions.java
+++ b/java/src/main/java/org/lance/compaction/CompactionOptions.java
@@ -51,6 +51,7 @@ public class CompactionOptions implements Serializable {
   private Optional<Long> maxSourceRows;
   private Optional<Long> maxSourceBytes;
   private List<Long> excludedFragmentIds;
+  private Optional<SourceBudgetMode> sourceBudgetMode;
 
   private CompactionOptions(
       Optional<Long> targetRowsPerFragment,
@@ -66,7 +67,8 @@ public class CompactionOptions implements Serializable {
       Optional<Long> maxSourceFragments,
       Optional<Long> maxSourceRows,
       Optional<Long> maxSourceBytes,
-      List<Long> excludedFragmentIds) {
+      List<Long> excludedFragmentIds,
+      Optional<SourceBudgetMode> sourceBudgetMode) {
     this.targetRowsPerFragment = targetRowsPerFragment;
     this.maxRowsPerGroup = maxRowsPerGroup;
     this.maxBytesPerFile = maxBytesPerFile;
@@ -81,6 +83,7 @@ public class CompactionOptions implements Serializable {
     this.maxSourceRows = maxSourceRows;
     this.maxSourceBytes = maxSourceBytes;
     this.excludedFragmentIds = List.copyOf(excludedFragmentIds);
+    this.sourceBudgetMode = sourceBudgetMode;
   }
 
   public Optional<Boolean> getDeferIndexRemap() {
@@ -110,6 +113,11 @@ public class CompactionOptions implements Serializable {
 
   public List<Long> getExcludedFragmentIds() {
     return excludedFragmentIds;
+  }
+
+  /** Returns the source budget mode as its string value for the native layer. */
+  public Optional<String> getSourceBudgetMode() {
+    return sourceBudgetMode.map(SourceBudgetMode::getValue);
   }
 
   public Optional<Boolean> getMaterializeDeletions() {
@@ -161,6 +169,7 @@ public class CompactionOptions implements Serializable {
         .add("maxSourceRows", maxSourceRows.orElse(null))
         .add("maxSourceBytes", maxSourceBytes.orElse(null))
         .add("excludedFragmentIds", excludedFragmentIds)
+        .add("sourceBudgetMode", sourceBudgetMode.orElse(null))
         .toString();
   }
 
@@ -179,6 +188,7 @@ public class CompactionOptions implements Serializable {
     output.writeObject(maxSourceRows.orElse(null));
     output.writeObject(maxSourceBytes.orElse(null));
     output.writeObject(excludedFragmentIds);
+    output.writeObject(sourceBudgetMode.map(SourceBudgetMode::getValue).orElse(null));
   }
 
   private void readObject(ObjectInputStream input) throws IOException, ClassNotFoundException {
@@ -205,6 +215,7 @@ public class CompactionOptions implements Serializable {
     this.maxSourceRows = readTrailingLong(input);
     this.maxSourceBytes = readTrailingLong(input);
     this.excludedFragmentIds = readTrailingLongList(input);
+    this.sourceBudgetMode = readTrailingSourceBudgetMode(input);
   }
 
   /**
@@ -238,6 +249,27 @@ public class CompactionOptions implements Serializable {
     }
   }
 
+  private static Optional<SourceBudgetMode> readTrailingSourceBudgetMode(ObjectInputStream input)
+      throws IOException, ClassNotFoundException {
+    try {
+      String value = (String) input.readObject();
+      if (value == null) {
+        return Optional.empty();
+      }
+      for (SourceBudgetMode mode : SourceBudgetMode.values()) {
+        if (mode.getValue().equals(value)) {
+          return Optional.of(mode);
+        }
+      }
+      return Optional.empty();
+    } catch (OptionalDataException e) {
+      if (!e.eof) {
+        throw e;
+      }
+      return Optional.empty();
+    }
+  }
+
   /** Builder for CompactionOptions. */
   public static class Builder {
     private Optional<Long> targetRowsPerFragment = Optional.empty();
@@ -254,6 +286,7 @@ public class CompactionOptions implements Serializable {
     private Optional<Long> maxSourceRows = Optional.empty();
     private Optional<Long> maxSourceBytes = Optional.empty();
     private List<Long> excludedFragmentIds = Collections.emptyList();
+    private Optional<SourceBudgetMode> sourceBudgetMode = Optional.empty();
 
     private Builder() {}
 
@@ -346,6 +379,19 @@ public class CompactionOptions implements Serializable {
     }
 
     /**
+     * Sets how planning applies all configured max-source budgets to cumulative totals across the
+     * tasks selected for one plan. {@link SourceBudgetMode#HARD} rejects a task when adding it
+     * would exceed a cumulative budget. {@link SourceBudgetMode#SOFT} always admits the first task;
+     * if it exceeds a budget the plan stops there, otherwise later tasks use the same cumulative
+     * checks as hard mode. If a byte budget is configured but the first task has a source file
+     * without a recorded size, soft mode admits that task and stops; hard mode reports an error.
+     */
+    public Builder withSourceBudgetMode(SourceBudgetMode sourceBudgetMode) {
+      this.sourceBudgetMode = Optional.of(Objects.requireNonNull(sourceBudgetMode));
+      return this;
+    }
+
+    /**
      * Fragment IDs to exclude from compaction planning. Excluded fragments remain unchanged and act
      * as boundaries, so fragments on opposite sides are not combined into the same task. Duplicate
      * and unknown IDs are ignored.
@@ -393,7 +439,8 @@ public class CompactionOptions implements Serializable {
           maxSourceFragments,
           maxSourceRows,
           maxSourceBytes,
-          excludedFragmentIds);
+          excludedFragmentIds,
+          sourceBudgetMode);
     }
   }
 }

--- a/java/src/main/java/org/lance/compaction/SourceBudgetMode.java
+++ b/java/src/main/java/org/lance/compaction/SourceBudgetMode.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.lance.compaction;
+
+/**
+ * Controls how compaction planning applies source budgets to cumulative totals across the tasks
+ * selected for one plan.
+ */
+public enum SourceBudgetMode {
+  /** Reject a task when adding it would make any cumulative source total exceed its budget. */
+  HARD("hard"),
+  /**
+   * Always admit the first indivisible task. If it exceeds a cumulative budget, the plan stops
+   * there; otherwise later tasks use the same cumulative checks as {@link #HARD}. If a byte budget
+   * is configured but the first task has a source file without a recorded size, admit that task and
+   * stop; hard mode reports an error.
+   */
+  SOFT("soft");
+
+  private final String value;
+
+  SourceBudgetMode(String value) {
+    this.value = value;
+  }
+
+  public String getValue() {
+    return value;
+  }
+}

--- a/java/src/test/java/org/lance/CompactionTest.java
+++ b/java/src/test/java/org/lance/CompactionTest.java
@@ -20,6 +20,7 @@ import org.lance.compaction.CompactionOptions;
 import org.lance.compaction.CompactionPlan;
 import org.lance.compaction.CompactionTask;
 import org.lance.compaction.RewriteResult;
+import org.lance.compaction.SourceBudgetMode;
 
 import org.apache.arrow.memory.RootAllocator;
 import org.junit.jupiter.api.Test;
@@ -36,6 +37,7 @@ import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Base64;
 import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -58,17 +60,22 @@ public class CompactionTest {
             CompactionOptions.builder()
                 .withTargetRowsPerFragment(100)
                 .withNumThreads(1)
-                .withMaxSourceRows(1000)
+                .withMaxSourceRows(1)
                 .withMaxSourceBytes(10L * 1024 * 1024)
+                .withSourceBudgetMode(SourceBudgetMode.SOFT)
                 .build();
         CompactionPlan compactionPlan = Compaction.planCompaction(dataset, compactionOptions);
 
-        // The source budgets are loose, so the plan is unaffected and the
-        // options must survive the JNI round trip.
-        assertEquals(Optional.of(1000L), compactionPlan.getCompactionOptions().getMaxSourceRows());
+        // The row budget is smaller than the indivisible task, but soft mode
+        // admits that first task so compaction can make progress. The options
+        // must also survive the JNI round trip.
+        assertEquals(Optional.of(1L), compactionPlan.getCompactionOptions().getMaxSourceRows());
         assertEquals(
             Optional.of(10L * 1024 * 1024),
             compactionPlan.getCompactionOptions().getMaxSourceBytes());
+        assertEquals(
+            Optional.of(SourceBudgetMode.SOFT.getValue()),
+            compactionPlan.getCompactionOptions().getSourceBudgetMode());
 
         // will plan to compact two fragments into one.
         assertEquals(1, compactionPlan.getCompactionTasks().size());
@@ -233,6 +240,23 @@ public class CompactionTest {
           + "lR0LlOCLAgAAeHAAAAAAAAAEAHBwc3IAEWphdmEubGFuZy5Cb29sZWFuzSBygNWc+u4CAAFaAAV2YWx1ZXhwAXBwcHB0"
           + "AA90cnlfYmluYXJ5X2NvcHlwc3EAfgADAAAAAAAAAAR4";
 
+  /**
+   * A serialized CompactionOptions produced by the class immediately before sourceBudgetMode was
+   * added. Unlike {@link #PRE_SOURCE_BUDGET_OPTIONS_BASE64}, this stream contains all three source
+   * budgets and excludedFragmentIds, then ends.
+   */
+  private static final String PRE_SOURCE_BUDGET_MODE_OPTIONS_BASE64 =
+      "rO0ABXNyACZvcmcubGFuY2UuY29tcGFjdGlvbi5Db21wYWN0aW9uT3B0aW9ucys6bRwua1fWAwAOTAAJYmF0Y2hTaXpldAAUTGph"
+          + "dmEvdXRpbC9PcHRpb25hbDtMABhiaW5hcnlDb3B5UmVhZEJhdGNoQnl0ZXNxAH4AAUwADmNvbXBhY3Rpb25Nb2RlcQB+AAFMAA9k"
+          + "ZWZlckluZGV4UmVtYXBxAH4AAUwAE2V4Y2x1ZGVkRnJhZ21lbnRJZHN0ABBMamF2YS91dGlsL0xpc3Q7TAAUbWF0ZXJpYWxpemVE"
+          + "ZWxldGlvbnNxAH4AAUwAHW1hdGVyaWFsaXplRGVsZXRpb25zVGhyZXNob2xkcQB+AAFMAA9tYXhCeXRlc1BlckZpbGVxAH4AAUwA"
+          + "D21heFJvd3NQZXJHcm91cHEAfgABTAAObWF4U291cmNlQnl0ZXNxAH4AAUwAEm1heFNvdXJjZUZyYWdtZW50c3EAfgABTAANbWF4"
+          + "U291cmNlUm93c3EAfgABTAAKbnVtVGhyZWFkc3EAfgABTAAVdGFyZ2V0Um93c1BlckZyYWdtZW50cQB+AAF4cHNyAA5qYXZhLmxh"
+          + "bmcuTG9uZzuL5JDMjyPfAgABSgAFdmFsdWV4cgAQamF2YS5sYW5nLk51bWJlcoaslR0LlOCLAgAAeHAAAAAAAAAEAHBwc3IAEWph"
+          + "dmEubGFuZy5Cb29sZWFuzSBygNWc+u4CAAFaAAV2YWx1ZXhwAXBwcHB0AA90cnlfYmluYXJ5X2NvcHlwc3EAfgAEAAAAAAAAAARz"
+          + "cQB+AAQAAAAAAAAABXNxAH4ABAAAAAAAAAAGc3IAEWphdmEudXRpbC5Db2xsU2VyV46rtjobqBEDAAFJAAN0YWd4cAAAAAF3BAAA"
+          + "AAJzcQB+AAQAAAAAAAAAB3NxAH4ABAAAAAAAAAAIeHg=";
+
   @Test
   public void testDeserializeOptionsFromOlderVersion() throws Exception {
     byte[] serialized = Base64.getDecoder().decode(PRE_SOURCE_BUDGET_OPTIONS_BASE64);
@@ -249,6 +273,21 @@ public class CompactionTest {
     assertEquals(Optional.empty(), options.getMaxSourceRows());
     assertEquals(Optional.empty(), options.getMaxSourceBytes());
     assertEquals(Collections.emptyList(), options.getExcludedFragmentIds());
+    assertEquals(Optional.empty(), options.getSourceBudgetMode());
+  }
+
+  @Test
+  public void testDeserializeOptionsFromBeforeSourceBudgetMode() throws Exception {
+    byte[] serialized = Base64.getDecoder().decode(PRE_SOURCE_BUDGET_MODE_OPTIONS_BASE64);
+    CompactionOptions options;
+    try (ObjectInputStream in = new ObjectInputStream(new ByteArrayInputStream(serialized))) {
+      options = (CompactionOptions) in.readObject();
+    }
+    assertEquals(Optional.of(4L), options.getMaxSourceFragments());
+    assertEquals(Optional.of(5L), options.getMaxSourceRows());
+    assertEquals(Optional.of(6L), options.getMaxSourceBytes());
+    assertEquals(List.of(7L, 8L), options.getExcludedFragmentIds());
+    assertEquals(Optional.empty(), options.getSourceBudgetMode());
   }
 
   private static <T> T serializeAndDeserialize(T object)

--- a/python/python/lance/dataset.py
+++ b/python/python/lance/dataset.py
@@ -7377,6 +7377,7 @@ class DatasetOptimizer:
         max_source_fragments: Optional[int] = None,
         max_source_rows: Optional[int] = None,
         max_source_bytes: Optional[int] = None,
+        source_budget_mode: Optional[Literal["hard", "soft"]] = None,
         excluded_fragment_ids: Optional[list[int]] = None,
     ) -> CompactionMetrics:
         """Compacts small files in the dataset, reducing total number of files.
@@ -7411,7 +7412,8 @@ class DatasetOptimizer:
         ``lance.compaction.binary_copy_read_batch_bytes``,
         ``lance.compaction.max_source_fragments``,
         ``lance.compaction.max_source_rows``,
-        ``lance.compaction.max_source_bytes``.
+        ``lance.compaction.max_source_bytes``,
+        ``lance.compaction.source_budget_mode``.
 
         Parameters
         ----------
@@ -7482,6 +7484,16 @@ class DatasetOptimizer:
             would exceed this limit. Blob v2 payloads live in separate
             blob files and are not counted, so this is not a cap on total
             compaction I/O for datasets with blob columns.
+        source_budget_mode: {"hard", "soft"}, optional
+            Controls how all configured ``max_source_*`` budgets are applied
+            to cumulative totals across the tasks selected for one plan.
+            ``"hard"`` rejects a task when adding it would exceed any
+            cumulative budget and is the default. ``"soft"`` always admits
+            the first indivisible task. If that task exceeds a budget, the
+            plan stops there; otherwise later tasks use the same cumulative
+            checks as ``"hard"``. If a byte budget is set but the first task
+            has a source file without a recorded size, ``"soft"`` admits that
+            task and stops; ``"hard"`` reports an error.
         excluded_fragment_ids: list[int], optional
             Fragment IDs to exclude from compaction planning. Excluded
             fragments remain unchanged and act as boundaries, so fragments
@@ -7513,6 +7525,7 @@ class DatasetOptimizer:
                 max_source_fragments=max_source_fragments,
                 max_source_rows=max_source_rows,
                 max_source_bytes=max_source_bytes,
+                source_budget_mode=source_budget_mode,
                 excluded_fragment_ids=excluded_fragment_ids,
             ).items()
             if v is not None

--- a/python/python/lance/optimize.py
+++ b/python/python/lance/optimize.py
@@ -13,7 +13,7 @@ from .lance import RewriteResult as RewriteResult
 # from .lance import CompactionPlan as CompactionPlan
 
 
-class CompactionOptions(TypedDict):
+class CompactionOptions(TypedDict, total=False):
     """Options for compaction."""
 
     target_rows_per_fragment: Optional[int]
@@ -113,6 +113,17 @@ class CompactionOptions(TypedDict):
     this is not a cap on total compaction I/O for datasets with blob
     columns.
     (default: None, no limit)
+    """
+    source_budget_mode: Optional[Literal["hard", "soft"]]
+    """
+    Controls how all configured max-source budgets are applied to cumulative
+    totals across the tasks selected for one plan. ``"hard"`` rejects a task
+    when adding it would exceed any cumulative budget and is the default.
+    ``"soft"`` always admits the first task. If that task exceeds a budget,
+    the plan stops there; otherwise later tasks use the same cumulative checks
+    as ``"hard"``. If a byte budget is set but the first task has a source
+    file without a recorded size, ``"soft"`` admits that task and stops;
+    ``"hard"`` reports an error.
     """
     excluded_fragment_ids: Optional[list[int]]
     """

--- a/python/python/tests/test_optimize.py
+++ b/python/python/tests/test_optimize.py
@@ -12,7 +12,7 @@ import numpy as np
 import pyarrow as pa
 import pytest
 from lance.lance import Compaction
-from lance.optimize import RewriteResult
+from lance.optimize import CompactionOptions, RewriteResult
 from lance.vector import vec_to_table
 
 
@@ -39,6 +39,11 @@ def test_dataset_optimize(tmp_path: Path):
     assert metrics.files_added == 1
 
     assert dataset.version == 3
+
+
+def test_compaction_options_keys_are_optional():
+    assert CompactionOptions.__required_keys__ == frozenset()
+    assert "source_budget_mode" in CompactionOptions.__optional_keys__
 
 
 def test_dataset_optimize_excluded_fragment_ids(tmp_path: Path):
@@ -89,8 +94,21 @@ def test_compact_files_source_budgets(tmp_path: Path):
     assert metrics.fragments_removed == 0
     assert dataset.version == version_before
 
+    # Soft mode admits one indivisible task even though it exceeds the byte
+    # budget, then stops before admitting another task.
+    metrics = dataset.optimize.compact_files(
+        target_rows_per_fragment=200,
+        num_threads=1,
+        max_source_bytes=1,
+        source_budget_mode="soft",
+    )
+    assert metrics.fragments_removed == 2
+
     with pytest.raises(OSError, match="must be greater than 0"):
         dataset.optimize.compact_files(max_source_rows=0)
+
+    with pytest.raises(ValueError, match="Invalid source budget mode"):
+        dataset.optimize.compact_files(source_budget_mode="invalid")
 
 
 def test_compact_files_max_source_fragments(tmp_path: Path):
@@ -628,6 +646,16 @@ def test_dataset_distributed_optimize(tmp_path: Path):
         ),
     )
     assert none_plan == plan
+
+    none_budget_mode_plan = Compaction.plan(
+        dataset,
+        options=dict(
+            target_rows_per_fragment=400,
+            source_budget_mode=None,
+            num_threads=1,
+        ),
+    )
+    assert none_budget_mode_plan == plan
 
     # Plan can be pickled
     assert pickle.loads(pickle.dumps(plan)) == plan

--- a/python/src/dataset/optimize.rs
+++ b/python/src/dataset/optimize.rs
@@ -16,7 +16,7 @@ use lance::dataset::{
     index::DatasetIndexRemapperOptions,
     optimize::{
         CompactionMetrics, CompactionMode, CompactionOptions, CompactionPlan, CompactionTask,
-        RewriteResult, commit_compaction, compact_files, plan_compaction,
+        RewriteResult, SourceBudgetMode, commit_compaction, compact_files, plan_compaction,
     },
 };
 use pyo3::{exceptions::PyNotImplementedError, pyclass::CompareOp, types::PyTuple};
@@ -81,6 +81,13 @@ fn parse_compaction_options(
             }
             "max_source_bytes" => {
                 opts.max_source_bytes = value.extract()?;
+            }
+            "source_budget_mode" => {
+                let mode_str: Option<String> = value.extract()?;
+                if let Some(mode_str) = mode_str {
+                    opts.source_budget_mode = SourceBudgetMode::try_from(mode_str.as_str())
+                        .map_err(|e| PyValueError::new_err(e.to_string()))?;
+                }
             }
             "excluded_fragment_ids" => {
                 opts.excluded_fragment_ids =

--- a/rust/lance/src/dataset/optimize.rs
+++ b/rust/lance/src/dataset/optimize.rs
@@ -330,9 +330,10 @@ pub struct CompactionOptions {
     /// it would exceed any budget. In [`SourceBudgetMode::Soft`] mode, the first
     /// task is always admitted. If it exceeds a budget, the plan stops there;
     /// otherwise later tasks use the same cumulative checks as hard mode.
-    /// If the first task has a source file without a recorded size while a
-    /// byte budget is configured, soft mode admits that task and stops because
-    /// no additional task can be admitted safely. Hard mode reports an error.
+    /// If a task has a source file without a recorded size while a byte budget
+    /// is configured, soft mode stops at that task because it cannot be safely
+    /// compared with the budget. The task is admitted only when it is first,
+    /// preserving the soft-mode progress guarantee. Hard mode reports an error.
     /// Defaults to [`SourceBudgetMode::Hard`].
     #[serde(default)]
     pub source_budget_mode: SourceBudgetMode,
@@ -1117,13 +1118,15 @@ fn limit_tasks_to_source_budget(
         total_fragments += task.fragments.len();
         total_rows = total_rows.saturating_add(live_rows);
         if options.max_source_bytes.is_some() {
-            let allow_missing_size =
-                tasks.is_empty() && options.source_budget_mode == SourceBudgetMode::Soft;
+            let allow_missing_size = options.source_budget_mode == SourceBudgetMode::Soft;
             let Some(task_bytes) = task_source_bytes(&task, &schema_field_ids, allow_missing_size)?
             else {
-                // Soft mode admits the first task unconditionally. Without its
-                // source size we cannot safely admit any additional task.
-                tasks.push(task);
+                // Soft mode stops at a task whose source size is unavailable.
+                // Admit it only when it is first so planning still makes
+                // progress; otherwise keep the already-safe selected prefix.
+                if tasks.is_empty() {
+                    tasks.push(task);
+                }
                 break;
             };
             total_bytes = total_bytes.saturating_add(task_bytes);
@@ -8374,6 +8377,47 @@ mod tests {
 
         let soft = CompactionOptions {
             max_source_bytes: Some(1),
+            source_budget_mode: SourceBudgetMode::Soft,
+            ..Default::default()
+        };
+        let selected = limit_tasks_to_source_budget(&soft, dataset.schema(), all_tasks).unwrap();
+        assert_eq!(selected.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_soft_source_budget_keeps_prefix_before_unknown_later_task() {
+        let test_dir = TempStrDir::default();
+        let dataset = dataset_with_ten_small_fragments(&test_dir).await;
+        let unbounded = CompactionOptions {
+            target_rows_per_fragment: 250,
+            ..Default::default()
+        };
+        let plan = plan_compaction(&dataset, &unbounded).await.unwrap();
+        assert!(plan.tasks.len() > 1);
+
+        let mut all_tasks = plan
+            .tasks
+            .into_iter()
+            .map(|task| (task, 0))
+            .collect::<Vec<_>>();
+        assert!(
+            all_tasks[0].0.fragments[0].files[0]
+                .file_size_bytes
+                .get()
+                .is_some()
+        );
+        all_tasks[1].0.fragments[0].files[0].file_size_bytes = CachedFileSize::unknown();
+
+        let hard = CompactionOptions {
+            max_source_bytes: Some(u64::MAX),
+            ..Default::default()
+        };
+        let err =
+            limit_tasks_to_source_budget(&hard, dataset.schema(), all_tasks.clone()).unwrap_err();
+        assert!(err.to_string().contains("has no size recorded"));
+
+        let soft = CompactionOptions {
+            max_source_bytes: Some(u64::MAX),
             source_budget_mode: SourceBudgetMode::Soft,
             ..Default::default()
         };

--- a/rust/lance/src/dataset/optimize.rs
+++ b/rust/lance/src/dataset/optimize.rs
@@ -168,6 +168,39 @@ impl TryFrom<&str> for CompactionMode {
     }
 }
 
+/// Controls how compaction planning applies the configured source budgets.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub enum SourceBudgetMode {
+    /// Reject a task when adding it would make any cumulative source total
+    /// exceed its configured budget.
+    ///
+    /// If the first indivisible compaction task exceeds any budget, the plan
+    /// is empty. This preserves the historical behavior.
+    #[default]
+    Hard,
+    /// Always admit the first indivisible compaction task, even when it exceeds
+    /// a configured cumulative source budget.
+    ///
+    /// If the first task exceeds a budget, the plan stops there. Otherwise,
+    /// later tasks use the same cumulative checks as [`SourceBudgetMode::Hard`].
+    Soft,
+}
+
+impl TryFrom<&str> for SourceBudgetMode {
+    type Error = Error;
+
+    fn try_from(value: &str) -> std::result::Result<Self, Self::Error> {
+        match value.to_lowercase().as_str() {
+            "hard" => Ok(Self::Hard),
+            "soft" => Ok(Self::Soft),
+            _ => Err(Error::invalid_input(format!(
+                "Invalid source budget mode \"{}\". Valid values: \"hard\", \"soft\"",
+                value
+            ))),
+        }
+    }
+}
+
 /// Controls how the old-to-new row-address mapping is built when remapping
 /// indices during compaction.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
@@ -289,6 +322,20 @@ pub struct CompactionOptions {
     /// columns.
     /// Defaults to `None` (no limit).
     pub max_source_bytes: Option<u64>,
+    /// Controls whether `max_source_fragments`, `max_source_rows`, and
+    /// `max_source_bytes` are hard or soft limits.
+    ///
+    /// Budgets apply to cumulative totals across the tasks selected for one
+    /// plan. In [`SourceBudgetMode::Hard`] mode, a task is rejected when adding
+    /// it would exceed any budget. In [`SourceBudgetMode::Soft`] mode, the first
+    /// task is always admitted. If it exceeds a budget, the plan stops there;
+    /// otherwise later tasks use the same cumulative checks as hard mode.
+    /// If the first task has a source file without a recorded size while a
+    /// byte budget is configured, soft mode admits that task and stops because
+    /// no additional task can be admitted safely. Hard mode reports an error.
+    /// Defaults to [`SourceBudgetMode::Hard`].
+    #[serde(default)]
+    pub source_budget_mode: SourceBudgetMode,
     /// Fragment IDs to exclude from compaction planning.
     ///
     /// Excluded fragments act as boundaries between adjacent compaction candidates,
@@ -337,6 +384,7 @@ impl Default for CompactionOptions {
             max_source_fragments: None,
             max_source_rows: None,
             max_source_bytes: None,
+            source_budget_mode: SourceBudgetMode::Hard,
             excluded_fragment_ids: Vec::new(),
             max_overlays_per_fragment: Some(10),
             transaction_properties: None,
@@ -367,6 +415,7 @@ impl CompactionOptions {
     /// - `lance.compaction.max_source_fragments`
     /// - `lance.compaction.max_source_rows`
     /// - `lance.compaction.max_source_bytes`
+    /// - `lance.compaction.source_budget_mode`
     /// - `lance.compaction.max_overlays_per_fragment`
     pub fn from_dataset_config(config: &HashMap<String, String>) -> Result<Self> {
         let mut opts = Self::default();
@@ -493,6 +542,9 @@ impl CompactionOptions {
                             key, value
                         ))
                     })?);
+                }
+                "source_budget_mode" => {
+                    self.source_budget_mode = SourceBudgetMode::try_from(value.as_str())?;
                 }
                 "max_overlays_per_fragment" => {
                     // The default is `Some(10)`, so an explicit "none" is the only
@@ -1027,11 +1079,12 @@ async fn collect_metrics(fragment: &FileFragment) -> Result<FragmentMetrics> {
 /// Truncates a planned task list to the configured per-run source budgets
 /// (`max_source_fragments`, `max_source_rows`, `max_source_bytes`).
 ///
-/// All configured budgets apply together: tasks are kept, in order, until
-/// adding the next task would exceed any one of them. The budgets are hard
-/// upper bounds, so if the first task already exceeds one of them the
-/// returned plan is empty and a warning is logged, since compaction would
-/// otherwise stall silently.
+/// All configured budgets apply together to cumulative totals across selected
+/// tasks. Tasks are kept, in order, until adding the next task would exceed any
+/// one of them. In [`SourceBudgetMode::Hard`] mode the returned plan is empty if
+/// the first task exceeds a budget. [`SourceBudgetMode::Soft`] always admits the
+/// first task. If it exceeds a budget, the plan stops there; otherwise later
+/// tasks use the same cumulative checks as hard mode.
 ///
 /// Each task is paired with the number of live rows in its source fragments.
 fn limit_tasks_to_source_budget(
@@ -1064,7 +1117,16 @@ fn limit_tasks_to_source_budget(
         total_fragments += task.fragments.len();
         total_rows = total_rows.saturating_add(live_rows);
         if options.max_source_bytes.is_some() {
-            total_bytes = total_bytes.saturating_add(task_source_bytes(&task, &schema_field_ids)?);
+            let allow_missing_size =
+                tasks.is_empty() && options.source_budget_mode == SourceBudgetMode::Soft;
+            let Some(task_bytes) = task_source_bytes(&task, &schema_field_ids, allow_missing_size)?
+            else {
+                // Soft mode admits the first task unconditionally. Without its
+                // source size we cannot safely admit any additional task.
+                tasks.push(task);
+                break;
+            };
+            total_bytes = total_bytes.saturating_add(task_bytes);
         }
 
         let over_budget = options
@@ -1074,7 +1136,12 @@ fn limit_tasks_to_source_budget(
             || options
                 .max_source_bytes
                 .is_some_and(|max| total_bytes > max);
+        let admit_oversized_first_task =
+            tasks.is_empty() && options.source_budget_mode == SourceBudgetMode::Soft;
         if over_budget {
+            if admit_oversized_first_task {
+                tasks.push(task);
+            }
             break;
         }
 
@@ -1101,10 +1168,15 @@ fn limit_tasks_to_source_budget(
 /// Files whose fields are all absent from `schema_field_ids` only back
 /// dropped columns; compaction does not read them, so they are neither
 /// counted nor required to have a recorded size.
-/// Only sizes recorded in the manifest are used: a missing size is an error
-/// rather than a metadata request against object storage, which would turn
-/// planning into one round trip per file. Deletion files are not counted.
-fn task_source_bytes(task: &TaskData, schema_field_ids: &HashSet<i32>) -> Result<u64> {
+/// Only sizes recorded in the manifest are used rather than issuing metadata
+/// requests against object storage, which would turn planning into one round
+/// trip per file. A missing size returns `None` only when `allow_missing_size`
+/// is true; otherwise it is an error. Deletion files are not counted.
+fn task_source_bytes(
+    task: &TaskData,
+    schema_field_ids: &HashSet<i32>,
+    allow_missing_size: bool,
+) -> Result<Option<u64>> {
     let mut total_bytes = 0_u64;
     for fragment in &task.fragments {
         let overlay_files = fragment.overlays.iter().map(|overlay| &overlay.data_file);
@@ -1116,17 +1188,20 @@ fn task_source_bytes(task: &TaskData, schema_field_ids: &HashSet<i32>) -> Result
             {
                 continue;
             }
-            let size = data_file.file_size_bytes.get().ok_or_else(|| {
-                Error::invalid_input(format!(
+            let Some(size) = data_file.file_size_bytes.get() else {
+                if allow_missing_size {
+                    return Ok(None);
+                }
+                return Err(Error::invalid_input(format!(
                     "max_source_bytes is set but file '{}' of fragment {} has no size recorded \
                      in the manifest; unset max_source_bytes to compact this dataset",
                     data_file.path, fragment.id
-                ))
-            })?;
+                )));
+            };
             total_bytes = total_bytes.saturating_add(size.get());
         }
     }
-    Ok(total_bytes)
+    Ok(Some(total_bytes))
 }
 
 /// A plan for what groups of fragments to compact.
@@ -7836,6 +7911,10 @@ mod tests {
                 "lance.compaction.max_source_bytes".to_string(),
                 "1073741824".to_string(),
             ),
+            (
+                "lance.compaction.source_budget_mode".to_string(),
+                "soft".to_string(),
+            ),
         ]);
 
         let opts = CompactionOptions::from_dataset_config(&config).unwrap();
@@ -7854,6 +7933,7 @@ mod tests {
         assert_eq!(opts.max_source_fragments, Some(20));
         assert_eq!(opts.max_source_rows, Some(1_000_000));
         assert_eq!(opts.max_source_bytes, Some(1_073_741_824));
+        assert_eq!(opts.source_budget_mode, SourceBudgetMode::Soft);
     }
 
     #[test]
@@ -7977,6 +8057,17 @@ mod tests {
         let result = CompactionOptions::from_dataset_config(&config);
         let err_msg = result.unwrap_err().to_string();
         assert!(err_msg.contains("invalid_mode"));
+    }
+
+    #[test]
+    fn test_from_dataset_config_invalid_source_budget_mode() {
+        let config = HashMap::from([(
+            "lance.compaction.source_budget_mode".to_string(),
+            "invalid".to_string(),
+        )]);
+
+        let err = CompactionOptions::from_dataset_config(&config).unwrap_err();
+        assert!(err.to_string().contains("Invalid source budget mode"));
     }
 
     #[test]
@@ -8231,6 +8322,138 @@ mod tests {
             .map(|f| f.physical_rows.unwrap())
             .sum();
         assert_eq!(physical_rows, 300);
+    }
+
+    #[tokio::test]
+    async fn test_soft_source_budget_admits_one_oversized_task() {
+        let test_dir = TempStrDir::default();
+        let dataset = dataset_with_ten_small_fragments(&test_dir).await;
+
+        // The first task contains three fragments and 250 live rows, and its
+        // source files are larger than one byte. In soft mode it is admitted
+        // so compaction can make progress, but the next task is not.
+        let opts = CompactionOptions {
+            target_rows_per_fragment: 250,
+            max_source_fragments: Some(1),
+            max_source_rows: Some(1),
+            max_source_bytes: Some(1),
+            source_budget_mode: SourceBudgetMode::Soft,
+            ..Default::default()
+        };
+        let plan = plan_compaction(&dataset, &opts).await.unwrap();
+
+        assert_eq!(plan.num_tasks(), 1);
+        assert_eq!(plan.tasks()[0].fragments.len(), 3);
+    }
+
+    #[tokio::test]
+    async fn test_soft_source_budget_missing_first_task_size() {
+        let test_dir = TempStrDir::default();
+        let dataset = dataset_with_ten_small_fragments(&test_dir).await;
+        let unbounded = CompactionOptions {
+            target_rows_per_fragment: 250,
+            ..Default::default()
+        };
+        let plan = plan_compaction(&dataset, &unbounded).await.unwrap();
+        assert!(plan.tasks.len() > 1);
+
+        let mut all_tasks = plan
+            .tasks
+            .into_iter()
+            .map(|task| (task, 0))
+            .collect::<Vec<_>>();
+        all_tasks[0].0.fragments[0].files[0].file_size_bytes = CachedFileSize::unknown();
+
+        let hard = CompactionOptions {
+            max_source_bytes: Some(1),
+            ..Default::default()
+        };
+        let err =
+            limit_tasks_to_source_budget(&hard, dataset.schema(), all_tasks.clone()).unwrap_err();
+        assert!(err.to_string().contains("has no size recorded"));
+
+        let soft = CompactionOptions {
+            max_source_bytes: Some(1),
+            source_budget_mode: SourceBudgetMode::Soft,
+            ..Default::default()
+        };
+        let selected = limit_tasks_to_source_budget(&soft, dataset.schema(), all_tasks).unwrap();
+        assert_eq!(selected.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_soft_source_budget_stops_after_oversized_first_task() {
+        let test_dir = TempStrDir::default();
+        let dataset = dataset_with_ten_small_fragments(&test_dir).await;
+        let unbounded = CompactionOptions {
+            target_rows_per_fragment: 250,
+            ..Default::default()
+        };
+        let plan = plan_compaction(&dataset, &unbounded).await.unwrap();
+        assert!(plan.tasks.len() > 1);
+
+        let mut all_tasks = plan
+            .tasks
+            .into_iter()
+            .map(|task| (task, 0))
+            .collect::<Vec<_>>();
+        // The first task has known source sizes and exceeds the row budget.
+        // The second task's unknown size must not be inspected after soft mode
+        // admits the first task, because the plan must stop at that point.
+        assert!(
+            all_tasks[0].0.fragments[0].files[0]
+                .file_size_bytes
+                .get()
+                .is_some()
+        );
+        all_tasks[0].1 = 2;
+        all_tasks[1].0.fragments[0].files[0].file_size_bytes = CachedFileSize::unknown();
+
+        let soft = CompactionOptions {
+            max_source_rows: Some(1),
+            max_source_bytes: Some(u64::MAX),
+            source_budget_mode: SourceBudgetMode::Soft,
+            ..Default::default()
+        };
+        let selected = limit_tasks_to_source_budget(&soft, dataset.schema(), all_tasks).unwrap();
+        assert_eq!(selected.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_soft_source_budget_uses_cumulative_totals_after_first_task() {
+        let test_dir = TempStrDir::default();
+        let dataset = dataset_with_ten_small_fragments(&test_dir).await;
+        let unbounded = CompactionOptions {
+            target_rows_per_fragment: 250,
+            ..Default::default()
+        };
+        let plan = plan_compaction(&dataset, &unbounded).await.unwrap();
+        assert!(plan.tasks.len() > 2);
+
+        // Each task's synthetic row count fits the budget independently. The
+        // first two fit cumulatively, but adding the third exceeds the total.
+        let all_tasks = plan
+            .tasks
+            .into_iter()
+            .take(3)
+            .map(|task| (task, 2))
+            .collect::<Vec<_>>();
+        let hard = CompactionOptions {
+            max_source_rows: Some(5),
+            ..Default::default()
+        };
+        let soft = CompactionOptions {
+            max_source_rows: Some(5),
+            source_budget_mode: SourceBudgetMode::Soft,
+            ..Default::default()
+        };
+
+        let hard_selected =
+            limit_tasks_to_source_budget(&hard, dataset.schema(), all_tasks.clone()).unwrap();
+        let soft_selected =
+            limit_tasks_to_source_budget(&soft, dataset.schema(), all_tasks).unwrap();
+        assert_eq!(hard_selected.len(), 2);
+        assert_eq!(soft_selected, hard_selected);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- add an opt-in `SourceBudgetMode` for compaction planning, with `hard` preserving the existing behavior
- let `soft` mode admit the first indivisible task when it exceeds a cumulative `max_source_*` budget, then stop the plan
- keep later tasks under the same cumulative budget checks when the first task fits
- expose the mode through manifest configuration, Python, and Java/JNI
- preserve Java serialization compatibility with older `CompactionOptions` streams

This is a follow-up to #8234.

## Motivation

A hard source budget can produce an empty compaction plan when the first indivisible task is larger than the configured per-run target. Repeated planning then makes no progress unless the user raises the budget.

Soft mode treats the budgets as workload targets instead of strict caps for the first task. It guarantees one task of progress while remaining conservative: once the first task is admitted because it is oversized (or its byte size is unavailable in an older manifest), planning stops.

## Semantics

- `hard` remains the default and is backward compatible.
- Budgets apply to cumulative source totals across tasks selected for one plan.
- `soft` always admits the first task.
- If the first task exceeds any configured budget, the plan contains only that task.
- If the first task fits, subsequent tasks use the same cumulative checks as `hard`.
- With `max_source_bytes`, a missing recorded size is still an error in `hard` mode. In `soft` mode, a missing size on the first task admits that task and stops.

## Testing

- `cargo test -p lance source_budget --lib` (5 passed)
- `cargo test -p lance max_source --lib` (3 passed)
- `cargo clippy -p lance --lib --no-deps -- -D warnings`
- `cargo fmt --all -- --check`
- `cd python && cargo check`
- `cd java && ./mvnw -Dtest=CompactionTest -DforkCount=0 test` (8 Java tests and 18 JNI Rust tests passed)
- Java Checkstyle and Spotless checks
- pre-commit hooks: ruff, ruff-format, fmt, and typos

The Python runtime pytest suite was not run locally because the environment could not download a missing dependency; the native extension compiled successfully and CI will run the Python suite.
