### PR TITLE
fix(fts): derive empty segment codec from format

### DIFF
--- a/rust/lance-index/src/scalar/inverted/index/inverted_index.rs
+++ b/rust/lance-index/src/scalar/inverted/index/inverted_index.rs
@@ -73,7 +73,11 @@ impl InvertedIndex {
         self.partitions
             .first()
             .map(|partition| partition.inverted_list.posting_tail_codec())
-            .unwrap_or_default()
+            .unwrap_or_else(|| {
+                // Empty segments have no partition-level codec metadata, so
+                // derive the codec from the segment's declared format.
+                self.format_version().posting_tail_codec()
+            })
     }
 
     fn to_builder(&self) -> InvertedIndexBuilder {

--- a/rust/lance-index/src/scalar/inverted/index/tests/lifecycle.rs
+++ b/rust/lance-index/src/scalar/inverted/index/tests/lifecycle.rs
@@ -360,6 +360,76 @@ async fn test_merge_segments_preserves_format_version(
     Ok(())
 }
 
+#[rstest::rstest]
+#[case::empty_first(true)]
+#[case::empty_last(false)]
+#[tokio::test]
+async fn test_merge_v1_segments_with_empty_segment(#[case] is_empty_first: bool) -> Result<()> {
+    let empty_dir = TempObjDir::default();
+    let populated_dir = TempObjDir::default();
+    let dest_dir = TempObjDir::default();
+    let empty_store = Arc::new(LanceIndexStore::new(
+        ObjectStore::local().into(),
+        empty_dir.clone(),
+        Arc::new(LanceCache::no_cache()),
+    ));
+    let populated_store = Arc::new(LanceIndexStore::new(
+        ObjectStore::local().into(),
+        populated_dir.clone(),
+        Arc::new(LanceCache::no_cache()),
+    ));
+    let dest_store = Arc::new(LanceIndexStore::new(
+        ObjectStore::local().into(),
+        dest_dir.clone(),
+        Arc::new(LanceCache::no_cache()),
+    ));
+    let params = InvertedIndexParams::default().format_version(InvertedListFormatVersion::V1);
+
+    write_test_metadata(&empty_store, Vec::new(), params.clone()).await;
+    let empty = InvertedIndex::load(empty_store, None, &LanceCache::no_cache()).await?;
+    assert_eq!(empty.partition_count(), 0);
+    assert_eq!(empty.format_version(), InvertedListFormatVersion::V1);
+
+    let populated = write_single_partition_index(
+        populated_store,
+        params,
+        TokenSetFormat::default(),
+        "hello",
+        100,
+    )
+    .await?;
+    let segments = if is_empty_first {
+        vec![empty, populated]
+    } else {
+        vec![populated, empty]
+    };
+
+    let created = InvertedIndex::merge_segments(
+        &segments,
+        empty_doc_stream(),
+        dest_store.as_ref(),
+        None,
+        crate::progress::noop_progress(),
+    )
+    .await?;
+    assert_eq!(created.index_version, INVERTED_INDEX_VERSION_V1);
+
+    let merged = InvertedIndex::load(dest_store, None, &LanceCache::no_cache()).await?;
+    assert_eq!(merged.format_version(), InvertedListFormatVersion::V1);
+    assert_eq!(merged.index_version(), INVERTED_INDEX_VERSION_V1);
+
+    let tokens = Arc::new(Tokens::new(vec!["hello".to_string()], DocType::Text));
+    let params = Arc::new(FtsSearchParams::new().with_limit(Some(10)));
+    let prefilter = Arc::new(NoFilter);
+    let metrics = Arc::new(NoOpMetricsCollector);
+    let (row_ids, _) = merged
+        .bm25_search(tokens, params, Operator::Or, prefilter, metrics, None)
+        .await?;
+    assert_eq!(row_ids, vec![100]);
+
+    Ok(())
+}
+
 #[tokio::test]
 async fn test_merge_segments_uses_memory_limit_for_old_partitions() -> Result<()> {
     let src_dir_1 = TempObjDir::default();


### PR DESCRIPTION
## What is the bug?

A distributed FTS rebuild can legitimately produce an intermediate segment with zero partitions when its assigned fragments contain no indexable tokens. `InvertedIndex::posting_tail_codec` currently falls back to the default `VarintDelta` codec for such a segment, even when its declared format is V1 / `Fixed32`.

Merging that empty V1 segment with a populated V1 segment then fails with:

```
cannot merge inverted index segments with different posting tail codecs
```

This is the same-format empty-segment failure observed in [ENT-2323](https://linear.app/lancedb/issue/ENT-2323/lanceerrorindex-cannot-merge-inverted-index-segments-with-different). It is narrower than the cross-format behavior proposed in #8681.

## What issues or incorrect behavior does the bug cause?

V1 distributed FTS rebuilds fail during `merge_existing_index_segments` before the replacement index can be committed. Automated maintenance can retry the same deterministic failure.

## How does this PR fix the problem?

When an inverted index has no partitions, derive its posting-tail codec from the segment's declared FTS format instead of using the global codec default. Populated segments continue to use their physical partition metadata, and cross-format merge behavior is unchanged.

## Tests

Adds a regression test that merges an empty V1 segment with a populated V1 segment in both input orders. It verifies that:

- the empty segment resolves to `Fixed32`
- the merged index remains V1
- the populated document remains searchable

Local compilation and tests were intentionally skipped; CI is the validation path for this PR.
