### PR TITLE
feat: support BinaryView in packed blob writer via iterator-based extraction

### DIFF
--- a/python/python/lance/lance/__init__.pyi
+++ b/python/python/lance/lance/__init__.pyi
@@ -206,7 +206,13 @@ class PackedBlobWriter:
     def write_blob(self, data: bytes) -> None: ...
     def write_blobs(
         self,
-        payloads: Union[pa.BinaryArray, pa.LargeBinaryArray, pa.ChunkedArray],
+        payloads: Union[
+            pa.BinaryArray,
+            pa.LargeBinaryArray,
+            pa.BinaryViewArray,
+            pa.FixedSizeBinaryArray,
+            pa.ChunkedArray,
+        ],
     ) -> None: ...
     def finish(self) -> List[BlobDescriptor]: ...
     def finish_array(self, field_name: str) -> pa.StructArray: ...

--- a/python/python/tests/test_blob.py
+++ b/python/python/tests/test_blob.py
@@ -1433,7 +1433,9 @@ def test_packed_blob_writer_scalar_buffer_inputs(tmp_path, payload):
     assert _blob_sidecar_path(tmp_path, file_id, blob_id).read_bytes() == b"payload"
 
 
-@pytest.mark.parametrize("array_type", [pa.binary(), pa.large_binary()])
+@pytest.mark.parametrize(
+    "array_type", [pa.binary(), pa.large_binary(), pa.binary_view()]
+)
 @pytest.mark.parametrize("as_chunked", [False, True], ids=["array", "chunked_array"])
 @pytest.mark.parametrize(
     "values,slice_offset,slice_length,expected_values,expected_data",
@@ -2403,3 +2405,75 @@ def test_to_pandas_returns_blob_files_when_nested_field_is_aliased(
     assert images[0].readall() == b"foo"
     assert images[1] is None
     assert images[2].readall() == b"baz"
+
+
+@pytest.mark.parametrize("as_chunked", [False, True], ids=["array", "chunked_array"])
+def test_packed_blob_writer_bulk_binary_view(tmp_path, as_chunked):
+    file_id = str(uuid.uuid4())
+    blob_id = 7
+    values = [b"hello", None, b"", b"world"]
+    payloads = pa.array(values, type=pa.binary_view())
+    if as_chunked:
+        payloads = pa.chunked_array([payloads.slice(0, 2), payloads.slice(2)])
+
+    files = LanceFileSession(tmp_path)
+    packed = files.open_packed_blob_writer(f"{file_id}.lance", blob_id)
+    packed.write_blobs(payloads)
+    descriptors = packed.finish_array("image_bytes")
+
+    expected_descriptors = []
+    position = 0
+    for value in values:
+        if value is None:
+            expected_descriptors.append(None)
+        else:
+            expected_descriptors.append(
+                {
+                    "kind": 1,
+                    "data": None,
+                    "uri": None,
+                    "blob_id": blob_id,
+                    "blob_size": len(value),
+                    "position": position,
+                }
+            )
+            position += len(value)
+
+    assert descriptors.to_pylist() == expected_descriptors
+    assert _blob_sidecar_path(tmp_path, file_id, blob_id).read_bytes() == b"helloworld"
+
+
+@pytest.mark.parametrize("as_chunked", [False, True], ids=["array", "chunked_array"])
+def test_packed_blob_writer_bulk_fixed_size_binary(tmp_path, as_chunked):
+    file_id = str(uuid.uuid4())
+    blob_id = 7
+    values = [b"word", None, b"test"]
+    payloads = pa.array(values, type=pa.binary(4))
+    if as_chunked:
+        payloads = pa.chunked_array([payloads.slice(0, 2), payloads.slice(2)])
+
+    files = LanceFileSession(tmp_path)
+    packed = files.open_packed_blob_writer(f"{file_id}.lance", blob_id)
+    packed.write_blobs(payloads)
+    descriptors = packed.finish_array("image_bytes")
+
+    expected_descriptors = []
+    position = 0
+    for value in values:
+        if value is None:
+            expected_descriptors.append(None)
+        else:
+            expected_descriptors.append(
+                {
+                    "kind": 1,
+                    "data": None,
+                    "uri": None,
+                    "blob_id": blob_id,
+                    "blob_size": len(value),
+                    "position": position,
+                }
+            )
+            position += len(value)
+
+    assert descriptors.to_pylist() == expected_descriptors
+    assert _blob_sidecar_path(tmp_path, file_id, blob_id).read_bytes() == b"wordtest"

--- a/python/src/blob.rs
+++ b/python/src/blob.rs
@@ -3,7 +3,7 @@
 
 use crate::{error::PythonErrorExt, rt};
 use arrow::{
-    array::{Array, ArrayRef, GenericBinaryArray, OffsetSizeTrait, cast::AsArray, make_array},
+    array::{Array, ArrayRef, make_array},
     pyarrow::{FromPyArrow, ToPyArrow},
 };
 use arrow_data::ArrayData;
@@ -12,6 +12,7 @@ use bytes::Bytes;
 use lance::{
     BlobDescriptor, BlobDescriptorArrayBuilder, BlobRange, DedicatedBlobWriter, PackedBlobWriter,
 };
+use lance_arrow::iter_binary_array;
 use pyo3::{
     Bound, PyErr, PyResult,
     exceptions::{PyRuntimeError, PyValueError},
@@ -91,9 +92,10 @@ fn descriptor_field_to_pyarrow<'py>(
 
 /// Normalize inputs accepted by [`PyPackedBlobWriter::write_blobs`] into Arrow arrays.
 ///
-/// BinaryArray, LargeBinaryArray, and ChunkedArray values of either binary type
-/// are accepted. Chunk boundaries, nulls, and empty values remain in the arrays;
-/// each row is later passed to the core writer as an optional byte slice.
+/// BinaryArray, LargeBinaryArray, BinaryViewArray, FixedSizeBinaryArray, and
+/// ChunkedArray values of any binary type are accepted. Chunk boundaries,
+/// nulls, and empty values remain in the arrays; each row is later passed to
+/// the core writer as an optional byte slice.
 fn extract_blob_payloads(payloads: &Bound<'_, PyAny>) -> PyResult<Vec<ArrayRef>> {
     match ArrayData::from_pyarrow_bound(payloads) {
         Ok(data) => Ok(vec![validated_blob_payload(data, None)?]),
@@ -108,9 +110,9 @@ fn extract_blob_payloads(payloads: &Bound<'_, PyAny>) -> PyResult<Vec<ArrayRef>>
             }
 
             let chunked_data_type = DataType::from_pyarrow_bound(&payloads.getattr("type")?)?;
-            if !matches!(chunked_data_type, DataType::Binary | DataType::LargeBinary) {
+            if !chunked_data_type.is_binary() {
                 return Err(PyValueError::new_err(format!(
-                    "Packed blob payloads must have Arrow type Binary or LargeBinary, got {chunked_data_type}"
+                    "Packed blob payloads must have a Binary Arrow type, got {chunked_data_type}"
                 )));
             }
 
@@ -129,9 +131,9 @@ fn validated_blob_payload(data: ArrayData, chunk_index: Option<usize>) -> PyResu
     let context = chunk_index
         .map(|index| format!("Packed blob payload chunk {index}"))
         .unwrap_or_else(|| "Packed blob payload array".to_string());
-    if !matches!(data.data_type(), DataType::Binary | DataType::LargeBinary) {
+    if !data.data_type().is_binary() {
         return Err(PyValueError::new_err(format!(
-            "{context} must have Arrow type Binary or LargeBinary, got {}",
+            "{context} must have a Binary Arrow type, got {}",
             data.data_type()
         )));
     }
@@ -147,20 +149,14 @@ fn validated_blob_payload(data: ArrayData, chunk_index: Option<usize>) -> PyResu
     Ok(make_array(data))
 }
 
-/// Stream one Arrow binary array into the core writer as zero-copy row slices.
-///
-/// Null rows become `None` so the core writer records null descriptors, keeping
-/// its output row-aligned with the input.
-async fn write_binary_payloads<O: OffsetSizeTrait>(
-    writer: &mut PackedBlobWriter,
-    payloads: &GenericBinaryArray<O>,
-) -> PyResult<()> {
-    writer
-        .write_packed_blobs(
-            (0..payloads.len()).map(|row| payloads.is_valid(row).then(|| payloads.value(row))),
-        )
-        .await
-        .infer_error()
+async fn write_binary_payloads(writer: &mut PackedBlobWriter, payloads: &ArrayRef) -> PyResult<()> {
+    let iter = iter_binary_array(payloads.as_ref()).map_err(|error| {
+        PyValueError::new_err(format!(
+            "Packed blob payloads must have a Binary Arrow type, got {}: {error}",
+            payloads.data_type()
+        ))
+    })?;
+    writer.write_packed_blobs(iter).await.infer_error()
 }
 
 #[pyclass(name = "BlobDescriptor", skip_from_py_object)]
@@ -348,7 +344,9 @@ impl PyPackedBlobWriter {
     ///
     /// Parameters
     /// ----------
-    /// payloads : pyarrow.BinaryArray, pyarrow.LargeBinaryArray, or pyarrow.ChunkedArray
+    /// payloads : pyarrow.BinaryArray, pyarrow.LargeBinaryArray,
+    ///     pyarrow.BinaryViewArray, pyarrow.FixedSizeBinaryArray, or
+    ///     pyarrow.ChunkedArray
     ///     A binary Arrow array. Every chunk of a chunked array must be binary.
     ///     Each input row produces one descriptor row, in order, across chunks
     ///     and repeated calls. Null rows produce null descriptors; empty but
@@ -368,19 +366,7 @@ impl PyPackedBlobWriter {
             let writer = self.inner_mut()?;
             rt().block_on(None, async {
                 for payloads in payloads {
-                    match payloads.data_type() {
-                        DataType::Binary => {
-                            write_binary_payloads(writer, payloads.as_binary::<i32>()).await?
-                        }
-                        DataType::LargeBinary => {
-                            write_binary_payloads(writer, payloads.as_binary::<i64>()).await?
-                        }
-                        data_type => {
-                            return Err(PyValueError::new_err(format!(
-                                "Packed blob payloads must have Arrow type Binary or LargeBinary, got {data_type}"
-                            )));
-                        }
-                    }
+                    write_binary_payloads(writer, &payloads).await?;
                 }
                 Ok(())
             })

--- a/rust/lance-arrow/src/lib.rs
+++ b/rust/lance-arrow/src/lib.rs
@@ -475,6 +475,20 @@ pub fn iter_str_array(arr: &dyn Array) -> Box<dyn Iterator<Item = Option<&str>> 
     }
 }
 
+pub fn iter_binary_array(
+    arr: &dyn Array,
+) -> Result<Box<dyn Iterator<Item = Option<&[u8]>> + Send + '_>> {
+    match arr.data_type() {
+        DataType::Binary => Ok(Box::new(arr.as_binary::<i32>().iter())),
+        DataType::LargeBinary => Ok(Box::new(arr.as_binary::<i64>().iter())),
+        DataType::BinaryView => Ok(Box::new(arr.as_binary_view().iter())),
+        DataType::FixedSizeBinary(_) => Ok(Box::new(arr.as_fixed_size_binary().iter())),
+        data_type => Err(ArrowError::InvalidArgumentError(format!(
+            "Expecting a binary type, found {data_type}"
+        ))),
+    }
+}
+
 /// Extends Arrow's [RecordBatch].
 pub trait RecordBatchExt {
     /// Append a new column to this [`RecordBatch`] and returns a new RecordBatch.
@@ -1584,8 +1598,11 @@ impl BufferExt for arrow_buffer::Buffer {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use arrow_array::{Float32Array, Int32Array, NullArray, StructArray};
-    use arrow_array::{ListArray, StringArray, new_empty_array, new_null_array};
+    use arrow_array::{
+        BinaryArray, BinaryViewArray, FixedSizeBinaryArray, Float32Array, Int32Array,
+        LargeBinaryArray, ListArray, NullArray, StringArray, StructArray, new_empty_array,
+        new_null_array,
+    };
     use arrow_buffer::OffsetBuffer;
 
     #[test]
@@ -2838,5 +2855,43 @@ mod tests {
             innermost_struct.column(1).as_ref(),
             &Int32Array::from(vec![1, 2]) as &dyn Array
         );
+    }
+
+    #[test]
+    fn test_iter_binary_array_accepts_binary_variants() {
+        let binary = BinaryArray::from(vec![b"a".as_slice(), b"bc"]);
+        assert_eq!(
+            iter_binary_array(&binary).unwrap().collect::<Vec<_>>(),
+            vec![Some(b"a".as_slice()), Some(b"bc".as_slice())]
+        );
+
+        let large_binary = LargeBinaryArray::from(vec![b"x".as_slice(), b"yz"]);
+        assert_eq!(
+            iter_binary_array(&large_binary)
+                .unwrap()
+                .collect::<Vec<_>>(),
+            vec![Some(b"x".as_slice()), Some(b"yz".as_slice())]
+        );
+
+        let binary_view = BinaryViewArray::from(vec![b"1".as_slice(), b"23"]);
+        assert_eq!(
+            iter_binary_array(&binary_view).unwrap().collect::<Vec<_>>(),
+            vec![Some(b"1".as_slice()), Some(b"23".as_slice())]
+        );
+
+        let fixed_size = FixedSizeBinaryArray::from(vec![b"abcd", b"efgh"]);
+        assert_eq!(
+            iter_binary_array(&fixed_size).unwrap().collect::<Vec<_>>(),
+            vec![Some(b"abcd".as_slice()), Some(b"efgh".as_slice())]
+        );
+    }
+
+    #[test]
+    fn test_iter_binary_array_rejects_non_binary() {
+        let int_array = Int32Array::from(vec![1, 2, 3]);
+        let Err(error) = iter_binary_array(&int_array) else {
+            panic!("expected an error for non-binary array");
+        };
+        assert!(error.to_string().contains("Expecting a binary type"));
     }
 }


### PR DESCRIPTION
## Summary

Closes #7789.

Refactor the packed blob writer to use an iterator-based binary extraction helper (mirroring the existing `iter_str_array` pattern), then extend it to accept `BinaryView` input.

## Why

The existing packed blob writer only supported `Binary` and `LargeBinary` because it was coupled to offset-based Arrow arrays via `GenericBinaryArray<O>`. Extracting a shared iterator (as @wjones127 suggested in the #7743 review) decouples the writer from the concrete Arrow type, making `BinaryView` support a one-line addition instead of a parallel code path.

## Compatibility

- No changes to the on-disk format or persisted bytes.
- Existing `Binary` and `LargeBinary` inputs produce identical output.
- `BinaryView` is purely additive — existing callers are unaffected.