### PR TITLE
refactor(mem-wal): remove the index-catchup feature bit

### DIFF
--- a/docs/src/format/table/mem_wal.md
+++ b/docs/src/format/table/mem_wal.md
@@ -341,10 +341,9 @@ Important fields:
 - `index_catchup`: per-index coverage progress after data has been compacted into the base table.
 - `snapshot_ts_millis`, `num_shards`, and `inline_snapshots`: optional shard snapshot fields for read optimization.
 
-What an absent entry means depends on the `FLAG_MEM_WAL_INDEX_CATCHUP` feature bit:
-
-- **Without the bit**, a shard absent from `index_catchup` for an index means that index is assumed fully caught up for the shard.
-- **With the bit**, absence means the opposite: the index is *not* known to have caught up, so the shard's SSTables must be retained until some commit records that it has.
+A shard absent from `index_catchup` for an index means that index is *not* known
+to have caught up, so the shard's SSTables must be retained until some commit
+records that it has.
 
 Catch-up is derived at commit time, not reported by the writer. An index whose segments together span every fragment live at the transaction's read version holds every row compaction had copied into the base table by then, so the commit records it as caught up to that version's `compacted_sstables`. That is the only proof available — nothing maps a compaction generation to the fragments its rows landed in — so covering the table as the transaction read it is how an index shows it covered those rows. Fragments appended since that read are a later catch-up gap and are not required.
 
