### PR TITLE
fix: preserve the row id high-water mark across restore

### DIFF
--- a/rust/lance-table/src/transaction/manifest_build.rs
+++ b/rust/lance-table/src/transaction/manifest_build.rs
@@ -113,6 +113,17 @@ impl Transaction {
         manifest.max_fragment_id = manifest
             .max_fragment_id
             .max(current_manifest.max_fragment_id);
+        // Row ids are a high-water mark like fragment ids: rewinding hands old ids to new rows.
+        manifest.next_row_id = manifest.next_row_id.max(current_manifest.next_row_id);
+        // Turning stable row ids off would revert `_rowid` to row addresses, whose
+        // namespace overlaps the ids this table has already handed out.
+        if current_manifest.uses_stable_row_ids() && !manifest.uses_stable_row_ids() {
+            return Err(Error::invalid_input(format!(
+                "Cannot restore version {version}: stable row ids were enabled \
+                 after it, and turning them back off would let row addresses \
+                 collide with ids this table has already used"
+            )));
+        }
         // A version from before catch-up was required carries MemWAL state this
         // protocol never validated -- catch-up values activation deliberately
         // cleared, or compaction progress it deliberately refused to trust.

--- a/rust/lance/src/dataset.rs
+++ b/rust/lance/src/dataset.rs
@@ -3157,11 +3157,11 @@ impl Dataset {
         Ok(())
     }
 
-    /// Assign stable row ID sequences to fragments that do not yet have them.
-    /// Assigns a contiguous `RowIdSequence` to every fragment starting from row
-    /// ID 0 and returns the resulting `next_row_id` high-water mark.
-    fn assign_stable_row_ids_for_migration(fragments: &mut [Fragment]) -> Result<u64> {
-        let mut next_row_id = 0u64;
+    /// Assign stable row ID sequences to fragments that do not yet have them,
+    /// contiguously from `start`, and return the resulting `next_row_id`
+    /// high-water mark.
+    fn assign_stable_row_ids_for_migration(fragments: &mut [Fragment], start: u64) -> Result<u64> {
+        let mut next_row_id = start;
         for fragment in fragments.iter_mut() {
             let physical_rows = fragment.physical_rows.ok_or_else(|| {
                 Error::internal(format!(
@@ -3203,7 +3203,11 @@ impl Dataset {
         }
 
         let mut fragments = self.manifest.fragments.as_ref().clone();
-        let next_row_id = Self::assign_stable_row_ids_for_migration(&mut fragments)?;
+        // Restore carries the high-water mark forward across a version that
+        // predates activation, so a re-migration must allocate above it rather
+        // than reissue ids the earlier versions still hold.
+        let next_row_id =
+            Self::assign_stable_row_ids_for_migration(&mut fragments, self.manifest.next_row_id)?;
         let schema = self.manifest.schema.clone();
         let read_version = self.manifest.version;
 

--- a/rust/lance/src/dataset/tests/dataset_migrations.rs
+++ b/rust/lance/src/dataset/tests/dataset_migrations.rs
@@ -11,7 +11,8 @@ use crate::utils::test::copy_test_data_to_tmp;
 use crate::{Dataset, Result};
 use lance_index::{IndexType, scalar::ScalarIndexParams};
 use lance_table::feature_flags::FLAG_STABLE_ROW_IDS;
-use lance_table::format::IndexMetadata;
+use lance_table::format::{Fragment, IndexMetadata, RowIdMeta};
+use lance_table::rowids::read_row_ids;
 
 use crate::dataset::write::{WriteMode, WriteParams};
 use arrow::compute::concat_batches;
@@ -819,4 +820,39 @@ async fn test_migrate_to_stable_row_ids_blocked_by_index() {
     assert_eq!(results.num_rows(), 1);
     let id_col = results["id"].as_any().downcast_ref::<Int64Array>().unwrap();
     assert_eq!(id_col.value(0), 15);
+}
+
+/// The migration numbers from the mark it is handed, so any manifest carrying a
+/// non-zero one cannot reissue ids the earlier versions still hold.
+#[rstest]
+#[case::fresh(0, vec![0..4, 4..10])]
+#[case::carried_mark(30, vec![30..34, 34..40])]
+fn test_migration_allocates_from_the_given_mark(
+    #[case] start: u64,
+    #[case] expected: Vec<std::ops::Range<u64>>,
+) {
+    let mut fragments: Vec<Fragment> = [4usize, 6]
+        .iter()
+        .enumerate()
+        .map(|(i, rows)| {
+            let mut f = Fragment::new(i as u64);
+            f.physical_rows = Some(*rows);
+            f
+        })
+        .collect();
+
+    let next = Dataset::assign_stable_row_ids_for_migration(&mut fragments, start).unwrap();
+    assert_eq!(next, expected.last().unwrap().end);
+
+    let sequences: Vec<Vec<u64>> = fragments
+        .iter()
+        .map(|f| {
+            let RowIdMeta::Inline(data) = f.row_id_meta.as_ref().unwrap() else {
+                panic!("migration writes inline row id meta");
+            };
+            read_row_ids(data).unwrap().iter().collect()
+        })
+        .collect();
+    let expected: Vec<Vec<u64>> = expected.into_iter().map(|r| r.collect()).collect();
+    assert_eq!(sequences, expected);
 }

--- a/rust/lance/src/dataset/tests/dataset_versioning.rs
+++ b/rust/lance/src/dataset/tests/dataset_versioning.rs
@@ -15,6 +15,8 @@ use lance_table::io::commit::ManifestNamingScheme;
 use crate::dataset::write::{CommitBuilder, WriteMode, WriteParams};
 use arrow_array::RecordBatch;
 use arrow_array::RecordBatchReader;
+use arrow_array::cast::AsArray;
+use arrow_array::types::UInt64Type;
 use arrow_array::{RecordBatchIterator, UInt32Array, types::Int32Type};
 use arrow_schema::{DataType, Field as ArrowField, Schema as ArrowSchema};
 use lance_core::utils::tempfile::{TempDir, TempStdDir, TempStrDir};
@@ -300,6 +302,94 @@ async fn test_stale_checks_cover_fast_successor_and_latest_version(
     );
     assert!(historical.is_stale().await.unwrap());
     assert!(historical.has_successor_version().await.unwrap());
+}
+
+/// All row ids visible in `dataset`, in scan order.
+async fn scan_row_ids(dataset: &Dataset) -> Vec<u64> {
+    let batch = dataset
+        .scan()
+        .with_row_id()
+        .project(&["i"])
+        .unwrap()
+        .try_into_batch()
+        .await
+        .unwrap();
+    batch["_rowid"]
+        .as_primitive::<UInt64Type>()
+        .values()
+        .to_vec()
+}
+
+fn u32_batch(values: std::ops::Range<u32>) -> RecordBatch {
+    arrow_array::record_batch!(("i", UInt32, values.collect::<Vec<u32>>())).unwrap()
+}
+
+/// Restoring past activation would turn stable row ids off, putting row
+/// addresses back into a namespace this table has already issued ids from.
+#[tokio::test]
+async fn test_restore_rejects_crossing_stable_id_activation() {
+    let test_uri = TempStrDir::default();
+    let batch = u32_batch(0..10);
+    let mut dataset = Dataset::write(
+        RecordBatchIterator::new([Ok(batch.clone())], batch.schema()),
+        test_uri.as_str(),
+        None,
+    )
+    .await
+    .unwrap();
+    dataset.migrate_to_stable_row_ids().await.unwrap();
+
+    let mut restored = dataset.checkout_version(1).await.unwrap();
+    let err = restored.restore().await.unwrap_err();
+    assert!(
+        err.to_string()
+            .contains("stable row ids were enabled after"),
+        "{err}"
+    );
+}
+
+/// A restore must not rewind the row-id high-water mark, or the next append reuses old ids.
+#[tokio::test]
+async fn test_restore_preserves_row_id_high_water_mark() {
+    let test_uri = TempStrDir::default();
+    let write = |values: std::ops::Range<u32>, mode| {
+        let uri = test_uri.as_str().to_string();
+        async move {
+            let batch = u32_batch(values);
+            Dataset::write(
+                RecordBatchIterator::new([Ok(batch.clone())], batch.schema()),
+                &uri,
+                Some(WriteParams {
+                    mode,
+                    enable_stable_row_ids: true,
+                    ..Default::default()
+                }),
+            )
+            .await
+            .unwrap()
+        }
+    };
+
+    write(0..10, WriteMode::Create).await;
+    let appended = write(10..20, WriteMode::Append).await;
+    let mark = appended.manifest.next_row_id;
+
+    let mut restored = appended.checkout_version(1).await.unwrap();
+    restored.restore().await.unwrap();
+    assert!(
+        restored.manifest.next_row_id >= mark,
+        "restore rewound the row id high-water mark: {} < {mark}",
+        restored.manifest.next_row_id
+    );
+
+    // The rows appended after the restore must not reuse the dropped rows' ids.
+    let reused = write(20..30, WriteMode::Append).await;
+    let ids = scan_row_ids(&reused).await;
+    assert_eq!(
+        ids.iter().filter(|id| **id >= mark).count(),
+        10,
+        "appended rows did not all take fresh ids past {mark}: {ids:?}"
+    );
 }
 
 #[rstest]


### PR DESCRIPTION
Restore carried forward the fragment-id high-water mark but not the
row-id one, so an append after a restore handed a historical stable id
to a new row. Stable ids are documented as unique across all of a
table's versions, and everything keyed by them -- caches, indexes,
provenance -- would attribute the old row's state to the new one.

Restore now keeps the maximum of the restored and current marks, the
same treatment fragment ids already get two lines above.

The carried mark only binds while the feature is on. Restoring a version
from before stable ids were enabled turns them back off, and _rowid
reverts to row addresses, whose namespace overlaps ids the table has
already issued -- a reader holding an old id silently gets a different
row. Such a restore is rejected, the same treatment the MemWAL catch-up
flag already gets here. The migration also numbers from the manifest's
mark rather than from zero, so that guard is policy rather than the
thing correctness rests on.
