### PR TITLE
perf(fts): enable bounded cross-column search

### DIFF
--- a/rust/lance-index/src/scalar/inverted/query.rs
+++ b/rust/lance-index/src/scalar/inverted/query.rs
@@ -136,8 +136,8 @@ impl std::fmt::Display for FtsQuery {
             Self::Boolean(query) => {
                 write!(
                     f,
-                    "Boolean(must={:?}, should={:?})",
-                    query.must, query.should
+                    "Boolean(must={:?}, should={:?}, must_not={:?})",
+                    query.must, query.should, query.must_not
                 )
             }
         }
@@ -1155,6 +1155,38 @@ mod tests {
         assert_eq!(plan.should, vec![should]);
         assert_eq!(plan.must, vec![must]);
         assert_eq!(plan.must_not, vec![must_not]);
+    }
+
+    #[test]
+    fn test_boolean_query_columns_include_must_not() {
+        use super::*;
+
+        let must = MatchQuery::new("required".to_string()).with_column(Some("title".to_string()));
+        let must_not = MatchQuery::new("blocked".to_string()).with_column(Some("body".to_string()));
+        let query = FtsQuery::Boolean(BooleanQuery::new([
+            (Occur::Must, must.into()),
+            (Occur::MustNot, must_not.into()),
+        ]));
+
+        assert_eq!(
+            query.columns(),
+            HashSet::from(["title".to_string(), "body".to_string()])
+        );
+        assert!(!query.is_missing_column());
+    }
+
+    #[test]
+    fn test_boolean_query_missing_must_not_column_is_detected() {
+        use super::*;
+
+        let must = MatchQuery::new("required".to_string()).with_column(Some("title".to_string()));
+        let must_not = MatchQuery::new("blocked".to_string());
+        let query = FtsQuery::Boolean(BooleanQuery::new([
+            (Occur::Must, must.into()),
+            (Occur::MustNot, must_not.into()),
+        ]));
+
+        assert!(query.is_missing_column());
     }
 
     #[test]

--- a/rust/lance/src/dataset/scanner.rs
+++ b/rust/lance/src/dataset/scanner.rs
@@ -66,6 +66,7 @@ use lance_datafusion::projection::ProjectionPlan;
 use lance_file::reader::FileReaderOptions;
 use lance_index::IndexCriteria;
 use lance_index::metrics::NoOpMetricsCollector;
+use lance_index::pbold::InvertedIndexDetails;
 use lance_index::scalar::FullTextSearchQuery;
 use lance_index::scalar::expression::PlannerIndexExt;
 use lance_index::scalar::expression::ScalarIndexExpr;
@@ -74,7 +75,8 @@ use lance_index::scalar::inverted::query::{
     fill_fts_query_column,
 };
 use lance_index::scalar::inverted::{
-    DOC_INDEX_COL, DOC_INDEX_FIELD, DocumentGranularity, SCORE_COL, SCORE_FIELD, fts_schema,
+    DOC_INDEX_COL, DOC_INDEX_FIELD, DocumentGranularity, INVERTED_INDEX_VERSION_V2,
+    INVERTED_INDEX_VERSION_V3, SCORE_COL, SCORE_FIELD, fts_schema,
 };
 use lance_index::scalar::registry::VALUE_COLUMN_NAME;
 use lance_index::vector::{ApproxMode, DEFAULT_QUERY_PARALLELISM, DIST_COL, Query};
@@ -94,9 +96,10 @@ use crate::dataset::row_offsets_to_row_addresses;
 use crate::dataset::rowids::{live_row_addrs_to_row_ids, translate_addr_treemap_to_row_ids};
 use crate::dataset::utils::SchemaAdapter;
 use crate::index::DatasetIndexInternalExt;