@@ -353,8 +352,6 @@ Two rules bound what a commit may record. It never credits more than its own `co
 Because the position is derived rather than transmitted, it cannot go stale between inspection and commit, and it survives rebase — `read_version` is fixed for a transaction's life, so what a commit can prove does not move, though a rebased attempt may record a different result because the head it commits against has changed. Any commit can earn a position, so an ordinary index build that happens to cover the table records catch-up as a side effect. A dedicated repair is still needed where no such commit occurs, or where an index does not yet span the table.
 
 A read version with no fragments proves nothing, even though an index trivially covers an empty table. An empty fragment list is also what a manifest written before the `UpdateMemWalState` fragment fix looks like, where the SSTables are the last copy of those rows; crediting coverage there would retire them. The cost is that a table whose rows have all been deleted keeps its SSTables.
-
-Setting the bit is one-way. Once SSTables have stopped being served against a recorded catch-up position, reading absence as "caught up" again could drop rows that only those SSTables still hold, so the bit is never cleared as a rollback. Writers must also hold the bit: a writer that does not maintain `index_catchup` can change an index without withdrawing the position recorded for it, leaving a position that no longer describes the index it names.
 
 Shard snapshots, when present, use the following Lance file schema:
 
@@ -507,7 +504,7 @@ On commit conflict, a compactor reloads the conflicting base-table version:
 The garbage collector may remove obsolete SSTables after:
 
 1. The SSTable has been compacted into the base table.
-2. Every index a query may rely on has caught up to cover the SSTable's generation, or the SSTable is no longer needed for indexed reads. With `FLAG_MEM_WAL_INDEX_CATCHUP` set, an index absent from `index_catchup` has *not* caught up, so this condition is not met for it.
+2. Every index a query may rely on has caught up to cover the SSTable's generation, or the SSTable is no longer needed for indexed reads. An index absent from `index_catchup` has *not* caught up, so this condition is not met for it.
 3. No retained base-table version needs the SSTable for time travel or consistency.
 
 !!! warning

--- a/docs/src/format/table/versioning.md
+++ b/docs/src/format/table/versioning.md
@@ -30,7 +30,6 @@ they should return an "unsupported" error on any read or write operation.
 | 16       | `FLAG_BASE_PATHS`               | Yes             | Yes             | Dataset uses multiple base paths (for shallow clones or multi-base datasets).                               |
 | 32       | `FLAG_DISABLE_TRANSACTION_FILE` | No              | Yes             | Transactions are recorded in the manifest rather than in a separate transaction file.                       |
 | 64       | `FLAG_UNSTABLE_DATA_OVERLAY_FILES` | Yes          | Yes             | Fragments may carry data overlay files. Unstable: release builds reject it unless explicitly opted in.      |
-| 128      | `FLAG_MEM_WAL_INDEX_CATCHUP`    | Yes             | Yes             | `index_catchup` is maintained on this table, so an index absent from it is *not* caught up. See [MemWAL](mem_wal.md). |
 
 </div>
 

--- a/protos/table.proto
+++ b/protos/table.proto
@@ -118,13 +118,6 @@ message Manifest {
   // * 1 << 6: data overlay files are present (see DataOverlayFile). Readers that do
   //   not understand overlays must refuse the dataset, since ignoring an overlay
   //   would silently return stale base values.
-  // * 1 << 7: index_catchup is maintained on this table, so an index absent from
-  //   it is *not* caught up rather than fully caught up (see MemWalIndexDetails).
-  //   Readers that do not understand it must refuse the dataset, since reading
-  //   absence as caught up could answer from an index missing rows that only the
-  //   MemWAL SSTables still hold. Writers must refuse it too: one that does not
-  //   maintain index_catchup can change an index without withdrawing the
-  //   position recorded for it. Setting it is one-way.
   uint64 reader_feature_flags = 9;
 
   // Feature flags for writers.
@@ -699,11 +692,8 @@ message IndexCatchupProgress {
 
   // Per-shard progress: the generation up to which this index covers.
   //
-  // An absent shard means "fully caught up" ONLY on a legacy table. On a table
-  // with the MemWAL index-catchup feature bit set it means *unknown*: this
-  // index has recorded no catch-up for that shard, so its SSTables must be retained
-  // and a repair scheduled. The manifest feature bit, not this message, selects
-  // which reading applies.
+  // An absent shard means *unknown*: this index has recorded no catch-up for
+  // that shard, so its SSTables must be retained and a repair scheduled.
   repeated CompactedSsTable caught_up_generations = 2;
 }
 
@@ -769,10 +759,9 @@ message MemWalIndexDetails {
   // readers should use SSTable indexes for the gap instead of
   // scanning unindexed data in the base table.
   //
-  // An index absent from this list is "fully caught up" ONLY on a legacy table.
-  // With the MemWAL index-catchup feature bit set, absence means the index has
-  // recorded no catch-up, so the SSTables it would need stay live until a repair
-  // records it. Only the dedicated WAL index-repair path may add entries here;
+  // An index absent from this list has recorded no catch-up, so the SSTables it
+  // would need stay live until a repair records it. Only the dedicated WAL
+  // index-repair path may add entries here;
   // ordinary index operations have their entry removed automatically when they
   // change an index, since they do not report what the new index covers.
   repeated IndexCatchupProgress index_catchup = 10;

--- a/protos/transaction.proto
+++ b/protos/transaction.proto
@@ -360,14 +360,6 @@ message Transaction {
   message UpdateMemWalState {
     // SSTables being marked as compacted.
     repeated CompactedSsTable compacted_sstables = 1;
-
-    // Presence with true requests the one-way migration to required catch-up.
-    // False is invalid; absence is an ordinary progress update.
-    //
-    // The migration is one-way because returning to legacy semantics — where a
-    // missing coverage entry reads as "fully caught up" — is unsafe once any
-    // SSTable has been retired against a recorded catch-up position.
-    optional bool require_index_catchup = 2;
   }
 
   // An operation that updates base paths in the dataset.

--- a/rust/lance-table/src/feature_flags.rs
+++ b/rust/lance-table/src/feature_flags.rs
@@ -30,21 +30,22 @@ pub const FLAG_DISABLE_TRANSACTION_FILE: u64 = 32;
 /// unless [`ENABLE_UNSTABLE_DATA_OVERLAY_FILES_ENV`] is set, which lets benchmarks opt in.
 /// Debug builds always understand it so tests exercise the path.
 pub const FLAG_UNSTABLE_DATA_OVERLAY_FILES: u64 = 64;
-/// `index_catchup` is maintained on this table, so a missing entry means the
-/// index is *not* caught up rather than fully caught up.
-///
-/// A reader without this bit would read a missing `index_catchup` entry as
-/// "fully caught up" and could answer an index-only query without the SSTables
-/// holding the newest rows. A writer without it would change an index without
-/// invalidating the catch-up position recorded for that index, leaving a stale
-/// position behind. Both must refuse the table.
-pub const FLAG_MEM_WAL_INDEX_CATCHUP: u64 = 128;
 /// The first bit that is unknown as a feature flag
-pub const FLAG_UNKNOWN: u64 = 256;
+pub const FLAG_UNKNOWN: u64 = 128;
 
-// This build only understands flags below the unknown boundary, so a bit
-// allocated at or above it would be refused by the very readers meant to use it.
-const _: () = assert!(FLAG_MEM_WAL_INDEX_CATCHUP < FLAG_UNKNOWN);
+// Every flag this build declares must sit below the unknown boundary, or
+// `supported_flags` would refuse a bit this code claims to understand. The next
+// flag allocated takes 128, so it has to move the boundary to 256 with it.
+const _: () = assert!(
+    (FLAG_DELETION_FILES
+        | FLAG_STABLE_ROW_IDS
+        | FLAG_USE_V2_FORMAT_DEPRECATED
+        | FLAG_TABLE_CONFIG
+        | FLAG_BASE_PATHS
+        | FLAG_DISABLE_TRANSACTION_FILE
+        | FLAG_UNSTABLE_DATA_OVERLAY_FILES)
+        < FLAG_UNKNOWN
+);
 
 /// Environment variable that opts a release build into reading and writing data
 /// overlay files before the feature is generally released.
@@ -56,26 +57,6 @@ pub fn apply_feature_flags(
     enable_stable_row_id: bool,
     disable_transaction_file: bool,
 ) -> Result<()> {
-    // Carried across the reset. This bit is not derivable from the manifest --
-    // it depends on the `__lance_mem_wal` index details, which a manifest only
-    // points at -- and this function runs twice per commit: once in
-    // `build_manifest` and again in `write_manifest_file`. Dropping it here
-    // would clear it immediately before the write, so an activated table would
-    // report success and stay legacy.
-    //
-    // Only a consistent state carries: one bit set is neither mode, and
-    // `inherit_mem_wal_index_catchup` refuses it at the boundary where a
-    // manifest is derived from another. Reaching here half-set means the
-    // manifest was already written that way, so leave it for the reader check
-    // rather than silently completing it.
-    let mem_wal_index_catchup = if manifest.reader_feature_flags & FLAG_MEM_WAL_INDEX_CATCHUP != 0
-        && manifest.writer_feature_flags & FLAG_MEM_WAL_INDEX_CATCHUP != 0
-    {
-        FLAG_MEM_WAL_INDEX_CATCHUP
-    } else {
-        0
-    };
-
     // Reset flags
     manifest.reader_feature_flags = 0;
     manifest.writer_feature_flags = 0;
@@ -134,38 +115,7 @@ pub fn apply_feature_flags(
         manifest.writer_feature_flags |= FLAG_DISABLE_TRANSACTION_FILE;
     }
 
-    manifest.reader_feature_flags |= mem_wal_index_catchup;
-    manifest.writer_feature_flags |= mem_wal_index_catchup;
-
     Ok(())
-}
-
-/// Carry [`FLAG_MEM_WAL_INDEX_CATCHUP`] from the manifest a new one is derived
-/// from.
-///
-/// [`apply_feature_flags`] carries this bit across its own reset, but it only
-/// ever sees one manifest. It cannot help where a *new* manifest is derived from
-/// an existing one -- `Manifest::new_from_previous` and `shallow_clone` both
-/// zero the feature words -- because the destination starts with nothing to
-/// carry. That transition is this function's job.
-///
-/// A half-set state is refused rather than normalized: one bit set means a
-/// legacy reader or a legacy writer is still permitted, which is neither mode.
-pub fn inherit_mem_wal_index_catchup(destination: &mut Manifest, source: &Manifest) -> Result<()> {
-    let reader = source.reader_feature_flags & FLAG_MEM_WAL_INDEX_CATCHUP != 0;
-    let writer = source.writer_feature_flags & FLAG_MEM_WAL_INDEX_CATCHUP != 0;
-    match (reader, writer) {
-        (false, false) => Ok(()),
-        (true, true) => {
-            destination.reader_feature_flags |= FLAG_MEM_WAL_INDEX_CATCHUP;
-            destination.writer_feature_flags |= FLAG_MEM_WAL_INDEX_CATCHUP;
-            Ok(())
-        }
-        _ => Err(Error::invalid_input(
-            "Manifest has only one of the MemWAL index-catchup reader and writer \
-             feature bits set, so its catch-up semantics are undefined",
-        )),
-    }
 }
 
 /// Whether this build understands data overlay files: always in debug builds,
@@ -210,24 +160,6 @@ pub fn can_write_dataset(writer_flags: u64) -> bool {
 
 pub fn has_deprecated_v2_feature_flag(writer_flags: u64) -> bool {
     writer_flags & FLAG_USE_V2_FORMAT_DEPRECATED != 0
-}
-
-/// Refuse a manifest whose MemWAL index-catchup bits disagree.
-///
-/// One word set and the other not is neither mode: it would let a legacy reader
-/// or a legacy writer through on a table where the other half is enforcing. The
-/// commit path refuses to *produce* this, so seeing it on read means the
-/// manifest was written by something that did not.
-pub fn validate_mem_wal_index_catchup_flags(manifest: &Manifest) -> Result<()> {
-    let reader = manifest.reader_feature_flags & FLAG_MEM_WAL_INDEX_CATCHUP != 0;
-    let writer = manifest.writer_feature_flags & FLAG_MEM_WAL_INDEX_CATCHUP != 0;
-    if reader != writer {
-        return Err(Error::invalid_input(
-            "Manifest has only one of the MemWAL index-catchup reader and writer \
-             feature bits set, so its catch-up semantics are undefined",
-        ));
-    }
-    Ok(())
 }
 
 #[cfg(test)]
@@ -387,113 +319,5 @@ mod tests {
             multi_base_manifest.writer_feature_flags & FLAG_BASE_PATHS,
             0
         );
-    }
-
-    /// The MemWAL bit depends on the `__lance_mem_wal` index details, which a
-    /// manifest cannot see — it holds only a byte offset to its index section.
-    /// So an unrelated recomputation must preserve the bit rather than derive
-    /// it, or a later transaction would silently downgrade the table to legacy
-    /// semantics and a reader would treat missing coverage as complete.
-    #[test]
-    fn inheriting_carries_the_mem_wal_bit_from_the_source() {
-        let mut source = empty_manifest();
-        source.reader_feature_flags = FLAG_MEM_WAL_INDEX_CATCHUP;
-        source.writer_feature_flags = FLAG_MEM_WAL_INDEX_CATCHUP;
-        // What `Manifest::new_from_previous` hands us: both words zeroed.
-        let mut destination = empty_manifest();
-
-        inherit_mem_wal_index_catchup(&mut destination, &source).unwrap();
-
-        assert_ne!(
-            destination.reader_feature_flags & FLAG_MEM_WAL_INDEX_CATCHUP,
-            0
-        );
-        assert_ne!(
-            destination.writer_feature_flags & FLAG_MEM_WAL_INDEX_CATCHUP,
-            0
-        );
-    }
-
-    #[test]
-    fn inheriting_refuses_a_half_set_source() {
-        for (reader, writer) in [
-            (FLAG_MEM_WAL_INDEX_CATCHUP, 0),
-            (0, FLAG_MEM_WAL_INDEX_CATCHUP),
-        ] {
-            let mut source = empty_manifest();
-            source.reader_feature_flags = reader;
-            source.writer_feature_flags = writer;
-            let mut destination = empty_manifest();
-
-            let err = inherit_mem_wal_index_catchup(&mut destination, &source).unwrap_err();
-
-            assert!(err.to_string().contains("only one of"), "{err}");
-        }
-    }
-
-    #[test]
-    fn apply_feature_flags_carries_the_mem_wal_bit_across_its_reset() {
-        // It runs twice per commit -- `build_manifest` and `write_manifest_file`
-        // -- so dropping the bit here would clear it immediately before the
-        // write, and an activated table would report success and stay legacy.
-        let mut manifest = empty_manifest();
-        manifest.reader_feature_flags = FLAG_MEM_WAL_INDEX_CATCHUP;
-        manifest.writer_feature_flags = FLAG_MEM_WAL_INDEX_CATCHUP;
-
-        apply_feature_flags(&mut manifest, false, false).unwrap();
-
-        assert_ne!(
-            manifest.reader_feature_flags & FLAG_MEM_WAL_INDEX_CATCHUP,
-            0
-        );
-        assert_ne!(
-            manifest.writer_feature_flags & FLAG_MEM_WAL_INDEX_CATCHUP,
-            0
-        );
-    }
-
-    #[test]
-    fn apply_feature_flags_drops_a_half_set_mem_wal_bit() {
-        // Neither mode, so leave it for the reader check rather than completing it.
-        let mut manifest = empty_manifest();
-        manifest.reader_feature_flags = FLAG_MEM_WAL_INDEX_CATCHUP;
-
-        apply_feature_flags(&mut manifest, false, false).unwrap();
-
-        assert_eq!(
-            manifest.reader_feature_flags & FLAG_MEM_WAL_INDEX_CATCHUP,
-            0
-        );
-        assert_eq!(
-            manifest.writer_feature_flags & FLAG_MEM_WAL_INDEX_CATCHUP,
-            0
-        );
-    }
-
-    fn empty_manifest() -> Manifest {
-        use crate::format::DataStorageFormat;
-        use arrow_schema::{DataType, Field as ArrowField, Schema as ArrowSchema};
-        use lance_core::datatypes::Schema;
-        use std::collections::HashMap;
-        use std::sync::Arc;
-
-        let arrow_schema = ArrowSchema::new(vec![ArrowField::new("i", DataType::Int32, false)]);
-        Manifest::new(
-            Schema::try_from(&arrow_schema).unwrap(),
-            Arc::new(vec![]),
-            DataStorageFormat::default(),
-            HashMap::new(),
-        )
-    }
-
-    /// A build that does not know the bit must refuse the table rather than
-    /// continue with legacy semantics.
-    #[test]
-    fn the_mem_wal_bit_is_below_the_unknown_boundary() {
-        assert!(can_read_dataset(FLAG_MEM_WAL_INDEX_CATCHUP));
-        assert!(can_write_dataset(FLAG_MEM_WAL_INDEX_CATCHUP));
-        // The next bit up is still unknown, so allocating this one did not
-        // silently widen what this build claims to understand.
-        assert!(!can_read_dataset(FLAG_UNKNOWN));
     }
 }

--- a/rust/lance-table/src/feature_flags.rs
+++ b/rust/lance-table/src/feature_flags.rs
@@ -33,19 +33,10 @@ pub const FLAG_UNSTABLE_DATA_OVERLAY_FILES: u64 = 64;
 /// The first bit that is unknown as a feature flag
 pub const FLAG_UNKNOWN: u64 = 128;
 
-// Every flag this build declares must sit below the unknown boundary, or
+// The highest flag allocated must stay below the unknown boundary, or
 // `supported_flags` would refuse a bit this code claims to understand. The next
-// flag allocated takes 128, so it has to move the boundary to 256 with it.
-const _: () = assert!(
-    (FLAG_DELETION_FILES
-        | FLAG_STABLE_ROW_IDS
-        | FLAG_USE_V2_FORMAT_DEPRECATED
-        | FLAG_TABLE_CONFIG
-        | FLAG_BASE_PATHS
-        | FLAG_DISABLE_TRANSACTION_FILE
-        | FLAG_UNSTABLE_DATA_OVERLAY_FILES)
-        < FLAG_UNKNOWN
-);
+// flag takes 128, so it has to move the boundary to 256 with it.
+const _: () = assert!(FLAG_UNSTABLE_DATA_OVERLAY_FILES < FLAG_UNKNOWN);
 
 /// Environment variable that opts a release build into reading and writing data
 /// overlay files before the feature is generally released.

--- a/rust/lance-table/src/format/manifest.rs
+++ b/rust/lance-table/src/format/manifest.rs
@@ -18,7 +18,6 @@ use std::ops::Range;
 use std::sync::Arc;
 
 use super::Fragment;
-use crate::feature_flags::FLAG_MEM_WAL_INDEX_CATCHUP;
 use crate::feature_flags::{FLAG_STABLE_ROW_IDS, has_deprecated_v2_feature_flag};
 use crate::format::fragment::DataFileFieldInterner;
 use crate::format::pb;
@@ -188,8 +187,8 @@ impl Manifest {
             index_section: None,
             timestamp_nanos: 0,
             tag: None,
-            reader_feature_flags: 0,
-            writer_feature_flags: 0,
+            reader_feature_flags: 0, // These will be set on commit
+            writer_feature_flags: 0, // These will be set on commit
             max_fragment_id: None,
             transaction_file: None,
             transaction_section: None,
@@ -276,11 +275,8 @@ impl Manifest {
             index_section: None, // These will be set on commit
             timestamp_nanos: self.timestamp_nanos,
             tag: None,
-            // Not derivable from the manifest, so it would be lost like any
-            // other zeroed word -- and a clone of a table that requires index
-            // catch-up would silently come back as legacy.
-            reader_feature_flags: self.reader_feature_flags & FLAG_MEM_WAL_INDEX_CATCHUP,
-            writer_feature_flags: self.writer_feature_flags & FLAG_MEM_WAL_INDEX_CATCHUP,
+            reader_feature_flags: 0, // These will be set on commit
+            writer_feature_flags: 0, // These will be set on commit
             max_fragment_id: self.max_fragment_id,
             transaction_file: Some(transaction_file),
             transaction_section: None,

--- a/rust/lance-table/src/system_index/mem_wal.rs
+++ b/rust/lance-table/src/system_index/mem_wal.rs
@@ -434,24 +434,6 @@ impl MemWalIndex {
             .find(|icp| icp.index_name == index_name)
             .and_then(|icp| icp.caught_up_generation_for_shard(shard_id))
     }
-
-    /// Whether an index covers all compacted data for a shard, under **legacy**
-    /// semantics.
-    ///
-    /// A missing `index_catchup` entry is read here as "fully caught up". That
-    /// is only correct for a table without the index-catchup feature bit. On
-    /// an activated table a missing entry means *unknown*: the index has not
-    /// recorded anything, so its SSTables must be retained and a repair
-    /// scheduled. This accessor cannot see the manifest, so it cannot make that
-    /// distinction -- callers must select the semantics from the feature bit,
-    /// and the name says which one they get here.
-    pub fn is_index_caught_up_legacy(&self, index_name: &str, shard_id: &Uuid) -> bool {
-        let compacted_gen = self.compacted_generation_for_shard(shard_id).unwrap_or(0);
-        let caught_up_gen = self.index_caught_up_generation(index_name, shard_id);
-
-        // Missing means "caught up" only because this is the legacy reading.
-        caught_up_gen.is_none_or(|generation| generation >= compacted_gen)
-    }
 }
 
 // Reading and updating the `IndexMetadata` entry that carries the details above.

--- a/rust/lance-table/src/transaction/conflicts.rs
+++ b/rust/lance-table/src/transaction/conflicts.rs
@@ -726,13 +726,11 @@ impl PartialEq for Operation {
             (
                 Self::UpdateMemWalState {
                     compacted_sstables: a_compacted,
-                    require_index_catchup: a_activate,
                 },
                 Self::UpdateMemWalState {
                     compacted_sstables: b_compacted,
-                    require_index_catchup: b_activate,
                 },
-            ) => compare_vec(a_compacted, b_compacted) && a_activate == b_activate,
+            ) => compare_vec(a_compacted, b_compacted),
             (Self::Clone { .. }, Self::Append { .. }) => {
                 std::mem::discriminant(self) == std::mem::discriminant(other)
             }

--- a/rust/lance-table/src/transaction/manifest_build.rs
+++ b/rust/lance-table/src/transaction/manifest_build.rs
@@ -10,10 +10,7 @@
 //! operation vocabulary it matches on, the index rules it applies, the row version
 //! metadata it stamps, the validation that runs before it.
 
-use crate::feature_flags::{
-    FLAG_MEM_WAL_INDEX_CATCHUP, FLAG_STABLE_ROW_IDS, apply_feature_flags,
-    inherit_mem_wal_index_catchup, validate_mem_wal_index_catchup_flags,
-};
+use crate::feature_flags::{FLAG_STABLE_ROW_IDS, apply_feature_flags};
 use crate::format::overlay::TOMBSTONE_FIELD_ID;
 use crate::format::{
     DataFile, DataStorageFormat, Fragment, IndexMetadata, Manifest, ManifestBuildConfig,
@@ -103,10 +100,6 @@ impl Transaction {
             .resolve_version_location(base_path, version, &object_store.inner)
             .await?;
         let mut manifest = read_manifest(object_store, &location.path, location.size).await?;
-        // Read below the reader validation boundary, so nothing else refuses a
-        // half-set manifest here: the flag reset would quietly drop the lone bit
-        // and republish an undefined state as legacy.
-        validate_mem_wal_index_catchup_flags(&manifest)?;
         manifest.set_timestamp(config.timestamp_nanos);
         manifest.transaction_file = Some(tx_path.to_string());
         let indices = read_manifest_indexes(object_store, &location, &manifest).await?;
@@ -124,69 +117,7 @@ impl Transaction {
                  collide with ids this table has already used"
             )));
         }
-        // A version from before catch-up was required carries MemWAL state this
-        // protocol never validated -- catch-up values activation deliberately
-        // cleared, or compaction progress it deliberately refused to trust.
-        // Keeping the bit would republish those as if this protocol had recorded
-        // them. Refuse instead: sanitizing is not possible here, because both
-        // fields would have to be re-derived from data Lance cannot see.
-        let current_requires = current_manifest.reader_feature_flags & FLAG_MEM_WAL_INDEX_CATCHUP
-            != 0
-            || current_manifest.writer_feature_flags & FLAG_MEM_WAL_INDEX_CATCHUP != 0;
-        let restored_requires = manifest.reader_feature_flags & FLAG_MEM_WAL_INDEX_CATCHUP != 0
-            && manifest.writer_feature_flags & FLAG_MEM_WAL_INDEX_CATCHUP != 0;
-        if current_requires && !restored_requires {
-            return Err(Error::invalid_input(format!(
-                "Cannot restore version {version}: this table requires MemWAL index \
-                 catch-up and that version predates it, so its recorded catch-up and \
-                 compaction progress were never validated by this protocol"
-            )));
-        }
-        inherit_mem_wal_index_catchup(&mut manifest, current_manifest)?;
         Ok((manifest, indices))
-    }
-
-    /// Require index catch-up on a table that has never required it.
-    ///
-    /// One-way, because returning to legacy semantics -- where a missing
-    /// coverage entry reads as "fully caught up" -- is unsafe once any SSTable
-    /// has been retired against a recorded catch-up position.
-    fn require_index_catchup(final_indices: &mut [IndexMetadata], new_version: u64) -> Result<()> {
-        let Some(pos) = final_indices
-            .iter()
-            .position(|idx| idx.name == MEM_WAL_INDEX_NAME)
-        else {
-            return Err(Error::invalid_input(format!(
-                "Cannot require MemWAL index catch-up: the {} system index does \
-                 not exist on this table",
-                MEM_WAL_INDEX_NAME
-            )));
-        };
-
-        let mut details = load_mem_wal_index_details(final_indices[pos].clone())?;
-
-        // The beta protocol wrote compaction progress that was never an active
-        // retirement record, and Lance cannot check those numbers against WAL
-        // shard manifests. Trusting them would let the first trim after
-        // activation delete SSTables no commit copied in, so a table carrying
-        // them must be drained through an explicit migration instead.
-        if !details.compacted_sstables.is_empty() {
-            return Err(Error::invalid_input(
-                "Cannot require MemWAL index catch-up: the table already records \
-                 SSTable compaction progress from the beta protocol, which cannot \
-                 be validated. Drain or reset the table first.",
-            ));
-        }
-
-        // Beta coverage was written under rules this protocol does not enforce,
-        // so it is not trustworthy. Left in place, a later compaction would find it
-        // already satisfied and could retire an SSTable that no index covers.
-        if details.index_catchup.is_empty() {
-            return Ok(());
-        }
-        details.index_catchup.clear();
-        final_indices[pos] = new_mem_wal_index_meta(new_version, details)?;
-        Ok(())
     }
 
     /// Every non-system logical index, mapped to what determines its coverage.
@@ -238,13 +169,8 @@ impl Transaction {
         final_indices: &mut [IndexMetadata],
         segments_before: &LogicalIndexSegments,
         read_version_state: Option<ReadVersionState<'_>>,
-        index_catchup_required: bool,
         new_version: u64,
     ) -> Result<()> {
-        if !index_catchup_required {
-            return Ok(());
-        }
-
         let Some(pos) = final_indices
             .iter()
             .position(|idx| idx.name == MEM_WAL_INDEX_NAME)
@@ -556,24 +482,14 @@ impl Transaction {
         let mut final_fragments = Vec::new();
         let mut final_indices = current_indices;
 
-        // Both words must agree: a reader that keeps legacy semantics would read a
-        // missing entry as "fully caught up", so a half-set state is not safe mode.
-        let index_catchup_required = current_manifest
-            .map(|m| {
-                m.reader_feature_flags & FLAG_MEM_WAL_INDEX_CATCHUP != 0
-                    && m.writer_feature_flags & FLAG_MEM_WAL_INDEX_CATCHUP != 0
-            })
-            .unwrap_or(false);
-
         // Snapshot taken before the operation rewrites the list, so coverage can
         // be compared against what each logical index looked like going in. Only
-        // tables in safe mode maintain coverage, so every other commit -- and the
-        // segment clones this costs -- pays nothing.
-        let mem_wal_segments_before = (index_catchup_required
-            && final_indices
-                .iter()
-                .any(|idx| idx.name == MEM_WAL_INDEX_NAME))
-        .then(|| Self::logical_index_segments(&final_indices));
+        // tables with a MemWAL index maintain coverage, so every other commit --
+        // and the segment clones this costs -- pays nothing.
+        let mem_wal_segments_before = final_indices
+            .iter()
+            .any(|idx| idx.name == MEM_WAL_INDEX_NAME)
+            .then(|| Self::logical_index_segments(&final_indices));
 
         let mut next_row_id = {
             // Only use row ids if the feature flag is set already, or this is
@@ -1325,13 +1241,11 @@ impl Transaction {
         // Applied once the final index list is known, so it sees exactly the
         // indices this commit publishes rather than what any one operation arm
         // intended.
-        if mem_wal_segments_before.is_some() {
-            let empty_segments = LogicalIndexSegments::new();
+        if let Some(segments_before) = mem_wal_segments_before.as_ref() {
             Self::apply_mem_wal_index_coverage(
                 &mut final_indices,
-                mem_wal_segments_before.as_ref().unwrap_or(&empty_segments),
+                segments_before,
                 read_version_state,
-                index_catchup_required,
                 new_version,
             )?;
         }
@@ -1379,51 +1293,6 @@ impl Transaction {
                 config.disable_transaction_file,
             )?;
         }
-        // Carried from the manifest this one is derived from. `new_from_previous`
-        // zeroes both feature words, so `apply_feature_flags` cannot see the
-        // previous state and every ordinary commit would otherwise drop the bit.
-        if let Some(current_manifest) = current_manifest {
-            inherit_mem_wal_index_catchup(&mut manifest, current_manifest)?;
-        }
-
-        // Set after apply_feature_flags, which resets both flag words: activation
-        // is the one place the bit is turned on, and it must survive that reset.
-        if let Operation::UpdateMemWalState {
-            require_index_catchup: true,
-            ..
-        } = &self.operation
-        {
-            let reader_set = current_manifest
-                .map(|m| m.reader_feature_flags & FLAG_MEM_WAL_INDEX_CATCHUP != 0)
-                .unwrap_or(false);
-            let writer_set = current_manifest
-                .map(|m| m.writer_feature_flags & FLAG_MEM_WAL_INDEX_CATCHUP != 0)
-                .unwrap_or(false);
-            match (reader_set, writer_set) {
-                (false, false) => {
-                    Self::require_index_catchup(&mut final_indices, new_version)?;
-                    log::info!(
-                        "MemWAL index catch-up is now required at version {new_version}; a \
-                         missing catch-up entry means an index is behind, not caught up. \
-                         This is one-way."
-                    );
-                }
-                // Already active. A retry whose first attempt landed but lost its
-                // response must not clear coverage repaired since, so this keeps
-                // every recorded generation.
-                (true, true) => {}
-                _ => {
-                    return Err(Error::invalid_input(
-                        "Cannot require MemWAL index catch-up: the table has only one of \
-                         the reader and writer feature bits set, so its catch-up \
-                         semantics are undefined",
-                    ));
-                }
-            }
-            manifest.reader_feature_flags |= FLAG_MEM_WAL_INDEX_CATCHUP;
-            manifest.writer_feature_flags |= FLAG_MEM_WAL_INDEX_CATCHUP;
-        }
-
         manifest.set_timestamp(config.timestamp_nanos);
 
         manifest.update_max_fragment_id();
@@ -3034,7 +2903,6 @@ mod tests {
 
     mod mem_wal_index_coverage {
         use super::*;
-        use crate::feature_flags::FLAG_MEM_WAL_INDEX_CATCHUP;
         use crate::system_index::mem_wal::{
             CompactedSsTable, IndexCatchupProgress, MEM_WAL_INDEX_NAME, MemWalIndexDetails,
         };
@@ -3094,7 +2962,6 @@ mod tests {
             before: &[IndexMetadata],
             read_frags: &[u32],
             read_indices: &[IndexMetadata],
-            required: bool,
         ) -> Result<()> {
             let manifest = manifest_with(read_frags);
             let segments_before = Transaction::logical_index_segments(before);
@@ -3105,7 +2972,6 @@ mod tests {
                     manifest: &manifest,
                     indices: read_indices,
                 }),
-                required,
                 2,
             )
         }
@@ -3139,7 +3005,7 @@ mod tests {
             let shard = Uuid::new_v4();
             let read = table(&[0, 1], Uuid::new_v4(), progress(shard, 5));
             let mut after = table(&[0, 1], Uuid::new_v4(), progress(shard, 5));
-            apply(&mut after, &read, &[0, 1], &read, true).unwrap();
+            apply(&mut after, &read, &[0, 1], &read).unwrap();
             assert_eq!(coverage_for(&after, "idx"), Some(compacted(shard, 5)));
         }
 
@@ -3150,7 +3016,7 @@ mod tests {
             let shard = Uuid::new_v4();
             let read = table(&[0], Uuid::new_v4(), progress(shard, 5));
             let mut after = table(&[0], Uuid::new_v4(), progress(shard, 5));
-            apply(&mut after, &read, &[0, 1], &read, true).unwrap();
+            apply(&mut after, &read, &[0, 1], &read).unwrap();
             assert_eq!(coverage_for(&after, "idx"), None);
         }
 
@@ -3168,7 +3034,7 @@ mod tests {
             let before = table(&[0, 1], uuid, progress_with_catchup(shard, 5, 5));
             // Same UUID, fragment 1 pruned away.
             let mut after = table(&[0], uuid, progress_with_catchup(shard, 5, 5));
-            apply(&mut after, &before, &[0, 1], &before, true).unwrap();
+            apply(&mut after, &before, &[0, 1], &before).unwrap();
             assert_eq!(
                 coverage_for(&after, "idx"),
                 None,
@@ -3188,7 +3054,7 @@ mod tests {
             let before = table(&[0], uuid, progress_with_catchup(shard, 5, 2));
             let mut after = before.clone();
             // Fragment 1 arrived with that compaction and this index lacks it.
-            apply(&mut after, &before, &[0, 1], &before, true).unwrap();
+            apply(&mut after, &before, &[0, 1], &before).unwrap();
             assert_eq!(coverage_for(&after, "idx"), Some(compacted(shard, 2)));
         }
 
@@ -3201,7 +3067,7 @@ mod tests {
             let uuid = Uuid::new_v4();
             let before = table(&[0], uuid, progress_with_catchup(shard, 3, 9));
             let mut after = before.clone();
-            apply(&mut after, &before, &[0], &before, true).unwrap();
+            apply(&mut after, &before, &[0], &before).unwrap();
             assert_eq!(coverage_for(&after, "idx"), Some(compacted(shard, 3)));
         }
 
@@ -3213,7 +3079,7 @@ mod tests {
             let uuid = Uuid::new_v4();
             let before = table(&[0], uuid, progress_with_catchup(shard, 9, 9));
             let mut after = before.clone();
-            apply(&mut after, &before, &[0, 1], &before, true).unwrap();
+            apply(&mut after, &before, &[0, 1], &before).unwrap();
             assert_eq!(coverage_for(&after, "idx"), Some(compacted(shard, 9)));
         }
 
@@ -3225,7 +3091,7 @@ mod tests {
             let shard = Uuid::new_v4();
             let read = table(&[0], Uuid::new_v4(), progress(shard, 9));
             let mut after = table(&[0], Uuid::new_v4(), progress(shard, 3));
-            apply(&mut after, &read, &[0], &read, true).unwrap();
+            apply(&mut after, &read, &[0], &read).unwrap();
             assert_eq!(coverage_for(&after, "idx"), Some(compacted(shard, 3)));
         }
 
@@ -3239,7 +3105,7 @@ mod tests {
             // Read at generation 2; generation 5 landed while this ran.
             let read = table(&[0], Uuid::new_v4(), progress(shard, 2));
             let mut after = table(&[0], Uuid::new_v4(), progress(shard, 5));
-            apply(&mut after, &read, &[0], &read, true).unwrap();
+            apply(&mut after, &read, &[0], &read).unwrap();
             assert_eq!(coverage_for(&after, "idx"), Some(compacted(shard, 2)));
         }
 
@@ -3257,7 +3123,7 @@ mod tests {
                 mem_wal_index(progress(shard, 5)),
             ];
             let mut after = read.clone();
-            apply(&mut after, &read, &[0, 1], &read, true).unwrap();
+            apply(&mut after, &read, &[0, 1], &read).unwrap();
             assert_eq!(coverage_for(&after, "idx"), None);
         }
 
@@ -3267,7 +3133,7 @@ mod tests {
             let shard = Uuid::new_v4();
             let before = table(&[0], Uuid::new_v4(), progress_with_catchup(shard, 5, 5));
             let mut after = vec![mem_wal_index(progress_with_catchup(shard, 5, 5))];
-            apply(&mut after, &before, &[0], &before, true).unwrap();
+            apply(&mut after, &before, &[0], &before).unwrap();
             assert_eq!(coverage_for(&after, "idx"), None);
         }
 
@@ -3281,20 +3147,20 @@ mod tests {
             let before = vec![mem_wal_index(progress(shard, 5))];
             let mut after = table(&[0], Uuid::new_v4(), progress(shard, 5));
             // Covers the read version, but was not there when it was read.
-            apply(&mut after, &before, &[0], &before, true).unwrap();
+            apply(&mut after, &before, &[0], &before).unwrap();
             assert_eq!(coverage_for(&after, "idx"), Some(compacted(shard, 5)));
         }
 
-        /// A legacy table reads a missing entry as "fully caught up", so this
-        /// must leave it alone rather than make it look more covered.
+        /// A table carrying compaction progress but no catch-up entry earns one
+        /// from an ordinary commit. This is how a table written before catch-up
+        /// was maintained heals itself: nothing has to be run against it.
         #[test]
-        fn a_legacy_table_is_untouched() {
+        fn a_table_with_no_catchup_entry_earns_one() {
             let shard = Uuid::new_v4();
             let before = table(&[0], Uuid::new_v4(), progress(shard, 5));
             let mut after = before.clone();
-            let untouched = after.clone();
-            apply(&mut after, &before, &[0], &before, false).unwrap();
-            assert_eq!(after, untouched);
+            apply(&mut after, &before, &[0], &before).unwrap();
+            assert_eq!(coverage_for(&after, "idx"), Some(compacted(shard, 5)));
         }
 
         /// Two shards, only one of them compacted.
@@ -3311,7 +3177,7 @@ mod tests {
             };
             let read = table(&[0], Uuid::new_v4(), details.clone());
             let mut after = table(&[0], Uuid::new_v4(), details);
-            apply(&mut after, &read, &[0], &read, true).unwrap();
+            apply(&mut after, &read, &[0], &read).unwrap();
             let coverage = coverage_for(&after, "idx").expect("credited");
             assert_eq!(
                 coverage
@@ -3339,7 +3205,7 @@ mod tests {
                 mem_wal_index(progress(shard, 6)),
             ];
             let mut after = read.clone();
-            apply(&mut after, &read, &[0, 1], &read, true).unwrap();
+            apply(&mut after, &read, &[0, 1], &read).unwrap();
             assert_eq!(coverage_for(&after, "fast"), Some(compacted(shard, 6)));
             assert_eq!(coverage_for(&after, "slow"), None);
         }
@@ -3352,7 +3218,7 @@ mod tests {
             idx.fragment_bitmap = None;
             let read = vec![idx, mem_wal_index(progress(shard, 5))];
             let mut after = read.clone();
-            apply(&mut after, &read, &[0], &read, true).unwrap();
+            apply(&mut after, &read, &[0], &read).unwrap();
             assert_eq!(coverage_for(&after, "idx"), None);
         }
 
@@ -3362,7 +3228,7 @@ mod tests {
             let before = table(&[0], Uuid::new_v4(), MemWalIndexDetails::default());
             let mut after = before.clone();
             let untouched = after.clone();
-            apply(&mut after, &before, &[0], &before, true).unwrap();
+            apply(&mut after, &before, &[0], &before).unwrap();
             assert_eq!(after, untouched);
         }
 
@@ -3372,7 +3238,7 @@ mod tests {
             let before = vec![user_index("idx", Uuid::new_v4(), &[0])];
             let mut after = before.clone();
             let untouched = after.clone();
-            apply(&mut after, &before, &[0], &before, true).unwrap();
+            apply(&mut after, &before, &[0], &before).unwrap();
             assert_eq!(after, untouched);
         }
 
@@ -3385,7 +3251,7 @@ mod tests {
             let before = table(&[0], uuid, progress_with_catchup(shard, 5, 5));
             let mut after = before.clone();
             let segments_before = Transaction::logical_index_segments(&before);
-            Transaction::apply_mem_wal_index_coverage(&mut after, &segments_before, None, true, 2)
+            Transaction::apply_mem_wal_index_coverage(&mut after, &segments_before, None, 2)
                 .unwrap();
             assert_eq!(coverage_for(&after, "idx"), Some(compacted(shard, 5)));
         }
@@ -3401,7 +3267,7 @@ mod tests {
                 mem_wal_index(progress(shard, 10)),
             ];
             let mut after = read.clone();
-            apply(&mut after, &read, &[0], &read, true).unwrap();
+            apply(&mut after, &read, &[0], &read).unwrap();
             assert_eq!(coverage_for(&after, "untrained"), None);
             assert_eq!(coverage_for(&after, "trained"), Some(compacted(shard, 10)));
         }
@@ -3433,7 +3299,7 @@ mod tests {
                 }),
             ];
             let mut after = vec![user_index("idx", uuid, &[0]), mem_wal_index(details(10))];
-            apply(&mut after, &read, &[0], &read, true).unwrap();
+            apply(&mut after, &read, &[0], &read).unwrap();
 
             let mut coverage = coverage_for(&after, "idx").expect("credited");
             coverage.sort_unstable_by_key(|sstable| sstable.shard_id);
@@ -3454,7 +3320,7 @@ mod tests {
             let before = table(&[0, 1], Uuid::new_v4(), progress_with_catchup(shard, 5, 5));
             // Rebuilt over a subset -- the shape a partial reindex leaves.
             let mut after = table(&[0], Uuid::new_v4(), progress_with_catchup(shard, 5, 5));
-            apply(&mut after, &before, &[0, 1], &before, true).unwrap();
+            apply(&mut after, &before, &[0, 1], &before).unwrap();
             assert_eq!(coverage_for(&after, "idx"), None);
         }
 
@@ -3468,7 +3334,7 @@ mod tests {
             let before = table(&[0], uuid, progress_with_catchup(shard, 5, 0));
             let mut after = before.clone();
             // Does not span the read version, so nothing lifts it off zero.
-            apply(&mut after, &before, &[0, 1], &before, true).unwrap();
+            apply(&mut after, &before, &[0, 1], &before).unwrap();
             assert_eq!(coverage_for(&after, "idx"), None);
         }
 
@@ -3495,7 +3361,7 @@ mod tests {
             let before = vec![user_index("idx", uuid, &[0]), mem_wal_index(details)];
             let mut after = before.clone();
             // Unchanged and unproven: both shards keep exactly what they had.
-            apply(&mut after, &before, &[0, 1], &before, true).unwrap();
+            apply(&mut after, &before, &[0, 1], &before).unwrap();
 
             let mut coverage = coverage_for(&after, "idx").expect("carried");
             coverage.sort_unstable_by_key(|sstable| sstable.shard_id);
@@ -3555,7 +3421,7 @@ mod tests {
             let uuid = Uuid::new_v4();
             let before = table(&[0], uuid, progress_with_catchup(shard, 5, 5));
             let mut after = before.clone();
-            apply(&mut after, &before, &[0], &before, true).unwrap();
+            apply(&mut after, &before, &[0], &before).unwrap();
 
             let system_uuid = |indices: &[IndexMetadata]| {
                 indices
@@ -3567,113 +3433,6 @@ mod tests {
             assert_eq!(system_uuid(&after), system_uuid(&before));
         }
 
-        /// Activation is what puts a table on the protocol. A table that has
-        /// never compacted is clean.
-        #[test]
-        fn activation_accepts_a_clean_table() {
-            let mut indices = vec![mem_wal_index(MemWalIndexDetails::default())];
-            Transaction::require_index_catchup(&mut indices, 2).unwrap();
-        }
-
-        /// There is nothing to put on the protocol.
-        #[test]
-        fn activation_requires_the_mem_wal_index() {
-            let err = Transaction::require_index_catchup(&mut [], 2).unwrap_err();
-            assert!(err.to_string().contains("does not exist"), "{err}");
-        }
-
-        /// Coverage recorded under the beta rules was written to a different
-        /// contract; keeping it would let the first trim run unchecked.
-        #[test]
-        fn activation_clears_beta_coverage() {
-            let shard = Uuid::new_v4();
-            let mut indices = vec![mem_wal_index(MemWalIndexDetails {
-                index_catchup: vec![IndexCatchupProgress::new(
-                    "idx".to_string(),
-                    compacted(shard, 100),
-                )],
-                ..Default::default()
-            })];
-
-            Transaction::require_index_catchup(&mut indices, 2).unwrap();
-
-            assert!(
-                load_mem_wal_index_details(indices[0].clone())
-                    .unwrap()
-                    .index_catchup
-                    .is_empty()
-            );
-        }
-
-        /// Beta compaction progress means SSTables were folded in without any
-        /// coverage rule. No later commit can prove which indexes hold them.
-        #[test]
-        fn activation_rejects_pre_existing_beta_compaction_progress() {
-            let mut indices = vec![mem_wal_index(progress(Uuid::new_v4(), 4))];
-            let err = Transaction::require_index_catchup(&mut indices, 2).unwrap_err();
-            assert!(err.to_string().contains("beta protocol"), "{err}");
-        }
-
-        fn config_transaction(current: &Manifest) -> Transaction {
-            Transaction::new(
-                current.version,
-                Operation::UpdateConfig {
-                    config_updates: None,
-                    table_metadata_updates: None,
-                    schema_metadata_updates: None,
-                    field_metadata_updates: HashMap::new(),
-                },
-                None,
-            )
-        }
-
-        /// One bit without the other is a manifest no writer should produce:
-        /// a reader-only bit lets an unaware writer trim, a writer-only bit
-        /// lets an unaware reader serve rows no index holds.
-        #[test]
-        fn a_half_set_feature_bit_is_refused() {
-            for (reader, writer) in [
-                (FLAG_MEM_WAL_INDEX_CATCHUP, 0),
-                (0, FLAG_MEM_WAL_INDEX_CATCHUP),
-            ] {
-                let mut current = sample_manifest_with_fragments(0..1);
-                current.reader_feature_flags = reader;
-                current.writer_feature_flags = writer;
-
-                let err = config_transaction(&current)
-                    .build_manifest(
-                        Some(&current),
-                        vec![mem_wal_index(MemWalIndexDetails::default())],
-                        "txn",
-                        &default_build_config(),
-                    )
-                    .unwrap_err();
-
-                assert!(err.to_string().contains("only one of"), "{err}");
-            }
-        }
-
-        /// A writer that knows nothing about catch-up must not silently take a
-        /// table off the protocol.
-        #[test]
-        fn an_ordinary_commit_keeps_the_feature_bit() {
-            let mut current = sample_manifest_with_fragments(0..1);
-            current.reader_feature_flags = FLAG_MEM_WAL_INDEX_CATCHUP;
-            current.writer_feature_flags = FLAG_MEM_WAL_INDEX_CATCHUP;
-
-            let (next, _) = config_transaction(&current)
-                .build_manifest(
-                    Some(&current),
-                    vec![mem_wal_index(MemWalIndexDetails::default())],
-                    "txn",
-                    &default_build_config(),
-                )
-                .unwrap();
-
-            assert_ne!(next.reader_feature_flags & FLAG_MEM_WAL_INDEX_CATCHUP, 0);
-            assert_ne!(next.writer_feature_flags & FLAG_MEM_WAL_INDEX_CATCHUP, 0);
-        }
-
         /// A commit with no read version still withdraws. It can prove nothing,
         /// so an index it changed keeps no position -- the alternative leaves a
         /// position describing an index that no longer exists.
@@ -3683,7 +3442,7 @@ mod tests {
             let before = table(&[0, 1], Uuid::new_v4(), progress_with_catchup(shard, 5, 5));
             let mut after = table(&[0], Uuid::new_v4(), progress_with_catchup(shard, 5, 5));
             let segments_before = Transaction::logical_index_segments(&before);
-            Transaction::apply_mem_wal_index_coverage(&mut after, &segments_before, None, true, 2)
+            Transaction::apply_mem_wal_index_coverage(&mut after, &segments_before, None, 2)
                 .unwrap();
             assert_eq!(coverage_for(&after, "idx"), None);
         }
@@ -3696,8 +3455,8 @@ mod tests {
             let read = table(&[0, 1], Uuid::new_v4(), progress(shard, 5));
             let mut first = table(&[0, 1], Uuid::new_v4(), progress(shard, 5));
             let mut second = first.clone();
-            apply(&mut first, &read, &[0, 1], &read, true).unwrap();
-            apply(&mut second, &read, &[0, 1], &read, true).unwrap();
+            apply(&mut first, &read, &[0, 1], &read).unwrap();
+            apply(&mut second, &read, &[0, 1], &read).unwrap();
             assert_eq!(coverage_for(&first, "idx"), coverage_for(&second, "idx"));
         }
     }

--- a/rust/lance-table/src/transaction/operation.rs
+++ b/rust/lance-table/src/transaction/operation.rs
@@ -198,12 +198,6 @@ pub enum Operation {
     /// SSTables have been compacted into the base table.
     UpdateMemWalState {
         compacted_sstables: Vec<CompactedSsTable>,
-        /// Requests the one-way migration to required index catch-up.
-        ///
-        /// One-way because returning to legacy semantics — where a missing
-        /// coverage entry reads as "fully caught up" — is unsafe once any
-        /// SSTable has been retired against a recorded catch-up position.
-        require_index_catchup: bool,
     },
 
     /// Clone a dataset.

--- a/rust/lance-table/src/transaction/proto.rs
+++ b/rust/lance-table/src/transaction/proto.rs
@@ -381,27 +381,12 @@ impl TryFrom<pb::Transaction> for Transaction {
                     .collect::<Result<Vec<_>>>()?,
             },
             Some(pb::transaction::Operation::UpdateMemWalState(
-                pb::transaction::UpdateMemWalState {
-                    compacted_sstables,
-                    require_index_catchup,
-                },
+                pb::transaction::UpdateMemWalState { compacted_sstables },
             )) => Operation::UpdateMemWalState {
                 compacted_sstables: compacted_sstables
                     .into_iter()
                     .map(CompactedSsTable::try_from)
                     .collect::<Result<_>>()?,
-                // Absent is an ordinary progress update. Explicit `false` is
-                // refused rather than read as absent, so a caller cannot express
-                // "deactivate" -- the migration is one-way.
-                require_index_catchup: match require_index_catchup {
-                    Some(false) => {
-                        return Err(Error::invalid_input(
-                            "require_index_catchup cannot be false: MemWAL index catch-up \
-                             cannot stop being required once it is",
-                        ));
-                    }
-                    other => other.unwrap_or(false),
-                },
             },
             Some(pb::transaction::Operation::UpdateBases(pb::transaction::UpdateBases {
                 new_bases,
@@ -704,18 +689,12 @@ impl From<&Transaction> for pb::Transaction {
                         .collect(),
                 })
             }
-            Operation::UpdateMemWalState {
-                compacted_sstables,
-                require_index_catchup,
-            } => {
+            Operation::UpdateMemWalState { compacted_sstables } => {
                 pb::transaction::Operation::UpdateMemWalState(pb::transaction::UpdateMemWalState {
                     compacted_sstables: compacted_sstables
                         .iter()
                         .map(pb::CompactedSsTable::from)
                         .collect::<Vec<_>>(),
-                    // Written only when requesting activation, so an ordinary
-                    // progress update stays byte-identical to before.
-                    require_index_catchup: require_index_catchup.then_some(true),
                 })
             }
             Operation::UpdateBases { new_bases } => {

--- a/rust/lance/src/dataset.rs
+++ b/rust/lance/src/dataset.rs
@@ -148,9 +148,7 @@ pub use lance_core::ROW_ID;
 use lance_core::box_error;
 use lance_index::scalar::lance_format::LanceIndexStore;
 use lance_namespace::models::{DeclareTableRequest, DescribeTableRequest};
-use lance_table::feature_flags::{
-    apply_feature_flags, can_read_dataset, validate_mem_wal_index_catchup_flags,
-};
+use lance_table::feature_flags::{apply_feature_flags, can_read_dataset};
 use lance_table::io::deletion::{DELETIONS_DIR, relative_deletion_file_path};
 use lance_table::rowids::{RowIdSequence, write_row_ids};
 pub use schema_evolution::{
@@ -765,8 +763,6 @@ impl Dataset {
         } else {
             read_struct(object_reader.as_ref(), offset).await
         }?;
-
-        validate_mem_wal_index_catchup_flags(&manifest)?;
 
         if !can_read_dataset(manifest.reader_feature_flags) {
             let message = format!(

--- a/rust/lance/src/dataset/mem_wal/api.rs
+++ b/rust/lance/src/dataset/mem_wal/api.rs
@@ -485,20 +485,6 @@ pub trait DatasetMemWalExt {
         Ok(None)
     }
 
-    /// Require a recorded index catch-up before an SSTable stops being served.
-    ///
-    /// Until this is called, a missing index-coverage entry reads as "fully
-    /// caught up". Afterwards it reads as "not caught up", so an SSTable is served
-    /// until some commit shows the indexes contain its rows.
-    ///
-    /// One-way: there is no matching deactivate, because a table that has
-    /// already retired SSTables against a recorded catch-up cannot go back to
-    /// treating missing coverage as caught up. Calling it on an already-active
-    /// table succeeds and changes nothing.
-    async fn require_mem_wal_index_catchup(&mut self) -> Result<()> {
-        Ok(())
-    }
-
     /// List current MemWAL shard IDs from object storage directory listing.
     async fn list_mem_wal_latest_shard_ids(&self) -> Result<Vec<Uuid>> {
         Ok(Vec::new())
@@ -577,30 +563,6 @@ impl DatasetMemWalExt for Dataset {
         };
 
         load_mem_wal_index_details(index_meta).map(Some)
-    }
-
-    async fn require_mem_wal_index_catchup(&mut self) -> Result<()> {
-        if self.load_index_by_name(MEM_WAL_INDEX_NAME).await?.is_none() {
-            return Err(Error::invalid_input(
-                "Cannot require MemWAL index catch-up: MemWAL is not initialized on \
-                 this dataset.",
-            ));
-        }
-
-        let transaction = Transaction::new(
-            self.manifest.version,
-            Operation::UpdateMemWalState {
-                compacted_sstables: Vec::new(),
-                require_index_catchup: true,
-            },
-            None,
-        );
-        // Assigned back: leaving the receiver on the pre-activation manifest
-        // would report success while `self` still reads as legacy.
-        *self = CommitBuilder::new(Arc::new(self.clone()))
-            .execute(transaction)
-            .await?;
-        Ok(())
     }
 
     async fn list_mem_wal_latest_shard_ids(&self) -> Result<Vec<Uuid>> {

--- a/rust/lance/src/index.rs
+++ b/rust/lance/src/index.rs
@@ -58,7 +58,6 @@ use lance_io::utils::{
     CachedFileSize, read_last_block, read_message, read_message_from_buf, read_metadata_offset,
     read_version,
 };
-use lance_table::feature_flags::FLAG_MEM_WAL_INDEX_CATCHUP;
 use lance_table::format::{Fragment, SelfDescribingFileReader};
 use lance_table::format::{IndexFile, IndexMetadata, list_index_files_with_sizes};
 use lance_table::io::manifest::read_manifest_indexes;
@@ -1434,9 +1433,7 @@ impl Dataset {
     /// would read is the current one -- which makes the speculative answer the
     /// same one the commit reaches.
     fn mem_wal_catch_up_would_advance(&self, indices: &[IndexMetadata]) -> Result<bool> {
-        if self.manifest.reader_feature_flags & FLAG_MEM_WAL_INDEX_CATCHUP == 0
-            || self.manifest.writer_feature_flags & FLAG_MEM_WAL_INDEX_CATCHUP == 0
-        {
+        if !indices.iter().any(|index| index.name == MEM_WAL_INDEX_NAME) {
             return Ok(false);
         }
         let catchup_of = |indices: &[IndexMetadata]| -> Result<Option<Vec<_>>> {
@@ -1459,7 +1456,6 @@ impl Dataset {
                 manifest: &self.manifest,
                 indices,
             }),
-            true,
             self.manifest.version + 1,
         )?;
         Ok(catchup_of(&speculative)? != catchup_of(indices)?)

--- a/rust/lance/src/index/mem_wal.rs
+++ b/rust/lance/src/index/mem_wal.rs
@@ -90,7 +90,6 @@ mod tests {
             dataset.manifest.version,
             Operation::UpdateMemWalState {
                 compacted_sstables: vec![CompactedSsTable::new(Uuid::new_v4(), 1)],
-                require_index_catchup: false,
             },
             None,
         );
@@ -123,7 +122,6 @@ mod tests {
             dataset.manifest.version,
             Operation::UpdateMemWalState {
                 compacted_sstables: vec![CompactedSsTable::new(shard, 10)],
-                require_index_catchup: false,
             },
             None,
         );
@@ -138,7 +136,6 @@ mod tests {
             dataset.manifest.version - 1, // Based on old version
             Operation::UpdateMemWalState {
                 compacted_sstables: vec![CompactedSsTable::new(shard, 5)],
-                require_index_catchup: false,
             },
             None,
         );
@@ -162,7 +159,6 @@ mod tests {
             dataset.manifest.version,
             Operation::UpdateMemWalState {
                 compacted_sstables: vec![CompactedSsTable::new(shard, 10)],
-                require_index_catchup: false,
             },
             None,
         );
@@ -176,7 +172,6 @@ mod tests {
             dataset.manifest.version - 1, // Based on old version
             Operation::UpdateMemWalState {
                 compacted_sstables: vec![CompactedSsTable::new(shard, 10)],
-                require_index_catchup: false,
             },
             None,
         );
@@ -201,7 +196,6 @@ mod tests {
             dataset.manifest.version,
             Operation::UpdateMemWalState {
                 compacted_sstables: vec![CompactedSsTable::new(shard, 5)],
-                require_index_catchup: false,
             },
             None,
         );
@@ -216,7 +210,6 @@ mod tests {
             dataset.manifest.version - 1, // Based on old version
             Operation::UpdateMemWalState {
                 compacted_sstables: vec![CompactedSsTable::new(shard, 10)],
-                require_index_catchup: false,
             },
             None,
         );
@@ -241,7 +234,6 @@ mod tests {
             dataset.manifest.version,
             Operation::UpdateMemWalState {
                 compacted_sstables: vec![CompactedSsTable::new(shard1, 10)],
-                require_index_catchup: false,
             },
             None,
         );
@@ -256,7 +248,6 @@ mod tests {
             dataset.manifest.version - 1, // Based on old version
             Operation::UpdateMemWalState {
                 compacted_sstables: vec![CompactedSsTable::new(shard2, 5)],
-                require_index_catchup: false,
             },
             None,
         );
@@ -294,7 +285,6 @@ mod tests {
             dataset.manifest.version,
             Operation::UpdateMemWalState {
                 compacted_sstables: vec![CompactedSsTable::new(shard, 10)],
-                require_index_catchup: false,
             },
             None,
         );
@@ -375,7 +365,6 @@ mod tests {
             dataset.manifest.version - 1, // Based on old version
             Operation::UpdateMemWalState {
                 compacted_sstables: vec![CompactedSsTable::new(shard, 5)],
-                require_index_catchup: false,
             },
             None,
         );
@@ -388,120 +377,13 @@ mod tests {
         );
     }
 
-    /// The bit must survive being written and read back, not just
-    /// `build_manifest`. `apply_feature_flags` runs a second time inside
-    /// `write_manifest_file`, so a version of this that stops at the in-memory
-    /// manifest passes while the stored table stays legacy.
-    #[tokio::test]
-    async fn required_catch_up_survives_a_persisted_round_trip() {
-        use crate::dataset::mem_wal::DatasetMemWalExt;
-        use lance_table::feature_flags::FLAG_MEM_WAL_INDEX_CATCHUP;
-
-        // A real directory, not `memory://`: reopening by URI builds a fresh
-        // store registry, and the point of this test is to read back what was
-        // actually written.
-        let dir = tempfile::tempdir().unwrap();
-        let uri = dir.path().to_str().unwrap();
-        let write_params = WriteParams {
-            max_rows_per_file: 10,
-            ..Default::default()
-        };
-        let data = RecordBatch::try_new(
-            Arc::new(Schema::new(vec![Field::new("a", DataType::Int32, false)])),
-            vec![Arc::new(Int32Array::from_iter_values(0..10_i32))],
-        )
-        .unwrap();
-        let dataset = InsertBuilder::new(uri)
-            .with_params(&write_params)
-            .execute(vec![data])
-            .await
-            .unwrap();
-
-        // Install the system index, then require catch-up.
-        let mem_wal_index =
-            new_mem_wal_index_meta(dataset.manifest.version, MemWalIndexDetails::default())
-                .unwrap();
-        let txn = Transaction::new(
-            dataset.manifest.version,
-            Operation::CreateIndex {
-                new_indices: vec![mem_wal_index],
-                removed_indices: vec![],
-            },
-            None,
-        );
-        let mut dataset = CommitBuilder::new(Arc::new(dataset))
-            .execute(txn)
-            .await
-            .unwrap();
-        dataset.require_mem_wal_index_catchup().await.unwrap();
-
-        let reopened = crate::dataset::builder::DatasetBuilder::from_uri(uri)
-            .load()
-            .await
-            .unwrap();
-        assert_ne!(
-            reopened.manifest.reader_feature_flags & FLAG_MEM_WAL_INDEX_CATCHUP,
-            0,
-            "activation did not reach storage"
-        );
-        assert_ne!(
-            reopened.manifest.writer_feature_flags & FLAG_MEM_WAL_INDEX_CATCHUP,
-            0,
-            "activation did not reach storage"
-        );
-
-        // An ordinary commit must not walk it back.
-        let txn = Transaction::new(
-            reopened.manifest.version,
-            Operation::UpdateConfig {
-                config_updates: Some(crate::dataset::transaction::UpdateMap {
-                    update_entries: vec![crate::dataset::transaction::UpdateMapEntry {
-                        key: "k".to_string(),
-                        value: Some("v".to_string()),
-                    }],
-                    replace: false,
-                }),
-                table_metadata_updates: None,
-                schema_metadata_updates: None,
-                field_metadata_updates: HashMap::new(),
-            },
-            None,
-        );
-        CommitBuilder::new(Arc::new(reopened))
-            .execute(txn)
-            .await
-            .unwrap();
-
-        let reopened = crate::dataset::builder::DatasetBuilder::from_uri(uri)
-            .load()
-            .await
-            .unwrap();
-        assert_ne!(
-            reopened.manifest.reader_feature_flags & FLAG_MEM_WAL_INDEX_CATCHUP,
-            0,
-            "an ordinary commit downgraded the stored table"
-        );
-        assert_ne!(
-            reopened.manifest.writer_feature_flags & FLAG_MEM_WAL_INDEX_CATCHUP,
-            0,
-            "an ordinary commit downgraded the stored table"
-        );
-    }
-
-    /// A table on the catch-up protocol with `generation` folded into base.
-    ///
-    /// Activation must precede any compaction progress: it refuses a table that
-    /// already has some, since nothing can prove which indexes hold it.
-    async fn activated_dataset(shard: Uuid, generation: u64) -> crate::Dataset {
-        use crate::dataset::mem_wal::DatasetMemWalExt;
-
-        let mut dataset = test_dataset_with_mem_wal().await;
-        dataset.require_mem_wal_index_catchup().await.unwrap();
+    /// A table with `generation` folded into base.
+    async fn compacted_dataset(shard: Uuid, generation: u64) -> crate::Dataset {
+        let dataset = test_dataset_with_mem_wal().await;
         let txn = Transaction::new(
             dataset.manifest.version,
             Operation::UpdateMemWalState {
                 compacted_sstables: vec![CompactedSsTable::new(shard, generation)],
-                require_index_catchup: false,
             },
             None,
         );
@@ -545,12 +427,11 @@ mod tests {
     }
 
     /// The commit path, not the derivation in isolation: `commit_transaction`
-    /// has to load the read version's indices and hand them down, and it only
-    /// does so for tables carrying the feature bit.
+    /// has to load the read version's indices and hand them down.
     #[tokio::test]
     async fn an_index_covering_the_table_earns_catch_up_on_commit() {
         let shard = Uuid::new_v4();
-        let dataset = activated_dataset(shard, 5).await;
+        let dataset = compacted_dataset(shard, 5).await;
 
         let txn = Transaction::new(
             dataset.manifest.version,
@@ -582,7 +463,7 @@ mod tests {
         use lance_index::optimize::OptimizeOptions;
 
         let shard = Uuid::new_v4();
-        let dataset = activated_dataset(shard, 7).await;
+        let dataset = compacted_dataset(shard, 7).await;
         // Already spans the table, so the optimize below has nothing to build.
         let txn = Transaction::new(
             dataset.manifest.version,
@@ -603,7 +484,6 @@ mod tests {
             dataset.manifest.version,
             Operation::UpdateMemWalState {
                 compacted_sstables: vec![CompactedSsTable::new(shard, 9)],
-                require_index_catchup: false,
             },
             None,
         );
@@ -633,7 +513,7 @@ mod tests {
     /// no-op: the early return is what keeps ordinary tables from committing an
     /// empty version on every maintenance pass.
     #[tokio::test]
-    async fn a_no_work_optimize_off_protocol_commits_nothing() {
+    async fn a_no_work_optimize_with_nothing_compacted_commits_nothing() {
         use lance_index::optimize::OptimizeOptions;
 
         let dataset = test_dataset_with_mem_wal().await;
@@ -659,18 +539,17 @@ mod tests {
         assert_eq!(dataset.manifest.version, before);
     }
 
-    /// A legacy table reads a missing entry as "fully caught up". Writing one
-    /// there would be the first step toward a trim it never agreed to, so the
-    /// commit path must not even look.
+    /// A table carrying compaction progress but no catch-up entry earns one
+    /// from an ordinary commit. This is how a table written before catch-up was
+    /// maintained heals itself: nothing has to be run against it.
     #[tokio::test]
-    async fn a_legacy_table_earns_nothing_on_commit() {
+    async fn a_table_with_no_catchup_entry_earns_one() {
         let dataset = test_dataset_with_mem_wal().await;
         let shard = Uuid::new_v4();
         let txn = Transaction::new(
             dataset.manifest.version,
             Operation::UpdateMemWalState {
                 compacted_sstables: vec![CompactedSsTable::new(shard, 5)],
-                require_index_catchup: false,
             },
             None,
         );
@@ -692,7 +571,7 @@ mod tests {
             .await
             .unwrap();
 
-        assert_eq!(catch_up_generation(&dataset, "idx").await, None);
+        assert_eq!(catch_up_generation(&dataset, "idx").await, Some(5));
     }
 
     /// What a commit earns is fixed by the version it read, and a rebase does
@@ -703,7 +582,7 @@ mod tests {
     #[tokio::test]
     async fn credit_is_anchored_to_the_read_version_across_a_rebase() {
         let shard = Uuid::new_v4();
-        let dataset = activated_dataset(shard, 5).await;
+        let dataset = compacted_dataset(shard, 5).await;
         let read_version = dataset.manifest.version;
 
         let data = RecordBatch::try_new(
@@ -753,14 +632,13 @@ mod tests {
     #[tokio::test]
     async fn a_user_index_build_cannot_rebase_past_a_compaction_commit() {
         let shard = Uuid::new_v4();
-        let dataset = activated_dataset(shard, 5).await;
+        let dataset = compacted_dataset(shard, 5).await;
         let read_version = dataset.manifest.version;
 
         let txn = Transaction::new(
             dataset.manifest.version,
             Operation::UpdateMemWalState {
                 compacted_sstables: vec![CompactedSsTable::new(shard, 9)],
-                require_index_catchup: false,
             },
             None,
         );
@@ -1003,7 +881,6 @@ mod tests {
                 version,
                 Operation::UpdateMemWalState {
                     compacted_sstables: vec![CompactedSsTable::new(shard, 10)],
-                    require_index_catchup: false,
                 },
                 None,
             ))
@@ -1117,7 +994,6 @@ mod tests {
             dataset.manifest.version,
             Operation::UpdateMemWalState {
                 compacted_sstables: vec![CompactedSsTable::new(shard, 1)],
-                require_index_catchup: false,
             },
             None,
         );

--- a/rust/lance/src/io/commit.rs
+++ b/rust/lance/src/io/commit.rs
@@ -1335,12 +1335,10 @@ pub(crate) async fn commit_transaction(
     // The Arc is kept rather than cloned out: `load_indices` returns shared
     // cached data, so the common case is a cache hit rather than a read.
     let read_version_dataset = dataset.clone();
-    let read_version_indices = Some(read_version_dataset.load_indices().await?);
-    let read_version_state = read_version_indices.as_ref().map(|indices| {
-        crate::dataset::transaction::ReadVersionState {
-            manifest: read_version_dataset.manifest.as_ref(),
-            indices: indices.as_slice(),
-        }
+    let read_version_indices = read_version_dataset.load_indices().await?;
+    let read_version_state = Some(crate::dataset::transaction::ReadVersionState {
+        manifest: read_version_dataset.manifest.as_ref(),
+        indices: read_version_indices.as_slice(),
     });
 
     let mut transaction = transaction.clone();

--- a/rust/lance/src/io/commit.rs
+++ b/rust/lance/src/io/commit.rs
@@ -1332,19 +1332,10 @@ pub(crate) async fn commit_transaction(
     // covering every fragment live here holds every row compaction had copied
     // in by then.
     //
-    // Only tables on the protocol pay for the extra index load; the bit is on
-    // the manifest already in hand.
+    // The Arc is kept rather than cloned out: `load_indices` returns shared
+    // cached data, so the common case is a cache hit rather than a read.
     let read_version_dataset = dataset.clone();
-    let read_version_indices = if read_version_dataset.manifest.reader_feature_flags
-        & lance_table::feature_flags::FLAG_MEM_WAL_INDEX_CATCHUP
-        != 0
-    {
-        // The Arc is kept rather than cloned out: `load_indices` returns shared
-        // cached data, and this runs on every commit to an activated table.
-        Some(read_version_dataset.load_indices().await?)
-    } else {
-        None
-    };
+    let read_version_indices = Some(read_version_dataset.load_indices().await?);
     let read_version_state = read_version_indices.as_ref().map(|indices| {
         crate::dataset::transaction::ReadVersionState {
             manifest: read_version_dataset.manifest.as_ref(),

--- a/rust/lance/src/io/commit/conflict_resolver.rs
+++ b/rust/lance/src/io/commit/conflict_resolver.rs
@@ -3395,7 +3395,6 @@ mod tests {
             (
                 Operation::UpdateMemWalState {
                     compacted_sstables: vec![],
-                    require_index_catchup: false,
                 },
                 NotCompatible,
             ),
@@ -4796,7 +4795,6 @@ mod tests {
             0,
             Operation::UpdateMemWalState {
                 compacted_sstables: vec![CompactedSsTable::new(shard, 10)],
-                require_index_catchup: false,
             },
             None,
         );
@@ -4805,7 +4803,6 @@ mod tests {
             0,
             Operation::UpdateMemWalState {
                 compacted_sstables: vec![CompactedSsTable::new(shard, 5)],
-                require_index_catchup: false,
             },
             None,
         );
@@ -4836,7 +4833,6 @@ mod tests {
             0,
             Operation::UpdateMemWalState {
                 compacted_sstables: vec![CompactedSsTable::new(shard, 10)],
-                require_index_catchup: false,
             },
             None,
         );
@@ -4845,7 +4841,6 @@ mod tests {
             0,
             Operation::UpdateMemWalState {
                 compacted_sstables: vec![CompactedSsTable::new(shard, 10)],
-                require_index_catchup: false,
             },
             None,
         );
@@ -4877,7 +4872,6 @@ mod tests {
             0,
             Operation::UpdateMemWalState {
                 compacted_sstables: vec![CompactedSsTable::new(shard, 5)],
-                require_index_catchup: false,
             },
             None,
         );
@@ -4886,7 +4880,6 @@ mod tests {
             0,
             Operation::UpdateMemWalState {
                 compacted_sstables: vec![CompactedSsTable::new(shard, 10)],
-                require_index_catchup: false,
             },
             None,
         );
@@ -4918,7 +4911,6 @@ mod tests {
             0,
             Operation::UpdateMemWalState {
                 compacted_sstables: vec![CompactedSsTable::new(shard1, 10)],
-                require_index_catchup: false,
             },
             None,
         );
@@ -4927,7 +4919,6 @@ mod tests {
             0,
             Operation::UpdateMemWalState {
                 compacted_sstables: vec![CompactedSsTable::new(shard2, 5)],
-                require_index_catchup: false,
             },
             None,
         );
@@ -4978,7 +4969,6 @@ mod tests {
             0,
             Operation::UpdateMemWalState {
                 compacted_sstables: vec![CompactedSsTable::new(shard, 5)],
-                require_index_catchup: false,
             },
             None,
         );
@@ -5004,7 +4994,6 @@ mod tests {
             0,
             Operation::UpdateMemWalState {
                 compacted_sstables: vec![CompactedSsTable::new(shard, 15)],
-                require_index_catchup: false,
             },
             None,
         );
@@ -5051,7 +5040,6 @@ mod tests {
             0,
             Operation::UpdateMemWalState {
                 compacted_sstables: vec![CompactedSsTable::new(shard, 10)],
-                require_index_catchup: false,
             },
             None,
         );


### PR DESCRIPTION
Index catch-up becomes unconditional. The bit existed so a reader without it
could not misread a missing `index_catchup` entry as "fully caught up"; with one
set of semantics there is nothing left to gate.

The bit could only ever be set by an explicit activation call that never
shipped, so no table carries it and there is no data to migrate.

## Removed

`FLAG_MEM_WAL_INDEX_CATCHUP`, `inherit_mem_wal_index_catchup`,
`validate_mem_wal_index_catchup_flags`, `require_mem_wal_index_catchup` and its
`Transaction::require_index_catchup` migration, the `require_index_catchup`
field on `Operation::UpdateMemWalState` and its protobuf field, the restore and
shallow-clone guards, and `is_index_caught_up_legacy` — which had no callers
once the two readings collapsed into one.

Plus the documentation the bit carried: its row in the feature-flag table, the
two-mode explanation and the one-way-activation paragraph in `mem_wal.md`, and
the `1 << 7` entry and every "ONLY on a legacy table" qualifier in
`table.proto`.

## Bit 128 and tag 2 are reclaimed, not reserved

`FLAG_UNKNOWN` returns to 128, which is what it was before the bit was
allocated. The `const _` assert that arrived with the bit is replaced by a
general one over every declared flag, because reclaiming 128 means the next flag
takes it and has to move the boundary to 256. Verified by lowering the boundary
and watching it fail to compile (E0080).

The protobuf tag is freed for the same reason: `optional bool` occupies a tag
only when written, and nothing ever wrote it. Happy to keep `reserved 2;` as
ordinary hygiene instead if you prefer — it is a one-line add.

## Two gates needed a predicate, not deletion

Coverage maintenance and the read-version index load were **skipped** for tables
without the bit. Making them unconditional would charge an index load to every
commit on every table, including tables with no MemWAL index. Both now key on
the presence of that index, which is what the bit stood in for.

## Existing tables

A table carrying compaction progress but no catch-up entry earns one from an
ordinary commit, so nothing has to be run against it. `a_legacy_table_is_untouched`
becomes `a_table_with_no_catchup_entry_earns_one`, and its counterpart in
`index/mem_wal.rs` likewise: they asserted the behaviour being removed, and
inverted they are the regression test for the upgrade. A table with neither
field recorded hits the existing early return and is untouched.

While no entry exists, a missing entry excludes nothing, so every generation
stays readable from its SSTable. Reads cannot lose a row in the meantime.

## Testing

309 `lance-table` tests, 2922 `lance` lib tests, doctests. `cargo fmt` clean.
