### PR TITLE
fix(fts): preserve exact top-level multimatch ties

### DIFF
--- a/rust/lance/src/dataset/scanner.rs
+++ b/rust/lance/src/dataset/scanner.rs
@@ -307,6 +307,39 @@ fn validate_fts_query_contract(query: &FtsQuery) -> Result<()> {
     }
 }
 
+fn normalize_fts_zero_boosts(query: &mut FtsQuery) {
+    fn normalize_zero(value: &mut f32) {
+        if *value == 0.0 {
+            *value = 0.0;
+        }
+    }
+
+    match query {
+        FtsQuery::Match(query) => normalize_zero(&mut query.boost),
+        FtsQuery::Phrase(_) => {}
+        FtsQuery::Boost(query) => {
+            normalize_zero(&mut query.negative_boost);
+            normalize_fts_zero_boosts(&mut query.positive);
+            normalize_fts_zero_boosts(&mut query.negative);
+        }
+        FtsQuery::MultiMatch(query) => {
+            for match_query in &mut query.match_queries {
+                normalize_zero(&mut match_query.boost);
+            }
+        }
+        FtsQuery::Boolean(query) => {
+            for child in query
+                .should
+                .iter_mut()
+                .chain(&mut query.must)
+                .chain(&mut query.must_not)
+            {
+                normalize_fts_zero_boosts(child);
+            }
+        }
+    }
+}
+
 /// Parse an environment variable as a specific type, logging a warning on parse failure.
 fn parse_env_var<T: std::str::FromStr>(env_var_name: &str, default_val: &str) -> Option<T>
 where
