### PR TITLE
feat(index): f64 centroids support in streaming coreset k-means

### DIFF
--- a/rust/lance/src/index/vector/ivf.rs
+++ b/rust/lance/src/index/vector/ivf.rs
@@ -5058,7 +5058,7 @@ mod tests {
 
     use arrow_array::types::UInt64Type;
     use arrow_array::{
-        FixedSizeListArray, Float16Array, Float32Array, Int8Array, RecordBatch,
+        FixedSizeListArray, Float16Array, Float32Array, Float64Array, Int8Array, RecordBatch,
         RecordBatchIterator, RecordBatchReader, UInt64Array, make_array,
     };
     use arrow_buffer::{BooleanBuffer, NullBuffer};
@@ -6861,6 +6861,207 @@ mod tests {
         assert_eq!(coreset.values, vec![EXPECTED_MEAN]);
         assert_eq!(coreset.weights, vec![2.0]);
         assert_eq!(coreset.losses, vec![2.0]);
+    }
+
+    #[test]
+    fn test_weighted_f64_coreset_preserves_extreme_magnitudes() {
+        let subnormal = f64::MIN_POSITIVE;
+        let mut tiny = WeightedCoreset::<Float64Type>::new(1, 2);
+        tiny.push(&[subnormal], 1.0, 0.0);
+        tiny.push(&[subnormal * 2.0], 1.0, 0.0);
+        tiny.reduce_to_budget(1, 1);
+        assert_eq!(tiny.values, vec![subnormal * 1.5]);
+        assert_ne!(tiny.values[0], tiny.values[0] as f32 as f64);
+
+        let large = 1.0e100_f64;
+        let delta = 2.0e84_f64;
+        let mut huge = WeightedCoreset::<Float64Type>::new(1, 2);
+        huge.push(&[large], 1.0, 0.0);
+        huge.push(&[large + delta], 1.0, 0.0);
+        huge.reduce_to_budget(1, 1);
+        assert!(huge.values[0].is_finite());
+        assert!(huge.losses[0].is_finite());
+        assert_ne!(huge.values[0], huge.values[0] as f32 as f64);
+    }
+
+    #[tokio::test]
+    async fn test_fixed_cosine_sampler_preserves_f64_normalization() {
+        let test_dir = TempStrDir::default();
+        let uri = format!("{}/cosine-f64", test_dir.as_str());
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "vector",
+            DataType::FixedSizeList(Arc::new(Field::new("item", DataType::Float64, true)), 2),
+            false,
+        )]));
+        let vectors = FixedSizeListArray::try_new_from_values(
+            Float64Array::from(vec![3.0, 4.0, 5.0, 12.0]),
+            2,
+        )
+        .unwrap();
+        let batch = RecordBatch::try_new(schema.clone(), vec![Arc::new(vectors)]).unwrap();
+        let dataset = Dataset::write(
+            RecordBatchIterator::new(vec![Ok(batch)], schema),
+            &uri,
+            None,
+        )
+        .await
+        .unwrap();
+        let sampler = FixedIvfTrainingSampler::try_new(&dataset, "vector")
+            .unwrap()
+            .unwrap();
+        let (sample, metric) = sampler
+            .sample_ranges(&[0..2], MetricType::Cosine)
+            .await
+            .unwrap();
+        assert_eq!(metric, MetricType::L2);
+        assert_eq!(sample.value_type(), DataType::Float64);
+        let values = sample.values().as_primitive::<Float64Type>().values();
+        for vector in values.chunks_exact(2) {
+            assert!((vector.iter().map(|value| value * value).sum::<f64>() - 1.0).abs() < 1e-14);
+        }
+        assert!((values[0] - 0.6).abs() < f64::EPSILON);
+    }
+
+    #[tokio::test]
+    async fn test_f64_refinement_sources_retain_exact_mean() {
+        const BASE: f64 = 16_777_216.0;
+        const EXPECTED_MEAN: f64 = 16_777_216.5;
+        let test_dir = TempStrDir::default();
+        let uri = format!("{}/refine-f64", test_dir.as_str());
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "vector",
+            DataType::FixedSizeList(Arc::new(Field::new("item", DataType::Float64, true)), 1),
+            false,
+        )]));
+        let vectors =
+            FixedSizeListArray::try_new_from_values(Float64Array::from(vec![BASE, BASE + 1.0]), 1)
+                .unwrap();
+        let batch = RecordBatch::try_new(schema.clone(), vec![Arc::new(vectors)]).unwrap();
+        let dataset = Dataset::write(
+            RecordBatchIterator::new(vec![Ok(batch)], schema),
+            &uri,
+            None,
+        )
+        .await
+        .unwrap();
+        let initial = streaming_kmeans_fsl_from_values::<Float64Type>(vec![BASE], 1).unwrap();
+        let sampler = FixedIvfTrainingSampler::try_new(&dataset, "vector")
+            .unwrap()
+            .unwrap();
+        let ranges = FixedIvfTrainingRanges::new(vec![0..2]);
+        let fixed = refine_streaming_kmeans_with_sampler::<Float64Type>(
+            &sampler,
+            MetricType::L2,
+            2,
+            &ranges,
+            &initial,
+            1,
+            Arc::new(|_, _| {}),
+        )
+        .await
+        .unwrap();
+        let fragment_ids = dataset
+            .get_fragments()
+            .iter()
+            .map(|fragment| fragment.id() as u32)
+            .collect::<Vec<_>>();
+        let resampled = refine_streaming_kmeans_with_resampling::<Float64Type>(
+            &dataset,
+            "vector",
+            MetricType::L2,
+            2,
+            2,
+            1,
+            &initial,
+            Some(&fragment_ids),
+            1,
+            Arc::new(|_, _| {}),
+        )
+        .await
+        .unwrap();
+        for refined in [fixed, resampled] {
+            assert_eq!(refined.value_type(), DataType::Float64);
+            let value = refined.values().as_primitive::<Float64Type>().value(0);
+            assert_eq!(value, EXPECTED_MEAN);
+            assert_ne!(value, value as f32 as f64);
+        }
+    }
+
+    #[rstest]
+    #[case::f16("f16", DataType::Float32)]
+    #[case::f32("f32", DataType::Float32)]
+    #[case::f64("f64", DataType::Float64)]
+    #[case::int8("int8", DataType::Float32)]
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_streaming_coreset_output_type_contract(
+        #[case] input_type: &str,
+        #[case] expected_output: DataType,
+    ) {
+        const DIMENSION: usize = 2;
+        const ROWS: usize = 600;
+        let value_count = ROWS * DIMENSION;
+        let (value_type, values): (DataType, ArrayRef) = match input_type {
+            "f16" => (
+                DataType::Float16,
+                Arc::new(Float16Array::from_iter_values(
+                    (0..value_count).map(|value| f16::from_f32(value as f32 / 100.0)),
+                )),
+            ),
+            "f32" => (
+                DataType::Float32,
+                Arc::new(Float32Array::from_iter_values(
+                    (0..value_count).map(|value| value as f32 / 100.0),
+                )),
+            ),
+            "f64" => (
+                DataType::Float64,
+                Arc::new(Float64Array::from_iter_values(
+                    (0..value_count).map(|value| value as f64 / 100.0 + f64::EPSILON),
+                )),
+            ),
+            "int8" => (
+                DataType::Int8,
+                Arc::new(Int8Array::from_iter_values((0..ROWS).flat_map(|row| {
+                    [(row & 0xff) as u8 as i8, (row >> 8) as u8 as i8]
+                }))),
+            ),
+            _ => unreachable!(),
+        };
+        let test_dir = TempStrDir::default();
+        let uri = format!("{}/type-{input_type}", test_dir.as_str());
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "vector",
+            DataType::FixedSizeList(
+                Arc::new(Field::new("item", value_type, true)),
+                DIMENSION as i32,
+            ),
+            false,
+        )]));
+        let vectors = FixedSizeListArray::try_new_from_values(values, DIMENSION as i32).unwrap();
+        let batch = RecordBatch::try_new(schema.clone(), vec![Arc::new(vectors)]).unwrap();
+        let dataset = Dataset::write(
+            RecordBatchIterator::new(vec![Ok(batch)], schema),
+            &uri,
+            None,
+        )
+        .await
+        .unwrap();
+        let mut params = IvfBuildParams::new(257);
+        params.sample_rate = 2;
+        params.streaming_sample_rate = Some(1);
+        params.max_iters = 1;
+        let model = build_ivf_model(
+            &dataset,
+            "vector",
+            DIMENSION,
+            MetricType::L2,
+            &params,
+            None,
+            lance_index::progress::noop_progress(),
+        )
+        .await
+        .unwrap();
+        assert_eq!(model.centroids.unwrap().value_type(), expected_output);
     }
 
     #[tokio::test]

