### PR TITLE
chore: enforce shared workspace dependencies via cargo-deny

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,6 +79,7 @@ lance-tokenizer = { version = "=11.0.0-beta.15", path = "./rust/lance-tokenizer"
 lance-table = { version = "=11.0.0-beta.15", path = "./rust/lance-table" }
 lance-test-macros = { version = "=11.0.0-beta.15", path = "./rust/lance-test-macros" }
 lance-testing = { version = "=11.0.0-beta.15", path = "./rust/lance-testing" }
+all_asserts = "2.3.1"
 approx = "0.5.1"
 # Note that this one does not include pyarrow
 arrow = { version = "58.0.0", optional = false, features = ["prettyprint"] }
@@ -128,6 +129,7 @@ criterion = { version = "0.8.2", features = [
 ] }
 crossbeam-queue = "0.3"
 crossbeam-skiplist = "0.1"
+dashmap = "6"
 datafusion = { version = "54.0.0", default-features = false, features = [
     "crypto_expressions",
     "datetime_expressions",
@@ -147,6 +149,7 @@ datafusion-physical-plan = "54.0.0"
 datafusion-substrait = { version = "54.0.0", default-features = false }
 dirs = "6.0.0"
 either = "1.0"
+env_logger = "0.11.7"
 fst = { version = "0.4.7", features = ["levenshtein"] }
 fsst = { version = "=11.0.0-beta.15", path = "./rust/compression/fsst" }
 futures = "0.3"
@@ -155,6 +158,7 @@ geoarrow-schema = "0.8"
 geodatafusion = "0.5.0"
 geo-traits = "0.3.0"
 geo-types = "0.7.16"
+hex = "0.4.3"
 http = "1.1.0"
 humantime = "2.2.0"
 hyperloglogplus = { version = "0.4.1", features = ["const-loop"] }
@@ -175,19 +179,27 @@ num-traits = "0.2"
 object_store = { version = "0.13.2" }
 opendal = { version = "0.58.1" }
 object_store_opendal = { version = "0.58" }
+parquet = { version = "58.0.0", default-features = false, features = [
+    "arrow",
+    "async",
+] }
 pin-project = "1.0"
 path_abs = "0.5"
 pprof = { version = "0.15.0", features = ["flamegraph"] }
+proc-macro2 = "1.0.67"
 proptest = "1.3.1"
 prost = "0.14.1"
 prost-build = "0.14.1"
 prost-types = "0.14.1"
+protobuf-src = "2.1"
+quote = "1.0.33"
 rand = { version = "0.9.1", features = ["small_rng"] }
 rand_distr = { version = "0.5.1" }
 rand_xoshiro = "0.7.0"
 rangemap = { version = "1.0" }
 rayon = "1.10"
 regex-syntax = "0.8.10"
+reqwest = { version = "0.12", default-features = false, features = ["json"] }
 roaring = "0.11.4"
 rstest = "0.26.1"
 serde = { version = "^1" }
@@ -195,6 +207,7 @@ serde_json = { version = "1" }
 semver = "1.0"
 serial_test = "3"
 snafu = "0.9"
+syn = { version = "2.0.37", features = ["full"] }
 lindera = { version = "3.0.7" }
 tempfile = "3"
 test-log = { version = "0.2.15" }

--- a/deny.toml
+++ b/deny.toml
@@ -166,6 +166,10 @@ registries = [
 # More documentation about the 'bans' section can be found here:
 # https://embarkstudios.github.io/cargo-deny/checks/bans/cfg.html
 [bans]
+# Lint every dependency declared by a workspace member against the shared
+# `[workspace.dependencies]` table: any crate used by more than one member must
+# go through `workspace = true`, and entries nothing uses are an error.
+workspace-dependencies = { duplicates = "deny", unused = "deny" }
 # Lint level for when multiple versions of the same crate are detected
 multiple-versions = "warn"
 # Lint level for when a crate version requirement is `*`

--- a/rust/examples/Cargo.toml
+++ b/rust/examples/Cargo.toml
@@ -46,9 +46,9 @@ lance-datagen = { workspace = true }
 object_store = {workspace = true}
 tempfile = { workspace = true }
 tokio = { workspace = true }
-all_asserts = "2.3.1"
-env_logger = "0.11.7"
+all_asserts.workspace = true
+env_logger.workspace = true
 hf-hub = "0.4.2"
-parquet = { version = "58.0.0", default-features = false, features = ["arrow", "async"] }
+parquet = { workspace = true }
 tokenizers = "0.15.2"
 rand.workspace = true

--- a/rust/lance-datafusion/Cargo.toml
+++ b/rust/lance-datafusion/Cargo.toml
@@ -38,7 +38,7 @@ tracing.workspace = true
 
 [build-dependencies]
 prost-build.workspace = true
-protobuf-src = {version = "2.1", optional = true}
+protobuf-src = { workspace = true, optional = true }
 
 [dev-dependencies]
 lance-datagen.workspace = true

--- a/rust/lance-datagen/Cargo.toml
+++ b/rust/lance-datagen/Cargo.toml
@@ -17,7 +17,7 @@ arrow-schema = { workspace = true }
 chrono = { workspace = true }
 futures = { workspace = true }
 half = { workspace = true }
-hex = "0.4.3"
+hex.workspace = true
 rand = { workspace = true }
 rand_distr = { workspace = true }
 rand_xoshiro = { workspace = true }

--- a/rust/lance-derive/Cargo.toml
+++ b/rust/lance-derive/Cargo.toml
@@ -14,9 +14,9 @@ categories.workspace = true
 proc-macro = true
 
 [dependencies]
-proc-macro2 = "1.0.67"
-quote = "1.0.33"
-syn = { version = "2.0.37", features = ["full"] }
+proc-macro2.workspace = true
+quote.workspace = true
+syn.workspace = true
 
 [lints]
 workspace = true

--- a/rust/lance-encoding/Cargo.toml
+++ b/rust/lance-encoding/Cargo.toml
@@ -25,7 +25,7 @@ lance-bitpacking = { workspace = true, optional = true }
 bytes.workspace = true
 futures.workspace = true
 fsst.workspace = true
-hex = "0.4.3"
+hex.workspace = true
 itertools.workspace = true
 log.workspace = true
 num-traits.workspace = true
@@ -34,7 +34,7 @@ hyperloglogplus.workspace = true
 tokio.workspace = true
 tracing.workspace = true
 xxhash-rust = { version = "0.8.15", features = ["xxh3"] }
-bytemuck = { version = "1.14", features = ["extern_crate_alloc"] }
+bytemuck.workspace = true
 byteorder.workspace = true
 lz4 = { version = "1", optional = true }
 zstd = { version = "0.13", optional = true }
@@ -53,7 +53,7 @@ serial_test.workspace = true
 
 [build-dependencies]
 prost-build.workspace = true
-protobuf-src = { version = "2.1", optional = true }
+protobuf-src = { workspace = true, optional = true }
 
 [features]
 default = ["lz4", "zstd", "bitpacking"]

--- a/rust/lance-file/Cargo.toml
+++ b/rust/lance-file/Cargo.toml
@@ -50,7 +50,7 @@ libc.workspace = true
 
 [build-dependencies]
 prost-build.workspace = true
-protobuf-src = { version = "2.1", optional = true }
+protobuf-src = { workspace = true, optional = true }
 
 [features]
 protoc = ["dep:protobuf-src"]

--- a/rust/lance-index/Cargo.toml
+++ b/rust/lance-index/Cargo.toml
@@ -77,7 +77,7 @@ rangemap.workspace = true
 [dev-dependencies]
 approx.workspace = true
 criterion.workspace = true
-env_logger = "0.11.6"
+env_logger.workspace = true
 geo-traits.workspace = true
 lance-datagen.workspace = true
 lance-datafusion = { workspace = true, features = ["datagen"] }
@@ -97,7 +97,7 @@ tokenizer-jieba = ["dep:jieba-rs", "lance-tokenizer/tokenizer-jieba"]
 
 [build-dependencies]
 prost-build.workspace = true
-protobuf-src = { version = "2.1", optional = true }
+protobuf-src = { workspace = true, optional = true }
 
 [package.metadata.docs.rs]
 # docs.rs uses an older version of Ubuntu that does not have the necessary protoc version

--- a/rust/lance-linalg/Cargo.toml
+++ b/rust/lance-linalg/Cargo.toml
@@ -22,7 +22,7 @@ rayon = { workspace = true }
 approx = { workspace = true }
 arrow-buffer = { workspace = true }
 criterion = { workspace = true }
-lance-testing = { path = "../lance-testing" }
+lance-testing = { workspace = true }
 proptest.workspace = true
 rand = { workspace = true }
 rstest.workspace = true

--- a/rust/lance-namespace-datafusion/Cargo.toml
+++ b/rust/lance-namespace-datafusion/Cargo.toml
@@ -12,7 +12,7 @@ rust-version.workspace = true
 
 [dependencies]
 async-trait.workspace = true
-dashmap = "6"
+dashmap.workspace = true
 datafusion.workspace = true
 lance.workspace = true
 lance-namespace.workspace = true

--- a/rust/lance-namespace-impls/Cargo.toml
+++ b/rust/lance-namespace-impls/Cargo.toml
@@ -32,8 +32,7 @@ lance-namespace.workspace = true
 lance-core.workspace = true
 
 # REST implementation dependencies (optional, enabled by "rest" feature)
-reqwest = { version = "0.12", optional = true, default-features = false, features = [
-    "json",
+reqwest = { workspace = true, optional = true, features = [
     "charset",
     "gzip",
     "http2",

--- a/rust/lance-table/Cargo.toml
+++ b/rust/lance-table/Cargo.toml
@@ -57,7 +57,7 @@ rstest.workspace = true
 
 [build-dependencies]
 prost-build.workspace = true
-protobuf-src = { version = "2.1", optional = true }
+protobuf-src = { workspace = true, optional = true }
 
 [features]
 dynamodb = ["dep:aws-sdk-dynamodb", "dep:aws-credential-types", "lance-io/aws"]

--- a/rust/lance-test-macros/Cargo.toml
+++ b/rust/lance-test-macros/Cargo.toml
@@ -14,9 +14,9 @@ categories.workspace = true
 proc-macro = true
 
 [dependencies]
-proc-macro2 = "1.0.67"
-quote = "1.0.33"
-syn = { version = "2.0.37", features = ["full"] }
+proc-macro2.workspace = true
+quote.workspace = true
+syn.workspace = true
 
 [lints]
 workspace = true

--- a/rust/lance/Cargo.toml
+++ b/rust/lance/Cargo.toml
@@ -48,7 +48,7 @@ async-trait.workspace = true
 byteorder.workspace = true
 bytes.workspace = true
 chrono.workspace = true
-clap = { version = "4.1.1", features = ["derive"], optional = true }
+clap = { workspace = true, optional = true }
 # Only used by the (disabled) `mem_wal_kv_point_lookup` benchmark's RocksDB arm.
 # Commented out so CI's all-features build never compiles the bundled librocksdb
 # C++ sources (needs libclang). Uncomment with the bench target + feature to run.
@@ -56,11 +56,11 @@ clap = { version = "4.1.1", features = ["derive"], optional = true }
 crossbeam-queue = { workspace = true }
 crossbeam-skiplist.workspace = true
 # This is already used by datafusion
-dashmap = "6"
+dashmap.workspace = true
 # Fast non-cryptographic hasher for the hot FTS mem-index insert path.
 rustc-hash = "2.1"
 # Compact FST term dictionary for the FTS mem-index partitions.
-fst = "0.4"
+fst.workspace = true
 itertools.workspace = true
 moka.workspace = true
 object_store = { workspace = true }
@@ -97,7 +97,7 @@ tokio-util = { workspace = true }
 
 [build-dependencies]
 prost-build.workspace = true
-protobuf-src = { version = "2.1", optional = true }
+protobuf-src = { workspace = true, optional = true }
 
 [target.'cfg(target_os = "linux")'.dev-dependencies]
 pprof.workspace = true
@@ -113,12 +113,12 @@ libc = { workspace = true }
 clap = { workspace = true, features = ["derive"] }
 criterion = { workspace = true }
 approx.workspace = true
-all_asserts = "2.3.1"
+all_asserts.workspace = true
 mock_instant.workspace = true
 lance-testing = { workspace = true }
 lance-io = { workspace = true, features = ["test-util"] }
 tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }
-env_logger = "0.11.7"
+env_logger.workspace = true
 tempfile.workspace = true
 test-log.workspace = true
 tracing-chrome = "0.7.1"
@@ -134,8 +134,8 @@ geoarrow-array = { workspace = true }
 geoarrow-schema = { workspace = true }
 geo-types = { workspace = true }
 datafusion-substrait = { workspace = true }
-parquet = { version = "58", default-features = false, features = ["arrow", "async"] }
-reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "json"] }
+parquet = { workspace = true }
+reqwest = { workspace = true, features = ["rustls-tls"] }
 
 [features]
 default = ["aws", "azure", "gcp", "oss", "huggingface", "tencent", "tos", "goosefs", "geo"]


### PR DESCRIPTION
`cargo deny` did not check crate-level dependency declarations against `[workspace.dependencies]`, so a crate used by several workspace members could be declared independently in each one and drift. For example `env_logger` was pinned at `0.11.6` in `lance-index` and `0.11.7` in `lance` and `lance-examples`, and `bytemuck` asked for default features in `lance-encoding` but not in `lance-arrow`.

This PR turns on cargo-deny's `bans.workspace-dependencies` lint, which fails when a dependency is used by more than one member without going through `workspace = true`, and when a `[workspace.dependencies]` entry is used by nobody.

Enabling it surfaced 14 violations. Fixing them means adding `all_asserts`, `dashmap`, `env_logger`, `hex`, `parquet`, `proc-macro2`, `protobuf-src`, `quote`, `reqwest`, and `syn` to `[workspace.dependencies]`, and pointing declarations that predate the existing entries for `bytemuck`, `clap`, `fst`, and `lance-testing` at those entries. `Cargo.lock`, `python/Cargo.lock`, and `java/lance-jni/Cargo.lock` are all unchanged, so resolution is the same as before.
