### PR TITLE
fix(io): add upload context to object store write failures

### DIFF
--- a/rust/lance-io/src/object_writer.rs
+++ b/rust/lance-io/src/object_writer.rs
@@ -5,6 +5,7 @@ use std::io;
 use std::pin::Pin;
 use std::sync::{Arc, OnceLock};
 use std::task::Poll;
+use std::time::Instant;
 
 use crate::object_store::ObjectStore as LanceObjectStore;
 use async_trait::async_trait;
@@ -12,7 +13,7 @@ use bytes::Bytes;
 use futures::FutureExt;
 use futures::future::BoxFuture;
 use object_store::{MultipartUpload, ObjectStoreExt};
-use object_store::{ObjectStore, Result as OSResult, path::Path};
+use object_store::{ObjectStore, path::Path};
 use tokio::io::{AsyncWrite, AsyncWriteExt};
 use tokio::task::JoinSet;
 
@@ -94,23 +95,78 @@ pub struct WriteResult {
     pub e_tag: Option<String>,
 }
 
+/// An object-store upload failure, annotated with what Lance was uploading.
+///
+/// `object_store` reports its own elapsed time, but its clock starts inside
+/// `RetryContext::new`, which runs on the *first poll* of the request future.
+/// The `elapsed` reported here is measured from the moment Lance handed the
+/// request to the uploader, so the two together tell a slow request (both
+/// durations agree) apart from one whose task sat unpolled before it ever
+/// issued (this duration is much larger). That distinction is what identifies
+/// runtime starvation as the cause of a whole-request timeout, and it is not
+/// recoverable from the object-store error alone.
+#[derive(Debug)]
+struct UploadFailure {
+    context: String,
+    source: Box<dyn std::error::Error + Send + Sync>,
+}
+
+impl UploadFailure {
+    fn new(context: String, source: impl std::error::Error + Send + Sync + 'static) -> Self {
+        Self {
+            context,
+            source: Box::new(source),
+        }
+    }
+
+    fn into_io_error(self) -> io::Error {
+        io::Error::other(self)
+    }
+}
+
+impl std::fmt::Display for UploadFailure {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}: {}", self.context, self.source)
+    }
+}
+
+impl std::error::Error for UploadFailure {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        Some(self.source.as_ref())
+    }
+}
+
+type UploadResult<T> = std::result::Result<T, UploadFailure>;
+
+/// Describes the upload knobs in effect, for inclusion in failure messages.
+///
+/// Both are process-global and read from the environment, so a failure that is
+/// sensitive to either is impossible to interpret without them.
+fn upload_settings() -> String {
+    format!(
+        "LANCE_INITIAL_UPLOAD_SIZE={} bytes, LANCE_UPLOAD_CONCURRENCY={}",
+        initial_upload_size(),
+        max_upload_parallelism()
+    )
+}
+
 enum UploadState {
     /// The writer has been opened but no data has been written yet. Will be in
     /// this state until the buffer is full or the writer is shut down.
     Started(Arc<dyn ObjectStore>),
     /// The writer is in the process of creating a multipart upload.
-    CreatingUpload(BoxFuture<'static, OSResult<Box<dyn MultipartUpload>>>),
+    CreatingUpload(BoxFuture<'static, UploadResult<Box<dyn MultipartUpload>>>),
     /// The writer is in the process of uploading parts.
     InProgress {
         part_idx: u16,
         upload: Box<dyn MultipartUpload>,
-        futures: JoinSet<OSResult<()>>,
+        futures: JoinSet<UploadResult<()>>,
     },
     /// The writer is in the process of uploading data in a single PUT request.
     /// This happens when shutdown is called before the buffer is full.
-    PuttingSingle(BoxFuture<'static, OSResult<WriteResult>>),
+    PuttingSingle(BoxFuture<'static, UploadResult<WriteResult>>),
     /// The writer is in the process of completing the multipart upload.
-    Completing(BoxFuture<'static, OSResult<WriteResult>>),
+    Completing(BoxFuture<'static, UploadResult<WriteResult>>),
     /// The writer has been shut down and all data has been written.
     Done(WriteResult),
 }
@@ -122,9 +178,19 @@ impl UploadState {
         let this = std::mem::replace(self, Self::Done(WriteResult::default()));
         *self = match this {
             Self::Started(store) => {
+                let started_at = Instant::now();
                 let fut = async move {
                     let size = buffer.len();
-                    let res = store.put(&path, buffer.into()).await?;
+                    let res = store.put(&path, buffer.into()).await.map_err(|source| {
+                        UploadFailure::new(
+                            format!(
+                                "single PUT of {path} failed after {:?} ({size} bytes, {})",
+                                started_at.elapsed(),
+                                upload_settings()
+                            ),
+                            source,
+                        )
+                    })?;
                     Ok(WriteResult {
                         size,
                         e_tag: res.e_tag,
@@ -136,18 +202,29 @@ impl UploadState {
         }
     }
 
-    fn in_progress_to_completing(&mut self) {
+    fn in_progress_to_completing(&mut self, path: Arc<Path>, bytes_written: usize) {
         // To get owned self, we temporarily swap with Done.
         let this = std::mem::replace(self, Self::Done(WriteResult::default()));
         *self = match this {
             Self::InProgress {
                 mut upload,
                 futures,
-                ..
+                part_idx,
             } => {
                 debug_assert!(futures.is_empty());
+                let started_at = Instant::now();
                 let fut = async move {
-                    let res = upload.complete().await?;
+                    let res = upload.complete().await.map_err(|source| {
+                        UploadFailure::new(
+                            format!(
+                                "completing multipart upload of {path} failed after {:?} \
+                                 ({part_idx} parts, {bytes_written} bytes, {})",
+                                started_at.elapsed(),
+                                upload_settings()
+                            ),
+                            source,
+                        )
+                    })?;
                     Ok(WriteResult {
                         size: 0, // This will be set properly later.
                         e_tag: res.e_tag,
@@ -189,12 +266,29 @@ impl ObjectWriter {
     fn put_part(
         upload: &mut dyn MultipartUpload,
         buffer: Bytes,
-    ) -> BoxFuture<'static, OSResult<()>> {
-        log::debug!(
-            "MultipartUpload submitting part with {} bytes",
-            buffer.len()
-        );
-        upload.put_part(buffer.into())
+        path: Arc<Path>,
+        part_idx: u16,
+        parts_in_flight: usize,
+    ) -> BoxFuture<'static, UploadResult<()>> {
+        let part_size = buffer.len();
+        log::debug!("MultipartUpload submitting part with {} bytes", part_size);
+        // Stamped before the future is spawned so the reported duration covers
+        // any time the task spent waiting to be polled, not just the request.
+        let queued_at = Instant::now();
+        let fut = upload.put_part(buffer.into());
+        Box::pin(async move {
+            fut.await.map_err(|source| {
+                UploadFailure::new(
+                    format!(
+                        "multipart upload of part {part_idx} of {path} failed after {:?} \
+                         ({part_size} bytes, {parts_in_flight} parts in flight, {})",
+                        queued_at.elapsed(),
+                        upload_settings()
+                    ),
+                    source,
+                )
+            })
+        })
     }
 
     fn poll_tasks(
@@ -214,7 +308,13 @@ impl ObjectWriter {
                             0,
                             mut_self.use_constant_size_upload_parts,
                         );
-                        futures.spawn(Self::put_part(upload.as_mut(), data));
+                        futures.spawn(Self::put_part(
+                            upload.as_mut(),
+                            data,
+                            mut_self.path.clone(),
+                            0,
+                            0,
+                        ));
 
                         mut_self.state = UploadState::InProgress {
                             part_idx: 1, // We just used 0
@@ -222,15 +322,24 @@ impl ObjectWriter {
                             upload,
                         };
                     }
-                    Poll::Ready(Err(e)) => return Err(std::io::Error::other(e)),
+                    Poll::Ready(Err(err)) => return Err(err.into_io_error()),
                     Poll::Pending => break,
                 },
                 UploadState::InProgress { futures, .. } => {
                     while let Poll::Ready(Some(res)) = futures.poll_join_next(cx) {
                         match res {
                             Ok(Ok(())) => {}
-                            Err(err) => return Err(std::io::Error::other(err)),
-                            Ok(Err(err)) => return Err(err.into()),
+                            Err(err) => {
+                                return Err(UploadFailure::new(
+                                    format!(
+                                        "multipart upload task for {} did not complete",
+                                        mut_self.path
+                                    ),
+                                    err,
+                                )
+                                .into_io_error());
+                            }
+                            Ok(Err(err)) => return Err(err.into_io_error()),
                         }
                     }
                     break;
@@ -241,7 +350,7 @@ impl ObjectWriter {
                             res.size = mut_self.cursor;
                             mut_self.state = UploadState::Done(res)
                         }
-                        Poll::Ready(Err(e)) => return Err(std::io::Error::other(e)),
+                        Poll::Ready(Err(err)) => return Err(err.into_io_error()),
                         Poll::Pending => break,
                     }
                 }
@@ -300,7 +409,19 @@ impl AsyncWrite for ObjectWriter {
                 UploadState::Started(store) => {
                     let path = mut_self.path.clone();
                     let store = store.clone();
-                    let fut = Box::pin(async move { store.put_multipart(path.as_ref()).await });
+                    let started_at = Instant::now();
+                    let fut = Box::pin(async move {
+                        store.put_multipart(path.as_ref()).await.map_err(|source| {
+                            UploadFailure::new(
+                                format!(
+                                    "failed to create multipart upload for {path} after {:?} ({})",
+                                    started_at.elapsed(),
+                                    upload_settings()
+                                ),
+                                source,
+                            )
+                        })
+                    });
                     self.state = UploadState::CreatingUpload(fut);
                 }
                 // TODO: Make max concurrency configurable from storage options.
@@ -315,8 +436,16 @@ impl AsyncWrite for ObjectWriter {
                         *part_idx,
                         mut_self.use_constant_size_upload_parts,
                     );
+                    let parts_in_flight = futures.len();
                     futures.spawn(
-                        Self::put_part(upload.as_mut(), data).instrument(tracing::Span::current()),
+                        Self::put_part(
+                            upload.as_mut(),
+                            data,
+                            mut_self.path.clone(),
+                            *part_idx,
+                            parts_in_flight,
+                        )
+                        .instrument(tracing::Span::current()),
                     );
                     *part_idx += 1;
                 }
@@ -375,15 +504,25 @@ impl AsyncWrite for ObjectWriter {
                     self.state.started_to_putting_single(path, part);
                 }
                 UploadState::InProgress {
-                    upload, futures, ..
+                    upload,
+                    futures,
+                    part_idx,
                 } => {
                     // Flush final batch
                     if !mut_self.buffer.is_empty() && futures.len() < max_upload_parallelism() {
                         // We can just use `take` since we don't need the buffer anymore.
                         let data = Bytes::from(std::mem::take(&mut mut_self.buffer));
+                        let parts_in_flight = futures.len();
+                        let final_part_idx = *part_idx;
                         futures.spawn(
-                            Self::put_part(upload.as_mut(), data)
-                                .instrument(tracing::Span::current()),
+                            Self::put_part(
+                                upload.as_mut(),
+                                data,
+                                mut_self.path.clone(),
+                                final_part_idx,
+                                parts_in_flight,
+                            )
+                            .instrument(tracing::Span::current()),
                         );
                         // We need to go back to beginning of loop to poll the
                         // new feature and get the waker registered on the ctx.
@@ -392,7 +531,9 @@ impl AsyncWrite for ObjectWriter {
 
                     // We handle the transition from in progress to completing here.
                     if futures.is_empty() {
-                        self.state.in_progress_to_completing();
+                        let path = mut_self.path.clone();
+                        let bytes_written = mut_self.cursor;
+                        self.state.in_progress_to_completing(path, bytes_written);
                     } else {
                         return Poll::Pending;
                     }
@@ -647,9 +788,288 @@ fn get_inode(_metadata: &std::fs::Metadata) -> u64 {
 
 #[cfg(test)]
 mod tests {
+    use futures::stream::BoxStream;
+    use object_store::{
+        CopyOptions, GetOptions, GetResult, ListResult, ObjectMeta, PutMultipartOptions,
+        PutOptions, PutPayload, PutResult, RenameOptions, Result as OSResult, UploadPart,
+    };
     use tokio::io::AsyncWriteExt;
 
     use super::*;
+
+    /// Which stage of an upload the mock store rejects.
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    enum FailAt {
+        CreateMultipart,
+        PutPart,
+        Complete,
+        SinglePut,
+    }
+
+    fn rejected(stage: &'static str) -> object_store::Error {
+        object_store::Error::Generic {
+            store: "FailingUploadStore",
+            source: format!("{stage} rejected by test").into(),
+        }
+    }
+
+    #[derive(Debug)]
+    struct FailingUpload {
+        fail_at: FailAt,
+    }
+
+    #[async_trait]
+    impl MultipartUpload for FailingUpload {
+        fn put_part(&mut self, _data: PutPayload) -> UploadPart {
+            let fails = self.fail_at == FailAt::PutPart;
+            Box::pin(async move { if fails { Err(rejected("part")) } else { Ok(()) } })
+        }
+
+        async fn complete(&mut self) -> OSResult<PutResult> {
+            if self.fail_at == FailAt::Complete {
+                Err(rejected("complete"))
+            } else {
+                Ok(PutResult {
+                    e_tag: None,
+                    version: None,
+                })
+            }
+        }
+
+        async fn abort(&mut self) -> OSResult<()> {
+            Ok(())
+        }
+    }
+
+    /// Rejects exactly one stage of an upload so each failure site can be
+    /// exercised on its own.
+    #[derive(Debug)]
+    struct FailingUploadStore {
+        fail_at: FailAt,
+    }
+
+    impl std::fmt::Display for FailingUploadStore {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            write!(f, "FailingUploadStore")
+        }
+    }
+
+    #[async_trait]
+    impl ObjectStore for FailingUploadStore {
+        async fn put_opts(
+            &self,
+            _location: &Path,
+            _bytes: PutPayload,
+            _opts: PutOptions,
+        ) -> OSResult<PutResult> {
+            if self.fail_at == FailAt::SinglePut {
+                Err(rejected("single put"))
+            } else {
+                Ok(PutResult {
+                    e_tag: None,
+                    version: None,
+                })
+            }
+        }
+
+        async fn put_multipart_opts(
+            &self,
+            _location: &Path,
+            _opts: PutMultipartOptions,
+        ) -> OSResult<Box<dyn MultipartUpload>> {
+            if self.fail_at == FailAt::CreateMultipart {
+                Err(rejected("create multipart"))
+            } else {
+                Ok(Box::new(FailingUpload {
+                    fail_at: self.fail_at,
+                }))
+            }
+        }
+
+        async fn get_opts(&self, _location: &Path, _options: GetOptions) -> OSResult<GetResult> {
+            unimplemented!()
+        }
+
+        fn delete_stream(
+            &self,
+            _locations: BoxStream<'static, OSResult<Path>>,
+        ) -> BoxStream<'static, OSResult<Path>> {
+            unimplemented!()
+        }
+
+        fn list(&self, _prefix: Option<&Path>) -> BoxStream<'static, OSResult<ObjectMeta>> {
+            unimplemented!()
+        }
+
+        fn list_with_offset(
+            &self,
+            _prefix: Option<&Path>,
+            _offset: &Path,
+        ) -> BoxStream<'static, OSResult<ObjectMeta>> {
+            unimplemented!()
+        }
+
+        async fn list_with_delimiter(&self, _prefix: Option<&Path>) -> OSResult<ListResult> {
+            unimplemented!()
+        }
+
+        async fn copy_opts(&self, _from: &Path, _to: &Path, _opts: CopyOptions) -> OSResult<()> {
+            unimplemented!()
+        }
+
+        async fn rename_opts(
+            &self,
+            _from: &Path,
+            _to: &Path,
+            _opts: RenameOptions,
+        ) -> OSResult<()> {
+            unimplemented!()
+        }
+    }
+
+    const FAILING_UPLOAD_PATH: &str = "part_7_invert.lance";
+
+    /// Drives a write against a store that rejects `fail_at`, returning the
+    /// error. The failure can surface either from a write or from shutdown
+    /// depending on when the rejected request is reaped, so both are checked.
+    async fn failing_upload(fail_at: FailAt, num_bytes: usize) -> io::Error {
+        let mut store = LanceObjectStore::memory();
+        store.inner = Arc::new(FailingUploadStore { fail_at });
+
+        let mut writer = ObjectWriter::new(&store, &Path::from(FAILING_UPLOAD_PATH))
+            .await
+            .unwrap();
+        let buf = vec![0u8; num_bytes];
+        match writer.write_all(buf.as_slice()).await {
+            Err(err) => err,
+            Ok(()) => AsyncWriteExt::shutdown(&mut writer)
+                .await
+                .expect_err("upload should have failed"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_part_upload_failure_reports_upload_context() {
+        // Two parts' worth, so the failing part has a sibling in flight.
+        let err = failing_upload(FailAt::PutPart, INITIAL_UPLOAD_STEP * 2).await;
+        let message = err.to_string();
+
+        assert!(
+            message.contains("multipart upload of part"),
+            "should name the failing stage: {message}"
+        );
+        assert!(
+            message.contains(FAILING_UPLOAD_PATH),
+            "should name the object: {message}"
+        );
+        assert!(
+            message.contains(&format!("{INITIAL_UPLOAD_STEP} bytes")),
+            "should report the part size: {message}"
+        );
+        assert!(
+            message.contains("parts in flight"),
+            "should report upload concurrency in use: {message}"
+        );
+        assert!(
+            message.contains("LANCE_INITIAL_UPLOAD_SIZE")
+                && message.contains("LANCE_UPLOAD_CONCURRENCY"),
+            "should report the knobs governing the request: {message}"
+        );
+        assert!(
+            message.contains("part rejected by test"),
+            "should keep the underlying object store error: {message}"
+        );
+    }
+
+    // The elapsed time is the whole point of the added context: it is what tells
+    // a slow request apart from one whose task was never polled.
+    #[tokio::test]
+    async fn test_part_upload_failure_reports_elapsed_time() {
+        let err = failing_upload(FailAt::PutPart, INITIAL_UPLOAD_STEP * 2).await;
+        let message = err.to_string();
+        assert!(
+            message.contains("failed after"),
+            "should report how long the request took: {message}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_part_upload_failure_preserves_source_chain() {
+        let err = failing_upload(FailAt::PutPart, INITIAL_UPLOAD_STEP * 2).await;
+
+        let failure = err
+            .get_ref()
+            .expect("io error should carry the upload failure");
+        let source = std::error::Error::source(failure)
+            .expect("upload failure should expose the object store error");
+        assert!(
+            source.downcast_ref::<object_store::Error>().is_some(),
+            "source should still be the object store error, got: {source}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_create_multipart_failure_reports_upload_context() {
+        let err = failing_upload(FailAt::CreateMultipart, INITIAL_UPLOAD_STEP * 2).await;
+        let message = err.to_string();
+
+        assert!(
+            message.contains("failed to create multipart upload for"),
+            "should name the failing stage: {message}"
+        );
+        assert!(
+            message.contains(FAILING_UPLOAD_PATH),
+            "should name the object: {message}"
+        );
+        assert!(
+            message.contains("create multipart rejected by test"),
+            "should keep the underlying object store error: {message}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_complete_multipart_failure_reports_upload_context() {
+        let num_bytes = INITIAL_UPLOAD_STEP * 2;
+        let err = failing_upload(FailAt::Complete, num_bytes).await;
+        let message = err.to_string();
+
+        assert!(
+            message.contains("completing multipart upload of"),
+            "should name the failing stage: {message}"
+        );
+        assert!(
+            message.contains(&format!("{num_bytes} bytes")),
+            "should report how much had been written: {message}"
+        );
+        assert!(
+            message.contains("complete rejected by test"),
+            "should keep the underlying object store error: {message}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_single_put_failure_reports_upload_context() {
+        // Below the multipart threshold, so shutdown takes the single-PUT path.
+        let err = failing_upload(FailAt::SinglePut, 256).await;
+        let message = err.to_string();
+
+        assert!(
+            message.contains("single PUT of"),
+            "should name the failing stage: {message}"
+        );
+        assert!(
+            message.contains(FAILING_UPLOAD_PATH),
+            "should name the object: {message}"
+        );
+        assert!(
+            message.contains("256 bytes"),
+            "should report the body size: {message}"
+        );
+        assert!(
+            message.contains("single put rejected by test"),
+            "should keep the underlying object store error: {message}"
+        );
+    }
 
     #[tokio::test]
     async fn test_write() {

--- a/rust/lance-io/src/object_writer.rs
+++ b/rust/lance-io/src/object_writer.rs
@@ -281,7 +281,7 @@ impl ObjectWriter {
                 UploadFailure::new(
                     format!(
                         "multipart upload of part {part_idx} of {path} failed after {:?} \
-                         ({part_size} bytes, {parts_in_flight} parts in flight at submission, {})",
+                         ({part_size} bytes, parts_in_flight={parts_in_flight} at submission, {})",
                         queued_at.elapsed(),
                         upload_settings()
                     ),
@@ -976,7 +976,7 @@ mod tests {
             "should report the part size: {message}"
         );
         assert!(
-            message.contains("parts in flight"),
+            message.contains("parts_in_flight="),
             "should report upload concurrency in use: {message}"
         );
         assert!(

--- a/rust/lance-io/src/object_writer.rs
+++ b/rust/lance-io/src/object_writer.rs
@@ -281,7 +281,7 @@ impl ObjectWriter {
                 UploadFailure::new(
                     format!(
                         "multipart upload of part {part_idx} of {path} failed after {:?} \
-                         ({part_size} bytes, {parts_in_flight} parts in flight, {})",
+                         ({part_size} bytes, {parts_in_flight} parts in flight at submission, {})",
                         queued_at.elapsed(),
                         upload_settings()
                     ),
@@ -313,7 +313,7 @@ impl ObjectWriter {
                             data,
                             mut_self.path.clone(),
                             0,
-                            0,
+                            1,
                         ));
 
                         mut_self.state = UploadState::InProgress {
@@ -436,7 +436,7 @@ impl AsyncWrite for ObjectWriter {
                         *part_idx,
                         mut_self.use_constant_size_upload_parts,
                     );
-                    let parts_in_flight = futures.len();
+                    let parts_in_flight = futures.len() + 1;
                     futures.spawn(
                         Self::put_part(
                             upload.as_mut(),
@@ -512,8 +512,11 @@ impl AsyncWrite for ObjectWriter {
                     if !mut_self.buffer.is_empty() && futures.len() < max_upload_parallelism() {
                         // We can just use `take` since we don't need the buffer anymore.
                         let data = Bytes::from(std::mem::take(&mut mut_self.buffer));
-                        let parts_in_flight = futures.len();
+                        let parts_in_flight = futures.len() + 1;
                         let final_part_idx = *part_idx;
+                        // Counted like every other part so the part total
+                        // reported when completing the upload is accurate.
+                        *part_idx += 1;
                         futures.spawn(
                             Self::put_part(
                                 upload.as_mut(),
@@ -929,6 +932,13 @@ mod tests {
 
     const FAILING_UPLOAD_PATH: &str = "part_7_invert.lance";
 
+    /// Enough bytes for two full multipart parts, so a failing part has a
+    /// sibling in flight. Derived from the configured part size rather than the
+    /// default, since `LANCE_INITIAL_UPLOAD_SIZE` may raise it.
+    fn two_parts() -> usize {
+        initial_upload_size() * 2
+    }
+
     /// Drives a write against a store that rejects `fail_at`, returning the
     /// error. The failure can surface either from a write or from shutdown
     /// depending on when the rejected request is reaped, so both are checked.
@@ -950,8 +960,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_part_upload_failure_reports_upload_context() {
-        // Two parts' worth, so the failing part has a sibling in flight.
-        let err = failing_upload(FailAt::PutPart, INITIAL_UPLOAD_STEP * 2).await;
+        let err = failing_upload(FailAt::PutPart, two_parts()).await;
         let message = err.to_string();
 
         assert!(
@@ -963,7 +972,7 @@ mod tests {
             "should name the object: {message}"
         );
         assert!(
-            message.contains(&format!("{INITIAL_UPLOAD_STEP} bytes")),
+            message.contains(&format!("{} bytes", initial_upload_size())),
             "should report the part size: {message}"
         );
         assert!(
@@ -985,7 +994,7 @@ mod tests {
     // a slow request apart from one whose task was never polled.
     #[tokio::test]
     async fn test_part_upload_failure_reports_elapsed_time() {
-        let err = failing_upload(FailAt::PutPart, INITIAL_UPLOAD_STEP * 2).await;
+        let err = failing_upload(FailAt::PutPart, two_parts()).await;
         let message = err.to_string();
         assert!(
             message.contains("failed after"),
@@ -995,7 +1004,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_part_upload_failure_preserves_source_chain() {
-        let err = failing_upload(FailAt::PutPart, INITIAL_UPLOAD_STEP * 2).await;
+        let err = failing_upload(FailAt::PutPart, two_parts()).await;
 
         let failure = err
             .get_ref()
@@ -1010,7 +1019,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_create_multipart_failure_reports_upload_context() {
-        let err = failing_upload(FailAt::CreateMultipart, INITIAL_UPLOAD_STEP * 2).await;
+        let err = failing_upload(FailAt::CreateMultipart, two_parts()).await;
         let message = err.to_string();
 
         assert!(
@@ -1029,7 +1038,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_complete_multipart_failure_reports_upload_context() {
-        let num_bytes = INITIAL_UPLOAD_STEP * 2;
+        let num_bytes = two_parts();
         let err = failing_upload(FailAt::Complete, num_bytes).await;
         let message = err.to_string();
 

--- a/rust/lance-io/src/object_writer.rs
+++ b/rust/lance-io/src/object_writer.rs
@@ -108,19 +108,46 @@ pub struct WriteResult {
 #[derive(Debug)]
 struct UploadFailure {
     context: String,
+    /// The kind `into_io_error` restores. Without it every contextualized
+    /// failure would collapse to `ErrorKind::Other`, changing what callers
+    /// matching on the kind observe.
+    kind: io::ErrorKind,
     source: Box<dyn std::error::Error + Send + Sync>,
 }
 
 impl UploadFailure {
-    fn new(context: String, source: impl std::error::Error + Send + Sync + 'static) -> Self {
+    /// Wraps an object store error.
+    ///
+    /// The `io::ErrorKind` is taken from `object_store`'s own conversion rather
+    /// than a local copy of its mapping, and the error itself is kept as the
+    /// source, so both callers matching on the kind and `Error::is_not_found`
+    /// (which downcasts along the source chain) keep working.
+    fn new(context: String, source: object_store::Error) -> Self {
+        let mapped = io::Error::from(source);
+        let kind = mapped.kind();
+        let source: Box<dyn std::error::Error + Send + Sync> =
+            match mapped.downcast::<object_store::Error>() {
+                Ok(source) => Box::new(source),
+                Err(mapped) => Box::new(mapped),
+            };
         Self {
             context,
+            kind,
+            source,
+        }
+    }
+
+    /// Wraps a failure that carries no object store error to map a kind from.
+    fn from_task(context: String, source: tokio::task::JoinError) -> Self {
+        Self {
+            context,
+            kind: io::ErrorKind::Other,
             source: Box::new(source),
         }
     }
 
     fn into_io_error(self) -> io::Error {
-        io::Error::other(self)
+        io::Error::new(self.kind, self)
     }
 }
 
@@ -138,10 +165,27 @@ impl std::error::Error for UploadFailure {
 
 type UploadResult<T> = std::result::Result<T, UploadFailure>;
 
+/// Identifies a single part upload, for its failure message.
+struct PartUpload {
+    path: Arc<Path>,
+    part_idx: u16,
+    /// Concurrent part uploads, counting this one, when it was submitted.
+    parts_in_flight: usize,
+    /// The part size in effect, which is the buffer capacity this part was
+    /// filled to. [`ObjectWriter::next_part_buffer`] grows the part size every
+    /// 100 parts so one upload can cover a very large object within the
+    /// 10,000-part limit, so on a long upload this is a multiple of
+    /// `LANCE_INITIAL_UPLOAD_SIZE` rather than equal to it. A body smaller than
+    /// this is the final flush.
+    part_size: usize,
+}
+
 /// Describes the upload knobs in effect, for inclusion in failure messages.
 ///
 /// Both are process-global and read from the environment, so a failure that is
-/// sensitive to either is impossible to interpret without them.
+/// sensitive to either is impossible to interpret without them. Note that
+/// `LANCE_INITIAL_UPLOAD_SIZE` is the starting part size, not the size in
+/// effect: see [`PartUpload::part_size`].
 fn upload_settings() -> String {
     format!(
         "LANCE_INITIAL_UPLOAD_SIZE={} bytes, LANCE_UPLOAD_CONCURRENCY={}",
@@ -266,22 +310,27 @@ impl ObjectWriter {
     fn put_part(
         upload: &mut dyn MultipartUpload,
         buffer: Bytes,
-        path: Arc<Path>,
-        part_idx: u16,
-        parts_in_flight: usize,
+        part: PartUpload,
     ) -> BoxFuture<'static, UploadResult<()>> {
-        let part_size = buffer.len();
-        log::debug!("MultipartUpload submitting part with {} bytes", part_size);
+        let body_size = buffer.len();
+        log::debug!("MultipartUpload submitting part with {} bytes", body_size);
         // Stamped before the future is spawned so the reported duration covers
         // any time the task spent waiting to be polled, not just the request.
         let queued_at = Instant::now();
         let fut = upload.put_part(buffer.into());
         Box::pin(async move {
             fut.await.map_err(|source| {
+                let PartUpload {
+                    path,
+                    part_idx,
+                    parts_in_flight,
+                    part_size,
+                } = part;
                 UploadFailure::new(
                     format!(
                         "multipart upload of part {part_idx} of {path} failed after {:?} \
-                         ({part_size} bytes, parts_in_flight={parts_in_flight} at submission, {})",
+                         ({body_size} bytes, part_size={part_size} bytes, \
+                          parts_in_flight={parts_in_flight} at submission, {})",
                         queued_at.elapsed(),
                         upload_settings()
                     ),
@@ -303,6 +352,9 @@ impl ObjectWriter {
                     Poll::Ready(Ok(mut upload)) => {
                         let mut futures = JoinSet::new();
 
+                        // Read before the buffer is swapped out: capacity is the
+                        // part size this body was filled to.
+                        let part_size = mut_self.buffer.capacity();
                         let data = Self::next_part_buffer(
                             &mut mut_self.buffer,
                             0,
@@ -311,9 +363,12 @@ impl ObjectWriter {
                         futures.spawn(Self::put_part(
                             upload.as_mut(),
                             data,
-                            mut_self.path.clone(),
-                            0,
-                            1,
+                            PartUpload {
+                                path: mut_self.path.clone(),
+                                part_idx: 0,
+                                parts_in_flight: 1,
+                                part_size,
+                            },
                         ));
 
                         mut_self.state = UploadState::InProgress {
@@ -330,7 +385,7 @@ impl ObjectWriter {
                         match res {
                             Ok(Ok(())) => {}
                             Err(err) => {
-                                return Err(UploadFailure::new(
+                                return Err(UploadFailure::from_task(
                                     format!(
                                         "multipart upload task for {} did not complete",
                                         mut_self.path
@@ -431,21 +486,24 @@ impl AsyncWrite for ObjectWriter {
                     futures,
                     ..
                 } if futures.len() < max_upload_parallelism() => {
+                    // Read before the buffer is swapped out: capacity is the
+                    // part size this body was filled to, which grows as the
+                    // upload progresses.
+                    let part_size = mut_self.buffer.capacity();
                     let data = Self::next_part_buffer(
                         &mut mut_self.buffer,
                         *part_idx,
                         mut_self.use_constant_size_upload_parts,
                     );
-                    let parts_in_flight = futures.len() + 1;
+                    let part = PartUpload {
+                        path: mut_self.path.clone(),
+                        part_idx: *part_idx,
+                        parts_in_flight: futures.len() + 1,
+                        part_size,
+                    };
                     futures.spawn(
-                        Self::put_part(
-                            upload.as_mut(),
-                            data,
-                            mut_self.path.clone(),
-                            *part_idx,
-                            parts_in_flight,
-                        )
-                        .instrument(tracing::Span::current()),
+                        Self::put_part(upload.as_mut(), data, part)
+                            .instrument(tracing::Span::current()),
                     );
                     *part_idx += 1;
                 }
@@ -511,21 +569,20 @@ impl AsyncWrite for ObjectWriter {
                     // Flush final batch
                     if !mut_self.buffer.is_empty() && futures.len() < max_upload_parallelism() {
                         // We can just use `take` since we don't need the buffer anymore.
+                        let part_size = mut_self.buffer.capacity();
                         let data = Bytes::from(std::mem::take(&mut mut_self.buffer));
-                        let parts_in_flight = futures.len() + 1;
-                        let final_part_idx = *part_idx;
+                        let part = PartUpload {
+                            path: mut_self.path.clone(),
+                            part_idx: *part_idx,
+                            parts_in_flight: futures.len() + 1,
+                            part_size,
+                        };
                         // Counted like every other part so the part total
                         // reported when completing the upload is accurate.
                         *part_idx += 1;
                         futures.spawn(
-                            Self::put_part(
-                                upload.as_mut(),
-                                data,
-                                mut_self.path.clone(),
-                                final_part_idx,
-                                parts_in_flight,
-                            )
-                            .instrument(tracing::Span::current()),
+                            Self::put_part(upload.as_mut(), data, part)
+                                .instrument(tracing::Span::current()),
                         );
                         // We need to go back to beginning of loop to poll the
                         // new feature and get the waker registered on the ctx.
@@ -553,12 +610,10 @@ impl Writer for ObjectWriter {
     }
 
     async fn shutdown(&mut self) -> Result<WriteResult> {
-        AsyncWriteExt::shutdown(self).await.map_err(|e| {
-            Error::io(format!(
-                "failed to shutdown object writer for {}: {}",
-                self.path, e
-            ))
-        })?;
+        // Propagated structurally rather than formatted into a message: every
+        // failure from this writer already names the path, and stringifying it
+        // would flatten the object store error out of the source chain.
+        AsyncWriteExt::shutdown(self).await?;
         if let UploadState::Done(result) = &self.state {
             Ok(result.clone())
         } else {
@@ -973,7 +1028,11 @@ mod tests {
         );
         assert!(
             message.contains(&format!("{} bytes", initial_upload_size())),
-            "should report the part size: {message}"
+            "should report the body size: {message}"
+        );
+        assert!(
+            message.contains(&format!("part_size={} bytes", initial_upload_size())),
+            "should report the part size in effect: {message}"
         );
         assert!(
             message.contains("parts_in_flight="),
@@ -1002,6 +1061,38 @@ mod tests {
         );
     }
 
+    // `part_size` in the failure message is the live buffer capacity, which is
+    // what makes it report the size actually in effect. The part size grows
+    // every 100 parts, so on a long upload that diverges from
+    // LANCE_INITIAL_UPLOAD_SIZE by a multiple; reporting only the configured
+    // value would understate a late part by that factor. Reaching part 100
+    // through the writer would mean allocating hundreds of MiB, so the growth
+    // is asserted on the buffer the message reads from.
+    #[test]
+    fn test_part_buffer_capacity_tracks_grown_part_size() {
+        let mut buffer = Vec::<u8>::with_capacity(initial_upload_size());
+        assert_eq!(buffer.capacity(), initial_upload_size());
+
+        let _ = ObjectWriter::next_part_buffer(&mut buffer, 0, false);
+        assert_eq!(
+            buffer.capacity(),
+            initial_upload_size(),
+            "early parts stay at the configured size"
+        );
+
+        let _ = ObjectWriter::next_part_buffer(&mut buffer, 100, false);
+        assert_eq!(
+            buffer.capacity(),
+            initial_upload_size().max(2 * INITIAL_UPLOAD_STEP),
+            "the part size has grown past the first step"
+        );
+
+        // A store pinned to constant part sizes never grows, so the reported
+        // size stays equal to the configured one.
+        let _ = ObjectWriter::next_part_buffer(&mut buffer, 100, true);
+        assert_eq!(buffer.capacity(), initial_upload_size());
+    }
+
     #[tokio::test]
     async fn test_part_upload_failure_preserves_source_chain() {
         let err = failing_upload(FailAt::PutPart, two_parts()).await;
@@ -1014,6 +1105,57 @@ mod tests {
         assert!(
             source.downcast_ref::<object_store::Error>().is_some(),
             "source should still be the object store error, got: {source}"
+        );
+    }
+
+    /// Adding context must not flatten the `io::ErrorKind` that `object_store`
+    /// maps an error to, since that kind is observable to callers.
+    #[test]
+    fn test_upload_failure_preserves_error_kind() {
+        fn not_found() -> object_store::Error {
+            object_store::Error::NotFound {
+                path: FAILING_UPLOAD_PATH.to_string(),
+                source: "not found".into(),
+            }
+        }
+
+        let unwrapped = io::Error::from(not_found());
+        assert_eq!(unwrapped.kind(), io::ErrorKind::NotFound);
+
+        let wrapped =
+            UploadFailure::new("part upload failed".to_string(), not_found()).into_io_error();
+        assert_eq!(wrapped.kind(), unwrapped.kind());
+    }
+
+    /// `Writer::shutdown` is the public boundary most callers see. The object
+    /// store error has to remain reachable through it, not be flattened into a
+    /// message.
+    #[tokio::test]
+    async fn test_writer_shutdown_preserves_object_store_source() {
+        let mut store = LanceObjectStore::memory();
+        store.inner = Arc::new(FailingUploadStore {
+            fail_at: FailAt::SinglePut,
+        });
+        let mut writer = ObjectWriter::new(&store, &Path::from(FAILING_UPLOAD_PATH))
+            .await
+            .unwrap();
+        writer.write_all(&[0u8; 256]).await.unwrap();
+        let err = Writer::shutdown(&mut writer).await.unwrap_err();
+
+        let mut current: Option<&(dyn std::error::Error + 'static)> = Some(&err);
+        let mut found_object_store = false;
+        while let Some(source) = current {
+            if source.downcast_ref::<object_store::Error>().is_some() {
+                found_object_store = true;
+                break;
+            }
+            current = source.source();
+        }
+        assert!(found_object_store, "source chain was flattened: {err:?}");
+
+        assert!(
+            err.to_string().contains(FAILING_UPLOAD_PATH),
+            "should still name the object: {err}"
         );
     }
 

--- a/rust/lance-io/src/object_writer.rs
+++ b/rust/lance-io/src/object_writer.rs
@@ -147,7 +147,8 @@ impl UploadFailure {
     }
 
     fn into_io_error(self) -> io::Error {
-        io::Error::new(self.kind, self)
+        let kind = self.kind;
+        io::Error::new(kind, self)
     }
 }
 


### PR DESCRIPTION
`ObjectWriter` turned every object store upload failure into a bare `io::Error`, so a failed write reported only what `object_store` itself prints. Nothing identified which object, which multipart part, how many bytes it carried, or how long it took — which makes upload timeouts undiagnosable in production.

This attaches that context to failures from creating a multipart upload, uploading a part, completing an upload, and the single-PUT path.

Before:

```
Generic S3 error: Error performing PUT https://.../part_7_invert.lance
```

After:

```
multipart upload of part 350 of .../part_7_invert.lance failed after 30.104s
  (20971520 bytes, part_size=20971520 bytes, parts_in_flight=7 at submission,
   LANCE_INITIAL_UPLOAD_SIZE=5242880 bytes, LANCE_UPLOAD_CONCURRENCY=10):
  Generic S3 error: Error performing PUT https://... in 30.09s ...
```

**Elapsed time.** Stamped when Lance hands the request to the uploader, before the task is spawned. `object_store`'s own clock starts inside `RetryContext::new`, which runs on the first poll of the request future, so comparing the two distinguishes a request that was genuinely slow from one whose task was never polled — the signature of runtime starvation causing a whole-request timeout. That distinction is not recoverable from the object store error alone.

**Part size.** The multipart part size grows every 100 parts, so `LANCE_INITIAL_UPLOAD_SIZE` understates the size in effect on a long upload by a multiple of itself. `part_size` is read from the live buffer capacity, and a body smaller than it identifies the final flush.

**Error contracts are preserved.** The `io::ErrorKind` is taken from `object_store`'s own conversion and restored when converting back, so an `object_store::Error::NotFound` still surfaces as `ErrorKind::NotFound` rather than collapsing to `Other`. The object store error also stays reachable as the `source`, including through `Writer::shutdown`, which now propagates the io error structurally instead of formatting it into a message that flattened the chain.