--- a/rust/lance/src/index/vector/ivf.rs
+++ b/rust/lance/src/index/vector/ivf.rs
@@ -37,7 +37,7 @@ use arrow_array::{
     types::{ArrowPrimitiveType, Float16Type, Float32Type, Float64Type},
 };
 use arrow_buffer::MutableBuffer;
-use arrow_schema::{DataType, Schema};
+use arrow_schema::{DataType, Field, Schema};
 use async_trait::async_trait;
 use datafusion::execution::SendableRecordBatchStream;
 use futures::TryFutureExt;
@@ -3520,6 +3520,118 @@ impl<'a> FixedIvfTrainingSampler<'a> {
 
 type KMeansProgressCallback = Arc<dyn Fn(u32, u32) + Send + Sync>;
 
+trait StreamingKMeansFloat:
+    Copy
+    + Default
+    + PartialOrd
+    + std::ops::Add<Output = Self>
+    + std::ops::AddAssign
+    + std::ops::Div<Output = Self>
+    + std::ops::Mul<Output = Self>
+    + std::ops::Sub<Output = Self>
+{
+    fn from_f64(value: f64) -> Self;
+
+    fn to_f64(self) -> f64;
+}
+
+impl StreamingKMeansFloat for f32 {
+    fn from_f64(value: f64) -> Self {
+        value as Self
+    }
+
+    fn to_f64(self) -> f64 {
+        self as f64
+    }
+}
+
+impl StreamingKMeansFloat for f64 {
+    fn from_f64(value: f64) -> Self {
+        value
+    }
+
+    fn to_f64(self) -> f64 {
+        self
+    }
+}
+
+trait StreamingKMeansArrowType: ArrowPrimitiveType<Native: StreamingKMeansFloat> + Sized {
+    fn from_values(values: Vec<Self::Native>) -> PrimitiveArray<Self>;
+}
+
+impl StreamingKMeansArrowType for Float32Type {
+    fn from_values(values: Vec<Self::Native>) -> PrimitiveArray<Self> {
+        PrimitiveArray::from(values)
+    }
+}
+
+impl StreamingKMeansArrowType for Float64Type {
+    fn from_values(values: Vec<Self::Native>) -> PrimitiveArray<Self> {
+        PrimitiveArray::from(values)
+    }
+}
+
+fn streaming_kmeans_values<T: StreamingKMeansArrowType>(
+    data: &FixedSizeListArray,
+) -> Result<&[T::Native]> {
+    if data.value_type() != T::DATA_TYPE {
+        return Err(Error::invalid_input(format!(
+            "streaming coreset kmeans expected {} values, got {}",
+            T::DATA_TYPE,
+            data.value_type()
+        )));
+    }
+    Ok(data.values().as_primitive::<T>().values())
+}
+
+fn streaming_kmeans_fsl_from_values<T: StreamingKMeansArrowType>(
+    values: Vec<T::Native>,
+    dimension: usize,
+) -> Result<FixedSizeListArray> {
+    Ok(FixedSizeListArray::try_new_from_values(
+        T::from_values(values),
+        dimension as i32,
+    )?)
+}
+
+fn prepare_streaming_coreset_sample<T: StreamingKMeansArrowType>(
+    training_data: FixedSizeListArray,
+) -> Result<FixedSizeListArray> {
+    if training_data.value_type() == T::DATA_TYPE {
+        return Ok(training_data);
+    }
+
+    let actual_type = training_data.value_type();
+    let prepared = match (&T::DATA_TYPE, &actual_type) {
+        (DataType::Float32, DataType::Float16) => {
+            let values = arrow::compute::cast(training_data.values().as_ref(), &DataType::Float32)?;
+            FixedSizeListArray::try_new(
+                Arc::new(Field::new("item", DataType::Float32, true)),
+                training_data.value_length(),
+                values,
+                training_data.nulls().cloned(),
+            )?
+        }
+        (DataType::Float32, DataType::Int8) => training_data.convert_to_floating_point()?,
+        _ => {
+            return Err(Error::invalid_input(format!(
+                "streaming coreset kmeans expected {} input values, got {}",
+                T::DATA_TYPE,
+                actual_type
+            )));
+        }
+    };
+
+    if prepared.value_type() != T::DATA_TYPE {
+        return Err(Error::invalid_input(format!(
+            "streaming coreset kmeans prepared {} values, expected {}",
+            prepared.value_type(),
+            T::DATA_TYPE
+        )));
+    }
+    Ok(prepared)
+}
+
 struct KMeansStepOptions {
     dimension: usize,
     metric_type: MetricType,
@@ -3617,10 +3729,10 @@ fn train_ivf_kmeans_step_arrow_array_no_loss(
     Ok(kmeans)
 }
 
-fn accumulate_refine_assignments(
+fn accumulate_refine_assignments<T: StreamingKMeansArrowType>(
     data: &FixedSizeListArray,
     centroids: &FixedSizeListArray,
-    cluster_sums: &mut [f32],
+    cluster_sums: &mut [T::Native],
     cluster_weights: &mut [f64],
 ) -> Result<f64> {
     let dimension = data.value_length() as usize;
@@ -3631,7 +3743,7 @@ fn accumulate_refine_assignments(
         f64::MAX,
     );
     let (membership, distances) = kmeans.compute_membership_and_distances(data)?;
-    let data_values = data.values().as_primitive::<Float32Type>().values();
+    let data_values = streaming_kmeans_values::<T>(data)?;
     let mut loss = 0.0;
 
     for row_idx in 0..data.len() {
@@ -3651,17 +3763,13 @@ fn accumulate_refine_assignments(
     Ok(loss)
 }
 
-fn update_refined_centroids(
+fn update_refined_centroids<T: StreamingKMeansArrowType>(
     centroids: &FixedSizeListArray,
-    cluster_sums: &[f32],
+    cluster_sums: &[T::Native],
     cluster_weights: &[f64],
 ) -> Result<FixedSizeListArray> {
     let dimension = centroids.value_length() as usize;
-    let mut next = centroids
-        .values()
-        .as_primitive::<Float32Type>()
-        .values()
-        .to_vec();
+    let mut next = streaming_kmeans_values::<T>(centroids)?.to_vec();
     for cluster_id in 0..centroids.len() {
         let weight = cluster_weights[cluster_id];
         if weight <= 0.0 {
@@ -3670,13 +3778,13 @@ fn update_refined_centroids(
         let centroid = &mut next[cluster_id * dimension..(cluster_id + 1) * dimension];
         let sum = &cluster_sums[cluster_id * dimension..(cluster_id + 1) * dimension];
         for (value, sum) in centroid.iter_mut().zip(sum) {
-            *value = *sum / weight as f32;
+            *value = *sum / T::Native::from_f64(weight);
         }
     }
-    f32_fsl_from_values(next, dimension)
+    streaming_kmeans_fsl_from_values::<T>(next, dimension)
 }
 
-async fn refine_streaming_f32_kmeans_with_sampler(
+async fn refine_streaming_kmeans_with_sampler<T: StreamingKMeansArrowType>(
     sampler: &FixedIvfTrainingSampler<'_>,
     metric_type: MetricType,
     streaming_sample_size: usize,
@@ -3688,7 +3796,7 @@ async fn refine_streaming_f32_kmeans_with_sampler(
     let dimension = initial_centroids.value_length() as usize;
     let mut centroids = initial_centroids.clone();
     for pass in 1..=passes {
-        let mut cluster_sums = vec![0.0_f32; centroids.len() * dimension];
+        let mut cluster_sums = vec![T::Native::default(); centroids.len() * dimension];
         let mut cluster_weights = vec![0.0_f64; centroids.len()];
         let mut loss = 0.0;
         let mut row_offset = 0;
@@ -3696,25 +3804,21 @@ async fn refine_streaming_f32_kmeans_with_sampler(
             let ranges = sample_ranges.chunk(row_offset, streaming_sample_size.max(1));
             row_offset += ranges.iter().map(range_len).sum::<usize>();
             let (training_data, mt) = sampler.sample_ranges(&ranges, metric_type).await?;
-            let training_data = if training_data.value_type() == DataType::Float32 {
-                training_data
-            } else {
-                training_data.convert_to_floating_point()?
-            };
+            let training_data = prepare_streaming_coreset_sample::<T>(training_data)?;
             if mt != DistanceType::L2 {
                 return Err(Error::invalid_input(format!(
                     "streaming IVF refinement currently supports L2/Cosine training, got {}",
                     metric_type
                 )));
             }
-            loss += accumulate_refine_assignments(
+            loss += accumulate_refine_assignments::<T>(
                 &training_data,
                 &centroids,
                 &mut cluster_sums,
                 &mut cluster_weights,
             )?;
         }
-        centroids = update_refined_centroids(&centroids, &cluster_sums, &cluster_weights)?;
+        centroids = update_refined_centroids::<T>(&centroids, &cluster_sums, &cluster_weights)?;
         on_progress(pass as u32, passes as u32);
         info!(
             "Streaming IVF raw-vector refinement pass {} / {} assigned {} vectors; pre-update loss={}",
@@ -3728,7 +3832,7 @@ async fn refine_streaming_f32_kmeans_with_sampler(
 }
 
 #[allow(clippy::too_many_arguments)]
-async fn refine_streaming_f32_kmeans_with_resampling(
+async fn refine_streaming_kmeans_with_resampling<T: StreamingKMeansArrowType>(
     dataset: &Dataset,
     column: &str,
     metric_type: MetricType,
@@ -3743,7 +3847,7 @@ async fn refine_streaming_f32_kmeans_with_resampling(
     let dimension = initial_centroids.value_length() as usize;
     let mut centroids = initial_centroids.clone();
     for pass in 1..=passes {
-        let mut cluster_sums = vec![0.0_f32; centroids.len() * dimension];
+        let mut cluster_sums = vec![T::Native::default(); centroids.len() * dimension];
         let mut cluster_weights = vec![0.0_f64; centroids.len()];
         let mut remaining_sample_rate = total_sample_rate;
         let mut loss = 0.0;
@@ -3758,18 +3862,14 @@ async fn refine_streaming_f32_kmeans_with_resampling(
                 fragment_ids,
             )
             .await?;
-            let training_data = if training_data.value_type() == DataType::Float32 {
-                training_data
-            } else {
-                training_data.convert_to_floating_point()?
-            };
+            let training_data = prepare_streaming_coreset_sample::<T>(training_data)?;
             if mt != DistanceType::L2 {
                 return Err(Error::invalid_input(format!(
                     "streaming IVF refinement currently supports L2/Cosine training, got {}",
                     metric_type
                 )));
             }
-            loss += accumulate_refine_assignments(
+            loss += accumulate_refine_assignments::<T>(
                 &training_data,
                 &centroids,
                 &mut cluster_sums,
@@ -3777,7 +3877,7 @@ async fn refine_streaming_f32_kmeans_with_resampling(
             )?;
             remaining_sample_rate -= step_sample_rate;
         }
-        centroids = update_refined_centroids(&centroids, &cluster_sums, &cluster_weights)?;
+        centroids = update_refined_centroids::<T>(&centroids, &cluster_sums, &cluster_weights)?;
         on_progress(pass as u32, passes as u32);
         info!(
             "Streaming IVF resampled raw-vector refinement pass {} / {} assigned {} vectors; pre-update loss={}",
@@ -3790,20 +3890,13 @@ async fn refine_streaming_f32_kmeans_with_resampling(
     Ok(centroids)
 }
 
-fn f32_fsl_from_values(values: Vec<f32>, dimension: usize) -> Result<FixedSizeListArray> {
-    Ok(FixedSizeListArray::try_new_from_values(
-        Float32Array::from(values),
-        dimension as i32,
-    )?)
-}
-
-struct WeightedCoreset {
-    values: Vec<f32>,
+struct WeightedCoreset<T: StreamingKMeansArrowType> {
+    values: Vec<T::Native>,
     weights: Vec<f64>,
     losses: Vec<f64>,
 }
 
-impl WeightedCoreset {
+impl<T: StreamingKMeansArrowType> WeightedCoreset<T> {
     fn new(dimension: usize, capacity: usize) -> Self {
         Self {
             values: Vec::with_capacity(capacity * dimension),
@@ -3816,7 +3909,7 @@ impl WeightedCoreset {
         self.weights.len()
     }
 
-    fn push(&mut self, centroid: &[f32], weight: f64, loss: f64) {
+    fn push(&mut self, centroid: &[T::Native], weight: f64, loss: f64) {
         if weight <= 0.0 {
             return;
         }
@@ -3833,7 +3926,7 @@ impl WeightedCoreset {
 
     fn into_fsl_parts(self, dimension: usize) -> Result<(FixedSizeListArray, Vec<f64>, Vec<f64>)> {
         Ok((
-            f32_fsl_from_values(self.values, dimension)?,
+            streaming_kmeans_fsl_from_values::<T>(self.values, dimension)?,
             self.weights,
             self.losses,
         ))
@@ -3854,7 +3947,7 @@ impl WeightedCoreset {
         for (row_idx, vector) in self.values.chunks_exact(dimension).enumerate() {
             let weight = self.weights[row_idx];
             for dim in 0..dimension {
-                let value = vector[dim] as f64;
+                let value = vector[dim].to_f64();
                 weighted_sums[dim] += weight * value;
                 weighted_square_sums[dim] += weight * value * value;
             }
@@ -3889,7 +3982,9 @@ impl WeightedCoreset {
             }
             let mut weight_sum = 0.0;
             let centroid_start = reduced.values.len();
-            reduced.values.resize(centroid_start + dimension, 0.0);
+            reduced
+                .values
+                .resize(centroid_start + dimension, T::Native::default());
             {
                 let centroid = &mut reduced.values[centroid_start..centroid_start + dimension];
                 for &idx in &indices[group_start..group_end] {
@@ -3897,7 +3992,7 @@ impl WeightedCoreset {
                     weight_sum += weight;
                     let vector = &self.values[idx * dimension..(idx + 1) * dimension];
                     for (sum, value) in centroid.iter_mut().zip(vector) {
-                        *sum += *value * weight as f32;
+                        *sum += *value * T::Native::from_f64(weight);
                     }
                 }
             }
@@ -3908,7 +4003,7 @@ impl WeightedCoreset {
             {
                 let centroid = &mut reduced.values[centroid_start..centroid_start + dimension];
                 for value in centroid {
-                    *value /= weight_sum as f32;
+                    *value = *value / T::Native::from_f64(weight_sum);
                 }
             }
 
@@ -3920,10 +4015,11 @@ impl WeightedCoreset {
                     .iter()
                     .zip(centroid)
                     .map(|(left, right)| {
-                        let diff = left - right;
+                        let diff = *left - *right;
                         diff * diff
                     })
-                    .sum::<f32>() as f64;
+                    .fold(T::Native::default(), |sum, value| sum + value)
+                    .to_f64();
                 loss += self.losses[idx] + self.weights[idx] * dist;
             }
             reduced.weights.push(weight_sum);
@@ -3933,21 +4029,21 @@ impl WeightedCoreset {
     }
 }
 
-struct WeightedKMeansResult {
-    centroids: Vec<f32>,
+struct WeightedKMeansResult<T: StreamingKMeansArrowType> {
+    centroids: Vec<T::Native>,
     membership: Vec<Option<u32>>,
     cluster_weights: Vec<f64>,
     cluster_losses: Vec<f64>,
     loss: f64,
 }
 
-fn initialize_weighted_centroids(
-    data_values: &[f32],
+fn initialize_weighted_centroids<T: StreamingKMeansArrowType>(
+    data_values: &[T::Native],
     dimension: usize,
     k: usize,
     n: usize,
     weights: &[f64],
-) -> Vec<f32> {
+) -> Vec<T::Native> {
     let mut rng = SmallRng::seed_from_u64(0x1f17_5eed);
     let mut centroids = Vec::with_capacity(k * dimension);
     let mut selected = vec![false; n];
@@ -3982,10 +4078,11 @@ fn initialize_weighted_centroids(
                 .iter()
                 .zip(last_centroid)
                 .map(|(left, right)| {
-                    let diff = left - right;
+                    let diff = *left - *right;
                     diff * diff
                 })
-                .sum::<f32>() as f64;
+                .fold(T::Native::default(), |sum, value| sum + value)
+                .to_f64();
             min_distances[row_idx] = min_distances[row_idx].min(distance);
         }
 
@@ -4027,20 +4124,20 @@ fn initialize_weighted_centroids(
     centroids
 }
 
-fn assign_weighted_f32_points(
+fn assign_weighted_points<T: StreamingKMeansArrowType>(
     data: &FixedSizeListArray,
     weights: &[f64],
     base_losses: &[f64],
-    centroid_values: &[f32],
+    centroid_values: &[T::Native],
     metric_type: MetricType,
-) -> Result<WeightedKMeansResult> {
+) -> Result<WeightedKMeansResult<T>> {
     let dimension = data.value_length() as usize;
     let k = centroid_values.len() / dimension;
-    let centroids = Arc::new(Float32Array::from(centroid_values.to_vec())) as ArrayRef;
+    let centroids = Arc::new(T::from_values(centroid_values.to_vec())) as ArrayRef;
     let kmeans = KMeans::with_centroids(centroids, dimension, metric_type, f64::MAX);
     let (membership, distances) = kmeans.compute_membership_and_distances(data)?;
-    let data_values = data.values().as_primitive::<Float32Type>().values();
-    let mut centroid_sums = vec![0.0_f32; k * dimension];
+    let data_values = streaming_kmeans_values::<T>(data)?;
+    let mut centroid_sums = vec![T::Native::default(); k * dimension];
     let mut cluster_weights = vec![0.0; k];
     let mut cluster_losses = vec![0.0; k];
 
@@ -4058,18 +4155,18 @@ fn assign_weighted_f32_points(
         let vector = &data_values[row_idx * dimension..(row_idx + 1) * dimension];
         let centroid_sum = &mut centroid_sums[cluster_id * dimension..(cluster_id + 1) * dimension];
         for (sum, value) in centroid_sum.iter_mut().zip(vector) {
-            *sum += *value * weight as f32;
+            *sum += *value * T::Native::from_f64(weight);
         }
     }
 
-    let mut next_centroids = vec![0.0_f32; k * dimension];
+    let mut next_centroids = vec![T::Native::default(); k * dimension];
     for cluster_id in 0..k {
         let next_centroid =
             &mut next_centroids[cluster_id * dimension..(cluster_id + 1) * dimension];
         if cluster_weights[cluster_id] > 0.0 {
             let centroid_sum = &centroid_sums[cluster_id * dimension..(cluster_id + 1) * dimension];
             for (value, sum) in next_centroid.iter_mut().zip(centroid_sum) {
-                *value = *sum / cluster_weights[cluster_id] as f32;
+                *value = *sum / T::Native::from_f64(cluster_weights[cluster_id]);
             }
         } else {
             next_centroid.copy_from_slice(
@@ -4088,7 +4185,7 @@ fn assign_weighted_f32_points(
     })
 }
 
-fn train_weighted_f32_kmeans(
+fn train_weighted_kmeans<T: StreamingKMeansArrowType>(
     data: &FixedSizeListArray,
     weights: &[f64],
     base_losses: &[f64],
@@ -4096,7 +4193,7 @@ fn train_weighted_f32_kmeans(
     metric_type: MetricType,
     max_iters: usize,
     on_progress: Arc<dyn Fn(u32, u32) + Send + Sync>,
-) -> Result<WeightedKMeansResult> {
+) -> Result<WeightedKMeansResult<T>> {
     if data.len() < k {
         return Err(Error::invalid_input(format!(
             "weighted kmeans requires at least {k} coreset rows, got {}",
@@ -4113,15 +4210,15 @@ fn train_weighted_f32_kmeans(
     }
 
     let dimension = data.value_length() as usize;
-    let data_values = data.values().as_primitive::<Float32Type>().values();
+    let data_values = streaming_kmeans_values::<T>(data)?;
     let mut centroids =
-        initialize_weighted_centroids(data_values, dimension, k, data.len(), weights);
+        initialize_weighted_centroids::<T>(data_values, dimension, k, data.len(), weights);
     let mut previous_loss = f64::MAX;
     let max_iters = max_iters.max(1);
     for iter in 1..=max_iters {
         on_progress(iter as u32, max_iters as u32);
         let mut result =
-            assign_weighted_f32_points(data, weights, base_losses, &centroids, metric_type)?;
+            assign_weighted_points::<T>(data, weights, base_losses, &centroids, metric_type)?;
         let converged = (previous_loss - result.loss).abs() < 1e-4 * result.loss.max(1.0);
         previous_loss = result.loss;
         if converged || iter == max_iters {
@@ -4132,7 +4229,7 @@ fn train_weighted_f32_kmeans(
     unreachable!("weighted kmeans runs at least one iteration")
 }
 
-fn refine_weighted_f32_kmeans(
+fn refine_weighted_kmeans<T: StreamingKMeansArrowType>(
     data: &FixedSizeListArray,
     weights: &[f64],
     base_losses: &[f64],
@@ -4140,18 +4237,14 @@ fn refine_weighted_f32_kmeans(
     metric_type: MetricType,
     max_iters: usize,
     on_progress: Arc<dyn Fn(u32, u32) + Send + Sync>,
-) -> Result<WeightedKMeansResult> {
-    let mut centroids = initial_centroids
-        .values()
-        .as_primitive::<Float32Type>()
-        .values()
-        .to_vec();
+) -> Result<WeightedKMeansResult<T>> {
+    let mut centroids = streaming_kmeans_values::<T>(initial_centroids)?.to_vec();
     let mut previous_loss = f64::MAX;
     let max_iters = max_iters.max(1);
     for iter in 1..=max_iters {
         on_progress(iter as u32, max_iters as u32);
         let mut result =
-            assign_weighted_f32_points(data, weights, base_losses, &centroids, metric_type)?;
+            assign_weighted_points::<T>(data, weights, base_losses, &centroids, metric_type)?;
         let converged = (previous_loss - result.loss).abs() < 1e-4 * result.loss.max(1.0);
         previous_loss = result.loss;
         if converged || iter == max_iters {
@@ -4162,8 +4255,8 @@ fn refine_weighted_f32_kmeans(
     unreachable!("weighted kmeans refinement runs at least one iteration")
 }
 
-fn append_local_coreset(
-    coreset: &mut WeightedCoreset,
+fn append_local_coreset<T: StreamingKMeansArrowType>(
+    coreset: &mut WeightedCoreset<T>,
     data: &FixedSizeListArray,
     metric_type: MetricType,
     local_k: usize,
@@ -4195,7 +4288,7 @@ fn append_local_coreset(
         losses[member as usize] += distance as f64;
     }
 
-    let centroid_values = centroids.values().as_primitive::<Float32Type>().values();
+    let centroid_values = streaming_kmeans_values::<T>(&centroids)?;
     for centroid_idx in 0..centroids.len() {
         coreset.push(
             &centroid_values[centroid_idx * dimension..(centroid_idx + 1) * dimension],
@@ -4206,25 +4299,37 @@ fn append_local_coreset(
     Ok(())
 }
 
-#[derive(Clone, Debug)]
-struct WeightedCluster {
+struct WeightedCluster<T: StreamingKMeansArrowType> {
     id: usize,
     indices: Vec<usize>,
-    centroid: Vec<f32>,
+    centroid: Vec<T::Native>,
     weight: f64,
     loss: f64,
     finalized: bool,
 }
 
-impl Eq for WeightedCluster {}
+impl<T: StreamingKMeansArrowType> Clone for WeightedCluster<T> {
+    fn clone(&self) -> Self {
+        Self {
+            id: self.id,
+            indices: self.indices.clone(),
+            centroid: self.centroid.clone(),
+            weight: self.weight,
+            loss: self.loss,
+            finalized: self.finalized,
+        }
+    }
+}
 
-impl PartialEq for WeightedCluster {
+impl<T: StreamingKMeansArrowType> Eq for WeightedCluster<T> {}
+
+impl<T: StreamingKMeansArrowType> PartialEq for WeightedCluster<T> {
     fn eq(&self, other: &Self) -> bool {
         self.loss == other.loss && self.weight == other.weight
     }
 }
 
-impl Ord for WeightedCluster {
+impl<T: StreamingKMeansArrowType> Ord for WeightedCluster<T> {
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
         match (self.finalized, other.finalized) {
             (false, true) => std::cmp::Ordering::Greater,
@@ -4242,7 +4347,7 @@ impl Ord for WeightedCluster {
     }
 }
 
-impl PartialOrd for WeightedCluster {
+impl<T: StreamingKMeansArrowType> PartialOrd for WeightedCluster<T> {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
         Some(self.cmp(other))
     }
@@ -4256,8 +4361,8 @@ struct WeightedHierarchicalKMeansParams {
     on_progress: Arc<dyn Fn(u32, u32) + Send + Sync>,
 }
 
-fn weighted_subset(
-    data_values: &[f32],
+fn weighted_subset<T: StreamingKMeansArrowType>(
+    data_values: &[T::Native],
     weights: &[f64],
     losses: &[f64],
     indices: &[usize],
@@ -4272,13 +4377,13 @@ fn weighted_subset(
         subset_losses.push(losses[idx]);
     }
     Ok((
-        f32_fsl_from_values(values, dimension)?,
+        streaming_kmeans_fsl_from_values::<T>(values, dimension)?,
         subset_weights,
         subset_losses,
     ))
 }
 
-fn train_weighted_hierarchical_f32_kmeans(
+fn train_weighted_hierarchical_kmeans<T: StreamingKMeansArrowType>(
     data: &FixedSizeListArray,
     weights: &[f64],
     losses: &[f64],
@@ -4301,7 +4406,7 @@ fn train_weighted_hierarchical_f32_kmeans(
     let metric_type = params.metric_type;
     let max_iters = params.max_iters;
     let initial_k = 16_usize.min(target_k).min(data.len()).max(1);
-    let initial = train_weighted_f32_kmeans(
+    let initial = train_weighted_kmeans::<T>(
         data,
         weights,
         losses,
@@ -4312,7 +4417,7 @@ fn train_weighted_hierarchical_f32_kmeans(
     )?;
 
     let centroids = initial.centroids;
-    let mut heap = std::collections::BinaryHeap::new();
+    let mut heap = std::collections::BinaryHeap::<WeightedCluster<T>>::new();
     let mut next_cluster_id = 0;
     for cluster_id in 0..initial_k {
         let mut indices = Vec::new();
@@ -4334,7 +4439,7 @@ fn train_weighted_hierarchical_f32_kmeans(
         }
     }
 
-    let data_values = data.values().as_primitive::<Float32Type>().values();
+    let data_values = streaming_kmeans_values::<T>(data)?;
     while heap.len() < target_k {
         let mut cluster = heap
             .pop()
@@ -4352,8 +4457,8 @@ fn train_weighted_hierarchical_f32_kmeans(
             (cluster.indices.len() / 16).min(remaining_k).clamp(2, 16)
         };
         let (sub_data, sub_weights, sub_losses) =
-            weighted_subset(data_values, weights, losses, &cluster.indices, dimension)?;
-        let split = train_weighted_f32_kmeans(
+            weighted_subset::<T>(data_values, weights, losses, &cluster.indices, dimension)?;
+        let split = train_weighted_kmeans::<T>(
             &sub_data,
             &sub_weights,
             &sub_losses,
@@ -4424,7 +4529,7 @@ fn train_weighted_hierarchical_f32_kmeans(
     for cluster in clusters {
         values.extend_from_slice(&cluster.centroid);
     }
-    f32_fsl_from_values(values, dimension)
+    streaming_kmeans_fsl_from_values::<T>(values, dimension)
 }
 
 async fn finish_streaming_ivf_training<T>(
@@ -4458,6 +4563,55 @@ async fn finish_streaming_ivf_training<T>(
 }
 
 async fn train_streaming_coreset_ivf_model(
+    dataset: &Dataset,
+    column: &str,
+    dimension: usize,
+    metric_type: MetricType,
+    params: &IvfBuildParams,
+    fragment_ids: Option<&[u32]>,
+    progress: std::sync::Arc<dyn lance_index::progress::IndexBuildProgress>,
+) -> Result<IvfModel> {
+    if !matches!(metric_type, DistanceType::L2 | DistanceType::Cosine) {
+        return Err(Error::invalid_input(format!(
+            "streaming coreset IVF currently supports L2/Cosine training, got {}",
+            metric_type
+        )));
+    }
+
+    let (_, element_type) = get_vector_type(dataset.schema(), column)?;
+    match element_type {
+        DataType::Float64 => {
+            train_streaming_coreset_ivf_model_typed::<Float64Type>(
+                dataset,
+                column,
+                dimension,
+                metric_type,
+                params,
+                fragment_ids,
+                progress,
+            )
+            .await
+        }
+        DataType::Float16 | DataType::Float32 | DataType::Int8 => {
+            train_streaming_coreset_ivf_model_typed::<Float32Type>(
+                dataset,
+                column,
+                dimension,
+                metric_type,
+                params,
+                fragment_ids,
+                progress,
+            )
+            .await
+        }
+        _ => Err(Error::invalid_input(format!(
+            "streaming coreset IVF does not support {} vector values with metric {}",
+            element_type, metric_type
+        ))),
+    }
+}
+
+async fn train_streaming_coreset_ivf_model_typed<T: StreamingKMeansArrowType>(
     dataset: &Dataset,
     column: &str,
     dimension: usize,
@@ -4525,7 +4679,7 @@ async fn train_streaming_coreset_ivf_model(
             .max(num_partitions);
         let total_steps = total_sample_rate.div_ceil(streaming_sample_rate);
         let decoupled_coreset_budget = params.streaming_coreset_rate.is_some();
-        let mut coreset = WeightedCoreset::new(dimension, coreset_budget.min(num_partitions * 16));
+        let mut coreset = WeightedCoreset::<T>::new(dimension, coreset_budget.min(num_partitions * 16));
         let mut step = 0;
         while remaining_sample_rate > 0 {
             let step_sample_rate = remaining_sample_rate.min(streaming_sample_rate);
@@ -4552,11 +4706,7 @@ async fn train_streaming_coreset_ivf_model(
                 )
                 .await?
             };
-            let training_data = if training_data.value_type() == DataType::Float32 {
-                training_data
-            } else {
-                training_data.convert_to_floating_point()?
-            };
+            let training_data = prepare_streaming_coreset_sample::<T>(training_data)?;
             if mt != DistanceType::L2 {
                 return Err(Error::invalid_input(format!(
                     "streaming coreset IVF currently supports L2/Cosine training, got {}",
@@ -4580,8 +4730,8 @@ async fn train_streaming_coreset_ivf_model(
                 total_steps,
                 decoupled_coreset_budget,
             );
-            let mut chunk_coreset = WeightedCoreset::new(dimension, local_k);
-            append_local_coreset(
+            let mut chunk_coreset = WeightedCoreset::<T>::new(dimension, local_k);
+            append_local_coreset::<T>(
                 &mut chunk_coreset,
                 &training_data,
                 mt,
@@ -4613,7 +4763,7 @@ async fn train_streaming_coreset_ivf_model(
                 max_iters: params.max_iters,
                 on_progress: on_progress.clone(),
             };
-            train_weighted_hierarchical_f32_kmeans(
+            train_weighted_hierarchical_kmeans::<T>(
                 &coreset_data,
                 &coreset_weights,
                 &coreset_losses,
@@ -4622,7 +4772,7 @@ async fn train_streaming_coreset_ivf_model(
         };
         let refine_iters = 3;
         if refine_iters > 0 {
-            let refined = refine_weighted_f32_kmeans(
+            let refined = refine_weighted_kmeans::<T>(
                 &coreset_data,
                 &coreset_weights,
                 &coreset_losses,
@@ -4631,7 +4781,7 @@ async fn train_streaming_coreset_ivf_model(
                 refine_iters,
                 on_progress.clone(),
             )?;
-            centroids = f32_fsl_from_values(refined.centroids, dimension)?;
+            centroids = streaming_kmeans_fsl_from_values::<T>(refined.centroids, dimension)?;
         }
         if params.streaming_refine_passes > 0 {
             info!(
@@ -4641,7 +4791,7 @@ async fn train_streaming_coreset_ivf_model(
             centroids = if let (Some(sample_ranges), Some(sampler)) =
                 (&fixed_sample_ranges, &fixed_sampler)
             {
-                refine_streaming_f32_kmeans_with_sampler(
+                refine_streaming_kmeans_with_sampler::<T>(
                     sampler,
                     metric_type,
                     num_partitions * streaming_sample_rate,
@@ -4652,7 +4802,7 @@ async fn train_streaming_coreset_ivf_model(
                 )
                 .await?
             } else {
-                refine_streaming_f32_kmeans_with_resampling(
+                refine_streaming_kmeans_with_resampling::<T>(
                     dataset,
                     column,
                     metric_type,
@@ -4908,8 +5058,8 @@ mod tests {
 
     use arrow_array::types::UInt64Type;
     use arrow_array::{
-        FixedSizeListArray, Float16Array, Float32Array, RecordBatch, RecordBatchIterator,
-        RecordBatchReader, UInt64Array, make_array,
+        FixedSizeListArray, Float16Array, Float32Array, Int8Array, RecordBatch,
+        RecordBatchIterator, RecordBatchReader, UInt64Array, make_array,
     };
     use arrow_buffer::{BooleanBuffer, NullBuffer};
     use arrow_schema::{DataType, Field, Schema};
@@ -6399,11 +6549,84 @@ mod tests {
 
         assert_eq!(ivf_model.num_partitions(), 257);
         assert_eq!(ivf_model.dimension(), SMALL_DIM);
+        assert_eq!(
+            ivf_model.centroids.as_ref().unwrap().value_type(),
+            DataType::Float32
+        );
         // The progress worker must have processed reports and then joined
         // cleanly (proven by `build_ivf_model` returning at all).
         assert!(
             progress.progress_calls.load(Ordering::Relaxed) > 0,
             "expected the progress worker to receive at least one report"
+        );
+    }
+
+    #[rstest]
+    #[case::fixed_l2_no_refine(MetricType::L2, 0, false)]
+    #[case::fixed_cosine_refine(MetricType::Cosine, 1, false)]
+    #[case::fragment_l2_refine(MetricType::L2, 1, true)]
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_streaming_coreset_f64_centroids(
+        #[case] metric_type: MetricType,
+        #[case] refine_passes: usize,
+        #[case] use_fragment_ids: bool,
+    ) {
+        use std::time::Duration;
+
+        const SMALL_DIM: usize = 8;
+
+        let test_dir = TempStrDir::default();
+        let uri = format!("{}/ds", test_dir.as_str());
+        let reader = gen_batch()
+            .col("id", array::step::<UInt64Type>())
+            .col(
+                "vector",
+                array::rand_vec::<Float64Type>((SMALL_DIM as u32).into()),
+            )
+            .into_reader_rows(RowCount::from(1536), BatchCount::from(3));
+        let dataset = Dataset::write(reader, &uri, None).await.unwrap();
+        let fragment_ids = use_fragment_ids.then(|| {
+            dataset
+                .get_fragments()
+                .iter()
+                .map(|fragment| fragment.id() as u32)
+                .collect::<Vec<_>>()
+        });
+
+        // > 256 partitions selects streaming coreset training.
+        let mut params = IvfBuildParams::new(257);
+        params.sample_rate = 4;
+        params.streaming_sample_rate = Some(2);
+        params.streaming_refine_passes = refine_passes;
+        params.max_iters = 1;
+
+        let ivf_model = tokio::time::timeout(
+            Duration::from_secs(120),
+            build_ivf_model(
+                &dataset,
+                "vector",
+                SMALL_DIM,
+                metric_type,
+                &params,
+                fragment_ids.as_deref(),
+                lance_index::progress::noop_progress(),
+            ),
+        )
+        .await
+        .expect("streaming coreset f64 training timed out")
+        .unwrap();
+
+        assert_eq!(ivf_model.num_partitions(), 257);
+        assert_eq!(ivf_model.dimension(), SMALL_DIM);
+        let centroids = ivf_model.centroids.as_ref().unwrap();
+        assert_eq!(centroids.value_type(), DataType::Float64);
+        let centroid_values = centroids.values().as_primitive::<Float64Type>().values();
+        assert!(centroid_values.iter().all(|value| value.is_finite()));
+        assert!(
+            centroid_values
+                .iter()
+                .any(|value| *value != *value as f32 as f64),
+            "expected at least one f64 centroid coordinate to retain precision beyond f32"
         );
     }
 
@@ -6475,28 +6698,50 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_weighted_coreset_reduction_groups_nearby_centroids() {
-        let mut coreset = WeightedCoreset::new(1, 4);
-        coreset.push(&[0.0], 1.0, 0.0);
-        coreset.push(&[100.0], 1.0, 0.0);
-        coreset.push(&[1.0], 1.0, 0.0);
-        coreset.push(&[101.0], 1.0, 0.0);
+    fn assert_weighted_coreset_reduction<T: StreamingKMeansArrowType>() {
+        let mut coreset = WeightedCoreset::<T>::new(1, 4);
+        for value in [0.0, 100.0, 1.0, 101.0] {
+            coreset.push(&[T::Native::from_f64(value)], 1.0, 0.0);
+        }
 
         coreset.reduce_to_budget(1, 2);
 
         assert_eq!(coreset.len(), 2);
-        assert!((coreset.values[0] - 0.5).abs() < 1e-6);
-        assert!((coreset.values[1] - 100.5).abs() < 1e-6);
-        assert_eq!(coreset.weights, vec![2.0, 2.0]);
-        assert!((coreset.losses.iter().sum::<f64>() - 1.0).abs() < 1e-6);
+        assert!((coreset.values[0].to_f64() - 0.5).abs() < 1e-6);
+        assert!((coreset.values[1].to_f64() - 100.5).abs() < 1e-6);
+
+        let (data, weights, losses) = coreset.into_fsl_parts(1).unwrap();
+        assert_eq!(data.value_type(), T::DATA_TYPE);
+        assert_eq!(weights, vec![2.0, 2.0]);
+        assert!((losses.iter().sum::<f64>() - 1.0).abs() < 1e-6);
+
+        let values = streaming_kmeans_values::<T>(&data).unwrap();
+        let (subset, subset_weights, subset_losses) =
+            weighted_subset::<T>(values, &weights, &losses, &[1, 0], 1).unwrap();
+        assert_eq!(subset.value_type(), T::DATA_TYPE);
+        assert_eq!(subset_weights, vec![2.0, 2.0]);
+        assert_eq!(subset_losses, vec![losses[1], losses[0]]);
+        assert_eq!(
+            streaming_kmeans_values::<T>(&subset)
+                .unwrap()
+                .iter()
+                .map(|value| value.to_f64())
+                .collect::<Vec<_>>(),
+            vec![100.5, 0.5]
+        );
+    }
+
+    #[test]
+    fn test_weighted_coreset_reduction_groups_nearby_centroids() {
+        assert_weighted_coreset_reduction::<Float32Type>();
+        assert_weighted_coreset_reduction::<Float64Type>();
     }
 
     #[test]
     fn test_weighted_kmeanspp_initialization_selects_distant_centroids() {
         let values = vec![0.0, 0.1, 100.0, 101.0];
         let weights = vec![1.0; 4];
-        let centroids = initialize_weighted_centroids(&values, 1, 2, 4, &weights);
+        let centroids = initialize_weighted_centroids::<Float32Type>(&values, 1, 2, 4, &weights);
 
         assert_eq!(centroids.len(), 2);
         assert!(
@@ -6504,6 +6749,118 @@ mod tests {
             "weighted kmeans++ should seed distant coreset regions, got {:?}",
             centroids
         );
+    }
+
+    #[test]
+    fn test_prepare_streaming_coreset_sample_selects_working_type() {
+        let f16_data = FixedSizeListArray::try_new_from_values(
+            Float16Array::from_iter_values([1.25, -2.5].into_iter().map(f16::from_f32)),
+            1,
+        )
+        .unwrap();
+        let prepared_f16 = prepare_streaming_coreset_sample::<Float32Type>(f16_data).unwrap();
+        assert_eq!(prepared_f16.value_type(), DataType::Float32);
+        assert_eq!(
+            prepared_f16.values().as_primitive::<Float32Type>().values(),
+            &[1.25, -2.5]
+        );
+
+        let int8_data =
+            FixedSizeListArray::try_new_from_values(Int8Array::from(vec![1, -2]), 1).unwrap();
+        let prepared_int8 = prepare_streaming_coreset_sample::<Float32Type>(int8_data).unwrap();
+        assert_eq!(prepared_int8.value_type(), DataType::Float32);
+        assert_eq!(
+            prepared_int8
+                .values()
+                .as_primitive::<Float32Type>()
+                .values(),
+            &[1.0, -2.0]
+        );
+
+        let f64_data =
+            streaming_kmeans_fsl_from_values::<Float64Type>(vec![1.0 + f64::EPSILON, 2.0], 1)
+                .unwrap();
+        let prepared_f64 = prepare_streaming_coreset_sample::<Float64Type>(f64_data).unwrap();
+        assert_eq!(prepared_f64.value_type(), DataType::Float64);
+        assert_eq!(
+            prepared_f64.values().as_primitive::<Float64Type>().values()[0],
+            1.0 + f64::EPSILON
+        );
+
+        let f32_data = streaming_kmeans_fsl_from_values::<Float32Type>(vec![1.0], 1).unwrap();
+        let prepared_f32 =
+            prepare_streaming_coreset_sample::<Float32Type>(f32_data.clone()).unwrap();
+        assert_eq!(prepared_f32.value_type(), DataType::Float32);
+        assert_eq!(
+            prepared_f32.values().as_primitive::<Float32Type>().values(),
+            &[1.0]
+        );
+
+        let error = prepare_streaming_coreset_sample::<Float64Type>(f32_data).unwrap_err();
+        assert!(matches!(&error, Error::InvalidInput { .. }));
+        assert!(
+            error
+                .to_string()
+                .contains("expected Float64 input values, got Float32"),
+            "{error}"
+        );
+    }
+
+    fn assert_weighted_assignment_preserves_empty_centroid<T: StreamingKMeansArrowType>() {
+        let data = streaming_kmeans_fsl_from_values::<T>(
+            vec![T::Native::from_f64(0.0), T::Native::from_f64(10.0)],
+            1,
+        )
+        .unwrap();
+        let centroids = vec![
+            T::Native::from_f64(0.0),
+            T::Native::from_f64(10.0),
+            T::Native::from_f64(20.0),
+        ];
+        let result = assign_weighted_points::<T>(
+            &data,
+            &[1.0, 1.0],
+            &[0.0, 0.0],
+            &centroids,
+            DistanceType::L2,
+        )
+        .unwrap();
+
+        assert_eq!(result.cluster_weights, vec![1.0, 1.0, 0.0]);
+        assert_eq!(result.centroids[2].to_f64(), 20.0);
+    }
+
+    #[test]
+    fn test_weighted_assignment_preserves_empty_centroid_for_both_types() {
+        assert_weighted_assignment_preserves_empty_centroid::<Float32Type>();
+        assert_weighted_assignment_preserves_empty_centroid::<Float64Type>();
+    }
+
+    #[test]
+    fn test_weighted_f64_centroids_retain_precision() {
+        const BASE: f64 = 16_777_216.0;
+        const EXPECTED_MEAN: f64 = 16_777_217.0;
+
+        let data =
+            streaming_kmeans_fsl_from_values::<Float64Type>(vec![BASE, BASE + 2.0], 1).unwrap();
+        let assigned = assign_weighted_points::<Float64Type>(
+            &data,
+            &[1.0, 1.0],
+            &[0.0, 0.0],
+            &[BASE],
+            DistanceType::L2,
+        )
+        .unwrap();
+        assert_eq!(assigned.centroids, vec![EXPECTED_MEAN]);
+        assert_ne!(assigned.centroids[0] as f32 as f64, EXPECTED_MEAN);
+
+        let mut coreset = WeightedCoreset::<Float64Type>::new(1, 2);
+        coreset.push(&[BASE], 1.0, 0.0);
+        coreset.push(&[BASE + 2.0], 1.0, 0.0);
+        coreset.reduce_to_budget(1, 1);
+        assert_eq!(coreset.values, vec![EXPECTED_MEAN]);
+        assert_eq!(coreset.weights, vec![2.0]);
+        assert_eq!(coreset.losses, vec![2.0]);
     }
 
     #[tokio::test]


### PR DESCRIPTION
**Implemented f64 centroid support for streaming coreset k-means.**

Key changes:

- Generalized centroid storage and arithmetic over f32/f64.
- Preserved Float64 throughout coreset construction, reduction, hierarchical training, and refinement.
- Added schema-based dispatch and explicit f16/int8 → f32 preparation.
- Added precision, type-preservation, refinement, cosine, and resampling tests.

**Benchmark report.**

Before changes: 

Percentages are relative to LanceStream `stream=64, coreset=16, prefetch=1,
refine=0` at the same vector type and `k`. A baseline cannot be calculated for f64 because the old streaming path fails.

| k | algorithm | status | train time | time delta | RSS | RSS delta | exact loss | loss delta |
| ---: | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: |
| 1,024 | LanceStream, f32 vectors, L2 distance | ok | 13.07s | baseline | 101.0 MiB | baseline | 2,593,041.879 | baseline |
| 1,024 | Lance non-stream, f32 vectors, L2 distance | ok | 4.14s | -68.3% | 254.6 MiB | +152.1% | 2,588,575.751 | -0.172% |
| 4,096 | LanceStream, f32 vectors, L2 distance | ok | 38.92s | baseline | 280.8 MiB | baseline | 10,141,326.860 | baseline |
| 4,096 | Lance non-stream, f32 vectors, L2 distance | ok | 15.27s | -60.8% | 733.4 MiB | +161.2% | 10,109,608.843 | -0.313% |
| 1,024 | LanceStream, f64 vectors, L2 distance | error: invalid Float32 downcast | — | unavailable | — | unavailable | — | unavailable |
| 1,024 | Lance non-stream, f64 vectors, L2 distance | ok | 4.25s | unavailable | 396.8 MiB | unavailable | 2,588,382.089 | unavailable |
| 4,096 | LanceStream, f64 vectors, L2 distance | error: invalid Float32 downcast | — | unavailable | — | unavailable | — | unavailable |
| 4,096 | Lance non-stream, f64 vectors, L2 distance | ok | 29.07s | unavailable | 1,336.6 MiB | unavailable | 10,109,749.792 | unavailable |


After changes:

Percentages use the same per-type, per-`k` LanceStream baseline.

| k | algorithm | status | train time | time delta | RSS | RSS delta | exact loss | loss delta |
| ---: | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: |
| 1,024 | LanceStream, f32 vectors, L2 distance | ok | 12.84s | baseline | 119.7 MiB | baseline | 2,593,060.384 | baseline |
| 1,024 | Lance non-stream, f32 vectors, L2 distance | ok | 4.04s | -68.5% | 268.8 MiB | +124.6% | 2,588,180.264 | -0.188% |
| 4,096 | LanceStream, f32 vectors, L2 distance | ok | 40.82s | baseline | 300.1 MiB | baseline | 10,141,197.028 | baseline |
| 4,096 | Lance non-stream, f32 vectors, L2 distance | ok | 18.21s | -55.4% | 751.2 MiB | +150.3% | 10,109,680.003 | -0.311% |
| 1,024 | LanceStream, f64 vectors, L2 distance | ok | 24.99s | baseline | 173.0 MiB | baseline | 2,592,598.480 | baseline |
| 1,024 | Lance non-stream, f64 vectors, L2 distance | ok | 4.86s | -80.5% | 414.4 MiB | +139.5% | 2,587,814.467 | -0.185% |
| 4,096 | LanceStream, f64 vectors, L2 distance | ok | 77.22s | baseline | 510.8 MiB | baseline | 10,143,331.479 | baseline |
| 4,096 | Lance non-stream, f64 vectors, L2 distance | ok | 32.13s | -58.4% | 1,352.8 MiB | +164.8% | 10,109,706.606 | -0.331% |


Direct after-versus-before comparison

These are the clean one-shot measurements above. Positive values mean the after revision is larger or slower.

| vector type | k | algorithm | train time change | raw RSS change | exact loss change |
| --- | ---: | --- | ---: | ---: | ---: |
| f32 | 1,024 | LanceStream | -1.8% | +18.5% (+18.7 MiB) | +0.0007% |
| f32 | 1,024 | Lance non-stream | -2.5% | +5.6% (+14.2 MiB) | -0.0153% |
| f32 | 4,096 | LanceStream | +4.9% | +6.9% (+19.3 MiB) | -0.0013% |
| f32 | 4,096 | Lance non-stream | +19.2% | +2.4% (+17.8 MiB) | +0.0007% |
| f64 | 1,024 | LanceStream | newly supported | newly supported | newly supported |
| f64 | 1,024 | Lance non-stream | +14.4% | +4.4% (+17.6 MiB) | -0.0219% |
| f64 | 4,096 | LanceStream | newly supported | newly supported | newly supported |
| f64 | 4,096 | Lance non-stream | +10.5% | +1.2% (+16.3 MiB) | -0.0004% |

Dataset and methodology:

- Dimension: 128, matching the convention in the referenced
  [LanceStream benchmark report](https://github.com/lance-format/lance/pull/6913).
- Datasets:
  - 10,000,000 `FixedSizeList<Float32, 128>` vectors, 4.8 GiB on disk.
  - 10,000,000 `FixedSizeList<Float64, 128>` vectors, 9.6 GiB on disk.
- Generator: independent uniform random coordinates in `[0, 1)`, generated in
  the dataset's native scalar type with `SmallRng` seed
  `2026082010000128`. Both datasets report exactly 10,000,000 rows and contain
  ten Lance data files.
- f32 generation took 9.52s and peaked at 169,472 KiB RSS; f64 generation took
  17.61s and peaked at 298,572 KiB RSS.
- Both algorithms use L2 distance, `sample_rate=256`, and `max_iters=50`.
- LanceStream uses `streaming_sample_rate=64`,
  `streaming_coreset_rate=16`, `LANCE_STREAMING_IVF_PREFETCH_DEPTH=1`, and
  `streaming_refine_passes=0`.
- Non-stream uses the same `k`, sample rate, iteration budget, metric, and
  dataset, with streaming parameters unset.
- Both revisions were built from isolated source archives with
  `release-with-debug`, Thin-LTO, 16 codegen units, and default Lance features
  disabled. The final binary SHA-256 values are
  `aed6884e...e5688` (before) and `ea15c7e2...868c6` (after).
- Train time is measured inside `build_ivf_model`; centroid serialization is
  outside the timer.
- RSS is GNU `/usr/bin/time -v` maximum resident set size from a fresh process
  for each configuration.
- Exact loss is evaluated in a separate process over the first `k * 256` rows:

  ```text
  sum_x min_c ||x - c||^2
  ```

  HNSW acceleration was explicitly disabled, so every evaluation vector was
  compared with every centroid. Lance's current L2 API returns each distance
  as `f32`, including for f64 vectors, and these values were summed into `f64`.
  Thus “exact” means exhaustive assignment, not fully f64 loss arithmetic.
- Streaming uses deterministic fixed sample ranges. Batch uses its normal
  random sampler, so one-run batch timing and loss include sampling and
  initialization variance.
- The main tables contain one measured run per configuration. The additional
  f32 `k=1024` repetitions were diagnostic and are reported separately.

Host:

- CPU: Intel Core i7-9700K at 3.60 GHz, 8 physical cores / 8 threads.
- Memory: 31 GiB.
- Architecture: x86-64.
- Toolchain: Rust 1.97.0, Cargo 1.97.0.
----


According to this benchmark, RSS is not very good, but seems it is not implementation problem.
So i repeated f64-centroid benchmark with more precise approach.

Five fresh-process repetitions were run for each configuration on each revision. Each
revision used its own isolated `release-with-debug` binary; processes were pinned to
CPUs 0–7 with `RAYON_NUM_THREADS=8`, and configuration order was shuffled per
repetition. RSS is `/usr/bin/time -v` maximum resident set size. Values below are
mean ± sample standard deviation.

Raw measurements: 

| revision | vectors | algorithm | k | status | train seconds | RSS (KiB) |
|---|---|---:|---:|---|---:|---:|
| before | f32 | stream | 1024 | 0 | 10.282 ± 0.827 | 120,163 ± 896 |
| before | f32 | batch | 1024 | 0 | 2.872 ± 0.721 | 271,254 ± 3,221 |
| before | f32 | stream | 4096 | 0 | 35.345 ± 3.339 | 303,823 ± 1,083 |
| before | f32 | batch | 4096 | 0 | 17.160 ± 1.740 | 759,851 ± 6,813 |
| before | f64 | stream | 1024 | 101 (unsupported) | — | — |
| before | f64 | batch | 1024 | 0 | 3.776 ± 0.265 | 427,419 ± 5,080 |
| before | f64 | stream | 4096 | 101 (unsupported) | — | — |
| before | f64 | batch | 4096 | 0 | 31.568 ± 1.582 | 1,385,742 ± 6,524 |
| after | f32 | stream | 1024 | 0 | 9.469 ± 0.060 | 118,806 ± 1,082 |
| after | f32 | batch | 1024 | 0 | 2.882 ± 0.789 | 274,706 ± 2,423 |
| after | f32 | stream | 4096 | 0 | 35.069 ± 1.899 | 300,614 ± 4,235 |
| after | f32 | batch | 4096 | 0 | 17.049 ± 1.253 | 759,155 ± 6,226 |
| after | f64 | stream | 1024 | 0 | 19.323 ± 1.778 | 175,271 ± 1,129 |
| after | f64 | batch | 1024 | 0 | 3.814 ± 0.139 | 422,583 ± 6,177 |
| after | f64 | stream | 4096 | 0 | 68.767 ± 3.056 | 519,189 ± 1,734 |
| after | f64 | batch | 4096 | 0 | 30.566 ± 1.052 | 1,380,254 ± 8,455 |

After vs before:

For configurations available on both revisions, percentage deltas use the revision
means. Streaming f32 changed by −7.9% time / −1.1% RSS at k=1024 and −0.8% /
−1.1% at k=4096. Batch f32 changed by +0.3% / +1.3% and −0.6% / −0.1%,
respectively. Batch f64 changed by +1.0% / −1.1% at k=1024 and −3.2% / −0.4%
at k=4096. The f64 streaming path is newly supported, so it has no before value.
