### PR TITLE
fix(fts): merge inverted index segments across format versions

### DIFF
--- a/rust/lance-index/src/scalar/inverted/builder.rs
+++ b/rust/lance-index/src/scalar/inverted/builder.rs
@@ -319,6 +319,26 @@ impl InvertedIndexBuilder {
                 if partition_builder.is_empty() {
                     continue;
                 }
+                // A source partition read from disk carries its own on-disk
+                // encoding (older segments may be V1/Fixed32 while the target is
+                // V2/V3/VarintDelta). Its `encoded_blocks` cannot be written under
+                // a different codec, so it can't simply become `merged` directly.
+                // Instead always fold it into a fresh builder created with the
+                // target format: `merge_from` decodes each posting to logical
+                // entries and re-encodes them with the target codec, yielding a
+                // single consistent format regardless of segment order.
+                let target_builder = |partition_builder: &InnerBuilder| {
+                    InnerBuilder::new_with_format_version_and_block_size(
+                        partition_builder.id(),
+                        partition_builder.with_position(),
+                        partition_builder.token_set_format(),
+                        self.format_version,
+                        self.params.block_size,
+                    )
+                };
+                let mut normalized = target_builder(&partition_builder);
+                normalized.merge_from(partition_builder)?;
+                let partition_builder = normalized;
                 match &mut merged {
                     Some(merged) => {
                         let would_exceed_memory = merged
@@ -906,6 +926,14 @@ impl InnerBuilder {
         self.id
     }
 
+    pub(crate) fn with_position(&self) -> bool {
+        self.with_position
+    }
+
+    pub(crate) fn token_set_format(&self) -> TokenSetFormat {
+        self.token_set_format
+    }
+
     fn set_id(&mut self, id: u64) {
         self.id = id;
     }
@@ -996,18 +1024,12 @@ impl InnerBuilder {
                 self.token_set_format, token_set_format
             )));
         }
