### PR TITLE
fix(fts): preserve exact wand score bounds

### DIFF
--- a/rust/lance-index/src/scalar/inverted/index/partition.rs
+++ b/rust/lance-index/src/scalar/inverted/index/partition.rs
@@ -3,6 +3,48 @@
 
 use super::*;
 
+/// Query-level inputs for a grouped-term score upper bound.
+///
+/// The exact grouped score multiplies and then sums every expansion term in a
+/// stable order. Computing the bound from the `f32` sum of query weights can
+/// round below that score, so retain the `f64` sum and widen once for the term
+/// multiplications plus the final `f32` additions.
+#[derive(Debug, Clone, Copy)]
+struct GroupedScoreUpperBound {
+    query_weight: f32,
+    exact_query_weight_sum: f64,
+    rounding_factor: f64,
+}
+
+impl GroupedScoreUpperBound {
+    fn new(query_weights: impl Iterator<Item = f32>) -> Self {
+        let mut query_weight = 0.0_f32;
+        let mut exact_query_weight_sum = 0.0_f64;
+        let mut num_terms = 0usize;
+        for weight in query_weights {
+            query_weight += weight;
+            exact_query_weight_sum += f64::from(weight);
+            num_terms += 1;
+        }
+        Self {
+            query_weight,
+            exact_query_weight_sum,
+            // Two extra stages cover each term's rounded BM25 evaluation and
+            // multiplication before the grouped f32 sum.
+            rounding_factor: score_sum_upper_bound_factor(num_terms.saturating_add(2)),
+        }
+    }
+
+    #[inline]
+    fn score(self, union_freq: u32, doc_length: u32, scorer: &MemBM25Scorer) -> f32 {
+        outward_f32_upper_bound(
+            self.exact_query_weight_sum
+                * f64::from(scorer.doc_weight(union_freq, doc_length))
+                * self.rounding_factor,
+        )
+    }
+}
+
 #[derive(Debug, Clone, DeepSizeOf)]
 pub struct InvertedPartition {
     // 0 for legacy format
@@ -162,7 +204,7 @@ impl InvertedPartition {
 
     #[inline]
     fn grouped_score_upper_bound(
-        query_weight: f32,
+        score_upper_bound: GroupedScoreUpperBound,
         union_freq: u32,
         doc_length: u32,
         scorer: &MemBM25Scorer,
@@ -170,7 +212,7 @@ impl InvertedPartition {
         // BM25's document weight is monotonic in frequency and every IDF is
         // non-negative. Scoring the summed frequency with the summed IDF is
         // therefore an upper bound on the sum of the individual term scores.
-        query_weight * scorer.doc_weight(union_freq, doc_length)
+        score_upper_bound.score(union_freq, doc_length, scorer)
     }
 
     fn grouped_block_max_scores(
@@ -178,7 +220,7 @@ impl InvertedPartition {
         frequencies: &[u32],
         block_size: usize,
         docs: &LoadedDocLengths,
-        query_weight: f32,
+        score_upper_bound: GroupedScoreUpperBound,
         scorer: &MemBM25Scorer,
     ) -> Vec<f32> {
         doc_ids
@@ -190,7 +232,7 @@ impl InvertedPartition {
                     .zip(frequencies)
                     .map(|(doc_id, freq)| {
                         Self::grouped_score_upper_bound(
-                            query_weight,
+                            score_upper_bound,
                             *freq,
                             docs.scoring_num_tokens(*doc_id),
                             scorer,
@@ -204,7 +246,7 @@ impl InvertedPartition {
     fn union_plain_posting_lists(
         postings: Vec<PostingList>,
         docs: &LoadedDocLengths,
-        query_weight: f32,
+        score_upper_bound: GroupedScoreUpperBound,
         scorer: &MemBM25Scorer,
     ) -> Result<PostingList> {
         let mut freqs_by_row_id = BTreeMap::new();
@@ -221,7 +263,7 @@ impl InvertedPartition {
         let mut max_score = 0.0_f32;
         for (row_id, freq) in freqs_by_row_id {
             max_score = max_score.max(Self::grouped_score_upper_bound(
-                query_weight,
+                score_upper_bound,
                 freq,
                 docs.num_tokens_by_row_id(row_id),
                 scorer,
@@ -240,7 +282,7 @@ impl InvertedPartition {
     fn union_plain_posting_lists_with_positions(
         postings: Vec<PostingList>,
         docs: &LoadedDocLengths,
-        query_weight: f32,
+        score_upper_bound: GroupedScoreUpperBound,
         scorer: &MemBM25Scorer,
     ) -> Result<PostingList> {
         let mut positions_by_row_id = BTreeMap::<u64, Vec<u32>>::new();
@@ -272,7 +314,7 @@ impl InvertedPartition {
             positions.sort_unstable();
             let frequency = positions.len() as u32;
             max_score = max_score.max(Self::grouped_score_upper_bound(
-                query_weight,
+                score_upper_bound,
                 frequency,
                 docs.num_tokens_by_row_id(row_id),
                 scorer,
@@ -296,7 +338,7 @@ impl InvertedPartition {
     fn union_compressed_posting_lists(
         postings: Vec<PostingList>,
         docs: &LoadedDocLengths,
-        query_weight: f32,
+        score_upper_bound: GroupedScoreUpperBound,
         scorer: &MemBM25Scorer,
     ) -> Result<PostingList> {
         let block_size = postings
@@ -343,7 +385,7 @@ impl InvertedPartition {
             &frequencies,
             block_size,
             docs,
-            query_weight,
+            score_upper_bound,
             scorer,
         );
         let batch = builder.to_batch(block_max_scores)?;
@@ -355,7 +397,7 @@ impl InvertedPartition {
     fn union_compressed_posting_lists_with_positions(
         postings: Vec<PostingList>,
         docs: &LoadedDocLengths,
-        query_weight: f32,
+        score_upper_bound: GroupedScoreUpperBound,
         scorer: &MemBM25Scorer,
     ) -> Result<PostingList> {
         let block_size = postings
@@ -407,7 +449,7 @@ impl InvertedPartition {
             &frequencies,
             block_size,
             docs,
-            query_weight,
+            score_upper_bound,
             scorer,
         );
         let batch = builder.to_batch(block_max_scores)?;
@@ -420,7 +462,7 @@ impl InvertedPartition {
         postings: Vec<PostingList>,
         docs: &LoadedDocLengths,
         with_positions: bool,
-        query_weight: f32,
+        score_upper_bound: GroupedScoreUpperBound,
         scorer: &MemBM25Scorer,
     ) -> Result<PostingList> {
         let has_plain = postings
@@ -433,18 +475,23 @@ impl InvertedPartition {
             (true, true) => Err(Error::index(
                 "cannot union mixed plain and compressed posting lists".to_owned(),
             )),
-            (true, false) if with_positions => {
-                Self::union_plain_posting_lists_with_positions(postings, docs, query_weight, scorer)
+            (true, false) if with_positions => Self::union_plain_posting_lists_with_positions(
+                postings,
+                docs,
+                score_upper_bound,
+                scorer,
+            ),
+            (true, false) => {
+                Self::union_plain_posting_lists(postings, docs, score_upper_bound, scorer)
             }
-            (true, false) => Self::union_plain_posting_lists(postings, docs, query_weight, scorer),
             (false, true) if with_positions => Self::union_compressed_posting_lists_with_positions(
                 postings,
                 docs,
-                query_weight,
+                score_upper_bound,
                 scorer,
             ),
             (false, true) => {
-                Self::union_compressed_posting_lists(postings, docs, query_weight, scorer)
+                Self::union_compressed_posting_lists(postings, docs, score_upper_bound, scorer)
             }
             (false, false) => Ok(PostingList::Plain(PlainPostingList::new(
                 ScalarBuffer::from(Vec::<u64>::new()),
@@ -617,7 +664,9 @@ impl InvertedPartition {
                     })
                     .collect::<Vec<_>>();
                 let terms = Arc::<[GroupedTermScorer]>::from(terms);
-                let query_weight = terms.iter().map(GroupedTermScorer::query_weight).sum();
+                let score_upper_bound =
+                    GroupedScoreUpperBound::new(terms.iter().map(GroupedTermScorer::query_weight));
+                let query_weight = score_upper_bound.query_weight;
                 grouped_expansions.push(GroupedExpansionTerms {
                     position,
                     terms: terms.clone(),
@@ -633,7 +682,7 @@ impl InvertedPartition {
                     postings,
                     docs,
                     is_phrase_query,
-                    query_weight,
+                    score_upper_bound,
                     impact_scorer,
                 )?;
                 if posting.is_empty() && (is_and_query || is_phrase_query) {
@@ -799,5 +848,115 @@ impl InvertedPartition {
                 .push(posting_list.into_builder(&builder.docs));
         }
         Ok(builder)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use rstest::rstest;
+
+    use super::*;
+
+    #[rstest]
+    #[case::plain(false)]
+    #[case::v3_compressed(true)]
+    fn grouped_union_bound_covers_exact_grouped_score(#[case] compressed: bool) {
+        let num_docs = 1_975_725usize;
+        let total_tokens = num_docs as u64 * u64::from(u32::MAX);
+        let token_names = ["t0", "t1"];
+        let token_docs = [1_970_713usize, 334_819];
+        let frequencies = [138_872u32, 794_767];
+        let doc_length = frequencies.into_iter().sum::<u32>();
+        let scorer = Arc::new(MemBM25Scorer::new(
+            total_tokens,
+            num_docs,
+            token_names
+                .into_iter()
+                .zip(token_docs)
+                .map(|(token, docs)| (token.to_owned(), docs))
+                .collect(),
+        ));
+        let query_weights = token_names.map(|token| scorer.query_weight(token));
+        let exact_score = query_weights.into_iter().zip(frequencies).fold(
+            0.0_f32,
+            |score, (query_weight, frequency)| {
+                score + query_weight * scorer.doc_weight(frequency, doc_length)
+            },
+        );
+        let query_weight = query_weights.into_iter().sum::<f32>();
+        let score_upper_bound = GroupedScoreUpperBound::new(query_weights.into_iter());
+        let union_frequency = frequencies.into_iter().sum::<u32>();
+        let naive_proxy_bound = query_weight * scorer.doc_weight(union_frequency, doc_length);
+        let term_postings = query_weights
+            .into_iter()
+            .zip(frequencies)
+            .map(|(query_weight, frequency)| {
+                let max_score = query_weight * scorer.doc_weight(frequency, doc_length);
+                if compressed {
+                    let mut builder =
+                        PostingListBuilder::new_with_block_size(false, MAX_POSTING_BLOCK_SIZE);
+                    builder.add(0, PositionRecorder::Count(frequency));
+                    let batch = builder.to_batch(vec![max_score]).unwrap();
+                    let max_score = batch[MAX_SCORE_COL].as_primitive::<Float32Type>().value(0);
+                    let length = batch[LENGTH_COL].as_primitive::<UInt32Type>().value(0);
+                    PostingList::from_batch(&batch, Some(max_score), Some(length)).unwrap()
+                } else {
+                    PostingList::Plain(PlainPostingList::new(
+                        ScalarBuffer::from(vec![0u64]),
+                        ScalarBuffer::from(vec![frequency as f32]),
+                        Some(max_score),
+                        None,
+                    ))
+                }
+            })
+            .collect::<Vec<_>>();
+        let grouped_terms = term_postings
+            .iter()
+            .zip(query_weights)
+            .map(|(posting, query_weight)| GroupedTermScorer::new(query_weight, posting))
+            .collect::<Arc<[GroupedTermScorer]>>();
+        let mut documents = DocSet::default();
+        documents.append(0, doc_length);
+        let loaded_documents = LoadedDocLengths::Legacy(Arc::new(documents.clone()));
+        let union_posting = InvertedPartition::union_posting_lists(
+            term_postings,
+            &loaded_documents,
+            false,
+            score_upper_bound,
+            &scorer,
+        )
+        .unwrap();
+        let grouped_bound = union_posting.max_score().unwrap();
+
+        assert_eq!(exact_score.to_bits(), 0x407a_4aa8);
+        assert_eq!(naive_proxy_bound.to_bits(), 0x407a_4aa7);
+        assert!(grouped_bound >= exact_score);
+
+        let posting = PostingIterator::with_query_weight(
+            "group".to_owned(),
+            0,
+            0,
+            query_weight,
+            union_posting,
+            1,
+        )
+        .with_grouped_terms(grouped_terms);
+        let metrics = NoOpMetricsCollector;
+        let params = FtsSearchParams::default();
+        let mut cursor = WandCursor::new(
+            Operator::Or,
+            vec![posting],
+            &documents,
+            scorer,
+            &params,
+            &metrics,
+        );
+        cursor.set_min_competitive_score(exact_score).unwrap();
+
+        assert_eq!(cursor.next().unwrap(), Some(0));
+        assert_eq!(
+            cursor.current_score().unwrap().to_bits(),
+            exact_score.to_bits()
+        );
     }
 }

--- a/rust/lance-index/src/scalar/inverted/index/search_candidates.rs
+++ b/rust/lance-index/src/scalar/inverted/index/search_candidates.rs
@@ -151,6 +151,7 @@ pub(super) fn rescore_partition_candidates<C>(
         .iter()
         .map(|group| group.position)
         .collect::<HashSet<_>>();
+    let mut position_scores = vec![0.0_f32; idf_by_position.len()];
 
     candidates
         .into_iter()
@@ -161,23 +162,31 @@ pub(super) fn rescore_partition_candidates<C>(
                  freqs,
                  doc_length,
              }| {
-                let mut score = 0.0;
+                position_scores.fill(0.0);
                 for (term_index, freq) in freqs {
                     if grouped_positions.contains(&term_index) {
                         continue;
                     }
                     debug_assert!((term_index as usize) < idf_by_position.len());
-                    score +=
+                    position_scores[term_index as usize] +=
                         idf_by_position[term_index as usize] * scorer.doc_weight(freq, doc_length);
                 }
                 for group in &grouped_expansions {
-                    for term in group.terms.iter() {
-                        let Some(freq) = term.frequency(posting_doc_id) else {
-                            continue;
-                        };
-                        score += term.query_weight() * scorer.doc_weight(freq, doc_length);
-                    }
+                    debug_assert!((group.position as usize) < position_scores.len());
+                    let grouped_score = group
+                        .terms
+                        .iter()
+                        .filter_map(|term| {
+                            term.frequency(posting_doc_id).map(|freq| {
+                                term.query_weight() * scorer.doc_weight(freq, doc_length)
+                            })
+                        })
+                        .fold(0.0_f32, |sum, score| sum + score);
+                    position_scores[group.position as usize] += grouped_score;
                 }
+                let score = position_scores
+                    .iter()
+                    .fold(0.0_f32, |sum, score| sum + *score);
                 (document, score)
             },
         )

--- a/rust/lance-index/src/scalar/inverted/scorer.rs
+++ b/rust/lance-index/src/scalar/inverted/scorer.rs
@@ -73,6 +73,12 @@ pub(super) fn bm25_doc_weight_with_norm(freq: u32, doc_norm: f32) -> f32 {
 pub const K1: f32 = 1.2;
 pub const B: f32 = 0.75;
 
+// The f32 multiply/add/divide sequence in `bm25_doc_weight_with_norm` can
+// round one ULP above the mathematical K1 + 1 limit.  Keep two ULPs of room so
+// every scorer-independent pruning bound remains conservative after its final
+// multiplication by the query weight.
+pub(super) const BM25_DOC_WEIGHT_UPPER_BOUND: f32 = f32::from_bits((K1 + 1.0).to_bits() + 2);
+
 #[inline]
 fn bm25_doc_norm(doc_tokens: u32, avg_doc_length: f32) -> f32 {
     let doc_tokens = doc_tokens as f32;
@@ -149,7 +155,7 @@ impl Scorer for MemBM25Scorer {
     }
 
     fn doc_weight_upper_bound(&self) -> Option<f32> {
-        Some(K1 + 1.0)
+        Some(BM25_DOC_WEIGHT_UPPER_BOUND)
     }
 
     fn doc_weight_cache_key(&self) -> Option<u64> {
@@ -219,7 +225,7 @@ impl Scorer for IndexBM25Scorer<'_> {
     }
 
     fn doc_weight_upper_bound(&self) -> Option<f32> {
-        Some(K1 + 1.0)
+        Some(BM25_DOC_WEIGHT_UPPER_BOUND)
     }
 
     fn doc_weight_cache_key(&self) -> Option<u64> {
@@ -231,4 +237,19 @@ impl Scorer for IndexBM25Scorer<'_> {
 pub fn idf(token_docs: usize, num_docs: usize) -> f32 {
     let num_docs = num_docs as f32;
     ((num_docs - token_docs as f32 + 0.5) / (token_docs as f32 + 0.5) + 1.0).ln()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bm25_doc_weight_upper_bound_covers_f32_rounding() {
+        let scorer = MemBM25Scorer::new(6_242_289_027, 2, HashMap::new());
+        let doc_weight = scorer.doc_weight(3_926_982_873, 4_078_552_115);
+
+        assert_eq!(doc_weight.to_bits(), 0x400c_ccce);
+        assert!(doc_weight > K1 + 1.0);
+        assert!(scorer.doc_weight_upper_bound().unwrap() >= doc_weight);
+    }
 }

--- a/rust/lance-index/src/scalar/inverted/wand.rs
+++ b/rust/lance-index/src/scalar/inverted/wand.rs
@@ -1531,10 +1531,8 @@ fn score_sum_cannot_compete(
     upper_bound_factor: f64,
     floor_mode: CompetitiveFloorMode,
 ) -> bool {
-    floor_mode.rejects_upper_bound(
-        (f64::from(partial_score) + remaining_upper_bound) * upper_bound_factor,
-        floor,
-    )
+    let upper_bound = (f64::from(partial_score) + remaining_upper_bound) * upper_bound_factor;
+    floor_mode.rejects_upper_bound(f64::from(outward_f32_upper_bound(upper_bound)), floor)
 }
 
 type ScoreContribution = ((u32, u32), f32);
@@ -4913,8 +4911,14 @@ fn conservative_score_sum(scores: impl Iterator<Item = f32>) -> f32 {
         (count + 1, sum + f64::from(score))
     });
     let widened = exact * score_sum_upper_bound_factor(num_scores);
-    let rounded = widened as f32;
-    if f64::from(rounded) < widened {
+    outward_f32_upper_bound(widened)
+}
+
+/// Round a wide score bound to the least `f32` that still covers it.
+#[inline]
+pub(super) fn outward_f32_upper_bound(value: f64) -> f32 {
+    let rounded = value as f32;
+    if f64::from(rounded) < value {
         next_up_f32(rounded)
     } else {
         rounded
@@ -5059,6 +5063,22 @@ mod tests {
             threshold,
             score_sum_upper_bound_factor(3),
             CompetitiveFloorMode::Exclusive,
+        ));
+    }
+
+    #[test]
+    fn two_clause_inclusive_bound_rounds_outward_at_f32_boundary() {
+        let partial_score = 1.0_f32;
+        let remaining_upper_bound = f32::from_bits(0x3380_0001);
+        let floor = partial_score + remaining_upper_bound;
+
+        assert_eq!(floor.to_bits(), 0x3f80_0001);
+        assert!(!score_sum_cannot_compete(
+            partial_score,
+            f64::from(remaining_upper_bound),
+            floor,
+            score_sum_upper_bound_factor(2),
+            CompetitiveFloorMode::Inclusive,
         ));
     }
 

--- a/rust/lance-index/src/scalar/inverted/wand.rs
+++ b/rust/lance-index/src/scalar/inverted/wand.rs
@@ -16,6 +16,7 @@ use itertools::Itertools;
 use lance_core::utils::address::RowAddress;
 use lance_core::{Error, Result};
 use lance_select::RowAddrMask;
+use smallvec::SmallVec;
 
 use crate::metrics::MetricsCollector;
 
@@ -25,7 +26,7 @@ use super::{
     impact::{IMPACT_LEVEL1_BLOCKS, ImpactScoreCache, ImpactSkipData},
     index::{PositionStreamCodec, dequantize_doc_length},
     query::Operator,
-    scorer::{K1, MemBM25Scorer, bm25_doc_weight_with_norm, idf},
+    scorer::{BM25_DOC_WEIGHT_UPPER_BOUND, MemBM25Scorer, bm25_doc_weight_with_norm, idf},
 };
 use super::{
     CompressedPostingList, DocSet, PostingList, RawDocInfo,
@@ -209,6 +210,31 @@ pub static FLAT_SEARCH_PERCENT_THRESHOLD: LazyLock<u64> = LazyLock::new(|| {
 // WAND loop. LANCE_FTS_MAXSCORE=0 opts back into the classic loop.
 static USE_MAXSCORE_SEARCH: LazyLock<bool> =
     LazyLock::new(|| std::env::var("LANCE_FTS_MAXSCORE").as_deref() != Ok("0"));
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+enum CompetitiveFloorMode {
+    #[default]
+    Exclusive,
+    Inclusive,
+}
+
+impl CompetitiveFloorMode {
+    #[inline]
+    fn rejects_upper_bound(self, upper_bound: f64, floor: f32) -> bool {
+        match self {
+            Self::Exclusive => upper_bound <= f64::from(floor),
+            Self::Inclusive => upper_bound < f64::from(floor),
+        }
+    }
+
+    #[inline]
+    fn accepts_score(self, score: f32, floor: f32) -> bool {
+        match self {
+            Self::Exclusive => score > floor,
+            Self::Inclusive => score >= floor,
+        }
+    }
+}
 // Bulk conjunction path for top-k AND / phrase queries: block-max window
 // skipping plus a slice-level merge over decompressed blocks, replacing the
 // per-doc `next()` leapfrog. Results are identical to the classic AND loop.
@@ -321,7 +347,7 @@ fn conservative_bm25_upper_bound(query_weight: f32) -> f32 {
     if query_weight <= 0.0 {
         0.0
     } else {
-        query_weight * (K1 + 1.0)
+        query_weight * BM25_DOC_WEIGHT_UPPER_BOUND
     }
 }
 
@@ -799,11 +825,9 @@ impl PostingIterator {
         list: PostingList,
         num_doc: usize,
     ) -> Self {
-        // BM25's doc weight is bounded by K1 + 1 for any freq and doc length,
-        // so query_weight * (K1 + 1) is a valid global bound even when index
-        // stats drift after appends. Keeping it finite matters: an INFINITY
-        // bound can never park the iterator in the WAND tail, forcing a deep
-        // advance on every candidate.
+        // Keep a finite scorer-independent BM25 ceiling even when index stats
+        // drift after appends.  The ceiling includes f32 evaluation error; an
+        // INFINITY bound can never park the iterator in the WAND tail.
         let approximate_upper_bound = match &list {
             PostingList::Compressed(posting) if posting.impacts.is_some() => f32::INFINITY,
             PostingList::Compressed(posting) if posting.block_size == MAX_POSTING_BLOCK_SIZE => {
@@ -811,7 +835,7 @@ impl PostingIterator {
             }
             _ => match list.max_score() {
                 Some(max_score) => max_score,
-                None => idf(list.len(), num_doc) * (K1 + 1.0),
+                None => conservative_bm25_upper_bound(idf(list.len(), num_doc)),
             },
         };
         let compressed = match &list {
@@ -846,6 +870,11 @@ impl PostingIterator {
     }
 
     pub(super) fn with_grouped_terms(mut self, terms: Arc<[GroupedTermScorer]>) -> Self {
+        // Grouped postings are built at query time with the same scoring
+        // lengths and scorer as this cursor.  Their baked list maximum is the
+        // authoritative bound, including on 256-document blocks where normal
+        // persisted postings must fall back to a scorer-wide ceiling.
+        self.approximate_upper_bound = self.list.max_score().unwrap_or(f32::INFINITY);
         self.grouped_terms = Some(terms);
         self
     }
@@ -872,6 +901,9 @@ impl PostingIterator {
     /// iterators park in the WAND tail instead of being force-advanced.
     #[inline]
     fn global_upper_bound<S: Scorer + ?Sized>(&self, scorer: &S) -> f32 {
+        if self.has_grouped_terms() {
+            return self.approximate_upper_bound;
+        }
         if self.query_weight <= 0.0 {
             return 0.0;
         }
@@ -1213,6 +1245,9 @@ impl PostingIterator {
     fn block_max_score<S: Scorer + ?Sized>(&self, scorer: &S) -> f32 {
         match self.list {
             PostingList::Compressed(ref list) => {
+                if self.has_grouped_terms() && list.block_size == MAX_POSTING_BLOCK_SIZE {
+                    return self.approximate_upper_bound;
+                }
                 if let Some(impacts) = list.impacts.as_ref() {
                     return self.impact_level0(impacts, scorer).1;
                 }
@@ -1243,6 +1278,12 @@ impl PostingIterator {
     ) -> BlockMaxScore {
         match self.list {
             PostingList::Compressed(ref list) => {
+                if self.has_grouped_terms() && list.block_size == MAX_POSTING_BLOCK_SIZE {
+                    return BlockMaxScore {
+                        score: self.approximate_upper_bound,
+                        blocks_scanned: 0,
+                    };
+                }
                 if let Some(impacts) = list.impacts.as_ref() {
                     let (level0_up_to, level0_score) = self.impact_level0(impacts, scorer);
                     if up_to <= u64::from(level0_up_to) {
@@ -1483,13 +1524,32 @@ pub(super) fn score_sum_upper_bound_factor(num_values: usize) -> f64 {
 }
 
 #[inline]
-fn score_sum_cannot_exceed(
+fn score_sum_cannot_compete(
     partial_score: f32,
     remaining_upper_bound: f64,
-    threshold: f32,
+    floor: f32,
     upper_bound_factor: f64,
+    floor_mode: CompetitiveFloorMode,
 ) -> bool {
-    ((f64::from(partial_score) + remaining_upper_bound) * upper_bound_factor) as f32 <= threshold
+    floor_mode.rejects_upper_bound(
+        (f64::from(partial_score) + remaining_upper_bound) * upper_bound_factor,
+        floor,
+    )
+}
+
+type ScoreContribution = ((u32, u32), f32);
+
+#[inline]
+fn score_contributions_in_query_order(mut contributions: SmallVec<[ScoreContribution; 8]>) -> f32 {
+    if !contributions
+        .windows(2)
+        .all(|window| window[0].0 <= window[1].0)
+    {
+        contributions.sort_unstable_by_key(|contribution| contribution.0);
+    }
+    contributions
+        .into_iter()
+        .fold(0.0_f32, |score, (_, contribution)| score + contribution)
 }
 
 /// Per-window score/frequency accumulator for the bulk MAXSCORE path. Slot i
@@ -1932,6 +1992,7 @@ impl Ord for TailPosting {
 
 pub struct Wand<'a, S: Scorer, D: WandDocuments> {
     threshold: f32, // multiple of factor and the minimum score of the top-k documents
+    floor_mode: CompetitiveFloorMode,
     operator: Operator,
     num_terms: usize,
     // Posting iterators whose current doc id is >= the next target doc.
@@ -1946,10 +2007,10 @@ pub struct Wand<'a, S: Scorer, D: WandDocuments> {
     // in play because their score upper bound could affect the decision for the
     // current candidate.
     tail: BinaryHeap<TailPosting>,
-    // Sum of upper bounds for all iterators currently held in `tail`.
-    // This lets us cheaply decide whether the current candidate can still beat
-    // the threshold before fully advancing every lagging iterator.
-    tail_max_score: f32,
+    // Conservatively rounded sum of upper bounds for all iterators in `tail`.
+    // It is maintained in f64 so candidate checks stay O(1) without allowing
+    // repeated f32 add/subtract rounding to underestimate the remaining score.
+    tail_max_score: f64,
     // Block-max scores are valid for all candidate docs up to this doc id.
     // `None` means the window has not been initialized yet and the next
     // candidate must refresh block-max state before making pruning decisions.
@@ -1967,6 +2028,10 @@ pub struct Wand<'a, S: Scorer, D: WandDocuments> {
     bulk_and_mode_override: Option<BulkAndMode>,
     #[cfg(test)]
     bulk_and_searches: usize,
+    #[cfg(test)]
+    maxscore_single_essential_windows: usize,
+    #[cfg(test)]
+    maxscore_general_windows: usize,
     documents: &'a D,
     scorer: S,
     // Shared cross-partition top-k floor. Each partition publishes its local
@@ -2015,7 +2080,11 @@ impl<'a, S: Scorer, D: WandDocuments> Wand<'a, S, D> {
         }
 
         Self {
+            // Standalone leaf top-k keeps its established exclusive floor.
+            // Composable cursors switch to an inclusive floor because their
+            // downstream collector applies the final document-key tie-breaker.
             threshold: 0.0,
+            floor_mode: CompetitiveFloorMode::Exclusive,
             operator,
             num_terms: if operator == Operator::And {
                 lead.len()
@@ -2034,6 +2103,10 @@ impl<'a, S: Scorer, D: WandDocuments> Wand<'a, S, D> {
             bulk_and_mode_override: None,
             #[cfg(test)]
             bulk_and_searches: 0,
+            #[cfg(test)]
+            maxscore_single_essential_windows: 0,
+            #[cfg(test)]
+            maxscore_general_windows: 0,
             documents,
             scorer,
             shared_threshold: None,
@@ -2045,6 +2118,11 @@ impl<'a, S: Scorer, D: WandDocuments> Wand<'a, S, D> {
     #[cfg(test)]
     fn with_bulk_and_mode(mut self, mode: BulkAndMode) -> Self {
         self.bulk_and_mode_override = Some(mode);
+        self
+    }
+
+    fn with_floor_mode(mut self, mode: CompetitiveFloorMode) -> Self {
+        self.floor_mode = mode;
         self
     }
 
@@ -2159,7 +2237,7 @@ impl<'a, S: Scorer, D: WandDocuments> Wand<'a, S, D> {
         });
         loop {
             self.raise_to_shared_floor(params.wand_factor);
-            let Some((doc, mut score)) = self.next()? else {
+            let Some((doc, _)) = self.next()? else {
                 break;
             };
             num_comparisons += 1;
@@ -2178,14 +2256,14 @@ impl<'a, S: Scorer, D: WandDocuments> Wand<'a, S, D> {
             let doc_length = self.documents.doc_length(&doc);
 
             let score = if self.operator == Operator::Or {
-                self.advance_all_tail(doc.doc_id(), Some(doc_length), Some(&mut score));
+                self.advance_all_tail(doc.doc_id(), None, None);
                 if params.phrase_slop.is_some()
                     && !self.check_positions(params.phrase_slop.unwrap() as i32)?
                 {
                     self.push_back_leads(doc.doc_id() + 1);
                     continue;
                 }
-                score
+                self.score_in_query_order(doc_length)
             } else {
                 self.advance_all_tail(doc.doc_id(), None, None);
                 if params.phrase_slop.is_some()
@@ -2196,7 +2274,7 @@ impl<'a, S: Scorer, D: WandDocuments> Wand<'a, S, D> {
                 if let Some(and_stats) = and_search_stats.as_mut() {
                     and_stats.full_scores += 1;
                 }
-                self.score(doc_length)
+                self.score_in_query_order(doc_length)
             };
 
             if candidates.insert(
@@ -2310,7 +2388,7 @@ impl<'a, S: Scorer, D: WandDocuments> Wand<'a, S, D> {
             }
 
             self.collect_tail_matches(doc_id);
-            let score = self.score(doc_length);
+            let score = self.score_in_query_order(doc_length);
 
             if candidates.insert(
                 ScoredDoc::new(document_key, score),
@@ -2345,6 +2423,7 @@ impl<'a, S: Scorer, D: WandDocuments> Wand<'a, S, D> {
     ) -> Result<Vec<DocCandidate<D::Candidate>>> {
         struct MaxScoreClause {
             posting: Box<PostingIterator>,
+            query_rank: usize,
             bound: f32,
             prefix_bound: f64,
         }
@@ -2355,11 +2434,20 @@ impl<'a, S: Scorer, D: WandDocuments> Wand<'a, S, D> {
             .into_iter()
             .map(|head| MaxScoreClause {
                 posting: head.posting,
+                query_rank: 0,
                 bound: 0.0,
                 prefix_bound: 0.0,
             })
             .collect::<Vec<_>>();
-        let total_sum_upper_bound_factor = score_sum_upper_bound_factor(clauses.len());
+        // Before a competitive floor exists every clause is essential. Keep
+        // that exhaustive accumulator in canonical query order so its score
+        // can be emitted directly instead of recomputing every contribution.
+        clauses.sort_unstable_by_key(|clause| (clause.posting.position, clause.posting.token_id));
+        for (query_rank, clause) in clauses.iter_mut().enumerate() {
+            clause.query_rank = query_rank;
+        }
+        let num_query_terms = clauses.len();
+        let total_sum_upper_bound_factor = score_sum_upper_bound_factor(num_query_terms);
 
         let mut acc = WindowAccumulator::new(clauses.len());
         let mut candidates = TopKCollector::new(limit, std::cmp::min(limit, BLOCK_SIZE * 10));
@@ -2428,14 +2516,18 @@ impl<'a, S: Scorer, D: WandDocuments> Wand<'a, S, D> {
                         .score
                 };
             }
-            clauses.sort_unstable_by(|a, b| a.bound.total_cmp(&b.bound));
+            let mut clauses_in_query_order = true;
             let mut first_essential = 0;
             let mut prefix = 0.0_f64;
             if self.threshold > 0.0 {
+                clauses.sort_unstable_by(|a, b| a.bound.total_cmp(&b.bound));
+                clauses_in_query_order = clauses
+                    .windows(2)
+                    .all(|window| window[0].query_rank <= window[1].query_rank);
                 for (i, clause) in clauses.iter_mut().enumerate() {
                     let next_prefix = prefix + f64::from(clause.bound);
-                    let widened = (next_prefix * score_sum_upper_bound_factor(i + 1)) as f32;
-                    if widened > self.threshold {
+                    let widened = next_prefix * score_sum_upper_bound_factor(i + 1);
+                    if widened > f64::from(self.threshold) {
                         break;
                     }
                     prefix = next_prefix;
@@ -2502,13 +2594,19 @@ impl<'a, S: Scorer, D: WandDocuments> Wand<'a, S, D> {
             // competitive): stream it directly against the non-essential
             // prefix, skipping the accumulator entirely.
             if first_essential + 1 == clauses.len() {
+                #[cfg(test)]
+                {
+                    self.maxscore_single_essential_windows += 1;
+                }
                 let (non_essential, essential) = clauses.split_at_mut(first_essential);
+                let essential_query_rank = essential[0].query_rank;
                 let posting = &mut essential[0].posting;
                 if posting.doc().is_some_and(|doc| doc.doc_id() < window_min) {
                     posting.next(window_min);
                 }
                 let essential_term = posting.term_index();
                 let essential_weight = posting.query_weight;
+                let sole_query_clause = non_essential.is_empty();
 
                 macro_rules! consider_candidate {
                     ($doc:expr, $freq:expr) => {{
@@ -2532,30 +2630,38 @@ impl<'a, S: Scorer, D: WandDocuments> Wand<'a, S, D> {
                             }
                         };
                         if !(self.threshold > 0.0
-                            && score_sum_cannot_exceed(
+                            && score_sum_cannot_compete(
                                 score,
                                 total_non_essential_bound,
                                 self.threshold,
                                 total_sum_upper_bound_factor,
+                                CompetitiveFloorMode::Exclusive,
                             ))
                         {
                             if let Some(document_key) =
                                 self.documents.document_key_for_doc_id(doc as u32)
                             {
                                 let mut total = score;
+                                let mut scores_by_query_rank = SmallVec::<[f32; 8]>::new();
+                                if !sole_query_clause {
+                                    scores_by_query_rank.resize(num_query_terms, 0.0);
+                                    scores_by_query_rank[essential_query_rank] = score;
+                                }
                                 let mut rejected = false;
                                 for i in (0..non_essential.len()).rev() {
                                     if self.threshold > 0.0
-                                        && score_sum_cannot_exceed(
+                                        && score_sum_cannot_compete(
                                             total,
                                             non_essential[i].prefix_bound,
                                             self.threshold,
                                             total_sum_upper_bound_factor,
+                                            CompetitiveFloorMode::Exclusive,
                                         )
                                     {
                                         rejected = true;
                                         break;
                                     }
+                                    let query_rank = non_essential[i].query_rank;
                                     let probe = &mut non_essential[i].posting;
                                     if probe.doc().is_some_and(|d| d.doc_id() < doc) {
                                         probe.next(doc);
@@ -2563,7 +2669,7 @@ impl<'a, S: Scorer, D: WandDocuments> Wand<'a, S, D> {
                                     if let Some(d) = probe.doc()
                                         && d.doc_id() == doc
                                     {
-                                        total += match norm_addend {
+                                        let contribution = match norm_addend {
                                             Some(addend) => {
                                                 probe.query_weight
                                                     * bm25_doc_weight_with_norm(
@@ -2577,31 +2683,44 @@ impl<'a, S: Scorer, D: WandDocuments> Wand<'a, S, D> {
                                                 self.documents.scoring_num_tokens(doc as u32),
                                             ),
                                         };
+                                        total += contribution;
+                                        scores_by_query_rank[query_rank] = contribution;
                                     }
                                 }
 
-                                // Match the classic path's emission rule: a
-                                // candidate must beat the running threshold,
-                                // which drops zero-score matches (e.g. terms
-                                // with idf 0) exactly like Wand::next does.
-                                if !rejected && total > self.threshold {
-                                    let doc_length = self.documents.scoring_num_tokens(doc as u32);
-                                    if candidates.insert(
-                                        ScoredDoc::new(document_key, total),
-                                        doc_length,
-                                        doc,
-                                        std::iter::once((essential_term, freq)).chain(
-                                            non_essential.iter().filter_map(|clause| {
-                                                clause.posting.doc().and_then(|d| {
-                                                    (d.doc_id() == doc).then(|| {
-                                                        (clause.posting.term_index(), d.frequency())
+                                // Apply the caller's floor mode only after the
+                                // canonical query-order score is available.
+                                if !rejected {
+                                    let canonical_score = if sole_query_clause {
+                                        score
+                                    } else {
+                                        scores_by_query_rank
+                                            .into_iter()
+                                            .fold(0.0_f32, |sum, contribution| sum + contribution)
+                                    };
+                                    if canonical_score > self.threshold {
+                                        let doc_length =
+                                            self.documents.scoring_num_tokens(doc as u32);
+                                        if candidates.insert(
+                                            ScoredDoc::new(document_key, canonical_score),
+                                            doc_length,
+                                            doc,
+                                            std::iter::once((essential_term, freq)).chain(
+                                                non_essential.iter().filter_map(|clause| {
+                                                    clause.posting.doc().and_then(|d| {
+                                                        (d.doc_id() == doc).then(|| {
+                                                            (
+                                                                clause.posting.term_index(),
+                                                                d.frequency(),
+                                                            )
+                                                        })
                                                     })
-                                                })
-                                            }),
-                                        ),
-                                    )? && let Some(kth) = candidates.kth_score_if_full()
-                                    {
-                                        self.update_threshold(kth, params.wand_factor);
+                                                }),
+                                            ),
+                                        )? && let Some(kth) = candidates.kth_score_if_full()
+                                        {
+                                            self.update_threshold(kth, params.wand_factor);
+                                        }
                                     }
                                 }
                             }
@@ -2673,6 +2792,10 @@ impl<'a, S: Scorer, D: WandDocuments> Wand<'a, S, D> {
             }
 
             // Stream the essential clauses through inner windows.
+            #[cfg(test)]
+            {
+                self.maxscore_general_windows += 1;
+            }
             let mut inner_min = window_min;
             loop {
                 let mut next_essential_doc = TERMINATED_DOC_ID;
@@ -2717,11 +2840,12 @@ impl<'a, S: Scorer, D: WandDocuments> Wand<'a, S, D> {
                         num_comparisons += 1;
 
                         if self.threshold > 0.0
-                            && score_sum_cannot_exceed(
+                            && score_sum_cannot_compete(
                                 score,
                                 total_non_essential_bound,
                                 self.threshold,
                                 total_sum_upper_bound_factor,
+                                CompetitiveFloorMode::Exclusive,
                             )
                         {
                             acc.clear_slot(slot);
@@ -2740,19 +2864,27 @@ impl<'a, S: Scorer, D: WandDocuments> Wand<'a, S, D> {
                         let norm_addend =
                             norm_k_ref.map(|(norms, cache)| cache[norms[doc as usize] as usize]);
                         let mut doc_length_cell: Option<u32> = None;
+                        let needs_canonical_rescore =
+                            first_essential != 0 || !clauses_in_query_order;
+                        let mut scores_by_query_rank = SmallVec::<[f32; 8]>::new();
+                        if needs_canonical_rescore {
+                            scores_by_query_rank.resize(num_query_terms, 0.0);
+                        }
                         let mut rejected = false;
                         for i in (0..first_essential).rev() {
                             if self.threshold > 0.0
-                                && score_sum_cannot_exceed(
+                                && score_sum_cannot_compete(
                                     score,
                                     clauses[i].prefix_bound,
                                     self.threshold,
                                     total_sum_upper_bound_factor,
+                                    CompetitiveFloorMode::Exclusive,
                                 )
                             {
                                 rejected = true;
                                 break;
                             }
+                            let query_rank = clauses[i].query_rank;
                             let posting = &mut clauses[i].posting;
                             if posting.doc().is_some_and(|d| d.doc_id() < doc) {
                                 posting.next(doc);
@@ -2760,7 +2892,7 @@ impl<'a, S: Scorer, D: WandDocuments> Wand<'a, S, D> {
                             if let Some(d) = posting.doc()
                                 && d.doc_id() == doc
                             {
-                                score += match norm_addend {
+                                let contribution = match norm_addend {
                                     Some(addend) => {
                                         posting.query_weight
                                             * bm25_doc_weight_with_norm(d.frequency(), addend)
@@ -2773,12 +2905,48 @@ impl<'a, S: Scorer, D: WandDocuments> Wand<'a, S, D> {
                                         posting.score(&self.scorer, d.frequency(), doc_length)
                                     }
                                 };
+                                score += contribution;
+                                if needs_canonical_rescore {
+                                    scores_by_query_rank[query_rank] = contribution;
+                                }
                             }
                         }
 
-                        if !rejected && score > self.threshold {
+                        if !rejected {
                             let doc_length = doc_length_cell
                                 .unwrap_or_else(|| self.documents.scoring_num_tokens(doc as u32));
+                            let score = if !needs_canonical_rescore {
+                                // `collect_window_scores` visited every
+                                // essential clause in query order, so the
+                                // accumulator already contains the canonical
+                                // f32 fold. Avoid rescoring exhaustive hits.
+                                score
+                            } else {
+                                for (i, clause) in clauses.iter().enumerate().skip(first_essential)
+                                {
+                                    let freq = acc.clause_freq(i, slot);
+                                    if freq == 0 {
+                                        continue;
+                                    }
+                                    let contribution = match norm_addend {
+                                        Some(addend) => {
+                                            clause.posting.query_weight
+                                                * bm25_doc_weight_with_norm(freq, addend)
+                                        }
+                                        None => {
+                                            clause.posting.score(&self.scorer, freq, doc_length)
+                                        }
+                                    };
+                                    scores_by_query_rank[clause.query_rank] = contribution;
+                                }
+                                scores_by_query_rank
+                                    .iter()
+                                    .fold(0.0_f32, |sum, contribution| sum + contribution)
+                            };
+                            if score <= self.threshold {
+                                acc.clear_slot(slot);
+                                continue;
+                            }
                             if candidates.insert(
                                 ScoredDoc::new(document_key, score),
                                 doc_length,
@@ -2820,15 +2988,35 @@ impl<'a, S: Scorer, D: WandDocuments> Wand<'a, S, D> {
         candidates.into_candidates(|key| self.documents.candidate_from_key(key))
     }
 
-    // calculate the score of the current document
-    fn score(&self, doc_length: u32) -> f32 {
-        let mut score = 0.0;
-        for posting in &self.lead {
-            if let Some(doc) = posting.doc() {
-                score += posting.score(&self.scorer, doc.frequency(), doc_length);
-            }
+    /// Calculate the current document's score in query order.
+    ///
+    /// WAND deliberately reorders postings by doc id, cost, and score bound.
+    /// Floating-point addition is not associative, so that execution order
+    /// must not leak into the public score or top-k tie boundary.
+    fn score_in_query_order(&self, doc_length: u32) -> f32 {
+        if self.lead.windows(2).all(|window| {
+            (window[0].position, window[0].token_id) <= (window[1].position, window[1].token_id)
+        }) {
+            return self.lead.iter().fold(0.0_f32, |score, posting| {
+                score
+                    + posting.doc().map_or(0.0, |doc| {
+                        posting.score(&self.scorer, doc.frequency(), doc_length)
+                    })
+            });
         }
-        score
+        let contributions = self
+            .lead
+            .iter()
+            .filter_map(|posting| {
+                posting.doc().map(|doc| {
+                    (
+                        (posting.position, posting.token_id),
+                        posting.score(&self.scorer, doc.frequency(), doc_length),
+                    )
+                })
+            })
+            .collect::<SmallVec<[ScoreContribution; 8]>>();
+        score_contributions_in_query_order(contributions)
     }
 
     // iterate over all the preceding terms and collect the term index and frequency
@@ -2858,10 +3046,15 @@ impl<'a, S: Scorer, D: WandDocuments> Wand<'a, S, D> {
 
         let remaining_upper_bound = remaining
             .iter()
-            .map(|posting| posting.block_max_score(&self.scorer))
-            .sum::<f32>();
-        first.score(&self.scorer, doc.frequency(), doc_length) + remaining_upper_bound
-            <= self.threshold
+            .map(|posting| f64::from(posting.block_max_score(&self.scorer)))
+            .sum::<f64>();
+        score_sum_cannot_compete(
+            first.score(&self.scorer, doc.frequency(), doc_length),
+            remaining_upper_bound,
+            self.threshold,
+            score_sum_upper_bound_factor(self.num_terms),
+            self.floor_mode,
+        )
     }
 
     // find the next doc candidate
@@ -2895,7 +3088,11 @@ impl<'a, S: Scorer, D: WandDocuments> Wand<'a, S, D> {
 
             // Block-Max WAND pruning: skip the whole window when its score upper
             // bound cannot reach the top-k threshold.
-            if self.threshold > 0.0 && self.or_block_window_max() <= self.threshold {
+            if self.threshold > 0.0
+                && self
+                    .floor_mode
+                    .rejects_upper_bound(f64::from(self.or_block_window_max()), self.threshold)
+            {
                 // On the final block `up_to` is the `u64::MAX` sentinel; step once
                 // there to avoid seeking past the valid doc id range.
                 let mut skip_to = match self.up_to {
@@ -2927,13 +3124,20 @@ impl<'a, S: Scorer, D: WandDocuments> Wand<'a, S, D> {
                 }
             }
 
-            while lead_score <= self.threshold {
-                if lead_score + self.tail_max_score <= self.threshold {
+            while !self.floor_mode.accepts_score(lead_score, self.threshold) {
+                if score_sum_cannot_compete(
+                    lead_score,
+                    self.tail_upper_bound_sum(),
+                    self.threshold,
+                    score_sum_upper_bound_factor(self.num_terms),
+                    self.floor_mode,
+                ) {
                     self.push_back_leads(first_doc.doc_id() + 1);
                     break;
                 }
                 if !self.advance_tail_top(target, doc_length, &mut lead_score) {
-                    self.push_back_leads(first_doc.doc_id() + 1);
+                    // Dynamic heap-order accumulation may be below the query-
+                    // order score. Let the final canonical scorer decide.
                     break;
                 }
             }
@@ -3037,6 +3241,11 @@ impl<'a, S: Scorer, D: WandDocuments> Wand<'a, S, D> {
         }
         let num_lists = self.lead.len();
         let phrase_slop = params.phrase_slop;
+        let mut score_order = (0..num_lists).collect::<Vec<_>>();
+        score_order.sort_unstable_by_key(|&index| {
+            let posting = &self.lead[index];
+            (posting.position, posting.token_id)
+        });
 
         // Per-window view of one clause's current block. Raw pointers into the
         // clause's `CompressedState`; valid for the whole window because the
@@ -3072,25 +3281,20 @@ impl<'a, S: Scorer, D: WandDocuments> Wand<'a, S, D> {
                 $(#[$feat])?
                 unsafe fn $name2(
                     wins: &[WindowList],
-                    lut: &[f32; FREQ_LUT_BUCKETS],
-                    others_block_max: f32,
-                    threshold: f32,
+                    freq_cannot_beat: &[bool; FREQ_LUT_BUCKETS],
                     docs_out: &mut Vec<u32>,
                     offs_out: &mut Vec<u8>,
                 ) {
                     let (d0, mut p0, e0) = (wins[0].docs, wins[0].pos, wins[0].end);
                     let (d1, mut p1, e1) = (wins[1].docs, wins[1].pos, wins[1].end);
                     let f0 = wins[0].freqs;
-                    let prune = threshold > f32::NEG_INFINITY;
                     unsafe {
                         while p0 < e0 {
                             let doc = *d0.add(p0);
-                            if prune {
-                                let freq = (*f0.add(p0) as usize).min(FREQ_LUT_BUCKETS - 1);
-                                if lut[freq] + others_block_max <= threshold {
-                                    p0 += 1;
-                                    continue;
-                                }
+                            let freq = (*f0.add(p0) as usize).min(FREQ_LUT_BUCKETS - 1);
+                            if freq_cannot_beat[freq] {
+                                p0 += 1;
+                                continue;
                             }
                             p1 = $geq(d1, p1, e1, doc);
                             if p1 >= e1 {
@@ -3112,9 +3316,7 @@ impl<'a, S: Scorer, D: WandDocuments> Wand<'a, S, D> {
                 $(#[$feat])?
                 unsafe fn $name3(
                     wins: &[WindowList],
-                    lut: &[f32; FREQ_LUT_BUCKETS],
-                    others_block_max: f32,
-                    threshold: f32,
+                    freq_cannot_beat: &[bool; FREQ_LUT_BUCKETS],
                     docs_out: &mut Vec<u32>,
                     offs_out: &mut Vec<u8>,
                 ) {
@@ -3122,16 +3324,13 @@ impl<'a, S: Scorer, D: WandDocuments> Wand<'a, S, D> {
                     let (d1, mut p1, e1) = (wins[1].docs, wins[1].pos, wins[1].end);
                     let (d2, mut p2, e2) = (wins[2].docs, wins[2].pos, wins[2].end);
                     let f0 = wins[0].freqs;
-                    let prune = threshold > f32::NEG_INFINITY;
                     unsafe {
                         'outer: while p0 < e0 {
                             let doc = *d0.add(p0);
-                            if prune {
-                                let freq = (*f0.add(p0) as usize).min(FREQ_LUT_BUCKETS - 1);
-                                if lut[freq] + others_block_max <= threshold {
-                                    p0 += 1;
-                                    continue 'outer;
-                                }
+                            let freq = (*f0.add(p0) as usize).min(FREQ_LUT_BUCKETS - 1);
+                            if freq_cannot_beat[freq] {
+                                p0 += 1;
+                                continue 'outer;
                             }
                             p1 = $geq(d1, p1, e1, doc);
                             if p1 >= e1 {
@@ -3183,25 +3382,20 @@ impl<'a, S: Scorer, D: WandDocuments> Wand<'a, S, D> {
         #[allow(clippy::too_many_arguments)]
         fn merge_window_n(
             wins: &[WindowList],
-            lut: &[f32; FREQ_LUT_BUCKETS],
-            others_block_max: f32,
-            threshold: f32,
+            freq_cannot_beat: &[bool; FREQ_LUT_BUCKETS],
             cursors: &mut Vec<usize>,
             docs_out: &mut Vec<u32>,
             offs_out: &mut Vec<u8>,
         ) {
-            let prune = threshold > f32::NEG_INFINITY;
             cursors.clear();
             cursors.extend(wins.iter().map(|win| win.pos));
             'outer: while cursors[0] < wins[0].end {
                 let doc = unsafe { *wins[0].docs.add(cursors[0]) };
-                if prune {
-                    let freq = unsafe { *wins[0].freqs.add(cursors[0]) as usize }
-                        .min(FREQ_LUT_BUCKETS - 1);
-                    if lut[freq] + others_block_max <= threshold {
-                        cursors[0] += 1;
-                        continue 'outer;
-                    }
+                let freq =
+                    unsafe { *wins[0].freqs.add(cursors[0]) as usize }.min(FREQ_LUT_BUCKETS - 1);
+                if freq_cannot_beat[freq] {
+                    cursors[0] += 1;
+                    continue 'outer;
                 }
                 for j in 1..wins.len() {
                     let win = &wins[j];
@@ -3359,19 +3553,28 @@ impl<'a, S: Scorer, D: WandDocuments> Wand<'a, S, D> {
                 // Constant within the window (block-anchored); mirrors
                 // `and_candidate_cannot_beat_threshold`'s remaining-clause
                 // bound of first-clause-exact + rest-block-max.
-                let others_block_max: f32 = self.lead[1..]
+                let others_block_max = self.lead[1..]
                     .iter()
-                    .map(|posting| posting.block_max_score(&self.scorer))
-                    .sum();
+                    .map(|posting| f64::from(posting.block_max_score(&self.scorer)))
+                    .sum::<f64>();
 
                 batch_docs.clear();
                 batch_offs.clear();
-                // NEG_INFINITY disables the kernel-level freq-bound prune
-                // (single clause, or no threshold yet).
-                let kernel_threshold = if self.threshold > 0.0 && num_lists >= 2 {
-                    self.threshold
+                // Precompute the conservative decision once per frequency
+                // bucket so the scalar and SIMD merge kernels stay
+                // floating-point-free.
+                let freq_cannot_beat = if self.threshold > 0.0 && num_lists >= 2 {
+                    std::array::from_fn(|frequency| {
+                        score_sum_cannot_compete(
+                            freq_bound_lut[frequency],
+                            others_block_max,
+                            self.threshold,
+                            score_sum_upper_bound_factor(num_lists),
+                            CompetitiveFloorMode::Exclusive,
+                        )
+                    })
                 } else {
-                    f32::NEG_INFINITY
+                    [false; FREQ_LUT_BUCKETS]
                 };
                 #[cfg(target_arch = "x86_64")]
                 let use_avx2 = *HAS_AVX2;
@@ -3383,9 +3586,7 @@ impl<'a, S: Scorer, D: WandDocuments> Wand<'a, S, D> {
                     (2, true) => unsafe {
                         merge_window_2_avx2(
                             &wins,
-                            &freq_bound_lut,
-                            others_block_max,
-                            kernel_threshold,
+                            &freq_cannot_beat,
                             &mut batch_docs,
                             &mut batch_offs,
                         )
@@ -3394,38 +3595,20 @@ impl<'a, S: Scorer, D: WandDocuments> Wand<'a, S, D> {
                     (3, true) => unsafe {
                         merge_window_3_avx2(
                             &wins,
-                            &freq_bound_lut,
-                            others_block_max,
-                            kernel_threshold,
+                            &freq_cannot_beat,
                             &mut batch_docs,
                             &mut batch_offs,
                         )
                     },
                     (2, _) => unsafe {
-                        merge_window_2(
-                            &wins,
-                            &freq_bound_lut,
-                            others_block_max,
-                            kernel_threshold,
-                            &mut batch_docs,
-                            &mut batch_offs,
-                        )
+                        merge_window_2(&wins, &freq_cannot_beat, &mut batch_docs, &mut batch_offs)
                     },
                     (3, _) => unsafe {
-                        merge_window_3(
-                            &wins,
-                            &freq_bound_lut,
-                            others_block_max,
-                            kernel_threshold,
-                            &mut batch_docs,
-                            &mut batch_offs,
-                        )
+                        merge_window_3(&wins, &freq_cannot_beat, &mut batch_docs, &mut batch_offs)
                     },
                     _ => merge_window_n(
                         &wins,
-                        &freq_bound_lut,
-                        others_block_max,
-                        kernel_threshold,
+                        &freq_cannot_beat,
                         &mut cursor_scratch,
                         &mut batch_docs,
                         &mut batch_offs,
@@ -3478,7 +3661,13 @@ impl<'a, S: Scorer, D: WandDocuments> Wand<'a, S, D> {
                             }
                             None => self.lead[0].score(&self.scorer, first_freq, doc_length),
                         };
-                        if first_score + others_block_max <= self.threshold {
+                        if score_sum_cannot_compete(
+                            first_score,
+                            others_block_max,
+                            self.threshold,
+                            score_sum_upper_bound_factor(num_lists),
+                            CompetitiveFloorMode::Exclusive,
+                        ) {
                             self.and_candidates_pruned_before_return += 1;
                             continue;
                         }
@@ -3516,9 +3705,11 @@ impl<'a, S: Scorer, D: WandDocuments> Wand<'a, S, D> {
                     }
                     stats.full_scores += 1;
 
-                    let mut score = 0.0f32;
-                    for ((win, posting), &off) in wins.iter().zip(self.lead.iter()).zip(offs.iter())
-                    {
+                    let mut score = 0.0_f32;
+                    for &clause_index in &score_order {
+                        let win = &wins[clause_index];
+                        let posting = &self.lead[clause_index];
+                        let off = offs[clause_index];
                         let freq = unsafe { *win.freqs.add(off as usize) };
                         score += match norm_addend {
                             Some(addend) => {
@@ -3597,11 +3788,11 @@ impl<'a, S: Scorer, D: WandDocuments> Wand<'a, S, D> {
             .map(|posting| Self::posting_block_up_to(posting, target))
             .min()
             .unwrap_or(TERMINATED_DOC_ID);
-        let narrow_max_score = self
-            .lead
-            .iter()
-            .map(|posting| posting.block_max_score(&self.scorer))
-            .sum::<f32>();
+        let narrow_max_score = conservative_score_sum(
+            self.lead
+                .iter()
+                .map(|posting| posting.block_max_score(&self.scorer)),
+        );
 
         if narrow_max_score >= self.threshold {
             self.up_to = Some(narrow_up_to);
@@ -3620,13 +3811,14 @@ impl<'a, S: Scorer, D: WandDocuments> Wand<'a, S, D> {
             && self.lead.iter().all(|posting| posting.is_compressed());
 
         if can_try_wide {
-            let mut wide_max_score = 0.0;
+            let mut wide_bounds = SmallVec::<[f32; 8]>::new();
             let mut range_blocks_scanned = 0;
             for posting in &mut self.lead {
                 let block_max = posting.block_max_score_up_to_with_stats(lead_up_to, &self.scorer);
-                wide_max_score += block_max.score;
+                wide_bounds.push(block_max.score);
                 range_blocks_scanned += block_max.blocks_scanned;
             }
+            let wide_max_score = conservative_score_sum(wide_bounds.into_iter());
             self.and_window_stats.range_blocks_scanned += range_blocks_scanned;
 
             if wide_max_score < self.threshold {
@@ -3711,19 +3903,19 @@ impl<'a, S: Scorer, D: WandDocuments> Wand<'a, S, D> {
     /// Upper bound on the score of any document in the window `[target, up_to]`
     /// for a disjunction. Sums the block-max of every overlapping iterator:
     /// `lead`, `head` (later docs still in the window, which
-    /// `can_target_beat_threshold` omits), and the tail via `tail_max_score`.
+    /// `can_target_beat_threshold` omits), and the individual tail bounds.
     fn or_block_window_max(&self) -> f32 {
-        let lead: f32 = self
-            .lead
-            .iter()
-            .map(|posting| posting.window_max_score(self.up_to, &self.scorer))
-            .sum();
-        let head: f32 = self
-            .head
-            .iter()
-            .map(|posting| posting.posting.window_max_score(self.up_to, &self.scorer))
-            .sum();
-        lead + head + self.tail_max_score
+        conservative_score_sum(
+            self.lead
+                .iter()
+                .map(|posting| posting.window_max_score(self.up_to, &self.scorer))
+                .chain(
+                    self.head
+                        .iter()
+                        .map(|posting| posting.posting.window_max_score(self.up_to, &self.scorer)),
+                )
+                .chain(self.tail.iter().map(|posting| posting.upper_bound)),
+        )
     }
 
     fn can_target_beat_threshold(&mut self, target: u64) -> bool {
@@ -3731,22 +3923,39 @@ impl<'a, S: Scorer, D: WandDocuments> Wand<'a, S, D> {
             self.update_max_scores(target);
         }
 
-        let mut sum = self
-            .lead
-            .iter()
-            .map(|posting| posting.window_max_score(self.up_to, &self.scorer))
-            .sum::<f32>();
         let mut possible_matches = self.lead.len();
         for posting in &self.tail {
             if matches!(posting.posting.block_first_doc(), Some(block_doc) if block_doc <= target) {
-                sum += posting.posting.window_max_score(self.up_to, &self.scorer);
                 possible_matches += 1;
             }
         }
+        let sum = conservative_score_sum(
+            self.lead
+                .iter()
+                .map(|posting| posting.window_max_score(self.up_to, &self.scorer))
+                .chain(
+                    self.tail
+                        .iter()
+                        .filter(|posting| {
+                            matches!(
+                                posting.posting.block_first_doc(),
+                                Some(block_doc) if block_doc <= target
+                            )
+                        })
+                        .map(|posting| posting.posting.window_max_score(self.up_to, &self.scorer)),
+                ),
+        );
 
         match self.operator {
-            Operator::And => possible_matches >= self.num_terms && sum > self.threshold,
-            Operator::Or => sum > self.threshold,
+            Operator::And => {
+                possible_matches >= self.num_terms
+                    && !self
+                        .floor_mode
+                        .rejects_upper_bound(f64::from(sum), self.threshold)
+            }
+            Operator::Or => !self
+                .floor_mode
+                .rejects_upper_bound(f64::from(sum), self.threshold),
         }
     }
 
@@ -3843,29 +4052,29 @@ impl<'a, S: Scorer, D: WandDocuments> Wand<'a, S, D> {
 
         // Second pass over the memoized bounds: sum only the iterators that
         // can produce a doc inside the skipped range.
-        let mut bounds_sum = 0.0_f32;
+        let mut bounds = SmallVec::<[f32; 8]>::new();
         for posting in &self.lead {
-            let (_, score) = posting.impact_group_bound(&self.scorer)?;
-            bounds_sum += score;
+            bounds.push(posting.impact_group_bound(&self.scorer)?.1);
         }
-        for posting in self.head.iter() {
-            if posting.doc_id() > group_up_to {
-                continue;
-            }
-            let (_, score) = posting.posting.impact_group_bound(&self.scorer)?;
-            bounds_sum += score;
+        for posting in self
+            .head
+            .iter()
+            .filter(|posting| posting.doc_id() <= group_up_to)
+        {
+            bounds.push(posting.posting.impact_group_bound(&self.scorer)?.1);
         }
-        for tail_posting in self.tail.iter() {
-            if !matches!(
+        for tail_posting in self.tail.iter().filter(|tail_posting| {
+            matches!(
                 tail_posting.posting.block_first_doc(),
                 Some(block_doc) if block_doc <= group_up_to
-            ) {
-                continue;
-            }
-            let (_, score) = tail_posting.posting.impact_group_bound(&self.scorer)?;
-            bounds_sum += score;
+            )
+        }) {
+            bounds.push(tail_posting.posting.impact_group_bound(&self.scorer)?.1);
         }
-        (bounds_sum <= self.threshold).then_some(group_up_to.saturating_add(1))
+        let bounds_sum = conservative_score_sum(bounds.into_iter());
+        self.floor_mode
+            .rejects_upper_bound(f64::from(bounds_sum), self.threshold)
+            .then_some(group_up_to.saturating_add(1))
     }
 
     fn refine_or_candidate(&mut self, target: u64, doc_length: u32) -> bool {
@@ -3883,12 +4092,21 @@ impl<'a, S: Scorer, D: WandDocuments> Wand<'a, S, D> {
             })
             .sum::<f32>();
 
-        while lead_score <= self.threshold {
-            if lead_score + self.tail_max_score <= self.threshold {
+        while !self.floor_mode.accepts_score(lead_score, self.threshold) {
+            if score_sum_cannot_compete(
+                lead_score,
+                self.tail_upper_bound_sum(),
+                self.threshold,
+                score_sum_upper_bound_factor(self.num_terms),
+                self.floor_mode,
+            ) {
                 return false;
             }
             if !self.advance_tail_top(target, doc_length, &mut lead_score) {
-                return false;
+                // No remaining posting can be advanced, but f32 execution-
+                // order rounding may still leave the canonical score at or
+                // above the inclusive floor.
+                return true;
             }
         }
 
@@ -3947,7 +4165,7 @@ impl<'a, S: Scorer, D: WandDocuments> Wand<'a, S, D> {
     }
 
     fn insert_tail(&mut self, posting: Box<PostingIterator>, upper_bound: f32) {
-        self.tail_max_score += upper_bound;
+        self.tail_max_score = next_up_f64(self.tail_max_score + f64::from(upper_bound));
         self.tail
             .push(TailPosting::new(upper_bound, posting.cost(), posting));
     }
@@ -3964,7 +4182,14 @@ impl<'a, S: Scorer, D: WandDocuments> Wand<'a, S, D> {
             return Some(posting);
         }
 
-        if self.tail_max_score + upper_bound < self.threshold {
+        let parked_upper_bound = self.tail_upper_bound_sum() + f64::from(upper_bound);
+        if score_sum_cannot_compete(
+            0.0,
+            parked_upper_bound,
+            self.threshold,
+            score_sum_upper_bound_factor(self.num_terms),
+            self.floor_mode,
+        ) {
             self.insert_tail(posting, upper_bound);
             return None;
         }
@@ -3978,7 +4203,8 @@ impl<'a, S: Scorer, D: WandDocuments> Wand<'a, S, D> {
             && top > &candidate
         {
             let evicted = self.tail.pop().expect("peeked tail posting should exist");
-            self.tail_max_score = self.tail_max_score - evicted.upper_bound + upper_bound;
+            self.remove_tail_upper_bound(evicted.upper_bound);
+            self.tail_max_score = next_up_f64(self.tail_max_score + f64::from(upper_bound));
             self.tail.push(candidate);
             return Some(evicted.posting);
         }
@@ -4057,7 +4283,7 @@ impl<'a, S: Scorer, D: WandDocuments> Wand<'a, S, D> {
         else {
             return false;
         };
-        self.tail_max_score -= upper_bound;
+        self.remove_tail_upper_bound(upper_bound);
         posting.next(target);
         match posting.doc() {
             Some(doc) if doc.doc_id() == target => {
@@ -4068,6 +4294,20 @@ impl<'a, S: Scorer, D: WandDocuments> Wand<'a, S, D> {
             None => {}
         }
         true
+    }
+
+    #[inline]
+    fn tail_upper_bound_sum(&self) -> f64 {
+        self.tail_max_score
+    }
+
+    #[inline]
+    fn remove_tail_upper_bound(&mut self, upper_bound: f32) {
+        if self.tail.is_empty() {
+            self.tail_max_score = 0.0;
+            return;
+        }
+        self.tail_max_score = next_up_f64((self.tail_max_score - f64::from(upper_bound)).max(0.0));
     }
 
     fn advance_all_tail(
@@ -4402,7 +4642,8 @@ impl<'a, D: WandDocuments> WandCursor<'a, D> {
         }
         .unwrap_or_default();
         Self {
-            wand: Wand::new(operator, postings.into_iter(), documents, scorer),
+            wand: Wand::new(operator, postings.into_iter(), documents, scorer)
+                .with_floor_mode(CompetitiveFloorMode::Inclusive),
             phrase_slop: params.phrase_slop,
             wand_factor: params.wand_factor,
             cost,
@@ -4443,7 +4684,7 @@ impl<'a, D: WandDocuments> WandCursor<'a, D> {
 
     fn position_next(&mut self) -> Result<Option<u64>> {
         loop {
-            let Some((doc, mut score)) = self.wand.next()? else {
+            let Some((doc, _)) = self.wand.next()? else {
                 self.clear_current();
                 self.record_metrics();
                 return Ok(None);
@@ -4457,13 +4698,8 @@ impl<'a, D: WandDocuments> WandCursor<'a, D> {
                 continue;
             };
             let doc_length = self.wand.documents.doc_length(&doc);
-            if self.wand.operator == Operator::Or {
-                self.wand
-                    .advance_all_tail(doc_id, Some(doc_length), Some(&mut score));
-            } else {
-                self.wand.advance_all_tail(doc_id, None, None);
-                score = self.wand.score(doc_length);
-            }
+            self.wand.advance_all_tail(doc_id, None, None);
+            let score = self.wand.score_in_query_order(doc_length);
             self.current_doc = Some(doc);
             self.current_document_key = Some(document_key);
             self.current_score = score;
@@ -4551,9 +4787,9 @@ impl<'a, D: WandDocuments> WandCursor<'a, D> {
                 "minimum competitive FTS score cannot be NaN",
             ));
         }
-        let threshold = next_down_f32(min_score) * self.wand_factor;
-        if threshold > self.wand.threshold {
-            self.wand.threshold = threshold;
+        let floor = min_score * self.wand_factor;
+        if floor > self.wand.threshold {
+            self.wand.threshold = floor;
         }
         Ok(())
     }
@@ -4700,18 +4936,19 @@ fn next_up_f32(value: f32) -> f32 {
     }
 }
 
-fn next_down_f32(value: f32) -> f32 {
+#[inline]
+fn next_up_f64(value: f64) -> f64 {
     if !value.is_finite() {
         return value;
     }
     if value == 0.0 {
-        return f32::from_bits((1_u32 << 31) | 1);
+        return f64::from_bits(1);
     }
     let bits = value.to_bits();
     if value > 0.0 {
-        f32::from_bits(bits - 1)
+        f64::from_bits(bits + 1)
     } else {
-        f32::from_bits(bits + 1)
+        f64::from_bits(bits - 1)
     }
 }
 
@@ -4816,11 +5053,12 @@ mod tests {
         assert!(actual_score > threshold);
 
         let prefix_bound = remaining_bounds.into_iter().map(f64::from).sum::<f64>();
-        assert!(!score_sum_cannot_exceed(
+        assert!(!score_sum_cannot_compete(
             essential_score,
             prefix_bound,
             threshold,
             score_sum_upper_bound_factor(3),
+            CompetitiveFloorMode::Exclusive,
         ));
     }
 
@@ -4834,6 +5072,256 @@ mod tests {
         fn doc_weight(&self, freq: u32, _doc_tokens: u32) -> f32 {
             freq as f32
         }
+    }
+
+    struct AdjacentScoreScorer;
+
+    impl Scorer for AdjacentScoreScorer {
+        fn query_weight(&self, _token: &str) -> f32 {
+            1.0
+        }
+
+        fn doc_weight(&self, freq: u32, _doc_tokens: u32) -> f32 {
+            match freq {
+                1 => f32::from_bits(1.0_f32.to_bits() - 1),
+                2 => 1.0,
+                _ => unreachable!("test only defines two score buckets"),
+            }
+        }
+    }
+
+    #[test]
+    fn inclusive_floor_keeps_tie_without_admitting_lower_ulp() {
+        let posting = PostingIterator::with_query_weight(
+            "term".to_owned(),
+            0,
+            0,
+            1.0,
+            generate_posting_list_with_freqs(vec![0, 1], vec![1, 2], 1.0, None, false),
+            2,
+        );
+        let mut docs = DocSet::default();
+        docs.append(0, 1);
+        docs.append(1, 1);
+        let mut wand = Wand::new(
+            Operator::Or,
+            std::iter::once(posting),
+            &docs,
+            AdjacentScoreScorer,
+        )
+        .with_floor_mode(CompetitiveFloorMode::Inclusive);
+        wand.update_threshold(1.0, 1.0);
+
+        let (doc, score) = wand.next().unwrap().unwrap();
+        assert_eq!(doc.doc_id(), 1);
+        assert_eq!(score, 1.0);
+    }
+
+    #[test]
+    fn final_score_uses_query_order_and_keeps_floor_ties() {
+        let contributions = [0.002_972_301_6_f32, 0.001_982_450_7_f32, 0.001_882_293_f32];
+        // Bounds deliberately make the WAND heap visit positions 2, 0, 1.
+        let bounds = [2.0_f32, 1.0, 3.0];
+        let postings = || {
+            contributions
+                .into_iter()
+                .zip(bounds)
+                .enumerate()
+                .map(|(position, (query_weight, max_score))| {
+                    PostingIterator::with_query_weight(
+                        format!("t{position}"),
+                        position as u32,
+                        position as u32,
+                        query_weight,
+                        generate_posting_list(vec![0], max_score, None, false),
+                        1,
+                    )
+                })
+                .collect::<Vec<_>>()
+        };
+        let mut docs = DocSet::default();
+        docs.append(0, 1);
+        let mut wand = Wand::new(Operator::Or, postings().into_iter(), &docs, UnitScorer);
+
+        let (_, heap_order_score) = wand.next().unwrap().unwrap();
+        let query_order_score = contributions
+            .into_iter()
+            .fold(0.0_f32, |score, contribution| score + contribution);
+        let wide_score = contributions
+            .into_iter()
+            .fold(0.0_f64, |score, contribution| {
+                score + f64::from(contribution)
+            }) as f32;
+
+        assert_eq!(query_order_score.to_bits(), 0x3be0_094c);
+        assert_eq!(wide_score.to_bits(), 0x3be0_094b);
+        assert_eq!(heap_order_score.to_bits(), 0x3be0_094a);
+        assert_eq!(wand.score_in_query_order(1), query_order_score);
+
+        let params = FtsSearchParams::default();
+        let metrics = NoOpMetricsCollector;
+        let mut cursor = WandCursor::new(
+            Operator::Or,
+            postings(),
+            &docs,
+            Arc::new(MemBM25Scorer::new(1, 1, std::collections::HashMap::new())),
+            &params,
+            &metrics,
+        );
+        // Equal-score candidates remain competitive because row id is the
+        // final tie-breaker. The internal heap-order sum is slightly lower.
+        cursor.set_min_competitive_score(query_order_score).unwrap();
+        assert_eq!(cursor.next().unwrap(), Some(0));
+        assert_eq!(cursor.current_score().unwrap(), query_order_score);
+    }
+
+    #[rstest]
+    #[case::initial_floor(false)]
+    #[case::explicit_zero_floor(true)]
+    fn wand_cursor_preserves_zero_score_membership(#[case] set_zero_floor: bool) {
+        let posting = PostingIterator::with_query_weight(
+            "common".to_owned(),
+            0,
+            0,
+            0.0,
+            generate_posting_list(vec![0], 0.0, None, false),
+            1,
+        );
+        let mut docs = DocSet::default();
+        docs.append(0, 1);
+        let params = FtsSearchParams::default();
+        let metrics = NoOpMetricsCollector;
+        let mut cursor = WandCursor::new(
+            Operator::Or,
+            vec![posting],
+            &docs,
+            Arc::new(MemBM25Scorer::new(1, 1, std::collections::HashMap::new())),
+            &params,
+            &metrics,
+        );
+        if set_zero_floor {
+            cursor.set_min_competitive_score(0.0).unwrap();
+        }
+
+        assert_eq!(cursor.next().unwrap(), Some(0));
+        assert_eq!(cursor.current_score().unwrap(), 0.0);
+    }
+
+    #[rstest]
+    #[case::all_essential(false)]
+    #[case::single_essential(true)]
+    fn maxscore_publishes_query_order_score_bits(#[case] single_essential: bool) {
+        let contributions = [0.002_972_301_6_f32, 0.001_982_450_7_f32, 0.001_882_293_f32];
+        // Each bound covers its term's exact contribution. Sorted by bound,
+        // the two smallest fit below a floor just under the exact score while
+        // all three do not, which forces the single-essential MAXSCORE path.
+        let bounds = [0.002_99_f32, 0.001_99_f32, 0.003_f32];
+        let postings = contributions
+            .into_iter()
+            .zip(bounds)
+            .enumerate()
+            .map(|(position, (query_weight, max_score))| {
+                PostingIterator::with_query_weight(
+                    format!("t{position}"),
+                    position as u32,
+                    position as u32,
+                    query_weight,
+                    generate_posting_list(vec![0], max_score, None, true),
+                    1,
+                )
+            })
+            .collect::<Vec<_>>();
+        let mut docs = DocSet::default();
+        docs.append(0, 1);
+        let shared_floor = Arc::new(AtomicU32::new(0.0_f32.to_bits()));
+        let scored = Arc::new(AtomicUsize::new(0));
+        let mut wand = Wand::new(
+            Operator::Or,
+            postings.into_iter(),
+            &docs,
+            CountingScorer {
+                scored: scored.clone(),
+            },
+        )
+        .with_shared_threshold(shared_floor.clone());
+        let query_order_score = contributions
+            .into_iter()
+            .fold(0.0_f32, |score, contribution| score + contribution);
+        if single_essential {
+            wand.threshold = f32::from_bits(query_order_score.to_bits() - 1);
+        }
+
+        let hits = wand
+            .maxscore_search(
+                &FtsSearchParams::default().with_limit(Some(1)),
+                &NoOpMetricsCollector,
+            )
+            .unwrap();
+
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].document, 0);
+        assert_eq!(shared_floor.load(Ordering::Relaxed), 0x3be0_094c);
+        assert_eq!(scored.load(Ordering::Relaxed), contributions.len());
+        assert_eq!(wand.maxscore_single_essential_windows > 0, single_essential);
+        assert_eq!(wand.maxscore_general_windows > 0, !single_essential);
+    }
+
+    #[test]
+    fn bulk_and_and_classic_publish_identical_query_order_score_bits() {
+        let contributions = [0.002_972_301_6_f32, 0.001_982_450_7_f32, 0.001_882_293_f32];
+        let bounds = [0.002_99_f32, 0.001_99_f32, 0.003_f32];
+        // Different posting lengths force cost order 1, 2, 0 instead of query
+        // order 0, 1, 2.
+        let clause_docs = [vec![0, 1, 2], vec![0], vec![0, 1]];
+        let mut docs = DocSet::default();
+        for doc_id in 0..3 {
+            docs.append(doc_id, 1);
+        }
+
+        let run = |mode| {
+            let postings = contributions
+                .into_iter()
+                .zip(bounds)
+                .zip(clause_docs.iter())
+                .enumerate()
+                .map(|(position, ((query_weight, max_score), doc_ids))| {
+                    PostingIterator::with_query_weight(
+                        format!("t{position}"),
+                        position as u32,
+                        position as u32,
+                        query_weight,
+                        generate_posting_list(doc_ids.clone(), max_score, None, true),
+                        docs.len(),
+                    )
+                })
+                .collect::<Vec<_>>();
+            let shared_floor = Arc::new(AtomicU32::new(0.0_f32.to_bits()));
+            let mut wand = Wand::new(Operator::And, postings.into_iter(), &docs, UnitScorer)
+                .with_bulk_and_mode(mode)
+                .with_shared_threshold(shared_floor.clone());
+            let hits = wand
+                .search(
+                    &FtsSearchParams::default().with_limit(Some(1)),
+                    &NoOpMetricsCollector,
+                )
+                .unwrap();
+            (
+                hits,
+                shared_floor.load(Ordering::Relaxed),
+                wand.bulk_and_searches > 0,
+            )
+        };
+
+        let (bulk, bulk_score, bulk_used) = run(BulkAndMode::On);
+        let (classic, classic_score, classic_used) = run(BulkAndMode::Off);
+        assert!(bulk_used);
+        assert!(!classic_used);
+        assert_eq!(bulk.len(), 1);
+        assert_eq!(classic.len(), 1);
+        assert_eq!(bulk[0].document, 0);
+        assert_eq!(classic[0].document, 0);
+        assert_eq!(bulk_score, 0x3be0_094c);
+        assert_eq!(classic_score, bulk_score);
     }
 
     struct PartialNormScorer;
@@ -6707,7 +7195,7 @@ mod tests {
             None,
         ));
         let posting = PostingIterator::new(String::from("term"), 0, 0, posting_list, doc_ids.len());
-        let expected_bound = K1 + 1.0;
+        let expected_bound = BM25_DOC_WEIGHT_UPPER_BOUND;
 
         assert_eq!(posting.approximate_upper_bound(), expected_bound);
         assert_eq!(posting.global_upper_bound(&scorer), expected_bound);


### PR DESCRIPTION
## Bug Fix

WAND can visit clauses in a different order from the query's canonical scoring order. Comparing that dynamic `f32` sum to the competitive floor before canonical rescoring can drop exact ties. Grouped BM25 and document-weight bounds also need outward rounding, and a zero competitive floor must not erase zero-score membership.

This PR:

- preserves query-order `f32` scoring for final results across classic WAND, MAXSCORE, and bulk AND
- uses conservative widened sums only for pruning bounds
- separates inclusive compound-scoring floors from standalone exclusive top-k floors
- widens BM25 and grouped-posting upper bounds
- preserves zero-score membership in composable WAND cursors
- adds adversarial ULP, tie, zero-score, MAXSCORE, bulk-AND, and grouped-bound regressions

This is the first PR in the OSS-1603 stack and only establishes scorer exactness. It does **not** enable the cross-column planner/executor yet.

## Scope boundary

This stack does not include the previously deferred same-column delayed `MUST_NOT` probing work from OSS-1705. This PR only contains general WAND scoring and bound correctness needed by the cross-column execution path.

## Validation

- `cargo test -p lance-index scalar::inverted::wand::tests` — 93 passed
- `cargo check -p lance-index --tests`
- `cargo clippy -p lance-index --tests -- -D warnings`
- `cargo fmt --all -- --check`

The full workspace CI matrix is left to GitHub CI.

## Stack

1. **This PR:** WAND scoring and bound exactness
2. Posting loading and cache policy
3. Row-address scorer foundations
4. Cross-column compound scorer core
5. Dataset planner / execution integration

Part of [OSS-1603](https://linear.app/lancedb/issue/OSS-1603/add-candidate-driven-execution-for-cross-column-boolean-fts-queries).