@@ -3887,6 +3920,7 @@ impl Scanner {
         query: &FullTextSearchQuery,
     ) -> Result<FullTextSearchQuery> {
         let mut resolved = query.clone();
+        normalize_fts_zero_boosts(&mut resolved.query);
         if resolved.query.is_missing_column() {
             if Self::query_requests_list_element(&resolved.query) {
                 return Err(Error::invalid_input(
@@ -4132,13 +4166,43 @@ impl Scanner {
             }
 
             FtsQuery::MultiMatch(query) => {
-                let mut children = Vec::with_capacity(query.match_queries.len());
-                for match_query in &query.match_queries {
-                    let child =
-                        self.plan_match_query(match_query, params, filter_plan, prefilter_source);
-                    children.push(child);
-                }
-                let children = futures::future::try_join_all(children).await?;
+                // A top-level cross-column MultiMatch scores each field independently and takes
+                // the maximum score for each row. A field's bounded compound top-k is therefore
+                // sufficient to determine the global top-k independently of the other fields.
+                // Preserve that bounded plan for every eligible field, while planning only
+                // partial-index and overlay-backed fields through the exhaustive leaf fallback.
+                let unlimited_params = params.clone().with_limit(None);
+                let can_use_bounded_compound =
+                    !document_granularity.is_list_element() && params.limit.is_some();
+                let children =
+                    futures::future::try_join_all(query.match_queries.iter().map(|match_query| {
+                        let unlimited_params = &unlimited_params;
+                        async move {
+                            if can_use_bounded_compound {
+                                let child_query = FtsQuery::Match(match_query.clone());
+                                if let Some(plan) = self
+                                    .plan_compound_scorer(
+                                        &child_query,
+                                        params,
+                                        prefilter_source,
+                                        document_granularity,
+                                    )
+                                    .await?
+                                {
+                                    return Ok(plan);
+                                }
+                            }
+
+                            self.plan_match_query(
+                                match_query,
+                                unlimited_params,
+                                filter_plan,
+                                prefilter_source,
+                            )
+                            .await
+                        }
+                    }))
+                    .await?;
 
                 let schema = children[0].schema();
                 let group_expr = vec![(
@@ -6876,6 +6940,63 @@ mod test {
         let error = validate_fts_query_contract(&infinite_boost).unwrap_err();
         assert!(matches!(error, Error::InvalidInput { .. }));
         assert!(error.to_string().contains("BoostQuery negative_boost"));
+    }
+
+    #[test]
+    fn test_normalize_fts_zero_boosts_recurses_and_preserves_nonzero_values() {
+        fn boost_bits(query: &FtsQuery) -> Vec<u32> {
+            match query {
+                FtsQuery::Match(query) => vec![query.boost.to_bits()],
+                FtsQuery::Phrase(_) => Vec::new(),
+                FtsQuery::Boost(query) => std::iter::once(query.negative_boost.to_bits())
+                    .chain(boost_bits(&query.positive))
+                    .chain(boost_bits(&query.negative))
+                    .collect(),
+                FtsQuery::MultiMatch(query) => query
+                    .match_queries
+                    .iter()
+                    .map(|query| query.boost.to_bits())
+                    .collect(),
+                FtsQuery::Boolean(query) => query
+                    .should
+                    .iter()
+                    .chain(&query.must)
+                    .chain(&query.must_not)
+                    .flat_map(boost_bits)
+                    .collect(),
+            }
+        }
+
+        let match_query =
+            |terms: &str, boost| MatchQuery::new(terms.to_string()).with_boost(boost).into();
+        let multi_match = MultiMatchQuery::try_new(
+            "needle".to_string(),
+            vec!["title".to_string(), "body".to_string()],
+        )
+        .unwrap()
+        .try_with_boosts(vec![-0.0, 2.5])
+        .unwrap();
+        let negative = BooleanQuery::new([
+            (Occur::Should, multi_match.into()),
+            (Occur::Must, match_query("required", 3.5)),
+            (Occur::MustNot, match_query("blocked", -0.0)),
+        ]);
+        let boost = BoostQuery::new(match_query("positive", -0.0), negative.into(), Some(-0.0));
+        let mut query: FtsQuery = BooleanQuery::new([
+            (Occur::Should, match_query("outer", -0.0)),
+            (Occur::Must, boost.into()),
+            (Occur::MustNot, match_query("unchanged", 4.5)),
+        ])
+        .into();
+
+        let nz = (-0.0_f32).to_bits();
+        let pz = 0.0_f32.to_bits();
+        let b2 = 2.5_f32.to_bits();
+        let b3 = 3.5_f32.to_bits();
+        let b4 = 4.5_f32.to_bits();
+        assert_eq!(boost_bits(&query), vec![nz, nz, nz, nz, b2, b3, nz, b4]);
+        normalize_fts_zero_boosts(&mut query);
+        assert_eq!(boost_bits(&query), vec![pz, pz, pz, pz, b2, b3, pz, b4]);
     }
 
     #[test]

--- a/rust/lance/src/dataset/tests/dataset_index.rs
+++ b/rust/lance/src/dataset/tests/dataset_index.rs
@@ -1391,7 +1391,7 @@ fn independent_compound_fts_oracle<'a>(
                         result
                             .entry(row_id)
                             .and_modify(|current| {
-                                if score > *current {
+                                if score.total_cmp(current).is_gt() {
                                     *current = score;
                                 }
                             })
@@ -1504,7 +1504,7 @@ async fn assert_compound_matches_independent_oracle(
     expected.truncate(limit);
     let actual = compound_fts_results(dataset, query.clone(), Some(limit as i64)).await;
     assert_scored_rows_close(case_name, &actual, &expected);
-    expected
+    actual
 }
 
 async fn compound_fts_plan(dataset: &Dataset, query: FtsQuery, limit: usize) -> String {
@@ -1758,6 +1758,136 @@ async fn test_cross_column_compound_scorer_matches_independent_leaf_oracle() {
     assert_eq!(
         resident_results, staged_results,
         "resident and staged cross-column scans must return identical ordered row ids and score bits"
+    );
+}
+
+#[tokio::test]
+async fn test_top_level_cross_column_multimatch_uses_field_local_compound_scorers() {
+    const LIMIT: usize = 2;
+
+    let mut dataset = write_cross_column_compound_dataset().await;
+    create_fragmented_fts_index(&mut dataset, "title", true).await;
+    create_fragmented_fts_index(&mut dataset, "body", true).await;
+
+    let explicit_query: FtsQuery = MultiMatchQuery::try_new(
+        "noise".to_owned(),
+        vec!["title".to_owned(), "body".to_owned()],
+    )
+    .unwrap()
+    .into();
+    let explicit_oracle = sorted_compound_fts_oracle(
+        independent_compound_fts_oracle(&dataset, &explicit_query).await,
+    );
+    assert_eq!(
+        explicit_oracle[1].1, explicit_oracle[2].1,
+        "the fixture should exercise an equal-score tie at the top-k boundary"
+    );
+    assert!(explicit_oracle[1].0 < explicit_oracle[2].0);
+    let explicit_results = assert_compound_matches_independent_oracle(
+        &dataset,
+        "top_level_cross_column_multimatch",
+        &explicit_query,
+        LIMIT,
+    )
+    .await;
+    let explicit_plan = compound_fts_plan(&dataset, explicit_query.clone(), LIMIT).await;
+    assert!(
+        !explicit_plan.contains(CROSS_COLUMN_COMPOUND_FTS_SCORER),
+        "top-level MultiMatch should keep field scoring independent:\n{explicit_plan}"
+    );
+    assert!(
+        explicit_plan.matches("CompoundFtsScorer").count() >= 2,
+        "each indexed field should use its own bounded compound scorer:\n{explicit_plan}"
+    );
+    let inferred_query = FtsQuery::Match(MatchQuery::new("noise".to_owned()));
+    let inferred_results =
+        compound_fts_results(&dataset, inferred_query.clone(), Some(LIMIT as i64)).await;
+    assert_eq!(
+        inferred_results, explicit_results,
+        "a fieldless Match expanded across all FTS columns should match an explicit MultiMatch"
+    );
+    let inferred_plan = compound_fts_plan(&dataset, inferred_query, LIMIT).await;
+    assert!(
+        !inferred_plan.contains(CROSS_COLUMN_COMPOUND_FTS_SCORER),
+        "a fieldless Match expanded to MultiMatch should keep field scoring independent:\n{inferred_plan}"
+    );
+    assert!(
+        inferred_plan.matches("CompoundFtsScorer").count() >= 2,
+        "each inferred field should use its own bounded compound scorer:\n{inferred_plan}"
+    );
+
+    let blocked_query = |boosts: Vec<f32>| -> FtsQuery {
+        MultiMatchQuery::try_new(
+            "blocked".to_owned(),
+            vec!["title".to_owned(), "body".to_owned()],
+        )
+        .unwrap()
+        .try_with_boosts(boosts)
+        .unwrap()
+        .into()
+    };
+    let signed_zero = compound_fts_results(&dataset, blocked_query(vec![-0.0, 0.0]), Some(1)).await;
+    let normalized = compound_fts_results(&dataset, blocked_query(vec![0.0, 0.0]), None).await;
+    assert_eq!(signed_zero, normalized[..1]);
+    assert_eq!(signed_zero[0].0, 4);
+    assert_eq!(signed_zero[0].1.to_bits(), 0.0_f32.to_bits());
+
+    let unbounded_results = compound_fts_results(&dataset, explicit_query.clone(), None).await;
+    assert_scored_rows_close(
+        "unbounded_top_level_cross_column_multimatch",
+        &unbounded_results,
+        &explicit_oracle,
+    );
+    let mut unbounded_scanner = dataset.scan();
+    unbounded_scanner
+        .with_row_id()
+        .full_text_search(FullTextSearchQuery::new_query(explicit_query.clone()))
+        .unwrap();
+    let unbounded_plan = unbounded_scanner.explain_plan(false).await.unwrap();
+    assert!(
+        !unbounded_plan.contains("CompoundFtsScorer"),
+        "an unbounded MultiMatch should retain exhaustive leaf planning:\n{unbounded_plan}"
+    );
+
+    let mut partial_dataset = write_cross_column_compound_dataset().await;
+    create_fragmented_fts_index(&mut partial_dataset, "body", true).await;
+    let appended = arrow_array::record_batch!(
+        ("title", Utf8, ["noise"]),
+        ("body", Utf8, ["noise"]),
+        ("id", Int32, [10])
+    )
+    .unwrap();
+    let schema = appended.schema();
+    partial_dataset
+        .append(
+            RecordBatchIterator::new(vec![appended].into_iter().map(Ok), schema),
+            None,
+        )
+        .await
+        .unwrap();
+    // Index only the title after the append so it can retain a bounded plan
+    // while the partially covered body uses the exhaustive leaf fallback.
+    create_fragmented_fts_index(&mut partial_dataset, "title", true).await;
+    assert_compound_matches_independent_oracle(
+        &partial_dataset,
+        "partial_top_level_cross_column_multimatch",
+        &explicit_query,
+        LIMIT,
+    )
+    .await;
+    let partial_plan = compound_fts_plan(&partial_dataset, explicit_query, LIMIT).await;
+    assert!(
+        !partial_plan.contains(CROSS_COLUMN_COMPOUND_FTS_SCORER),
+        "top-level MultiMatch should keep field scoring independent:\n{partial_plan}"
+    );
+    assert_eq!(
+        partial_plan.matches("CompoundFtsScorer").count(),
+        1,
+        "the fully indexed title should retain its bounded compound scorer:\n{partial_plan}"
+    );
+    assert!(
+        partial_plan.contains("FlatMatchQuery"),
+        "the partially covered body should use the exact indexed-plus-flat fallback:\n{partial_plan}"
     );
 }
 


### PR DESCRIPTION
## What is the bug?

Top-level cross-column `MultiMatch` pushes the global `k` into each field's `Match` child. The leaf path truncates score ties before final row IDs are resolved, so the final `MAX(_score)` aggregate and `(score DESC, row_id ASC)` sort can only reorder the wrong survivor set.

On the 10M-row MMLB direct workload, current main mismatched the exhaustive oracle in 121 of 500 cases and produced unstable timed signatures for the same boundary-tie queries.

Linear: https://linear.app/lancedb/issue/OSS-1602

## How does this PR fix the problem?

- Plans one bounded, exact single-column `CompoundQueryExec` per field.
- Keeps field scoring independent and retains the existing bounded outer DisMax / `MAX(_score)` aggregation.
- Plans each field independently: complete, unchanged indexed fields retain an exact bounded compound scorer.
- Replans only partial-index, overlay-backed, missing-index, or otherwise ineligible fields through the unbounded exact leaf fallback before the final aggregate.
- Preserves exhaustive execution for unbounded queries.
- Supports both explicit `MultiMatch` and fieldless `Match` expansion.
- Canonicalizes signed zero boosts to `+0.0` before field expansion so MAX aggregation and total-order sorting agree.

The generic cross-column compound scorer was also prototyped for this root shape, but it paid row-address merge costs without a selective probe leaf. The field-local exact design was faster and keeps the final intermediate set bounded by `fields * k`.

## Correctness validation

Environment: 10M-row MMLB dataset, two independently indexed text columns, `c4-highmem-16`, 8 workers, 64 GiB index cache.

| Oracle case | Current main | This PR |
| --- | ---: | ---: |
| `k=10`, 250 queries | 120 mismatches | 0 mismatches |
| `k=100`, 250 queries | 1 mismatch | 0 mismatches |
| Total | 121 / 500 mismatches | 500 / 500 exact |

The target also had zero row/result signature instability across four timed processes.

This is primarily a correctness fix. Current main's higher throughput is not a valid performance baseline because its result set is incorrect on the affected queries.

## Tests and checks

- Added explicit and fieldless top-level cross-column MultiMatch oracle coverage.
- Covers equal-score kth ties, reversed segment order, signed zero boosts, unbounded execution, and mixed bounded/exact planning with one partially covered field.
- `cargo check -p lance --tests`
- `cargo fmt --all -- --check`
- `git diff --check`
- Pre-commit fmt and typos checks

Per the requested workflow, I did not run local `cargo test` or `cargo clippy`; CI will run them.
