### PR TITLE
feat(fts): add cross-column scorer composition

### DIFF
--- a/rust/lance-index-core/src/metrics.rs
+++ b/rust/lance-index-core/src/metrics.rs
@@ -20,6 +20,10 @@ pub const COMPOUND_SHOULD_ESSENTIAL_EVALUATIONS_METRIC: &str =
     "compound_should_essential_evaluations";
 pub const COMPOUND_SHOULD_NON_ESSENTIAL_EVALUATIONS_METRIC: &str =
     "compound_should_non_essential_evaluations";
+pub const CROSS_COLUMN_STAGED_ATTEMPTS_METRIC: &str = "cross_column_staged_attempts";
+pub const CROSS_COLUMN_STAGED_SUCCESSES_METRIC: &str = "cross_column_staged_successes";
+pub const CROSS_COLUMN_STAGED_FALLBACKS_METRIC: &str = "cross_column_staged_fallbacks";
+pub const CROSS_COLUMN_STAGED_CANDIDATES_METRIC: &str = "cross_column_staged_candidates";
 
 /// A trait used by the index to report metrics
 ///
@@ -124,6 +128,18 @@ pub trait MetricsCollector: Send + Sync {
 
     /// Record non-essential-clause evaluations for pure-SHOULD compound FTS.
     fn record_compound_should_non_essential_evaluations(&self, _num_evaluations: usize) {}
+
+    /// Record cross-column queries that attempted candidate-driven staging.
+    fn record_cross_column_staged_attempts(&self, _num_attempts: usize) {}
+
+    /// Record staged executions that produced a complete candidate set.
+    fn record_cross_column_staged_successes(&self, _num_successes: usize) {}
+
+    /// Record staged executions abandoned in favor of exact eager execution.
+    fn record_cross_column_staged_fallbacks(&self, _num_fallbacks: usize) {}
+
+    /// Record unique row-address candidates produced by successful staging.
+    fn record_cross_column_staged_candidates(&self, _num_candidates: usize) {}
 
     /// Returns an optional sink for recording exact I/O statistics (bytes read,
     /// IOPS, and requests) performed on behalf of this collector.

--- a/rust/lance-index/src/scalar/inverted.rs
+++ b/rust/lance-index/src/scalar/inverted.rs
@@ -4,6 +4,7 @@
 pub mod builder;
 mod cache_codec;
 mod compound;
+mod cross_column;
 mod documents;
 mod encoding;
 mod impact;
@@ -23,6 +24,8 @@ use arrow_schema::{DataType, Field};
 use async_trait::async_trait;
 pub use builder::InvertedIndexBuilder;
 pub use compound::{compound_search, compound_search_with_base_scorer};
+#[doc(hidden)]
+pub use cross_column::cross_column_compound_search;
 use datafusion::execution::SendableRecordBatchStream;
 pub use index::*;
 use lance_core::{Result, cache::LanceCache};

--- a/rust/lance-index/src/scalar/inverted/compound.rs
+++ b/rust/lance-index/src/scalar/inverted/compound.rs
@@ -3,7 +3,8 @@
 
 mod should_maxscore;
 
-use std::cmp::Ordering;
+use std::cell::RefCell;
+use std::cmp::{Ordering, Reverse};
 use std::collections::{BinaryHeap, HashSet};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU32, Ordering as AtomicOrdering};
