### PR TITLE
fix(fts): chunk posting reads during segment merge

### DIFF
--- a/rust/lance-index/src/scalar/inverted/index/partition.rs
+++ b/rust/lance-index/src/scalar/inverted/index/partition.rs
@@ -824,6 +824,14 @@ impl InvertedPartition {
     }
 
     pub async fn into_builder(self) -> Result<InnerBuilder> {
+        Ok(self.into_builder_chunked(None, None).await?.0)
+    }
+
+    async fn into_builder_chunked(
+        self,
+        chunk_tokens_override: Option<usize>,
+        max_list_children_override: Option<u64>,
+    ) -> Result<(InnerBuilder, usize)> {
         let mut builder = InnerBuilder::new_with_posting_tail_codec_and_block_size(
             self.id,
             self.inverted_list.has_positions(),
@@ -837,17 +845,31 @@ impl InvertedPartition {
         builder
             .posting_lists
             .reserve_exact(self.inverted_list.len());
-        for posting_list in self
+        let chunk_count = self
             .inverted_list
-            .read_all(self.inverted_list.has_positions())
-            .await?
-        {
-            let posting_list = posting_list?;
-            builder
-                .posting_lists
-                .push(posting_list.into_builder(&builder.docs));
-        }
-        Ok(builder)
+            .for_each_posting_list_chunked(
+                self.inverted_list.has_positions(),
+                chunk_tokens_override,
+                max_list_children_override,
+                |posting_list| {
+                    builder
+                        .posting_lists
+                        .push(posting_list.into_builder(&builder.docs));
+                    Ok(())
+                },
+            )
+            .await?;
+        Ok((builder, chunk_count))
+    }
+
+    #[cfg(test)]
+    pub(super) async fn into_builder_with_chunk_limits(
+        self,
+        chunk_tokens: usize,
+        max_list_children: u64,
+    ) -> Result<(InnerBuilder, usize)> {
+        self.into_builder_chunked(Some(chunk_tokens), Some(max_list_children))
+            .await
     }
 }
 

--- a/rust/lance-index/src/scalar/inverted/index/posting_prewarm.rs
+++ b/rust/lance-index/src/scalar/inverted/index/posting_prewarm.rs
@@ -63,10 +63,11 @@ impl PostingListReader {
     /// Build posting lists for one chunk's token range from `chunk_batch`, rebasing
     /// global offsets to chunk-local rows. Returns `(global token_id, PostingList)`
     /// pairs identical to the whole-file path, only bounded to one chunk.
-    fn build_prewarm_posting_lists_chunk(
+    fn build_posting_lists_chunk(
         chunk_batch: RecordBatch,
-        chunk: PrewarmChunk<'_>,
-        ctx: &PrewarmBuildCtx<'_>,
+        chunk: PostingChunk<'_>,
+        ctx: &PostingBuildCtx<'_>,
+        mode: ChunkPostingMode,
     ) -> Result<Vec<(u32, PostingList)>> {
         let mut posting_lists = Vec::with_capacity(chunk.token_count);
         for local in 0..chunk.token_count {
@@ -86,7 +87,14 @@ impl PostingListReader {
                 // V2: one posting row per token; row `local` within the chunk.
                 chunk_batch.slice(local, 1)
             };
-            let row_batch = row_batch.shrink_to_fit()?;
+            let row_batch = match mode {
+                // Cached posting lists outlive the read chunk and should not
+                // retain unrelated token rows through shared Arrow buffers.
+                ChunkPostingMode::Prewarm => row_batch.shrink_to_fit()?,
+                // Merge consumes every posting before advancing to the next
+                // chunk, so retaining the chunk temporarily avoids a deep copy.
+                ChunkPostingMode::Merge => row_batch,
+            };
             let posting_list = Self::posting_list_from_batch_parts(
                 &row_batch,
                 ctx.max_scores.map(|scores| scores[global]),
@@ -166,7 +174,7 @@ impl PostingListReader {
         let token_count = self.len();
         let posting_data_size_bytes = self.posting_data_size_bytes();
         let chunk_tokens = chunk_tokens_override
-            .unwrap_or_else(|| prewarm_chunk_tokens(token_count, posting_data_size_bytes))
+            .unwrap_or_else(|| posting_read_chunk_tokens(token_count, posting_data_size_bytes))
             .max(1);
         let chunk_ranges = prewarm_chunk_ranges(&grouping, token_count, chunk_tokens);
         let chunk_count = chunk_ranges.len();
@@ -195,7 +203,13 @@ impl PostingListReader {
                             "materialized prewarm must initialize posting-list build state",
                         );
                         let posting_lists = self
-                            .build_chunk_postings(tok_start, tok_end, with_position, state)
+                            .build_chunk_postings(
+                                tok_start,
+                                tok_end,
+                                with_position,
+                                state,
+                                ChunkPostingMode::Prewarm,
+                            )
                             .await?;
                         self.publish_chunk_postings(
                             posting_lists,
@@ -255,14 +269,15 @@ impl PostingListReader {
     }
 
     /// Read one token-row chunk and build its posting lists off the runtime thread.
-    /// The large batch is dropped inside the blocking task once built, bounding
-    /// resident memory to one chunk.
+    /// Shared buffers are retained only by that chunk's returned posting lists,
+    /// bounding resident memory to one chunk.
     async fn build_chunk_postings(
         &self,
         tok_start: usize,
         tok_end: usize,
         with_position: bool,
         state: &ChunkBuildState,
+        mode: ChunkPostingMode,
     ) -> Result<Vec<(u32, PostingList)>> {
         let chunk_token_count = tok_end - tok_start;
         let chunk_batch = self
@@ -287,20 +302,20 @@ impl PostingListReader {
         let positions_layout = state.positions_layout;
         let num_docs = self.modern_num_docs;
         let posting_lists = spawn_blocking(move || {
-            let ctx = PrewarmBuildCtx {
+            let ctx = PostingBuildCtx {
                 max_scores: max_scores.as_deref().map(|v| v.as_slice()),
                 lengths: lengths.as_deref().map(|v| v.as_slice()),
                 posting_tail_codec,
                 block_size,
                 positions_layout,
             };
-            let chunk = PrewarmChunk {
+            let chunk = PostingChunk {
                 tok_start,
                 token_count: chunk_token_count,
                 offsets: chunk_offsets.as_deref(),
                 end_row: chunk_end_row,
             };
-            let posting_lists = Self::build_prewarm_posting_lists_chunk(chunk_batch, chunk, &ctx)?;
+            let posting_lists = Self::build_posting_lists_chunk(chunk_batch, chunk, &ctx, mode)?;
             if let Some(num_docs) = num_docs {
                 for (token_id, posting) in &posting_lists {
                     Self::validate_modern_posting(*token_id, posting, num_docs)?;
@@ -311,7 +326,7 @@ impl PostingListReader {
         .await
         .map_err(|err| {
             Error::internal(format!(
-                "Failed to build prewarm posting lists in blocking task: {err}"
+                "Failed to build chunk posting lists in blocking task: {err}"
             ))
         })??;
         for (token_id, _) in &posting_lists {
@@ -481,8 +496,8 @@ impl PostingListReader {
     }
 
     /// Cheap `invert.lance` size estimate (file length from object metadata, no
-    /// data read), used only to size prewarm chunks. Falls back to a row-count
-    /// proxy when the reader can't surface the length (legacy v1).
+    /// data read), used to size bounded posting-list reads. Falls back to a
+    /// row-count proxy when the reader can't surface the length (legacy v1).
     pub(crate) fn posting_data_size_bytes(&self) -> u64 {
         if let Some(size) = self.reader.file_size_bytes() {
             return size;
@@ -493,37 +508,160 @@ impl PostingListReader {
         (self.reader.num_rows() as u64).saturating_mul(ESTIMATED_BYTES_PER_ROW)
     }
 
-    pub(crate) async fn read_batch(&self, with_position: bool) -> Result<RecordBatch> {
-        let columns = self.posting_columns(with_position);
-        let batch = self
-            .reader
-            .read_range(0..self.reader.num_rows(), Some(&columns))
-            .await?;
-        Ok(batch)
-    }
-
-    pub(crate) async fn read_all(
+    /// Visit every posting list in ascending token-id order while reading the
+    /// partition in bounded chunks. This is used by index merge/finalization:
+    /// a whole-partition Arrow batch can overflow 32-bit list offsets even
+    /// though every individual posting row is valid.
+    pub(super) async fn for_each_posting_list_chunked<F>(
         &self,
         with_position: bool,
-    ) -> Result<impl Iterator<Item = Result<PostingList>> + '_> {
-        // read_all walks every posting list; the bulk metadata is paid for
-        // unconditionally, so just load it once up front and index into it
-        // synchronously below.
+        chunk_tokens_override: Option<usize>,
+        max_list_children_override: Option<u64>,
+        mut visit: F,
+    ) -> Result<usize>
+    where
+        F: FnMut(PostingList) -> Result<()>,
+    {
         self.ensure_metadata_loaded().await?;
-        let batch = self.read_batch(with_position).await?;
-        Ok((0..self.len()).map(move |i| {
-            let token_id = i as u32;
-            let range = self.posting_list_range(token_id);
-            let batch = batch.slice(i, range.end - range.start);
-            let (max_score, length) = self.bulk_metadata_for_token(token_id);
-            self.posting_list_from_batch(&batch, max_score, length)
-        }))
+        let token_count = self.len();
+        let chunk_tokens = chunk_tokens_override
+            .unwrap_or_else(|| {
+                posting_read_chunk_tokens(token_count, self.posting_data_size_bytes())
+            })
+            .max(1);
+        let max_list_children = max_list_children_override
+            .unwrap_or(POSTING_READ_MAX_LIST_CHILDREN)
+            .max(1);
+        let chunk_ranges =
+            self.posting_read_chunk_ranges(chunk_tokens, max_list_children, with_position)?;
+        let chunk_count = chunk_ranges.len();
+        let state = self.chunk_build_state();
+
+        for (tok_start, tok_end) in chunk_ranges {
+            let posting_lists = self
+                .build_chunk_postings(
+                    tok_start,
+                    tok_end,
+                    with_position,
+                    &state,
+                    ChunkPostingMode::Merge,
+                )
+                .await?;
+            for (_, posting_list) in posting_lists {
+                visit(posting_list)?;
+            }
+        }
+        Ok(chunk_count)
+    }
+
+    #[cfg(test)]
+    pub(super) async fn build_chunk_postings_for_test(
+        &self,
+        tok_start: usize,
+        tok_end: usize,
+        with_position: bool,
+        mode: ChunkPostingMode,
+    ) -> Result<Vec<PostingList>> {
+        self.ensure_metadata_loaded().await?;
+        let state = self.chunk_build_state();
+        self.build_chunk_postings(tok_start, tok_end, with_position, &state, mode)
+            .await
+            .map(|postings| postings.into_iter().map(|(_, posting)| posting).collect())
+    }
+
+    /// Plan merge reads by both token count and the child-value count of the
+    /// widest projected `List<i32>` column. V2/V3 posting lengths determine
+    /// posting blocks, position-block offsets, and impact entries exactly.
+    /// Compressed V1 positions use nested per-document lists whose child count
+    /// is not available in metadata, so those reads stay at one token per batch.
+    /// For row-based legacy indexes, persisted posting row offsets provide the
+    /// best available bound.
+    fn posting_read_chunk_ranges(
+        &self,
+        max_tokens: usize,
+        max_list_children: u64,
+        with_position: bool,
+    ) -> Result<Vec<(usize, usize)>> {
+        if with_position
+            && matches!(&self.metadata, PostingMetadata::V2 { .. })
+            && matches!(self.positions_layout, PositionsLayout::LegacyPerDoc)
+        {
+            return Ok((0..self.len())
+                .map(|token_id| (token_id, token_id + 1))
+                .collect());
+        }
+
+        let mut ranges = Vec::new();
+        let mut tok_start = 0usize;
+        while tok_start < self.len() {
+            let mut tok_end = tok_start;
+            let mut list_children = 0u64;
+            while tok_end < self.len() && tok_end - tok_start < max_tokens {
+                let next_children = self.max_list_children_for_token(tok_end, with_position);
+                if next_children > max_list_children {
+                    return Err(Error::index(format!(
+                        "posting token {tok_end} requires {next_children} List child values, exceeding the per-batch limit {max_list_children}"
+                    )));
+                }
+                if tok_end > tok_start
+                    && list_children.saturating_add(next_children) > max_list_children
+                {
+                    break;
+                }
+                list_children = list_children.saturating_add(next_children);
+                tok_end += 1;
+                if list_children >= max_list_children {
+                    break;
+                }
+            }
+            ranges.push((tok_start, tok_end));
+            tok_start = tok_end;
+        }
+        Ok(ranges)
+    }
+
+    fn max_list_children_for_token(&self, token_id: usize, with_position: bool) -> u64 {
+        match &self.metadata {
+            PostingMetadata::LegacyV1 { offsets, .. } => {
+                let start = offsets[token_id];
+                let end = offsets
+                    .get(token_id + 1)
+                    .copied()
+                    .unwrap_or_else(|| self.reader.num_rows());
+                (end - start) as u64
+            }
+            PostingMetadata::V2 { metadata } => {
+                let loaded = metadata
+                    .get()
+                    .expect("v2 metadata must be loaded before planning chunked posting reads");
+                let posting_length = u64::from(loaded.lengths[token_id]);
+                let posting_blocks = posting_length.div_ceil(self.block_size as u64);
+                let impact_entries = self.has_impacts.then(|| {
+                    posting_blocks
+                        .saturating_add(posting_blocks.div_ceil(IMPACT_LEVEL1_BLOCKS as u64))
+                });
+                let position_offsets = (with_position
+                    && matches!(self.positions_layout, PositionsLayout::SharedStream(_)))
+                .then_some(posting_blocks);
+                let legacy_position_docs = (with_position
+                    && matches!(self.positions_layout, PositionsLayout::LegacyPerDoc))
+                .then_some(posting_length);
+                impact_entries
+                    .into_iter()
+                    .chain(position_offsets)
+                    .chain(legacy_position_docs)
+                    .chain(std::iter::once(posting_blocks))
+                    .max()
+                    .unwrap_or(0)
+            }
+        }
     }
 
     /// Sync lookup of `(max_score, length)` from the bulk-loaded metadata.
     /// Only safe after [`Self::ensure_metadata_loaded`]; callers that hold
-    /// the OnceCell-loaded reference (e.g. read_all, prewarm) use this to
-    /// avoid the per-token IO path.
+    /// the OnceCell-loaded reference (e.g. chunked bulk reads and prewarm) use
+    /// this to avoid the per-token IO path.
+    #[cfg(test)]
     pub(super) fn bulk_metadata_for_token(&self, token_id: u32) -> (Option<f32>, Option<u32>) {
         match &self.metadata {
             PostingMetadata::LegacyV1 { max_scores, .. } => {
@@ -644,7 +782,16 @@ impl PostingListReader {
     }
 }
 
-/// Loop-invariant state for [`InvertedPartition::build_chunk_postings`]. The
+/// Controls whether posting lists retain their read chunk's Arrow buffers.
+#[derive(Clone, Copy, Debug)]
+pub(super) enum ChunkPostingMode {
+    /// Build independently-owned posting lists for the index cache.
+    Prewarm,
+    /// Share the current read chunk while merge immediately consumes its lists.
+    Merge,
+}
+
+/// Loop-invariant state for [`PostingListReader::build_chunk_postings`]. The
 /// metadata vecs are `Arc`d so each chunk's blocking build shares them cheaply.
 pub(super) struct ChunkBuildState {
     offsets: Option<Arc<Vec<usize>>>,
@@ -655,10 +802,10 @@ pub(super) struct ChunkBuildState {
     positions_layout: PositionsLayout,
 }
 
-/// Chunk-invariant inputs to [`InvertedPartition::build_prewarm_posting_lists_chunk`]:
+/// Chunk-invariant inputs to [`PostingListReader::build_posting_lists_chunk`]:
 /// the per-partition codec/layout and the (shared, whole-partition) metadata
 /// slices indexed by global token id. These don't change across chunks.
-pub(super) struct PrewarmBuildCtx<'a> {
+pub(super) struct PostingBuildCtx<'a> {
     max_scores: Option<&'a [f32]>,
     lengths: Option<&'a [u32]>,
     posting_tail_codec: PostingTailCodec,
@@ -666,10 +813,10 @@ pub(super) struct PrewarmBuildCtx<'a> {
     positions_layout: PositionsLayout,
 }
 
-/// Per-chunk inputs to [`InvertedPartition::build_prewarm_posting_lists_chunk`]:
+/// Per-chunk inputs to [`PostingListReader::build_posting_lists_chunk`]:
 /// the token sub-range `[tok_start, tok_start + token_count)` and, for legacy
 /// v1, the rebased offset slice plus the chunk's end row.
-pub(super) struct PrewarmChunk<'a> {
+pub(super) struct PostingChunk<'a> {
     tok_start: usize,
     token_count: usize,
     /// Legacy v1 only: `offsets[tok_start..tok_start+token_count]` (no sentinel).

--- a/rust/lance-index/src/scalar/inverted/index/prewarm.rs
+++ b/rust/lance-index/src/scalar/inverted/index/prewarm.rs
@@ -3,16 +3,21 @@
 
 use super::*;
 
-/// Target on-disk size of one prewarm chunk. Keep this large enough that cloud
-/// stores do not spend prewarm time on thousands of tiny range reads, but still
-/// bounded so one large partition is not materialized all at once.
-pub(super) const PREWARM_CHUNK_TARGET_BYTES: u64 = 128 << 20;
+/// Target on-disk size of one posting-list read chunk. Keep this large enough
+/// that cloud stores do not spend bulk reads on thousands of tiny ranges, but
+/// still bounded so one large partition is not materialized all at once.
+pub(super) const POSTING_READ_CHUNK_TARGET_BYTES: u64 = 128 << 20;
 
 /// Cap on token rows per chunk, bounding the built `Vec` when posting lists are tiny.
-pub(super) const PREWARM_MAX_CHUNK_TOKENS: usize = 256 * 1024;
+pub(super) const POSTING_READ_MAX_CHUNK_TOKENS: usize = 256 * 1024;
 
 /// Floor on token rows per chunk, so a partition always makes progress.
-pub(super) const PREWARM_MIN_CHUNK_TOKENS: usize = 1;
+pub(super) const POSTING_READ_MIN_CHUNK_TOKENS: usize = 1;
+
+/// Maximum number of child values materialized in any 32-bit-offset posting
+/// column. The planner accounts for the widest selected column (impacts when
+/// present), keeping Arrow's `List<i32>` offsets representable.
+pub(super) const POSTING_READ_MAX_LIST_CHILDREN: u64 = i32::MAX as u64;
 
 /// Maximum number of posting lists in a runtime synthetic cache group. This is
 /// deliberately token-count based so grouping works for old v2 indexes without
@@ -98,13 +103,13 @@ impl PostingGrouping {
 }
 
 /// Token rows per chunk: byte target / average bytes-per-token, clamped to `[MIN, MAX]`.
-pub(super) fn prewarm_chunk_tokens(token_count: usize, file_size_bytes: u64) -> usize {
+pub(super) fn posting_read_chunk_tokens(token_count: usize, file_size_bytes: u64) -> usize {
     if token_count == 0 {
-        return PREWARM_MIN_CHUNK_TOKENS;
+        return POSTING_READ_MIN_CHUNK_TOKENS;
     }
     let bytes_per_token = (file_size_bytes / token_count as u64).max(1); // >= 1: no div-by-zero
-    let by_bytes = (PREWARM_CHUNK_TARGET_BYTES / bytes_per_token) as usize;
-    by_bytes.clamp(PREWARM_MIN_CHUNK_TOKENS, PREWARM_MAX_CHUNK_TOKENS)
+    let by_bytes = (POSTING_READ_CHUNK_TARGET_BYTES / bytes_per_token) as usize;
+    by_bytes.clamp(POSTING_READ_MIN_CHUNK_TOKENS, POSTING_READ_MAX_CHUNK_TOKENS)
 }
 
 pub(super) fn synthetic_group_aligned_chunk_end(

--- a/rust/lance-index/src/scalar/inverted/index/tests/format_and_builder.rs
+++ b/rust/lance-index/src/scalar/inverted/index/tests/format_and_builder.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright The Lance Authors
 
+use super::super::posting_prewarm::ChunkPostingMode;
 use super::*;
 
 #[test]
@@ -345,6 +346,208 @@ async fn test_build_search_uses_configured_posting_block_size() {
     assert_eq!(row_ids.len(), 10);
     assert_eq!(scores.len(), 10);
     assert!(row_ids.iter().all(|row_id| *row_id >= 1_000));
+}
+
+#[rstest::rstest]
+#[case::v1(InvertedListFormatVersion::V1, LEGACY_BLOCK_SIZE, 514, 7)]
+#[case::v3(InvertedListFormatVersion::V3, 256, 6, 4)]
+#[tokio::test]
+async fn test_into_builder_chunks_postings_by_list_children(
+    #[case] format_version: InvertedListFormatVersion,
+    #[case] block_size: usize,
+    #[case] max_list_children: u64,
+    #[case] expected_chunk_count: usize,
+) {
+    const NUM_TOKENS: usize = 7;
+    const NUM_DOCS: usize = 257;
+    // V1's nested per-document position block count is not stored in metadata,
+    // so each token gets its own read. V3's exact metadata-derived bound admits
+    // two token rows per read.
+
+    let source_dir = TempObjDir::default();
+    let source_store = Arc::new(LanceIndexStore::new(
+        ObjectStore::local().into(),
+        source_dir.clone(),
+        Arc::new(LanceCache::no_cache()),
+    ));
+    let mut source = InnerBuilder::new_with_format_version_and_block_size(
+        0,
+        true,
+        TokenSetFormat::default(),
+        format_version,
+        block_size,
+    );
+    for token_id in 0..NUM_TOKENS {
+        source.tokens.add(format!("token_{token_id}"));
+        let mut posting = PostingListBuilder::new_with_posting_tail_codec_and_block_size(
+            true,
+            format_version.posting_tail_codec(),
+            block_size,
+        );
+        for doc_id in 0..NUM_DOCS {
+            posting.add(
+                doc_id as u32,
+                PositionRecorder::Position(vec![token_id as u32, token_id as u32 + 10].into()),
+            );
+        }
+        source.posting_lists.push(posting);
+    }
+    for doc_id in 0..NUM_DOCS {
+        source
+            .docs
+            .append(1_000 + doc_id as u64, (NUM_TOKENS * 2) as u32);
+    }
+    source.write(source_store.as_ref()).await.unwrap();
+
+    let source_partition = InvertedPartition::load(
+        source_store,
+        0,
+        None,
+        &LanceCache::no_cache(),
+        TokenSetFormat::default(),
+    )
+    .await
+    .unwrap();
+    let (mut merged, chunk_count) = source_partition
+        .into_builder_with_chunk_limits(NUM_TOKENS, max_list_children)
+        .await
+        .unwrap();
+    assert_eq!(
+        chunk_count, expected_chunk_count,
+        "list-child limit must split merge reads"
+    );
+    assert_eq!(merged.posting_lists.len(), NUM_TOKENS);
+    assert!(
+        merged
+            .posting_lists
+            .iter()
+            .all(|posting| posting.len() == NUM_DOCS && posting.has_positions())
+    );
+
+    // Rewriting the chunk-built builder verifies that V3 positions survived
+    // conversion and that impact data can be regenerated from every posting.
+    let dest_dir = TempObjDir::default();
+    let dest_store = Arc::new(LanceIndexStore::new(
+        ObjectStore::local().into(),
+        dest_dir.clone(),
+        Arc::new(LanceCache::no_cache()),
+    ));
+    merged.write(dest_store.as_ref()).await.unwrap();
+    let merged_cache = LanceCache::with_capacity(1 << 20);
+    let merged_partition = InvertedPartition::load(
+        dest_store,
+        0,
+        None,
+        &merged_cache,
+        TokenSetFormat::default(),
+    )
+    .await
+    .unwrap();
+    let posting = merged_partition
+        .inverted_list
+        .posting_list(0, true, &NoOpMetricsCollector)
+        .await
+        .unwrap();
+    let PostingList::Compressed(posting) = posting else {
+        panic!("expected compressed posting list");
+    };
+    assert_eq!(posting.block_size, block_size);
+    assert!(posting.impacts.is_some());
+    let actual = PostingList::Compressed(posting)
+        .iter()
+        .map(|(doc_id, frequency, positions)| {
+            (doc_id, frequency, positions.unwrap().collect::<Vec<_>>())
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(actual.len(), NUM_DOCS);
+    assert_eq!(actual[0], (0, 2, vec![0, 10]));
+    assert_eq!(actual[NUM_DOCS - 1], (256, 2, vec![0, 10]));
+}
+
+#[tokio::test]
+async fn test_chunk_posting_mode_controls_buffer_sharing() {
+    const NUM_TOKENS: usize = 2;
+    const NUM_DOCS: usize = 257;
+
+    let source_dir = TempObjDir::default();
+    let source_store = Arc::new(LanceIndexStore::new(
+        ObjectStore::local().into(),
+        source_dir.clone(),
+        Arc::new(LanceCache::no_cache()),
+    ));
+    let mut source = InnerBuilder::new_with_format_version_and_block_size(
+        0,
+        false,
+        TokenSetFormat::default(),
+        InvertedListFormatVersion::V3,
+        MAX_POSTING_BLOCK_SIZE,
+    );
+    for token_id in 0..NUM_TOKENS {
+        source.tokens.add(format!("token_{token_id}"));
+        let mut posting = PostingListBuilder::new_with_posting_tail_codec_and_block_size(
+            false,
+            PostingTailCodec::VarintDelta,
+            MAX_POSTING_BLOCK_SIZE,
+        );
+        for doc_id in 0..NUM_DOCS {
+            posting.add(doc_id as u32, PositionRecorder::Count(1));
+        }
+        source.posting_lists.push(posting);
+    }
+    for doc_id in 0..NUM_DOCS {
+        source.docs.append(1_000 + doc_id as u64, NUM_TOKENS as u32);
+    }
+    source.write(source_store.as_ref()).await.unwrap();
+
+    let source_partition = InvertedPartition::load(
+        source_store,
+        0,
+        None,
+        &LanceCache::no_cache(),
+        TokenSetFormat::default(),
+    )
+    .await
+    .unwrap();
+    let merge_postings = source_partition
+        .inverted_list
+        .build_chunk_postings_for_test(0, NUM_TOKENS, false, ChunkPostingMode::Merge)
+        .await
+        .unwrap();
+    let prewarm_postings = source_partition
+        .inverted_list
+        .build_chunk_postings_for_test(0, NUM_TOKENS, false, ChunkPostingMode::Prewarm)
+        .await
+        .unwrap();
+
+    let [
+        PostingList::Compressed(merge_first),
+        PostingList::Compressed(merge_second),
+    ] = merge_postings.as_slice()
+    else {
+        panic!("expected two compressed merge posting lists");
+    };
+    assert!(
+        merge_first
+            .blocks
+            .values()
+            .ptr_eq(merge_second.blocks.values()),
+        "merge posting lists from one chunk should share backing storage"
+    );
+
+    let [
+        PostingList::Compressed(prewarm_first),
+        PostingList::Compressed(prewarm_second),
+    ] = prewarm_postings.as_slice()
+    else {
+        panic!("expected two compressed prewarm posting lists");
+    };
+    assert!(
+        !prewarm_first
+            .blocks
+            .values()
+            .ptr_eq(prewarm_second.blocks.values()),
+        "prewarm posting lists should own compact backing storage"
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
## What is the bug?

FTS segment merge materializes every posting row in an `invert.lance` partition as one Arrow `RecordBatch`. Large partitions can exceed the `i32` child-offset capacity of the posting, impact, or position `List` columns while Arrow concatenates pages, causing an `offset overflow` panic after indexing has otherwise completed.

## What issues or incorrect behavior does the bug cause?

Large segmented FTS rebuilds can finish tokenization but fail while finalizing intermediate segments. Because the final index segment is never committed, callers cannot complete the rebuild and automated maintenance can encounter the same deterministic failure again.

## How does this PR fix the problem?

- replace the partition-wide posting read in `InvertedPartition::into_builder` with sequential token-range chunks
- reuse the existing posting chunk decoder so each batch is released before the next range is read
- let merge slices share the current chunk Arrow buffers while prewarm retains compact independently-owned buffers
- bound current shared-position chunks by token count, an approximately 128 MiB on-disk target, and the exact widest `List<i32>` child count derived from posting metadata
- read compressed V1 per-document positions one token at a time because their nested position-block child count is not stored in metadata
- return a descriptive error if one metadata-bounded token alone cannot fit within the configured child-offset limit

The pre-compression row-based legacy layout keeps its existing row-count fallback and is outside this incident scope.

Token ordering, posting contents, position data, impact data, public APIs, and the on-disk format remain unchanged.

## Tests

- `cargo test -p lance-index test_into_builder_chunks_postings_by_list_children -- --nocapture`
- `cargo test -p lance-index test_chunk_posting_mode_controls_buffer_sharing -- --nocapture`
- `cargo test -p lance-index test_prewarm_streams_in_chunks -- --nocapture`
- `cargo test -p lance-index test_merge_segments_ -- --nocapture`
- `cargo check -p lance-index --tests`
- `cargo fmt --all -- --check`
- `git diff --check main...HEAD`
- `cargo clippy -p lance-index --tests -- -D warnings -A clippy::single-range-in-vec-init -A clippy::implicit-clone`

Strict local Clippy on Rust 1.97 currently reports pre-existing `single-range-in-vec-init` and `implicit-clone` findings in untouched files; allowing only those two lints makes the changed package pass cleanly.