### PR TITLE
fix(dataset): keep secondary base object stores alive for connection pooling

### DIFF
--- a/rust/lance/src/dataset.rs
+++ b/rust/lance/src/dataset.rs
@@ -65,7 +65,7 @@ use std::fmt::Debug;
 use std::num::NonZero;
 use std::ops::Range;
 use std::pin::Pin;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 use tracing::{info, instrument};
 
 pub(crate) mod blob;
@@ -195,6 +195,14 @@ pub struct Dataset {
     pub(crate) store_params: Option<Box<ObjectStoreParams>>,
     /// Optional runtime-only object store parameters keyed by base path URI.
     pub(crate) base_store_params: Option<Arc<HashMap<String, ObjectStoreParams>>>,
+    /// Object stores for additional base paths, resolved lazily on first use.
+    ///
+    /// The session's `ObjectStoreRegistry` only holds weak references, so
+    /// this cache keeps base stores (and their connection pools) alive for the
+    /// lifetime of the dataset, mirroring the primary `object_store` field.
+    /// Base ids are assigned once at dataset creation and never remapped, so
+    /// sharing this cache across clones of the dataset is safe.
+    pub(crate) base_object_stores: Arc<Mutex<HashMap<u32, Arc<ObjectStore>>>>,
 }
 
 impl std::fmt::Debug for Dataset {
@@ -853,6 +861,7 @@ impl Dataset {
             file_reader_options,
             store_params: store_params.map(Box::new),
             base_store_params,
+            base_object_stores: Arc::new(Mutex::new(HashMap::new())),
         })
     }
 
@@ -1962,6 +1971,9 @@ impl Dataset {
         if let Some(store_params) = store_params {
             cloned.store_params = Some(Box::new(store_params));
         }
+        // The clone resolves base stores with different params; don't let it
+        // share (or serve) stores cached under the old binding.
+        cloned.base_object_stores = Arc::new(Mutex::new(HashMap::new()));
         cloned
     }
 
@@ -2010,6 +2022,9 @@ impl Dataset {
                     .collect(),
             )
         });
+        // Base stores cached before the wrappers were appended would bypass
+        // them; make the clone resolve its base stores fresh.
+        cloned.base_object_stores = Arc::new(Mutex::new(HashMap::new()));
         cloned
     }
 
@@ -2419,6 +2434,15 @@ impl Dataset {
     }
 
     async fn base_object_store(&self, base_id: u32) -> Result<Arc<ObjectStore>> {
+        if let Some(store) = self
+            .base_object_stores
+            .lock()
+            .expect("base_object_stores lock poisoned")
+            .get(&base_id)
+        {
+            return Ok(store.clone());
+        }
+
         let base_path = self.manifest.base_paths.get(&base_id).ok_or_else(|| {
             Error::invalid_input(format!("Dataset base path with ID {} not found", base_id))
         })?;
@@ -2431,7 +2455,16 @@ impl Dataset {
         )
         .await?;
 
-        Ok(store)
+        // Concurrent first uses can race to build the store; converge on the
+        // one that landed in the cache so every caller shares one store (and
+        // one connection pool).
+        Ok(self
+            .base_object_stores
+            .lock()
+            .expect("base_object_stores lock poisoned")
+            .entry(base_id)
+            .or_insert(store)
+            .clone())
     }
 
     /// Resolve the object store for the primary dataset or an additional base.

--- a/rust/lance/src/dataset/write.rs
+++ b/rust/lance/src/dataset/write.rs
@@ -2963,6 +2963,67 @@ mod tests {
         assert_eq!(num_rows, 5);
     }
 
+    // Regression test for https://github.com/lance-format/lance/issues/8692:
+    // the session registry only holds weak references to object stores, so the
+    // dataset itself must keep base stores alive. Otherwise every read from an
+    // additional base rebuilds the store and its connection pool.
+    #[tokio::test]
+    async fn test_base_object_store_kept_alive_by_dataset() {
+        use lance_core::utils::tempfile::TempStrDir;
+        use lance_testing::datagen::{BatchGenerator, IncrementingInt32};
+
+        let primary_dir = TempStrDir::default();
+        let base1_dir = TempStrDir::default();
+
+        // A base-scoped option gives the base store a registry cache key
+        // distinct from the primary store's, so nothing but the dataset can
+        // keep the base store alive.
+        let store_params = ObjectStoreParams {
+            storage_options_accessor: Some(Arc::new(StorageOptionsAccessor::with_static_options(
+                HashMap::from([(
+                    "base_1.scoped_option".to_string(),
+                    "base1-value".to_string(),
+                )]),
+            ))),
+            ..Default::default()
+        };
+
+        let mut data_gen =
+            BatchGenerator::new().col(Box::new(IncrementingInt32::new().named("id".to_owned())));
+        let dataset = Dataset::write(
+            data_gen.batch(5),
+            primary_dir.as_str(),
+            Some(WriteParams {
+                mode: WriteMode::Create,
+                store_params: Some(store_params),
+                initial_bases: Some(vec![BasePath {
+                    id: 1,
+                    name: Some("base1".to_string()),
+                    path: base1_dir.as_str().to_string(),
+                    is_dataset_root: true,
+                }]),
+                target_bases: Some(vec![1]),
+                ..Default::default()
+            }),
+        )
+        .await
+        .unwrap();
+
+        let store = dataset.object_store(Some(1)).await.unwrap();
+        let weak_store = Arc::downgrade(&store);
+        drop(store);
+
+        // The dataset holds a strong reference, so the store survives the
+        // caller dropping its handle and the next call reuses the instance.
+        let store_again = dataset.object_store(Some(1)).await.unwrap();
+        assert!(
+            weak_store
+                .upgrade()
+                .is_some_and(|original| Arc::ptr_eq(&original, &store_again)),
+            "base object store was rebuilt instead of reused"
+        );
+    }
+
     #[tokio::test]
     async fn test_multi_base_overwrite() {
         use lance_testing::datagen::{BatchGenerator, IncrementingInt32};

--- a/rust/lance/src/dataset/write/commit.rs
+++ b/rust/lance/src/dataset/write/commit.rs
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright The Lance Authors
 
 use std::collections::HashMap;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use lance_file::version::LanceFileVersion;
@@ -461,6 +461,7 @@ impl<'a> CommitBuilder<'a> {
                     file_reader_options: None,
                     store_params: self.store_params.clone().map(Box::new),
                     base_store_params: None,
+                    base_object_stores: Arc::new(Mutex::new(HashMap::new())),
                 })
             }
         }


### PR DESCRIPTION
# Issue
https://github.com/lance-format/lance/issues/8692

Stores for additional base paths were only strongly referenced by the
per-call `BlobV2ReadContext`, while the session's `ObjectStoreRegistry` holds
weak references. Once a read finished, the store and its HTTP connection
pool dropped, so every subsequent read of external blobs on a secondary
base rebuilt the store and paid new TCP+TLS handshakes, even with
connection pooling configured.

# Fix
Cache base stores on Dataset itself, lazily resolved in
base_object_store(), so they live as long as the dataset — mirroring the
primary object_store field. This also benefits data files, deletion
files, and indexes on secondary bases. `with_object_store()` and
`with_object_store_wrappers()` reset the cache on their clones so stores
resolved under the old params or without the new wrappers are not
reused.