### PR TITLE
fix(linalg): gate AMX FP16 import by target

### DIFF
--- a/rust/lance-linalg/src/simd/amx_fp16.rs
+++ b/rust/lance-linalg/src/simd/amx_fp16.rs
@@ -58,6 +58,11 @@
     target_os = "linux"
 ))]
 use crate::distance::dot_f16::strided_len;
+#[cfg(all(
+    kernel_support = "amx_fp16",
+    target_arch = "x86_64",
+    target_os = "linux"
+))]
 use half::f16;
 
 #[cfg(all(


### PR DESCRIPTION
## The problem

Lance v11.0.0-beta.16 imports half::f16 unconditionally in the AMX-FP16 module, while every use is limited to Linux x86_64 builds where the AMX kernel is available. Sophon PR #7335 builds dependencies on ARM64 with warnings denied, so the unused import fails the build.

## The fix

Gate the import with the same kernel, architecture, and OS cfg as its use sites.

## Testing

- RUSTFLAGS=-Dwarnings cargo check -p lance-linalg (reproduced before; passes after on aarch64-apple-darwin)
- cargo clippy -p lance-linalg --tests --benches -- -D warnings
- cargo fmt --all --check
- git diff --check

Fixes the code failure in lancedb/sophon#7335.