### PR TITLE
ci: remove lockless Rust build

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -294,31 +294,6 @@ jobs:
         run: |
           ALL_FEATURES=`cargo metadata --format-version=1 --no-deps | jq -r '.packages[] | .features | keys | .[]' | grep -v -e protoc | sort | uniq | paste -s -d "," -`
           cargo test --profile ci --locked --features ${ALL_FEATURES}
-  build-no-lock:
-    runs-on: ubuntu-24.04-8x
-    timeout-minutes: 30
-    env:
-      # Need up-to-date compilers for kernels
-      CC: clang
-      CXX: clang++
-    steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-      - name: Set up Rust
-        run: |
-          rustup update stable
-          rustup default stable
-      # Remote cargo.lock to force a fresh build
-      - name: Remove Cargo.lock
-        run: rm -f Cargo.lock
-      - uses: rui314/setup-mold@725a8794d15fc7563f59595bd9556495c0564878 # v1
-      - name: Install protoc
-        uses: taiki-e/install-action@66068bfca13dcb2ea07c3f613ca2836a37c755d5 # protoc
-        with:
-          tool: protoc
-      - name: Build all
-        run: |
-          ALL_FEATURES=`cargo metadata --format-version=1 --no-deps | jq -r '.packages[] | .features | keys | .[]' | grep -v -e protoc | sort | uniq | paste -s -d "," -`
-          cargo build --profile ci --benches --features ${ALL_FEATURES} --tests
   mac-build:
     runs-on: warp-macos-14-arm64-6x
     timeout-minutes: 45
@@ -349,8 +324,8 @@ jobs:
       # macOS runner capacity is the scarcest in CI, so this job is kept as short
       # as it can be. nextest runs each test in its own process and schedules
       # across all cores, rather than one test binary at a time. Benchmarks are
-      # only compile-checked here, which build-no-lock already does on Linux;
-      # nothing about bench compilation is macOS-specific.
+      # already compile-checked by clippy on Linux; nothing about bench
+      # compilation is macOS-specific.
       - name: Build tests
         run: |
           cargo nextest run --cargo-profile ci --locked --features fp16kernels,cli,dynamodb,substrait --no-run
@@ -379,8 +354,8 @@ jobs:
         with:
           tool: nextest
       # Same reasoning as mac-build: nextest schedules across all cores instead
-      # of running one test binary at a time, and build-no-lock already
-      # compile-checks the benchmarks on Linux.
+      # of running one test binary at a time, and clippy already compile-checks
+      # the benchmarks on Linux.
       - name: Build tests
         run: cargo nextest run --cargo-profile ci --locked --no-run
       - name: Run tests


### PR DESCRIPTION
The `build-no-lock` job resolved the malicious `arrayref 0.3.10` release during the August 20 supply-chain attack and executed its build dependency on CI runners. Remove the job so repository CI stays on reviewed lockfiles; Linux clippy continues to compile-check benchmarks.

`actionlint` remains non-zero on pre-existing ShellCheck findings and custom runner labels; this change introduces no new findings.