-        if self.format_version != format_version {
-            return Err(Error::index(format!(
-                "cannot merge partitions with mismatched FTS format versions: {:?} vs {:?}",
-                self.format_version, format_version
-            )));
-        }
-        if self.posting_tail_codec != posting_tail_codec {
-            return Err(Error::index(format!(
-                "cannot merge partitions with mismatched posting tail codecs: {:?} vs {:?}",
-                self.posting_tail_codec, posting_tail_codec
-            )));
-        }
+        // `format_version`/`posting_tail_codec` intentionally may differ. This
+        // merge reads `other`'s already-decoded entries (doc_id/freq/positions)
+        // and re-encodes them with `self`'s codec below, so the source encoding
+        // is irrelevant. Rejecting a mismatch here would break maintaining a
+        // pre-upgrade V1 index alongside newer V2/V3 delta segments.
+        let _ = (format_version, posting_tail_codec);
         if self.block_size != block_size {
             return Err(Error::index(format!(
                 "cannot merge partitions with mismatched FTS block sizes: {} vs {}",

--- a/rust/lance-index/src/scalar/inverted/builder.rs
+++ b/rust/lance-index/src/scalar/inverted/builder.rs
@@ -320,25 +320,29 @@ impl InvertedIndexBuilder {
                     continue;
                 }
                 // A source partition read from disk carries its own on-disk
-                // encoding (older segments may be V1/Fixed32 while the target is
-                // V2/V3/VarintDelta). Its `encoded_blocks` cannot be written under
-                // a different codec, so it can't simply become `merged` directly.
-                // Instead always fold it into a fresh builder created with the
-                // target format: `merge_from` decodes each posting to logical
-                // entries and re-encodes them with the target codec, yielding a
-                // single consistent format regardless of segment order.
-                let target_builder = |partition_builder: &InnerBuilder| {
-                    InnerBuilder::new_with_format_version_and_block_size(
+                // encoding. When it already matches the target format it can be
+                // used as-is (the common single-format optimize/delta-merge path,
+                // with no re-encoding). When it differs (older V1/Fixed32 segment
+                // vs a V2/V3/VarintDelta target) its `encoded_blocks` cannot be
+                // written under the target codec, so fold it into a fresh builder
+                // in the target format: `merge_from` decodes each posting to
+                // logical entries and re-encodes them with the target codec.
+                let partition_builder = if partition_builder.format_version() == self.format_version
+                    && partition_builder.posting_tail_codec()
+                        == self.format_version.posting_tail_codec()
+                {
+                    partition_builder
+                } else {
+                    let mut normalized = InnerBuilder::new_with_format_version_and_block_size(
                         partition_builder.id(),
                         partition_builder.with_position(),
                         partition_builder.token_set_format(),
                         self.format_version,
                         self.params.block_size,
-                    )
+                    );
+                    normalized.merge_from(partition_builder)?;
+                    normalized
                 };
-                let mut normalized = target_builder(&partition_builder);
-                normalized.merge_from(partition_builder)?;
-                let partition_builder = normalized;
                 match &mut merged {
                     Some(merged) => {
                         let would_exceed_memory = merged
@@ -934,6 +938,14 @@ impl InnerBuilder {
         self.token_set_format
     }
 
+    pub(crate) fn format_version(&self) -> InvertedListFormatVersion {
+        self.format_version
+    }
+
+    pub(crate) fn posting_tail_codec(&self) -> PostingTailCodec {
+        self.posting_tail_codec
+    }
+
     fn set_id(&mut self, id: u64) {
         self.id = id;
     }
@@ -1004,8 +1016,13 @@ impl InnerBuilder {
             id: _,
             with_position,
             token_set_format,
-            format_version,
-            posting_tail_codec,
+            // `format_version`/`posting_tail_codec` intentionally may differ:
+            // `other`'s already-decoded entries (doc_id/freq/positions) are
+            // re-encoded with `self`'s codec below, so the source encoding is
+            // irrelevant. Rejecting a mismatch here would break maintaining a
+            // pre-upgrade V1 index alongside newer V2/V3 delta segments.
+            format_version: _,
+            posting_tail_codec: _,
             block_size,
             tokens,
             posting_lists,
@@ -1024,12 +1041,6 @@ impl InnerBuilder {
                 self.token_set_format, token_set_format
             )));
         }
-        // `format_version`/`posting_tail_codec` intentionally may differ. This
-        // merge reads `other`'s already-decoded entries (doc_id/freq/positions)
-        // and re-encodes them with `self`'s codec below, so the source encoding
-        // is irrelevant. Rejecting a mismatch here would break maintaining a
-        // pre-upgrade V1 index alongside newer V2/V3 delta segments.
-        let _ = (format_version, posting_tail_codec);
         if self.block_size != block_size {
             return Err(Error::index(format!(
                 "cannot merge partitions with mismatched FTS block sizes: {} vs {}",

--- a/rust/lance-index/src/scalar/inverted/index/inverted_index.rs
+++ b/rust/lance-index/src/scalar/inverted/index/inverted_index.rs
@@ -175,16 +175,15 @@ impl InvertedIndex {
             }
         }
 
-        // Re-encode every segment to the highest format version present. Because
-        // `params` (and thus block_size) is identical across segments, the maximum
-        // is guaranteed to be compatible with that block_size. `token_set_format`
-        // is also identical (checked above), so the segment carrying the highest
-        // format version also carries the resulting merged index version.
-        let target_segment = segments
-            .iter()
-            .max_by_key(|segment| segment.format_version().index_version())
-            .expect("segments is non-empty; checked above");
-        let target_format_version = target_segment.format_version();
+        // Normalize every segment to the reference (`first`) segment's format,
+        // not the newest one present. Maintaining an existing FTS index must
+        // preserve its format (see docs/src/guide/migration.md): a deployment
+        // pinned to an older format for reader compatibility must not be silently
+        // upgraded by a merge. Other segments are decoded with their own codec and
+        // re-encoded to the reference format. `token_set_format` and block_size are
+        // identical across segments (checked above), so the reference format is a
+        // valid target for all of them.
+        let target_format_version = first.format_version();
 
         let mut builder = InvertedIndexBuilder::new(first.params.clone()).with_progress(progress);
         builder = builder
@@ -194,16 +193,15 @@ impl InvertedIndex {
             .update_from_segments(new_data, dest_store, segments, old_data_filter)
             .await?;
 
-        // Persist the details for the format we actually wrote, not `first`'s.
-        // Otherwise a V1 `first` would stamp posting_format_version=1 onto files
-        // re-encoded as the (higher) target version, and readers would pick the
-        // wrong decoder.
+        // Stamp details with the reference segment's actual format so the written
+        // metadata matches the encoding above, regardless of whether `params`
+        // carried an explicit format_version.
         let target_params = first.params.clone().format_version(target_format_version);
         let details = pbold::InvertedIndexDetails::try_from(&target_params)?;
 
         Ok(CreatedIndex {
             index_details: prost_types::Any::from_msg(&details).unwrap(),
-            index_version: target_segment.index_version(),
+            index_version: first.index_version(),
             files,
         })
     }

--- a/rust/lance-index/src/scalar/inverted/index/inverted_index.rs
+++ b/rust/lance-index/src/scalar/inverted/index/inverted_index.rs
@@ -183,7 +183,7 @@ impl InvertedIndex {
         let target_segment = segments
             .iter()
             .max_by_key(|segment| segment.format_version().index_version())
-            .unwrap_or(first);
+            .expect("segments is non-empty; checked above");
         let target_format_version = target_segment.format_version();
 
         let mut builder = InvertedIndexBuilder::new(first.params.clone()).with_progress(progress);

--- a/rust/lance-index/src/scalar/inverted/index/inverted_index.rs
+++ b/rust/lance-index/src/scalar/inverted/index/inverted_index.rs
@@ -152,8 +152,17 @@ impl InvertedIndex {
             ));
         };
 
+        // `params` (which includes block_size) and `token_set_format` must match:
+        // they determine how text is tokenized and how the token set is laid out,
+        // so segments built with different values cannot be combined. In contrast,
+        // `format_version`/`posting_tail_codec` only govern the on-disk posting
+        // encoding. Each segment is decoded with its own codec when read into an
+        // in-memory builder (see `InvertedPartition::into_builder`), so mixed-format
+        // segments can be merged and re-encoded to a single target format. Merging
+        // across those older-format segments is required after an upgrade, when a
+        // pre-existing V1/V2 index is maintained alongside newly written V2/V3 deltas.
         for segment in segments.iter().skip(1) {
-            if segment.params != first.params {
+            if !segment.params.is_compatible_for_merge(&first.params) {
                 return Err(Error::index(
                     "cannot merge inverted index segments with different parameters".to_string(),
                 ));
@@ -164,33 +173,40 @@ impl InvertedIndex {
                         .to_string(),
                 ));
             }
-            if segment.format_version() != first.format_version() {
-                return Err(Error::index(
-                    "cannot merge inverted index segments with different format versions"
-                        .to_string(),
-                ));
-            }
-            if segment.posting_tail_codec() != first.posting_tail_codec() {
-                return Err(Error::index(
-                    "cannot merge inverted index segments with different posting tail codecs"
-                        .to_string(),
-                ));
-            }
         }
+
+        // Re-encode every segment to the highest format version present. Because
+        // `params` (and thus block_size) is identical across segments, the maximum
+        // is guaranteed to be compatible with that block_size. `token_set_format`
+        // is also identical (checked above), so the segment carrying the highest
+        // format version also carries the resulting merged index version.
+        let target_segment = segments
+            .iter()
+            .max_by_key(|segment| segment.format_version().index_version())
+            .unwrap_or(first);
+        let target_format_version = target_segment.format_version();
 
         let mut builder = InvertedIndexBuilder::new(first.params.clone()).with_progress(progress);
         builder = builder
             .with_token_set_format(first.token_set_format)
-            .with_format_version(first.format_version());
+            .with_format_version(target_format_version);
         let files = builder
             .update_from_segments(new_data, dest_store, segments, old_data_filter)
             .await?;
 
-        let details = pbold::InvertedIndexDetails::try_from(&first.params)?;
+        // Persist the details for the format we actually wrote, not `first`'s.
+        // Otherwise a V1 `first` would stamp posting_format_version=1 onto files
+        // re-encoded as the (higher) target version, and readers would pick the
+        // wrong decoder.
+        let target_params = first
+            .params
+            .clone()
+            .format_version(target_format_version);
+        let details = pbold::InvertedIndexDetails::try_from(&target_params)?;
 
         Ok(CreatedIndex {
             index_details: prost_types::Any::from_msg(&details).unwrap(),
-            index_version: first.index_version(),
+            index_version: target_segment.index_version(),
             files,
         })
     }

--- a/rust/lance-index/src/scalar/inverted/index/inverted_index.rs
+++ b/rust/lance-index/src/scalar/inverted/index/inverted_index.rs
@@ -198,10 +198,7 @@ impl InvertedIndex {
         // Otherwise a V1 `first` would stamp posting_format_version=1 onto files
         // re-encoded as the (higher) target version, and readers would pick the
         // wrong decoder.
-        let target_params = first
-            .params
-            .clone()
-            .format_version(target_format_version);
+        let target_params = first.params.clone().format_version(target_format_version);
         let details = pbold::InvertedIndexDetails::try_from(&target_params)?;
 
         Ok(CreatedIndex {

--- a/rust/lance-index/src/scalar/inverted/index/tests/lifecycle.rs
+++ b/rust/lance-index/src/scalar/inverted/index/tests/lifecycle.rs
@@ -360,6 +360,86 @@ async fn test_merge_segments_preserves_format_version(
     Ok(())
 }
 
+/// Segments built with different posting-encoding format versions must be
+/// mergeable: after an upgrade a pre-existing V1 index is maintained alongside
+/// newly written V2/V3 delta segments. The merge should succeed (not reject on
+/// "different posting tail codecs"/"different format versions"), re-encode every
+/// segment to the highest version present, and keep all documents searchable.
+#[tokio::test]
+async fn test_merge_segments_across_format_versions() -> Result<()> {
+    let v1_dir = TempObjDir::default();
+    let v3_dir = TempObjDir::default();
+    let dest_dir = TempObjDir::default();
+    let make_store = |dir: &TempObjDir| {
+        Arc::new(LanceIndexStore::new(
+            ObjectStore::local().into(),
+            (*dir).clone(),
+            Arc::new(LanceCache::no_cache()),
+        ))
+    };
+
+    // Same tokenization params + block size, different posting encodings.
+    let v1_index = write_single_partition_index(
+        make_store(&v1_dir),
+        InvertedIndexParams::default()
+            .block_size(LEGACY_BLOCK_SIZE)?
+            .format_version(InvertedListFormatVersion::V1),
+        TokenSetFormat::Fst,
+        "hello",
+        100,
+    )
+    .await?;
+    let v3_index = write_single_partition_index(
+        make_store(&v3_dir),
+        InvertedIndexParams::default()
+            .block_size(LEGACY_BLOCK_SIZE)?
+            .format_version(InvertedListFormatVersion::V3),
+        TokenSetFormat::Fst,
+        "world",
+        200,
+    )
+    .await?;
+    assert_eq!(v1_index.format_version(), InvertedListFormatVersion::V1);
+    assert_eq!(v3_index.format_version(), InvertedListFormatVersion::V3);
+
+    let dest_store = make_store(&dest_dir);
+    let created = InvertedIndex::merge_segments(
+        &[v1_index, v3_index],
+        empty_doc_stream(),
+        dest_store.as_ref(),
+        None,
+        crate::progress::noop_progress(),
+    )
+    .await?;
+
+    // Merged segment is written at the highest version present (V3).
+    assert_eq!(
+        created.index_version,
+        InvertedListFormatVersion::V3.index_version()
+    );
+    let merged = InvertedIndex::load(dest_store, None, &LanceCache::no_cache()).await?;
+    assert_eq!(merged.format_version(), InvertedListFormatVersion::V3);
+
+    // Documents from both source segments survive and remain searchable.
+    for (token, expected_row) in [("hello", 100_u64), ("world", 200_u64)] {
+        let tokens = Arc::new(Tokens::new(vec![token.to_string()], DocType::Text));
+        let params = Arc::new(FtsSearchParams::new().with_limit(Some(10)));
+        let (row_ids, _) = merged
+            .bm25_search(
+                tokens,
+                params,
+                Operator::Or,
+                Arc::new(NoFilter),
+                Arc::new(NoOpMetricsCollector),
+                None,
+            )
+            .await?;
+        assert_eq!(row_ids, vec![expected_row]);
+    }
+
+    Ok(())
+}
+
 #[tokio::test]
 async fn test_merge_segments_uses_memory_limit_for_old_partitions() -> Result<()> {
     let src_dir_1 = TempObjDir::default();

--- a/rust/lance-index/src/scalar/inverted/index/tests/lifecycle.rs
+++ b/rust/lance-index/src/scalar/inverted/index/tests/lifecycle.rs
@@ -361,12 +361,23 @@ async fn test_merge_segments_preserves_format_version(
 }
 
 /// Segments built with different posting-encoding format versions must be
-/// mergeable: after an upgrade a pre-existing V1 index is maintained alongside
-/// newly written V2/V3 delta segments. The merge should succeed (not reject on
-/// "different posting tail codecs"/"different format versions"), re-encode every
-/// segment to the highest version present, and keep all documents searchable.
+/// mergeable: after an upgrade a pre-existing index is maintained alongside
+/// newly written delta segments of another format. The merge must succeed (not
+/// reject on "different posting tail codecs"/"different format versions"),
+/// preserve the reference (first) segment's format per
+/// docs/src/guide/migration.md, and keep all documents searchable. The
+/// non-reference segment is decoded with its own codec and re-encoded to the
+/// reference format.
+///
+/// `reference` selects which segment is `first`, proving the output format
+/// follows the reference rather than the min/max of the inputs.
+#[rstest::rstest]
+#[case::reference_v1(InvertedListFormatVersion::V1)]
+#[case::reference_v3(InvertedListFormatVersion::V3)]
 #[tokio::test]
-async fn test_merge_segments_across_format_versions() -> Result<()> {
+async fn test_merge_segments_across_format_versions(
+    #[case] reference: InvertedListFormatVersion,
+) -> Result<()> {
     let v1_dir = TempObjDir::default();
     let v3_dir = TempObjDir::default();
     let dest_dir = TempObjDir::default();
@@ -402,9 +413,15 @@ async fn test_merge_segments_across_format_versions() -> Result<()> {
     assert_eq!(v1_index.format_version(), InvertedListFormatVersion::V1);
     assert_eq!(v3_index.format_version(), InvertedListFormatVersion::V3);
 
+    // The reference (first) segment fixes the output format.
+    let segments = match reference {
+        InvertedListFormatVersion::V1 => [v1_index, v3_index],
+        _ => [v3_index, v1_index],
+    };
+
     let dest_store = make_store(&dest_dir);
     let created = InvertedIndex::merge_segments(
-        &[v1_index, v3_index],
+        &segments,
         empty_doc_stream(),
         dest_store.as_ref(),
         None,
@@ -412,13 +429,10 @@ async fn test_merge_segments_across_format_versions() -> Result<()> {
     )
     .await?;
 
-    // Merged segment is written at the highest version present (V3).
-    assert_eq!(
-        created.index_version,
-        InvertedListFormatVersion::V3.index_version()
-    );
+    // Output preserves the reference segment's format, not the newest present.
+    assert_eq!(created.index_version, reference.index_version());
     let merged = InvertedIndex::load(dest_store, None, &LanceCache::no_cache()).await?;
-    assert_eq!(merged.format_version(), InvertedListFormatVersion::V3);
+    assert_eq!(merged.format_version(), reference);
 
     // Documents from both source segments survive and remain searchable.
     for (token, expected_row) in [("hello", 100_u64), ("world", 200_u64)] {

--- a/rust/lance-index/src/scalar/inverted/tokenizer.rs
+++ b/rust/lance-index/src/scalar/inverted/tokenizer.rs
@@ -931,14 +931,53 @@ impl InvertedIndexParams {
     /// them to match here would wrongly reject maintaining a pre-existing index
     /// (e.g. a V1 index built before an upgrade) alongside newer V2/V3 deltas.
     pub fn is_compatible_for_merge(&self, other: &Self) -> bool {
-        let merge_relevant = |params: &Self| {
-            let mut params = params.clone();
-            params.format_version = None;
-            params.memory_limit_mb = None;
-            params.num_workers = None;
-            params
-        };
-        merge_relevant(self) == merge_relevant(other)
+        // Destructure so any field added later is a compile error until its merge
+        // relevance is decided here, rather than silently defaulting to "must
+        // match". The three ignored fields are encoding-only (`format_version`)
+        // or per-run resources (`memory_limit_mb`, `num_workers`).
+        let Self {
+            document_granularity,
+            lance_tokenizer,
+            base_tokenizer,
+            language,
+            with_position,
+            max_token_length,
+            lower_case,
+            stem,
+            remove_stop_words,
+            custom_stop_words,
+            ascii_folding,
+            min_ngram_length,
+            max_ngram_length,
+            prefix_only,
+            block_size,
+            split_identifiers,
+            split_on_numerics,
+            preserve_original,
+            index_operators,
+            memory_limit_mb: _,
+            num_workers: _,
+            format_version: _,
+        } = self;
+        *document_granularity == other.document_granularity
+            && *lance_tokenizer == other.lance_tokenizer
+            && *base_tokenizer == other.base_tokenizer
+            && *language == other.language
+            && *with_position == other.with_position
+            && *max_token_length == other.max_token_length
+            && *lower_case == other.lower_case
+            && *stem == other.stem
+            && *remove_stop_words == other.remove_stop_words
+            && *custom_stop_words == other.custom_stop_words
+            && *ascii_folding == other.ascii_folding
+            && *min_ngram_length == other.min_ngram_length
+            && *max_ngram_length == other.max_ngram_length
+            && *prefix_only == other.prefix_only
+            && *block_size == other.block_size
+            && *split_identifiers == other.split_identifiers
+            && *split_on_numerics == other.split_on_numerics
+            && *preserve_original == other.preserve_original
+            && *index_operators == other.index_operators
     }
 
     /// Resolve the requested FTS format version, falling back to the default for

--- a/rust/lance-index/src/scalar/inverted/tokenizer.rs
+++ b/rust/lance-index/src/scalar/inverted/tokenizer.rs
@@ -920,6 +920,27 @@ impl InvertedIndexParams {
         self
     }
 
+    /// Whether two parameter sets describe compatible index segments that may be
+    /// merged into one.
+    ///
+    /// Every field that affects tokenization or the on-disk token/posting layout
+    /// (block size included) must match. Fields that are purely about the posting
+    /// *encoding* (`format_version`) or per-run resources (`memory_limit_mb`,
+    /// `num_workers`) are excluded: mixed-encoding segments are decoded with their
+    /// own format and re-encoded to a single target during the merge, so requiring
+    /// them to match here would wrongly reject maintaining a pre-existing index
+    /// (e.g. a V1 index built before an upgrade) alongside newer V2/V3 deltas.
+    pub fn is_compatible_for_merge(&self, other: &Self) -> bool {
+        let merge_relevant = |params: &Self| {
+            let mut params = params.clone();
+            params.format_version = None;
+            params.memory_limit_mb = None;
+            params.num_workers = None;
+            params
+        };
+        merge_relevant(self) == merge_relevant(other)
+    }
+
     /// Resolve the requested FTS format version, falling back to the default for
     /// the configured analyzer and block size.
     pub fn resolved_format_version(&self) -> InvertedListFormatVersion {


### PR DESCRIPTION
## Problem

Merging FTS (inverted) index segments required every source segment to share
the same `format_version` and `posting_tail_codec`, and the `params`
comparison also included `format_version`. When the default posting encoding
changes between releases, a pre-existing index (e.g. V1 / `Fixed32`) gets
maintained alongside newly written delta segments (V2/V3 / `VarintDelta`).
The two encodings can never match, so `InvertedIndex::merge_segments` fails
deterministically:

```
cannot merge inverted index segments with different posting tail codecs
  rust/lance-index/src/scalar/inverted/index/inverted_index.rs
```

(or the equivalent "different format versions" / "different parameters"), and
index maintenance retries the same merge forever.

In cases where the guard happens to pass but the codecs still differ, the
older large segment is decoded under the wrong layout and panics deeper down
with an arrow `offset overflow` in the posting-tail decode path.

## Why the guards were too strict

A partition is always decoded with **its own** codec when read into an
in-memory builder (`InvertedPartition::into_builder`), and `merge_from` folds
**already-decoded logical entries** (doc id / frequency / positions) into the
target builder, re-encoding them with the target codec. The on-disk source
encoding is therefore irrelevant to whether two segments can be merged — they
only need to agree on things that actually affect tokenization and the
token/posting layout (`params`, `token_set_format`, `block_size`).

## Changes

- **`InvertedIndex::merge_segments`**: replace the `params` equality check with
  a new `InvertedIndexParams::is_compatible_for_merge` (ignores the
  encoding-only `format_version` and the run-only `memory_limit_mb` /
  `num_workers`); drop the `format_version` / `posting_tail_codec` guards.
  Re-encode to the **highest** format version present, and stamp the written
  details / `index_version` with that target (not `first`'s) so readers pick
  the correct decoder.
- **`InvertedIndexBuilder::merge_existing_segments`**: fold every source
  partition into a fresh builder created with the **target** format before
  merging, so a partition's already-encoded blocks are decoded and re-encoded
  with the target codec regardless of segment order (a source partition can't
  simply become the merge accumulator, since its `encoded_blocks` carry the old
  codec).
- **`InnerBuilder::merge_from`**: drop the `format_version` /
  `posting_tail_codec` equality guards (still requires matching positions,
  token set format, and block size).

## Test

Adds `test_merge_segments_across_format_versions`: builds a V1 and a V3 segment
with identical params/token-set-format, merges them, and asserts the result is
a single V3 index in which documents from **both** source segments remain
searchable. Full `lance-index` inverted suite (406 tests) passes; `clippy`
clean.