### PR TITLE
feat: resolve stable file format to 2.2

### DIFF
--- a/java/src/test/java/org/lance/CommitBuilderStorageFormatTest.java
+++ b/java/src/test/java/org/lance/CommitBuilderStorageFormatTest.java
@@ -33,7 +33,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class CommitBuilderStorageFormatTest extends OperationTestBase {
 
   /**
-   * Append to a freshly created (2.1) dataset with the given storage format and return the
+   * Append to a freshly created (2.2) dataset with the given storage format and return the
    * committed dataset's format version.
    */
   private String commitWithStorageFormat(String datasetPath, String storageFormat)
@@ -60,22 +60,22 @@ public class CommitBuilderStorageFormatTest extends OperationTestBase {
   /**
    * The numeric versions are what {@link Dataset#getLanceFileFormatVersion()} returns and what
    * {@link WriteParams.Builder#withDataStorageVersion(String)} accepts, so they must work here too
-   * — a caller that encodes fragments as "2.1" has to be able to commit them as "2.1".
+   * — a caller that encodes fragments as "2.2" has to be able to commit them as "2.2".
    */
   @Test
   void testCanonicalVersionAccepted(@TempDir Path tempDir) throws Exception {
     assertEquals(
-        LanceConstants.FILE_FORMAT_VERSION_2_1,
+        LanceConstants.FILE_FORMAT_VERSION_2_2,
         commitWithStorageFormat(
-            tempDir.resolve("canonical").toString(), LanceConstants.FILE_FORMAT_VERSION_2_1));
+            tempDir.resolve("canonical").toString(), LanceConstants.FILE_FORMAT_VERSION_2_2));
   }
 
   /** The "v"-prefixed spelling shipped in this method's Javadoc and stays accepted. */
   @Test
   void testDeprecatedAliasAccepted(@TempDir Path tempDir) throws Exception {
     assertEquals(
-        LanceConstants.FILE_FORMAT_VERSION_2_1,
-        commitWithStorageFormat(tempDir.resolve("alias").toString(), "v2_1"));
+        LanceConstants.FILE_FORMAT_VERSION_2_2,
+        commitWithStorageFormat(tempDir.resolve("alias").toString(), "v2_2"));
   }
 
   /**
@@ -100,21 +100,21 @@ public class CommitBuilderStorageFormatTest extends OperationTestBase {
               .build()) {
         dataset = new CommitBuilder(dataset).execute(appendTxn);
       }
-      assertEquals(LanceConstants.FILE_FORMAT_VERSION_2_1, dataset.getLanceFileFormatVersion());
+      assertEquals(LanceConstants.FILE_FORMAT_VERSION_2_2, dataset.getLanceFileFormatVersion());
 
       List<Long> fragmentIds =
           dataset.getFragments().stream()
               .map(f -> Long.valueOf(f.getId()))
               .collect(Collectors.toList());
 
-      // "2.2" parses fine, so a failure here is the mismatch guard and not the parser.
+      // "2.1" parses fine, so a failure here is the mismatch guard and not the parser.
       try (Transaction deleteTxn = deleteAll(fragmentIds)) {
         IllegalArgumentException error =
             assertThrows(
                 IllegalArgumentException.class,
                 () ->
                     new CommitBuilder(dataset)
-                        .storageFormat(LanceConstants.FILE_FORMAT_VERSION_2_2)
+                        .storageFormat(LanceConstants.FILE_FORMAT_VERSION_2_1)
                         .execute(deleteTxn));
         assertTrue(error.getMessage().contains("Storage format mismatch"), error.getMessage());
       }
@@ -123,7 +123,7 @@ public class CommitBuilderStorageFormatTest extends OperationTestBase {
       try (Transaction deleteTxn = deleteAll(fragmentIds)) {
         try (Dataset deleted =
             new CommitBuilder(dataset)
-                .storageFormat(LanceConstants.FILE_FORMAT_VERSION_2_1)
+                .storageFormat(LanceConstants.FILE_FORMAT_VERSION_2_2)
                 .execute(deleteTxn)) {
           assertEquals(0, deleted.countRows());
         }

--- a/java/src/test/java/org/lance/DatasetTest.java
+++ b/java/src/test/java/org/lance/DatasetTest.java
@@ -123,12 +123,12 @@ public class DatasetTest {
   @Test
   void testGetLanceFileFormatVersion(@TempDir Path tempDir) {
     try (RootAllocator allocator = new RootAllocator(Long.MAX_VALUE)) {
-      // Test default version (V2_1)
+      // Test default version (V2_2)
       String defaultPath = tempDir.resolve("default_version").toString();
       TestUtils.SimpleTestDataset testDataset =
           new TestUtils.SimpleTestDataset(allocator, defaultPath);
       try (Dataset dataset = testDataset.createEmptyDataset()) {
-        assertEquals(LanceConstants.FILE_FORMAT_VERSION_2_1, dataset.getLanceFileFormatVersion());
+        assertEquals(LanceConstants.FILE_FORMAT_VERSION_2_2, dataset.getLanceFileFormatVersion());
         WriterVersion writerVersion = dataset.getWriterVersion().orElseThrow(AssertionError::new);
         assertEquals("lance", writerVersion.getLibrary());
         assertFalse(writerVersion.getVersion().isEmpty());

--- a/java/src/test/java/org/lance/DatasetTest.java
+++ b/java/src/test/java/org/lance/DatasetTest.java
@@ -1132,7 +1132,7 @@ public class DatasetTest {
       dataset = testDataset.createEmptyDataset();
 
       try (Dataset dataset2 = testDataset.write(1, 5)) {
-        assertEquals(108, dataset2.calculateDataSize());
+        assertEquals(112, dataset2.calculateDataSize());
       }
     }
   }

--- a/java/src/test/java/org/lance/TestUtils.java
+++ b/java/src/test/java/org/lance/TestUtils.java
@@ -684,6 +684,7 @@ public class TestUtils {
           new WriteParams.Builder()
               // Enable stable row ids to simplify test assertions across fragments
               .withEnableStableRowIds(true)
+              .withDataStorageVersion(LanceConstants.FILE_FORMAT_VERSION_2_1)
               .withMode(WriteParams.WriteMode.CREATE)
               .build();
       Dataset ds = Dataset.create(allocator, datasetPath, getSchema(), params);
@@ -734,6 +735,7 @@ public class TestUtils {
                 .withMaxRowsPerFile(maxRowsPerFile)
                 .withMode(WriteParams.WriteMode.APPEND)
                 .withEnableStableRowIds(true)
+                .withDataStorageVersion(LanceConstants.FILE_FORMAT_VERSION_2_1)
                 .build();
 
         List<FragmentMetadata> metas = Fragment.create(datasetPath, allocator, root, params);

--- a/java/src/test/java/org/lance/operation/OperationTestBase.java
+++ b/java/src/test/java/org/lance/operation/OperationTestBase.java
@@ -35,7 +35,7 @@ import java.util.UUID;
 public class OperationTestBase {
 
   public static final int TEST_FILE_FORMAT_MAJOR_VERSION = 2;
-  public static final int TEST_FILE_FORMAT_MINOR_VERSION = 1;
+  public static final int TEST_FILE_FORMAT_MINOR_VERSION = 2;
   protected Dataset dataset;
 
   @BeforeAll

--- a/python/python/tests/compat/test_file_formats.py
+++ b/python/python/tests/compat/test_file_formats.py
@@ -18,7 +18,20 @@ from .compat_decorator import (
     UpgradeDowngradeTest,
     compat_test,
 )
-from .util import build_basic_types, build_large
+from .util import build_basic_types, build_large, safe_data_storage_version
+
+
+@pytest.mark.parametrize(
+    ("lance_version", "expected_storage_version"),
+    [
+        ("0.36.0", "2.0"),
+        ("0.38.0", "2.1"),
+        ("0.39.0", "2.1"),
+        ("11.0.0", "2.1"),
+    ],
+)
+def test_safe_data_storage_version(lance_version, expected_storage_version):
+    assert safe_data_storage_version(lance_version) == expected_storage_version
 
 
 # We start testing against the first release where 2.1 was stable. Before that

--- a/python/python/tests/compat/util.py
+++ b/python/python/tests/compat/util.py
@@ -12,16 +12,17 @@ import pyarrow as pa
 def safe_data_storage_version(version_str):
     """Return a data_storage_version safe for the given lance version.
 
-    Versions 0.30 and older use "2.0", newer versions use "stable".
+    Versions before 0.38 use "2.0"; newer released versions use "2.1".
+
+    Do not return a moving alias here: compatibility tests create data with the
+    current Lance build and then read it with the requested older release.
     """
     parts = version_str.split(".")
     major = int(parts[0])
-    if major > 0:
-        return "stable"
     minor = int(parts[1]) if len(parts) > 1 else 0
-    if minor <= 30:
+    if major == 0 and minor < 38:
         return "2.0"
-    return "stable"
+    return "2.1"
 
 
 def build_basic_types():

--- a/python/python/tests/test_blob.py
+++ b/python/python/tests/test_blob.py
@@ -23,6 +23,8 @@ from lance.fragment import write_fragments
 
 lance_dataset_module = importlib.import_module("lance.dataset")
 
+LEGACY_BLOB_STORAGE_VERSION = "2.1"
+
 
 def _blob_row_ids(dataset):
     return dataset.to_table(columns=[], with_row_id=True).column("_rowid").to_pylist()
@@ -153,7 +155,11 @@ def test_blob_descriptions(tmp_path):
             ]
         ),
     )
-    ds = lance.write_dataset(table, tmp_path / "test_ds")
+    ds = lance.write_dataset(
+        table,
+        tmp_path / "test_ds",
+        data_storage_version=LEGACY_BLOB_STORAGE_VERSION,
+    )
     # These positions may be surprising but lance pads buffers to 64-byte boundaries
     expected_positions = pa.array([0, 64, 128], pa.uint64())
     expected_sizes = pa.array([3, 3, 3], pa.uint64())
@@ -176,7 +182,11 @@ def test_scan_blob_as_binary(tmp_path):
             ]
         ),
     )
-    ds = lance.write_dataset(table, tmp_path / "test_ds")
+    ds = lance.write_dataset(
+        table,
+        tmp_path / "test_ds",
+        data_storage_version=LEGACY_BLOB_STORAGE_VERSION,
+    )
 
     tbl = ds.scanner(columns=["blobs"], blob_handling="all_binary").to_table()
     assert tbl.column("blobs").to_pylist() == values
@@ -194,7 +204,11 @@ def test_sql_blob_as_binary(tmp_path):
             ]
         ),
     )
-    ds = lance.write_dataset(table, tmp_path / "test_ds")
+    ds = lance.write_dataset(
+        table,
+        tmp_path / "test_ds",
+        data_storage_version=LEGACY_BLOB_STORAGE_VERSION,
+    )
 
     batches = (
         ds.sql("SELECT blobs FROM dataset")
@@ -252,7 +266,11 @@ def test_fragment_scan_blob_as_binary(tmp_path):
             ]
         ),
     )
-    ds = lance.write_dataset(table, tmp_path / "test_ds")
+    ds = lance.write_dataset(
+        table,
+        tmp_path / "test_ds",
+        data_storage_version=LEGACY_BLOB_STORAGE_VERSION,
+    )
 
     fragment = ds.get_fragments()[0]
 
@@ -278,7 +296,11 @@ def dataset_with_blobs(tmp_path):
             ]
         ),
     )
-    ds = lance.write_dataset(table, tmp_path / "test_ds")
+    ds = lance.write_dataset(
+        table,
+        tmp_path / "test_ds",
+        data_storage_version=LEGACY_BLOB_STORAGE_VERSION,
+    )
 
     values = pa.array([b"qux", b"quux", b"corge"], pa.large_binary())
     idx = pa.array([3, 4, 5], pa.uint64())
@@ -366,7 +388,11 @@ def test_blob_files_close_no_shutdown_panic(tmp_path):
                 ]
             ),
         )
-        ds = lance.write_dataset(table, {str(tmp_path / "ds")!r})
+        ds = lance.write_dataset(
+            table,
+            {str(tmp_path / "ds")!r},
+            data_storage_version={LEGACY_BLOB_STORAGE_VERSION!r},
+        )
         row_ids = ds.to_table(columns=[], with_row_id=True).column("_rowid").to_pylist()
         blobs = ds.take_blobs("blob", ids=row_ids)
         for blob in blobs:
@@ -416,6 +442,7 @@ def test_blob_files_by_address_with_stable_row_ids(tmp_path):
     ds = lance.write_dataset(
         table,
         tmp_path / "test_ds",
+        data_storage_version=LEGACY_BLOB_STORAGE_VERSION,
         enable_stable_row_ids=True,
     )
 
@@ -826,7 +853,11 @@ def test_null_blobs(tmp_path):
             ]
         ),
     )
-    ds = lance.write_dataset(table, tmp_path / "test_ds")
+    ds = lance.write_dataset(
+        table,
+        tmp_path / "test_ds",
+        data_storage_version=LEGACY_BLOB_STORAGE_VERSION,
+    )
 
     blobs = ds.take_blobs("blob", ids=range(100))
     assert blobs == [None] * 100
@@ -2009,7 +2040,11 @@ def dataset_for_pandas_blob_tests(tmp_path):
             ]
         ),
     )
-    return lance.write_dataset(table, tmp_path / "blob_pandas_ds")
+    return lance.write_dataset(
+        table,
+        tmp_path / "blob_pandas_ds",
+        data_storage_version=LEGACY_BLOB_STORAGE_VERSION,
+    )
 
 
 @pytest.fixture
@@ -2256,7 +2291,11 @@ def dataset_with_nested_blobs(tmp_path):
         [pa.array([1, 2, 3], pa.int64()), info_array],
         schema=pa.schema([pa.field("id", pa.int64()), pa.field("info", info_type)]),
     )
-    return lance.write_dataset(table, tmp_path / "nested_blob_ds")
+    return lance.write_dataset(
+        table,
+        tmp_path / "nested_blob_ds",
+        data_storage_version=LEGACY_BLOB_STORAGE_VERSION,
+    )
 
 
 def test_to_pandas_returns_blob_file_handles_for_nested_fields(

--- a/python/python/tests/test_optimize.py
+++ b/python/python/tests/test_optimize.py
@@ -132,7 +132,7 @@ def test_blob_compaction(tmp_path: Path):
         base_dir,
         schema=schema,
         max_rows_per_file=1,
-        data_storage_version="stable",
+        data_storage_version="2.1",
     )
     assert len(dataset.get_fragments()) == 2
 

--- a/python/python/tests/torch_tests/test_data.py
+++ b/python/python/tests/torch_tests/test_data.py
@@ -297,7 +297,7 @@ def test_blob_api(tmp_path: Path):
     tbl = pa.Table.from_arrays([ints, vals], schema=schema)
 
     uri = tmp_path / "data.lance"
-    dataset = lance.write_dataset(tbl, uri)
+    dataset = lance.write_dataset(tbl, uri, data_storage_version="2.1")
 
     torch_ds = LanceDataset(
         uri, batch_size=4, dataset_options={"version": dataset.version}

--- a/rust/lance-file/src/version.rs
+++ b/rust/lance-file/src/version.rs
@@ -17,7 +17,7 @@ pub const V2_FORMAT_2_3: &str = "2.3";
 
 /// Resolve the current stable release policy to an exact file version.
 pub const fn stable_file_version() -> ConcreteFileVersion {
-    ConcreteFileVersion::V2_1
+    ConcreteFileVersion::V2_2
 }
 
 /// Resolve the current next release policy to an exact file version.
@@ -35,12 +35,12 @@ pub enum LanceFileVersion {
     Legacy,
     /// Exact v2.0.
     V2_0,
-    /// Exact v2.1 and the current default.
-    #[default]
+    /// Exact v2.1.
     V2_1,
     /// The latest stable release.
     Stable,
-    /// Exact v2.2.
+    /// Exact v2.2 and the current default.
+    #[default]
     V2_2,
     /// The latest unstable release.
     Next,
@@ -274,7 +274,7 @@ mod tests {
             (LanceFileVersion::Legacy, ConcreteFileVersion::V1),
             (LanceFileVersion::V2_0, ConcreteFileVersion::V2_0),
             (LanceFileVersion::V2_1, ConcreteFileVersion::V2_1),
-            (LanceFileVersion::Stable, ConcreteFileVersion::V2_1),
+            (LanceFileVersion::Stable, ConcreteFileVersion::V2_2),
             (LanceFileVersion::V2_2, ConcreteFileVersion::V2_2),
             (LanceFileVersion::Next, ConcreteFileVersion::V2_3),
             (LanceFileVersion::V2_3, ConcreteFileVersion::V2_3),
@@ -283,6 +283,7 @@ mod tests {
         for (selector, expected) in cases {
             assert_eq!(selector.resolve(), expected);
         }
+        assert_eq!(LanceFileVersion::default(), LanceFileVersion::V2_2);
     }
 
     #[test]

--- a/rust/lance/src/dataset/blob.rs
+++ b/rust/lance/src/dataset/blob.rs
@@ -4392,7 +4392,7 @@ mod tests {
                 .unwrap();
 
             let dataset = Arc::new(
-                TestDatasetGenerator::new(data.clone(), LanceFileVersion::default())
+                TestDatasetGenerator::new(data.clone(), LanceFileVersion::V2_1)
                     .make_hostile(&test_dir)
                     .await,
             );
@@ -4692,7 +4692,18 @@ mod tests {
         };
 
         let reader = RecordBatchIterator::new(batches.into_iter().map(Ok), schema);
-        let dataset = Arc::new(Dataset::write(reader, &test_dir, None).await.unwrap());
+        let dataset = Arc::new(
+            Dataset::write(
+                reader,
+                &test_dir,
+                Some(WriteParams {
+                    data_storage_version: Some(LanceFileVersion::V2_1),
+                    ..Default::default()
+                }),
+            )
+            .await
+            .unwrap(),
+        );
 
         let blobs = dataset
             .take_blobs_by_indices(&[0, 1, 2, 3], "blob")
@@ -4883,6 +4894,7 @@ mod tests {
 
         // Write with enable_stable_row_ids=true and force multiple fragments
         let write_params = WriteParams {
+            data_storage_version: Some(LanceFileVersion::V2_1),
             enable_stable_row_ids: true,
             max_rows_per_file: 3, // Force 2 fragments with 3 rows each
             ..Default::default()

--- a/rust/lance/src/dataset/optimize.rs
+++ b/rust/lance/src/dataset/optimize.rs
@@ -3351,6 +3351,7 @@ mod tests {
             reader,
             &test_dir,
             Some(WriteParams {
+                data_storage_version: Some(LanceFileVersion::V2_1),
                 max_rows_per_file: 1,
                 ..Default::default()
             }),

--- a/rust/lance/src/dataset/scanner.rs
+++ b/rust/lance/src/dataset/scanner.rs
@@ -12094,7 +12094,7 @@ full_filter=name LIKE Utf8(\"test%2\"), refine_filter=name LIKE Utf8(\"test%2\")
             "memory://test",
             Some(WriteParams {
                 commit_handler: Some(Arc::new(RenameCommitHandler)),
-                data_storage_version: Some(LanceFileVersion::Stable),
+                data_storage_version: Some(LanceFileVersion::V2_1),
                 ..Default::default()
             }),
         )
@@ -12182,7 +12182,7 @@ full_filter=name LIKE Utf8(\"test%2\"), refine_filter=name LIKE Utf8(\"test%2\")
             "memory://test",
             Some(WriteParams {
                 commit_handler: Some(Arc::new(RenameCommitHandler)),
-                data_storage_version: Some(LanceFileVersion::Stable),
+                data_storage_version: Some(LanceFileVersion::V2_1),
                 ..Default::default()
             }),
         )

--- a/rust/lance/src/dataset/tests/dataset_merge_update.rs
+++ b/rust/lance/src/dataset/tests/dataset_merge_update.rs
@@ -607,6 +607,7 @@ async fn test_insert_balanced_subschemas() {
     let options = WriteParams {
         enable_stable_row_ids: true,
         enable_v2_manifest_paths: true,
+        data_storage_version: Some(LanceFileVersion::V2_1),
         ..Default::default()
     };
     let mut dataset = Dataset::write(empty_reader, &test_uri, Some(options))
@@ -748,7 +749,7 @@ async fn test_datafile_replacement() {
         .create(&Path::from("data/test.lance"))
         .await
         .unwrap();
-    let mut writer = lance_file::versions::v2_1::create_writer(
+    let mut writer = lance_file::versions::v2_2::create_writer(
         object_writer,
         schema.as_ref().try_into().unwrap(),
         Default::default(),
@@ -856,7 +857,7 @@ async fn test_datafile_partial_replacement() {
         .create(&Path::from("data/test.lance"))
         .await
         .unwrap();
-    let mut writer = lance_file::versions::v2_1::create_writer(
+    let mut writer = lance_file::versions::v2_2::create_writer(
         object_writer,
         partial_schema.as_ref().try_into().unwrap(),
         Default::default(),
@@ -2179,7 +2180,7 @@ async fn test_data_replacement_advances_row_lineage() {
         .create(&Path::from("data/lineage_replacement.lance"))
         .await
         .unwrap();
-    let mut writer = lance_file::versions::v2_1::create_writer(
+    let mut writer = lance_file::versions::v2_2::create_writer(
         object_writer,
         schema.as_ref().try_into().unwrap(),
         Default::default(),
@@ -2285,7 +2286,7 @@ async fn test_data_replacement_invalidates_index_bitmap() {
         .create(&Path::from("data/replacement.lance"))
         .await
         .unwrap();
-    let mut writer = lance_file::versions::v2_1::create_writer(
+    let mut writer = lance_file::versions::v2_2::create_writer(
         object_writer,
         single_col_schema.as_ref().try_into().unwrap(),
         Default::default(),
@@ -2463,7 +2464,7 @@ async fn test_merge_rewriting_indexed_column_keeps_index_consistent() {
     .unwrap();
     let new_a_path = dataset.data_dir().join("merge_new_a.lance");
     let object_writer = dataset.object_store.create(&new_a_path).await.unwrap();
-    let mut writer = lance_file::versions::v2_1::create_writer(
+    let mut writer = lance_file::versions::v2_2::create_writer(
         object_writer,
         a_only.as_ref().try_into().unwrap(),
         Default::default(),
@@ -2567,7 +2568,7 @@ async fn test_data_replacement_populates_invalidated_bitmap() {
         .create(&Path::from("data/replacement_inv.lance"))
         .await
         .unwrap();
-    let mut writer = lance_file::versions::v2_1::create_writer(
+    let mut writer = lance_file::versions::v2_2::create_writer(
         object_writer,
         value_schema.as_ref().try_into().unwrap(),
         Default::default(),
@@ -2692,7 +2693,7 @@ async fn test_fts_stale_entries_after_data_replacement() {
         .create(&replacement_path)
         .await
         .unwrap();
-    let mut writer = lance_file::versions::v2_1::create_writer(
+    let mut writer = lance_file::versions::v2_2::create_writer(
         object_writer,
         schema.as_ref().try_into().unwrap(),
         Default::default(),
@@ -2869,7 +2870,7 @@ async fn test_vector_index_after_data_replacement() {
         .create(&replacement_path)
         .await
         .unwrap();
-    let mut writer = lance_file::versions::v2_1::create_writer(
+    let mut writer = lance_file::versions::v2_2::create_writer(
         object_writer,
         schema.as_ref().try_into().unwrap(),
         Default::default(),


### PR DESCRIPTION
Lance 2.2 is the current stable file format, but the centralized release policy and enum default still resolve new datasets to 2.1. As a result, the `stable` selector and default writes lag behind the intended stable format.

Resolve both paths to 2.2 and align the Java integration expectations. Lance 2.3 remains the `next` unstable format.