+use crate::index::scalar::fetch_index_details;
 use crate::index::scalar::inverted::{
-    fts_index_fragment_bitmap, load_segment_details, load_segments, resolve_fts_field,
-    resolve_query_document_granularity,
+    fts_index_fragment_bitmap, load_segment_details, load_segments, normalize_inverted_details,
+    resolve_fts_field, resolve_query_document_granularity,
 };
 use crate::index::scalar_logical::{load_named_scalar_segments, scalar_index_fragment_bitmap};
 use crate::index::vector::utils::{
@@ -106,8 +109,8 @@ use crate::io::exec::filtered_read::{
     FilteredReadExec, FilteredReadOptions, FilteredReadThreadingMode,
 };
 use crate::io::exec::fts::{
-    BoostQueryExec, CompoundQueryExec, FlatMatchFilterExec, FlatMatchQueryExec, FtsDocumentExec,
-    MatchQueryExec, PhraseQueryExec, SharedFtsScorer,
+    BoostQueryExec, CompoundQueryExec, CrossColumnCompoundQueryExec, FlatMatchFilterExec,
+    FlatMatchQueryExec, FtsDocumentExec, MatchQueryExec, PhraseQueryExec, SharedFtsScorer,
 };
 use crate::io::exec::knn::MultivectorScoringExec;
 use crate::io::exec::scalar_index::{MaterializeIndexExec, ScalarIndexExec};
@@ -146,28 +149,65 @@ enum FtsOverlayPlan {
     FullScan,
 }
 
-fn collect_all_fts_columns(query: &FtsQuery, columns: &mut HashSet<String>) {
-    match query {
-        FtsQuery::Match(query) => {
-            if let Some(column) = &query.column {
-                columns.insert(column.clone());
+fn collect_fts_columns_in_order(query: &FtsQuery) -> Vec<String> {
+    fn visit(query: &FtsQuery, columns: &mut Vec<String>, seen: &mut HashSet<String>) {
+        match query {
+            FtsQuery::Match(query) => {
+                if let Some(column) = &query.column
+                    && seen.insert(column.clone())
+                {
+                    columns.push(column.clone());
+                }
+            }
+            FtsQuery::Phrase(query) => {
+                if let Some(column) = &query.column
+                    && seen.insert(column.clone())
+                {
+                    columns.push(column.clone());
+                }
+            }
+            FtsQuery::Boost(query) => {
+                visit(&query.positive, columns, seen);
+                visit(&query.negative, columns, seen);
+            }
+            FtsQuery::MultiMatch(query) => {
+                for match_query in &query.match_queries {
+                    if let Some(column) = &match_query.column
+                        && seen.insert(column.clone())
+                    {
+                        columns.push(column.clone());
+                    }
+                }
+            }
+            FtsQuery::Boolean(query) => {
+                for child in query
+                    .should
+                    .iter()
+                    .chain(&query.must)
+                    .chain(&query.must_not)
+                {
+                    visit(child, columns, seen);
+                }
             }
         }
+    }
+
+    let mut columns = Vec::new();
+    let mut seen = HashSet::new();
+    visit(query, &mut columns, &mut seen);
+    columns
+}
+
+fn collect_phrase_columns(query: &FtsQuery, columns: &mut HashSet<String>) {
+    match query {
         FtsQuery::Phrase(query) => {
             if let Some(column) = &query.column {
                 columns.insert(column.clone());
             }
         }
         FtsQuery::Boost(query) => {
-            collect_all_fts_columns(&query.positive, columns);
-            collect_all_fts_columns(&query.negative, columns);
-        }
-        FtsQuery::MultiMatch(query) => {
-            for match_query in &query.match_queries {
-                if let Some(column) = &match_query.column {
-                    columns.insert(column.clone());
-                }
-            }
+            collect_phrase_columns(&query.positive, columns);
+            collect_phrase_columns(&query.negative, columns);
         }
         FtsQuery::Boolean(query) => {
             for child in query
@@ -176,10 +216,25 @@ fn collect_all_fts_columns(query: &FtsQuery, columns: &mut HashSet<String>) {
                 .chain(&query.must)
                 .chain(&query.must_not)
             {
-                collect_all_fts_columns(child, columns);
+                collect_phrase_columns(child, columns);
             }
         }
+        FtsQuery::Match(_) | FtsQuery::MultiMatch(_) => {}
     }
+}
+
+async fn load_physical_fts_details(
+    dataset: &Dataset,
+    column: &str,
+    segment: &IndexMetadata,
+) -> Result<InvertedIndexDetails> {
+    let details = fetch_index_details(dataset, column, segment).await?;
+    let details = InvertedIndexDetails::decode(details.value.as_slice()).map_err(|err| {
+        Error::io(format!(
+            "failed to decode InvertedIndexDetails payload: {err}"
+        ))
+    })?;
+    normalize_inverted_details(segment, details)
 }
 
 fn supports_compound_scorer(query: &FtsQuery) -> bool {
@@ -204,25 +259,8 @@ fn supports_compound_scorer(query: &FtsQuery) -> bool {
     if matches!(query, FtsQuery::Match(_) | FtsQuery::Phrase(_)) || !supports_shape(query) {
         return false;
     }
-    let mut columns = HashSet::new();
-    collect_all_fts_columns(query, &mut columns);
-    columns.len() == 1
-}
-
-fn contains_phrase_query(query: &FtsQuery) -> bool {
-    match query {
-        FtsQuery::Phrase(_) => true,
-        FtsQuery::Match(_) | FtsQuery::MultiMatch(_) => false,
-        FtsQuery::Boost(query) => {
-            contains_phrase_query(&query.positive) || contains_phrase_query(&query.negative)
-        }
-        FtsQuery::Boolean(query) => query
-            .should
-            .iter()
-            .chain(&query.must)
-            .chain(&query.must_not)
-            .any(contains_phrase_query),
-    }
+    let columns = collect_fts_columns_in_order(query);
+    !columns.is_empty() && (!matches!(query, FtsQuery::MultiMatch(_)) || columns.len() == 1)
 }
 
 fn validate_fts_query_contract(query: &FtsQuery) -> Result<()> {
@@ -3909,24 +3947,18 @@ impl Scanner {
         prefilter_source: &PreFilterSource,
         document_granularity: DocumentGranularity,
     ) -> Result<Option<Arc<dyn ExecutionPlan>>> {
-        let mut columns = HashSet::new();
-        collect_all_fts_columns(query, &mut columns);
-        let Some(column) = columns.into_iter().next() else {
+        let columns = collect_fts_columns_in_order(query);
+        if columns.is_empty() {
             return Ok(None);
-        };
+        }
+        let cross_column = columns.len() > 1;
+        if cross_column && params.limit.is_none() {
+            // Candidate-driven cross-column execution requires a bounded top-k
+            // collector. The existing DataFusion plan remains the exact path
+            // for callers that request the full result set.
+            return Ok(None);
+        }
 
-        let index = self
-            .dataset
-            .load_scalar_index(
-                IndexCriteria::default()
-                    .for_column(&column)
-                    .supports_fts()
-                    .with_fts_document_granularity(document_granularity),
-            )
-            .await?;
-        let Some(index) = index else {
-            return Ok(None);
-        };
         let target_fragments: &[Fragment] = self
             .fragments
             .as_deref()
@@ -3934,45 +3966,113 @@ impl Scanner {
         if target_fragments.is_empty() {
             return Ok(None);
         }
-        if !self
-            .retain_target_fragments(self.dataset.unindexed_fragments(&index.name).await?)
-            .is_empty()
-        {
-            // Flat and posting-backed leaves do not share a document domain.
-            // Preserve the exact DataFusion fallback until flat leaves expose
-            // the same candidate protocol.
+        let mut phrase_columns = HashSet::new();
+        collect_phrase_columns(query, &mut phrase_columns);
+
+        let segment_groups = futures::future::try_join_all(columns.into_iter().map(|column| {
+            let phrase_columns = &phrase_columns;
+            async move {
+                let index = self
+                    .dataset
+                    .load_scalar_index(
+                        IndexCriteria::default()
+                            .for_column(&column)
+                            .supports_fts()
+                            .with_fts_document_granularity(document_granularity),
+                    )
+                    .await?;
+                let Some(index) = index else {
+                    return Ok(None);
+                };
+
+                let (unindexed_fragments, overlay_plan) = futures::future::try_join(
+                    self.dataset.unindexed_fragments(&index.name),
+                    self.fts_overlay_plan(&column, document_granularity, target_fragments),
+                )
+                .await?;
+                if !self.retain_target_fragments(unindexed_fragments).is_empty() {
+                    // Flat and posting-backed leaves do not share a document
+                    // domain, so preserve the exact fallback for partial index
+                    // coverage.
+                    return Ok(None);
+                }
+                let segments = match overlay_plan {
+                    FtsOverlayPlan::Unchanged(Some(segments)) => segments,
+                    FtsOverlayPlan::Unchanged(None) => {
+                        load_segments(&self.dataset, &column, document_granularity)
+                            .await?
+                            .ok_or_else(|| {
+                                Error::invalid_input(format!(
+                                    "No Inverted index found for column {column}"
+                                ))
+                            })?
+                    }
+                    FtsOverlayPlan::RowLevel { .. } | FtsOverlayPlan::FullScan => return Ok(None),
+                };
+
+                if cross_column {
+                    let details = futures::future::try_join_all(
+                        segments.iter().map(|segment| {
+                            load_physical_fts_details(&self.dataset, &column, segment)
+                        }),
+                    )
+                    .await?;
+                    if phrase_columns.contains(&column)
+                        && details.iter().any(|details| !details.with_position)
+                    {
+                        return Err(Error::invalid_input(
+                            "position is not found but required for phrase queries, try recreating the index with position"
+                                .to_string(),
+                        ));
+                    }
+                    let all_modern = details.iter().all(|details| {
+                        matches!(
+                            details.posting_format_version,
+                            Some(INVERTED_INDEX_VERSION_V2 | INVERTED_INDEX_VERSION_V3)
+                        )
+                    });
+                    if !all_modern {
+                        return Ok(None);
+                    }
+                } else if phrase_columns.contains(&column) {
+                    let details = load_segment_details(&self.dataset, &column, &segments).await?;
+                    if !details.with_position {
+                        return Err(Error::invalid_input(
+                            "position is not found but required for phrase queries, try recreating the index with position"
+                                .to_string(),
+                        ));
+                    }
+                }
+
+                Ok(Some((column, segments)))
+            }
+        }))
+        .await?;
+        let Some(segment_groups) = segment_groups.into_iter().collect::<Option<Vec<_>>>() else {
             return Ok(None);
-        }
-        let segments = match self
-            .fts_overlay_plan(&column, document_granularity, target_fragments)
-            .await?
-        {
-            FtsOverlayPlan::Unchanged(Some(segments)) => segments,
-            FtsOverlayPlan::Unchanged(None) => {
-                load_segments(&self.dataset, &column, document_granularity)
-                    .await?
-                    .ok_or_else(|| {
-                        Error::invalid_input(format!("No Inverted index found for column {column}"))
-                    })?
-            }
-            FtsOverlayPlan::RowLevel { .. } | FtsOverlayPlan::FullScan => return Ok(None),
         };
-        if contains_phrase_query(query) {
-            let details = load_segment_details(&self.dataset, &column, &segments).await?;
-            if !details.with_position {
-                return Err(Error::invalid_input(
-                    "position is not found but required for phrase queries, try recreating the index with position"
-                        .to_string(),
-                ));
-            }
+
+        if !cross_column {
+            let (_, segments) = segment_groups.into_iter().next().ok_or_else(|| {
+                Error::internal("compound scorer requires one column".to_string())
+            })?;
+            return Ok(Some(Arc::new(CompoundQueryExec::new_with_segments(
+                self.dataset.clone(),
+                query.clone(),
+                params.clone(),
+                prefilter_source.clone(),
+                segments,
+            ))));
         }
-        Ok(Some(Arc::new(CompoundQueryExec::new_with_segments(
+
+        let exec = CrossColumnCompoundQueryExec::new_with_segments(
             self.dataset.clone(),
             query.clone(),
             params.clone(),
             prefilter_source.clone(),
-            segments,
-        ))))
+            segment_groups,
+        )?;
+        Ok(Some(Arc::new(exec)))
     }
 
     async fn plan_fts(
@@ -3992,9 +4092,8 @@ impl Scanner {
             return Ok(plan);
         }
 
-        // Cross-column, flat, and overlay-backed compound queries retain the
-        // exact DataFusion fallback because their leaves do not share one
-        // posting document domain.
+        // Unsupported, unbounded, partial-index, and overlay-backed cross-column
+        // shapes retain the exact DataFusion fallback.
         let plan: Arc<dyn ExecutionPlan> = match query {
             FtsQuery::Match(query) => {
                 self.plan_match_query(query, params, filter_plan, prefilter_source)
@@ -6722,7 +6821,7 @@ mod test {
     use lance_file::version::LanceFileVersion;
     use lance_index::optimize::OptimizeOptions;
     use lance_index::scalar::inverted::query::{
-        BooleanQuery, BoostQuery, FtsQuery, MatchQuery, Occur, PhraseQuery,
+        BooleanQuery, BoostQuery, FtsQuery, MatchQuery, MultiMatchQuery, Occur, PhraseQuery,
     };
     use lance_index::vector::hnsw::builder::HnswBuildParams;
     use lance_index::vector::ivf::IvfBuildParams;
@@ -6767,6 +6866,73 @@ mod test {
         let error = validate_fts_query_contract(&infinite_boost).unwrap_err();
         assert!(matches!(error, Error::InvalidInput { .. }));
         assert!(error.to_string().contains("BoostQuery negative_boost"));
+    }
+
+    #[test]
+    fn test_compound_scorer_shape_supports_cross_column_boolean_queries() {
+        let query = FtsQuery::Boolean(BooleanQuery::new([
+            (
+                Occur::Should,
+                MatchQuery::new("alpha".to_string())
+                    .with_column(Some("title".to_string()))
+                    .into(),
+            ),
+            (
+                Occur::Must,
+                MatchQuery::new("beta".to_string())
+                    .with_column(Some("body".to_string()))
+                    .into(),
+            ),
+            (
+                Occur::MustNot,
+                MatchQuery::new("gamma".to_string())
+                    .with_column(Some("summary".to_string()))
+                    .into(),
+            ),
+        ]));
+
+        assert!(supports_compound_scorer(&query));
+        assert_eq!(
+            collect_fts_columns_in_order(&query),
+            ["title", "body", "summary"]
+        );
+    }
+
+    #[test]
+    fn test_compound_scorer_leaves_top_level_cross_column_multi_match_on_existing_path() {
+        let single_column = FtsQuery::MultiMatch(
+            MultiMatchQuery::try_new("alpha".to_string(), vec!["title".to_string()]).unwrap(),
+        );
+        let cross_column = FtsQuery::MultiMatch(
+            MultiMatchQuery::try_new(
+                "alpha".to_string(),
+                vec!["title".to_string(), "body".to_string()],
+            )
+            .unwrap(),
+        );
+
+        assert!(supports_compound_scorer(&single_column));
+        assert!(!supports_compound_scorer(&cross_column));
+    }
+
+    #[test]
+    fn test_collect_phrase_columns_traverses_prohibited_subtrees() {
+        let phrase =
+            PhraseQuery::new("exact phrase".to_string()).with_column(Some("body".to_string()));
+        let query = FtsQuery::Boolean(BooleanQuery::new([
+            (
+                Occur::Must,
+                MatchQuery::new("alpha".to_string())
+                    .with_column(Some("title".to_string()))
+                    .into(),
+            ),
+            (Occur::MustNot, phrase.into()),
+        ]));
+        let mut columns = HashSet::new();
+
+        collect_phrase_columns(&query, &mut columns);
+
+        assert_eq!(columns, HashSet::from(["body".to_string()]));
     }
 
     #[test]

--- a/rust/lance/src/dataset/tests/dataset_index.rs
+++ b/rust/lance/src/dataset/tests/dataset_index.rs
@@ -46,7 +46,9 @@ use lance_index::metrics::{
     COMPOUND_PEAK_ADDRESS_RESOLUTION_BATCH_SIZE_METRIC, COMPOUND_PEAK_BUFFERED_CANDIDATES_METRIC,
     COMPOUND_SCORE_FLOOR_OVERFLOWS_METRIC, COMPOUND_SHOULD_BOUND_RECOMPUTATIONS_METRIC,
     COMPOUND_SHOULD_ESSENTIAL_EVALUATIONS_METRIC, COMPOUND_SHOULD_NON_ESSENTIAL_EVALUATIONS_METRIC,
-    COMPOUND_SHOULD_SKIPPED_WINDOWS_METRIC,
+    COMPOUND_SHOULD_SKIPPED_WINDOWS_METRIC, CROSS_COLUMN_STAGED_ATTEMPTS_METRIC,
+    CROSS_COLUMN_STAGED_CANDIDATES_METRIC, CROSS_COLUMN_STAGED_FALLBACKS_METRIC,
+    CROSS_COLUMN_STAGED_SUCCESSES_METRIC,
 };
 use lance_index::optimize::OptimizeOptions;
 use lance_index::scalar::inverted::{
@@ -971,24 +973,34 @@ async fn create_fragmented_fts_index_with_order(
     with_position: bool,
     reverse_segments: bool,
 ) {
+    let mut fragment_groups = dataset
+        .get_fragments()
+        .iter()
+        .map(|fragment| vec![fragment.id() as u32])
+        .collect::<Vec<_>>();
+    if reverse_segments {
+        fragment_groups.reverse();
+    }
+    create_fragmented_fts_index_with_groups(dataset, column, with_position, fragment_groups).await;
+}
+
+async fn create_fragmented_fts_index_with_groups(
+    dataset: &mut Dataset,
+    column: &str,
+    with_position: bool,
+    fragment_groups: Vec<Vec<u32>>,
+) {
     let index_name = format!("{column}_idx");
     let columns = [column];
     let params = InvertedIndexParams::default().with_position(with_position);
-    let fragment_ids = dataset
-        .get_fragments()
-        .iter()
-        .map(|fragment| fragment.id() as u32)
-        .collect::<Vec<_>>();
-    let mut segments = Vec::with_capacity(fragment_ids.len());
-    for fragment_id in &fragment_ids {
+    let expected_segments = fragment_groups.len();
+    let mut segments = Vec::with_capacity(expected_segments);
+    for fragment_ids in fragment_groups {
         let mut builder = dataset
             .create_index_builder(&columns, IndexType::Inverted, &params)
             .name(index_name.clone())
-            .fragments(vec![*fragment_id]);
+            .fragments(fragment_ids);
         segments.push(builder.execute_uncommitted().await.unwrap());
-    }
-    if reverse_segments {
-        segments.reverse();
     }
     dataset
         .commit_existing_index_segments(&index_name, column, segments)
@@ -1000,7 +1012,7 @@ async fn create_fragmented_fts_index_with_order(
             .await
             .unwrap()
             .unwrap();
-    assert_eq!(segments.len(), fragment_ids.len());
+    assert_eq!(segments.len(), expected_segments);
 }
 
 fn compound_multimatch_query() -> FtsQuery {
@@ -1043,6 +1055,16 @@ async fn compound_fts_results(
         .collect()
 }
 
+fn compound_fts_result_bits(batch: &RecordBatch) -> Vec<(u64, u32)> {
+    let row_ids = batch[ROW_ID].as_primitive::<UInt64Type>().values();
+    let scores = batch[SCORE_COL].as_primitive::<Float32Type>().values();
+    row_ids
+        .iter()
+        .copied()
+        .zip(scores.iter().map(|score| score.to_bits()))
+        .collect()
+}
+
 async fn assert_compound_fts_top_k(dataset: &Dataset, query: FtsQuery, limit: usize) {
     let exhaustive = compound_fts_results(dataset, query.clone(), None).await;
     assert!(
@@ -1069,6 +1091,625 @@ fn expected_must_score_sum(left: Vec<(u64, f32)>, right: Vec<(u64, f32)>) -> Vec
             .then_with(|| left_row_id.cmp(right_row_id))
     });
     expected
+}
+
+const CROSS_COLUMN_COMPOUND_FTS_SCORER: &str = "CrossColumnCompoundFtsScorer";
+
+fn independent_compound_fts_oracle<'a>(
+    dataset: &'a Dataset,
+    query: &'a FtsQuery,
+) -> Pin<Box<dyn Future<Output = HashMap<u64, f32>> + Send + 'a>> {
+    Box::pin(async move {
+        match query {
+            FtsQuery::Match(_) | FtsQuery::Phrase(_) => {
+                compound_fts_results(dataset, query.clone(), None)
+                    .await
+                    .into_iter()
+                    .collect()
+            }
+            FtsQuery::MultiMatch(query) => {
+                let mut result = HashMap::new();
+                for match_query in &query.match_queries {
+                    let leaf = FtsQuery::Match(match_query.clone());
+                    for (row_id, score) in independent_compound_fts_oracle(dataset, &leaf).await {
+                        result
+                            .entry(row_id)
+                            .and_modify(|current| {
+                                if score > *current {
+                                    *current = score;
+                                }
+                            })
+                            .or_insert(score);
+                    }
+                }
+                result
+            }
+            FtsQuery::Boost(query) => {
+                let mut result =
+                    independent_compound_fts_oracle(dataset, query.positive.as_ref()).await;
+                let negative =
+                    independent_compound_fts_oracle(dataset, query.negative.as_ref()).await;
+                for (row_id, negative_score) in negative {
+                    if let Some(score) = result.get_mut(&row_id) {
+                        *score -= query.negative_boost * negative_score;
+                    }
+                }
+                result
+            }
+            FtsQuery::Boolean(query) => {
+                let mut required = None::<HashMap<u64, f32>>;
+                for clause in &query.must {
+                    let clause = independent_compound_fts_oracle(dataset, clause).await;
+                    if let Some(required) = required.as_mut() {
+                        required.retain(|row_id, score| {
+                            clause.get(row_id).is_some_and(|clause_score| {
+                                *score += *clause_score;
+                                true
+                            })
+                        });
+                    } else {
+                        required = Some(clause);
+                    }
+                }
+
+                let has_required = required.is_some();
+                let mut result = required.unwrap_or_default();
+                for clause in &query.should {
+                    let clause = independent_compound_fts_oracle(dataset, clause).await;
+                    for (row_id, clause_score) in clause {
+                        if has_required {
+                            if let Some(score) = result.get_mut(&row_id) {
+                                *score += clause_score;
+                            }
+                        } else {
+                            *result.entry(row_id).or_insert(0.0) += clause_score;
+                        }
+                    }
+                }
+
+                for clause in &query.must_not {
+                    for row_id in independent_compound_fts_oracle(dataset, clause)
+                        .await
+                        .keys()
+                    {
+                        result.remove(row_id);
+                    }
+                }
+                result
+            }
+        }
+    })
+}
+
+fn sorted_compound_fts_oracle(result: HashMap<u64, f32>) -> Vec<(u64, f32)> {
+    result
+        .into_iter()
+        .sorted_unstable_by(|(left_row_id, left_score), (right_row_id, right_score)| {
+            right_score
+                .total_cmp(left_score)
+                .then_with(|| left_row_id.cmp(right_row_id))
+        })
+        .collect()
+}
+
+fn assert_scored_rows_close(case_name: &str, actual: &[(u64, f32)], expected: &[(u64, f32)]) {
+    assert_eq!(
+        actual.len(),
+        expected.len(),
+        "{case_name} returned a different number of rows"
+    );
+    for ((actual_row_id, actual_score), (expected_row_id, expected_score)) in
+        actual.iter().zip(expected)
+    {
+        assert_eq!(
+            actual_row_id, expected_row_id,
+            "{case_name} returned rows in the wrong order"
+        );
+        let tolerance = 1.0e-5 * expected_score.abs().max(1.0);
+        assert!(
+            (actual_score - expected_score).abs() <= tolerance,
+            "{case_name} returned score {actual_score} for row {actual_row_id}, expected {expected_score}"
+        );
+    }
+}
+
+async fn assert_compound_matches_independent_oracle(
+    dataset: &Dataset,
+    case_name: &str,
+    query: &FtsQuery,
+    limit: usize,
+) -> Vec<(u64, f32)> {
+    let mut expected =
+        sorted_compound_fts_oracle(independent_compound_fts_oracle(dataset, query).await);
+    assert!(
+        expected.len() > limit,
+        "{case_name} must have candidates beyond k"
+    );
+    expected.truncate(limit);
+    let actual = compound_fts_results(dataset, query.clone(), Some(limit as i64)).await;
+    assert_scored_rows_close(case_name, &actual, &expected);
+    expected
+}
+
+async fn compound_fts_plan(dataset: &Dataset, query: FtsQuery, limit: usize) -> String {
+    let mut scanner = dataset.scan();
+    scanner
+        .with_row_id()
+        .full_text_search(FullTextSearchQuery::new_query(query))
+        .unwrap();
+    scanner.limit(Some(limit as i64), None).unwrap();
+    scanner.explain_plan(false).await.unwrap()
+}
+
+async fn write_cross_column_compound_dataset() -> Dataset {
+    let batch = arrow_array::record_batch!(
+        (
+            "title",
+            Utf8,
+            [
+                "alpha quick brown fox",
+                "alpha quick fox brown",
+                "quick brown fox",
+                "tie",
+                "alpha blocked",
+                "noise",
+                "alpha quick brown",
+                "tie",
+                "alpha",
+                "noise"
+            ]
+        ),
+        (
+            "body",
+            Utf8,
+            [
+                "gamma",
+                "gamma gamma optional",
+                "gamma",
+                "tiebody",
+                "gamma blocked",
+                "gamma optional",
+                "noise",
+                "tiebody",
+                "optional",
+                "blocked"
+            ]
+        ),
+        ("id", Int32, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
+    )
+    .unwrap();
+    let schema = batch.schema();
+    let dataset = Dataset::write(
+        RecordBatchIterator::new(vec![batch].into_iter().map(Ok), schema),
+        "memory://",
+        Some(WriteParams {
+            max_rows_per_file: 5,
+            ..Default::default()
+        }),
+    )
+    .await
+    .unwrap();
+    assert_eq!(dataset.get_fragments().len(), 2);
+    dataset
+}
+
+#[tokio::test]
+async fn test_cross_column_compound_scorer_matches_independent_leaf_oracle() {
+    let mut dataset = write_cross_column_compound_dataset().await;
+    create_fragmented_fts_index(&mut dataset, "title", true).await;
+    create_fragmented_fts_index(&mut dataset, "body", true).await;
+
+    let phrase = || {
+        PhraseQuery::new("quick brown".to_owned())
+            .with_column(Some("title".to_owned()))
+            .into()
+    };
+    let phrase_approximation: FtsQuery = MatchQuery::new("quick brown".to_owned())
+        .with_column(Some("title".to_owned()))
+        .with_operator(Operator::And)
+        .into();
+    let phrase_query = phrase();
+    let phrase_matches = independent_compound_fts_oracle(&dataset, &phrase_query).await;
+    let approximation_matches =
+        independent_compound_fts_oracle(&dataset, &phrase_approximation).await;
+    assert!(
+        approximation_matches.len() > phrase_matches.len(),
+        "the fixture must include an approximation hit rejected by phrase confirmation"
+    );
+
+    let nested_required: FtsQuery = BooleanQuery::new([
+        (Occur::Should, compound_match_query("alpha", "title", 2.0)),
+        (Occur::Should, compound_match_query("gamma", "body", 3.0)),
+    ])
+    .into();
+    let staged_required_optional: FtsQuery = BooleanQuery::new([
+        (Occur::Must, compound_match_query("alpha", "title", 1.0)),
+        (Occur::Should, compound_match_query("optional", "body", 4.0)),
+    ])
+    .into();
+    let cases: Vec<(&str, FtsQuery, usize)> = vec![
+        (
+            "must_sum",
+            BooleanQuery::new([
+                (Occur::Must, compound_match_query("alpha", "title", 2.0)),
+                (Occur::Must, compound_match_query("gamma", "body", 3.0)),
+            ])
+            .into(),
+            2,
+        ),
+        (
+            "should_sum",
+            BooleanQuery::new([
+                (Occur::Should, compound_match_query("alpha", "title", 2.0)),
+                (Occur::Should, compound_match_query("gamma", "body", 3.0)),
+            ])
+            .into(),
+            3,
+        ),
+        ("required_optional", staged_required_optional.clone(), 3),
+        (
+            "must_not",
+            BooleanQuery::new([
+                (Occur::Must, compound_match_query("gamma", "body", 3.0)),
+                (
+                    Occur::MustNot,
+                    compound_match_query("blocked", "title", 1_000_000.0),
+                ),
+            ])
+            .into(),
+            3,
+        ),
+        (
+            "phrase_two_phase",
+            BooleanQuery::new([
+                (Occur::Must, phrase()),
+                (Occur::Must, compound_match_query("gamma", "body", 1.0)),
+            ])
+            .into(),
+            1,
+        ),
+        (
+            "boost",
+            BoostQuery::new(
+                compound_match_query("gamma", "body", 3.0),
+                compound_match_query("alpha", "title", 2.0),
+                Some(0.5),
+            )
+            .into(),
+            3,
+        ),
+        (
+            "nested",
+            BooleanQuery::new([
+                (Occur::Must, nested_required),
+                (Occur::Should, phrase()),
+                (Occur::MustNot, compound_match_query("blocked", "body", 1.0)),
+            ])
+            .into(),
+            3,
+        ),
+    ];
+
+    let mut plans = Vec::with_capacity(cases.len());
+    for (case_name, query, limit) in cases {
+        assert_compound_matches_independent_oracle(&dataset, case_name, &query, limit).await;
+        plans.push((case_name, compound_fts_plan(&dataset, query, limit).await));
+    }
+
+    for (case_name, plan) in plans {
+        assert!(
+            plan.contains(CROSS_COLUMN_COMPOUND_FTS_SCORER),
+            "{case_name} should use the cross-column scorer:\n{plan}"
+        );
+        assert!(
+            !plan.contains("HashJoinExec"),
+            "{case_name} should not materialize an intermediate hash join:\n{plan}"
+        );
+    }
+
+    let collected_stats = Arc::new(Mutex::new(None::<ExecutionSummaryCounts>));
+    let stats_setter = collected_stats.clone();
+    let mut scanner = dataset.scan();
+    scanner
+        .scan_stats_callback(Arc::new(move |stats| {
+            *stats_setter.lock().unwrap() = Some(stats.clone());
+        }))
+        .with_row_id()
+        .full_text_search(FullTextSearchQuery::new_query(
+            staged_required_optional.clone(),
+        ))
+        .unwrap();
+    scanner.limit(Some(3), None).unwrap();
+    let staged_results = compound_fts_result_bits(&scanner.try_into_batch().await.unwrap());
+    let stats = collected_stats.lock().unwrap().take().unwrap();
+    assert_eq!(
+        stats.all_counts.get(CROSS_COLUMN_STAGED_ATTEMPTS_METRIC),
+        Some(&1)
+    );
+    assert_eq!(
+        stats.all_counts.get(CROSS_COLUMN_STAGED_SUCCESSES_METRIC),
+        Some(&1)
+    );
+    assert_eq!(
+        stats.all_counts.get(CROSS_COLUMN_STAGED_FALLBACKS_METRIC),
+        Some(&0)
+    );
+    assert!(
+        stats
+            .all_counts
+            .get(CROSS_COLUMN_STAGED_CANDIDATES_METRIC)
+            .is_some_and(|candidates| *candidates > 0),
+        "required+optional execution should materialize staged candidates"
+    );
+
+    dataset
+        .prewarm_index_with_options(
+            "title_idx",
+            &PrewarmOptions::Fts(FtsPrewarmOptions::default()),
+        )
+        .await
+        .unwrap();
+    dataset
+        .prewarm_index_with_options(
+            "body_idx",
+            &PrewarmOptions::Fts(FtsPrewarmOptions::default()),
+        )
+        .await
+        .unwrap();
+
+    let collected_stats = Arc::new(Mutex::new(None::<ExecutionSummaryCounts>));
+    let stats_setter = collected_stats.clone();
+    let mut scanner = dataset.scan();
+    scanner
+        .scan_stats_callback(Arc::new(move |stats| {
+            *stats_setter.lock().unwrap() = Some(stats.clone());
+        }))
+        .with_row_id()
+        .full_text_search(FullTextSearchQuery::new_query(staged_required_optional))
+        .unwrap();
+    scanner.limit(Some(3), None).unwrap();
+    let resident_results = compound_fts_result_bits(&scanner.try_into_batch().await.unwrap());
+    let stats = collected_stats.lock().unwrap().take().unwrap();
+    assert_eq!(
+        stats.all_counts.get(CROSS_COLUMN_STAGED_ATTEMPTS_METRIC),
+        Some(&0),
+        "prewarmed cross-column queries should use the resident bounded coordinator"
+    );
+    assert_eq!(
+        stats.all_counts.get(CROSS_COLUMN_STAGED_SUCCESSES_METRIC),
+        Some(&0)
+    );
+    assert_eq!(
+        resident_results, staged_results,
+        "resident and staged cross-column scans must return identical ordered row ids and score bits"
+    );
+}
+
+#[tokio::test]
+async fn test_cross_column_compound_uses_one_scalar_prefilter_mask() {
+    const FILTER: &str = "id IN (0, 2, 5, 6, 8)";
+    const LIMIT: usize = 3;
+
+    let mut dataset = write_cross_column_compound_dataset().await;
+    create_fragmented_fts_index(&mut dataset, "title", true).await;
+    create_fragmented_fts_index(&mut dataset, "body", true).await;
+    dataset
+        .create_index(
+            &["id"],
+            IndexType::BTree,
+            None,
+            &ScalarIndexParams::default(),
+            true,
+        )
+        .await
+        .unwrap();
+
+    let query: FtsQuery = BooleanQuery::new([
+        (Occur::Should, compound_match_query("alpha", "title", 2.0)),
+        (Occur::Should, compound_match_query("gamma", "body", 3.0)),
+    ])
+    .into();
+    let mut allowed_scan = dataset.scan();
+    allowed_scan.use_scalar_index(false);
+    allowed_scan.with_row_id().filter(FILTER).unwrap();
+    let allowed_batch = allowed_scan.try_into_batch().await.unwrap();
+    let allowed_row_ids = allowed_batch[ROW_ID]
+        .as_primitive::<UInt64Type>()
+        .values()
+        .iter()
+        .copied()
+        .collect::<HashSet<_>>();
+    let mut expected = independent_compound_fts_oracle(&dataset, &query).await;
+    expected.retain(|row_id, _| allowed_row_ids.contains(row_id));
+    let mut expected = sorted_compound_fts_oracle(expected);
+    assert!(expected.len() > LIMIT);
+    expected.truncate(LIMIT);
+
+    let mut scanner = dataset.scan();
+    scanner
+        .prefilter(true)
+        .with_row_id()
+        .full_text_search(FullTextSearchQuery::new_query(query))
+        .unwrap()
+        .filter(FILTER)
+        .unwrap()
+        .limit(Some(LIMIT as i64), None)
+        .unwrap();
+    let plan = scanner.explain_plan(false).await.unwrap();
+    assert!(
+        plan.contains(CROSS_COLUMN_COMPOUND_FTS_SCORER),
+        "filtered cross-column search should use the cross-column scorer:\n{plan}"
+    );
+    assert!(
+        plan.contains("ScalarIndexQuery") && plan.contains("BTree"),
+        "the shared prefilter should be built from the BTree scalar index:\n{plan}"
+    );
+    assert_eq!(
+        plan.matches("ScalarIndexQuery").count(),
+        1,
+        "the cross-column scorer should have one shared scalar prefilter:\n{plan}"
+    );
+
+    let actual = scanner.try_into_batch().await.unwrap();
+    let actual = actual[ROW_ID]
+        .as_primitive::<UInt64Type>()
+        .values()
+        .iter()
+        .copied()
+        .zip(
+            actual[SCORE_COL]
+                .as_primitive::<Float32Type>()
+                .values()
+                .iter()
+                .copied(),
+        )
+        .collect::<Vec<_>>();
+    assert_scored_rows_close("scalar_prefilter", &actual, &expected);
+}
+
+#[tokio::test]
+async fn test_cross_column_compound_tie_uses_final_row_id() {
+    let mut dataset = write_cross_column_compound_dataset().await;
+    create_fragmented_fts_index_with_order(&mut dataset, "title", true, true).await;
+    create_fragmented_fts_index_with_order(&mut dataset, "body", true, true).await;
+
+    let query: FtsQuery = BooleanQuery::new([
+        (Occur::Must, compound_match_query("tie", "title", 1.0)),
+        (Occur::Must, compound_match_query("tiebody", "body", 1.0)),
+    ])
+    .into();
+    let expected =
+        sorted_compound_fts_oracle(independent_compound_fts_oracle(&dataset, &query).await);
+    assert_eq!(expected.len(), 2);
+    assert_eq!(expected[0].1, expected[1].1);
+    assert!(expected[0].0 < expected[1].0);
+
+    let actual = compound_fts_results(&dataset, query.clone(), Some(1)).await;
+    assert_scored_rows_close("equal_score_row_id_tie", &actual, &expected[..1]);
+    let plan = compound_fts_plan(&dataset, query, 1).await;
+    assert!(
+        plan.contains(CROSS_COLUMN_COMPOUND_FTS_SCORER),
+        "equal-score cross-column search should use the cross-column scorer:\n{plan}"
+    );
+}
+
+async fn assert_cross_column_layout_uses_fast_path(dataset: &Dataset, case_name: &str) {
+    let query: FtsQuery = BooleanQuery::new([
+        (Occur::Must, compound_match_query("alpha", "title", 2.0)),
+        (Occur::Must, compound_match_query("gamma", "body", 3.0)),
+    ])
+    .into();
+    assert_compound_matches_independent_oracle(dataset, case_name, &query, 2).await;
+    let plan = compound_fts_plan(dataset, query, 2).await;
+    assert!(
+        plan.contains(CROSS_COLUMN_COMPOUND_FTS_SCORER),
+        "{case_name} should align independent segment layouts by row address:\n{plan}"
+    );
+}
+
+#[tokio::test]
+async fn test_cross_column_compound_handles_independent_segment_layouts() {
+    let mut reordered = write_cross_column_compound_dataset().await;
+    let fragment_ids = reordered
+        .get_fragments()
+        .iter()
+        .map(|fragment| fragment.id() as u32)
+        .collect::<Vec<_>>();
+    create_fragmented_fts_index_with_groups(
+        &mut reordered,
+        "title",
+        true,
+        vec![vec![fragment_ids[0]], vec![fragment_ids[1]]],
+    )
+    .await;
+    create_fragmented_fts_index_with_groups(
+        &mut reordered,
+        "body",
+        true,
+        vec![vec![fragment_ids[1]], vec![fragment_ids[0]]],
+    )
+    .await;
+    assert_cross_column_layout_uses_fast_path(&reordered, "reordered_segments").await;
+
+    let mut differently_split = write_cross_column_compound_dataset().await;
+    let fragment_ids = differently_split
+        .get_fragments()
+        .iter()
+        .map(|fragment| fragment.id() as u32)
+        .collect::<Vec<_>>();
+    create_fragmented_fts_index_with_groups(
+        &mut differently_split,
+        "title",
+        true,
+        vec![vec![fragment_ids[0]], vec![fragment_ids[1]]],
+    )
+    .await;
+    create_fragmented_fts_index_with_groups(
+        &mut differently_split,
+        "body",
+        true,
+        vec![fragment_ids],
+    )
+    .await;
+    assert_cross_column_layout_uses_fast_path(&differently_split, "differently_split_segments")
+        .await;
+}
+
+#[tokio::test]
+async fn test_cross_column_compound_incomplete_coverage_uses_exact_fallback() {
+    let initial = arrow_array::record_batch!(
+        ("title", Utf8, ["old alpha", "old noise"]),
+        ("body", Utf8, ["old gamma", "old noise"])
+    )
+    .unwrap();
+    let schema = initial.schema();
+    let mut dataset = Dataset::write(
+        RecordBatchIterator::new(vec![initial].into_iter().map(Ok), schema),
+        "memory://",
+        Some(WriteParams {
+            max_rows_per_file: 2,
+            ..Default::default()
+        }),
+    )
+    .await
+    .unwrap();
+    create_fragmented_fts_index(&mut dataset, "body", true).await;
+
+    let appended = arrow_array::record_batch!(
+        ("title", Utf8, ["fresh alpha"]),
+        ("body", Utf8, ["fresh gamma"])
+    )
+    .unwrap();
+    let schema = appended.schema();
+    dataset
+        .append(
+            RecordBatchIterator::new(vec![appended].into_iter().map(Ok), schema),
+            None,
+        )
+        .await
+        .unwrap();
+    create_fragmented_fts_index(&mut dataset, "title", true).await;
+
+    let query: FtsQuery = BooleanQuery::new([
+        (Occur::Must, compound_match_query("fresh", "title", 1.0)),
+        (Occur::Must, compound_match_query("fresh", "body", 1.0)),
+    ])
+    .into();
+    let expected =
+        sorted_compound_fts_oracle(independent_compound_fts_oracle(&dataset, &query).await);
+    assert_eq!(expected.len(), 1, "the appended row must be the only hit");
+    let actual = compound_fts_results(&dataset, query.clone(), Some(1)).await;
+    assert_scored_rows_close("incomplete_coverage", &actual, &expected);
+
+    let plan = compound_fts_plan(&dataset, query, 1).await;
+    assert!(
+        !plan.contains(CROSS_COLUMN_COMPOUND_FTS_SCORER),
+        "incomplete column coverage must not use the cross-column scorer:\n{plan}"
+    );
+    assert!(
+        plan.contains("BooleanQuery"),
+        "incomplete column coverage should retain the exact fallback:\n{plan}"
+    );
 }
 
 #[tokio::test]
@@ -1217,8 +1858,12 @@ async fn test_boolean_must_scores_sum_across_execution_paths() {
     scanner.limit(Some(LIMIT as i64), None).unwrap();
     let plan = scanner.explain_plan(false).await.unwrap();
     assert!(
-        plan.contains("HashJoinExec"),
-        "cross-column MUST should exercise the exact fallback:\n{plan}"
+        plan.contains(CROSS_COLUMN_COMPOUND_FTS_SCORER),
+        "cross-column MUST should exercise the cross-column scorer:\n{plan}"
+    );
+    assert!(
+        !plan.contains("HashJoinExec"),
+        "cross-column MUST should not materialize an intermediate hash join:\n{plan}"
     );
 }
 
@@ -1281,7 +1926,39 @@ async fn test_nested_multimatch_limit_propagation() {
             .any(|rows| rows[0].1 == rows[1].1 && rows[0].0 < rows[1].0),
         "the exhaustive result should include a deterministic score tie"
     );
-    assert_compound_fts_top_k(&dataset, must_query, 2).await;
+    assert_compound_matches_independent_oracle(&dataset, "nested_multimatch_must", &must_query, 2)
+        .await;
+    let collected_stats = Arc::new(Mutex::new(None::<ExecutionSummaryCounts>));
+    let stats_setter = collected_stats.clone();
+    let mut staged_scanner = dataset.scan();
+    staged_scanner
+        .scan_stats_callback(Arc::new(move |stats| {
+            *stats_setter.lock().unwrap() = Some(stats.clone());
+        }))
+        .with_row_id()
+        .full_text_search(FullTextSearchQuery::new_query(must_query.clone()))
+        .unwrap();
+    staged_scanner.limit(Some(2), None).unwrap();
+    staged_scanner.try_into_batch().await.unwrap();
+    let staged_stats = collected_stats.lock().unwrap().take().unwrap();
+    assert_eq!(
+        staged_stats
+            .all_counts
+            .get(CROSS_COLUMN_STAGED_ATTEMPTS_METRIC),
+        Some(&1)
+    );
+    assert_eq!(
+        staged_stats
+            .all_counts
+            .get(CROSS_COLUMN_STAGED_SUCCESSES_METRIC),
+        Some(&1)
+    );
+    assert_eq!(
+        staged_stats
+            .all_counts
+            .get(CROSS_COLUMN_STAGED_FALLBACKS_METRIC),
+        Some(&0)
+    );
 
     let should_query: FtsQuery = BooleanQuery::new([
         (Occur::Should, compound_multimatch_query()),
@@ -1291,21 +1968,27 @@ async fn test_nested_multimatch_limit_propagation() {
         ),
     ])
     .into();
-    assert_compound_fts_top_k(&dataset, should_query.clone(), 2).await;
-    let mut fallback_scanner = dataset.scan();
-    fallback_scanner
+    assert_compound_matches_independent_oracle(
+        &dataset,
+        "nested_multimatch_should",
+        &should_query,
+        2,
+    )
+    .await;
+    let mut scanner = dataset.scan();
+    scanner
         .with_row_id()
         .full_text_search(FullTextSearchQuery::new_query(should_query))
         .unwrap();
-    fallback_scanner.limit(Some(2), None).unwrap();
-    let fallback_plan = fallback_scanner.explain_plan(false).await.unwrap();
+    scanner.limit(Some(2), None).unwrap();
+    let plan = scanner.explain_plan(false).await.unwrap();
     assert!(
-        fallback_plan.contains("BooleanQuery"),
-        "cross-column compound FTS should retain its exact fallback:\n{fallback_plan}"
+        plan.contains(CROSS_COLUMN_COMPOUND_FTS_SCORER),
+        "cross-column compound FTS should use the cross-column scorer:\n{plan}"
     );
     assert!(
-        !fallback_plan.contains("CompoundFtsScorer"),
-        "cross-column compound FTS is not yet supported by the scorer tree:\n{fallback_plan}"
+        !plan.contains("HashJoinExec"),
+        "cross-column compound FTS should not materialize intermediate joins:\n{plan}"
     );
 
     let boost_query: FtsQuery = BoostQuery::new(
@@ -1314,9 +1997,22 @@ async fn test_nested_multimatch_limit_propagation() {
         Some(1.0),
     )
     .into();
-    assert_compound_fts_top_k(&dataset, boost_query, 2).await;
+    assert_compound_matches_independent_oracle(
+        &dataset,
+        "nested_multimatch_boost",
+        &boost_query,
+        2,
+    )
+    .await;
 
-    assert_compound_fts_top_k(&dataset, compound_multimatch_query(), 1).await;
+    let multimatch_query = compound_multimatch_query();
+    assert_compound_matches_independent_oracle(
+        &dataset,
+        "cross_column_multimatch",
+        &multimatch_query,
+        1,
+    )
+    .await;
 }
 
 #[tokio::test]

--- a/rust/lance/src/io/exec/fts.rs
+++ b/rust/lance/src/io/exec/fts.rs
@@ -48,7 +48,9 @@ use lance_index::metrics::{
     COMPOUND_PEAK_ADDRESS_RESOLUTION_BATCH_SIZE_METRIC, COMPOUND_PEAK_BUFFERED_CANDIDATES_METRIC,
     COMPOUND_SCORE_FLOOR_OVERFLOWS_METRIC, COMPOUND_SHOULD_BOUND_RECOMPUTATIONS_METRIC,
     COMPOUND_SHOULD_ESSENTIAL_EVALUATIONS_METRIC, COMPOUND_SHOULD_NON_ESSENTIAL_EVALUATIONS_METRIC,
-    COMPOUND_SHOULD_SKIPPED_WINDOWS_METRIC, FREQS_COLLECTED_METRIC, MetricsCollector,
+    COMPOUND_SHOULD_SKIPPED_WINDOWS_METRIC, CROSS_COLUMN_STAGED_ATTEMPTS_METRIC,
+    CROSS_COLUMN_STAGED_CANDIDATES_METRIC, CROSS_COLUMN_STAGED_FALLBACKS_METRIC,
+    CROSS_COLUMN_STAGED_SUCCESSES_METRIC, FREQS_COLLECTED_METRIC, MetricsCollector,
 };
 use lance_index::scalar::inverted::builder::ScoredDoc;
 use lance_index::scalar::inverted::builder::document_input;
@@ -61,7 +63,8 @@ use lance_index::scalar::inverted::tokenizer::document_tokenizer::TextTokenizer;
 use lance_index::scalar::inverted::{
     DOC_INDEX_COL, DocumentGranularity, FTS_SCHEMA, FlatBm25SearchOptions, InvertedIndex,
     MemBM25Scorer, SCORE_COL, build_global_bm25_scorer, compound_search,
-    compound_search_with_base_scorer, flat_bm25_search_stream_with_options_and_scorer, fts_schema,
+    compound_search_with_base_scorer, cross_column_compound_search,
+    flat_bm25_search_stream_with_options_and_scorer, fts_schema,
 };
 use lance_index::{prefilter::PreFilter, scalar::inverted::query::BooleanQuery};
 use lance_select::RowAddrMask;
@@ -480,6 +483,52 @@ fn count_fts_leaves(query: &FtsQuery) -> usize {
     }
 }
 
+/// Return every leaf column, including prohibited Boolean leaves.
+///
+/// The repeated, ordered list is useful beyond the distinct set returned by
+/// `FtsQueryNode::columns`: each leaf contributes its own posting-partition
+/// work and must use the tokenizer and statistics of its field.
+fn compound_leaf_columns(query: &FtsQuery) -> Result<Vec<&str>> {
+    fn visit<'a>(query: &'a FtsQuery, columns: &mut Vec<&'a str>) -> Result<()> {
+        let required_column = |column: &'a Option<String>, kind: &str| {
+            column.as_deref().ok_or_else(|| {
+                Error::invalid_input(format!(
+                    "cross-column compound FTS {kind} leaf is missing its resolved column"
+                ))
+            })
+        };
+
+        match query {
+            FtsQuery::Match(query) => columns.push(required_column(&query.column, "Match")?),
+            FtsQuery::Phrase(query) => columns.push(required_column(&query.column, "Phrase")?),
+            FtsQuery::Boost(query) => {
+                visit(&query.positive, columns)?;
+                visit(&query.negative, columns)?;
+            }
+            FtsQuery::MultiMatch(query) => {
+                for query in &query.match_queries {
+                    columns.push(required_column(&query.column, "MultiMatch")?);
+                }
+            }
+            FtsQuery::Boolean(query) => {
+                for query in query
+                    .should
+                    .iter()
+                    .chain(&query.must)
+                    .chain(&query.must_not)
+                {
+                    visit(query, columns)?;
+                }
+            }
+        }
+        Ok(())
+    }
+
+    let mut columns = Vec::with_capacity(count_fts_leaves(query));
+    visit(query, &mut columns)?;
+    Ok(columns)
+}
+
 /// One DataFusion boundary around a posting-backed compound scorer tree.
 #[derive(Debug)]
 pub struct CompoundQueryExec {
@@ -786,6 +835,369 @@ impl ExecutionPlan for CompoundQueryExec {
     }
 }
 
+#[derive(Debug, Clone)]
+struct CompoundColumnSelection {
+    column: String,
+    segment_selection: FtsSegmentSelection,
+}
+
+/// One DataFusion boundary around a cross-column posting-backed scorer tree.
+///
+/// Each column keeps its own ordered segment selection and tokenizer. The
+/// lower-level scorer joins leaves in the common row-address domain; segment
+/// ordinals are deliberately never paired across columns.
+#[derive(Debug)]
+pub struct CrossColumnCompoundQueryExec {
+    dataset: Arc<Dataset>,
+    query: FtsQuery,
+    tokenized_query: Arc<OnceLock<TokenizedCompoundQuery>>,
+    params: FtsSearchParams,
+    prefilter_source: PreFilterSource,
+    columns: Arc<[CompoundColumnSelection]>,
+    properties: Arc<PlanProperties>,
+    metrics: ExecutionPlanMetricsSet,
+}
+
+impl CrossColumnCompoundQueryExec {
+    pub fn new_with_segments(
+        dataset: Arc<Dataset>,
+        query: FtsQuery,
+        params: FtsSearchParams,
+        prefilter_source: PreFilterSource,
+        columns: Vec<(String, Vec<IndexMetadata>)>,
+    ) -> Result<Self> {
+        if params.limit.is_none() {
+            return Err(Error::invalid_input(
+                "cross-column compound FTS requires a bounded result limit",
+            ));
+        }
+        let leaf_columns = compound_leaf_columns(&query)?;
+        let query_columns = leaf_columns.iter().copied().collect::<HashSet<_>>();
+        if query_columns.len() < 2 {
+            return Err(Error::invalid_input(format!(
+                "cross-column compound FTS requires at least two query columns, got {}",
+                query_columns.len()
+            )));
+        }
+
+        let mut selected_columns = HashSet::with_capacity(columns.len());
+        for (column, segments) in &columns {
+            if column.is_empty() {
+                return Err(Error::invalid_input(
+                    "cross-column compound FTS segment selection has an empty column name",
+                ));
+            }
+            if segments.is_empty() {
+                return Err(Error::invalid_input(format!(
+                    "cross-column compound FTS requires at least one segment for column {column}"
+                )));
+            }
+            if !selected_columns.insert(column.as_str()) {
+                return Err(Error::invalid_input(format!(
+                    "cross-column compound FTS has duplicate segment selections for column {column}"
+                )));
+            }
+        }
+
+        if selected_columns != query_columns {
+            let mut missing = query_columns
+                .difference(&selected_columns)
+                .copied()
+                .collect::<Vec<_>>();
+            let mut unexpected = selected_columns
+                .difference(&query_columns)
+                .copied()
+                .collect::<Vec<_>>();
+            missing.sort_unstable();
+            unexpected.sort_unstable();
+            return Err(Error::invalid_input(format!(
+                "cross-column compound FTS segment selections do not match query leaves: \
+                 missing={missing:?}, unexpected={unexpected:?}"
+            )));
+        }
+
+        let columns = columns
+            .into_iter()
+            .map(|(column, segments)| CompoundColumnSelection {
+                column,
+                segment_selection: FtsSegmentSelection::ExactResolved(Arc::from(segments)),
+            })
+            .collect::<Vec<_>>();
+        Ok(Self {
+            dataset,
+            query,
+            tokenized_query: Arc::new(OnceLock::new()),
+            params,
+            prefilter_source,
+            columns: Arc::from(columns),
+            properties: Arc::new(PlanProperties::new(
+                EquivalenceProperties::new(FTS_SCHEMA.clone()),
+                Partitioning::RoundRobinBatch(1),
+                EmissionType::Final,
+                Boundedness::Bounded,
+            )),
+            metrics: ExecutionPlanMetricsSet::new(),
+        })
+    }
+
+    pub fn dataset(&self) -> &Arc<Dataset> {
+        &self.dataset
+    }
+
+    pub fn query(&self) -> &FtsQuery {
+        &self.query
+    }
+
+    pub fn params(&self) -> &FtsSearchParams {
+        &self.params
+    }
+
+    pub fn prefilter_source(&self) -> &PreFilterSource {
+        &self.prefilter_source
+    }
+}
+
+impl DisplayAs for CrossColumnCompoundQueryExec {
+    fn fmt_as(&self, t: DisplayFormatType, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match t {
+            DisplayFormatType::Default | DisplayFormatType::Verbose => {
+                write!(f, "CrossColumnCompoundFtsScorer: query={}", self.query)?;
+                fmt_tokenized_compound_query(&self.tokenized_query, ", ", f)
+            }
+            DisplayFormatType::TreeRender => {
+                write!(f, "CrossColumnCompoundFtsScorer\nquery={}", self.query)?;
+                fmt_tokenized_compound_query(&self.tokenized_query, "\n", f)
+            }
+        }
+    }
+}
+
+impl ExecutionPlan for CrossColumnCompoundQueryExec {
+    fn name(&self) -> &str {
+        "CrossColumnCompoundQueryExec"
+    }
+
+    fn children(&self) -> Vec<&Arc<dyn ExecutionPlan>> {
+        match &self.prefilter_source {
+            PreFilterSource::None => vec![],
+            PreFilterSource::FilteredRowIds(source) | PreFilterSource::ScalarIndexQuery(source) => {
+                vec![source]
+            }
+        }
+    }
+
+    fn required_input_distribution(&self) -> Vec<Distribution> {
+        self.children()
+            .iter()
+            .map(|_| Distribution::SinglePartition)
+            .collect()
+    }
+
+    fn with_new_children(
+        self: Arc<Self>,
+        mut children: Vec<Arc<dyn ExecutionPlan>>,
+    ) -> DataFusionResult<Arc<dyn ExecutionPlan>> {
+        let prefilter_source = match children.len() {
+            0 if matches!(self.prefilter_source, PreFilterSource::None) => PreFilterSource::None,
+            1 => {
+                let Some(source) = children.pop() else {
+                    return Err(DataFusionError::Internal(
+                        "cross-column compound FTS lost its prefilter child".to_string(),
+                    ));
+                };
+                match &self.prefilter_source {
+                    PreFilterSource::FilteredRowIds(_) => PreFilterSource::FilteredRowIds(source),
+                    PreFilterSource::ScalarIndexQuery(_) => {
+                        PreFilterSource::ScalarIndexQuery(source)
+                    }
+                    PreFilterSource::None => {
+                        return Err(DataFusionError::Internal(
+                            "cross-column compound FTS received an unexpected prefilter child"
+                                .to_string(),
+                        ));
+                    }
+                }
+            }
+            count => {
+                return Err(DataFusionError::Internal(format!(
+                    "cross-column compound FTS expected at most one prefilter child, got {count}"
+                )));
+            }
+        };
+
+        Ok(Arc::new(Self {
+            dataset: self.dataset.clone(),
+            query: self.query.clone(),
+            tokenized_query: self.tokenized_query.clone(),
+            params: self.params.clone(),
+            prefilter_source,
+            columns: self.columns.clone(),
+            properties: self.properties.clone(),
+            metrics: ExecutionPlanMetricsSet::new(),
+        }))
+    }
+
+    #[instrument(
+        name = "cross_column_compound_fts_scorer_exec",
+        level = "debug",
+        skip_all
+    )]
+    fn execute(
+        &self,
+        partition: usize,
+        context: Arc<datafusion::execution::TaskContext>,
+    ) -> DataFusionResult<SendableRecordBatchStream> {
+        let dataset = self.dataset.clone();
+        let query = self.query.clone();
+        let tokenized_query = self.tokenized_query.clone();
+        let params = self.params.clone();
+        let prefilter_source = self.prefilter_source.clone();
+        let columns = self.columns.clone();
+        let metrics = Arc::new(FtsIndexMetrics::new(&self.metrics, partition));
+
+        let stream = stream::once(async move {
+            let _timer = metrics.baseline_metrics.elapsed_compute().timer();
+            let selected_segments = columns
+                .iter()
+                .flat_map(|selection| {
+                    selection
+                        .segment_selection
+                        .preset_segments()
+                        .into_iter()
+                        .flatten()
+                        .cloned()
+                })
+                .collect::<Vec<_>>();
+            if selected_segments.is_empty() {
+                return Err(DataFusionError::Internal(
+                    "cross-column compound FTS lost its exact segment selections".to_string(),
+                ));
+            }
+            // DatasetPreFilter starts its deletion and filter prerequisites in
+            // the background. Construct it before opening index segments so
+            // both I/O paths can make progress concurrently.
+            let mut prefilter = build_prefilter(
+                context,
+                partition,
+                &prefilter_source,
+                dataset.clone(),
+                &selected_segments,
+                None,
+            )?;
+            let opened_columns = try_join_all(columns.iter().cloned().map(|selection| {
+                let dataset = dataset.clone();
+                let metrics = metrics.clone();
+                async move {
+                    let segments = selection
+                        .segment_selection
+                        .resolve(
+                            &dataset,
+                            &selection.column,
+                            DocumentGranularity::Row,
+                            &metrics.segment_bind_duration,
+                        )
+                        .await?;
+                    let indices = open_fts_segments(
+                        &dataset,
+                        &selection.column,
+                        &segments,
+                        &metrics.index_metrics,
+                    )
+                    .await?;
+                    Ok::<_, DataFusionError>((selection.column, indices))
+                }
+            }))
+            .await?;
+
+            let mut tokenizer_indices = HashMap::with_capacity(opened_columns.len());
+            let mut partition_counts = HashMap::with_capacity(opened_columns.len());
+            for (column, indices) in &opened_columns {
+                let first_index = indices.first().ok_or_else(|| {
+                    DataFusionError::Execution(format!(
+                        "cross-column compound FTS opened no segments for column {column}"
+                    ))
+                })?;
+                tokenizer_indices.insert(column.as_str(), first_index.as_ref());
+                partition_counts.insert(
+                    column.as_str(),
+                    indices
+                        .iter()
+                        .map(|index| index.partition_count())
+                        .sum::<usize>(),
+                );
+            }
+            let tokens = tokenize_cross_column_compound_query(&query, &tokenizer_indices)?;
+            tokenized_query.get_or_init(|| tokens);
+
+            let searched_parts = compound_leaf_columns(&query)?.into_iter().try_fold(
+                0usize,
+                |searched, column| {
+                    let column_parts = partition_counts.get(column).copied().ok_or_else(|| {
+                        DataFusionError::Execution(format!(
+                            "cross-column compound FTS has no opened index for query column \
+                             {column}"
+                        ))
+                    })?;
+                    Ok::<_, DataFusionError>(searched.saturating_add(column_parts))
+                },
+            )?;
+            metrics.record_parts_searched(searched_parts);
+
+            let deleted_fragments = opened_columns.iter().flat_map(|(_, indices)| indices).fold(
+                roaring::RoaringBitmap::new(),
+                |mut deleted, index| {
+                    deleted |= index.deleted_fragments().clone();
+                    deleted
+                },
+            );
+            if !deleted_fragments.is_empty() {
+                let prefilter = Arc::get_mut(&mut prefilter).ok_or_else(|| {
+                    DataFusionError::Internal(
+                        "cross-column compound FTS prefilter was unexpectedly shared before \
+                         initialization"
+                            .to_string(),
+                    )
+                })?;
+                prefilter.set_deleted_fragments(deleted_fragments);
+            }
+
+            let search_columns = opened_columns;
+            let (row_ids, scores) = cross_column_compound_search(
+                &search_columns,
+                &query,
+                &params,
+                prefilter,
+                metrics.clone(),
+            )
+            .await?;
+            metrics.baseline_metrics.record_output(row_ids.len());
+            Ok::<_, DataFusionError>(RecordBatch::try_new(
+                FTS_SCHEMA.clone(),
+                vec![
+                    Arc::new(UInt64Array::from(row_ids)),
+                    Arc::new(Float32Array::from(scores)),
+                ],
+            )?)
+        });
+        Ok(Box::pin(RecordBatchStreamAdapter::new(
+            self.schema(),
+            stream.stream_in_current_span().boxed(),
+        )))
+    }
+
+    fn metrics(&self) -> Option<MetricsSet> {
+        Some(self.metrics.clone_inner())
+    }
+
+    fn properties(&self) -> &Arc<PlanProperties> {
+        &self.properties
+    }
+
+    fn supports_limit_pushdown(&self) -> bool {
+        false
+    }
+}
+
 /// Fall back to the default simple tokenizer when no on-disk FTS segment exists.
 fn default_text_tokenizer() -> Box<dyn LanceTokenizer> {
     Box::new(TextTokenizer::new(
@@ -860,6 +1272,90 @@ fn tokenize_compound_query(query: &FtsQuery, index: &InvertedIndex) -> Tokenized
     let mut leaves = Vec::with_capacity(count_fts_leaves(query));
     visit(query, index, &mut leaves);
     TokenizedCompoundQuery(leaves)
+}
+
+fn tokenize_cross_column_compound_query(
+    query: &FtsQuery,
+    indices: &HashMap<&str, &InvertedIndex>,
+) -> Result<TokenizedCompoundQuery> {
+    fn index_for_leaf<'a>(
+        column: Option<&str>,
+        kind: &str,
+        indices: &HashMap<&str, &'a InvertedIndex>,
+    ) -> Result<(&'a InvertedIndex, String)> {
+        let column = column.ok_or_else(|| {
+            Error::invalid_input(format!(
+                "cross-column compound FTS {kind} leaf is missing its resolved column"
+            ))
+        })?;
+        let index = indices.get(column).copied().ok_or_else(|| {
+            Error::invalid_input(format!(
+                "cross-column compound FTS has no opened index for {kind} column {column}"
+            ))
+        })?;
+        Ok((index, column.to_string()))
+    }
+
+    fn visit(
+        query: &FtsQuery,
+        indices: &HashMap<&str, &InvertedIndex>,
+        leaves: &mut Vec<TokenizedQueryLeaf>,
+    ) -> Result<()> {
+        match query {
+            FtsQuery::Match(query) => {
+                let (index, column) = index_for_leaf(query.column.as_deref(), "Match", indices)?;
+                let mut tokenizer = tokenizer_for_match_query(index, query.fuzziness);
+                let tokens = collect_query_tokens(&query.terms, &mut tokenizer);
+                leaves.push(TokenizedQueryLeaf {
+                    kind: TokenizedLeafKind::Match,
+                    column: Some(column),
+                    tokens: TokenizedQuery::from_tokens(&tokens),
+                });
+            }
+            FtsQuery::Phrase(query) => {
+                let (index, column) = index_for_leaf(query.column.as_deref(), "Phrase", indices)?;
+                let mut tokenizer = index.tokenizer();
+                let tokens = collect_query_tokens(&query.terms, &mut tokenizer);
+                leaves.push(TokenizedQueryLeaf {
+                    kind: TokenizedLeafKind::Phrase,
+                    column: Some(column),
+                    tokens: TokenizedQuery::from_tokens(&tokens),
+                });
+            }
+            FtsQuery::Boost(query) => {
+                visit(&query.positive, indices, leaves)?;
+                visit(&query.negative, indices, leaves)?;
+            }
+            FtsQuery::MultiMatch(query) => {
+                for query in &query.match_queries {
+                    let (index, column) =
+                        index_for_leaf(query.column.as_deref(), "MultiMatch", indices)?;
+                    let mut tokenizer = tokenizer_for_match_query(index, query.fuzziness);
+                    let tokens = collect_query_tokens(&query.terms, &mut tokenizer);
+                    leaves.push(TokenizedQueryLeaf {
+                        kind: TokenizedLeafKind::Match,
+                        column: Some(column),
+                        tokens: TokenizedQuery::from_tokens(&tokens),
+                    });
+                }
+            }
+            FtsQuery::Boolean(query) => {
+                for query in query
+                    .should
+                    .iter()
+                    .chain(&query.must)
+                    .chain(&query.must_not)
+                {
+                    visit(query, indices, leaves)?;
+                }
+            }
+        }
+        Ok(())
+    }
+
+    let mut leaves = Vec::with_capacity(count_fts_leaves(query));
+    visit(query, indices, &mut leaves)?;
+    Ok(TokenizedCompoundQuery(leaves))
 }
 
 type SharedScorerResult = std::result::Result<Arc<MemBM25Scorer>, Arc<str>>;
@@ -1064,6 +1560,10 @@ pub struct FtsIndexMetrics {
     compound_should_bound_recomputations: Count,
     compound_should_essential_evaluations: Count,
     compound_should_non_essential_evaluations: Count,
+    cross_column_staged_attempts: Count,
+    cross_column_staged_successes: Count,
+    cross_column_staged_fallbacks: Count,
+    cross_column_staged_candidates: Count,
     /// Wall time (ms) of the exec-local `build_global_bm25_scorer`
     /// fallback; zero when a preset base scorer was injected.
     scorer_build_ms: Gauge,
@@ -1101,6 +1601,14 @@ impl FtsIndexMetrics {
                 .new_count(COMPOUND_SHOULD_ESSENTIAL_EVALUATIONS_METRIC, partition),
             compound_should_non_essential_evaluations: metrics
                 .new_count(COMPOUND_SHOULD_NON_ESSENTIAL_EVALUATIONS_METRIC, partition),
+            cross_column_staged_attempts: metrics
+                .new_count(CROSS_COLUMN_STAGED_ATTEMPTS_METRIC, partition),
+            cross_column_staged_successes: metrics
+                .new_count(CROSS_COLUMN_STAGED_SUCCESSES_METRIC, partition),
+            cross_column_staged_fallbacks: metrics
+                .new_count(CROSS_COLUMN_STAGED_FALLBACKS_METRIC, partition),
+            cross_column_staged_candidates: metrics
+                .new_count(CROSS_COLUMN_STAGED_CANDIDATES_METRIC, partition),
             scorer_build_ms: metrics.new_gauge("scorer_build_ms", partition),
             segment_bind_duration: metrics.new_time(FTS_SEGMENT_BIND_DURATION_METRIC, partition),
             baseline_metrics: BaselineMetrics::new(metrics, partition),
@@ -1192,6 +1700,22 @@ impl MetricsCollector for FtsIndexMetrics {
     fn record_compound_should_non_essential_evaluations(&self, num_evaluations: usize) {
         self.compound_should_non_essential_evaluations
             .add(num_evaluations);
+    }
+
+    fn record_cross_column_staged_attempts(&self, num_attempts: usize) {
+        self.cross_column_staged_attempts.add(num_attempts);
+    }
+
+    fn record_cross_column_staged_successes(&self, num_successes: usize) {
+        self.cross_column_staged_successes.add(num_successes);
+    }
+
+    fn record_cross_column_staged_fallbacks(&self, num_fallbacks: usize) {
+        self.cross_column_staged_fallbacks.add(num_fallbacks);
+    }
+
+    fn record_cross_column_staged_candidates(&self, num_candidates: usize) {
+        self.cross_column_staged_candidates.add(num_candidates);
     }
 }
 
@@ -3518,9 +4042,9 @@ mod tests {
     };
 
     use super::{
-        BoolSlot, BoostQueryExec, CompoundQueryExec, FTS_SEGMENT_BIND_DURATION_METRIC,
-        FlatMatchFilterExec, FlatMatchQueryExec, MatchQueryExec, PhraseQueryExec,
-        build_boolean_query_children, default_text_tokenizer, open_fts_segments,
+        BoolSlot, BoostQueryExec, CompoundQueryExec, CrossColumnCompoundQueryExec,
+        FTS_SEGMENT_BIND_DURATION_METRIC, FlatMatchFilterExec, FlatMatchQueryExec, MatchQueryExec,
+        PhraseQueryExec, build_boolean_query_children, default_text_tokenizer, open_fts_segments,
     };
     use crate::io::exec::utils::IndexMetrics;
     use datafusion::physical_plan::empty::EmptyExec;
@@ -3560,6 +4084,22 @@ mod tests {
         assert_eq!(metrics.compound_should_bound_recomputations.value(), 3);
         assert_eq!(metrics.compound_should_essential_evaluations.value(), 5);
         assert_eq!(metrics.compound_should_non_essential_evaluations.value(), 7);
+    }
+
+    #[test]
+    fn test_cross_column_staged_metrics_are_counted_independently() {
+        let metrics_set = ExecutionPlanMetricsSet::new();
+        let metrics = super::FtsIndexMetrics::new(&metrics_set, 0);
+
+        metrics.record_cross_column_staged_attempts(2);
+        metrics.record_cross_column_staged_successes(1);
+        metrics.record_cross_column_staged_fallbacks(1);
+        metrics.record_cross_column_staged_candidates(17);
+
+        assert_eq!(metrics.cross_column_staged_attempts.value(), 2);
+        assert_eq!(metrics.cross_column_staged_successes.value(), 1);
+        assert_eq!(metrics.cross_column_staged_fallbacks.value(), 1);
+        assert_eq!(metrics.cross_column_staged_candidates.value(), 17);
     }
 
     async fn create_segment_selection_fixture() -> (Arc<Dataset>, Vec<IndexMetadata>, Vec<u32>) {
@@ -4900,6 +5440,78 @@ mod tests {
                 .to_string()
                 .contains("injected BM25 scorer is missing compound FTS token 'quick'"),
             "unexpected fuzzy-scorer error: {error}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_cross_column_compound_exec_validates_constructor_inputs() {
+        let (dataset, segments, _) = create_segment_selection_fixture().await;
+        let query: FtsQuery = BooleanQuery::new([
+            (
+                Occur::Must,
+                MatchQuery::new("quick".to_string())
+                    .with_column(Some("title".to_string()))
+                    .into(),
+            ),
+            (
+                Occur::MustNot,
+                MatchQuery::new("blocked".to_string())
+                    .with_column(Some("body".to_string()))
+                    .into(),
+            ),
+        ])
+        .into();
+        let params = FtsSearchParams::default().with_limit(Some(10));
+
+        let error = CrossColumnCompoundQueryExec::new_with_segments(
+            dataset.clone(),
+            query.clone(),
+            params.clone(),
+            PreFilterSource::None,
+            vec![("title".to_string(), segments.clone())],
+        )
+        .unwrap_err();
+        assert!(
+            error.to_string().contains(r#"missing=["body"]"#),
+            "unexpected missing-column error: {error}"
+        );
+
+        let error = CrossColumnCompoundQueryExec::new_with_segments(
+            dataset.clone(),
+            query.clone(),
+            FtsSearchParams::default(),
+            PreFilterSource::None,
+            vec![
+                ("title".to_string(), segments.clone()),
+                ("body".to_string(), segments.clone()),
+            ],
+        )
+        .unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("requires a bounded result limit"),
+            "unexpected unbounded-query error: {error}"
+        );
+
+        let exec = CrossColumnCompoundQueryExec::new_with_segments(
+            dataset,
+            query,
+            params,
+            PreFilterSource::None,
+            vec![
+                ("title".to_string(), segments.clone()),
+                ("body".to_string(), segments),
+            ],
+        )
+        .unwrap();
+        let display = format!(
+            "{}",
+            datafusion::physical_plan::displayable(&exec).one_line()
+        );
+        assert!(
+            display.contains("CrossColumnCompoundFtsScorer:"),
+            "unexpected display name: {display}"
         );
     }
 


### PR DESCRIPTION
## Performance Improvement

Cross-column Boolean and Boost FTS queries currently use the DataFusion fallback. Parent planning clears the leaf limits so every field produces its full match set, which disables useful top-k score floors and then materializes hash joins, aggregates, and full sorts even when the caller only requests a small result set.

This PR connects the cross-column scorer core from #8685 to the dataset Scanner:

- selects the fast path only for bounded, row-granularity compound queries over at least two columns
- requires complete, unchanged V2/V3 FTS coverage for every referenced column
- preserves the existing exact fallback for unbounded, partial-index, stale-overlay, flat, legacy, list-element, and unsupported query shapes
- loads independently partitioned column indices without assuming aligned segment layouts
- builds one shared scalar/deletion prefilter
- executes Match, Phrase, Boolean, Boost, and nested MultiMatch in the common row-address domain
- owns one exact global top-k collector with deterministic `(score DESC, row_address ASC)` ordering
- records staged attempt, success, fallback, and candidate metrics

A committed Scanner differential now verifies that cold staged execution and fully prewarmed resident execution return identical ordered row IDs and exact score bits while exercising different metric paths.

## API and compatibility

There is no user-facing query API or file-format change.

`CrossColumnCompoundQueryExec` follows the existing internal execution-node pattern. Unsupported shapes continue through the previous DataFusion plan.

## Scope boundary

This is the final OSS-1603 stack PR. It does not include the deferred same-column delayed `MUST_NOT` probing work from OSS-1705. Same-column queries continue to use the existing `CompoundQueryExec`; cross-column `MUST_NOT` below is ordinary query semantics, not the OSS-1705 optimization.

## Correctness validation

Environment for the checks below:

- baseline: #8685 merge `4c70e5e1f2f7310d2146f58bae1840cb97ba3ef2`
- target: `969cefacf329ae373ef49d77d4f88f4e2ba160e5`
- baseline module SHA-256: `16b35eb72655f2750eea04d6a54fd22009e9bebb4c41e971ac3f57c435d10de1`
- target module SHA-256: `24214d02eac5bb3ef71e440ee40c8a3cb18a29868a7bcc6c2c777382ae5974b6`
- frozen harness wrapper SHA-256: `702dd281d20225eb8f174b1d58b25458d13fe16a2213e40e97bc517b0ae384bb`
- dataset: MMLB 10M rows, 42 languages, 10 fragments
- indices: `text_idx` and `oss1603_summary_idx`
- profile: `release-with-debug`

Results:

- activation canary: baseline 28/28 plans stayed on fallback; target 28/28 used `CrossColumnCompoundFtsScorer`
- bounded-vs-unbounded oracle: 56/56 cases passed on each build
- cross-build oracle comparison: zero result or row-order differences
- warm timed signatures: zero differences across all 14 cases
- cold timed signatures: zero differences across all 10 ABBA blocks
- local pre-publication checks: `cargo fmt --all -- --check` and `git diff --check`
- GitHub CI is the authoritative Cargo test and Clippy run for this rebased head

Preflight artifacts:

- `/mnt/benchmark-ssd/oss1603/results/final-969cefacf-preflight-20260821`

## Warm benchmark

Methodology: GCP `c4-highmem-16`, 64 GiB index cache, both indices prewarmed in each process, seven shapes, `k={10,100}`, 250 frozen queries, five repetitions, eight workers, isolated `main-forward → target-forward → target-reverse → main-reverse` ABBA. Each build executed 2,500 queries per case.

Higher QPS is better.

| Scenario / metric | Baseline | This PR | Benefit |
| --- | ---: | ---: | ---: |
| Boost k=10 QPS | 23.92 QPS | 359.19 QPS | 15.01x |
| Boost k=100 QPS | 23.93 QPS | 187.45 QPS | 7.83x |
| Cross-column MUST_NOT k=10 QPS | 24.02 QPS | 210.60 QPS | 8.77x |
| Cross-column MUST_NOT k=100 QPS | 24.06 QPS | 100.85 QPS | 4.19x |
| MUST intersection k=10 QPS | 28.60 QPS | 190.80 QPS | 6.67x |
| MUST intersection k=100 QPS | 28.52 QPS | 84.33 QPS | 2.96x |
| Nested MultiMatch k=10 QPS | 25.70 QPS | 414.50 QPS | 16.13x |
| Nested MultiMatch k=100 QPS | 25.72 QPS | 119.65 QPS | 4.65x |
| Phrase required+optional k=10 QPS | 243.60 QPS | 1,856.49 QPS | 7.62x |
| Phrase required+optional k=100 QPS | 245.30 QPS | 1,641.13 QPS | 6.69x |
| Required+optional k=10 QPS | 246.40 QPS | 1,871.51 QPS | 7.60x |
| Required+optional k=100 QPS | 242.49 QPS | 1,665.61 QPS | 6.87x |
| SHOULD sum k=10 QPS | 29.03 QPS | 168.33 QPS | 5.80x |
| SHOULD sum k=100 QPS | 29.06 QPS | 73.67 QPS | 2.54x |

Artifacts:

- `/mnt/benchmark-ssd/oss1603/results/final-969cefacf-warm-abba250-r5-w8`

## Fresh-cold benchmark

Methodology: same VM and dataset, no FTS prewarm, fresh process and Linux page-cache drop before every observation, one frozen query, one repetition, eight workers, two independent ABBA blocks per shape. Values below are medians across four observations per build. Lower latency is better.

| Scenario / metric | Baseline | This PR | Benefit |
| --- | ---: | ---: | ---: |
| Required+optional k=10 p50 | 755.35 ms | 664.29 ms | 1.14x |
| Phrase required+optional k=10 p50 | 760.69 ms | 704.05 ms | 1.08x |
| Cross-column MUST_NOT k=100 p50 | 865.79 ms | 711.18 ms | 1.22x |
| Nested MultiMatch k=10 p50 | 704.02 ms | 690.66 ms | 1.02x |
| SHOULD sum k=10 p50 | 684.40 ms | 703.15 ms | 0.97x (2.7% regression) |

Cold median RSS decreased by 4.8%–18.4% across these shapes, and filesystem input decreased by roughly 0.7%–1.4%. Cold latency is dominated by process startup and document/index I/O; the SHOULD-sum regression is retained as an explicit caveat rather than hidden by the much larger warm improvements.

Artifacts:

- `/mnt/benchmark-ssd/oss1603/results/final-969cefacf-cold-abba2blocks-v2`

## Stack

1. #8666 — WAND scoring and bound exactness (merged)
2. #8667 — posting loading and cache policy (merged)
3. #8685 — row-address and cross-column scorer core (merged)
4. **This PR:** dataset planner/execution integration and end-to-end benchmark

Closes [OSS-1603](https://linear.app/lancedb/issue/OSS-1603/add-candidate-driven-execution-for-cross-column-boolean-fts-queries).