@@ -17,7 +18,10 @@ use lance_tokenizer::{SimpleTokenizer, TextAnalyzer};
 use super::{
     InvertedIndex, build_global_bm25_scorer,
     document_tokenizer::{DocType, JsonTokenizer, LanceTokenizer},
-    documents::{DocId, DocLengths, DocVisibility, PartitionDocuments, ResidentAddressProjection},
+    documents::{
+        CachedRowAddressOrder, DocId, DocLengths, DocVisibility, OrderedRowAddressProjection,
+        PartitionDocuments, ResidentAddressProjection, RowAddressProjectionOrderError,
+    },
     index::{DocSet, InvertedPartition},
     query::{
         FtsQuery, FtsSearchParams, MatchQuery, Operator, PhraseQuery, Tokens, collect_query_tokens,
@@ -67,16 +71,47 @@ pub(super) struct ScoreBounds {
 }
 
 impl ScoreBounds {
-    const ZERO: Self = Self {
+    pub(super) const ZERO: Self = Self {
         lower: 0.0,
         upper: 0.0,
     };
-    const UNBOUNDED: Self = Self {
+    pub(super) const UNBOUNDED: Self = Self {
         lower: f32::NEG_INFINITY,
         upper: f32::INFINITY,
     };
 
+    pub(super) fn try_new(lower: f32, upper: f32) -> Result<Self> {
+        let bounds = Self { lower, upper };
+        if !bounds.is_valid_for_finite_scores() {
+            return Err(Error::invalid_input(format!(
+                "FTS score bounds require an ordered interval that can contain finite scores, got [{lower}, {upper}]"
+            )));
+        }
+        Ok(bounds)
+    }
+
     #[cfg(test)]
+    pub(super) fn lower(self) -> f32 {
+        self.lower
+    }
+
+    #[cfg(test)]
+    pub(super) fn upper(self) -> f32 {
+        self.upper
+    }
+
+    fn is_valid_for_finite_scores(self) -> bool {
+        !self.lower.is_nan()
+            && !self.upper.is_nan()
+            && self.lower <= self.upper
+            && self.lower != f32::INFINITY
+            && self.upper != f32::NEG_INFINITY
+    }
+
+    pub(super) fn contains(self, score: f32) -> bool {
+        score.is_finite() && self.lower <= score && score <= self.upper
+    }
+
     fn point(score: f32) -> Result<Self> {
         if !score.is_finite() {
             return Err(Error::invalid_input(format!(
@@ -222,7 +257,7 @@ pub(super) trait ComposableScorer: Send {
     }
 }
 
-type BoxScorer<'a> = Box<dyn ComposableScorer + 'a>;
+pub(super) type BoxScorer<'a> = Box<dyn ComposableScorer + 'a>;
 
 fn sum_global_score_upper_bounds(children: &[BoxScorer<'_>]) -> Option<f32> {
     children.iter().try_fold(0.0, |upper, child| {
@@ -240,8 +275,59 @@ fn sum_global_score_upper_bounds(children: &[BoxScorer<'_>]) -> Option<f32> {
     })
 }
 
+/// Posting-payload-independent metadata for one semantic leaf in a staged
+/// search task.
+///
+/// Bounds describe the unboosted leaf score. [`CompoundScorerPlan`] applies
+/// the `MatchQuery` boost recorded in its leaf node while composing the root
+/// interval. An impossible leaf contributes neither candidates nor score.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub(super) struct CompoundLeafPlanInput {
+    pub(super) possible: bool,
+    pub(super) cost: usize,
+    pub(super) bounds: ScoreBounds,
+}
+
+impl CompoundLeafPlanInput {
+    pub(super) fn new(possible: bool, cost: usize, bounds: ScoreBounds) -> Self {
+        Self {
+            possible,
+            cost,
+            bounds,
+        }
+    }
+}
+
+/// Pure metadata analysis used before staged source I/O begins.
+#[derive(Debug, Clone, PartialEq)]
+pub(super) struct CompoundPlanAnalysis {
+    pub(super) possible: bool,
+    pub(super) bounds: ScoreBounds,
+    pub(super) generator_cost: usize,
+    pub(super) generator_leaves: Vec<usize>,
+}
+
+#[derive(Debug)]
+struct NodePlanAnalysis {
+    possible: bool,
+    bounds: ScoreBounds,
+    generator_cost: usize,
+    generator_leaves: Vec<usize>,
+}
+
+impl NodePlanAnalysis {
+    fn impossible() -> Self {
+        Self {
+            possible: false,
+            bounds: ScoreBounds::ZERO,
+            generator_cost: 0,
+            generator_leaves: Vec::new(),
+        }
+    }
+}
+
 #[derive(Debug, Clone)]
-enum CompoundScorerPlan {
+pub(super) enum CompoundScorerPlan {
     Leaf {
         index: usize,
         boost: f32,
@@ -260,7 +346,261 @@ enum CompoundScorerPlan {
 }
 
 impl CompoundScorerPlan {
-    fn from_query(query: &FtsQuery, num_leaves: &mut usize) -> Result<Self> {
+    pub(super) fn leaf_count(&self) -> usize {
+        match self {
+            Self::Leaf { .. } => 1,
+            Self::Boost {
+                positive, negative, ..
+            } => positive.leaf_count().saturating_add(negative.leaf_count()),
+            Self::MultiMatch(children) => children
+                .iter()
+                .fold(0, |count, child| count.saturating_add(child.leaf_count())),
+            Self::Boolean {
+                should,
+                must,
+                must_not,
+            } => should
+                .iter()
+                .chain(must)
+                .chain(must_not)
+                .fold(0, |count, child| count.saturating_add(child.leaf_count())),
+        }
+    }
+
+    /// Select a complete positive generator cover and compose conservative
+    /// root score bounds without constructing or loading any scorer.
+    pub(super) fn analyze_leaves(
+        &self,
+        leaves: &[CompoundLeafPlanInput],
+    ) -> Result<CompoundPlanAnalysis> {
+        let leaf_count = self.leaf_count();
+        if leaves.len() != leaf_count {
+            return Err(Error::internal(format!(
+                "compound FTS plan has {leaf_count} leaves but received {} staged leaf inputs",
+                leaves.len()
+            )));
+        }
+        for (index, leaf) in leaves.iter().enumerate() {
+            if !leaf.bounds.is_valid_for_finite_scores() {
+                return Err(Error::internal(format!(
+                    "compound FTS staged leaf {index} reported invalid score bounds [{}, {}]",
+                    leaf.bounds.lower, leaf.bounds.upper
+                )));
+            }
+        }
+
+        let mut seen = vec![false; leaf_count];
+        self.validate_leaf_indices(&mut seen)?;
+        if let Some(missing) = seen.iter().position(|seen| !*seen) {
+            return Err(Error::internal(format!(
+                "compound FTS plan does not reference staged leaf {missing}"
+            )));
+        }
+
+        let mut node = self.analyze_node(leaves)?;
+        node.generator_leaves.sort_unstable();
+        node.generator_leaves.dedup();
+        Ok(CompoundPlanAnalysis {
+            possible: node.possible,
+            bounds: node.bounds,
+            generator_cost: node.generator_cost,
+            generator_leaves: node.generator_leaves,
+        })
+    }
+
+    fn validate_leaf_indices(&self, seen: &mut [bool]) -> Result<()> {
+        match self {
+            Self::Leaf { index, .. } => {
+                let slot_count = seen.len();
+                let slot = seen.get_mut(*index).ok_or_else(|| {
+                    Error::internal(format!(
+                        "compound FTS plan references staged leaf {index}, but only {} slots exist",
+                        slot_count
+                    ))
+                })?;
+                if *slot {
+                    return Err(Error::internal(format!(
+                        "compound FTS plan references staged leaf {index} more than once"
+                    )));
+                }
+                *slot = true;
+                Ok(())
+            }
+            Self::Boost {
+                positive, negative, ..
+            } => {
+                positive.validate_leaf_indices(seen)?;
+                negative.validate_leaf_indices(seen)
+            }
+            Self::MultiMatch(children) => {
+                for child in children {
+                    child.validate_leaf_indices(seen)?;
+                }
+                Ok(())
+            }
+            Self::Boolean {
+                should,
+                must,
+                must_not,
+            } => {
+                for child in should.iter().chain(must).chain(must_not) {
+                    child.validate_leaf_indices(seen)?;
+                }
+                Ok(())
+            }
+        }
+    }
+
+    fn analyze_node(&self, leaves: &[CompoundLeafPlanInput]) -> Result<NodePlanAnalysis> {
+        match self {
+            Self::Leaf { index, boost } => {
+                if !boost.is_finite() || *boost < 0.0 {
+                    return Err(Error::invalid_input(format!(
+                        "MatchQuery boost must be finite and non-negative, got {boost}"
+                    )));
+                }
+                let leaf = leaves.get(*index).ok_or_else(|| {
+                    Error::internal(format!(
+                        "compound FTS plan references missing staged leaf {index}"
+                    ))
+                })?;
+                if !leaf.possible {
+                    return Ok(NodePlanAnalysis::impossible());
+                }
+                Ok(NodePlanAnalysis {
+                    possible: true,
+                    bounds: leaf.bounds.scale_non_negative(*boost),
+                    generator_cost: leaf.cost,
+                    generator_leaves: vec![*index],
+                })
+            }
+            Self::Boost {
+                positive,
+                negative,
+                negative_boost,
+            } => {
+                if !negative_boost.is_finite() || *negative_boost < 0.0 {
+                    return Err(Error::invalid_input(format!(
+                        "BoostQuery negative_boost must be finite and non-negative, got {negative_boost}"
+                    )));
+                }
+                let positive = positive.analyze_node(leaves)?;
+                let negative = negative.analyze_node(leaves)?;
+                if !positive.possible {
+                    return Ok(NodePlanAnalysis::impossible());
+                }
+                let bounds = if negative.possible {
+                    positive
+                        .bounds
+                        .subtract_scaled(negative.bounds.include_zero(), *negative_boost)
+                } else {
+                    positive.bounds
+                };
+                Ok(NodePlanAnalysis {
+                    possible: true,
+                    bounds,
+                    generator_cost: positive.generator_cost,
+                    generator_leaves: positive.generator_leaves,
+                })
+            }
+            Self::MultiMatch(children) => {
+                let children = children
+                    .iter()
+                    .map(|child| child.analyze_node(leaves))
+                    .collect::<Result<Vec<_>>>()?;
+                let mut possible = children.iter().filter(|child| child.possible);
+                let Some(first) = possible.next() else {
+                    return Ok(NodePlanAnalysis::impossible());
+                };
+                let mut bounds = first.bounds;
+                for child in possible {
+                    bounds.lower = bounds.lower.min(child.bounds.lower);
+                    bounds.upper = bounds.upper.max(child.bounds.upper);
+                }
+                let mut generator_cost = 0_usize;
+                let mut generator_leaves = Vec::new();
+                for child in children.into_iter().filter(|child| child.possible) {
+                    generator_cost = generator_cost.saturating_add(child.generator_cost);
+                    generator_leaves.extend(child.generator_leaves);
+                }
+                Ok(NodePlanAnalysis {
+                    possible: true,
+                    bounds,
+                    generator_cost,
+                    generator_leaves,
+                })
+            }
+            Self::Boolean {
+                should,
+                must,
+                must_not,
+            } => {
+                let should = should
+                    .iter()
+                    .map(|child| child.analyze_node(leaves))
+                    .collect::<Result<Vec<_>>>()?;
+                let must = must
+                    .iter()
+                    .map(|child| child.analyze_node(leaves))
+                    .collect::<Result<Vec<_>>>()?;
+                for child in must_not {
+                    child.analyze_node(leaves)?;
+                }
+
+                if !must.is_empty() {
+                    if must.iter().any(|child| !child.possible) {
+                        return Ok(NodePlanAnalysis::impossible());
+                    }
+                    let mut bounds = ScoreBounds::ZERO;
+                    for child in &must {
+                        bounds = bounds.add(child.bounds);
+                    }
+                    for child in should.iter().filter(|child| child.possible) {
+                        bounds = bounds.add(child.bounds.include_zero());
+                    }
+                    let mut must = must.into_iter();
+                    let mut generator = must.next().ok_or_else(|| {
+                        Error::internal("compound FTS Boolean MUST analysis lost its generator")
+                    })?;
+                    for child in must {
+                        if child.generator_cost < generator.generator_cost {
+                            generator = child;
+                        }
+                    }
+                    return Ok(NodePlanAnalysis {
+                        possible: true,
+                        bounds,
+                        generator_cost: generator.generator_cost,
+                        generator_leaves: generator.generator_leaves,
+                    });
+                }
+
+                let possible_should = should
+                    .into_iter()
+                    .filter(|child| child.possible)
+                    .collect::<Vec<_>>();
+                if possible_should.is_empty() {
+                    return Ok(NodePlanAnalysis::impossible());
+                }
+                let mut bounds = ScoreBounds::ZERO;
+                let mut generator_cost = 0_usize;
+                let mut generator_leaves = Vec::new();
+                for child in possible_should {
+                    bounds = bounds.add(child.bounds.include_zero());
+                    generator_cost = generator_cost.saturating_add(child.generator_cost);
+                    generator_leaves.extend(child.generator_leaves);
+                }
+                Ok(NodePlanAnalysis {
+                    possible: true,
+                    bounds,
+                    generator_cost,
+                    generator_leaves,
+                })
+            }
+        }
+    }
+
+    pub(super) fn from_query(query: &FtsQuery, num_leaves: &mut usize) -> Result<Self> {
         match query {
             FtsQuery::Match(query) => {
                 let index = *num_leaves;
@@ -307,7 +647,7 @@ impl CompoundScorerPlan {
         }
     }
 
-    fn build<'a>(
+    pub(super) fn build<'a>(
         &self,
         leaves: &mut [Option<BoxScorer<'a>>],
         metrics: &'a dyn MetricsCollector,
@@ -420,29 +760,32 @@ impl<D: WandDocuments + Sync> ComposableScorer for WandCursor<'_, D> {
 }
 
 #[derive(Debug, Clone, Copy)]
-#[cfg(test)]
 struct ShallowRange {
     target: u64,
     up_to: u64,
-    start: usize,
-    end: usize,
+    block_index: Option<usize>,
 }
 
-/// Exact in-memory scorer used to unit-test compound nodes and the collector.
-#[cfg(test)]
-struct MaterializedScorer {
+/// Exact in-memory scorer used for unordered-address fallbacks and unit tests.
+pub(super) struct MaterializedScorer {
     rows: Vec<ScoredRow>,
     block_size: usize,
+    block_bounds: Box<[ScoreBounds]>,
+    global_score_upper_bound: f32,
     index: Option<usize>,
     shallow: Option<ShallowRange>,
     min_competitive_score: f32,
     scores_non_negative: bool,
+    #[cfg(test)]
+    bound_score_visits: usize,
 }
 
-#[cfg(test)]
 impl MaterializedScorer {
-    fn try_new(mut rows: Vec<ScoredRow>) -> Result<Self> {
+    pub(super) fn try_new(mut rows: Vec<ScoredRow>) -> Result<Self> {
         rows.sort_unstable_by_key(|row| row.row_id);
+        for row in &rows {
+            ScoreBounds::point(row.score)?;
+        }
         for pair in rows.windows(2) {
             if pair[0].row_id == pair[1].row_id {
                 return Err(Error::internal(format!(
@@ -451,14 +794,23 @@ impl MaterializedScorer {
                 )));
             }
         }
+        let block_size = DEFAULT_BLOCK_SIZE;
+        let block_bounds = Self::build_block_bounds(&rows, block_size);
+        let global_score_upper_bound = Self::global_upper_bound(&block_bounds);
         let scores_non_negative = rows.iter().all(|row| row.score >= 0.0);
+        #[cfg(test)]
+        let bound_score_visits = rows.len();
         Ok(Self {
             rows,
-            block_size: DEFAULT_BLOCK_SIZE,
+            block_size,
+            block_bounds,
+            global_score_upper_bound,
             index: None,
             shallow: None,
             min_competitive_score: f32::NEG_INFINITY,
             scores_non_negative,
+            #[cfg(test)]
+            bound_score_visits,
         })
     }
 
@@ -466,27 +818,79 @@ impl MaterializedScorer {
     fn with_block_size(mut self, block_size: usize) -> Self {
         assert!(block_size > 0);
         self.block_size = block_size;
+        self.block_bounds = Self::build_block_bounds(&self.rows, block_size);
+        self.global_score_upper_bound = Self::global_upper_bound(&self.block_bounds);
+        self.bound_score_visits = self.rows.len();
         self
     }
 
-    fn block_bounds(&self, start: usize, end: usize) -> Result<ScoreBounds> {
-        let Some(first) = self.rows.get(start) else {
-            return Ok(ScoreBounds::ZERO);
-        };
-        let mut bounds = ScoreBounds::point(first.score)?;
-        for row in &self.rows[start + 1..end] {
-            bounds.lower = bounds.lower.min(row.score);
-            bounds.upper = bounds.upper.max(row.score);
+    fn build_block_bounds(rows: &[ScoredRow], block_size: usize) -> Box<[ScoreBounds]> {
+        debug_assert!(block_size > 0);
+        rows.chunks(block_size)
+            .map(|block| {
+                let first = block[0].score;
+                let mut bounds = ScoreBounds {
+                    lower: first,
+                    upper: first,
+                };
+                for row in &block[1..] {
+                    bounds.lower = bounds.lower.min(row.score);
+                    bounds.upper = bounds.upper.max(row.score);
+                }
+                bounds
+            })
+            .collect()
+    }
+
+    fn global_upper_bound(block_bounds: &[ScoreBounds]) -> f32 {
+        block_bounds
+            .iter()
+            .map(|bounds| bounds.upper)
+            .max_by(f32::total_cmp)
+            .unwrap_or(0.0)
+    }
+
+    fn block_bounds_at(&self, block_index: usize) -> Result<ScoreBounds> {
+        self.block_bounds.get(block_index).copied().ok_or_else(|| {
+            Error::internal(format!(
+                "materialized FTS scorer has no score bounds for block {block_index}"
+            ))
+        })
+    }
+
+    #[cfg(test)]
+    fn bound_score_visits(&self) -> usize {
+        self.bound_score_visits
+    }
+
+    #[cfg(test)]
+    fn num_bound_blocks(&self) -> usize {
+        self.block_bounds.len()
+    }
+
+    fn block_end(&self, block_index: usize) -> usize {
+        (block_index + 1)
+            .saturating_mul(self.block_size)
+            .min(self.rows.len())
+    }
+
+    fn block_index(&self, row_index: usize) -> usize {
+        row_index / self.block_size
+    }
+
+    fn skip_non_competitive_block(&self, row_index: usize) -> Result<Option<usize>> {
+        let block_index = self.block_index(row_index);
+        if self.block_bounds_at(block_index)?.upper < self.min_competitive_score {
+            Ok(Some(self.block_end(block_index)))
+        } else {
+            Ok(None)
         }
-        Ok(bounds)
     }
 
     fn position_at(&mut self, mut index: usize) -> Result<Option<u64>> {
         while index < self.rows.len() {
-            let block_start = (index / self.block_size) * self.block_size;
-            let block_end = (block_start + self.block_size).min(self.rows.len());
-            if self.block_bounds(block_start, block_end)?.upper < self.min_competitive_score {
-                index = block_end;
+            if let Some(next_index) = self.skip_non_competitive_block(index)? {
+                index = next_index;
                 continue;
             }
             self.index = Some(index);
@@ -499,7 +903,6 @@ impl MaterializedScorer {
     }
 }
 
-#[cfg(test)]
 impl ComposableScorer for MaterializedScorer {
     fn doc(&self) -> Option<u64> {
         self.index.map(|index| self.rows[index].row_id)
@@ -534,13 +937,12 @@ impl ComposableScorer for MaterializedScorer {
             self.shallow = Some(ShallowRange {
                 target,
                 up_to: u64::MAX,
-                start,
-                end: start,
+                block_index: None,
             });
             return Ok(u64::MAX);
         }
-        let block_start = (start / self.block_size) * self.block_size;
-        let end = (block_start + self.block_size).min(self.rows.len());
+        let block_index = self.block_index(start);
+        let end = self.block_end(block_index);
         let up_to = self
             .rows
             .get(end)
@@ -549,8 +951,7 @@ impl ComposableScorer for MaterializedScorer {
         self.shallow = Some(ShallowRange {
             target,
             up_to,
-            start,
-            end,
+            block_index: Some(block_index),
         });
         Ok(up_to)
     }
@@ -565,17 +966,15 @@ impl ComposableScorer for MaterializedScorer {
                 shallow.target, shallow.up_to
             )));
         }
-        let end = shallow.start
-            + self.rows[shallow.start..shallow.end].partition_point(|row| row.row_id <= up_to);
-        self.block_bounds(shallow.start, end)
+        shallow
+            .block_index
+            .map_or(Ok(ScoreBounds::ZERO), |block_index| {
+                self.block_bounds_at(block_index)
+            })
     }
 
     fn global_score_upper_bound(&self) -> Option<f32> {
-        self.rows
-            .iter()
-            .map(|row| row.score)
-            .max_by(f32::total_cmp)
-            .or(Some(0.0))
+        Some(self.global_score_upper_bound)
     }
 
     fn set_min_competitive_score(&mut self, min_score: f32) -> Result<()> {
@@ -592,6 +991,789 @@ impl ComposableScorer for MaterializedScorer {
 
     fn scores_non_negative(&self) -> bool {
         self.scores_non_negative
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+struct MappedShallowRange {
+    target: u64,
+    up_to: u64,
+    source_target: u64,
+    source_up_to: u64,
+    has_source_docs: bool,
+}
+
+/// Project a strictly ordered partition-local scorer into the shared physical
+/// row-address domain.
+struct RowAddressScorer<'a> {
+    source: BoxScorer<'a>,
+    projection: OrderedRowAddressProjection,
+    current: Option<u64>,
+    exhausted: bool,
+    shallow: Option<MappedShallowRange>,
+}
+
+impl<'a> RowAddressScorer<'a> {
+    fn new(source: BoxScorer<'a>, projection: OrderedRowAddressProjection) -> Self {
+        Self {
+            source,
+            projection,
+            current: None,
+            exhausted: false,
+            shallow: None,
+        }
+    }
+
+    fn set_source_position(&mut self, source_doc: Option<u64>) -> Result<Option<u64>> {
+        self.shallow = None;
+        let Some(source_doc) = source_doc else {
+            self.current = None;
+            self.exhausted = true;
+            return Ok(None);
+        };
+        if self.source.doc() != Some(source_doc) {
+            return Err(Error::internal(format!(
+                "FTS source returned local document {source_doc} but reported position {:?}",
+                self.source.doc()
+            )));
+        }
+        let row_address = self.projection.address(source_doc).ok_or_else(|| {
+            Error::internal(format!(
+                "FTS source returned non-live or out-of-range local document {source_doc} for a projection with {} slots",
+                self.projection.len()
+            ))
+        })?;
+        if self.current.is_some_and(|current| row_address <= current) {
+            return Err(Error::internal(format!(
+                "FTS row-address projection moved from {:?} to non-increasing address {row_address}",
+                self.current
+            )));
+        }
+        self.current = Some(row_address);
+        Ok(self.current)
+    }
+
+    fn ensure_positioned(&self) -> Result<()> {
+        if self.current.is_none() {
+            Err(Error::internal(
+                "row-address FTS scorer is not positioned on a document",
+            ))
+        } else {
+            Ok(())
+        }
+    }
+
+    fn local_upper_bound(&self, global_up_to: u64, shallow: MappedShallowRange) -> Option<u64> {
+        if global_up_to >= shallow.up_to {
+            return Some(shallow.source_up_to);
+        }
+        let next_global = global_up_to.checked_add(1)?;
+        match self.projection.lower_bound(next_global) {
+            Some(next_local) => next_local
+                .checked_sub(1)
+                .map(|local| local.min(shallow.source_up_to)),
+            None => Some(shallow.source_up_to),
+        }
+    }
+}
+
+impl ComposableScorer for RowAddressScorer<'_> {
+    fn doc(&self) -> Option<u64> {
+        self.current
+    }
+
+    fn document_key(&self) -> Option<u64> {
+        self.current
+    }
+
+    fn next(&mut self) -> Result<Option<u64>> {
+        if self.exhausted {
+            return Ok(None);
+        }
+        let source_doc = self.source.next()?;
+        self.set_source_position(source_doc)
+    }
+
+    fn advance(&mut self, target: u64) -> Result<Option<u64>> {
+        if self.current.is_some_and(|current| current >= target) {
+            return Ok(self.current);
+        }
+        if self.exhausted {
+            return Ok(None);
+        }
+        let Some(source_target) = self.projection.lower_bound(target) else {
+            self.current = None;
+            self.exhausted = true;
+            self.shallow = None;
+            return Ok(None);
+        };
+        let source_doc = self.source.advance(source_target)?;
+        if source_doc.is_some_and(|doc| doc < source_target) {
+            return Err(Error::internal(format!(
+                "FTS source advanced to local document {:?} before target {source_target}",
+                source_doc
+            )));
+        }
+        let row_address = self.set_source_position(source_doc)?;
+        if row_address.is_some_and(|address| address < target) {
+            return Err(Error::internal(format!(
+                "FTS projection advanced to row address {:?} before target {target}",
+                row_address
+            )));
+        }
+        Ok(row_address)
+    }
+
+    fn cost(&self) -> usize {
+        self.source.cost().min(self.projection.live_len())
+    }
+
+    fn score(&mut self) -> Result<f32> {
+        self.ensure_positioned()?;
+        self.source.score()
+    }
+
+    fn advance_shallow(&mut self, target: u64) -> Result<u64> {
+        if self.exhausted {
+            self.shallow = Some(MappedShallowRange {
+                target,
+                up_to: u64::MAX,
+                source_target: 0,
+                source_up_to: 0,
+                has_source_docs: false,
+            });
+            return Ok(u64::MAX);
+        }
+        let Some(source_target) = self.projection.lower_bound(target) else {
+            self.shallow = Some(MappedShallowRange {
+                target,
+                up_to: u64::MAX,
+                source_target: 0,
+                source_up_to: 0,
+                has_source_docs: false,
+            });
+            return Ok(u64::MAX);
+        };
+        let source_target = self
+            .source
+            .doc()
+            .map_or(source_target, |doc| source_target.max(doc));
+        let source_up_to = self.source.advance_shallow(source_target)?;
+        if source_up_to < source_target {
+            return Err(Error::internal(format!(
+                "FTS source returned shallow range ending at local document {source_up_to} before target {source_target}"
+            )));
+        }
+        let up_to = self
+            .projection
+            .next_address(source_up_to)
+            .map(|next| next.saturating_sub(1))
+            .unwrap_or(u64::MAX);
+        if up_to < target {
+            return Err(Error::internal(format!(
+                "FTS projection mapped local shallow end {source_up_to} to row address {up_to} before target {target}"
+            )));
+        }
+        self.shallow = Some(MappedShallowRange {
+            target,
+            up_to,
+            source_target,
+            source_up_to,
+            has_source_docs: true,
+        });
+        Ok(up_to)
+    }
+
+    fn score_bounds(&mut self, up_to: u64) -> Result<ScoreBounds> {
+        let shallow = self.shallow.ok_or_else(|| {
+            Error::internal("score_bounds requires advance_shallow on the row-address FTS scorer")
+        })?;
+        if up_to < shallow.target || up_to > shallow.up_to {
+            return Err(Error::internal(format!(
+                "FTS row-address score bound up_to={up_to} is outside shallow range [{}, {}]",
+                shallow.target, shallow.up_to
+            )));
+        }
+        if !shallow.has_source_docs {
+            return Ok(ScoreBounds::ZERO);
+        }
+        let Some(source_up_to) = self.local_upper_bound(up_to, shallow) else {
+            return Ok(ScoreBounds::ZERO);
+        };
+        if source_up_to < shallow.source_target {
+            return Ok(ScoreBounds::ZERO);
+        }
+        self.source.score_bounds(source_up_to)
+    }
+
+    fn global_score_upper_bound(&self) -> Option<f32> {
+        self.source.global_score_upper_bound()
+    }
+
+    fn set_min_competitive_score(&mut self, min_score: f32) -> Result<()> {
+        self.source.set_min_competitive_score(min_score)
+    }
+
+    fn matches(&mut self) -> Result<bool> {
+        self.ensure_positioned()?;
+        self.source.matches()
+    }
+
+    fn match_cost(&self) -> Option<f32> {
+        self.source.match_cost()
+    }
+
+    fn scores_non_negative(&self) -> bool {
+        self.source.scores_non_negative()
+    }
+}
+
+fn projected_address(projection: &ResidentAddressProjection, source_doc: u64) -> Result<u64> {
+    let source_doc = u32::try_from(source_doc).map_err(|_| {
+        Error::index(format!(
+            "FTS local document {source_doc} exceeds the modern u32 domain"
+        ))
+    })?;
+    projection.address(DocId::new(source_doc)).ok_or_else(|| {
+        Error::internal(format!(
+            "FTS source returned non-live local document {source_doc} while materializing row addresses"
+        ))
+    })
+}
+
+fn materialize_row_address_scorer<'a>(
+    source: BoxScorer<'a>,
+    projection: &ResidentAddressProjection,
+    collisions: &MaterializedProjectionCollisions,
+) -> Result<Option<RowAddressSource<'a>>> {
+    let mut mapped_documents = Vec::with_capacity(source.cost().min(DEFAULT_BLOCK_SIZE));
+    let scorer = materialize_mapped_scorer(source, |local_doc| {
+        let row_address = projected_address(projection, local_doc)?;
+        mapped_documents.push((row_address, local_doc));
+        Ok(row_address)
+    })?;
+
+    // Constructing the materialized scorer first preserves its more local
+    // duplicate diagnostic when one leaf produces both colliding documents.
+    // Only a valid leaf is then published to the source-wide tracker.
+    collisions.register(&mapped_documents)?;
+    Ok(scorer)
+}
+
+fn materialize_mapped_scorer<'a>(
+    mut source: BoxScorer<'a>,
+    mut map_document: impl FnMut(u64) -> Result<u64>,
+) -> Result<Option<RowAddressSource<'a>>> {
+    let mut rows = Vec::with_capacity(source.cost().min(DEFAULT_BLOCK_SIZE));
+    let mut source_doc = source.next()?;
+    while let Some(doc) = source_doc {
+        if source.matches()? {
+            rows.push(ScoredRow {
+                row_id: map_document(doc)?,
+                score: checked_score(source.score()?, "materialized row-address FTS scorer")?,
+            });
+        }
+        source_doc = source.next()?;
+    }
+    let scorer = MaterializedScorer::try_new(rows)?;
+    let min_possible_row_address = scorer.rows.first().map(|row| row.row_id);
+    Ok(
+        min_possible_row_address.map(|min_possible_row_address| RowAddressSource {
+            min_possible_row_address,
+            scorer: Box::new(scorer),
+        }),
+    )
+}
+
+#[derive(Debug, Default)]
+struct MaterializedProjectionCollisions {
+    local_doc_by_address: RefCell<std::collections::HashMap<u64, u64>>,
+}
+
+impl MaterializedProjectionCollisions {
+    fn register(&self, mapped_documents: &[(u64, u64)]) -> Result<()> {
+        let mut local_doc_by_address =
+            self.local_doc_by_address.try_borrow_mut().map_err(|_| {
+                Error::internal(
+                    "materialized FTS row-address collision tracker is already borrowed",
+                )
+            })?;
+
+        for &(row_address, local_doc) in mapped_documents {
+            if let Some(&existing_local_doc) = local_doc_by_address.get(&row_address)
+                && existing_local_doc != local_doc
+            {
+                return Err(Error::index(format!(
+                    "FTS row address {row_address} maps to distinct local documents {existing_local_doc} and {local_doc} in one physical source"
+                )));
+            }
+        }
+        for &(row_address, local_doc) in mapped_documents {
+            local_doc_by_address.insert(row_address, local_doc);
+        }
+        Ok(())
+    }
+}
+
+/// Query-scoped projection state shared by every leaf from one physical
+/// source. Preparation is O(1); ordered validation is triggered lazily only
+/// when a dense source makes streaming cheaper than candidate materialization.
+#[derive(Debug)]
+pub(super) struct PreparedRowAddressProjection {
+    projection: ResidentAddressProjection,
+    collisions: MaterializedProjectionCollisions,
+}
+
+pub(super) fn prepare_row_address_projection(
+    projection: &ResidentAddressProjection,
+) -> PreparedRowAddressProjection {
+    PreparedRowAddressProjection {
+        projection: projection.clone(),
+        collisions: MaterializedProjectionCollisions::default(),
+    }
+}
+
+fn invalid_row_address_projection(error: RowAddressProjectionOrderError) -> Error {
+    Error::index(format!("invalid FTS row-address projection: {error}"))
+}
+
+fn map_validated_scorer_to_row_addresses<'a>(
+    source: BoxScorer<'a>,
+    projection: &PreparedRowAddressProjection,
+    validation: std::result::Result<OrderedRowAddressProjection, RowAddressProjectionOrderError>,
+    local_document_lower_bound: u64,
+) -> Result<Option<RowAddressSource<'a>>> {
+    match validation {
+        Ok(ordered) => {
+            let Some(first_row_address) = ordered
+                .address(local_document_lower_bound)
+                .or_else(|| ordered.next_address(local_document_lower_bound))
+            else {
+                return Ok(None);
+            };
+            Ok(Some(RowAddressSource::new(
+                first_row_address,
+                Box::new(RowAddressScorer::new(source, ordered)),
+            )))
+        }
+        Err(error @ RowAddressProjectionOrderError::Duplicate { .. }) => {
+            Err(invalid_row_address_projection(error))
+        }
+        Err(RowAddressProjectionOrderError::OutOfOrder { .. }) => {
+            materialize_row_address_scorer(source, &projection.projection, &projection.collisions)
+        }
+    }
+}
+
+/// A lazily initialized scorer source and a conservative lower bound on its
+/// first possible row address.
+pub(super) struct RowAddressSource<'a> {
+    min_possible_row_address: u64,
+    scorer: BoxScorer<'a>,
+}
+
+impl<'a> RowAddressSource<'a> {
+    pub(super) fn new(min_possible_row_address: u64, scorer: BoxScorer<'a>) -> Self {
+        Self {
+            min_possible_row_address,
+            scorer,
+        }
+    }
+
+    pub(super) fn into_scorer(self) -> BoxScorer<'a> {
+        self.scorer
+    }
+}
+
+/// Map a partition-local scorer into the shared row-address domain.
+///
+/// Strictly ordered projections stay streaming. Descending or sufficiently
+/// sparse unknown projections use an exact materialized fallback. Duplicate
+/// projections are rejected because two local documents cannot share one row.
+pub(super) fn map_scorer_to_row_addresses<'a>(
+    source: BoxScorer<'a>,
+    projection: &PreparedRowAddressProjection,
+    local_document_lower_bound: u64,
+) -> Result<Option<RowAddressSource<'a>>> {
+    map_scorer_to_row_addresses_with_threshold(
+        source,
+        projection,
+        local_document_lower_bound,
+        *FLAT_SEARCH_PERCENT_THRESHOLD,
+    )
+}
+
+fn map_scorer_to_row_addresses_with_threshold<'a>(
+    source: BoxScorer<'a>,
+    projection: &PreparedRowAddressProjection,
+    local_document_lower_bound: u64,
+    flat_search_percent_threshold: u64,
+) -> Result<Option<RowAddressSource<'a>>> {
+    match projection.projection.cached_row_address_order() {
+        CachedRowAddressOrder::Ordered => map_validated_scorer_to_row_addresses(
+            source,
+            projection,
+            projection.projection.try_ordered_row_addresses(),
+            local_document_lower_bound,
+        ),
+        CachedRowAddressOrder::Duplicate => map_validated_scorer_to_row_addresses(
+            source,
+            projection,
+            projection.projection.try_ordered_row_addresses(),
+            local_document_lower_bound,
+        ),
+        CachedRowAddressOrder::OutOfOrder => {
+            materialize_row_address_scorer(source, &projection.projection, &projection.collisions)
+        }
+        CachedRowAddressOrder::Unknown
+            if projection.projection.should_materialize_unknown_projection(
+                source.cost(),
+                flat_search_percent_threshold,
+            ) =>
+        {
+            materialize_row_address_scorer(source, &projection.projection, &projection.collisions)
+        }
+        CachedRowAddressOrder::Unknown => map_validated_scorer_to_row_addresses(
+            source,
+            projection,
+            projection.projection.try_ordered_row_addresses(),
+            local_document_lower_bound,
+        ),
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+enum MergeShallowBounds {
+    Current { source_index: usize },
+    Global(ScoreBounds),
+    Empty,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct MergeShallowRange {
+    target: u64,
+    up_to: u64,
+    bounds: MergeShallowBounds,
+}
+
+/// Merge disjoint sources for one semantic leaf in their shared row-address
+/// domain.
+///
+/// Exactly one source must own each row address. Keeping the current source
+/// outside the heap makes both `next` and one-source `advance` O(log P), where
+/// P is the number of sources, instead of scanning every source per hit.
+pub(super) struct RowAddressMergeScorer<'a> {
+    sources: Vec<BoxScorer<'a>>,
+    source_minimums: Vec<u64>,
+    pending: BinaryHeap<Reverse<(u64, usize)>>,
+    heads: BinaryHeap<Reverse<(u64, usize)>>,
+    active_sources: HashSet<usize>,
+    current: Option<(u64, usize)>,
+    shallow: Option<MergeShallowRange>,
+    min_competitive_score: f32,
+}
+
+impl<'a> RowAddressMergeScorer<'a> {
+    pub(super) fn try_new(sources: Vec<RowAddressSource<'a>>) -> Result<Self> {
+        if sources.is_empty() {
+            return Err(Error::internal(
+                "row-address merge scorer requires at least one source",
+            ));
+        }
+        let mut pending = BinaryHeap::with_capacity(sources.len());
+        let mut source_minimums = Vec::with_capacity(sources.len());
+        let mut scorers = Vec::with_capacity(sources.len());
+        for (source_index, source) in sources.into_iter().enumerate() {
+            pending.push(Reverse((source.min_possible_row_address, source_index)));
+            source_minimums.push(source.min_possible_row_address);
+            scorers.push(source.scorer);
+        }
+        Ok(Self {
+            heads: BinaryHeap::with_capacity(scorers.len()),
+            active_sources: HashSet::with_capacity(scorers.len()),
+            sources: scorers,
+            source_minimums,
+            pending,
+            current: None,
+            shallow: None,
+            min_competitive_score: f32::NEG_INFINITY,
+        })
+    }
+
+    fn push_positioned_source(&mut self, source_index: usize, doc: u64) -> Result<()> {
+        if self.sources[source_index].doc() != Some(doc) {
+            return Err(Error::internal(format!(
+                "FTS source {source_index} returned row address {doc} but reported position {:?}",
+                self.sources[source_index].doc()
+            )));
+        }
+        self.heads.push(Reverse((doc, source_index)));
+        Ok(())
+    }
+
+    fn initialize_source(&mut self, source_index: usize, target: u64) -> Result<()> {
+        if self.min_competitive_score > f32::NEG_INFINITY {
+            self.sources[source_index].set_min_competitive_score(self.min_competitive_score)?;
+        }
+        let source_target = target.max(self.source_minimums[source_index]);
+        if let Some(doc) = self.sources[source_index].advance(source_target)? {
+            if doc < source_target {
+                return Err(Error::internal(format!(
+                    "FTS source {source_index} initialized at row address {doc} before target {source_target}"
+                )));
+            }
+            self.active_sources.insert(source_index);
+            self.push_positioned_source(source_index, doc)?;
+        }
+        Ok(())
+    }
+
+    fn ensure_candidate_head(&mut self, target: u64) -> Result<()> {
+        loop {
+            let actual_head = self.heads.peek().map(|Reverse((doc, _))| *doc);
+            let pending_head = self.pending.peek().map(|Reverse((minimum, _))| *minimum);
+            let should_initialize = match (actual_head, pending_head) {
+                (_, None) => false,
+                (None, Some(_)) => true,
+                (Some(actual), Some(pending)) => pending <= actual,
+            };
+            if !should_initialize {
+                return Ok(());
+            }
+            let Reverse((_, source_index)) = self.pending.pop().ok_or_else(|| {
+                Error::internal("FTS pending source heap unexpectedly became empty")
+            })?;
+            self.initialize_source(source_index, target)?;
+        }
+    }
+
+    fn select_current(&mut self, target: u64) -> Result<Option<u64>> {
+        self.shallow = None;
+        self.ensure_candidate_head(target)?;
+        let Some(Reverse((doc, source_index))) = self.heads.pop() else {
+            self.current = None;
+            return Ok(None);
+        };
+        if let Some(Reverse((duplicate, duplicate_source))) = self.heads.peek()
+            && *duplicate == doc
+        {
+            self.current = None;
+            return Err(Error::internal(format!(
+                "FTS sources {source_index} and {duplicate_source} produced duplicate row address {doc}"
+            )));
+        }
+        self.current = Some((doc, source_index));
+        Ok(Some(doc))
+    }
+
+    fn advance_source(&mut self, source_index: usize, target: u64) -> Result<()> {
+        if let Some(doc) = self.sources[source_index].advance(target)? {
+            if doc < target {
+                return Err(Error::internal(format!(
+                    "FTS source {source_index} advanced to row address {doc} before target {target}"
+                )));
+            }
+            self.push_positioned_source(source_index, doc)?;
+        } else {
+            self.active_sources.remove(&source_index);
+        }
+        Ok(())
+    }
+
+    fn next_source(&mut self, source_index: usize) -> Result<()> {
+        if let Some(doc) = self.sources[source_index].next()? {
+            self.push_positioned_source(source_index, doc)?;
+        } else {
+            self.active_sources.remove(&source_index);
+        }
+        Ok(())
+    }
+
+    fn current_source_mut(&mut self) -> Result<&mut BoxScorer<'a>> {
+        let (_, source_index) = self.current.ok_or_else(|| {
+            Error::internal("row-address merge scorer is not positioned on a document")
+        })?;
+        Ok(&mut self.sources[source_index])
+    }
+
+    fn next_source_boundary(&self) -> Option<u64> {
+        self.heads
+            .peek()
+            .map(|Reverse((doc, _))| *doc)
+            .into_iter()
+            .chain(self.pending.peek().map(|Reverse((minimum, _))| *minimum))
+            .min()
+    }
+
+    fn global_range_bounds(&self) -> ScoreBounds {
+        ScoreBounds {
+            lower: if self.scores_non_negative() {
+                0.0
+            } else {
+                f32::NEG_INFINITY
+            },
+            upper: self.global_score_upper_bound().unwrap_or(f32::INFINITY),
+        }
+    }
+}
+
+impl ComposableScorer for RowAddressMergeScorer<'_> {
+    fn doc(&self) -> Option<u64> {
+        self.current.map(|(doc, _)| doc)
+    }
+
+    fn document_key(&self) -> Option<u64> {
+        self.doc()
+    }
+
+    fn next(&mut self) -> Result<Option<u64>> {
+        let target = match self.current.take() {
+            Some((u64::MAX, source_index)) => {
+                self.active_sources.remove(&source_index);
+                self.shallow = None;
+                return Ok(None);
+            }
+            Some((doc, source_index)) => {
+                self.next_source(source_index)?;
+                doc + 1
+            }
+            None if self.heads.is_empty() && self.pending.is_empty() => return Ok(None),
+            None => 0,
+        };
+        self.select_current(target)
+    }
+
+    fn advance(&mut self, target: u64) -> Result<Option<u64>> {
+        if self.doc().is_some_and(|doc| doc >= target) {
+            return Ok(self.doc());
+        }
+        if let Some((_, source_index)) = self.current.take() {
+            self.advance_source(source_index, target)?;
+        }
+        while let Some(Reverse((doc, _))) = self.heads.peek() {
+            if *doc >= target {
+                break;
+            }
+            let Reverse((_, source_index)) = self
+                .heads
+                .pop()
+                .ok_or_else(|| Error::internal("FTS source heap unexpectedly became empty"))?;
+            self.advance_source(source_index, target)?;
+        }
+        self.select_current(target)
+    }
+
+    fn cost(&self) -> usize {
+        self.sources
+            .iter()
+            .map(|source| source.cost())
+            .fold(0, usize::saturating_add)
+    }
+
+    fn score(&mut self) -> Result<f32> {
+        self.current_source_mut()?.score()
+    }
+
+    fn advance_shallow(&mut self, target: u64) -> Result<u64> {
+        let Some((current, source_index)) = self.current else {
+            self.shallow = Some(MergeShallowRange {
+                target,
+                up_to: u64::MAX,
+                bounds: MergeShallowBounds::Empty,
+            });
+            return Ok(u64::MAX);
+        };
+        let next_source = self.next_source_boundary();
+        if next_source.is_some_and(|boundary| boundary <= target) {
+            let bounds = self.global_range_bounds();
+            self.shallow = Some(MergeShallowRange {
+                target,
+                up_to: target,
+                bounds: MergeShallowBounds::Global(bounds),
+            });
+            return Ok(target);
+        }
+
+        let source_target = target.max(current);
+        let source_up_to = self.sources[source_index].advance_shallow(source_target)?;
+        if source_up_to < source_target {
+            return Err(Error::internal(format!(
+                "FTS source {source_index} returned shallow range ending at {source_up_to} before target {source_target}"
+            )));
+        }
+        let up_to = next_source
+            .map(|boundary| source_up_to.min(boundary.saturating_sub(1)))
+            .unwrap_or(source_up_to);
+        self.shallow = Some(MergeShallowRange {
+            target,
+            up_to,
+            bounds: MergeShallowBounds::Current { source_index },
+        });
+        Ok(up_to)
+    }
+
+    fn score_bounds(&mut self, up_to: u64) -> Result<ScoreBounds> {
+        let shallow = self.shallow.ok_or_else(|| {
+            Error::internal("score_bounds requires advance_shallow on the row-address merge scorer")
+        })?;
+        if up_to < shallow.target || up_to > shallow.up_to {
+            return Err(Error::internal(format!(
+                "FTS row-address merge bound up_to={up_to} is outside shallow range [{}, {}]",
+                shallow.target, shallow.up_to
+            )));
+        }
+        match shallow.bounds {
+            MergeShallowBounds::Current { source_index } => {
+                self.sources[source_index].score_bounds(up_to)
+            }
+            MergeShallowBounds::Global(bounds) => Ok(bounds),
+            MergeShallowBounds::Empty => Ok(ScoreBounds::ZERO),
+        }
+    }
+
+    fn global_score_upper_bound(&self) -> Option<f32> {
+        self.sources
+            .iter()
+            .map(|source| source.global_score_upper_bound())
+            .try_fold(f32::NEG_INFINITY, |upper, source_upper| {
+                let source_upper = source_upper?;
+                source_upper.is_finite().then_some(upper.max(source_upper))
+            })
+    }
+
+    fn set_min_competitive_score(&mut self, min_score: f32) -> Result<()> {
+        if min_score.is_nan() {
+            return Err(Error::invalid_input(
+                "minimum competitive FTS score cannot be NaN",
+            ));
+        }
+        if min_score <= self.min_competitive_score {
+            return Ok(());
+        }
+        for source_index in self.active_sources.iter().copied() {
+            self.sources[source_index].set_min_competitive_score(min_score)?;
+        }
+        self.min_competitive_score = min_score;
+        Ok(())
+    }
+
+    fn matches(&mut self) -> Result<bool> {
+        self.current_source_mut()?.matches()
+    }
+
+    fn match_cost(&self) -> Option<f32> {
+        self.sources
+            .iter()
+            .map(|source| source.match_cost())
+            .try_fold(0.0_f32, |cost, source_cost| {
+                source_cost.map(|source_cost| cost.max(source_cost))
+            })
+    }
+
+    fn scores_non_negative(&self) -> bool {
+        self.sources
+            .iter()
+            .all(|source| source.scores_non_negative())
     }
 }
 
@@ -885,7 +2067,7 @@ impl<K: Copy + Ord> TopKCollector<K> {
         rows
     }
 
-    fn into_rows(self) -> Vec<ScoredRow<K>> {
+    pub(super) fn into_rows(self) -> Vec<ScoredRow<K>> {
         let limit = self.limit;
         let mut rows = self.into_candidates();
         rows.truncate(limit);
@@ -894,8 +2076,7 @@ impl<K: Copy + Ord> TopKCollector<K> {
 }
 
 impl TopKCollector<u64> {
-    #[cfg(test)]
-    fn collect(mut self, scorer: &mut dyn ComposableScorer) -> Result<Vec<ScoredRow>> {
+    pub(super) fn collect(mut self, scorer: &mut dyn ComposableScorer) -> Result<Vec<ScoredRow>> {
         self.collect_mapped(scorer, Ok)?;
         Ok(self.into_rows())
     }
@@ -907,7 +2088,7 @@ pub(super) enum DisjunctionScore {
     Max,
 }
 
-struct EmptyScorer;
+pub(super) struct EmptyScorer;
 
 impl ComposableScorer for EmptyScorer {
     fn doc(&self) -> Option<u64> {
@@ -2174,27 +3355,27 @@ impl ComposableScorer for BooleanScorer<'_> {
 }
 
 #[derive(Clone)]
-enum LeafQuery {
+pub(super) enum LeafQuery {
     Match(MatchQuery),
     Phrase(PhraseQuery),
 }
 
 impl LeafQuery {
-    fn terms(&self) -> &str {
+    pub(super) fn terms(&self) -> &str {
         match self {
             Self::Match(query) => &query.terms,
             Self::Phrase(query) => &query.terms,
         }
     }
 
-    fn operator(&self) -> Operator {
+    pub(super) fn operator(&self) -> Operator {
         match self {
             Self::Match(query) => query.operator,
             Self::Phrase(_) => Operator::And,
         }
     }
 
-    fn effective_params(&self, params: &FtsSearchParams) -> FtsSearchParams {
+    pub(super) fn effective_params(&self, params: &FtsSearchParams) -> FtsSearchParams {
         match self {
             Self::Match(query) => params
                 .clone()
@@ -2211,7 +3392,7 @@ impl LeafQuery {
     }
 }
 
-fn collect_leaf_queries(query: &FtsQuery, leaves: &mut Vec<LeafQuery>) -> Result<()> {
+pub(super) fn collect_leaf_queries(query: &FtsQuery, leaves: &mut Vec<LeafQuery>) -> Result<()> {
     match query {
         FtsQuery::Match(query) => leaves.push(LeafQuery::Match(query.clone())),
         FtsQuery::Phrase(query) => leaves.push(LeafQuery::Phrase(query.clone())),
@@ -2243,7 +3424,11 @@ struct PreparedLeaf {
     scorer: Arc<MemBM25Scorer>,
 }
 
-fn tokenize_leaf(index: &InvertedIndex, leaf: &LeafQuery, params: &FtsSearchParams) -> Tokens {
+pub(super) fn tokenize_leaf(
+    index: &InvertedIndex,
+    leaf: &LeafQuery,
+    params: &FtsSearchParams,
+) -> Tokens {
     let is_fuzzy_match = matches!(leaf, LeafQuery::Match(_))
         && matches!(params.fuzziness, Some(distance) if distance != 0);
     let mut tokenizer = if is_fuzzy_match {
@@ -2258,7 +3443,7 @@ fn tokenize_leaf(index: &InvertedIndex, leaf: &LeafQuery, params: &FtsSearchPara
     collect_query_tokens(leaf.terms(), &mut tokenizer)
 }
 
-fn expanded_leaf_tokens(
+pub(super) fn expanded_leaf_tokens(
     index: &InvertedIndex,
     tokens: &Tokens,
     params: &FtsSearchParams,
@@ -2833,9 +4018,16 @@ mod tests {
     use std::collections::HashMap;
     use std::sync::atomic::AtomicUsize;
 
+    use arrow::buffer::ScalarBuffer;
     use rand::{Rng, SeedableRng, rngs::SmallRng};
 
+    use super::super::documents::{
+        ordered_row_address_projection_for_test, resident_row_address_projection_for_test,
+    };
+    use super::super::index::{PlainPostingList, PostingList};
+    use super::super::scorer::Scorer;
     use super::*;
+    use crate::metrics::NoOpMetricsCollector;
 
     fn rows(values: &[(u64, f32)]) -> Vec<ScoredRow> {
         values
@@ -2846,6 +4038,44 @@ mod tests {
 
     fn materialized(values: &[(u64, f32)]) -> Box<dyn ComposableScorer> {
         Box::new(MaterializedScorer::try_new(rows(values)).unwrap())
+    }
+
+    fn zero_weight_wand<'a>(
+        documents: &'a DocSet,
+        scorer: Arc<MemBM25Scorer>,
+        params: &'a FtsSearchParams,
+        metrics: &'a dyn MetricsCollector,
+    ) -> BoxScorer<'a> {
+        let query_weight = scorer.query_weight("common");
+        assert_eq!(query_weight, 0.0);
+        let posting = PostingIterator::with_query_weight(
+            "common".to_owned(),
+            0,
+            0,
+            query_weight,
+            PostingList::Plain(PlainPostingList::new(
+                ScalarBuffer::from(vec![0_u64]),
+                ScalarBuffer::from(vec![1.0_f32]),
+                Some(0.0),
+                None,
+            )),
+            1,
+        );
+        Box::new(WandCursor::new(
+            Operator::Or,
+            vec![posting],
+            documents,
+            scorer,
+            params,
+            metrics,
+        ))
+    }
+
+    fn mapping_error(result: Result<Option<RowAddressSource<'_>>>) -> Error {
+        match result {
+            Err(error) => error,
+            Ok(_) => panic!("row-address mapping unexpectedly succeeded"),
+        }
     }
 
     fn should_maxscore<'a>(
@@ -2924,6 +4154,46 @@ mod tests {
         let bounds = scorer.score_bounds(up_to).unwrap();
         assert!(bounds.lower <= second_score);
         assert!(bounds.upper >= second_score);
+    }
+
+    #[test]
+    fn materialized_scorer_precomputes_multi_block_bounds() {
+        assert_eq!(std::mem::size_of::<ScoreBounds>(), 8);
+        let values = [
+            (0, 5.0),
+            (1, 1.0),
+            (2, 3.0),
+            (3, -2.0),
+            (4, 7.0),
+            (5, 4.0),
+            (6, 8.0),
+            (7, 6.0),
+            (8, 9.0),
+            (9, 0.0),
+        ];
+        let mut scorer = MaterializedScorer::try_new(rows(&values))
+            .unwrap()
+            .with_block_size(3);
+
+        assert_eq!(scorer.num_bound_blocks(), 4);
+        assert_eq!(scorer.bound_score_visits(), values.len());
+        assert_eq!(scorer.global_score_upper_bound(), Some(9.0));
+        assert_eq!(scorer.advance_shallow(4).unwrap(), 5);
+        assert_eq!(
+            scorer.score_bounds(4).unwrap(),
+            ScoreBounds {
+                lower: -2.0,
+                upper: 7.0,
+            }
+        );
+        for _ in 0..100 {
+            assert_eq!(scorer.score_bounds(5).unwrap().upper, 7.0);
+        }
+        assert_eq!(scorer.bound_score_visits(), values.len());
+
+        scorer.set_min_competitive_score(8.0).unwrap();
+        assert_eq!(scorer.next().unwrap(), Some(6));
+        assert_eq!(scorer.bound_score_visits(), values.len());
     }
 
     #[test]
@@ -3098,6 +4368,7 @@ mod tests {
         confirmations: AtomicUsize,
         shallow_advances: AtomicUsize,
         bounds: AtomicUsize,
+        floors: AtomicUsize,
     }
 
     struct InstrumentedScorer<'a> {
@@ -3155,6 +4426,7 @@ mod tests {
         }
 
         fn set_min_competitive_score(&mut self, min_score: f32) -> Result<()> {
+            self.work.floors.fetch_add(1, AtomicOrdering::Relaxed);
             self.inner.set_min_competitive_score(min_score)
         }
 
@@ -3183,6 +4455,449 @@ mod tests {
             }),
             work,
         )
+    }
+
+    fn row_address_source(values: &[(u64, f32)]) -> RowAddressSource<'static> {
+        let min_possible_row_address = values
+            .iter()
+            .map(|(row_address, _)| *row_address)
+            .min()
+            .unwrap();
+        RowAddressSource::new(min_possible_row_address, materialized(values))
+    }
+
+    #[test]
+    fn row_address_scorer_maps_gaps_advance_and_shallow_bounds() {
+        let projection = ordered_row_address_projection_for_test(vec![10, 20, 50, 100, 200]);
+        let source = Box::new(
+            MaterializedScorer::try_new(rows(&[(0, 1.0), (2, 5.0), (4, 9.0)]))
+                .unwrap()
+                .with_block_size(2),
+        );
+        let mut scorer = RowAddressScorer::new(source, projection);
+
+        assert_eq!(scorer.next().unwrap(), Some(10));
+        assert_eq!(scorer.document_key(), Some(10));
+        let up_to = scorer.advance_shallow(10).unwrap();
+        assert_eq!(up_to, 199);
+        assert_eq!(
+            scorer.score_bounds(150).unwrap(),
+            ScoreBounds {
+                lower: 1.0,
+                upper: 5.0,
+            }
+        );
+        assert_eq!(scorer.global_score_upper_bound(), Some(9.0));
+
+        assert_eq!(scorer.advance(21).unwrap(), Some(50));
+        assert_eq!(scorer.score().unwrap(), 5.0);
+        assert_eq!(scorer.advance(51).unwrap(), Some(200));
+        assert_eq!(scorer.score().unwrap(), 9.0);
+        assert_eq!(scorer.next().unwrap(), None);
+    }
+
+    #[test]
+    fn prepared_row_address_projection_is_reusable_across_leaf_scorers() {
+        let ordered_projection = resident_row_address_projection_for_test(vec![10, 20, 50]);
+        let ordered = prepare_row_address_projection(&ordered_projection);
+        assert_eq!(
+            ordered_projection.cached_row_address_order(),
+            CachedRowAddressOrder::Unknown
+        );
+        assert_eq!(ordered_projection.ordered_validation_visited_docs(), 0);
+
+        let first = map_scorer_to_row_addresses_with_threshold(
+            materialized(&[(0, 1.0), (2, 3.0)]),
+            &ordered,
+            0,
+            10,
+        )
+        .unwrap()
+        .unwrap();
+        assert_eq!(
+            ordered_projection.cached_row_address_order(),
+            CachedRowAddressOrder::Ordered
+        );
+        assert_eq!(ordered_projection.ordered_validation_visited_docs(), 3);
+        let second = map_scorer_to_row_addresses(materialized(&[(1, 2.0)]), &ordered, 0)
+            .unwrap()
+            .unwrap();
+        assert_eq!(ordered_projection.ordered_validation_visited_docs(), 3);
+        let first = TopKCollector::new(10)
+            .collect(first.into_scorer().as_mut())
+            .unwrap();
+        let second = TopKCollector::new(10)
+            .collect(second.into_scorer().as_mut())
+            .unwrap();
+        assert_eq!(first, rows(&[(50, 3.0), (10, 1.0)]));
+        assert_eq!(second, rows(&[(20, 2.0)]));
+
+        let delayed = map_scorer_to_row_addresses(materialized(&[(2, 3.0)]), &ordered, 2)
+            .unwrap()
+            .unwrap();
+        assert_eq!(delayed.min_possible_row_address, 50);
+
+        let unordered_projection = resident_row_address_projection_for_test(vec![30, 10, 20]);
+        let unordered = prepare_row_address_projection(&unordered_projection);
+        let first = map_scorer_to_row_addresses_with_threshold(
+            materialized(&[(0, 1.0), (1, 2.0)]),
+            &unordered,
+            0,
+            10,
+        )
+        .unwrap()
+        .unwrap();
+        assert!(matches!(
+            unordered_projection.cached_row_address_order(),
+            CachedRowAddressOrder::OutOfOrder
+        ));
+        assert_eq!(unordered_projection.ordered_validation_visited_docs(), 2);
+        let second = map_scorer_to_row_addresses(materialized(&[(2, 4.0)]), &unordered, 0)
+            .unwrap()
+            .unwrap();
+        assert_eq!(unordered_projection.ordered_validation_visited_docs(), 2);
+        let first = TopKCollector::new(10)
+            .collect(first.into_scorer().as_mut())
+            .unwrap();
+        let second = TopKCollector::new(10)
+            .collect(second.into_scorer().as_mut())
+            .unwrap();
+        assert_eq!(first, rows(&[(10, 2.0), (30, 1.0)]));
+        assert_eq!(second, rows(&[(20, 4.0)]));
+    }
+
+    #[test]
+    fn adaptive_projection_materializes_sparse_unknown_without_validation() {
+        let projection = resident_row_address_projection_for_test(
+            (0..100).map(|local_doc| local_doc * 10).collect(),
+        );
+        let prepared = prepare_row_address_projection(&projection);
+
+        let source = map_scorer_to_row_addresses_with_threshold(
+            materialized(&[(73, 4.0)]),
+            &prepared,
+            73,
+            10,
+        )
+        .unwrap()
+        .unwrap();
+
+        assert_eq!(projection.ordered_validation_visited_docs(), 0);
+        assert_eq!(
+            projection.cached_row_address_order(),
+            CachedRowAddressOrder::Unknown
+        );
+        let result = TopKCollector::new(1)
+            .collect(source.into_scorer().as_mut())
+            .unwrap();
+        assert_eq!(result, rows(&[(730, 4.0)]));
+    }
+
+    #[test]
+    fn adaptive_projection_amortizes_repeated_sparse_materialization() {
+        let projection = resident_row_address_projection_for_test(
+            (0..100).map(|local_doc| local_doc * 10).collect(),
+        );
+        let prepared = prepare_row_address_projection(&projection);
+
+        for _ in 0..10 {
+            map_scorer_to_row_addresses_with_threshold(
+                materialized(&[(73, 4.0)]),
+                &prepared,
+                73,
+                10,
+            )
+            .unwrap();
+        }
+        assert_eq!(projection.ordered_validation_visited_docs(), 0);
+        assert_eq!(
+            projection.cached_row_address_order(),
+            CachedRowAddressOrder::Unknown
+        );
+
+        map_scorer_to_row_addresses_with_threshold(materialized(&[(73, 4.0)]), &prepared, 73, 10)
+            .unwrap();
+        assert_eq!(projection.ordered_validation_visited_docs(), 100);
+        assert_eq!(
+            projection.cached_row_address_order(),
+            CachedRowAddressOrder::Ordered
+        );
+
+        map_scorer_to_row_addresses_with_threshold(materialized(&[(73, 4.0)]), &prepared, 73, 10)
+            .unwrap();
+        assert_eq!(projection.ordered_validation_visited_docs(), 100);
+    }
+
+    #[test]
+    fn adaptive_projection_validates_dense_unknown_once() {
+        let projection = resident_row_address_projection_for_test(vec![10, 20, 30, 40]);
+        let prepared = prepare_row_address_projection(&projection);
+
+        map_scorer_to_row_addresses_with_threshold(
+            materialized(&[(0, 1.0), (1, 1.0), (2, 1.0), (3, 1.0)]),
+            &prepared,
+            0,
+            10,
+        )
+        .unwrap();
+        assert_eq!(projection.ordered_validation_visited_docs(), 4);
+        assert_eq!(
+            projection.cached_row_address_order(),
+            CachedRowAddressOrder::Ordered
+        );
+
+        map_scorer_to_row_addresses_with_threshold(
+            materialized(&[(0, 2.0), (1, 2.0), (2, 2.0), (3, 2.0)]),
+            &prepared,
+            0,
+            10,
+        )
+        .unwrap();
+        assert_eq!(projection.ordered_validation_visited_docs(), 4);
+    }
+
+    #[test]
+    fn adaptive_projection_tracks_unknown_duplicates_across_leaves() {
+        let projection = resident_row_address_projection_for_test(vec![10, 10]);
+        let prepared = prepare_row_address_projection(&projection);
+
+        map_scorer_to_row_addresses_with_threshold(materialized(&[(0, 1.0)]), &prepared, 0, 1000)
+            .unwrap();
+        // The same physical local document can match more than one leaf.
+        map_scorer_to_row_addresses_with_threshold(materialized(&[(0, 2.0)]), &prepared, 0, 1000)
+            .unwrap();
+        let error = mapping_error(map_scorer_to_row_addresses_with_threshold(
+            materialized(&[(1, 3.0)]),
+            &prepared,
+            1,
+            1000,
+        ));
+
+        assert!(
+            error
+                .to_string()
+                .contains("distinct local documents 0 and 1")
+        );
+        assert_eq!(projection.ordered_validation_visited_docs(), 0);
+        assert_eq!(
+            projection.cached_row_address_order(),
+            CachedRowAddressOrder::Unknown
+        );
+    }
+
+    #[test]
+    fn adaptive_projection_tracks_out_of_order_duplicates_across_leaves() {
+        let projection = resident_row_address_projection_for_test(vec![10, 30, 10]);
+        let prepared = prepare_row_address_projection(&projection);
+
+        map_scorer_to_row_addresses_with_threshold(materialized(&[(0, 1.0)]), &prepared, 0, 0)
+            .unwrap();
+        assert!(matches!(
+            projection.cached_row_address_order(),
+            CachedRowAddressOrder::OutOfOrder
+        ));
+        assert_eq!(projection.ordered_validation_visited_docs(), 3);
+
+        let error = mapping_error(map_scorer_to_row_addresses_with_threshold(
+            materialized(&[(2, 2.0)]),
+            &prepared,
+            2,
+            100,
+        ));
+        assert!(
+            error
+                .to_string()
+                .contains("distinct local documents 0 and 2")
+        );
+        assert_eq!(projection.ordered_validation_visited_docs(), 3);
+    }
+
+    #[test]
+    fn adaptive_projection_rejects_cached_duplicates_without_materializing() {
+        let projection = resident_row_address_projection_for_test(vec![10, 10]);
+        let prepared = prepare_row_address_projection(&projection);
+
+        let first_error = mapping_error(map_scorer_to_row_addresses_with_threshold(
+            materialized(&[(0, 1.0)]),
+            &prepared,
+            0,
+            0,
+        ));
+        assert!(
+            first_error
+                .to_string()
+                .contains("shared by local documents 0 and 1")
+        );
+        assert_eq!(projection.ordered_validation_visited_docs(), 2);
+        assert!(matches!(
+            projection.cached_row_address_order(),
+            CachedRowAddressOrder::Duplicate
+        ));
+
+        let second_error = mapping_error(map_scorer_to_row_addresses_with_threshold(
+            materialized(&[(1, 2.0)]),
+            &prepared,
+            1,
+            100,
+        ));
+        assert!(
+            second_error
+                .to_string()
+                .contains("shared by local documents 0 and 1")
+        );
+        // The atomic cache stores only the invalid category. Reconstructing
+        // exact duplicate diagnostics is a rare error-path rescan.
+        assert_eq!(projection.ordered_validation_visited_docs(), 4);
+    }
+
+    #[test]
+    fn materialized_projection_reports_single_leaf_duplicates_locally() {
+        let projection = resident_row_address_projection_for_test(vec![10, 10]);
+        let prepared = prepare_row_address_projection(&projection);
+        let error = mapping_error(map_scorer_to_row_addresses_with_threshold(
+            materialized(&[(0, 1.0), (1, 2.0)]),
+            &prepared,
+            0,
+            100,
+        ));
+
+        assert!(error.to_string().contains("duplicate row_id=10"));
+        assert_eq!(projection.ordered_validation_visited_docs(), 0);
+    }
+
+    #[test]
+    fn row_address_merge_orders_gapped_sources_and_keeps_score_ties() {
+        let mut scorer = RowAddressMergeScorer::try_new(vec![
+            row_address_source(&[(10, 5.0), (100, 2.0)]),
+            row_address_source(&[(20, 5.0), (70, 8.0)]),
+        ])
+        .unwrap();
+
+        let results = TopKCollector::new(10).collect(&mut scorer).unwrap();
+        assert_eq!(
+            results,
+            rows(&[(70, 8.0), (10, 5.0), (20, 5.0), (100, 2.0)])
+        );
+    }
+
+    #[test]
+    fn row_address_merge_advance_skips_sources_with_a_heap() {
+        let mut scorer = RowAddressMergeScorer::try_new(vec![
+            row_address_source(&[(10, 1.0), (100, 2.0)]),
+            row_address_source(&[(20, 3.0), (70, 4.0)]),
+            row_address_source(&[(30, 5.0), (90, 6.0)]),
+        ])
+        .unwrap();
+
+        assert_eq!(scorer.advance(65).unwrap(), Some(70));
+        assert_eq!(scorer.next().unwrap(), Some(90));
+        assert_eq!(scorer.next().unwrap(), Some(100));
+        assert_eq!(scorer.next().unwrap(), None);
+    }
+
+    #[test]
+    fn row_address_merge_delays_pending_sources_and_shallow_work() {
+        let first = Box::new(
+            MaterializedScorer::try_new(rows(&[(10, 1.0), (20, 4.0), (2_000, 8.0)]))
+                .unwrap()
+                .with_block_size(3),
+        );
+        let second = Box::new(
+            MaterializedScorer::try_new(rows(&[(1_000, 10.0)]))
+                .unwrap()
+                .with_block_size(1),
+        );
+        let (first, first_work) = instrumented(first);
+        let (second, second_work) = instrumented(second);
+        let mut scorer = RowAddressMergeScorer::try_new(vec![
+            RowAddressSource::new(10, first),
+            RowAddressSource::new(1_000, second),
+        ])
+        .unwrap();
+
+        assert_eq!(scorer.next().unwrap(), Some(10));
+        assert_eq!(first_work.advances.load(AtomicOrdering::Relaxed), 1);
+        assert_eq!(second_work.advances.load(AtomicOrdering::Relaxed), 0);
+
+        let up_to = scorer.advance_shallow(10).unwrap();
+        assert_eq!(up_to, 999);
+        // Materialized bounds conservatively cover the whole source block,
+        // including its row at 2_000, while the merge window still stops
+        // before the pending source at 1_000.
+        assert_eq!(scorer.score_bounds(up_to).unwrap().upper, 8.0);
+        assert_eq!(first_work.shallow_advances.load(AtomicOrdering::Relaxed), 1);
+        assert_eq!(first_work.bounds.load(AtomicOrdering::Relaxed), 1);
+        assert_eq!(
+            second_work.shallow_advances.load(AtomicOrdering::Relaxed),
+            0
+        );
+        assert_eq!(second_work.bounds.load(AtomicOrdering::Relaxed), 0);
+        assert_eq!(scorer.global_score_upper_bound(), Some(10.0));
+    }
+
+    #[test]
+    fn row_address_merge_pushes_new_floors_only_to_active_sources() {
+        let (first, first_work) = instrumented(materialized(&[(10, 1.0), (20, 2.0)]));
+        let (second, second_work) = instrumented(materialized(&[(1_000, 10.0)]));
+        let mut scorer = RowAddressMergeScorer::try_new(vec![
+            RowAddressSource::new(10, first),
+            RowAddressSource::new(1_000, second),
+        ])
+        .unwrap();
+
+        assert_eq!(scorer.next().unwrap(), Some(10));
+        scorer.set_min_competitive_score(5.0).unwrap();
+        scorer.set_min_competitive_score(5.0).unwrap();
+        assert_eq!(first_work.floors.load(AtomicOrdering::Relaxed), 1);
+        assert_eq!(second_work.floors.load(AtomicOrdering::Relaxed), 0);
+
+        assert_eq!(scorer.advance(1_000).unwrap(), Some(1_000));
+        assert_eq!(second_work.floors.load(AtomicOrdering::Relaxed), 1);
+    }
+
+    #[test]
+    fn row_address_merge_rejects_duplicate_source_addresses() {
+        let mut scorer = RowAddressMergeScorer::try_new(vec![
+            row_address_source(&[(20, 1.0)]),
+            row_address_source(&[(20, 2.0)]),
+        ])
+        .unwrap();
+
+        let error = scorer.next().unwrap_err();
+        assert!(error.to_string().contains("duplicate row address 20"));
+    }
+
+    #[test]
+    fn materialized_address_fallback_sorts_nonmonotonic_projection() {
+        let addresses = [30, 10, 20];
+        let source = materialized(&[(0, 1.0), (1, 2.0), (2, 3.0)]);
+        let source = materialize_mapped_scorer(source, |doc| {
+            addresses
+                .get(doc as usize)
+                .copied()
+                .ok_or_else(|| Error::internal(format!("missing test address for document {doc}")))
+        })
+        .unwrap()
+        .unwrap();
+        let mut scorer = source.into_scorer();
+
+        assert_eq!(scorer.next().unwrap(), Some(10));
+        assert_eq!(scorer.score().unwrap(), 2.0);
+        assert_eq!(scorer.next().unwrap(), Some(20));
+        assert_eq!(scorer.score().unwrap(), 3.0);
+        assert_eq!(scorer.next().unwrap(), Some(30));
+        assert_eq!(scorer.score().unwrap(), 1.0);
+        assert_eq!(scorer.next().unwrap(), None);
+    }
+
+    #[test]
+    fn materialized_address_fallback_rejects_duplicate_matches() {
+        let source = materialized(&[(0, 1.0), (1, 2.0)]);
+        let Err(error) = materialize_mapped_scorer(source, |_| Ok(10)) else {
+            panic!("duplicate projected addresses must fail");
+        };
+
+        assert!(error.to_string().contains("duplicate row_id=10"));
     }
 
     struct UnboundedScorer {
@@ -3461,6 +5176,43 @@ mod tests {
     }
 
     #[test]
+    fn boolean_preserves_zero_weight_required_and_prohibited_membership() {
+        let mut token_docs = HashMap::new();
+        token_docs.insert("common".to_owned(), 10_000_000);
+        let scorer = Arc::new(MemBM25Scorer::new(10_000_000, 10_000_000, token_docs));
+        assert_eq!(scorer.query_weight("common"), 0.0);
+
+        let mut documents = DocSet::default();
+        documents.append(0, 1);
+        let params = FtsSearchParams::default();
+        let metrics = NoOpMetricsCollector;
+
+        let mut required = BooleanScorer::try_new(
+            Vec::new(),
+            vec![zero_weight_wand(
+                &documents,
+                scorer.clone(),
+                &params,
+                &metrics,
+            )],
+            Vec::new(),
+        )
+        .unwrap();
+        assert_eq!(required.next().unwrap(), Some(0));
+        assert!(required.matches().unwrap());
+        assert_eq!(required.score().unwrap(), 0.0);
+        drop(required);
+
+        let mut excluded = BooleanScorer::try_new(
+            Vec::new(),
+            vec![materialized(&[(0, 1.0)])],
+            vec![zero_weight_wand(&documents, scorer, &params, &metrics)],
+        )
+        .unwrap();
+        assert_eq!(excluded.next().unwrap(), None);
+    }
+
+    #[test]
     fn reqopt_delays_sparse_optional_probes() {
         let values = (0..100).map(|doc| (doc, 1.0)).collect::<Vec<_>>();
         let build = || {
@@ -3645,6 +5397,592 @@ mod tests {
         rows.sort_unstable_by(compare_scored_rows);
         rows.truncate(limit);
         rows
+    }
+
+    fn exhaustive_compound_scores(
+        plan: &CompoundScorerPlan,
+        leaves: &[HashMap<u64, f32>],
+    ) -> HashMap<u64, f32> {
+        match plan {
+            CompoundScorerPlan::Leaf { index, boost } => leaves[*index]
+                .iter()
+                .map(|(row_address, score)| (*row_address, *score * *boost))
+                .collect(),
+            CompoundScorerPlan::Boost {
+                positive,
+                negative,
+                negative_boost,
+            } => {
+                let mut positive = exhaustive_compound_scores(positive, leaves);
+                let negative = exhaustive_compound_scores(negative, leaves);
+                for (row_address, score) in &mut positive {
+                    if let Some(negative_score) = negative.get(row_address) {
+                        *score -= *negative_boost * *negative_score;
+                    }
+                }
+                positive
+            }
+            CompoundScorerPlan::MultiMatch(children) => {
+                let mut scores = HashMap::<u64, f32>::new();
+                for child in children {
+                    for (row_address, score) in exhaustive_compound_scores(child, leaves) {
+                        scores
+                            .entry(row_address)
+                            .and_modify(|current| *current = current.max(score))
+                            .or_insert(score);
+                    }
+                }
+                scores
+            }
+            CompoundScorerPlan::Boolean {
+                should,
+                must,
+                must_not,
+            } => {
+                let mut scores = if let Some((first, remaining)) = must.split_first() {
+                    let mut scores = exhaustive_compound_scores(first, leaves);
+                    for child in remaining {
+                        let required = exhaustive_compound_scores(child, leaves);
+                        scores.retain(|row_address, score| {
+                            if let Some(required_score) = required.get(row_address) {
+                                *score += required_score;
+                                true
+                            } else {
+                                false
+                            }
+                        });
+                    }
+                    for child in should {
+                        for (row_address, optional_score) in
+                            exhaustive_compound_scores(child, leaves)
+                        {
+                            if let Some(score) = scores.get_mut(&row_address) {
+                                *score += optional_score;
+                            }
+                        }
+                    }
+                    scores
+                } else {
+                    let mut scores = HashMap::<u64, f32>::new();
+                    for child in should {
+                        for (row_address, score) in exhaustive_compound_scores(child, leaves) {
+                            *scores.entry(row_address).or_default() += score;
+                        }
+                    }
+                    scores
+                };
+
+                for child in must_not {
+                    for row_address in exhaustive_compound_scores(child, leaves).into_keys() {
+                        scores.remove(&row_address);
+                    }
+                }
+                scores
+            }
+        }
+    }
+
+    fn exhaustive_compound_top_k(
+        plan: &CompoundScorerPlan,
+        leaves: &[HashMap<u64, f32>],
+        limit: usize,
+    ) -> Vec<ScoredRow> {
+        let mut scores = exhaustive_compound_scores(plan, leaves)
+            .into_iter()
+            .collect::<Vec<_>>();
+        scores.sort_unstable_by(|(left_row, left_score), (right_row, right_score)| {
+            right_score
+                .total_cmp(left_score)
+                .then_with(|| left_row.cmp(right_row))
+        });
+        scores.truncate(limit);
+        scores
+            .into_iter()
+            .map(|(row_address, score)| ScoredRow::new(row_address, score).unwrap())
+            .collect()
+    }
+
+    fn randomized_mapped_leaf(
+        scores: &HashMap<u64, f32>,
+        canonical_row_addresses: &[u64],
+        rng: &mut SmallRng,
+    ) -> BoxScorer<'static> {
+        let source_count = rng.random_range(2..=3);
+        let source_by_row = (0..256)
+            .find_map(|_| {
+                let source_by_row = (0..canonical_row_addresses.len())
+                    .map(|_| rng.random_range(0..source_count))
+                    .collect::<Vec<_>>();
+                let mut projection_lengths = vec![0_u64; source_count];
+                let mut local_matches = vec![Vec::<u64>::new(); source_count];
+                for (row_index, row_address) in canonical_row_addresses.iter().enumerate() {
+                    let source_index = source_by_row[row_index];
+                    let local_doc = projection_lengths[source_index];
+                    projection_lengths[source_index] += 1;
+                    if scores.contains_key(row_address) {
+                        local_matches[source_index].push(local_doc);
+                    }
+                }
+
+                let local_gap_patterns = local_matches
+                    .iter()
+                    .map(|matches| {
+                        matches
+                            .windows(2)
+                            .map(|pair| pair[1] - pair[0])
+                            .collect::<Vec<_>>()
+                    })
+                    .collect::<Vec<_>>();
+                let has_distinct_gapped_sources =
+                    local_matches
+                        .iter()
+                        .enumerate()
+                        .all(|(source_index, matches)| {
+                            matches.len() >= 2
+                                && matches.windows(2).any(|pair| pair[1] > pair[0] + 1)
+                                && matches.len() * 4 > projection_lengths[source_index] as usize
+                        })
+                        && local_gap_patterns
+                            .iter()
+                            .enumerate()
+                            .all(|(source_index, gaps)| {
+                                local_gap_patterns[..source_index]
+                                    .iter()
+                                    .all(|previous| previous != gaps)
+                            });
+                has_distinct_gapped_sources.then_some(source_by_row)
+            })
+            .expect("randomized physical sources should have distinct local-document gaps");
+
+        let mut sources = Vec::with_capacity(source_count);
+        for source_index in 0..source_count {
+            let projection_addresses = canonical_row_addresses
+                .iter()
+                .enumerate()
+                .filter_map(|(row_index, row_address)| {
+                    (source_by_row[row_index] == source_index).then_some(*row_address)
+                })
+                .collect::<Vec<_>>();
+            let local_rows = projection_addresses
+                .iter()
+                .enumerate()
+                .filter_map(|(local_doc, row_address)| {
+                    scores
+                        .get(row_address)
+                        .map(|score| (local_doc as u64, *score))
+                })
+                .collect::<Vec<_>>();
+            let first_match = local_rows
+                .first()
+                .expect("every randomized physical source should have postings")
+                .0;
+            let local_document_lower_bound = rng.random_range(0..=first_match);
+            let projection = resident_row_address_projection_for_test(projection_addresses.clone());
+            let prepared = prepare_row_address_projection(&projection);
+            let source = map_scorer_to_row_addresses(
+                materialized(&local_rows),
+                &prepared,
+                local_document_lower_bound,
+            )
+            .unwrap()
+            .expect("a randomized physical source with postings should map");
+            assert_eq!(
+                projection.cached_row_address_order(),
+                CachedRowAddressOrder::Ordered
+            );
+            assert_eq!(
+                projection.ordered_validation_visited_docs(),
+                projection_addresses.len()
+            );
+            sources.push(source);
+        }
+
+        Box::new(RowAddressMergeScorer::try_new(sources).unwrap())
+    }
+
+    fn plan_leaf(index: usize) -> CompoundScorerPlan {
+        CompoundScorerPlan::Leaf { index, boost: 1.0 }
+    }
+
+    fn plan_input(possible: bool, cost: usize, lower: f32, upper: f32) -> CompoundLeafPlanInput {
+        CompoundLeafPlanInput::new(possible, cost, ScoreBounds::try_new(lower, upper).unwrap())
+    }
+
+    #[test]
+    fn staged_plan_analysis_selects_stable_must_generator() {
+        let plan = CompoundScorerPlan::Boolean {
+            should: vec![plan_leaf(0)],
+            must: vec![
+                CompoundScorerPlan::MultiMatch(vec![plan_leaf(1), plan_leaf(2)]),
+                CompoundScorerPlan::Boost {
+                    positive: Box::new(plan_leaf(3)),
+                    negative: Box::new(plan_leaf(4)),
+                    negative_boost: 0.5,
+                },
+            ],
+            must_not: vec![plan_leaf(5)],
+        };
+        let analysis = plan
+            .analyze_leaves(&[
+                plan_input(true, 9, 1.0, 2.0),
+                plan_input(true, 2, 2.0, 4.0),
+                plan_input(true, 2, -1.0, 3.0),
+                plan_input(true, 4, 5.0, 6.0),
+                plan_input(true, 1, 1.0, 2.0),
+                plan_input(true, 1, 0.0, 10.0),
+            ])
+            .unwrap();
+
+        assert_eq!(plan.leaf_count(), 6);
+        assert!(analysis.possible);
+        assert_eq!(analysis.generator_cost, 4);
+        // Equal-cost MUST covers retain query order, then expose a canonical
+        // sorted/deduplicated leaf list to the I/O scheduler.
+        assert_eq!(analysis.generator_leaves, vec![1, 2]);
+        assert!(analysis.bounds.lower() <= 3.0);
+        assert!(analysis.bounds.upper() >= 12.0);
+    }
+
+    #[test]
+    fn staged_plan_analysis_handles_optional_missing_and_impossible_required() {
+        let pure_should = CompoundScorerPlan::Boolean {
+            // Deliberately use non-canonical traversal order so the public
+            // generator list must sort independently of query-tree layout.
+            should: vec![plan_leaf(2), plan_leaf(0), plan_leaf(1)],
+            must: Vec::new(),
+            must_not: Vec::new(),
+        };
+        let analysis = pure_should
+            .analyze_leaves(&[
+                plan_input(true, 7, 1.0, 2.0),
+                plan_input(false, 1, 100.0, 200.0),
+                plan_input(true, 3, -4.0, -1.0),
+            ])
+            .unwrap();
+        assert!(analysis.possible);
+        assert_eq!(analysis.generator_cost, 10);
+        assert_eq!(analysis.generator_leaves, vec![0, 2]);
+        assert!(analysis.bounds.lower() <= -4.0);
+        assert!(analysis.bounds.upper() >= 2.0);
+
+        let missing_must = CompoundScorerPlan::Boolean {
+            should: vec![plan_leaf(0)],
+            must: vec![plan_leaf(1)],
+            must_not: Vec::new(),
+        };
+        let analysis = missing_must
+            .analyze_leaves(&[
+                plan_input(true, 1, 0.0, 10.0),
+                plan_input(false, 1, 0.0, 10.0),
+            ])
+            .unwrap();
+        assert!(!analysis.possible);
+        assert_eq!(analysis.bounds, ScoreBounds::ZERO);
+        assert!(analysis.generator_leaves.is_empty());
+
+        let only_must_not = CompoundScorerPlan::Boolean {
+            should: Vec::new(),
+            must: Vec::new(),
+            must_not: vec![plan_leaf(0)],
+        };
+        let analysis = only_must_not
+            .analyze_leaves(&[plan_input(true, 1, 0.0, 10.0)])
+            .unwrap();
+        assert!(!analysis.possible);
+        assert!(analysis.generator_leaves.is_empty());
+    }
+
+    #[test]
+    fn staged_plan_analysis_composes_signed_nested_boost_and_unbounded_inputs() {
+        let plan = CompoundScorerPlan::Boost {
+            positive: Box::new(plan_leaf(0)),
+            negative: Box::new(CompoundScorerPlan::Boost {
+                positive: Box::new(plan_leaf(1)),
+                negative: Box::new(plan_leaf(2)),
+                negative_boost: 1.0,
+            }),
+            negative_boost: 0.5,
+        };
+        let analysis = plan
+            .analyze_leaves(&[
+                plan_input(true, 3, 2.0, 3.0),
+                plan_input(true, 1, 1.0, 2.0),
+                plan_input(true, 1, 4.0, 5.0),
+            ])
+            .unwrap();
+        assert_eq!(analysis.generator_leaves, vec![0]);
+        // The nested negative can itself be negative, so subtracting it may
+        // increase the outer Boost score.
+        assert!(analysis.bounds.lower() <= 1.0);
+        assert!(analysis.bounds.upper() >= 5.0);
+
+        let unbounded = CompoundScorerPlan::Boolean {
+            should: vec![plan_leaf(0), plan_leaf(1)],
+            must: Vec::new(),
+            must_not: Vec::new(),
+        }
+        .analyze_leaves(&[
+            CompoundLeafPlanInput::new(true, 1, ScoreBounds::UNBOUNDED),
+            plan_input(true, 1, 0.0, 1.0),
+        ])
+        .unwrap();
+        assert_eq!(unbounded.bounds, ScoreBounds::UNBOUNDED);
+
+        assert!(ScoreBounds::try_new(f32::NAN, 1.0).is_err());
+        let invalid = [CompoundLeafPlanInput {
+            possible: true,
+            cost: 1,
+            bounds: ScoreBounds {
+                lower: 2.0,
+                upper: 1.0,
+            },
+        }];
+        assert!(plan_leaf(0).analyze_leaves(&invalid).is_err());
+    }
+
+    fn random_staged_plan(
+        rng: &mut SmallRng,
+        depth: usize,
+        next_leaf: &mut usize,
+    ) -> CompoundScorerPlan {
+        if depth == 0 || rng.random_bool(0.35) {
+            let index = *next_leaf;
+            *next_leaf += 1;
+            return CompoundScorerPlan::Leaf {
+                index,
+                boost: [0.0, 0.5, 1.0, 2.0][rng.random_range(0..4)],
+            };
+        }
+        match rng.random_range(0..3) {
+            0 => CompoundScorerPlan::Boost {
+                positive: Box::new(random_staged_plan(rng, depth - 1, next_leaf)),
+                negative: Box::new(random_staged_plan(rng, depth - 1, next_leaf)),
+                negative_boost: [0.0, 0.5, 1.0, 1.5][rng.random_range(0..4)],
+            },
+            1 => CompoundScorerPlan::MultiMatch(
+                (0..rng.random_range(1..=3))
+                    .map(|_| random_staged_plan(rng, depth - 1, next_leaf))
+                    .collect(),
+            ),
+            _ => {
+                let must_count = rng.random_range(0..=2);
+                let should_count = if must_count == 0 {
+                    rng.random_range(1..=3)
+                } else {
+                    rng.random_range(0..=2)
+                };
+                let should = (0..should_count)
+                    .map(|_| random_staged_plan(rng, depth - 1, next_leaf))
+                    .collect();
+                let must = (0..must_count)
+                    .map(|_| random_staged_plan(rng, depth - 1, next_leaf))
+                    .collect();
+                let must_not = (0..rng.random_range(0..=2))
+                    .map(|_| random_staged_plan(rng, depth - 1, next_leaf))
+                    .collect();
+                CompoundScorerPlan::Boolean {
+                    should,
+                    must,
+                    must_not,
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn randomized_staged_plan_bounds_and_generator_cover_exact_matches() {
+        for seed in 0..64 {
+            let mut rng = SmallRng::seed_from_u64(seed);
+            let mut leaf_count = 0;
+            let plan = random_staged_plan(&mut rng, 3, &mut leaf_count);
+            assert_eq!(plan.leaf_count(), leaf_count, "seed={seed}");
+            let inputs = (0..leaf_count)
+                .map(|_| {
+                    let possible = rng.random_bool(0.8);
+                    let lower = rng.random_range(-4..=2) as f32;
+                    let upper = rng.random_range(lower as i32..=5) as f32;
+                    plan_input(possible, rng.random_range(1..=32), lower, upper)
+                })
+                .collect::<Vec<_>>();
+            let analysis = plan.analyze_leaves(&inputs).unwrap();
+            assert!(
+                analysis
+                    .generator_leaves
+                    .windows(2)
+                    .all(|pair| pair[0] < pair[1])
+            );
+
+            for document in 0..128_u64 {
+                let mut leaves = vec![HashMap::new(); leaf_count];
+                for (leaf_index, input) in inputs.iter().enumerate() {
+                    if input.possible && rng.random_bool(0.5) {
+                        let score = rng.random_range(input.bounds.lower()..=input.bounds.upper());
+                        leaves[leaf_index].insert(document, score);
+                    }
+                }
+                if let Some(score) = exhaustive_compound_scores(&plan, &leaves).get(&document) {
+                    assert!(analysis.possible, "seed={seed}, document={document}");
+                    assert!(
+                        analysis.bounds.lower() <= *score && *score <= analysis.bounds.upper(),
+                        "seed={seed}, document={document}, score={score}, bounds={:?}",
+                        analysis.bounds
+                    );
+                    assert!(
+                        analysis
+                            .generator_leaves
+                            .iter()
+                            .any(|leaf| leaves[*leaf].contains_key(&document)),
+                        "seed={seed}, document={document}, generators={:?}",
+                        analysis.generator_leaves
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn randomized_mapped_sources_match_recursive_exhaustive_oracle() {
+        let plans = [
+            (
+                "should_sum",
+                CompoundScorerPlan::Boolean {
+                    should: (0..4).map(plan_leaf).collect(),
+                    must: Vec::new(),
+                    must_not: Vec::new(),
+                },
+            ),
+            (
+                "multimatch_max",
+                CompoundScorerPlan::MultiMatch((0..4).map(plan_leaf).collect()),
+            ),
+            (
+                "must_sum",
+                CompoundScorerPlan::Boolean {
+                    should: Vec::new(),
+                    must: (0..4).map(plan_leaf).collect(),
+                    must_not: Vec::new(),
+                },
+            ),
+            (
+                "required_optional",
+                CompoundScorerPlan::Boolean {
+                    should: vec![plan_leaf(1), plan_leaf(2), plan_leaf(3)],
+                    must: vec![plan_leaf(0)],
+                    must_not: Vec::new(),
+                },
+            ),
+            (
+                "signed_boost",
+                CompoundScorerPlan::Boost {
+                    positive: Box::new(CompoundScorerPlan::MultiMatch(vec![
+                        plan_leaf(0),
+                        CompoundScorerPlan::Leaf {
+                            index: 1,
+                            boost: 0.5,
+                        },
+                    ])),
+                    negative: Box::new(CompoundScorerPlan::Boolean {
+                        should: vec![plan_leaf(2), plan_leaf(3)],
+                        must: Vec::new(),
+                        must_not: Vec::new(),
+                    }),
+                    negative_boost: 1.5,
+                },
+            ),
+            (
+                "must_not",
+                CompoundScorerPlan::Boolean {
+                    should: vec![plan_leaf(1)],
+                    must: vec![plan_leaf(0)],
+                    must_not: vec![CompoundScorerPlan::MultiMatch(vec![
+                        plan_leaf(2),
+                        plan_leaf(3),
+                    ])],
+                },
+            ),
+        ];
+
+        for seed in 0..12 {
+            let mut rng = SmallRng::seed_from_u64(seed);
+            let num_rows = rng.random_range(32..=64);
+            let mut next_row_address = (seed + 1) << 32;
+            let canonical_row_addresses = (0..num_rows)
+                .map(|_| {
+                    next_row_address += rng.random_range(1..=16);
+                    next_row_address
+                })
+                .collect::<Vec<_>>();
+            let mut leaves = vec![HashMap::<u64, f32>::new(); 4];
+            for (row_index, row_address) in canonical_row_addresses.iter().enumerate() {
+                let mut matched = false;
+                for (leaf_index, leaf) in leaves.iter_mut().enumerate() {
+                    let is_required_only_canary = row_index < 16 && leaf_index < 2;
+                    let is_random_match = row_index >= 16 && rng.random_bool(0.5);
+                    if row_index < 8 || is_required_only_canary || is_random_match {
+                        let score = if row_index < 8 {
+                            2.0
+                        } else {
+                            rng.random_range(1..=4) as f32 * 0.5
+                        };
+                        leaf.insert(*row_address, score);
+                        matched = true;
+                    }
+                }
+                if !matched {
+                    let leaf_index = rng.random_range(0..leaves.len());
+                    let score = rng.random_range(1..=4) as f32 * 0.5;
+                    leaves[leaf_index].insert(*row_address, score);
+                }
+            }
+
+            let max_scores = exhaustive_compound_scores(&plans[1].1, &leaves);
+            let max_score = max_scores.values().copied().max_by(f32::total_cmp).unwrap();
+            assert!(
+                max_scores
+                    .values()
+                    .filter(|score| **score == max_score)
+                    .count()
+                    >= 8,
+                "seed={seed} should retain enough top-score ties to cross every tested limit"
+            );
+            assert!(
+                exhaustive_compound_scores(&plans[4].1, &leaves)
+                    .values()
+                    .any(|score| *score < 0.0),
+                "seed={seed} should exercise signed Boost scores"
+            );
+            let must_not_scores = exhaustive_compound_scores(&plans[5].1, &leaves);
+            assert!(
+                canonical_row_addresses[..8]
+                    .iter()
+                    .all(|row_address| !must_not_scores.contains_key(row_address))
+                    && canonical_row_addresses[8..16]
+                        .iter()
+                        .all(|row_address| must_not_scores.contains_key(row_address)),
+                "seed={seed} should exercise both prohibited and retained candidates"
+            );
+
+            for (shape, plan) in &plans {
+                for limit in [1, 3, 7] {
+                    let expected = exhaustive_compound_top_k(plan, &leaves, limit);
+                    let metrics = ShouldMetrics::default();
+                    let mut mapped_leaves = leaves
+                        .iter()
+                        .map(|leaf| {
+                            Some(randomized_mapped_leaf(
+                                leaf,
+                                &canonical_row_addresses,
+                                &mut rng,
+                            ))
+                        })
+                        .collect::<Vec<_>>();
+                    let mut scorer = plan.build(&mut mapped_leaves, &metrics).unwrap();
+                    assert!(mapped_leaves.iter().all(Option::is_none));
+                    let actual = TopKCollector::new(limit).collect(scorer.as_mut()).unwrap();
+                    assert_eq!(actual, expected, "seed={seed} shape={shape} limit={limit}");
+                }
+            }
+        }
     }
 
     #[test]

--- a/rust/lance-index/src/scalar/inverted/cross_column.rs
+++ b/rust/lance-index/src/scalar/inverted/cross_column.rs
@@ -1,0 +1,2151 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+//! Posting-backed compound FTS over more than one indexed column.
+//!
+//! A partition-local FTS scorer iterates `DocId`s, but `DocId` is only stable
+//! within one partition of one column.  This module maps every leaf source to
+//! the dataset row-address domain before composing the query.  Consequently,
+//! columns may have different segment and partition boundaries without an
+//! intermediate hash join or a materialized result set per query node.
+
+use std::cmp::Ordering;
+use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
+
+use futures::{StreamExt, TryStreamExt, stream};
+use lance_core::utils::tokio::{get_num_compute_intensive_cpus, spawn_cpu};
+use lance_core::{Error, Result};
+use lance_select::RowAddrMask;
+use roaring::{RoaringBitmap, RoaringTreemap};
+
+use super::compound::{
+    BoxScorer, ComposableScorer, CompoundLeafPlanInput, CompoundPlanAnalysis, CompoundScorerPlan,
+    EmptyScorer, LeafQuery, MaterializedScorer, RowAddressMergeScorer, RowAddressSource,
+    ScoreBounds, ScoredRow, TopKCollector, collect_leaf_queries, expanded_leaf_tokens,
+    map_scorer_to_row_addresses, prepare_row_address_projection, tokenize_leaf,
+};
+use super::documents::{
+    DocId, DocLengths, DocVisibility, PartitionDocuments, ResidentAddressProjection,
+};
+use super::index::{InvertedPartition, PostingLoadOptions};
+use super::query::{FtsQuery, FtsSearchParams, Operator, Tokens};
+use super::scorer::MemBM25Scorer;
+use super::wand::{
+    FLAT_SEARCH_PERCENT_THRESHOLD, FlatDocuments, PostingIterator, WandCursor, WandDocuments,
+};
+use super::{DocInfo, DocumentGranularity, InvertedIndex};
+use crate::metrics::MetricsCollector;
+use crate::prefilter::PreFilter;
+
+const MAX_CONCURRENT_SOURCE_LOADS: usize = 32;
+
+/// Stage optional/prohibited source I/O only when the positive generator is
+/// expected to match at most this percentage of its column corpus.
+const MAX_STAGED_GENERATOR_PERCENT: usize = 1;
+
+/// Very small candidate sets are cheap enough to stage regardless of corpus
+/// size and keep the path useful for small shards.
+const MIN_STAGED_GENERATOR_CANDIDATES: usize = 128;
+
+/// Bound the row-address candidate buffer even for very large corpora.
+const MAX_STAGED_GENERATOR_CANDIDATES: usize = 1_000_000;
+
+struct PreparedCrossColumnLeaf {
+    column_ordinal: usize,
+    tokens_by_segment: Vec<Arc<Tokens>>,
+    params: Arc<FtsSearchParams>,
+    operator: Operator,
+    scorer: Arc<MemBM25Scorer>,
+}
+
+struct LoadedCrossColumnLeaf {
+    leaf_ordinal: usize,
+    postings: Vec<PostingIterator>,
+    params: Arc<FtsSearchParams>,
+    operator: Operator,
+    scorer: Arc<MemBM25Scorer>,
+}
+
+fn local_candidate_lower_bound(operator: Operator, postings: &[PostingIterator]) -> Option<u64> {
+    match operator {
+        Operator::Or => postings
+            .iter()
+            .filter_map(PostingIterator::current_doc_id)
+            .min(),
+        Operator::And => postings
+            .iter()
+            .map(PostingIterator::current_doc_id)
+            .try_fold(0, |lower_bound, doc| doc.map(|doc| lower_bound.max(doc))),
+    }
+}
+
+fn compare_leaf_mapping_priority(
+    left_leaf_ordinal: usize,
+    left_cost: usize,
+    right_leaf_ordinal: usize,
+    right_cost: usize,
+) -> Ordering {
+    right_cost
+        .cmp(&left_cost)
+        .then_with(|| left_leaf_ordinal.cmp(&right_leaf_ordinal))
+}
+
+struct LoadedCrossColumnSource {
+    num_docs: usize,
+    lengths: LoadedScoringLengths,
+    visibility: DocVisibility,
+    projection: ResidentAddressProjection,
+    leaves: Vec<LoadedCrossColumnLeaf>,
+}
+
+enum LoadedScoringLengths {
+    Dense(Arc<DocLengths>),
+    Sparse(Vec<ResolvedCandidateDocument>),
+}
+
+#[derive(Clone, Copy)]
+struct ResolvedCandidateDocument {
+    doc_id: u32,
+    row_address: u64,
+    scoring_length: u32,
+}
+
+struct LoadedGeneratorSource {
+    documents: Arc<PartitionDocuments>,
+    visibility: DocVisibility,
+    leaves: Vec<LoadedCrossColumnLeaf>,
+}
+
+/// Document view used by the two CPU phases of staged generation.
+///
+/// The membership pass supplies no lengths and runs with a negative WAND
+/// floor, so every exact match remains visible. The scoring pass supplies
+/// lengths only for selected generator candidates; non-selected posting docs
+/// use zero solely while they are advanced past and can never escape through
+/// `document_key`.
+#[derive(Clone, Copy)]
+enum ScoringLengths<'a> {
+    Missing,
+    Dense(&'a DocLengths),
+    Sparse(&'a [ResolvedCandidateDocument]),
+}
+
+struct StagedWandDocuments<'a> {
+    num_docs: usize,
+    visibility: &'a DocVisibility,
+    scoring_lengths: ScoringLengths<'a>,
+}
+
+impl StagedWandDocuments<'_> {
+    fn scoring_length(&self, doc_id: u32) -> u32 {
+        match self.scoring_lengths {
+            ScoringLengths::Missing => 0,
+            ScoringLengths::Dense(lengths) => lengths.scoring(DocId::new(doc_id)),
+            ScoringLengths::Sparse(documents) => documents
+                .binary_search_by_key(&doc_id, |document| document.doc_id)
+                .ok()
+                .map(|index| documents[index].scoring_length)
+                .unwrap_or_default(),
+        }
+    }
+
+    fn row_address(&self, doc_id: u32) -> Option<u64> {
+        let ScoringLengths::Sparse(documents) = self.scoring_lengths else {
+            return None;
+        };
+        documents
+            .binary_search_by_key(&doc_id, |document| document.doc_id)
+            .ok()
+            .map(|index| documents[index].row_address)
+    }
+}
+
+impl WandDocuments for StagedWandDocuments<'_> {
+    type Candidate = DocId;
+
+    fn len(&self) -> usize {
+        self.num_docs
+    }
+
+    fn visible_cost_upper_bound(&self) -> usize {
+        self.visibility.len(self.num_docs)
+    }
+
+    fn scoring_norms(&self) -> Option<&[u8]> {
+        match self.scoring_lengths {
+            ScoringLengths::Dense(lengths) => lengths.scoring_norms(),
+            ScoringLengths::Missing | ScoringLengths::Sparse(_) => None,
+        }
+    }
+
+    fn scoring_num_tokens(&self, doc_id: u32) -> u32 {
+        self.scoring_length(doc_id)
+    }
+
+    fn doc_length(&self, doc: &DocInfo) -> u32 {
+        match doc {
+            DocInfo::Raw(doc) => self.scoring_length(doc.doc_id),
+            DocInfo::Located(_) => unreachable!("modern posting lists contain dense DocIds"),
+        }
+    }
+
+    fn document_key(&self, doc: &DocInfo) -> Option<u64> {
+        match doc {
+            DocInfo::Raw(doc) if self.visibility.selected(DocId::new(doc.doc_id)) => {
+                Some(u64::from(doc.doc_id))
+            }
+            DocInfo::Raw(_) => None,
+            DocInfo::Located(_) => unreachable!("modern posting lists contain dense DocIds"),
+        }
+    }
+
+    fn document_key_for_doc_id(&self, doc_id: u32) -> Option<u64> {
+        self.visibility
+            .selected(DocId::new(doc_id))
+            .then_some(u64::from(doc_id))
+    }
+
+    fn candidate_from_key(&self, key: u64) -> Self::Candidate {
+        DocId::new(key as u32)
+    }
+
+    fn flat_documents(&self) -> Option<FlatDocuments<'_>> {
+        if matches!(self.scoring_lengths, ScoringLengths::Missing) {
+            return None;
+        }
+        self.visibility.iter().map(|doc_ids| {
+            let len = self.visibility.len(self.num_docs);
+            let docs = doc_ids.map(|doc_id| {
+                let value = u64::from(doc_id.get());
+                (value, value)
+            });
+            (len, Box::new(docs) as Box<dyn Iterator<Item = (u64, u64)>>)
+        })
+    }
+
+    fn flat_doc_length(&self, doc_id: u64, _document_key: u64, _compressed: bool) -> u32 {
+        u32::try_from(doc_id)
+            .ok()
+            .map(|doc_id| self.scoring_length(doc_id))
+            .unwrap_or_default()
+    }
+}
+
+#[derive(Clone)]
+struct SourceDescriptor {
+    column_ordinal: usize,
+    segment_ordinal: usize,
+    partition: Arc<InvertedPartition>,
+}
+
+fn staged_candidate_budget(num_docs: usize, limit: usize) -> usize {
+    let percentage_budget = num_docs
+        .saturating_mul(MAX_STAGED_GENERATOR_PERCENT)
+        .div_ceil(100);
+    percentage_budget.max(limit).clamp(
+        MIN_STAGED_GENERATOR_CANDIDATES,
+        MAX_STAGED_GENERATOR_CANDIDATES,
+    )
+}
+
+fn leaf_plan_input(leaf: &PreparedCrossColumnLeaf) -> Result<CompoundLeafPlanInput> {
+    let mut seen_terms = HashSet::<(u32, String)>::new();
+    let mut costs_by_position = HashMap::<u32, usize>::new();
+    for tokens in &leaf.tokens_by_segment {
+        for token_index in 0..tokens.len() {
+            let position = tokens.position(token_index);
+            let token = tokens.get_token(token_index);
+            if seen_terms.insert((position, token.to_owned())) {
+                let frequency = leaf.scorer.num_docs_containing_token(token);
+                let position_cost = costs_by_position.entry(position).or_default();
+                *position_cost = position_cost.saturating_add(frequency);
+            }
+        }
+    }
+
+    let requires_every_position =
+        leaf.operator == Operator::And || leaf.params.phrase_slop.is_some();
+    let possible = !costs_by_position.is_empty()
+        && if requires_every_position {
+            costs_by_position.values().all(|cost| *cost > 0)
+        } else {
+            costs_by_position.values().any(|cost| *cost > 0)
+        };
+    if !possible {
+        return Ok(CompoundLeafPlanInput::new(false, 0, ScoreBounds::ZERO));
+    }
+
+    // Position alternatives can overlap, so this is deliberately an upper
+    // estimate. Overestimating only disables staging; the actual candidate
+    // count is guarded independently before any probe source is skipped.
+    let cost = if requires_every_position {
+        costs_by_position.values().copied().min().unwrap_or(0)
+    } else {
+        costs_by_position
+            .values()
+            .copied()
+            .fold(0, usize::saturating_add)
+    }
+    .min(leaf.scorer.num_docs());
+    Ok(CompoundLeafPlanInput::new(
+        true,
+        cost,
+        ScoreBounds::try_new(0.0, f32::INFINITY)?,
+    ))
+}
+
+fn staged_generator(
+    analysis: &CompoundPlanAnalysis,
+    inputs: &[CompoundLeafPlanInput],
+    leaves: &[PreparedCrossColumnLeaf],
+    limit: usize,
+) -> Option<(Vec<usize>, usize)> {
+    if analysis.generator_leaves.is_empty() {
+        return None;
+    }
+    let generator_leaves = analysis
+        .generator_leaves
+        .iter()
+        .copied()
+        .collect::<HashSet<_>>();
+    if !inputs
+        .iter()
+        .enumerate()
+        .any(|(leaf_ordinal, input)| input.possible && !generator_leaves.contains(&leaf_ordinal))
+    {
+        return None;
+    }
+    let num_docs = analysis
+        .generator_leaves
+        .iter()
+        .map(|&leaf_ordinal| leaves.get(leaf_ordinal).map(|leaf| leaf.scorer.num_docs()))
+        .collect::<Option<Vec<_>>>()?
+        .into_iter()
+        .max()
+        .unwrap_or(0);
+    let candidate_budget = staged_candidate_budget(num_docs, limit);
+    (analysis.generator_cost <= candidate_budget)
+        .then_some((analysis.generator_leaves.clone(), candidate_budget))
+}
+
+fn query_state_is_prewarmed(
+    columns: &[(String, Vec<Arc<InvertedIndex>>)],
+    leaves: &[PreparedCrossColumnLeaf],
+) -> bool {
+    columns
+        .iter()
+        .enumerate()
+        .all(|(column_ordinal, (_, indices))| {
+            let with_position = leaves.iter().any(|leaf| {
+                leaf.column_ordinal == column_ordinal && leaf.params.phrase_slop.is_some()
+            });
+            indices
+                .iter()
+                .all(|index| index.prewarmed_query_state_ready(with_position))
+        })
+}
+
+fn leaf_column(leaf: &LeafQuery) -> Option<&str> {
+    match leaf {
+        LeafQuery::Match(query) => query.column.as_deref(),
+        LeafQuery::Phrase(query) => query.column.as_deref(),
+    }
+}
+
+fn validate_row_leaf_granularities(leaves: &[LeafQuery]) -> Result<()> {
+    for (leaf_ordinal, leaf) in leaves.iter().enumerate() {
+        let (leaf_kind, column, document_granularity) = match leaf {
+            LeafQuery::Match(query) => {
+                ("Match", query.column.as_deref(), query.document_granularity)
+            }
+            LeafQuery::Phrase(query) => (
+                "Phrase",
+                query.column.as_deref(),
+                query.document_granularity,
+            ),
+        };
+        if document_granularity == Some(DocumentGranularity::ListElement) {
+            let column = column.unwrap_or("<unspecified>");
+            return Err(Error::invalid_input(format!(
+                "cross-column compound FTS {leaf_kind} leaf {leaf_ordinal} for column '{column}' requested ListElement document granularity, but only Row is supported"
+            )));
+        }
+    }
+    Ok(())
+}
+
+/// Validate the query-local column domain and return the input column ordinal
+/// for every query leaf.  Keeping this separate from index validation makes it
+/// possible to test plan/leaf alignment without constructing index fixtures.
+fn resolve_leaf_columns(column_names: &[String], leaves: &[LeafQuery]) -> Result<Vec<usize>> {
+    if column_names.len() < 2 {
+        return Err(Error::invalid_input(
+            "cross-column compound FTS requires at least two columns",
+        ));
+    }
+
+    let mut columns_by_name = HashMap::with_capacity(column_names.len());
+    for (column_ordinal, column) in column_names.iter().enumerate() {
+        if column.is_empty() {
+            return Err(Error::invalid_input(
+                "cross-column compound FTS column names cannot be empty",
+            ));
+        }
+        if columns_by_name
+            .insert(column.as_str(), column_ordinal)
+            .is_some()
+        {
+            return Err(Error::invalid_input(format!(
+                "cross-column compound FTS received duplicate column '{column}'"
+            )));
+        }
+    }
+
+    let mut referenced_columns = HashSet::with_capacity(column_names.len());
+    let mut leaf_columns = Vec::with_capacity(leaves.len());
+    for (leaf_ordinal, leaf) in leaves.iter().enumerate() {
+        let column = leaf_column(leaf).ok_or_else(|| {
+            Error::invalid_input(format!(
+                "cross-column compound FTS leaf {leaf_ordinal} is missing a column"
+            ))
+        })?;
+        let column_ordinal = columns_by_name.get(column).copied().ok_or_else(|| {
+            Error::invalid_input(format!(
+                "cross-column compound FTS leaf {leaf_ordinal} references column '{column}', which has no supplied index"
+            ))
+        })?;
+        referenced_columns.insert(column_ordinal);
+        leaf_columns.push(column_ordinal);
+    }
+
+    if referenced_columns.len() != column_names.len() {
+        let unused = column_names
+            .iter()
+            .enumerate()
+            .filter(|(ordinal, _)| !referenced_columns.contains(ordinal))
+            .map(|(_, column)| column.as_str())
+            .collect::<Vec<_>>();
+        return Err(Error::invalid_input(format!(
+            "cross-column compound FTS received indices for unreferenced columns: {}",
+            unused.join(", ")
+        )));
+    }
+
+    Ok(leaf_columns)
+}
+
+fn validate_modern_row_indices(columns: &[(String, Vec<Arc<InvertedIndex>>)]) -> Result<()> {
+    for (column, indices) in columns {
+        if indices.is_empty() {
+            return Err(Error::invalid_input(format!(
+                "cross-column compound FTS column '{column}' has no index segments"
+            )));
+        }
+        for (segment_ordinal, index) in indices.iter().enumerate() {
+            if index.is_legacy() {
+                return Err(Error::invalid_input(format!(
+                    "cross-column compound FTS requires modern indices, but column '{column}' segment {segment_ordinal} is legacy"
+                )));
+            }
+            for (partition_ordinal, partition) in index.partitions.iter().enumerate() {
+                if partition.docs.modern().is_none() {
+                    return Err(Error::invalid_input(format!(
+                        "cross-column compound FTS requires modern documents, but column '{column}' segment {segment_ordinal} partition {partition_ordinal} is legacy"
+                    )));
+                }
+                if partition.docs.coordinate_rank() != 0 {
+                    return Err(Error::invalid_input(format!(
+                        "cross-column compound FTS only supports row documents, but column '{column}' segment {segment_ordinal} partition {partition_ordinal} has coordinate rank {}",
+                        partition.docs.coordinate_rank()
+                    )));
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+async fn build_column_scorer(
+    indices: &[Arc<InvertedIndex>],
+    terms: Vec<String>,
+    metrics: Arc<dyn MetricsCollector>,
+) -> Result<Arc<MemBM25Scorer>> {
+    let terms = Arc::new(terms);
+    let parallelism = get_num_compute_intensive_cpus()
+        .clamp(1, MAX_CONCURRENT_SOURCE_LOADS)
+        .min(indices.len().max(1));
+    let stats = stream::iter(indices.iter().cloned().map(|index| {
+        let terms = terms.clone();
+        let metrics = metrics.clone();
+        async move {
+            index
+                .bm25_stats_for_terms(terms.as_ref(), Some(metrics.as_ref()))
+                .await
+        }
+    }))
+    .buffer_unordered(parallelism)
+    .try_collect::<Vec<_>>()
+    .await?;
+
+    let mut total_tokens = 0_u64;
+    let mut num_docs = 0_usize;
+    let mut term_doc_freqs = vec![0_usize; terms.len()];
+    for (segment_total_tokens, segment_num_docs, segment_term_doc_freqs) in stats {
+        if segment_term_doc_freqs.len() != terms.len() {
+            return Err(Error::internal(format!(
+                "FTS segment returned {} document frequencies for {} requested terms",
+                segment_term_doc_freqs.len(),
+                terms.len()
+            )));
+        }
+        total_tokens = total_tokens
+            .checked_add(segment_total_tokens)
+            .ok_or_else(|| Error::index("cross-column FTS corpus token count overflows u64"))?;
+        num_docs = num_docs.checked_add(segment_num_docs).ok_or_else(|| {
+            Error::index("cross-column FTS corpus document count overflows usize")
+        })?;
+        for (total, segment) in term_doc_freqs.iter_mut().zip(segment_term_doc_freqs) {
+            *total = total.checked_add(segment).ok_or_else(|| {
+                Error::index("cross-column FTS term document frequency overflows usize")
+            })?;
+        }
+    }
+
+    let token_docs = terms
+        .iter()
+        .cloned()
+        .zip(term_doc_freqs)
+        .collect::<HashMap<_, _>>();
+    Ok(Arc::new(MemBM25Scorer::new(
+        total_tokens,
+        num_docs,
+        token_docs,
+    )))
+}
+
+async fn prepare_column_leaves(
+    column_ordinal: usize,
+    indices: &[Arc<InvertedIndex>],
+    leaf_queries: &[(usize, LeafQuery)],
+    params: &FtsSearchParams,
+    metrics: Arc<dyn MetricsCollector>,
+) -> Result<Vec<(usize, PreparedCrossColumnLeaf)>> {
+    let first_index = indices.first().ok_or_else(|| {
+        Error::invalid_input("cross-column compound FTS requires at least one index segment")
+    })?;
+    let mut leaf_metadata = Vec::with_capacity(leaf_queries.len());
+    let mut union_terms = Vec::new();
+    let mut seen_terms = HashSet::new();
+
+    for (leaf_ordinal, leaf) in leaf_queries {
+        let effective_params = leaf.effective_params(params);
+        let tokens = tokenize_leaf(first_index, leaf, &effective_params);
+        let tokens_by_segment = indices
+            .iter()
+            .map(|index| {
+                expanded_leaf_tokens(index, &tokens, &effective_params, leaf.operator())
+                    .map(Arc::new)
+            })
+            .collect::<Result<Vec<_>>>()?;
+        for tokens in &tokens_by_segment {
+            for token in tokens.as_ref() {
+                if seen_terms.insert(token.clone()) {
+                    union_terms.push(token.clone());
+                }
+            }
+        }
+        leaf_metadata.push((
+            *leaf_ordinal,
+            tokens_by_segment,
+            Arc::new(effective_params),
+            leaf.operator(),
+        ));
+    }
+
+    // One union-term scorer per column means every leaf shares the same corpus
+    // totals and the index metadata for each segment is fetched only once.
+    let scorer = build_column_scorer(indices, union_terms, metrics).await?;
+
+    Ok(leaf_metadata
+        .into_iter()
+        .map(|(leaf_ordinal, tokens_by_segment, params, operator)| {
+            (
+                leaf_ordinal,
+                PreparedCrossColumnLeaf {
+                    column_ordinal,
+                    tokens_by_segment,
+                    params,
+                    operator,
+                    scorer: scorer.clone(),
+                },
+            )
+        })
+        .collect())
+}
+
+fn viable_leaf_ordinals(
+    column_ordinal: usize,
+    segment_ordinal: usize,
+    partition: &InvertedPartition,
+    prepared_leaves: &[PreparedCrossColumnLeaf],
+    leaf_ordinals: &[usize],
+) -> Result<Vec<usize>> {
+    let mut viable_leaf_ordinals = Vec::with_capacity(leaf_ordinals.len());
+    for &leaf_ordinal in leaf_ordinals {
+        let leaf = prepared_leaves.get(leaf_ordinal).ok_or_else(|| {
+            Error::internal(format!(
+                "cross-column FTS source references missing leaf {leaf_ordinal}"
+            ))
+        })?;
+        if leaf.column_ordinal != column_ordinal {
+            return Err(Error::internal(format!(
+                "cross-column FTS leaf {leaf_ordinal} belongs to column {}, not {column_ordinal}",
+                leaf.column_ordinal
+            )));
+        }
+        let tokens = leaf.tokens_by_segment.get(segment_ordinal).ok_or_else(|| {
+            Error::internal(format!(
+                "cross-column FTS leaf {leaf_ordinal} has no tokens for segment {segment_ordinal}"
+            ))
+        })?;
+        if partition.may_match_tokens(
+            tokens.as_ref(),
+            leaf.operator,
+            leaf.params.phrase_slop.is_some(),
+        ) {
+            viable_leaf_ordinals.push(leaf_ordinal);
+        }
+    }
+    Ok(viable_leaf_ordinals)
+}
+
+async fn load_source_leaves(
+    partition: Arc<InvertedPartition>,
+    segment_ordinal: usize,
+    viable_leaf_ordinals: Vec<usize>,
+    prepared_leaves: Arc<Vec<PreparedCrossColumnLeaf>>,
+    metrics: Arc<dyn MetricsCollector>,
+) -> Result<Vec<LoadedCrossColumnLeaf>> {
+    let leaf_parallelism = partition
+        .store()
+        .io_parallelism()
+        .max(1)
+        .min(viable_leaf_ordinals.len());
+    let leaves = stream::iter(viable_leaf_ordinals.into_iter().map(|leaf_ordinal| {
+        let partition = partition.clone();
+        let prepared_leaves = prepared_leaves.clone();
+        let metrics = metrics.clone();
+        async move {
+            let leaf = prepared_leaves.get(leaf_ordinal).ok_or_else(|| {
+                Error::internal(format!(
+                    "cross-column FTS source references missing leaf {leaf_ordinal}"
+                ))
+            })?;
+            let tokens = leaf.tokens_by_segment.get(segment_ordinal).ok_or_else(|| {
+                Error::internal(format!(
+                    "cross-column FTS leaf {leaf_ordinal} has no tokens for segment {segment_ordinal}"
+                ))
+            })?;
+            let postings = if tokens.is_empty() {
+                Vec::new()
+            } else {
+                partition
+                    .load_posting_lists_with_policy(
+                        tokens.as_ref(),
+                        leaf.params.as_ref(),
+                        leaf.operator,
+                        leaf.scorer.as_ref(),
+                        metrics.as_ref(),
+                        PostingLoadOptions::cache_aware_exact(true),
+                    )
+                    .await?
+                    .postings
+            };
+            Result::Ok(LoadedCrossColumnLeaf {
+                leaf_ordinal,
+                postings,
+                params: leaf.params.clone(),
+                operator: leaf.operator,
+                scorer: leaf.scorer.clone(),
+            })
+        }
+    }))
+    .buffer_unordered(leaf_parallelism)
+    .try_collect::<Vec<_>>()
+    .await?
+    .into_iter()
+    .filter(|leaf| !leaf.postings.is_empty())
+    .collect::<Vec<_>>();
+    Ok(leaves)
+}
+
+async fn source_visibility(
+    documents: &Arc<PartitionDocuments>,
+    mask: Arc<RowAddrMask>,
+) -> Result<DocVisibility> {
+    let materialize_selected = mask.max_len().is_some_and(|selected| {
+        u128::from(selected).saturating_mul(100)
+            <= u128::from(*FLAT_SEARCH_PERCENT_THRESHOLD).saturating_mul(documents.len() as u128)
+    });
+    match documents.immediate_visibility(mask.clone(), materialize_selected) {
+        Some(visibility) => Ok(visibility),
+        None => documents.visibility(mask, materialize_selected).await,
+    }
+}
+
+async fn load_masked_cross_column_source_for_leaves(
+    descriptor: SourceDescriptor,
+    prepared_leaves: Arc<Vec<PreparedCrossColumnLeaf>>,
+    leaf_ordinals: Vec<usize>,
+    mask: Arc<RowAddrMask>,
+    metrics: Arc<dyn MetricsCollector>,
+) -> Result<Option<LoadedCrossColumnSource>> {
+    let SourceDescriptor {
+        column_ordinal,
+        segment_ordinal,
+        partition,
+    } = descriptor;
+    let viable_leaf_ordinals = viable_leaf_ordinals(
+        column_ordinal,
+        segment_ordinal,
+        partition.as_ref(),
+        prepared_leaves.as_ref(),
+        &leaf_ordinals,
+    )?;
+    if viable_leaf_ordinals.is_empty() {
+        return Ok(None);
+    }
+
+    let documents = partition.docs.modern().cloned().ok_or_else(|| {
+        Error::internal("cross-column FTS source changed from modern to legacy documents")
+    })?;
+    let visibility = source_visibility(&documents, mask).await?;
+    if visibility.is_empty() {
+        return Ok(None);
+    }
+
+    // Visibility is resolved before posting reads so a filtered-out source
+    // never touches its posting payloads.
+    let leaves = load_source_leaves(
+        partition,
+        segment_ordinal,
+        viable_leaf_ordinals,
+        prepared_leaves,
+        metrics,
+    )
+    .await?;
+    if leaves.is_empty() {
+        return Ok(None);
+    }
+
+    // Only sources with at least one matching posting need scoring lengths or
+    // row-address projection. These independent document columns load once and
+    // in parallel.
+    let lengths = async {
+        match documents.cached_lengths() {
+            Some(lengths) => Ok(lengths),
+            None => documents.lengths().await,
+        }
+    };
+    let projection = documents.address_projection();
+    let (lengths, projection) = futures::try_join!(lengths, projection)?;
+
+    Ok(Some(LoadedCrossColumnSource {
+        num_docs: documents.len(),
+        lengths: LoadedScoringLengths::Dense(lengths),
+        visibility,
+        projection,
+        leaves,
+    }))
+}
+
+async fn load_masked_generator_source(
+    descriptor: SourceDescriptor,
+    prepared_leaves: Arc<Vec<PreparedCrossColumnLeaf>>,
+    leaf_ordinals: Vec<usize>,
+    mask: Arc<RowAddrMask>,
+    metrics: Arc<dyn MetricsCollector>,
+) -> Result<Option<LoadedGeneratorSource>> {
+    let SourceDescriptor {
+        column_ordinal,
+        segment_ordinal,
+        partition,
+    } = descriptor;
+    let viable_leaf_ordinals = viable_leaf_ordinals(
+        column_ordinal,
+        segment_ordinal,
+        partition.as_ref(),
+        prepared_leaves.as_ref(),
+        &leaf_ordinals,
+    )?;
+    if viable_leaf_ordinals.is_empty() {
+        return Ok(None);
+    }
+
+    let documents = partition.docs.modern().cloned().ok_or_else(|| {
+        Error::internal("cross-column FTS source changed from modern to legacy documents")
+    })?;
+    let visibility = source_visibility(&documents, mask).await?;
+    if visibility.is_empty() {
+        return Ok(None);
+    }
+    let leaves = load_source_leaves(
+        partition,
+        segment_ordinal,
+        viable_leaf_ordinals,
+        prepared_leaves,
+        metrics,
+    )
+    .await?;
+    if leaves.is_empty() {
+        return Ok(None);
+    }
+    Ok(Some(LoadedGeneratorSource {
+        documents,
+        visibility,
+        leaves,
+    }))
+}
+
+async fn load_masked_cross_column_source(
+    descriptor: SourceDescriptor,
+    prepared_leaves: Arc<Vec<PreparedCrossColumnLeaf>>,
+    leaves_by_column: Arc<Vec<Vec<usize>>>,
+    mask: Arc<RowAddrMask>,
+    metrics: Arc<dyn MetricsCollector>,
+) -> Result<Option<LoadedCrossColumnSource>> {
+    let leaf_ordinals = leaves_by_column
+        .get(descriptor.column_ordinal)
+        .cloned()
+        .ok_or_else(|| Error::internal("cross-column FTS source references a missing column"))?;
+    load_masked_cross_column_source_for_leaves(
+        descriptor,
+        prepared_leaves,
+        leaf_ordinals,
+        mask,
+        metrics,
+    )
+    .await
+}
+
+async fn load_candidate_cross_column_source(
+    descriptor: SourceDescriptor,
+    prepared_leaves: Arc<Vec<PreparedCrossColumnLeaf>>,
+    leaves_by_column: Arc<Vec<Vec<usize>>>,
+    candidates: Arc<Vec<u64>>,
+    metrics: Arc<dyn MetricsCollector>,
+) -> Result<Option<LoadedCrossColumnSource>> {
+    let SourceDescriptor {
+        column_ordinal,
+        segment_ordinal,
+        partition,
+    } = descriptor;
+    let leaf_ordinals = leaves_by_column
+        .get(column_ordinal)
+        .ok_or_else(|| Error::internal("cross-column FTS source references a missing column"))?;
+    let viable_leaf_ordinals = viable_leaf_ordinals(
+        column_ordinal,
+        segment_ordinal,
+        partition.as_ref(),
+        prepared_leaves.as_ref(),
+        leaf_ordinals,
+    )?;
+    if viable_leaf_ordinals.is_empty() {
+        return Ok(None);
+    }
+
+    let documents = partition.docs.modern().cloned().ok_or_else(|| {
+        Error::internal("cross-column FTS source changed from modern to legacy documents")
+    })?;
+    let projection = documents.address_projection().await?;
+    let selected = projection
+        .select_sorted_addresses(candidates.as_slice())
+        .await?;
+    let candidate_doc_ids = selected.iter().map(DocId::new).collect::<Vec<_>>();
+    let visibility = DocVisibility::Selected(selected);
+    if visibility.is_empty() {
+        return Ok(None);
+    }
+
+    // Candidate projection is exact in this source's local DocId domain. Only
+    // a non-empty intersection is allowed to trigger posting or length I/O.
+    let leaves = load_source_leaves(
+        partition,
+        segment_ordinal,
+        viable_leaf_ordinals,
+        prepared_leaves,
+        metrics,
+    )
+    .await?;
+    if leaves.is_empty() {
+        return Ok(None);
+    }
+    let lengths = match documents.cached_lengths() {
+        Some(lengths) => LoadedScoringLengths::Dense(lengths),
+        None if documents.prefer_sparse_document_read(candidate_doc_ids.len()) => {
+            let resolved = documents
+                .resolve_scoring_documents(&candidate_doc_ids)
+                .await?
+                .into_iter()
+                .map(
+                    |(doc_id, row_address, scoring_length)| ResolvedCandidateDocument {
+                        doc_id,
+                        row_address,
+                        scoring_length,
+                    },
+                )
+                .collect();
+            LoadedScoringLengths::Sparse(resolved)
+        }
+        None => LoadedScoringLengths::Dense(documents.lengths().await?),
+    };
+
+    Ok(Some(LoadedCrossColumnSource {
+        num_docs: documents.len(),
+        lengths,
+        visibility,
+        projection,
+        leaves,
+    }))
+}
+
+struct StagedGeneratorCandidates {
+    addresses: Vec<u64>,
+    materialized_leaves: Vec<(usize, Vec<ScoredRow>)>,
+}
+
+struct LocalGeneratorLeaf {
+    leaf_ordinal: usize,
+    postings: Vec<PostingIterator>,
+    params: Arc<FtsSearchParams>,
+    operator: Operator,
+    scorer: Arc<MemBM25Scorer>,
+    candidate_docs: RoaringBitmap,
+}
+
+struct LocalGeneratorCandidates {
+    documents: Arc<PartitionDocuments>,
+    leaves: Vec<LocalGeneratorLeaf>,
+    candidate_docs: Vec<DocId>,
+}
+
+struct ResolvedGeneratorCandidates {
+    num_docs: usize,
+    leaves: Vec<LocalGeneratorLeaf>,
+    /// Sorted by local DocId.
+    documents: Vec<ResolvedCandidateDocument>,
+}
+
+fn collect_local_generator_candidates(
+    sources: Vec<LoadedGeneratorSource>,
+    generator_leaf_ordinals: Vec<usize>,
+    max_candidates: usize,
+    metrics: Arc<dyn MetricsCollector>,
+) -> Result<Option<Vec<LocalGeneratorCandidates>>> {
+    let mut materialized_row_count = 0_usize;
+    let generator_leaf_set = generator_leaf_ordinals
+        .iter()
+        .copied()
+        .collect::<HashSet<_>>();
+    let mut collected = Vec::with_capacity(sources.len());
+    for source in sources {
+        let documents = StagedWandDocuments {
+            num_docs: source.documents.len(),
+            visibility: &source.visibility,
+            scoring_lengths: ScoringLengths::Missing,
+        };
+        let mut candidate_docs = RoaringBitmap::new();
+        let mut collected_leaves = Vec::with_capacity(source.leaves.len());
+        for leaf in source.leaves {
+            if !generator_leaf_set.contains(&leaf.leaf_ordinal) {
+                return Err(Error::internal(format!(
+                    "staged cross-column FTS loaded non-generator leaf {}",
+                    leaf.leaf_ordinal
+                )));
+            }
+            let Some(local_document_lower_bound) =
+                local_candidate_lower_bound(leaf.operator, &leaf.postings)
+            else {
+                continue;
+            };
+            let score_postings = leaf
+                .postings
+                .iter()
+                .map(PostingIterator::fork_from_start)
+                .collect::<Vec<_>>();
+            let mut local_scorer = WandCursor::new(
+                leaf.operator,
+                leaf.postings,
+                &documents,
+                leaf.scorer.clone(),
+                leaf.params.as_ref(),
+                metrics.as_ref(),
+            );
+            let mut leaf_candidate_docs = RoaringBitmap::new();
+            let mut candidate = local_scorer.advance(local_document_lower_bound)?;
+            while let Some(local_doc) = candidate {
+                if local_scorer.matches()? {
+                    let local_doc = u32::try_from(local_doc).map_err(|_| {
+                        Error::index(format!(
+                            "staged cross-column FTS local document {local_doc} exceeds the modern u32 domain"
+                        ))
+                    })?;
+                    if leaf_candidate_docs.insert(local_doc) {
+                        materialized_row_count = materialized_row_count.saturating_add(1);
+                    }
+                    candidate_docs.insert(local_doc);
+                    if materialized_row_count > max_candidates {
+                        // A partial candidate set is never used. Returning
+                        // None makes the async caller run the complete eager
+                        // execution path.
+                        return Ok(None);
+                    }
+                }
+                candidate = local_scorer.next()?;
+            }
+            if !leaf_candidate_docs.is_empty() {
+                collected_leaves.push(LocalGeneratorLeaf {
+                    leaf_ordinal: leaf.leaf_ordinal,
+                    postings: score_postings,
+                    params: leaf.params,
+                    operator: leaf.operator,
+                    scorer: leaf.scorer,
+                    candidate_docs: leaf_candidate_docs,
+                });
+            }
+        }
+        if !candidate_docs.is_empty() {
+            collected.push(LocalGeneratorCandidates {
+                documents: source.documents,
+                leaves: collected_leaves,
+                candidate_docs: candidate_docs.iter().map(DocId::new).collect(),
+            });
+        }
+    }
+    Ok(Some(collected))
+}
+
+async fn resolve_generator_candidates(
+    source: LocalGeneratorCandidates,
+) -> Result<ResolvedGeneratorCandidates> {
+    let documents = source
+        .documents
+        .resolve_scoring_documents(&source.candidate_docs)
+        .await?
+        .into_iter()
+        .map(
+            |(doc_id, row_address, scoring_length)| ResolvedCandidateDocument {
+                doc_id,
+                row_address,
+                scoring_length,
+            },
+        )
+        .collect();
+    Ok(ResolvedGeneratorCandidates {
+        num_docs: source.documents.len(),
+        leaves: source.leaves,
+        documents,
+    })
+}
+
+fn score_generator_candidates(
+    sources: Vec<ResolvedGeneratorCandidates>,
+    generator_leaf_ordinals: Vec<usize>,
+    max_candidates: usize,
+    metrics: Arc<dyn MetricsCollector>,
+) -> Result<Option<StagedGeneratorCandidates>> {
+    let mut addresses = RoaringTreemap::new();
+    let mut materialized_row_count = 0_usize;
+    let mut scored_rows_by_leaf = generator_leaf_ordinals
+        .iter()
+        .map(|&leaf_ordinal| {
+            (
+                leaf_ordinal,
+                (
+                    RoaringTreemap::new(),
+                    Vec::with_capacity(max_candidates.min(MIN_STAGED_GENERATOR_CANDIDATES)),
+                ),
+            )
+        })
+        .collect::<HashMap<_, _>>();
+
+    for source in sources {
+        let mut source_address_owners = HashMap::<u64, u32>::new();
+        for leaf in source.leaves {
+            let visibility = DocVisibility::Selected(leaf.candidate_docs.clone());
+            let documents = StagedWandDocuments {
+                num_docs: source.num_docs,
+                visibility: &visibility,
+                scoring_lengths: ScoringLengths::Sparse(&source.documents),
+            };
+            let expected_matches = leaf.candidate_docs.len();
+            let mut actual_matches = 0_u64;
+            let mut local_scorer = WandCursor::new(
+                leaf.operator,
+                leaf.postings,
+                &documents,
+                leaf.scorer,
+                leaf.params.as_ref(),
+                metrics.as_ref(),
+            );
+            for local_doc in leaf.candidate_docs.iter() {
+                let positioned = local_scorer.advance(u64::from(local_doc))?;
+                if positioned != Some(u64::from(local_doc)) || !local_scorer.matches()? {
+                    return Err(Error::internal(format!(
+                        "staged cross-column FTS could not reproduce generator leaf {} candidate {local_doc}",
+                        leaf.leaf_ordinal
+                    )));
+                }
+                let row_address = documents.row_address(local_doc).ok_or_else(|| {
+                    Error::internal(format!(
+                        "staged cross-column FTS did not resolve generator local document {local_doc}"
+                    ))
+                })?;
+                if let Some(existing_doc) = source_address_owners.insert(row_address, local_doc)
+                    && existing_doc != local_doc
+                {
+                    return Err(Error::index(format!(
+                        "invalid FTS row-address projection: row address {row_address} is shared by local documents {existing_doc} and {local_doc}"
+                    )));
+                }
+                let (leaf_addresses, scored_rows) = scored_rows_by_leaf
+                    .get_mut(&leaf.leaf_ordinal)
+                    .ok_or_else(|| {
+                        Error::internal(format!(
+                            "staged cross-column FTS lost generator leaf {}",
+                            leaf.leaf_ordinal
+                        ))
+                    })?;
+                if !leaf_addresses.insert(row_address) {
+                    return Err(Error::internal(format!(
+                        "cross-column FTS generator leaf {} produced duplicate row address {row_address}",
+                        leaf.leaf_ordinal
+                    )));
+                }
+                scored_rows.push(ScoredRow {
+                    row_id: row_address,
+                    score: local_scorer.score()?,
+                });
+                materialized_row_count = materialized_row_count.saturating_add(1);
+                addresses.insert(row_address);
+                actual_matches += 1;
+                if addresses.len() > max_candidates as u64
+                    || materialized_row_count > max_candidates
+                {
+                    return Ok(None);
+                }
+            }
+            if actual_matches != expected_matches {
+                return Err(Error::internal(format!(
+                    "staged cross-column FTS rescored {actual_matches} of {expected_matches} candidates for generator leaf {}",
+                    leaf.leaf_ordinal
+                )));
+            }
+        }
+    }
+    let mut materialized_leaves = scored_rows_by_leaf
+        .into_iter()
+        .map(|(leaf_ordinal, (_, mut rows))| {
+            rows.sort_unstable_by_key(|row| row.row_id);
+            (leaf_ordinal, rows)
+        })
+        .collect::<Vec<_>>();
+    materialized_leaves.sort_unstable_by_key(|(leaf_ordinal, _)| *leaf_ordinal);
+    Ok(Some(StagedGeneratorCandidates {
+        addresses: addresses.into_iter().collect(),
+        materialized_leaves,
+    }))
+}
+
+struct SourceDocuments {
+    num_docs: usize,
+    lengths: LoadedScoringLengths,
+    visibility: DocVisibility,
+    projection: ResidentAddressProjection,
+}
+
+fn score_cross_column_sources(
+    sources: Vec<LoadedCrossColumnSource>,
+    plan: CompoundScorerPlan,
+    plan_bounds: ScoreBounds,
+    num_leaves: usize,
+    materialized_leaves: Vec<(usize, Vec<ScoredRow>)>,
+    limit: usize,
+    metrics: Arc<dyn MetricsCollector>,
+) -> Result<(Vec<u64>, Vec<f32>)> {
+    let mut source_documents = Vec::with_capacity(sources.len());
+    let mut source_leaves = Vec::with_capacity(sources.len());
+    for source in sources {
+        source_documents.push(SourceDocuments {
+            num_docs: source.num_docs,
+            lengths: source.lengths,
+            visibility: source.visibility,
+            projection: source.projection,
+        });
+        source_leaves.push(source.leaves);
+    }
+    let wand_documents = source_documents
+        .iter()
+        .map(|source| StagedWandDocuments {
+            num_docs: source.num_docs,
+            visibility: &source.visibility,
+            scoring_lengths: match &source.lengths {
+                LoadedScoringLengths::Dense(lengths) => ScoringLengths::Dense(lengths.as_ref()),
+                LoadedScoringLengths::Sparse(documents) => {
+                    ScoringLengths::Sparse(documents.as_slice())
+                }
+            },
+        })
+        .collect::<Vec<_>>();
+    let address_projections = source_documents
+        .iter()
+        .map(|source| prepare_row_address_projection(&source.projection))
+        .collect::<Vec<_>>();
+
+    let mut sources_by_leaf = (0..num_leaves)
+        .map(|_| Vec::<RowAddressSource<'_>>::new())
+        .collect::<Vec<_>>();
+    for (source_ordinal, leaves) in source_leaves.into_iter().enumerate() {
+        let mut local_scorers = Vec::with_capacity(leaves.len());
+        for leaf in leaves {
+            if leaf.postings.is_empty() {
+                continue;
+            }
+            let Some(local_document_lower_bound) =
+                local_candidate_lower_bound(leaf.operator, &leaf.postings)
+            else {
+                continue;
+            };
+            let local_scorer: BoxScorer<'_> = Box::new(WandCursor::new(
+                leaf.operator,
+                leaf.postings,
+                &wand_documents[source_ordinal],
+                leaf.scorer,
+                leaf.params.as_ref(),
+                metrics.as_ref(),
+            ));
+            let cost = local_scorer.cost();
+            local_scorers.push((
+                leaf.leaf_ordinal,
+                cost,
+                local_document_lower_bound,
+                local_scorer,
+            ));
+        }
+
+        // A dense leaf validates an unknown projection once and caches the
+        // ordered result for sparse siblings. Mapping high-cost leaves first
+        // therefore avoids materializing sparse leaves before that validation.
+        local_scorers.sort_unstable_by(|left, right| {
+            compare_leaf_mapping_priority(left.0, left.1, right.0, right.1)
+        });
+        for (leaf_ordinal, _, local_document_lower_bound, local_scorer) in local_scorers {
+            let Some(address_source) = map_scorer_to_row_addresses(
+                local_scorer,
+                &address_projections[source_ordinal],
+                local_document_lower_bound,
+            )?
+            else {
+                continue;
+            };
+            sources_by_leaf
+                .get_mut(leaf_ordinal)
+                .ok_or_else(|| {
+                    Error::internal(format!(
+                        "cross-column FTS loaded unexpected leaf {}",
+                        leaf_ordinal
+                    ))
+                })?
+                .push(address_source);
+        }
+    }
+    // Materialized fallbacks retain a source-wide collision map only while
+    // sibling leaves are being mapped. Scorers no longer borrow this state.
+    drop(address_projections);
+
+    let mut materialized_leaf_ordinals = vec![false; num_leaves];
+    for (leaf_ordinal, _) in &materialized_leaves {
+        let materialized = materialized_leaf_ordinals
+            .get_mut(*leaf_ordinal)
+            .ok_or_else(|| {
+                Error::internal(format!(
+                    "staged cross-column FTS materialized unexpected leaf {leaf_ordinal}"
+                ))
+            })?;
+        if std::mem::replace(materialized, true) {
+            return Err(Error::internal(format!(
+                "staged cross-column FTS materialized leaf {leaf_ordinal} more than once"
+            )));
+        }
+    }
+    let mut leaf_scorers = sources_by_leaf
+        .into_iter()
+        .enumerate()
+        .map(|(leaf_ordinal, mut sources)| {
+            if materialized_leaf_ordinals[leaf_ordinal] {
+                if !sources.is_empty() {
+                    return Err(Error::internal(format!(
+                        "staged cross-column FTS loaded materialized generator leaf {leaf_ordinal} twice"
+                    )));
+                }
+                return Ok(None);
+            }
+            let scorer: BoxScorer<'_> = match sources.len() {
+                0 => Box::new(EmptyScorer),
+                1 => sources
+                    .pop()
+                    .ok_or_else(|| Error::internal("cross-column FTS lost its only leaf source"))?
+                    .into_scorer(),
+                _ => Box::new(RowAddressMergeScorer::try_new(sources)?),
+            };
+            Ok(Some(scorer))
+        })
+        .collect::<Result<Vec<_>>>()?;
+    for (leaf_ordinal, rows) in materialized_leaves {
+        let slot = leaf_scorers.get_mut(leaf_ordinal).ok_or_else(|| {
+            Error::internal(format!(
+                "staged cross-column FTS materialized unexpected leaf {leaf_ordinal}"
+            ))
+        })?;
+        debug_assert!(slot.is_none());
+        *slot = Some(Box::new(MaterializedScorer::try_new(rows)?));
+    }
+    let mut scorer = plan.build(&mut leaf_scorers, metrics.as_ref())?;
+    if leaf_scorers.iter().any(Option::is_some) {
+        return Err(Error::internal(
+            "cross-column compound FTS scorer did not consume every prepared leaf",
+        ));
+    }
+    let rows = TopKCollector::new(limit).collect(scorer.as_mut())?;
+    if let Some(row) = rows.iter().find(|row| !plan_bounds.contains(row.score)) {
+        return Err(Error::internal(format!(
+            "cross-column compound FTS score {} for row address {} escaped plan bounds {plan_bounds:?}",
+            row.score, row.row_id
+        )));
+    }
+    Ok(rows.into_iter().map(|row| (row.row_id, row.score)).unzip())
+}
+
+/// Internal cross-crate hook for a bounded compound FTS query over multiple
+/// indexed columns.
+///
+/// Each leaf is scored with corpus statistics from its own column.  Partition
+/// scorers are mapped to current row addresses and heap-merged before the
+/// Boolean/Boost/MultiMatch tree is composed, so one exact global collector
+/// owns both the competitive score and final row-address tie breaking.
+///
+/// Every Match and Phrase leaf must omit document granularity or request
+/// [`DocumentGranularity::Row`]. `columns` must contain at least two modern,
+/// row-document indices and every supplied column must be referenced. `params`
+/// must specify a bounded result limit. Invalid query or index shapes return
+/// [`Error::InvalidInput`]; list-element requests are rejected before any
+/// prefilter or index work begins.
+#[doc(hidden)]
+pub async fn cross_column_compound_search(
+    columns: &[(String, Vec<Arc<InvertedIndex>>)],
+    query: &FtsQuery,
+    params: &FtsSearchParams,
+    prefilter: Arc<dyn PreFilter>,
+    metrics: Arc<dyn MetricsCollector>,
+) -> Result<(Vec<u64>, Vec<f32>)> {
+    let mut leaf_queries = Vec::new();
+    collect_leaf_queries(query, &mut leaf_queries)?;
+    validate_row_leaf_granularities(&leaf_queries)?;
+
+    let limit = params.limit.ok_or_else(|| {
+        Error::invalid_input("cross-column compound FTS requires a bounded result limit")
+    })?;
+    if limit == 0 {
+        return Ok((Vec::new(), Vec::new()));
+    }
+
+    let column_names = columns
+        .iter()
+        .map(|(column, _)| column.clone())
+        .collect::<Vec<_>>();
+    let leaf_columns = resolve_leaf_columns(&column_names, &leaf_queries)?;
+    validate_modern_row_indices(columns)?;
+
+    let mut num_plan_leaves = 0;
+    let plan = CompoundScorerPlan::from_query(query, &mut num_plan_leaves)?;
+    if num_plan_leaves != leaf_queries.len() {
+        return Err(Error::internal(format!(
+            "cross-column compound FTS planned {num_plan_leaves} leaves but prepared {}",
+            leaf_queries.len()
+        )));
+    }
+
+    // The prefilter owns potentially asynchronous deletion/filter work. It is
+    // shared by every column but reaches readiness exactly once here. An empty
+    // filter avoids all token-statistics and posting I/O.
+    prefilter.wait_for_ready().await?;
+    let mask = prefilter.mask();
+    if mask.max_len() == Some(0) {
+        return Ok((Vec::new(), Vec::new()));
+    }
+
+    let mut queries_by_column = (0..columns.len())
+        .map(|_| Vec::<(usize, LeafQuery)>::new())
+        .collect::<Vec<_>>();
+    for (leaf_ordinal, (leaf, column_ordinal)) in
+        leaf_queries.into_iter().zip(leaf_columns).enumerate()
+    {
+        queries_by_column[column_ordinal].push((leaf_ordinal, leaf));
+    }
+
+    // Own the work items before building the stream. Besides keeping this
+    // future `Send`, it prevents borrowed iterator closure types from leaking
+    // into callers that box their execution stream.
+    let preparation_work = columns
+        .iter()
+        .enumerate()
+        .map(|(column_ordinal, (_, indices))| {
+            (
+                column_ordinal,
+                indices.clone(),
+                queries_by_column[column_ordinal].clone(),
+            )
+        })
+        .collect::<Vec<_>>();
+    let preparation_parallelism = get_num_compute_intensive_cpus()
+        .clamp(1, MAX_CONCURRENT_SOURCE_LOADS)
+        .min(preparation_work.len());
+    let prepared_by_column = stream::iter(preparation_work.into_iter().map(
+        |(column_ordinal, indices, leaf_queries)| {
+            let params = params.clone();
+            let metrics = metrics.clone();
+            async move {
+                prepare_column_leaves(column_ordinal, &indices, &leaf_queries, &params, metrics)
+                    .await
+            }
+        },
+    ))
+    .buffer_unordered(preparation_parallelism)
+    .try_collect::<Vec<_>>()
+    .await?;
+    let mut prepared_leaves = (0..num_plan_leaves)
+        .map(|_| None)
+        .collect::<Vec<Option<PreparedCrossColumnLeaf>>>();
+    for column_leaves in prepared_by_column {
+        for (leaf_ordinal, leaf) in column_leaves {
+            let slot = prepared_leaves.get_mut(leaf_ordinal).ok_or_else(|| {
+                Error::internal(format!(
+                    "cross-column FTS prepared unexpected leaf {leaf_ordinal}"
+                ))
+            })?;
+            if slot.replace(leaf).is_some() {
+                return Err(Error::internal(format!(
+                    "cross-column FTS prepared leaf {leaf_ordinal} more than once"
+                )));
+            }
+        }
+    }
+    let prepared_leaves = prepared_leaves
+        .into_iter()
+        .enumerate()
+        .map(|(leaf_ordinal, leaf)| {
+            leaf.ok_or_else(|| {
+                Error::internal(format!(
+                    "cross-column FTS did not prepare leaf {leaf_ordinal}"
+                ))
+            })
+        })
+        .collect::<Result<Vec<_>>>()?;
+    let plan_inputs = prepared_leaves
+        .iter()
+        .map(leaf_plan_input)
+        .collect::<Result<Vec<_>>>()?;
+    let plan_analysis = plan.analyze_leaves(&plan_inputs)?;
+    if !plan_analysis.possible {
+        return Ok((Vec::new(), Vec::new()));
+    }
+    // Staging trades a second bounded CPU pass for deferred cold I/O. Once an
+    // explicit prewarm has made every selected index query-ready, that trade is
+    // strictly worse: the original bounded coordinator can consume resident
+    // postings and document columns directly. The hint is checked without I/O;
+    // any mixed or uncertain state conservatively keeps the staged cold path.
+    let staged_generator = (!query_state_is_prewarmed(columns, &prepared_leaves))
+        .then(|| staged_generator(&plan_analysis, &plan_inputs, &prepared_leaves, limit))
+        .flatten();
+    let leaves_by_column = prepared_leaves.iter().enumerate().fold(
+        (0..columns.len()).map(|_| Vec::new()).collect::<Vec<_>>(),
+        |mut by_column, (leaf_ordinal, leaf)| {
+            by_column[leaf.column_ordinal].push(leaf_ordinal);
+            by_column
+        },
+    );
+
+    let prepared_leaves = Arc::new(prepared_leaves);
+    let leaves_by_column = Arc::new(leaves_by_column);
+    let descriptors = columns
+        .iter()
+        .enumerate()
+        .flat_map(|(column_ordinal, (_, indices))| {
+            indices
+                .iter()
+                .enumerate()
+                .flat_map(move |(segment_ordinal, index)| {
+                    index
+                        .partitions
+                        .iter()
+                        .cloned()
+                        .map(move |partition| SourceDescriptor {
+                            column_ordinal,
+                            segment_ordinal,
+                            partition,
+                        })
+                })
+        })
+        .collect::<Vec<_>>();
+    let parallelism = get_num_compute_intensive_cpus().clamp(1, MAX_CONCURRENT_SOURCE_LOADS);
+    let staged_candidates = if let Some((generator_leaf_ordinals, candidate_budget)) =
+        staged_generator
+    {
+        metrics.record_cross_column_staged_attempts(1);
+        let generator_leaf_set = generator_leaf_ordinals
+            .iter()
+            .copied()
+            .collect::<HashSet<_>>();
+        let generator_leaves_by_column = Arc::new(
+            leaves_by_column
+                .iter()
+                .map(|leaves| {
+                    leaves
+                        .iter()
+                        .copied()
+                        .filter(|leaf| generator_leaf_set.contains(leaf))
+                        .collect::<Vec<_>>()
+                })
+                .collect::<Vec<_>>(),
+        );
+        let generator_descriptors = descriptors
+            .iter()
+            .filter(|descriptor| {
+                generator_leaves_by_column
+                    .get(descriptor.column_ordinal)
+                    .is_some_and(|leaves| !leaves.is_empty())
+            })
+            .cloned()
+            .collect::<Vec<_>>();
+        let generator_sources = stream::iter(generator_descriptors.into_iter().map(|descriptor| {
+            let leaf_ordinals = generator_leaves_by_column
+                .get(descriptor.column_ordinal)
+                .cloned()
+                .unwrap_or_default();
+            load_masked_generator_source(
+                descriptor,
+                prepared_leaves.clone(),
+                leaf_ordinals,
+                mask.clone(),
+                metrics.clone(),
+            )
+        }))
+        .buffer_unordered(parallelism)
+        .try_collect::<Vec<_>>()
+        .await?
+        .into_iter()
+        .flatten()
+        .collect::<Vec<_>>();
+        let candidate_metrics = metrics.clone();
+        let collection_leaf_ordinals = generator_leaf_ordinals.clone();
+        let local_candidates = spawn_cpu(move || {
+            collect_local_generator_candidates(
+                generator_sources,
+                collection_leaf_ordinals,
+                candidate_budget,
+                candidate_metrics,
+            )
+        })
+        .await?;
+        let staged = if let Some(local_candidates) = local_candidates {
+            let resolved = stream::iter(
+                local_candidates
+                    .into_iter()
+                    .map(resolve_generator_candidates),
+            )
+            .buffer_unordered(parallelism)
+            .try_collect::<Vec<_>>()
+            .await?;
+            let candidate_metrics = metrics.clone();
+            spawn_cpu(move || {
+                score_generator_candidates(
+                    resolved,
+                    generator_leaf_ordinals,
+                    candidate_budget,
+                    candidate_metrics,
+                )
+            })
+            .await?
+        } else {
+            None
+        };
+        match staged {
+            Some(candidates) => {
+                metrics.record_cross_column_staged_successes(1);
+                metrics.record_cross_column_staged_candidates(candidates.addresses.len());
+                Some(candidates)
+            }
+            None => {
+                metrics.record_cross_column_staged_fallbacks(1);
+                None
+            }
+        }
+    } else {
+        None
+    };
+
+    let (sources, materialized_leaves) = if let Some(candidates) = staged_candidates {
+        if candidates.addresses.is_empty() {
+            return Ok((Vec::new(), Vec::new()));
+        }
+        let StagedGeneratorCandidates {
+            addresses,
+            materialized_leaves,
+        } = candidates;
+        let generator_leaf_set = materialized_leaves
+            .iter()
+            .map(|(leaf_ordinal, _)| *leaf_ordinal)
+            .collect::<HashSet<_>>();
+        let candidates = Arc::new(addresses);
+        let deferred_leaves_by_column = Arc::new(
+            leaves_by_column
+                .iter()
+                .map(|leaves| {
+                    leaves
+                        .iter()
+                        .copied()
+                        .filter(|leaf| !generator_leaf_set.contains(leaf))
+                        .collect::<Vec<_>>()
+                })
+                .collect::<Vec<_>>(),
+        );
+        let sources = stream::iter(descriptors.into_iter().map(|descriptor| {
+            load_candidate_cross_column_source(
+                descriptor,
+                prepared_leaves.clone(),
+                deferred_leaves_by_column.clone(),
+                candidates.clone(),
+                metrics.clone(),
+            )
+        }))
+        .buffer_unordered(parallelism)
+        .try_collect::<Vec<_>>()
+        .await?
+        .into_iter()
+        .flatten()
+        .collect::<Vec<_>>();
+        (sources, materialized_leaves)
+    } else {
+        let sources = stream::iter(descriptors.into_iter().map(|descriptor| {
+            load_masked_cross_column_source(
+                descriptor,
+                prepared_leaves.clone(),
+                leaves_by_column.clone(),
+                mask.clone(),
+                metrics.clone(),
+            )
+        }))
+        .buffer_unordered(parallelism)
+        .try_collect::<Vec<_>>()
+        .await?
+        .into_iter()
+        .flatten()
+        .collect::<Vec<_>>();
+        (sources, Vec::new())
+    };
+
+    spawn_cpu(move || {
+        score_cross_column_sources(
+            sources,
+            plan,
+            plan_analysis.bounds,
+            num_plan_leaves,
+            materialized_leaves,
+            limit,
+            metrics,
+        )
+    })
+    .await
+}
+
+#[cfg(test)]
+mod tests {
+    use arrow::buffer::ScalarBuffer;
+
+    use super::*;
+    use crate::metrics::NoOpMetricsCollector;
+    use crate::prefilter::NoFilter;
+    use crate::scalar::inverted::encoding::compress_posting_list;
+    use crate::scalar::inverted::query::{
+        BooleanQuery, MatchQuery, MultiMatchQuery, Occur, PhraseQuery,
+    };
+    use crate::scalar::inverted::tokenizer::document_tokenizer::DocType;
+    use crate::scalar::inverted::{
+        CompressedPostingList, DocumentGranularity, LEGACY_BLOCK_SIZE, PlainPostingList,
+        PostingList, PostingTailCodec,
+    };
+
+    fn match_query(column: Option<&str>, terms: &str) -> FtsQuery {
+        FtsQuery::Match(
+            MatchQuery::new(terms.to_owned()).with_column(column.map(ToOwned::to_owned)),
+        )
+    }
+
+    fn posting(doc_ids: &[u64]) -> PostingIterator {
+        if doc_ids.is_empty() {
+            return PostingIterator::new(
+                "term".to_owned(),
+                0,
+                0,
+                PostingList::Plain(PlainPostingList::new(
+                    ScalarBuffer::from(Vec::<u64>::new()),
+                    ScalarBuffer::from(Vec::<f32>::new()),
+                    Some(0.0),
+                    None,
+                )),
+                100,
+            );
+        }
+        let doc_ids = doc_ids
+            .iter()
+            .map(|&doc_id| u32::try_from(doc_id).unwrap())
+            .collect::<Vec<_>>();
+        let frequencies = vec![1_u32; doc_ids.len()];
+        let blocks = compress_posting_list(
+            doc_ids.len(),
+            doc_ids.iter(),
+            frequencies.iter(),
+            vec![1.0; doc_ids.len()].into_iter(),
+        )
+        .unwrap();
+        PostingIterator::new(
+            "term".to_owned(),
+            0,
+            0,
+            PostingList::Compressed(CompressedPostingList::new(
+                blocks,
+                1.0,
+                doc_ids.len() as u32,
+                PostingTailCodec::VarintDelta,
+                LEGACY_BLOCK_SIZE,
+                None,
+                None,
+            )),
+            100,
+        )
+    }
+
+    fn prepared_leaf(
+        tokens_by_segment: Vec<Tokens>,
+        operator: Operator,
+        phrase_slop: Option<u32>,
+        num_docs: usize,
+        token_docs: impl IntoIterator<Item = (&'static str, usize)>,
+    ) -> PreparedCrossColumnLeaf {
+        PreparedCrossColumnLeaf {
+            column_ordinal: 0,
+            tokens_by_segment: tokens_by_segment.into_iter().map(Arc::new).collect(),
+            params: Arc::new(FtsSearchParams::new().with_phrase_slop(phrase_slop)),
+            operator,
+            scorer: Arc::new(MemBM25Scorer::new(
+                num_docs as u64,
+                num_docs,
+                token_docs
+                    .into_iter()
+                    .map(|(token, count)| (token.to_owned(), count))
+                    .collect(),
+            )),
+        }
+    }
+
+    fn loaded_generator_source(
+        leaf_ordinal: usize,
+        addresses: Vec<u64>,
+        matching_docs: &[u64],
+    ) -> ResolvedGeneratorCandidates {
+        let num_docs = addresses.len();
+        let candidate_docs = matching_docs
+            .iter()
+            .map(|&doc_id| u32::try_from(doc_id).unwrap())
+            .collect::<RoaringBitmap>();
+        ResolvedGeneratorCandidates {
+            num_docs,
+            documents: candidate_docs
+                .iter()
+                .map(|doc_id| ResolvedCandidateDocument {
+                    doc_id,
+                    row_address: addresses[doc_id as usize],
+                    scoring_length: 1,
+                })
+                .collect(),
+            leaves: vec![LoadedCrossColumnLeaf {
+                leaf_ordinal,
+                postings: vec![posting(matching_docs)],
+                params: Arc::new(FtsSearchParams::new()),
+                operator: Operator::Or,
+                scorer: Arc::new(MemBM25Scorer::new(
+                    num_docs as u64,
+                    num_docs,
+                    HashMap::from([("term".to_owned(), matching_docs.len())]),
+                )),
+            }]
+            .into_iter()
+            .map(|leaf| LocalGeneratorLeaf {
+                leaf_ordinal: leaf.leaf_ordinal,
+                postings: leaf.postings,
+                params: leaf.params,
+                operator: leaf.operator,
+                scorer: leaf.scorer,
+                candidate_docs: candidate_docs.clone(),
+            })
+            .collect(),
+        }
+    }
+
+    #[tokio::test]
+    async fn rejects_list_element_leaves_before_column_or_index_validation() {
+        let mut multi_match = MultiMatchQuery::try_new(
+            "term".to_owned(),
+            vec!["title".to_owned(), "body".to_owned()],
+        )
+        .unwrap();
+        multi_match.match_queries[1].document_granularity = Some(DocumentGranularity::ListElement);
+        let cases = [
+            (
+                "Match leaf 0 for column 'title'",
+                FtsQuery::Match(
+                    MatchQuery::new("term".to_owned())
+                        .with_column(Some("title".to_owned()))
+                        .with_document_granularity(DocumentGranularity::ListElement),
+                ),
+            ),
+            (
+                "Phrase leaf 0 for column 'body'",
+                FtsQuery::Phrase(
+                    PhraseQuery::new("two terms".to_owned())
+                        .with_column(Some("body".to_owned()))
+                        .with_document_granularity(DocumentGranularity::ListElement),
+                ),
+            ),
+            (
+                "Match leaf 1 for column 'body'",
+                FtsQuery::MultiMatch(multi_match),
+            ),
+        ];
+
+        for (leaf_context, query) in cases {
+            let error = cross_column_compound_search(
+                &[],
+                &query,
+                &FtsSearchParams::new().with_limit(Some(10)),
+                Arc::new(NoFilter),
+                Arc::new(NoOpMetricsCollector),
+            )
+            .await
+            .unwrap_err();
+
+            assert!(matches!(&error, Error::InvalidInput { .. }));
+            let message = error.to_string();
+            assert!(
+                message.contains(leaf_context),
+                "unexpected error: {message}"
+            );
+            assert!(
+                message.contains(
+                    "requested ListElement document granularity, but only Row is supported"
+                ),
+                "unexpected error: {message}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn permits_unspecified_and_row_leaf_granularity() {
+        for document_granularity in [None, Some(DocumentGranularity::Row)] {
+            let mut match_query =
+                MatchQuery::new("term".to_owned()).with_column(Some("title".to_owned()));
+            match_query.document_granularity = document_granularity;
+            let error = cross_column_compound_search(
+                &[],
+                &FtsQuery::Match(match_query),
+                &FtsSearchParams::new().with_limit(Some(10)),
+                Arc::new(NoFilter),
+                Arc::new(NoOpMetricsCollector),
+            )
+            .await
+            .unwrap_err();
+
+            assert!(matches!(&error, Error::InvalidInput { .. }));
+            assert!(error.to_string().contains("requires at least two columns"));
+        }
+    }
+
+    #[test]
+    fn derives_conservative_local_candidate_lower_bound() {
+        let postings = vec![posting(&[10, 20]), posting(&[5, 30])];
+        assert_eq!(
+            local_candidate_lower_bound(Operator::Or, &postings),
+            Some(5)
+        );
+        assert_eq!(
+            local_candidate_lower_bound(Operator::And, &postings),
+            Some(10)
+        );
+
+        let postings_with_empty = vec![posting(&[10]), posting(&[])];
+        assert_eq!(
+            local_candidate_lower_bound(Operator::Or, &postings_with_empty),
+            Some(10)
+        );
+        assert_eq!(
+            local_candidate_lower_bound(Operator::And, &postings_with_empty),
+            None
+        );
+    }
+
+    #[test]
+    fn maps_dense_leaves_before_sparse_siblings() {
+        let mut leaves = vec![(3, 10), (2, 100), (1, 10), (0, 100)];
+        leaves.sort_unstable_by(|left, right| {
+            compare_leaf_mapping_priority(left.0, left.1, right.0, right.1)
+        });
+
+        assert_eq!(leaves, vec![(0, 100), (2, 100), (1, 10), (3, 10)]);
+    }
+
+    #[test]
+    fn estimates_generator_cost_by_unique_query_positions() {
+        let tokens = Tokens::with_positions(
+            vec![
+                "rare".to_owned(),
+                "rare_alt".to_owned(),
+                "common".to_owned(),
+            ],
+            vec![0, 0, 1],
+            DocType::Text,
+        );
+        let leaf = prepared_leaf(
+            vec![tokens.clone(), tokens],
+            Operator::And,
+            None,
+            10_000,
+            [("rare", 7), ("rare_alt", 3), ("common", 1_000)],
+        );
+        let input = leaf_plan_input(&leaf).unwrap();
+        assert!(input.possible);
+        assert_eq!(input.cost, 10);
+        assert_eq!(input.bounds.lower(), 0.0);
+        assert_eq!(input.bounds.upper(), f32::INFINITY);
+
+        let missing = prepared_leaf(
+            vec![Tokens::with_positions(
+                vec!["rare".to_owned(), "missing".to_owned()],
+                vec![0, 1],
+                DocType::Text,
+            )],
+            Operator::And,
+            None,
+            10_000,
+            [("rare", 7), ("missing", 0)],
+        );
+        assert!(!leaf_plan_input(&missing).unwrap().possible);
+    }
+
+    #[test]
+    fn stages_only_selective_single_leaf_generators_with_probe_work() {
+        let leaves = vec![
+            prepared_leaf(
+                vec![Tokens::new(vec!["rare".to_owned()], DocType::Text)],
+                Operator::Or,
+                None,
+                10_000,
+                [("rare", 100)],
+            ),
+            prepared_leaf(
+                vec![Tokens::new(vec!["optional".to_owned()], DocType::Text)],
+                Operator::Or,
+                None,
+                10_000,
+                [("optional", 2_000)],
+            ),
+            prepared_leaf(
+                vec![Tokens::new(vec!["probe".to_owned()], DocType::Text)],
+                Operator::Or,
+                None,
+                10_000,
+                [("probe", 500)],
+            ),
+        ];
+        let inputs = leaves
+            .iter()
+            .map(leaf_plan_input)
+            .collect::<Result<Vec<_>>>()
+            .unwrap();
+        let analysis = CompoundPlanAnalysis {
+            possible: true,
+            bounds: ScoreBounds::UNBOUNDED,
+            generator_cost: 100,
+            generator_leaves: vec![0],
+        };
+        assert_eq!(
+            staged_generator(&analysis, &inputs, &leaves, 10),
+            Some((vec![0], 128))
+        );
+        let no_probe_inputs = vec![inputs[0]];
+        assert_eq!(
+            staged_generator(&analysis, &no_probe_inputs, &leaves[..1], 10),
+            None
+        );
+
+        let multi_generator = CompoundPlanAnalysis {
+            generator_cost: 100,
+            generator_leaves: vec![0, 1],
+            ..analysis
+        };
+        assert_eq!(
+            staged_generator(&multi_generator, &inputs, &leaves, 10),
+            Some((vec![0, 1], 128))
+        );
+
+        let too_dense = CompoundPlanAnalysis {
+            generator_cost: 129,
+            ..multi_generator
+        };
+        assert_eq!(staged_generator(&too_dense, &inputs, &leaves, 10), None);
+    }
+
+    #[test]
+    fn generator_collection_is_complete_and_overflow_falls_back() {
+        let make_sources = || {
+            vec![
+                loaded_generator_source(1, vec![10, 20, 30], &[0, 2]),
+                loaded_generator_source(1, vec![40, 50], &[1]),
+            ]
+        };
+        let metrics: Arc<dyn MetricsCollector> = Arc::new(NoOpMetricsCollector);
+        let candidates = score_generator_candidates(make_sources(), vec![1], 3, metrics.clone())
+            .unwrap()
+            .unwrap();
+        assert_eq!(candidates.addresses, vec![10, 30, 50]);
+        assert_eq!(candidates.materialized_leaves.len(), 1);
+        let (leaf_ordinal, scored_rows) = &candidates.materialized_leaves[0];
+        assert_eq!(*leaf_ordinal, 1);
+        assert_eq!(
+            scored_rows.iter().map(|row| row.row_id).collect::<Vec<_>>(),
+            vec![10, 30, 50]
+        );
+        assert!(
+            scored_rows
+                .iter()
+                .all(|row| row.score.is_finite() && row.score > 0.0)
+        );
+
+        assert!(
+            score_generator_candidates(make_sources(), vec![1], 2, metrics)
+                .unwrap()
+                .is_none(),
+            "overflow must abandon the entire staged candidate set"
+        );
+    }
+
+    #[test]
+    fn generator_collection_materializes_every_leaf_in_a_union_cover() {
+        let sources = vec![
+            loaded_generator_source(0, vec![10, 20], &[0]),
+            loaded_generator_source(1, vec![10, 20], &[0, 1]),
+        ];
+        let metrics: Arc<dyn MetricsCollector> = Arc::new(NoOpMetricsCollector);
+        let candidates = score_generator_candidates(sources, vec![0, 1], 3, metrics)
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(candidates.addresses, vec![10, 20]);
+        assert_eq!(
+            candidates
+                .materialized_leaves
+                .iter()
+                .map(|(leaf, rows)| {
+                    (*leaf, rows.iter().map(|row| row.row_id).collect::<Vec<_>>())
+                })
+                .collect::<Vec<_>>(),
+            vec![(0, vec![10]), (1, vec![10, 20])]
+        );
+    }
+
+    #[test]
+    fn generator_collection_rejects_same_leaf_duplicates_across_sources() {
+        let sources = vec![
+            loaded_generator_source(0, vec![10], &[0]),
+            loaded_generator_source(0, vec![10], &[0]),
+        ];
+        let metrics: Arc<dyn MetricsCollector> = Arc::new(NoOpMetricsCollector);
+
+        let Err(error) = score_generator_candidates(sources, vec![0], 2, metrics) else {
+            panic!("duplicate row addresses should be rejected");
+        };
+        assert!(
+            error
+                .to_string()
+                .contains("generator leaf 0 produced duplicate row address 10")
+        );
+    }
+
+    #[test]
+    fn resolves_leaf_columns_in_compound_plan_order() {
+        let query = FtsQuery::Boolean(BooleanQuery::new([
+            (Occur::Should, match_query(Some("body"), "optional")),
+            (
+                Occur::Must,
+                FtsQuery::Phrase(
+                    PhraseQuery::new("required phrase".to_owned())
+                        .with_column(Some("title".to_owned())),
+                ),
+            ),
+            (Occur::MustNot, match_query(Some("body"), "blocked")),
+        ]));
+        let mut leaves = Vec::new();
+        collect_leaf_queries(&query, &mut leaves).unwrap();
+
+        assert_eq!(
+            resolve_leaf_columns(&["title".to_owned(), "body".to_owned()], &leaves).unwrap(),
+            vec![1, 0, 1]
+        );
+        let mut num_plan_leaves = 0;
+        CompoundScorerPlan::from_query(&query, &mut num_plan_leaves).unwrap();
+        assert_eq!(num_plan_leaves, leaves.len());
+    }
+
+    #[test]
+    fn rejects_missing_duplicate_and_unreferenced_columns() {
+        let leaves = vec![LeafQuery::Match(
+            MatchQuery::new("term".to_owned()).with_column(Some("title".to_owned())),
+        )];
+
+        let error = resolve_leaf_columns(&["title".to_owned()], &leaves).unwrap_err();
+        assert!(error.to_string().contains("at least two columns"));
+
+        let error =
+            resolve_leaf_columns(&["title".to_owned(), "title".to_owned()], &leaves).unwrap_err();
+        assert!(error.to_string().contains("duplicate column 'title'"));
+
+        let error =
+            resolve_leaf_columns(&["title".to_owned(), "body".to_owned()], &leaves).unwrap_err();
+        assert!(error.to_string().contains("unreferenced columns: body"));
+    }
+
+    #[test]
+    fn rejects_leaf_without_a_supplied_column_index() {
+        let leaves = vec![LeafQuery::Match(MatchQuery::new("term".to_owned()))];
+        let error =
+            resolve_leaf_columns(&["title".to_owned(), "body".to_owned()], &leaves).unwrap_err();
+        assert!(error.to_string().contains("leaf 0 is missing a column"));
+
+        let leaves = vec![LeafQuery::Match(
+            MatchQuery::new("term".to_owned()).with_column(Some("summary".to_owned())),
+        )];
+        let error =
+            resolve_leaf_columns(&["title".to_owned(), "body".to_owned()], &leaves).unwrap_err();
+        assert!(error.to_string().contains("no supplied index"));
+    }
+}

--- a/rust/lance-index/src/scalar/inverted/documents.rs
+++ b/rust/lance-index/src/scalar/inverted/documents.rs
@@ -8,6 +8,7 @@
 //! never has to infer which value a numeric slot represents.
 
 use std::borrow::Cow;
+use std::sync::atomic::{AtomicU8, AtomicUsize, Ordering as AtomicOrdering};
 use std::sync::{Arc, OnceLock, Weak};
 
 use arc_swap::ArcSwapWeak;
@@ -33,6 +34,11 @@ use super::index::{
 
 /// Schema metadata key persisted in every modern `docs.lance` partition.
 pub(super) const TOTAL_TOKENS_KEY: &str = "total_tokens";
+
+/// Candidate-side document reads stay sparse below this share of a partition.
+/// Larger selections amortize one dense column read and populate the reusable
+/// document cache for subsequent queries.
+const SPARSE_DOCUMENT_READ_PERCENT: usize = 10;
 
 /// Dense, immutable document identity inside one FTS partition.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -254,7 +260,8 @@ impl AddressDocIdLookup {
             Some(live_docs) => live_docs.iter().collect::<Vec<_>>(),
             None => (0..projection.len() as u32).collect::<Vec<_>>(),
         };
-        doc_ids.sort_unstable_by_key(|&doc_id| projection.stored_address(doc_id as usize));
+        doc_ids
+            .sort_unstable_by_key(|&doc_id| (projection.stored_address(doc_id as usize), doc_id));
         Self::Sorted(doc_ids.into_boxed_slice())
     }
 
@@ -335,6 +342,29 @@ impl AddressDocIdLookup {
         selected
     }
 
+    fn matching_sorted_addresses(
+        &self,
+        projection: &ResidentAddressProjection,
+        addresses: &[u64],
+    ) -> std::result::Result<RoaringBitmap, RowAddressProjectionOrderError> {
+        let mut selected = RoaringBitmap::new();
+        for &address in addresses {
+            let first = self.partition_point(projection, |candidate| candidate < address);
+            let after_last = self.partition_point(projection, |candidate| candidate <= address);
+            if after_last.saturating_sub(first) > 1 {
+                return Err(RowAddressProjectionOrderError::Duplicate {
+                    first_doc_id: DocId::new(self.doc_id_at(first)),
+                    duplicate_doc_id: DocId::new(self.doc_id_at(first + 1)),
+                    address: RowAddress::new_from_u64(address),
+                });
+            }
+            if first < after_last {
+                selected.insert(self.doc_id_at(first));
+            }
+        }
+        Ok(selected)
+    }
+
     fn visibility(
         &self,
         projection: &ResidentAddressProjection,
@@ -362,6 +392,13 @@ pub(super) struct VersionAddressProjection {
     /// slot but are absent from this bitmap.
     live_docs: Option<RoaringBitmap>,
     doc_ids_by_address: OnceCell<Arc<AddressDocIdLookup>>,
+    ordered_validation: AtomicU8,
+    /// Upper-bound candidate work materialized while order is still unknown.
+    /// Once this exceeds the normal one-query flat-search budget, the next
+    /// mapper pays for one reusable ordered validation instead.
+    materialized_candidate_cost: AtomicUsize,
+    #[cfg(test)]
+    ordered_validation_visited_docs: AtomicUsize,
 }
 
 /// A query-scoped projection guard. Shared addresses remain alive only while
@@ -376,6 +413,318 @@ pub(super) struct ResidentAddressProjection {
 enum ResidentAddressValues {
     Shared(Arc<UInt64Array>),
     Owned(Arc<Vec<u64>>),
+}
+
+/// A row-granularity projection whose live row addresses are strictly ordered
+/// by partition-local document id.
+///
+/// Cross-column scorers can use this view to translate their local document
+/// domain into the shared row-address domain without materializing all hits.
+/// Construction deliberately rejects duplicate or descending live addresses;
+/// callers can distinguish those cases and select a materialized fallback.
+#[derive(Debug, Clone)]
+pub(super) struct OrderedRowAddressProjection {
+    projection: ResidentAddressProjection,
+}
+
+/// Why a resident address projection cannot be streamed in local DocId order.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum RowAddressProjectionOrderError {
+    Duplicate {
+        first_doc_id: DocId,
+        duplicate_doc_id: DocId,
+        address: RowAddress,
+    },
+    OutOfOrder {
+        previous_doc_id: DocId,
+        previous_address: RowAddress,
+        doc_id: DocId,
+        address: RowAddress,
+    },
+}
+
+/// Non-triggering view of the immutable ordered-validation cache.
+#[repr(u8)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum CachedRowAddressOrder {
+    Unknown = 0,
+    Ordered = 1,
+    Duplicate = 2,
+    OutOfOrder = 3,
+}
+
+impl CachedRowAddressOrder {
+    fn from_raw(value: u8) -> Self {
+        match value {
+            value if value == Self::Ordered as u8 => Self::Ordered,
+            value if value == Self::Duplicate as u8 => Self::Duplicate,
+            value if value == Self::OutOfOrder as u8 => Self::OutOfOrder,
+            value => {
+                debug_assert_eq!(
+                    value,
+                    Self::Unknown as u8,
+                    "ordered row-address validation cache contains invalid state {value}"
+                );
+                // Treat impossible/corrupt state as cold in release builds so
+                // callers safely recompute the immutable projection order.
+                Self::Unknown
+            }
+        }
+    }
+
+    fn from_validation(
+        validation: &std::result::Result<(), RowAddressProjectionOrderError>,
+    ) -> Self {
+        match validation {
+            Ok(()) => Self::Ordered,
+            Err(RowAddressProjectionOrderError::Duplicate { .. }) => Self::Duplicate,
+            Err(RowAddressProjectionOrderError::OutOfOrder { .. }) => Self::OutOfOrder,
+        }
+    }
+}
+
+impl std::fmt::Display for RowAddressProjectionOrderError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Duplicate {
+                first_doc_id,
+                duplicate_doc_id,
+                address,
+            } => write!(
+                formatter,
+                "row address {} is shared by local documents {} and {}",
+                u64::from(*address),
+                first_doc_id.get(),
+                duplicate_doc_id.get()
+            ),
+            Self::OutOfOrder {
+                previous_doc_id,
+                previous_address,
+                doc_id,
+                address,
+            } => write!(
+                formatter,
+                "row address {} for local document {} follows larger address {} for local document {}",
+                u64::from(*address),
+                doc_id.get(),
+                u64::from(*previous_address),
+                previous_doc_id.get()
+            ),
+        }
+    }
+}
+
+impl std::error::Error for RowAddressProjectionOrderError {}
+
+impl OrderedRowAddressProjection {
+    fn validate_doc_ids(
+        projection: &ResidentAddressProjection,
+        doc_ids: impl Iterator<Item = u32>,
+    ) -> std::result::Result<(), RowAddressProjectionOrderError> {
+        let mut previous = None;
+        for doc_id in doc_ids {
+            #[cfg(test)]
+            projection
+                .projection
+                .ordered_validation_visited_docs
+                .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+
+            let doc_id = DocId::new(doc_id);
+            let address = projection.stored_address(doc_id.as_usize());
+            if let Some((previous_doc_id, previous_address)) = previous {
+                if address == previous_address {
+                    return Err(RowAddressProjectionOrderError::Duplicate {
+                        first_doc_id: previous_doc_id,
+                        duplicate_doc_id: doc_id,
+                        address: RowAddress::new_from_u64(address),
+                    });
+                }
+                if address < previous_address {
+                    return Err(RowAddressProjectionOrderError::OutOfOrder {
+                        previous_doc_id,
+                        previous_address: RowAddress::new_from_u64(previous_address),
+                        doc_id,
+                        address: RowAddress::new_from_u64(address),
+                    });
+                }
+            }
+            previous = Some((doc_id, address));
+        }
+        Ok(())
+    }
+
+    fn validate(
+        projection: &ResidentAddressProjection,
+    ) -> std::result::Result<(), RowAddressProjectionOrderError> {
+        match projection.projection.live_docs.as_ref() {
+            Some(live_docs) => Self::validate_doc_ids(projection, live_docs.iter()),
+            None => Self::validate_doc_ids(projection, 0..projection.len() as u32),
+        }
+    }
+
+    fn try_new(
+        projection: &ResidentAddressProjection,
+    ) -> std::result::Result<Self, RowAddressProjectionOrderError> {
+        match projection.cached_row_address_order() {
+            CachedRowAddressOrder::Ordered => {}
+            CachedRowAddressOrder::Unknown => {
+                // Validation intentionally runs before the atomic publish. A
+                // racing query may repeat this work, but never waits for a
+                // query holding a lock while occupying a CPU worker.
+                let validation = projection.compute_ordered_validation();
+                projection.publish_ordered_validation(&validation);
+                validation?;
+            }
+            cached @ (CachedRowAddressOrder::Duplicate | CachedRowAddressOrder::OutOfOrder) => {
+                // The compact cache intentionally stores only the category.
+                // Reconstruct the exact diagnostics only for callers that ask
+                // for an ordered view after learning the projection is invalid.
+                let validation = projection.compute_ordered_validation();
+                debug_assert_eq!(CachedRowAddressOrder::from_validation(&validation), cached);
+                validation?;
+            }
+        }
+
+        Ok(Self {
+            projection: projection.clone(),
+        })
+    }
+
+    fn has_sparse_live_docs(&self) -> bool {
+        self.projection
+            .projection
+            .live_docs
+            .as_ref()
+            .is_some_and(|live_docs| live_docs.len() as usize != self.len())
+    }
+
+    fn doc_id_at(&self, position: usize) -> Option<u32> {
+        if self.has_sparse_live_docs() {
+            self.projection
+                .projection
+                .live_docs
+                .as_ref()?
+                .select(u32::try_from(position).ok()?)
+        } else {
+            let doc_id = u32::try_from(position).ok()?;
+            (position < self.len()).then_some(doc_id)
+        }
+    }
+
+    fn first_after(&self, local_doc: u64) -> Option<u32> {
+        let next_doc = u32::try_from(local_doc.checked_add(1)?).ok()?;
+        if self.has_sparse_live_docs() {
+            self.projection
+                .projection
+                .live_docs
+                .as_ref()?
+                .range(next_doc..)
+                .next()
+        } else {
+            ((next_doc as usize) < self.len()).then_some(next_doc)
+        }
+    }
+
+    /// Number of slots in the partition-local DocId domain, including deleted
+    /// slots. This is the terminal boundary used by shallow-advance mapping.
+    pub(super) fn len(&self) -> usize {
+        self.projection.len()
+    }
+
+    pub(super) fn live_len(&self) -> usize {
+        self.projection.live_len()
+    }
+
+    /// Inclusive minimum and maximum row addresses among live documents.
+    ///
+    /// Strict ordering makes this an O(1) lookup apart from sparse-bitmap
+    /// selection. Deleted DocId slots never contribute to the hull.
+    #[cfg(test)]
+    pub(super) fn live_address_hull(&self) -> Option<(u64, u64)> {
+        let first_doc_id = self.doc_id_at(0)?;
+        let last_position = self.live_len().checked_sub(1)?;
+        let last_doc_id = self.doc_id_at(last_position)?;
+        Some((
+            self.projection.stored_address(first_doc_id as usize),
+            self.projection.stored_address(last_doc_id as usize),
+        ))
+    }
+
+    /// Map sorted, deduplicated row-address candidates into live local DocIds.
+    ///
+    /// Each candidate uses binary search over live documents. Independent
+    /// lookups also keep the result exact if an internal caller accidentally
+    /// supplies duplicate or out-of-order candidates.
+    pub(super) fn select_sorted_addresses(&self, addresses: &[u64]) -> RoaringBitmap {
+        addresses
+            .iter()
+            .filter_map(|&address| {
+                let local_doc = self.lower_bound(address)?;
+                (self.address(local_doc) == Some(address)).then_some(local_doc as u32)
+            })
+            .collect()
+    }
+
+    /// Translate a live partition-local document into its row address.
+    pub(super) fn address(&self, local_doc: u64) -> Option<u64> {
+        let local_doc = u32::try_from(local_doc).ok()?;
+        if local_doc as usize >= self.len() {
+            return None;
+        }
+        self.projection.address(DocId::new(local_doc))
+    }
+
+    /// Return the first live local document whose row address is at least the
+    /// requested global row address.
+    pub(super) fn lower_bound(&self, global_row_address: u64) -> Option<u64> {
+        let mut left = 0;
+        let mut right = self.live_len();
+        while left < right {
+            let middle = left + (right - left) / 2;
+            let doc_id = self.doc_id_at(middle)?;
+            if self.projection.stored_address(doc_id as usize) < global_row_address {
+                left = middle + 1;
+            } else {
+                right = middle;
+            }
+        }
+        self.doc_id_at(left).map(u64::from)
+    }
+
+    /// Return the address of the first live document after `local_doc`.
+    ///
+    /// Deleted slots are skipped, so this can turn an inclusive local shallow
+    /// endpoint into an exclusive boundary in the shared row-address domain.
+    pub(super) fn next_address(&self, local_doc: u64) -> Option<u64> {
+        let next_doc = self.first_after(local_doc)?;
+        Some(self.projection.stored_address(next_doc as usize))
+    }
+}
+
+#[cfg(test)]
+pub(super) fn resident_row_address_projection_for_test(
+    addresses: Vec<u64>,
+) -> ResidentAddressProjection {
+    let projection = Arc::new(VersionAddressProjection {
+        addresses: AddressValues::Owned(Arc::new(addresses)),
+        live_docs: None,
+        doc_ids_by_address: OnceCell::new(),
+        ordered_validation: AtomicU8::new(CachedRowAddressOrder::Unknown as u8),
+        materialized_candidate_cost: AtomicUsize::new(0),
+        ordered_validation_visited_docs: AtomicUsize::new(0),
+    });
+    projection
+        .resident(None)
+        .expect("owned test row addresses must be resident")
+}
+
+#[cfg(test)]
+pub(super) fn ordered_row_address_projection_for_test(
+    addresses: Vec<u64>,
+) -> OrderedRowAddressProjection {
+    resident_row_address_projection_for_test(addresses)
+        .try_ordered_row_addresses()
+        .expect("test row addresses must be strictly increasing and unique")
 }
 
 impl DeepSizeOf for VersionAddressProjection {
@@ -419,6 +768,10 @@ impl VersionAddressProjection {
                 addresses: AddressValues::Shared { len: raw.len() },
                 live_docs: None,
                 doc_ids_by_address: OnceCell::new(),
+                ordered_validation: AtomicU8::new(CachedRowAddressOrder::Unknown as u8),
+                materialized_candidate_cost: AtomicUsize::new(0),
+                #[cfg(test)]
+                ordered_validation_visited_docs: AtomicUsize::new(0),
             });
         };
 
@@ -441,6 +794,10 @@ impl VersionAddressProjection {
             addresses: AddressValues::Owned(Arc::new(addresses)),
             live_docs: Some(live_docs),
             doc_ids_by_address: OnceCell::new(),
+            ordered_validation: AtomicU8::new(CachedRowAddressOrder::Unknown as u8),
+            materialized_candidate_cost: AtomicUsize::new(0),
+            #[cfg(test)]
+            ordered_validation_visited_docs: AtomicUsize::new(0),
         })
     }
 
@@ -468,6 +825,123 @@ impl VersionAddressProjection {
 impl ResidentAddressProjection {
     fn len(&self) -> usize {
         self.projection.addresses.len()
+    }
+
+    pub(super) fn live_len(&self) -> usize {
+        self.projection
+            .live_docs
+            .as_ref()
+            .map_or(self.len(), |live_docs| live_docs.len() as usize)
+    }
+
+    /// Inclusive minimum and maximum row addresses among live documents.
+    ///
+    /// Unlike [`OrderedRowAddressProjection::live_address_hull`], this scans
+    /// the live projection because remapping may reorder addresses. Deleted
+    /// DocId slots never contribute to the hull.
+    #[cfg(test)]
+    pub(super) fn live_address_hull(&self) -> Option<(u64, u64)> {
+        let mut hull: Option<(u64, u64)> = None;
+        let mut include_doc = |doc_id: u32| {
+            let address = self.stored_address(doc_id as usize);
+            hull = Some(match hull {
+                Some((minimum, maximum)) => (minimum.min(address), maximum.max(address)),
+                None => (address, address),
+            });
+        };
+        match self.projection.live_docs.as_ref() {
+            Some(live_docs) => live_docs.iter().for_each(&mut include_doc),
+            None => (0..self.len() as u32).for_each(include_doc),
+        }
+        hull
+    }
+
+    /// Decide whether another unknown-order source should be materialized.
+    ///
+    /// A single sparse query avoids an O(all documents) validation. Repeated
+    /// queries share this lock-free budget through the immutable version
+    /// projection, so materialization cannot remain the permanent execution
+    /// mode once its cumulative upper-bound cost exceeds one validation
+    /// threshold.
+    pub(super) fn should_materialize_unknown_projection(
+        &self,
+        source_cost: usize,
+        flat_search_percent_threshold: u64,
+    ) -> bool {
+        let mut current = self
+            .projection
+            .materialized_candidate_cost
+            .load(AtomicOrdering::Relaxed);
+        let cumulative_cost = loop {
+            let next = current.saturating_add(source_cost);
+            match self
+                .projection
+                .materialized_candidate_cost
+                .compare_exchange_weak(
+                    current,
+                    next,
+                    AtomicOrdering::Relaxed,
+                    AtomicOrdering::Relaxed,
+                ) {
+                Ok(_) => break next,
+                Err(observed) => current = observed,
+            }
+        };
+
+        (cumulative_cost as u128).saturating_mul(100)
+            <= u128::from(flat_search_percent_threshold).saturating_mul(self.live_len() as u128)
+    }
+
+    #[cfg(test)]
+    pub(super) fn ordered_validation_visited_docs(&self) -> usize {
+        self.projection
+            .ordered_validation_visited_docs
+            .load(std::sync::atomic::Ordering::Relaxed)
+    }
+
+    /// Inspect ordered-validation state without starting validation or waiting
+    /// for another query's validation.
+    pub(super) fn cached_row_address_order(&self) -> CachedRowAddressOrder {
+        CachedRowAddressOrder::from_raw(
+            self.projection
+                .ordered_validation
+                .load(AtomicOrdering::Acquire),
+        )
+    }
+
+    fn compute_ordered_validation(
+        &self,
+    ) -> std::result::Result<(), RowAddressProjectionOrderError> {
+        OrderedRowAddressProjection::validate(self)
+    }
+
+    fn publish_ordered_validation(
+        &self,
+        validation: &std::result::Result<(), RowAddressProjectionOrderError>,
+    ) {
+        let status = CachedRowAddressOrder::from_validation(validation);
+        // All validation work happened before this non-blocking publication.
+        // Immutable projections make racing results deterministic, so losing
+        // the compare-exchange requires no reconciliation or wait.
+        if let Err(observed) = self.projection.ordered_validation.compare_exchange(
+            CachedRowAddressOrder::Unknown as u8,
+            status as u8,
+            AtomicOrdering::Release,
+            AtomicOrdering::Relaxed,
+        ) {
+            debug_assert_eq!(
+                observed, status as u8,
+                "immutable row-address projection published conflicting validation states"
+            );
+        }
+    }
+
+    /// Validate that this row-granularity projection can be streamed in the
+    /// shared row-address domain.
+    pub(super) fn try_ordered_row_addresses(
+        &self,
+    ) -> std::result::Result<OrderedRowAddressProjection, RowAddressProjectionOrderError> {
+        OrderedRowAddressProjection::try_new(self)
     }
 
     fn stored_address(&self, index: usize) -> u64 {
@@ -509,6 +983,48 @@ impl ResidentAddressProjection {
             })
             .await
             .cloned()
+    }
+
+    /// Map sorted, deduplicated row-address candidates into live local DocIds.
+    ///
+    /// The reusable reverse lookup handles unordered remapped projections. A
+    /// candidate that resolves to multiple live DocIds is rejected as an
+    /// invalid FTS row-address projection instead of silently merging them.
+    /// The lookup is exact for any candidate order; sorting only avoids
+    /// redundant caller work.
+    pub(super) async fn select_sorted_addresses(&self, addresses: &[u64]) -> Result<RoaringBitmap> {
+        if addresses.is_empty() || self.live_len() == 0 {
+            return Ok(RoaringBitmap::new());
+        }
+
+        let ordered = match self.cached_row_address_order() {
+            CachedRowAddressOrder::Ordered => {
+                Some(self.try_ordered_row_addresses().map_err(|error| {
+                    Error::index(format!("invalid FTS row-address projection: {error}"))
+                })?)
+            }
+            CachedRowAddressOrder::OutOfOrder => None,
+            CachedRowAddressOrder::Unknown | CachedRowAddressOrder::Duplicate => {
+                let projection = self.clone();
+                match spawn_cpu(move || Result::Ok(projection.try_ordered_row_addresses())).await? {
+                    Ok(ordered) => Some(ordered),
+                    Err(error @ RowAddressProjectionOrderError::Duplicate { .. }) => {
+                        return Err(Error::index(format!(
+                            "invalid FTS row-address projection: {error}"
+                        )));
+                    }
+                    Err(RowAddressProjectionOrderError::OutOfOrder { .. }) => None,
+                }
+            }
+        };
+        if let Some(ordered) = ordered {
+            return Ok(ordered.select_sorted_addresses(addresses));
+        }
+
+        let lookup = self.doc_ids_by_address().await?;
+        lookup
+            .matching_sorted_addresses(self, addresses)
+            .map_err(|error| Error::index(format!("invalid FTS row-address projection: {error}")))
     }
 
     async fn materialize_visibility(self, mask: Arc<RowAddrMask>) -> Result<DocVisibility> {
@@ -1004,6 +1520,164 @@ impl PartitionDocuments {
             .iter()
             .map(|doc_id| row_ids.value(doc_id.as_usize()))
             .collect())
+    }
+
+    /// Load scoring document lengths for a bounded candidate set.
+    ///
+    /// The current format stores lengths in an independent dense column. Cold
+    /// selective staged queries read only candidate rows; resident or dense
+    /// queries reuse/populate the normal full-column cache. Returned values
+    /// exactly match [`DocLengths::scoring`], including the quantized V3 path.
+    pub(crate) async fn resolve_scoring_lengths(&self, doc_ids: &[DocId]) -> Result<Vec<u32>> {
+        if doc_ids.is_empty() {
+            return Ok(Vec::new());
+        }
+        self.validate_doc_ids(doc_ids)?;
+        if let Some(lengths) = self.cached_lengths() {
+            return Ok(doc_ids
+                .iter()
+                .map(|&doc_id| lengths.scoring(doc_id))
+                .collect());
+        }
+        if !self.prefer_sparse_document_read(doc_ids.len()) {
+            let lengths = self.lengths().await?;
+            return Ok(doc_ids
+                .iter()
+                .map(|&doc_id| lengths.scoring(doc_id))
+                .collect());
+        }
+
+        let ranges = doc_ids
+            .iter()
+            .map(|doc_id| {
+                let index = doc_id.as_usize();
+                index..index + 1
+            })
+            .collect::<Vec<_>>();
+        let batch = self
+            .reader()
+            .await?
+            .read_ranges(&ranges, Some(&[NUM_TOKEN_COL]))
+            .await?;
+        let lengths = required_u32_column(&batch, NUM_TOKEN_COL, &self.path)?;
+        if lengths.null_count() != 0 || lengths.len() != doc_ids.len() {
+            return Err(corrupt_docs(
+                &self.path,
+                format!(
+                    "sparse {NUM_TOKEN_COL} projection returned {} rows with {} nulls for {} candidates",
+                    lengths.len(),
+                    lengths.null_count(),
+                    doc_ids.len()
+                ),
+            ));
+        }
+        Ok(lengths
+            .values()
+            .iter()
+            .map(|&length| {
+                if self.quantized_scoring {
+                    dequantize_doc_length(quantize_doc_length(length))
+                } else {
+                    length
+                }
+            })
+            .collect())
+    }
+
+    /// Resolve the row address and scoring length for a bounded candidate set.
+    ///
+    /// When neither document column is resident and the selection is sparse,
+    /// both columns are projected by one `read_ranges` call. This avoids
+    /// opening and scheduling the same document file twice during staged
+    /// cross-column execution. Asymmetric cache states continue to reuse the
+    /// resident side through the existing typed resolvers.
+    pub(crate) async fn resolve_scoring_documents(
+        &self,
+        doc_ids: &[DocId],
+    ) -> Result<Vec<(u32, u64, u32)>> {
+        if doc_ids.is_empty() {
+            return Ok(Vec::new());
+        }
+        self.validate_doc_ids(doc_ids)?;
+
+        let addresses_need_sparse_read = self.resident_address_projection().is_none()
+            && self.remapper.is_none()
+            && self.shared_addresses.load().upgrade().is_none()
+            && self.prefer_sparse_document_read(doc_ids.len());
+        let lengths_need_sparse_read =
+            self.cached_lengths().is_none() && self.prefer_sparse_document_read(doc_ids.len());
+        if addresses_need_sparse_read && lengths_need_sparse_read {
+            let ranges = doc_ids
+                .iter()
+                .map(|doc_id| {
+                    let index = doc_id.as_usize();
+                    index..index + 1
+                })
+                .collect::<Vec<_>>();
+            let batch = self
+                .reader()
+                .await?
+                .read_ranges(&ranges, Some(&[ROW_ID, NUM_TOKEN_COL]))
+                .await?;
+            let row_ids = required_u64_column(&batch, ROW_ID, &self.path)?;
+            let lengths = required_u32_column(&batch, NUM_TOKEN_COL, &self.path)?;
+            if row_ids.null_count() != 0
+                || lengths.null_count() != 0
+                || row_ids.len() != doc_ids.len()
+                || lengths.len() != doc_ids.len()
+            {
+                return Err(corrupt_docs(
+                    &self.path,
+                    format!(
+                        "sparse document projection returned {} row addresses ({} nulls) and {} lengths ({} nulls) for {} candidates",
+                        row_ids.len(),
+                        row_ids.null_count(),
+                        lengths.len(),
+                        lengths.null_count(),
+                        doc_ids.len()
+                    ),
+                ));
+            }
+            return Ok(doc_ids
+                .iter()
+                .zip(row_ids.values())
+                .zip(lengths.values())
+                .map(|((&doc_id, &row_address), &length)| {
+                    let scoring_length = if self.quantized_scoring {
+                        dequantize_doc_length(quantize_doc_length(length))
+                    } else {
+                        length
+                    };
+                    (doc_id.get(), row_address, scoring_length)
+                })
+                .collect());
+        }
+
+        let (row_addresses, scoring_lengths) = futures::try_join!(
+            self.resolve_addresses(doc_ids),
+            self.resolve_scoring_lengths(doc_ids)
+        )?;
+        if row_addresses.len() != doc_ids.len() || scoring_lengths.len() != doc_ids.len() {
+            return Err(Error::internal(format!(
+                "resolved {} row addresses and {} lengths for {} FTS candidates",
+                row_addresses.len(),
+                scoring_lengths.len(),
+                doc_ids.len()
+            )));
+        }
+        Ok(doc_ids
+            .iter()
+            .zip(row_addresses)
+            .zip(scoring_lengths)
+            .map(|((&doc_id, row_address), scoring_length)| {
+                (doc_id.get(), row_address, scoring_length)
+            })
+            .collect())
+    }
+
+    pub(crate) fn prefer_sparse_document_read(&self, selected: usize) -> bool {
+        (selected as u128).saturating_mul(100)
+            <= (SPARSE_DOCUMENT_READ_PERCENT as u128).saturating_mul(self.num_docs as u128)
     }
 
     /// Resolve final global top-k DocIds to their logical FTS document keys.
@@ -1637,10 +2311,252 @@ mod tests {
             addresses: AddressValues::Owned(Arc::new(vec![10, 20, 30])),
             live_docs: Some(RoaringBitmap::from_iter([0, 2])),
             doc_ids_by_address: OnceCell::new(),
+            ordered_validation: AtomicU8::new(CachedRowAddressOrder::Unknown as u8),
+            materialized_candidate_cost: AtomicUsize::new(0),
+            ordered_validation_visited_docs: AtomicUsize::new(0),
         });
         let projection = projection.resident(None).unwrap();
         let selected = projection.live_doc_ids();
         assert_eq!(selected.iter().collect::<Vec<_>>(), vec![0, 2]);
+        assert_eq!(projection.live_address_hull(), Some((10, 30)));
+
+        let empty = Arc::new(VersionAddressProjection {
+            addresses: AddressValues::Owned(Arc::new(vec![10, 20, 30])),
+            live_docs: Some(RoaringBitmap::new()),
+            doc_ids_by_address: OnceCell::new(),
+            ordered_validation: AtomicU8::new(CachedRowAddressOrder::Unknown as u8),
+            materialized_candidate_cost: AtomicUsize::new(0),
+            ordered_validation_visited_docs: AtomicUsize::new(0),
+        });
+        assert_eq!(empty.resident(None).unwrap().live_address_hull(), None);
+    }
+
+    #[test]
+    fn ordered_row_address_projection_maps_identity_domain() {
+        let addresses = Arc::new(UInt64Array::from(vec![10, 20, 30]));
+        let projection = Arc::new(VersionAddressProjection {
+            addresses: AddressValues::Shared {
+                len: addresses.len(),
+            },
+            live_docs: None,
+            doc_ids_by_address: OnceCell::new(),
+            ordered_validation: AtomicU8::new(CachedRowAddressOrder::Unknown as u8),
+            materialized_candidate_cost: AtomicUsize::new(0),
+            ordered_validation_visited_docs: AtomicUsize::new(0),
+        });
+        let projection = projection.resident(Some(addresses)).unwrap();
+        let ordered = projection.try_ordered_row_addresses().unwrap();
+
+        assert_eq!(ordered.len(), 3);
+        assert_eq!(ordered.live_len(), 3);
+        assert_eq!(ordered.live_address_hull(), Some((10, 30)));
+        assert_eq!(
+            ordered
+                .select_sorted_addresses(&[5, 10, 25, 30, 50])
+                .iter()
+                .collect::<Vec<_>>(),
+            vec![0, 2]
+        );
+        assert!(ordered.select_sorted_addresses(&[]).is_empty());
+        assert_eq!(ordered.address(0), Some(10));
+        assert_eq!(ordered.address(2), Some(30));
+        assert_eq!(ordered.address(3), None);
+        assert_eq!(ordered.lower_bound(0), Some(0));
+        assert_eq!(ordered.lower_bound(10), Some(0));
+        assert_eq!(ordered.lower_bound(11), Some(1));
+        assert_eq!(ordered.lower_bound(30), Some(2));
+        assert_eq!(ordered.lower_bound(31), None);
+        assert_eq!(ordered.next_address(0), Some(20));
+        assert_eq!(ordered.next_address(1), Some(30));
+        assert_eq!(ordered.next_address(2), None);
+        assert_eq!(ordered.next_address(u64::MAX), None);
+    }
+
+    #[test]
+    fn ordered_row_address_projection_caches_successful_validation() {
+        let projection = resident_row_address_projection_for_test(vec![10, 20, 30, 40]);
+        assert_eq!(
+            projection.cached_row_address_order(),
+            CachedRowAddressOrder::Unknown
+        );
+        assert_eq!(projection.ordered_validation_visited_docs(), 0);
+
+        let first = projection.try_ordered_row_addresses().unwrap();
+        assert_eq!(
+            projection.cached_row_address_order(),
+            CachedRowAddressOrder::Ordered
+        );
+        assert_eq!(projection.ordered_validation_visited_docs(), 4);
+        assert_eq!(first.lower_bound(25), Some(2));
+
+        let second_query = projection.projection.resident(None).unwrap();
+        let second = second_query.try_ordered_row_addresses().unwrap();
+        assert_eq!(second_query.ordered_validation_visited_docs(), 4);
+        assert_eq!(second.lower_bound(25), Some(2));
+    }
+
+    #[test]
+    fn ordered_validation_computes_before_short_cache_publication() {
+        let projection = resident_row_address_projection_for_test(vec![10, 20, 30, 40]);
+
+        let validation = projection.compute_ordered_validation();
+        assert_eq!(validation, Ok(()));
+        assert_eq!(projection.ordered_validation_visited_docs(), 4);
+        assert_eq!(
+            projection.cached_row_address_order(),
+            CachedRowAddressOrder::Unknown
+        );
+
+        projection.publish_ordered_validation(&validation);
+        assert_eq!(
+            projection.cached_row_address_order(),
+            CachedRowAddressOrder::Ordered
+        );
+        assert_eq!(projection.ordered_validation_visited_docs(), 4);
+    }
+
+    #[test]
+    fn ordered_validation_concurrent_race_publishes_one_stable_state() {
+        let projection = resident_row_address_projection_for_test(vec![10, 20, 30, 40]);
+        let barrier = Arc::new(std::sync::Barrier::new(3));
+        let handles = (0..2)
+            .map(|_| {
+                let projection = projection.clone();
+                let barrier = barrier.clone();
+                std::thread::spawn(move || {
+                    barrier.wait();
+                    projection.try_ordered_row_addresses().map(drop)
+                })
+            })
+            .collect::<Vec<_>>();
+
+        barrier.wait();
+        for handle in handles {
+            handle.join().unwrap().unwrap();
+        }
+        assert_eq!(
+            projection.cached_row_address_order(),
+            CachedRowAddressOrder::Ordered
+        );
+        assert!(matches!(
+            projection.ordered_validation_visited_docs(),
+            4 | 8
+        ));
+    }
+
+    #[test]
+    fn ordered_row_address_projection_skips_deleted_slots() {
+        let projection = Arc::new(VersionAddressProjection {
+            addresses: AddressValues::Owned(Arc::new(vec![10, 0, 30, 0, 50])),
+            live_docs: Some(RoaringBitmap::from_iter([0, 2, 4])),
+            doc_ids_by_address: OnceCell::new(),
+            ordered_validation: AtomicU8::new(CachedRowAddressOrder::Unknown as u8),
+            materialized_candidate_cost: AtomicUsize::new(0),
+            ordered_validation_visited_docs: AtomicUsize::new(0),
+        });
+        let projection = projection.resident(None).unwrap();
+        assert_eq!(projection.ordered_validation_visited_docs(), 0);
+        let ordered = projection.try_ordered_row_addresses().unwrap();
+        assert_eq!(projection.ordered_validation_visited_docs(), 3);
+        projection.try_ordered_row_addresses().unwrap();
+        assert_eq!(projection.ordered_validation_visited_docs(), 3);
+
+        assert_eq!(ordered.len(), 5);
+        assert_eq!(ordered.live_len(), 3);
+        assert_eq!(ordered.live_address_hull(), Some((10, 50)));
+        assert_eq!(
+            ordered
+                .select_sorted_addresses(&[0, 10, 30, 40, 50, 60])
+                .iter()
+                .collect::<Vec<_>>(),
+            vec![0, 2, 4]
+        );
+        assert_eq!(ordered.address(0), Some(10));
+        assert_eq!(ordered.address(1), None);
+        assert_eq!(ordered.address(2), Some(30));
+        assert_eq!(ordered.lower_bound(11), Some(2));
+        assert_eq!(ordered.lower_bound(30), Some(2));
+        assert_eq!(ordered.lower_bound(31), Some(4));
+        assert_eq!(ordered.lower_bound(51), None);
+        assert_eq!(ordered.next_address(0), Some(30));
+        assert_eq!(ordered.next_address(1), Some(30));
+        assert_eq!(ordered.next_address(2), Some(50));
+        assert_eq!(ordered.next_address(4), None);
+        assert_eq!(
+            ordered.address(1).or_else(|| ordered.next_address(1)),
+            Some(30)
+        );
+    }
+
+    #[test]
+    fn ordered_row_address_projection_rejects_nonmonotonic_remap() {
+        let raw = UInt64Array::from(vec![10, 20, 30, 40]);
+        let remapper = TestRemapper {
+            mapping: HashMap::from([(10, Some(100)), (20, None), (30, Some(300))]),
+        };
+        let projection = Arc::new(
+            VersionAddressProjection::try_new(&raw, 4, Some(&remapper), "docs")
+                .expect("valid projection"),
+        );
+        let projection = projection.resident(None).unwrap();
+
+        let expected = RowAddressProjectionOrderError::OutOfOrder {
+            previous_doc_id: DocId::new(2),
+            previous_address: RowAddress::new_from_u64(300),
+            doc_id: DocId::new(3),
+            address: RowAddress::new_from_u64(40),
+        };
+        assert_eq!(
+            projection.try_ordered_row_addresses().unwrap_err(),
+            expected
+        );
+        assert_eq!(
+            projection.cached_row_address_order(),
+            CachedRowAddressOrder::OutOfOrder
+        );
+        assert_eq!(projection.ordered_validation_visited_docs(), 3);
+        assert_eq!(
+            projection.try_ordered_row_addresses().unwrap_err(),
+            expected
+        );
+        assert_eq!(
+            projection.cached_row_address_order(),
+            CachedRowAddressOrder::OutOfOrder
+        );
+        assert_eq!(projection.ordered_validation_visited_docs(), 6);
+    }
+
+    #[test]
+    fn ordered_row_address_projection_rejects_duplicate_address() {
+        let projection = Arc::new(VersionAddressProjection {
+            addresses: AddressValues::Owned(Arc::new(vec![10, 20, 20, 30])),
+            live_docs: None,
+            doc_ids_by_address: OnceCell::new(),
+            ordered_validation: AtomicU8::new(CachedRowAddressOrder::Unknown as u8),
+            materialized_candidate_cost: AtomicUsize::new(0),
+            ordered_validation_visited_docs: AtomicUsize::new(0),
+        });
+        let projection = projection.resident(None).unwrap();
+
+        let expected = RowAddressProjectionOrderError::Duplicate {
+            first_doc_id: DocId::new(1),
+            duplicate_doc_id: DocId::new(2),
+            address: RowAddress::new_from_u64(20),
+        };
+        assert_eq!(
+            projection.try_ordered_row_addresses().unwrap_err(),
+            expected
+        );
+        assert_eq!(
+            projection.cached_row_address_order(),
+            CachedRowAddressOrder::Duplicate
+        );
+        assert_eq!(projection.ordered_validation_visited_docs(), 3);
+        assert_eq!(
+            projection.try_ordered_row_addresses().unwrap_err(),
+            expected
+        );
+        assert_eq!(projection.ordered_validation_visited_docs(), 6);
     }
 
     #[tokio::test]
@@ -1662,6 +2578,7 @@ mod tests {
 
         let all_live = projection.live_doc_ids();
         assert_eq!(all_live.iter().collect::<Vec<_>>(), vec![0, 2, 3]);
+        assert_eq!(projection.live_address_hull(), Some((40, 300)));
 
         let allowed = Arc::new(RowAddrMask::from_allowed(RowAddrTreeMap::from_iter([
             100, 40,
@@ -1675,6 +2592,11 @@ mod tests {
             panic!("allow-list must compile to DocIds")
         };
         assert_eq!(selected.iter().collect::<Vec<_>>(), vec![0, 3]);
+        let candidate_selected = projection
+            .select_sorted_addresses(&[10, 40, 100])
+            .await
+            .expect("valid candidate projection");
+        assert_eq!(candidate_selected, selected);
 
         let first_lookup = projection
             .doc_ids_by_address()
@@ -1711,8 +2633,22 @@ mod tests {
             ])),
             live_docs: None,
             doc_ids_by_address: OnceCell::new(),
+            ordered_validation: AtomicU8::new(CachedRowAddressOrder::Unknown as u8),
+            materialized_candidate_cost: AtomicUsize::new(0),
+            ordered_validation_visited_docs: AtomicUsize::new(0),
         });
         let projection = projection.resident(None).unwrap();
+
+        let duplicate = projection
+            .select_sorted_addresses(&[row_address(1, 2)])
+            .await
+            .unwrap_err();
+        assert!(matches!(duplicate, Error::Index { .. }));
+        assert!(
+            duplicate
+                .to_string()
+                .contains("row address 4294967298 is shared by local documents 1 and 2")
+        );
 
         let allowed = Arc::new(RowAddrMask::from_allowed(RowAddrTreeMap::from_iter([
             row_address(1, 2),
@@ -1741,12 +2677,35 @@ mod tests {
         assert_eq!(selected.iter().collect::<Vec<_>>(), vec![0]);
     }
 
+    #[tokio::test]
+    async fn candidate_projection_ignores_deleted_duplicate_addresses() {
+        let projection = Arc::new(VersionAddressProjection {
+            addresses: AddressValues::Owned(Arc::new(vec![30, 10, 10, 20])),
+            live_docs: Some(RoaringBitmap::from_iter([0, 1, 3])),
+            doc_ids_by_address: OnceCell::new(),
+            ordered_validation: AtomicU8::new(CachedRowAddressOrder::Unknown as u8),
+            materialized_candidate_cost: AtomicUsize::new(0),
+            ordered_validation_visited_docs: AtomicUsize::new(0),
+        });
+        let projection = projection.resident(None).unwrap();
+
+        assert_eq!(projection.live_address_hull(), Some((10, 30)));
+        let selected = projection
+            .select_sorted_addresses(&[10, 20, 25, 30])
+            .await
+            .expect("deleted duplicate does not collide");
+        assert_eq!(selected.iter().collect::<Vec<_>>(), vec![0, 1, 3]);
+    }
+
     #[test]
     fn lazy_visibility_projects_only_candidate_doc_ids() {
         let projection = Arc::new(VersionAddressProjection {
             addresses: AddressValues::Owned(Arc::new(vec![10, 20, 30])),
             live_docs: Some(RoaringBitmap::from_iter([0, 2])),
             doc_ids_by_address: OnceCell::new(),
+            ordered_validation: AtomicU8::new(CachedRowAddressOrder::Unknown as u8),
+            materialized_candidate_cost: AtomicUsize::new(0),
+            ordered_validation_visited_docs: AtomicUsize::new(0),
         });
         let resident = projection.resident(None).unwrap();
         let visibility = DocVisibility::Filtered {
@@ -2184,6 +3143,127 @@ mod tests {
         assert_eq!(counts.range_calls.load(Ordering::Relaxed), 1);
         assert_eq!(counts.address_rows.load(Ordering::Relaxed), 600);
         assert!(!documents.projection_loaded());
+    }
+
+    #[tokio::test]
+    async fn selective_scoring_lengths_read_only_candidate_rows() {
+        let (_directory, store, cache) = test_store();
+        let path = "docs.lance";
+        let num_docs = 600_u32;
+        write_documents(
+            store.as_ref(),
+            path,
+            UInt64Array::from_iter_values((0..num_docs).map(u64::from)),
+            UInt32Array::from_iter_values(1..=num_docs),
+            Some(
+                &u64::from(num_docs)
+                    .saturating_mul(u64::from(num_docs + 1))
+                    .div_ceil(2)
+                    .to_string(),
+            ),
+        )
+        .await;
+        let (counting, counts) = counted_store(store, path);
+        let documents = open_documents(counting, path, cache.as_ref(), None)
+            .await
+            .unwrap();
+        let doc_ids = [DocId::new(2), DocId::new(10), DocId::new(2)];
+
+        assert_eq!(
+            documents.resolve_scoring_lengths(&doc_ids).await.unwrap(),
+            vec![3, 11, 3]
+        );
+        assert_eq!(counts.ranges_calls.load(Ordering::Relaxed), 1);
+        assert_eq!(counts.range_calls.load(Ordering::Relaxed), 0);
+        assert_eq!(counts.length_rows.load(Ordering::Relaxed), doc_ids.len());
+        assert!(!documents.lengths_loaded());
+    }
+
+    #[tokio::test]
+    async fn selective_scoring_documents_share_one_candidate_read() {
+        let (_directory, store, cache) = test_store();
+        let path = "docs.lance";
+        let num_docs = 600_u32;
+        write_documents(
+            store.as_ref(),
+            path,
+            UInt64Array::from_iter_values((0..num_docs).map(|doc_id| 10_000 + u64::from(doc_id))),
+            UInt32Array::from_iter_values((0..num_docs).map(|doc_id| doc_id + 1)),
+            Some("180300"),
+        )
+        .await;
+        let (counting, counts) = counted_store(store, path);
+        let documents = open_documents(counting, path, cache.as_ref(), None)
+            .await
+            .unwrap();
+        let doc_ids = [DocId::new(2), DocId::new(10), DocId::new(2)];
+
+        assert_eq!(
+            documents.resolve_scoring_documents(&doc_ids).await.unwrap(),
+            vec![(2, 10_002, 3), (10, 10_010, 11), (2, 10_002, 3)]
+        );
+        assert_eq!(counts.ranges_calls.load(Ordering::Relaxed), 1);
+        assert_eq!(counts.range_calls.load(Ordering::Relaxed), 0);
+        assert_eq!(counts.address_rows.load(Ordering::Relaxed), doc_ids.len());
+        assert_eq!(counts.length_rows.load(Ordering::Relaxed), doc_ids.len());
+        assert!(!documents.lengths_loaded());
+        assert!(!documents.projection_loaded());
+    }
+
+    #[tokio::test]
+    async fn selective_scoring_documents_preserve_quantized_lengths() {
+        let (_directory, store, cache) = test_store();
+        let path = "docs.lance";
+        let num_docs = 600_u32;
+        let lengths = (0..num_docs)
+            .map(|doc_id| if doc_id == 10 { 300 } else { doc_id + 1 })
+            .collect::<Vec<_>>();
+        let total_tokens = lengths
+            .iter()
+            .map(|&length| u64::from(length))
+            .sum::<u64>()
+            .to_string();
+        write_documents(
+            store.as_ref(),
+            path,
+            UInt64Array::from_iter_values((0..num_docs).map(|doc_id| 20_000 + u64::from(doc_id))),
+            UInt32Array::from(lengths.clone()),
+            Some(&total_tokens),
+        )
+        .await;
+        let (counting, counts) = counted_store(store, path);
+        let reader = counting.open_index_file(path).await.unwrap();
+        let documents = PartitionDocuments::try_new(
+            counting,
+            path.to_owned(),
+            0,
+            WeakLanceCache::from(cache.as_ref()),
+            reader.as_ref(),
+            None,
+            true,
+        )
+        .unwrap();
+        let doc_ids = [DocId::new(10), DocId::new(500)];
+
+        assert_eq!(
+            documents.resolve_scoring_documents(&doc_ids).await.unwrap(),
+            vec![
+                (
+                    10,
+                    20_010,
+                    dequantize_doc_length(quantize_doc_length(lengths[10])),
+                ),
+                (
+                    500,
+                    20_500,
+                    dequantize_doc_length(quantize_doc_length(lengths[500])),
+                ),
+            ]
+        );
+        assert_eq!(counts.ranges_calls.load(Ordering::Relaxed), 1);
+        assert_eq!(counts.address_rows.load(Ordering::Relaxed), doc_ids.len());
+        assert_eq!(counts.length_rows.load(Ordering::Relaxed), doc_ids.len());
+        assert!(!documents.lengths_loaded());
     }
 
     #[tokio::test]

--- a/rust/lance-index/src/scalar/inverted/index/inverted_index.rs
+++ b/rust/lance-index/src/scalar/inverted/index/inverted_index.rs
@@ -455,6 +455,19 @@ impl Index for InvertedIndex {
 }
 
 impl InvertedIndex {
+    /// Return whether an explicit prewarm prepared everything this query needs.
+    ///
+    /// This is an O(1) routing hint for query planning. It never starts I/O or
+    /// waits for a concurrent prewarm. The projection check also clears a stale
+    /// optimistic hint after cache eviction; an unexpected posting eviction is
+    /// still handled exactly by the normal eager loader.
+    pub(in super::super) fn prewarmed_query_state_ready(&self, with_position: bool) -> bool {
+        let Ok(state) = self.prewarm_state.try_lock() else {
+            return false;
+        };
+        state.satisfies(with_position) && self.has_resident_document_projections()
+    }
+
     pub async fn prewarm_with_options(&self, options: &FtsPrewarmOptions) -> Result<()> {
         self.prewarm_with_options_result(options).await.map(|_| ())
     }

--- a/rust/lance-index/src/scalar/inverted/index/partition.rs
+++ b/rust/lance-index/src/scalar/inverted/index/partition.rs
@@ -24,7 +24,6 @@ impl PostingLoadOptions {
         }
     }
 
-    #[cfg(test)]
     pub(in super::super) const fn cache_aware_exact(force_global_scorer: bool) -> Self {
         Self {
             force_global_scorer,
@@ -56,6 +55,32 @@ fn summarize_position_matches(mut positions: SmallVec<[(u32, bool); 8]>) -> Posi
         exact_scoring_required,
         every_position_matched,
     }
+}
+
+fn token_dictionary_may_match(
+    dictionary: &TokenSet,
+    tokens: &Tokens,
+    operator: Operator,
+    is_phrase_query: bool,
+) -> bool {
+    if tokens.is_empty() {
+        return false;
+    }
+    if operator != Operator::And && !is_phrase_query {
+        return (0..tokens.len()).any(|index| dictionary.get(tokens.get_token(index)).is_some());
+    }
+
+    // Query positions are normally adjacent, but `Tokens::with_positions` is
+    // public and does not require that ordering. Keep the exact behavior
+    // without allocating two hash tables for every leaf in every partition.
+    let mut positions = SmallVec::<[(u32, bool); 8]>::new();
+    for index in 0..tokens.len() {
+        positions.push((
+            tokens.position(index),
+            dictionary.get(tokens.get_token(index)).is_some(),
+        ));
+    }
+    summarize_position_matches(positions).every_position_matched
 }
 
 fn posting_group_demand_counts(
@@ -221,6 +246,23 @@ impl InvertedPartition {
 
     fn map(&self, token: &str) -> Option<u32> {
         self.tokens.get(token)
+    }
+
+    /// Return whether this partition's token dictionary can satisfy a query
+    /// leaf without reading any posting data.
+    ///
+    /// Fuzzy expansions and identifier subwords that belong to the same
+    /// original query position are alternatives. AND and phrase leaves need
+    /// at least one dictionary term for every original position; OR leaves
+    /// need any term. A `false` result is therefore an exact empty-source
+    /// proof, while `true` remains conservative until postings are loaded.
+    pub(in super::super) fn may_match_tokens(
+        &self,
+        tokens: &Tokens,
+        operator: Operator,
+        is_phrase_query: bool,
+    ) -> bool {
+        token_dictionary_may_match(&self.tokens, tokens, operator, is_phrase_query)
     }
 
     pub fn expand_fuzzy(&self, tokens: &Tokens, params: &FtsSearchParams) -> Result<Tokens> {
@@ -991,6 +1033,15 @@ mod tests {
     use rstest::rstest;
 
     use super::*;
+    use crate::scalar::inverted::document_tokenizer::DocType;
+
+    fn dictionary(terms: &[&str]) -> TokenSet {
+        let mut dictionary = TokenSet::default();
+        for term in terms {
+            dictionary.add((*term).to_owned());
+        }
+        dictionary
+    }
 
     fn position_summary(entries: &[(u32, bool)]) -> PositionMatchSummary {
         summarize_position_matches(entries.iter().copied().collect())
@@ -1033,6 +1084,70 @@ mod tests {
         let summary = summarize_position_matches(positions);
         assert!(summary.exact_scoring_required);
         assert!(summary.every_position_matched);
+    }
+
+    #[test]
+    fn token_dictionary_or_needs_any_expansion() {
+        let tokens = Tokens::with_positions(
+            vec!["missing".to_owned(), "alpha".to_owned()],
+            vec![0, 1],
+            DocType::Text,
+        );
+
+        assert!(token_dictionary_may_match(
+            &dictionary(&["alpha"]),
+            &tokens,
+            Operator::Or,
+            false,
+        ));
+        assert!(!token_dictionary_may_match(
+            &dictionary(&["other"]),
+            &tokens,
+            Operator::Or,
+            false,
+        ));
+    }
+
+    #[test]
+    fn token_dictionary_and_and_phrase_need_every_original_position() {
+        let expanded = Tokens::with_positions(
+            vec!["alpha".to_owned(), "alphi".to_owned(), "beta".to_owned()],
+            vec![0, 0, 1],
+            DocType::Text,
+        );
+        let complete = dictionary(&["alphi", "beta"]);
+        let missing_position = dictionary(&["alpha", "alphi"]);
+
+        assert!(token_dictionary_may_match(
+            &complete,
+            &expanded,
+            Operator::And,
+            false,
+        ));
+        assert!(!token_dictionary_may_match(
+            &missing_position,
+            &expanded,
+            Operator::And,
+            false,
+        ));
+        assert!(!token_dictionary_may_match(
+            &missing_position,
+            &expanded,
+            Operator::Or,
+            true,
+        ));
+
+        let non_adjacent_positions = Tokens::with_positions(
+            vec!["beta".to_owned(), "alpha".to_owned(), "alphi".to_owned()],
+            vec![1, 0, 1],
+            DocType::Text,
+        );
+        assert!(token_dictionary_may_match(
+            &dictionary(&["alpha", "alphi"]),
+            &non_adjacent_positions,
+            Operator::And,
+            false,
+        ));
     }
 
     #[rstest]

--- a/rust/lance-index/src/scalar/inverted/wand.rs
+++ b/rust/lance-index/src/scalar/inverted/wand.rs
@@ -879,6 +879,39 @@ impl PostingIterator {
         self
     }
 
+    /// Create an independent cursor over the same immutable posting payload.
+    ///
+    /// Staged cross-column execution uses one cursor to enumerate exact
+    /// membership before asynchronous candidate-side document reads, then a
+    /// fresh cursor to compute the canonical score. Arrow buffers and grouped
+    /// term tables remain shared; only mutable decode and position state is
+    /// recreated.
+    pub(super) fn fork_from_start(&self) -> Self {
+        let compressed = match &self.list {
+            PostingList::Compressed(list) => {
+                Some(UnsafeCell::new(CompressedState::new(list.block_size)))
+            }
+            PostingList::Plain(_) => None,
+        };
+        let mut posting = Self {
+            token: self.token.clone(),
+            token_id: self.token_id,
+            position: self.position,
+            query_weight: self.query_weight,
+            list: self.list.clone(),
+            index: 0,
+            block_idx: 0,
+            current_doc: None,
+            approximate_upper_bound: self.approximate_upper_bound,
+            use_scorer_upper_bound: self.use_scorer_upper_bound,
+            grouped_terms: self.grouped_terms.clone(),
+            position_scratch: RefCell::new(Some(Vec::new())),
+            compressed,
+        };
+        posting.refresh_current_doc();
+        posting
+    }
+
     #[inline]
     pub(crate) fn term_index(&self) -> u32 {
         self.position
@@ -957,6 +990,16 @@ impl PostingIterator {
     #[inline]
     fn doc(&self) -> Option<DocInfo> {
         self.current_doc
+    }
+
+    /// The posting's current local document before it is moved into a scorer.
+    ///
+    /// Cross-partition row-address merging uses this only to derive a
+    /// conservative lower bound for lazy source activation. It is not an
+    /// exact match decision: visibility and phrase confirmation still happen
+    /// in [`WandCursor`].
+    pub(super) fn current_doc_id(&self) -> Option<u64> {
+        self.current_doc.map(|doc| doc.doc_id())
     }
 
     fn refresh_current_doc(&mut self) {
@@ -1603,12 +1646,17 @@ pub struct DocCandidate<C> {
 
 /// Document-side contract consumed by WAND.  Implementations fix candidate
 /// identity and visibility before the CPU executor starts.
-type FlatDocuments<'a> = (usize, Box<dyn Iterator<Item = (u64, u64)> + 'a>);
+pub(super) type FlatDocuments<'a> = (usize, Box<dyn Iterator<Item = (u64, u64)> + 'a>);
 
 pub(super) trait WandDocuments {
     type Candidate: Copy + Debug;
 
     fn len(&self) -> usize;
+    /// Conservative upper bound on documents that can survive visibility.
+    /// Used only to estimate scorer cost; iteration remains authoritative.
+    fn visible_cost_upper_bound(&self) -> usize {
+        self.len()
+    }
     fn scoring_norms(&self) -> Option<&[u8]>;
     fn scoring_num_tokens(&self, doc_id: u32) -> u32;
     fn doc_length(&self, doc: &DocInfo) -> u32;
@@ -1686,6 +1734,10 @@ impl<V: ModernVisibility> WandDocuments for ModernWandDocuments<'_, V> {
 
     fn len(&self) -> usize {
         self.lengths.len()
+    }
+
+    fn visible_cost_upper_bound(&self) -> usize {
+        self.visibility.len(self.lengths.len())
     }
 
     fn scoring_norms(&self) -> Option<&[u8]> {
@@ -4638,7 +4690,8 @@ impl<'a, D: WandDocuments> WandCursor<'a, D> {
                     .fold(0, usize::saturating_add),
             ),
         }
-        .unwrap_or_default();
+        .unwrap_or_default()
+        .min(documents.visible_cost_upper_bound());
         Self {
             wand: Wand::new(operator, postings.into_iter(), documents, scorer)
                 .with_floor_mode(CompetitiveFloorMode::Inclusive),
@@ -4963,6 +5016,7 @@ mod tests {
 
     use std::sync::atomic::{AtomicUsize, Ordering};
 
+    use super::super::documents::resident_row_address_projection_for_test;
     use super::super::impact::build_impact_skip_data;
     use super::*;
     use crate::scalar::inverted::scorer::{IndexBM25Scorer, MemBM25Scorer};
@@ -4977,6 +5031,129 @@ mod tests {
             },
         },
     };
+
+    struct CostOnlyDocuments {
+        total_docs: usize,
+        visible_cost_upper_bound: usize,
+    }
+
+    impl WandDocuments for CostOnlyDocuments {
+        type Candidate = u64;
+
+        fn len(&self) -> usize {
+            self.total_docs
+        }
+
+        fn visible_cost_upper_bound(&self) -> usize {
+            self.visible_cost_upper_bound
+        }
+
+        fn scoring_norms(&self) -> Option<&[u8]> {
+            None
+        }
+
+        fn scoring_num_tokens(&self, _doc_id: u32) -> u32 {
+            1
+        }
+
+        fn doc_length(&self, _doc: &DocInfo) -> u32 {
+            1
+        }
+
+        fn document_key(&self, doc: &DocInfo) -> Option<u64> {
+            Some(doc.doc_id())
+        }
+
+        fn document_key_for_doc_id(&self, doc_id: u32) -> Option<u64> {
+            Some(u64::from(doc_id))
+        }
+
+        fn candidate_from_key(&self, key: u64) -> Self::Candidate {
+            key
+        }
+
+        fn flat_documents(&self) -> Option<FlatDocuments<'_>> {
+            None
+        }
+
+        fn flat_doc_length(&self, _doc_id: u64, _document_key: u64, _compressed: bool) -> u32 {
+            1
+        }
+    }
+
+    #[test]
+    fn wand_cursor_cost_uses_materialized_visibility_upper_bound() {
+        let total_docs = 10;
+        let selected = DocVisibility::Selected(roaring::RoaringBitmap::from_iter([1, 7]));
+        let selected_bound = <&DocVisibility as ModernVisibility>::len(&&selected, total_docs);
+
+        let filtered = DocVisibility::Filtered {
+            projection: resident_row_address_projection_for_test((0..total_docs as u64).collect()),
+            mask: Arc::new(RowAddrMask::all_rows()),
+        };
+        let filtered_bound = <&DocVisibility as ModernVisibility>::len(&&filtered, total_docs);
+        let all_bound = AllModernDocuments.len(total_docs);
+
+        assert_eq!(selected_bound, 2);
+        assert_eq!(filtered_bound, total_docs);
+        assert_eq!(all_bound, total_docs);
+
+        let scorer = Arc::new(MemBM25Scorer::new(
+            total_docs as u64,
+            total_docs,
+            std::collections::HashMap::from([("term".to_owned(), 8)]),
+        ));
+        let posting = || {
+            PostingIterator::new(
+                "term".to_owned(),
+                0,
+                0,
+                generate_posting_list((0..8).collect(), 1.0, None, true),
+                total_docs,
+            )
+        };
+        let params = FtsSearchParams::default();
+        let metrics = NoOpMetricsCollector;
+
+        let selected_documents = CostOnlyDocuments {
+            total_docs,
+            visible_cost_upper_bound: selected_bound,
+        };
+        let selected_cursor = WandCursor::new(
+            Operator::Or,
+            vec![posting()],
+            &selected_documents,
+            scorer.clone(),
+            &params,
+            &metrics,
+        );
+        assert_eq!(selected_cursor.cost(), 2);
+
+        for visible_cost_upper_bound in [filtered_bound, all_bound] {
+            let documents = CostOnlyDocuments {
+                total_docs,
+                visible_cost_upper_bound,
+            };
+            let cursor = WandCursor::new(
+                Operator::Or,
+                vec![posting()],
+                &documents,
+                scorer.clone(),
+                &params,
+                &metrics,
+            );
+            assert_eq!(cursor.cost(), 8);
+        }
+
+        let mut complete_docs = DocSet::default();
+        for doc_id in 0..total_docs {
+            complete_docs.append(doc_id as u64, 1);
+        }
+        assert_eq!(
+            WandDocuments::visible_cost_upper_bound(&complete_docs),
+            total_docs
+        );
+    }
 
     #[test]
     fn conservative_score_sum_covers_query_order_f32_rounding() {
@@ -5919,6 +6096,30 @@ mod tests {
 
         iter.next(num_docs as u64 + 10);
         assert!(iter.doc().is_none());
+    }
+
+    #[test]
+    fn posting_iterator_fork_restarts_shared_compressed_payload() {
+        let num_docs = (BLOCK_SIZE * 2 + 5) as u32;
+        let posting = generate_posting_list((0..num_docs).collect(), 1.0, None, true);
+        let mut original =
+            PostingIterator::new(String::from("term"), 7, 3, posting, num_docs as usize);
+
+        original.next(BLOCK_SIZE as u64 + 3);
+        assert_eq!(
+            original.doc().map(|doc| doc.doc_id()),
+            Some(BLOCK_SIZE as u64 + 3)
+        );
+
+        let mut replay = original.fork_from_start();
+        assert_eq!(replay.doc().map(|doc| doc.doc_id()), Some(0));
+        replay.next(5);
+        assert_eq!(replay.doc().map(|doc| doc.doc_id()), Some(5));
+        assert_eq!(
+            original.doc().map(|doc| doc.doc_id()),
+            Some(BLOCK_SIZE as u64 + 3),
+            "fork advancement must not mutate the membership cursor"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Feature

Each FTS index source scores in its own partition-local DocId domain. Cross-column compound queries need to compose those scorers in one globally ordered row-address domain without assuming independently built indices share local document layouts.

This PR adds the cross-column scorer core:

- validates and caches strictly ordered row-address projections
- maps local scorer iteration, shallow bounds, and advances into row-address order
- materializes an exact fallback for reordered projections
- rejects duplicate row-address mappings that could combine content from different local documents
- lazily merges multiple physical sources for one semantic leaf
- preserves conservative bounds, competitive floors, and equal-score row-address ties
- analyzes compound plans for positive generator coverage, cost, feasibility, and conservative score bounds
- supports staged positive generation followed by candidate-scoped required, optional, and prohibited probing
- performs one exact global top-k collection after composing Match, Phrase, Boolean, MultiMatch, and Boost scorers
- uses candidate-scoped row-address and scoring-length reads when staging is selective

The dataset Scanner does not call this core yet; that integration remains in the final consumer PR.

## API and compatibility

There is no file-format change.

This PR exports the low-level async Rust entry point used by the later `lance` planner integration:

```rust
pub async fn cross_column_compound_search(
    columns: &[(String, Vec<Arc<InvertedIndex>>)],
    query: &FtsQuery,
    params: &FtsSearchParams,
    prefilter: Arc<dyn PreFilter>,
    metrics: Arc<dyn MetricsCollector>,
) -> Result<(Vec<u64>, Vec<f32>)>
```

The API requires a bounded limit, preserves exact `(score DESC, row_address ASC)` ordering, and returns an error for unsupported or internally inconsistent scorer state.

Existing `PartitionDocuments::resolve_addresses` and `estimated_address_read_bytes` behavior remains unchanged from `main`, so current production cache and I/O behavior is not altered before Scanner integration.

## CI failure addressed

The previous head split scorer foundations from their production consumer, leaving 43 groups of private items unused under `-D dead-code`. This revision folds the cross-column core into the same PR so those components have real production call paths.

Unused leaf-role metadata was deleted. No `allow(dead_code)`, test-only gating, or visibility workaround was added.

## Scope boundary

This is PR 3 of the OSS-1603 stack and builds on #8666 and #8667, both merged.

It does not include the previously deferred same-column delayed `MUST_NOT` probing work from OSS-1705. Cross-column prohibited clauses are supported as ordinary query semantics, but this PR does not change the same-column `BooleanScorer` or its probing strategy.

## Validation

- `cargo fmt --all -- --check`
- `git diff --check origin/main...HEAD`
- deterministic projection tests for ordered, deleted, remapped, duplicate, and out-of-order layouts
- materialized fallback and collision regressions
- merge-scorer ordering, lazy initialization, advance, shallow-bound, floor, tie, and duplicate tests
- seeded randomized exhaustive oracle coverage for SUM, MAX, MUST, required-optional, signed Boost, and nested prohibited shapes
- staged generator, candidate resolution, phrase, visibility, and quantized-length tests
- static reachability audit covering every item reported by the failed CI jobs

Per project workflow, GitHub CI is the authoritative Cargo test and Clippy run for this revised head.

## Performance validation

No end-to-end performance benefit is claimed yet because the dataset Scanner does not call this entry point in this PR. A main-vs-this-PR dataset benchmark would execute the existing fallback path and measure noise.

The final consumer PR will enable this core and report independent warm/cold ABBA results with latency, throughput, CPU, bytes, requests, cache metrics, and exact result digests.

## Stack

1. #8666 — WAND scoring and bound exactness (merged)
2. #8667 — posting loading and cache policy (merged)
3. **This PR:** row-address and cross-column compound scorer core
4. Dataset planner / execution integration and end-to-end benchmark

Part of [OSS-1603](https://linear.app/lancedb/issue/OSS-1603/add-candidate-driven-execution-for-cross-column-boolean-fts-queries).
