### PR TITLE
perf(fts): add WAND exactness certificate

### DIFF
--- a/rust/lance-index-core/src/metrics.rs
+++ b/rust/lance-index-core/src/metrics.rs
@@ -24,6 +24,14 @@ pub const CROSS_COLUMN_STAGED_ATTEMPTS_METRIC: &str = "cross_column_staged_attem
 pub const CROSS_COLUMN_STAGED_SUCCESSES_METRIC: &str = "cross_column_staged_successes";
 pub const CROSS_COLUMN_STAGED_FALLBACKS_METRIC: &str = "cross_column_staged_fallbacks";
 pub const CROSS_COLUMN_STAGED_CANDIDATES_METRIC: &str = "cross_column_staged_candidates";
+pub const WAND_EXACTNESS_CERTIFICATE_ATTEMPTS_METRIC: &str = "wand_exactness_certificate_attempts";
+pub const WAND_EXACTNESS_CERTIFICATE_STRICT_METRIC: &str = "wand_exactness_certificate_strict";
+pub const WAND_EXACTNESS_CERTIFICATE_EXHAUSTIVE_METRIC: &str =
+    "wand_exactness_certificate_exhaustive";
+pub const WAND_EXACTNESS_CERTIFICATE_FALLBACKS_METRIC: &str =
+    "wand_exactness_certificate_fallbacks";
+pub const WAND_EXACTNESS_CERTIFICATE_CANDIDATES_METRIC: &str =
+    "wand_exactness_certificate_candidates";
 
 /// A trait used by the index to report metrics
 ///
@@ -140,6 +148,21 @@ pub trait MetricsCollector: Send + Sync {
 
     /// Record unique row-address candidates produced by successful staging.
     fn record_cross_column_staged_candidates(&self, _num_candidates: usize) {}
+
+    /// Record root Match WAND executions that attempted a k+1 exactness certificate.
+    fn record_wand_exactness_certificate_attempts(&self, _num_attempts: usize) {}
+
+    /// Record certificates proven by a strict score gap after the kth result.
+    fn record_wand_exactness_certificate_strict(&self, _num_certificates: usize) {}
+
+    /// Record certificates proven because WAND exhausted all matching documents.
+    fn record_wand_exactness_certificate_exhaustive(&self, _num_certificates: usize) {}
+
+    /// Record ambiguous certificates that fell back to the exact compound scorer.
+    fn record_wand_exactness_certificate_fallbacks(&self, _num_fallbacks: usize) {}
+
+    /// Record WAND candidates returned to the certificate classifier.
+    fn record_wand_exactness_certificate_candidates(&self, _num_candidates: usize) {}
 
     /// Returns an optional sink for recording exact I/O statistics (bytes read,
     /// IOPS, and requests) performed on behalf of this collector.

--- a/rust/lance-index/src/scalar/inverted/index/inverted_index.rs
+++ b/rust/lance-index/src/scalar/inverted/index/inverted_index.rs
@@ -272,6 +272,20 @@ impl InvertedIndex {
         self.partitions.len() == 1 && self.partitions[0].docs.legacy().is_some()
     }
 
+    /// Returns whether bounded WAND results can certify exact global top-k membership.
+    ///
+    /// The certificate requires a modern index whose every physical partition
+    /// contains impact metadata. Modern postings without impacts can prune with
+    /// partition-local scores before applying a corpus-wide scorer, so their
+    /// bounded candidate set cannot establish global exactness.
+    pub fn supports_wand_exactness_certificate(&self) -> bool {
+        !self.is_legacy()
+            && self
+                .partitions
+                .iter()
+                .all(|partition| partition.inverted_list.has_impacts)
+    }
+
     /// Read only the index's [`InvertedIndexParams`],
     /// Contains more complete info than manifest's lossy `InvertedIndexDetails`.
     pub async fn load_params(store: &dyn IndexStore) -> Result<InvertedIndexParams> {

--- a/rust/lance-index/src/scalar/inverted/index/tests/scoring.rs
+++ b/rust/lance-index/src/scalar/inverted/index/tests/scoring.rs
@@ -133,6 +133,32 @@ async fn write_test_partition_with_optional_impacts(
     doc_writer.finish().await.unwrap();
 }
 
+async fn load_single_partition_test_index(
+    builder: InnerBuilder,
+    with_impacts: bool,
+) -> (TempObjDir, Arc<LanceCache>, Arc<InvertedIndex>) {
+    let tmpdir = TempObjDir::default();
+    let store = Arc::new(LanceIndexStore::new(
+        ObjectStore::local().into(),
+        tmpdir.clone(),
+        Arc::new(LanceCache::no_cache()),
+    ));
+    write_test_partition_with_optional_impacts(
+        &store,
+        0,
+        builder,
+        TokenSetFormat::default(),
+        with_impacts,
+    )
+    .await;
+    write_test_metadata(&store, vec![0], InvertedIndexParams::default()).await;
+    let cache = Arc::new(LanceCache::with_capacity(4096));
+    let index = InvertedIndex::load(store, None, cache.as_ref())
+        .await
+        .unwrap();
+    (tmpdir, cache, index)
+}
+
 async fn load_global_scoring_test_index(
     first_partition_has_impacts: bool,
     second_partition_has_impacts: bool,
@@ -192,6 +218,130 @@ async fn load_global_scoring_test_index(
         .await
         .unwrap();
     (tmpdir, cache, index)
+}
+
+#[tokio::test]
+async fn test_wand_exactness_certificate_support_requires_all_impact_postings() {
+    let (_tmpdir, _cache, mixed_impact_index) = load_global_scoring_test_index(true, false).await;
+    assert!(!mixed_impact_index.is_legacy());
+    assert!(!mixed_impact_index.supports_wand_exactness_certificate());
+
+    let (_tmpdir, _cache, all_impact_index) = load_global_scoring_test_index(true, true).await;
+    assert!(!all_impact_index.is_legacy());
+    assert!(all_impact_index.supports_wand_exactness_certificate());
+}
+
+#[tokio::test]
+async fn test_no_impact_segments_cannot_certify_strict_bounded_candidates() {
+    // Segment-local BM25 strongly favors beta in the first segment, while
+    // corpus-wide IDF makes every alpha row the true global winner.
+    let mut first_segment = InnerBuilder::new_with_format_version(
+        0,
+        false,
+        TokenSetFormat::default(),
+        InvertedListFormatVersion::V1,
+    );
+    first_segment.tokens.add("alpha".to_owned());
+    first_segment.tokens.add("beta".to_owned());
+    first_segment
+        .posting_lists
+        .push(PostingListBuilder::new_with_posting_tail_codec(
+            false,
+            InvertedListFormatVersion::V1.posting_tail_codec(),
+        ));
+    first_segment
+        .posting_lists
+        .push(PostingListBuilder::new_with_posting_tail_codec(
+            false,
+            InvertedListFormatVersion::V1.posting_tail_codec(),
+        ));
+    for doc_id in 0_u32..98 {
+        first_segment.posting_lists[0].add(doc_id, PositionRecorder::Count(1));
+        first_segment.docs.append(u64::from(doc_id), 1);
+    }
+    first_segment.posting_lists[1].add(98, PositionRecorder::Count(10));
+    first_segment.docs.append(98, 10);
+    first_segment.posting_lists[1].add(99, PositionRecorder::Count(5));
+    first_segment.docs.append(99, 10);
+
+    let mut second_segment = InnerBuilder::new_with_format_version(
+        0,
+        false,
+        TokenSetFormat::default(),
+        InvertedListFormatVersion::V1,
+    );
+    second_segment.tokens.add("beta".to_owned());
+    second_segment
+        .posting_lists
+        .push(PostingListBuilder::new_with_posting_tail_codec(
+            false,
+            InvertedListFormatVersion::V1.posting_tail_codec(),
+        ));
+    for doc_id in 0_u32..10_000 {
+        second_segment.posting_lists[0].add(doc_id, PositionRecorder::Count(1));
+        second_segment.docs.append(1_001 + u64::from(doc_id), 1);
+    }
+
+    let (_first_tmpdir, _first_cache, first_index) =
+        load_single_partition_test_index(first_segment, false).await;
+    let (_second_tmpdir, _second_cache, second_index) =
+        load_single_partition_test_index(second_segment, false).await;
+    for index in [&first_index, &second_index] {
+        assert!(!index.is_legacy());
+        assert!(!index.supports_wand_exactness_certificate());
+    }
+
+    let scorer = MemBM25Scorer::new(
+        10_118,
+        10_100,
+        HashMap::from([("alpha".to_owned(), 98), ("beta".to_owned(), 10_002)]),
+    );
+    let tokens = Arc::new(Tokens::new(
+        vec!["alpha".to_owned(), "beta".to_owned()],
+        DocType::Text,
+    ));
+    let params = Arc::new(FtsSearchParams::new().with_limit(Some(2)));
+    let mut candidates = Vec::new();
+    for index in [first_index, second_index] {
+        let (row_ids, scores) = index
+            .bm25_search(
+                tokens.clone(),
+                params.clone(),
+                Operator::Or,
+                Arc::new(NoFilter),
+                Arc::new(NoOpMetricsCollector),
+                Some(&scorer),
+            )
+            .await
+            .unwrap();
+        candidates.extend(row_ids.into_iter().zip(scores));
+    }
+    candidates.sort_unstable_by(|left, right| {
+        right
+            .1
+            .total_cmp(&left.1)
+            .then_with(|| left.0.cmp(&right.0))
+    });
+    candidates.truncate(2);
+
+    // A k=1 certificate would see this strict returned gap and accept row 98,
+    // even though the omitted alpha tie group has the much larger exact score
+    // and row 0 wins its global `(score DESC, row_id ASC)` tie.
+    assert_eq!(
+        candidates
+            .iter()
+            .map(|candidate| candidate.0)
+            .collect::<Vec<_>>(),
+        vec![98, 1_001]
+    );
+    assert!(candidates[0].1.total_cmp(&candidates[1].1).is_gt());
+    assert!((candidates[0].1 - 0.011_179_519).abs() < 1e-6);
+    assert!((candidates[1].1 - 0.009_806_488).abs() < 1e-6);
+
+    let exact_winner_score = scorer.query_weight("alpha") * scorer.doc_weight(1, 1);
+    assert!((exact_winner_score - 4.633_705).abs() < 1e-5);
+    assert!(exact_winner_score > candidates[0].1);
+    assert!(!candidates.iter().any(|candidate| candidate.0 == 0));
 }
 
 #[tokio::test]

--- a/rust/lance/src/dataset/tests/dataset_index.rs
+++ b/rust/lance/src/dataset/tests/dataset_index.rs
@@ -50,7 +50,9 @@ use lance_index::metrics::{
     COMPOUND_SHOULD_ESSENTIAL_EVALUATIONS_METRIC, COMPOUND_SHOULD_NON_ESSENTIAL_EVALUATIONS_METRIC,
     COMPOUND_SHOULD_SKIPPED_WINDOWS_METRIC, CROSS_COLUMN_STAGED_ATTEMPTS_METRIC,
     CROSS_COLUMN_STAGED_CANDIDATES_METRIC, CROSS_COLUMN_STAGED_FALLBACKS_METRIC,
-    CROSS_COLUMN_STAGED_SUCCESSES_METRIC,
+    CROSS_COLUMN_STAGED_SUCCESSES_METRIC, WAND_EXACTNESS_CERTIFICATE_ATTEMPTS_METRIC,
+    WAND_EXACTNESS_CERTIFICATE_CANDIDATES_METRIC, WAND_EXACTNESS_CERTIFICATE_EXHAUSTIVE_METRIC,
+    WAND_EXACTNESS_CERTIFICATE_FALLBACKS_METRIC, WAND_EXACTNESS_CERTIFICATE_STRICT_METRIC,
 };
 use lance_index::optimize::OptimizeOptions;
 use lance_index::scalar::inverted::{
@@ -1331,6 +1333,34 @@ async fn compound_fts_results(
         .collect()
 }
 
+async fn compound_fts_results_with_stats(
+    dataset: &Dataset,
+    query: FtsQuery,
+    limit: i64,
+) -> (Vec<(u64, f32)>, ExecutionSummaryCounts) {
+    let collected_stats = Arc::new(Mutex::new(None::<ExecutionSummaryCounts>));
+    let stats_setter = collected_stats.clone();
+    let mut scan = dataset.scan();
+    scan.scan_stats_callback(Arc::new(move |stats| {
+        *stats_setter.lock().unwrap() = Some(stats.clone());
+    }))
+    .with_row_id()
+    .full_text_search(FullTextSearchQuery::new_query(query))
+    .unwrap()
+    .limit(Some(limit), None)
+    .unwrap();
+    let batch = scan.try_into_batch().await.unwrap();
+    let row_ids = batch[ROW_ID].as_primitive::<UInt64Type>().values();
+    let scores = batch[SCORE_COL].as_primitive::<Float32Type>().values();
+    let results = row_ids
+        .iter()
+        .copied()
+        .zip(scores.iter().copied())
+        .collect();
+    let stats = collected_stats.lock().unwrap().take().unwrap();
+    (results, stats)
+}
+
 fn compound_fts_result_bits(batch: &RecordBatch) -> Vec<(u64, u32)> {
     let row_ids = batch[ROW_ID].as_primitive::<UInt64Type>().values();
     let scores = batch[SCORE_COL].as_primitive::<Float32Type>().values();
@@ -1875,6 +1905,18 @@ async fn test_top_level_cross_column_multimatch_uses_field_local_compound_scorer
         LIMIT,
     )
     .await;
+    let (_, partial_stats) =
+        compound_fts_results_with_stats(&partial_dataset, explicit_query.clone(), LIMIT as i64)
+            .await;
+    assert_eq!(
+        partial_stats
+            .all_counts
+            .get(WAND_EXACTNESS_CERTIFICATE_ATTEMPTS_METRIC)
+            .copied()
+            .unwrap_or_default(),
+        1,
+        "only the fully indexed title field should attempt a bounded WAND certificate"
+    );
     let partial_plan = compound_fts_plan(&partial_dataset, explicit_query, LIMIT).await;
     assert!(
         !partial_plan.contains(CROSS_COLUMN_COMPOUND_FTS_SCORER),
@@ -1888,6 +1930,195 @@ async fn test_top_level_cross_column_multimatch_uses_field_local_compound_scorer
     assert!(
         partial_plan.contains("FlatMatchQuery"),
         "the partially covered body should use the exact indexed-plus-flat fallback:\n{partial_plan}"
+    );
+}
+
+#[tokio::test]
+async fn test_field_local_match_wand_exactness_certificates() {
+    let mut dataset = write_cross_column_compound_dataset().await;
+    create_fragmented_fts_index_with_order(&mut dataset, "title", true, true).await;
+    create_fragmented_fts_index_with_order(&mut dataset, "body", true, true).await;
+
+    let field_local_query = |term: &str| -> FtsQuery {
+        MultiMatchQuery::try_new(term.to_owned(), vec!["title".to_owned(), "body".to_owned()])
+            .unwrap()
+            .into()
+    };
+
+    let strict_query = field_local_query("alpha");
+    let strict_plan = compound_fts_plan(&dataset, strict_query.clone(), 1).await;
+    assert!(
+        strict_plan.matches("CompoundFtsScorer").count() >= 2
+            && !strict_plan.contains(CROSS_COLUMN_COMPOUND_FTS_SCORER),
+        "certificate coverage must execute through field-local compound children:\n{strict_plan}"
+    );
+    let strict_oracle =
+        sorted_compound_fts_oracle(independent_compound_fts_oracle(&dataset, &strict_query).await);
+    assert!(strict_oracle[0].1.total_cmp(&strict_oracle[1].1).is_gt());
+    let (strict, stats) = compound_fts_results_with_stats(&dataset, strict_query, 1).await;
+    assert_scored_rows_close("wand_certificate_strict", &strict, &strict_oracle[..1]);
+    assert_eq!(
+        stats
+            .all_counts
+            .get(WAND_EXACTNESS_CERTIFICATE_ATTEMPTS_METRIC),
+        Some(&1)
+    );
+    assert_eq!(
+        stats
+            .all_counts
+            .get(WAND_EXACTNESS_CERTIFICATE_STRICT_METRIC),
+        Some(&1)
+    );
+    assert_eq!(
+        stats
+            .all_counts
+            .get(WAND_EXACTNESS_CERTIFICATE_EXHAUSTIVE_METRIC),
+        Some(&0)
+    );
+    assert_eq!(
+        stats
+            .all_counts
+            .get(WAND_EXACTNESS_CERTIFICATE_FALLBACKS_METRIC),
+        Some(&0)
+    );
+    assert_eq!(
+        stats
+            .all_counts
+            .get(WAND_EXACTNESS_CERTIFICATE_CANDIDATES_METRIC),
+        Some(&2)
+    );
+
+    let exhaustive_query = field_local_query("tiebody");
+    let exhaustive_oracle = sorted_compound_fts_oracle(
+        independent_compound_fts_oracle(&dataset, &exhaustive_query).await,
+    );
+    let (exhaustive, stats) = compound_fts_results_with_stats(&dataset, exhaustive_query, 3).await;
+    assert_scored_rows_close(
+        "wand_certificate_exhaustive",
+        &exhaustive,
+        &exhaustive_oracle,
+    );
+    assert_eq!(
+        stats
+            .all_counts
+            .get(WAND_EXACTNESS_CERTIFICATE_ATTEMPTS_METRIC),
+        Some(&1)
+    );
+    assert_eq!(
+        stats
+            .all_counts
+            .get(WAND_EXACTNESS_CERTIFICATE_STRICT_METRIC),
+        Some(&0)
+    );
+    assert_eq!(
+        stats
+            .all_counts
+            .get(WAND_EXACTNESS_CERTIFICATE_EXHAUSTIVE_METRIC),
+        Some(&1)
+    );
+    assert_eq!(
+        stats
+            .all_counts
+            .get(WAND_EXACTNESS_CERTIFICATE_FALLBACKS_METRIC),
+        Some(&0)
+    );
+    assert_eq!(
+        stats
+            .all_counts
+            .get(WAND_EXACTNESS_CERTIFICATE_CANDIDATES_METRIC),
+        Some(&2)
+    );
+
+    let tied_query = field_local_query("tie");
+    let tied_oracle =
+        sorted_compound_fts_oracle(independent_compound_fts_oracle(&dataset, &tied_query).await);
+    assert_eq!(tied_oracle.len(), 2);
+    assert_eq!(tied_oracle[0].1, tied_oracle[1].1);
+    assert!(tied_oracle[0].0 < tied_oracle[1].0);
+    let (tied, stats) = compound_fts_results_with_stats(&dataset, tied_query, 1).await;
+    assert_scored_rows_close("wand_certificate_tie_fallback", &tied, &tied_oracle[..1]);
+    assert_eq!(
+        stats
+            .all_counts
+            .get(WAND_EXACTNESS_CERTIFICATE_ATTEMPTS_METRIC),
+        Some(&1)
+    );
+    assert_eq!(
+        stats
+            .all_counts
+            .get(WAND_EXACTNESS_CERTIFICATE_STRICT_METRIC),
+        Some(&0)
+    );
+    assert_eq!(
+        stats
+            .all_counts
+            .get(WAND_EXACTNESS_CERTIFICATE_EXHAUSTIVE_METRIC),
+        Some(&0)
+    );
+    assert_eq!(
+        stats
+            .all_counts
+            .get(WAND_EXACTNESS_CERTIFICATE_FALLBACKS_METRIC),
+        Some(&1)
+    );
+    assert_eq!(
+        stats
+            .all_counts
+            .get(WAND_EXACTNESS_CERTIFICATE_CANDIDATES_METRIC),
+        Some(&2)
+    );
+
+    let mixed_query = field_local_query("noise");
+    let mixed_oracle =
+        sorted_compound_fts_oracle(independent_compound_fts_oracle(&dataset, &mixed_query).await);
+    let (mixed, stats) = compound_fts_results_with_stats(&dataset, mixed_query, 1).await;
+    assert_scored_rows_close("wand_certificate_mixed_fields", &mixed, &mixed_oracle[..1]);
+    assert_eq!(
+        stats
+            .all_counts
+            .get(WAND_EXACTNESS_CERTIFICATE_ATTEMPTS_METRIC),
+        Some(&2)
+    );
+    assert_eq!(
+        stats
+            .all_counts
+            .get(WAND_EXACTNESS_CERTIFICATE_EXHAUSTIVE_METRIC),
+        Some(&1)
+    );
+    assert_eq!(
+        stats
+            .all_counts
+            .get(WAND_EXACTNESS_CERTIFICATE_STRICT_METRIC),
+        Some(&0)
+    );
+    assert_eq!(
+        stats
+            .all_counts
+            .get(WAND_EXACTNESS_CERTIFICATE_FALLBACKS_METRIC),
+        Some(&1)
+    );
+    assert_eq!(
+        stats
+            .all_counts
+            .get(WAND_EXACTNESS_CERTIFICATE_CANDIDATES_METRIC),
+        Some(&3)
+    );
+
+    let zero_boost_query: FtsQuery = MultiMatchQuery::try_new(
+        "blocked".to_owned(),
+        vec!["title".to_owned(), "body".to_owned()],
+    )
+    .unwrap()
+    .try_with_boosts(vec![0.0, 0.0])
+    .unwrap()
+    .into();
+    let (_, stats) = compound_fts_results_with_stats(&dataset, zero_boost_query, 1).await;
+    assert_eq!(
+        stats
+            .all_counts
+            .get(WAND_EXACTNESS_CERTIFICATE_ATTEMPTS_METRIC),
+        Some(&0),
+        "zero-boost fields must use the exact path without attempting a certificate"
     );
 }
 

--- a/rust/lance/src/io/exec/fts.rs
+++ b/rust/lance/src/io/exec/fts.rs
@@ -52,6 +52,9 @@ use lance_index::metrics::{
     COMPOUND_SHOULD_SKIPPED_WINDOWS_METRIC, CROSS_COLUMN_STAGED_ATTEMPTS_METRIC,
     CROSS_COLUMN_STAGED_CANDIDATES_METRIC, CROSS_COLUMN_STAGED_FALLBACKS_METRIC,
     CROSS_COLUMN_STAGED_SUCCESSES_METRIC, FREQS_COLLECTED_METRIC, MetricsCollector,
+    WAND_EXACTNESS_CERTIFICATE_ATTEMPTS_METRIC, WAND_EXACTNESS_CERTIFICATE_CANDIDATES_METRIC,
+    WAND_EXACTNESS_CERTIFICATE_EXHAUSTIVE_METRIC, WAND_EXACTNESS_CERTIFICATE_FALLBACKS_METRIC,
+    WAND_EXACTNESS_CERTIFICATE_STRICT_METRIC,
 };
 use lance_index::scalar::inverted::builder::ScoredDoc;
 use lance_index::scalar::inverted::builder::document_input;
@@ -63,7 +66,7 @@ use lance_index::scalar::inverted::query::{
 use lance_index::scalar::inverted::tokenizer::document_tokenizer::TextTokenizer;
 use lance_index::scalar::inverted::{
     DOC_INDEX_COL, DocumentGranularity, FTS_SCHEMA, FlatBm25SearchOptions, InvertedIndex,
-    MemBM25Scorer, SCORE_COL, build_global_bm25_scorer, compound_search,
+    MemBM25Scorer, SCORE_COL, Scorer, build_global_bm25_scorer, compound_search,
     compound_search_with_base_scorer, cross_column_compound_search,
     flat_bm25_search_stream_with_options_and_scorer, fts_schema,
 };
@@ -649,6 +652,52 @@ impl CompoundQueryExec {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum WandExactnessCertificate {
+    Exhaustive,
+    Strict,
+    Ambiguous,
+}
+
+/// Classify a globally merged k+1 Match WAND result.
+///
+/// Sorting before classification is essential: per-segment WAND output is not
+/// a final cross-segment ordering. A strict score gap after result k proves
+/// that score-only pruning could not have discarded a row-id tie at the final
+/// boundary. Ties wholly inside top-k remain safe because all members of their
+/// score group are present before the strict boundary.
+fn classify_wand_exactness_certificate(
+    documents: &mut [ScoredDoc],
+    limit: usize,
+) -> WandExactnessCertificate {
+    if limit == 0
+        || documents
+            .iter()
+            .any(|document| !document.score.0.is_finite())
+    {
+        return WandExactnessCertificate::Ambiguous;
+    }
+    documents.sort_unstable_by(|left, right| {
+        right
+            .score
+            .0
+            .total_cmp(&left.score.0)
+            .then_with(|| left.row_id.cmp(&right.row_id))
+    });
+    if documents.len() <= limit {
+        WandExactnessCertificate::Exhaustive
+    } else if documents[limit - 1]
+        .score
+        .0
+        .total_cmp(&documents[limit].score.0)
+        == Ordering::Greater
+    {
+        WandExactnessCertificate::Strict
+    } else {
+        WandExactnessCertificate::Ambiguous
+    }
+}
+
 impl DisplayAs for CompoundQueryExec {
     fn fmt_as(&self, t: DisplayFormatType, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match t {
@@ -805,8 +854,57 @@ impl ExecutionPlan for CompoundQueryExec {
                     .sum::<usize>()
                     .saturating_mul(count_fts_leaves(&query)),
             );
-            let (row_ids, scores) = match base_scorer {
-                Some(base_scorer) => {
+            let certificate_limit = match (&query, params.limit) {
+                (FtsQuery::Match(match_query), Some(limit))
+                    if limit > 0
+                        && params.wand_factor == 1.0
+                        && match_query.boost.is_finite()
+                        && match_query.boost > 0.0
+                        && base_scorer.is_none()
+                        && indices
+                            .iter()
+                            .all(|index| index.supports_wand_exactness_certificate()) =>
+                {
+                    limit
+                        .checked_add(1)
+                        .map(|wand_limit| (match_query.clone(), limit, wand_limit))
+                }
+                _ => None,
+            };
+            let (row_ids, scores) = if let Some((match_query, limit, wand_limit)) =
+                certificate_limit
+            {
+                let first_index = indices.first().ok_or_else(|| {
+                    DataFusionError::Execution(format!(
+                        "FTS index for column {column} has no segments"
+                    ))
+                })?;
+                let mut tokenizer =
+                    tokenizer_for_match_query(first_index.as_ref(), match_query.fuzziness);
+                let tokens = collect_query_tokens(&match_query.terms, &mut tokenizer);
+                let wand_params = MatchQueryExec::effective_params(&match_query, params.clone())
+                    .with_phrase_slop(None)
+                    .with_limit(Some(wand_limit));
+                let scorer_start = std::time::Instant::now();
+                let base_scorer = Arc::new(
+                    build_global_bm25_scorer(
+                        &indices,
+                        &tokens,
+                        &wand_params,
+                        Some(metrics.as_ref()),
+                    )
+                    .await?,
+                );
+                metrics.record_scorer_build(scorer_start.elapsed());
+
+                // Zero-weight terms can match documents without contributing a
+                // positive score. A short score-only WAND result therefore does
+                // not prove exhaustion. Preserve exact membership semantics for
+                // those rare corpora without recording a certificate attempt.
+                if base_scorer.token_docs.keys().any(|token| {
+                    let weight = base_scorer.query_weight(token);
+                    !weight.is_finite() || weight <= 0.0
+                }) {
                     compound_search_with_base_scorer(
                         &indices,
                         &query,
@@ -816,9 +914,71 @@ impl ExecutionPlan for CompoundQueryExec {
                         base_scorer,
                     )
                     .await?
+                } else {
+                    metrics.record_wand_exactness_certificate_attempts(1);
+                    prefilter.wait_for_ready().await?;
+                    let mut documents = search_segments(
+                        &indices,
+                        Arc::new(tokens),
+                        Arc::new(wand_params),
+                        match_query.operator,
+                        prefilter.clone(),
+                        metrics.clone(),
+                        base_scorer.clone(),
+                    )
+                    .await?;
+                    documents.iter_mut().for_each(|document| {
+                        document.score.0 *= match_query.boost;
+                    });
+                    metrics.record_wand_exactness_certificate_candidates(documents.len());
+                    match classify_wand_exactness_certificate(&mut documents, limit) {
+                        WandExactnessCertificate::Exhaustive => {
+                            metrics.record_wand_exactness_certificate_exhaustive(1);
+                            documents.truncate(limit);
+                            documents
+                                .into_iter()
+                                .map(|document| (document.row_id, document.score.0))
+                                .unzip()
+                        }
+                        WandExactnessCertificate::Strict => {
+                            metrics.record_wand_exactness_certificate_strict(1);
+                            documents.truncate(limit);
+                            documents
+                                .into_iter()
+                                .map(|document| (document.row_id, document.score.0))
+                                .unzip()
+                        }
+                        WandExactnessCertificate::Ambiguous => {
+                            metrics.record_wand_exactness_certificate_fallbacks(1);
+                            compound_search_with_base_scorer(
+                                &indices,
+                                &query,
+                                &params,
+                                prefilter,
+                                metrics.clone(),
+                                base_scorer,
+                            )
+                            .await?
+                        }
+                    }
                 }
-                None => {
-                    compound_search(&indices, &query, &params, prefilter, metrics.clone()).await?
+            } else {
+                match base_scorer {
+                    Some(base_scorer) => {
+                        compound_search_with_base_scorer(
+                            &indices,
+                            &query,
+                            &params,
+                            prefilter,
+                            metrics.clone(),
+                            base_scorer,
+                        )
+                        .await?
+                    }
+                    None => {
+                        compound_search(&indices, &query, &params, prefilter, metrics.clone())
+                            .await?
+                    }
                 }
             };
             metrics.baseline_metrics.record_output(row_ids.len());
@@ -1591,6 +1751,11 @@ pub struct FtsIndexMetrics {
     cross_column_staged_successes: Count,
     cross_column_staged_fallbacks: Count,
     cross_column_staged_candidates: Count,
+    wand_exactness_certificate_attempts: Count,
+    wand_exactness_certificate_strict: Count,
+    wand_exactness_certificate_exhaustive: Count,
+    wand_exactness_certificate_fallbacks: Count,
+    wand_exactness_certificate_candidates: Count,
     /// Wall time (ms) of the exec-local `build_global_bm25_scorer`
     /// fallback; zero when a preset base scorer was injected.
     scorer_build_ms: Gauge,
@@ -1636,6 +1801,16 @@ impl FtsIndexMetrics {
                 .new_count(CROSS_COLUMN_STAGED_FALLBACKS_METRIC, partition),
             cross_column_staged_candidates: metrics
                 .new_count(CROSS_COLUMN_STAGED_CANDIDATES_METRIC, partition),
+            wand_exactness_certificate_attempts: metrics
+                .new_count(WAND_EXACTNESS_CERTIFICATE_ATTEMPTS_METRIC, partition),
+            wand_exactness_certificate_strict: metrics
+                .new_count(WAND_EXACTNESS_CERTIFICATE_STRICT_METRIC, partition),
+            wand_exactness_certificate_exhaustive: metrics
+                .new_count(WAND_EXACTNESS_CERTIFICATE_EXHAUSTIVE_METRIC, partition),
+            wand_exactness_certificate_fallbacks: metrics
+                .new_count(WAND_EXACTNESS_CERTIFICATE_FALLBACKS_METRIC, partition),
+            wand_exactness_certificate_candidates: metrics
+                .new_count(WAND_EXACTNESS_CERTIFICATE_CANDIDATES_METRIC, partition),
             scorer_build_ms: metrics.new_gauge("scorer_build_ms", partition),
             segment_bind_duration: metrics.new_time(FTS_SEGMENT_BIND_DURATION_METRIC, partition),
             baseline_metrics: BaselineMetrics::new(metrics, partition),
@@ -1743,6 +1918,28 @@ impl MetricsCollector for FtsIndexMetrics {
 
     fn record_cross_column_staged_candidates(&self, num_candidates: usize) {
         self.cross_column_staged_candidates.add(num_candidates);
+    }
+
+    fn record_wand_exactness_certificate_attempts(&self, num_attempts: usize) {
+        self.wand_exactness_certificate_attempts.add(num_attempts);
+    }
+
+    fn record_wand_exactness_certificate_strict(&self, num_certificates: usize) {
+        self.wand_exactness_certificate_strict.add(num_certificates);
+    }
+
+    fn record_wand_exactness_certificate_exhaustive(&self, num_certificates: usize) {
+        self.wand_exactness_certificate_exhaustive
+            .add(num_certificates);
+    }
+
+    fn record_wand_exactness_certificate_fallbacks(&self, num_fallbacks: usize) {
+        self.wand_exactness_certificate_fallbacks.add(num_fallbacks);
+    }
+
+    fn record_wand_exactness_certificate_candidates(&self, num_candidates: usize) {
+        self.wand_exactness_certificate_candidates
+            .add(num_candidates);
     }
 }
 
@@ -4081,6 +4278,7 @@ mod tests {
     use lance_datafusion::utils::PARTITIONS_SEARCHED_METRIC;
     use lance_datagen::{BatchCount, ByteCount, RowCount};
     use lance_index::metrics::{MetricsCollector, NoOpMetricsCollector};
+    use lance_index::scalar::inverted::builder::ScoredDoc;
     use lance_index::scalar::inverted::query::{
         BooleanQuery, BoostQuery, FtsQuery, FtsSearchParams, MatchQuery, Occur, Operator,
         PhraseQuery, collect_query_tokens, has_query_token,
@@ -4106,7 +4304,8 @@ mod tests {
     use super::{
         BoolSlot, BoostQueryExec, CompoundQueryExec, CrossColumnCompoundQueryExec,
         FTS_SEGMENT_BIND_DURATION_METRIC, FlatMatchFilterExec, FlatMatchQueryExec, MatchQueryExec,
-        PhraseQueryExec, build_boolean_query_children, default_text_tokenizer, open_fts_segments,
+        PhraseQueryExec, WandExactnessCertificate, build_boolean_query_children,
+        classify_wand_exactness_certificate, default_text_tokenizer, open_fts_segments,
     };
     use crate::io::exec::utils::IndexMetrics;
     use datafusion::physical_plan::empty::EmptyExec;
@@ -4162,6 +4361,74 @@ mod tests {
         assert_eq!(metrics.cross_column_staged_successes.value(), 1);
         assert_eq!(metrics.cross_column_staged_fallbacks.value(), 1);
         assert_eq!(metrics.cross_column_staged_candidates.value(), 17);
+    }
+
+    #[test]
+    fn test_wand_exactness_certificate_classification() {
+        let documents = |scores: &[f32]| {
+            scores
+                .iter()
+                .enumerate()
+                .rev()
+                .map(|(row_id, score)| ScoredDoc::new(row_id as u64, *score))
+                .collect::<Vec<_>>()
+        };
+
+        let mut exhaustive = documents(&[3.0, 2.0]);
+        assert_eq!(
+            classify_wand_exactness_certificate(&mut exhaustive, 3),
+            WandExactnessCertificate::Exhaustive
+        );
+
+        let mut strict = documents(&[4.0, 3.0, 3.0, 1.0]);
+        assert_eq!(
+            classify_wand_exactness_certificate(&mut strict, 3),
+            WandExactnessCertificate::Strict
+        );
+        assert_eq!(
+            strict
+                .iter()
+                .map(|document| document.row_id)
+                .collect::<Vec<_>>(),
+            vec![0, 1, 2, 3],
+            "ties wholly inside top-k must use row-id ordering without forcing fallback"
+        );
+
+        let mut ambiguous = documents(&[4.0, 3.0, 2.0, 2.0]);
+        assert_eq!(
+            classify_wand_exactness_certificate(&mut ambiguous, 3),
+            WandExactnessCertificate::Ambiguous
+        );
+
+        let mut non_finite = documents(&[4.0, f32::INFINITY]);
+        assert_eq!(
+            classify_wand_exactness_certificate(&mut non_finite, 1),
+            WandExactnessCertificate::Ambiguous
+        );
+
+        let mut zero_limit = documents(&[1.0]);
+        assert_eq!(
+            classify_wand_exactness_certificate(&mut zero_limit, 0),
+            WandExactnessCertificate::Ambiguous
+        );
+    }
+
+    #[test]
+    fn test_wand_exactness_certificate_metrics_are_counted_independently() {
+        let metrics_set = ExecutionPlanMetricsSet::new();
+        let metrics = super::FtsIndexMetrics::new(&metrics_set, 0);
+
+        metrics.record_wand_exactness_certificate_attempts(2);
+        metrics.record_wand_exactness_certificate_strict(3);
+        metrics.record_wand_exactness_certificate_exhaustive(5);
+        metrics.record_wand_exactness_certificate_fallbacks(7);
+        metrics.record_wand_exactness_certificate_candidates(11);
+
+        assert_eq!(metrics.wand_exactness_certificate_attempts.value(), 2);
+        assert_eq!(metrics.wand_exactness_certificate_strict.value(), 3);
+        assert_eq!(metrics.wand_exactness_certificate_exhaustive.value(), 5);
+        assert_eq!(metrics.wand_exactness_certificate_fallbacks.value(), 7);
+        assert_eq!(metrics.wand_exactness_certificate_candidates.value(), 11);
     }
 
     async fn create_segment_selection_fixture() -> (Arc<Dataset>, Vec<IndexMetadata>, Vec<u32>) {


### PR DESCRIPTION
## Performance issue

The exact field-local top-level MultiMatch path introduced by #8702 uses `CompoundQueryExec` for every field. This preserves final `(score DESC, row_id ASC)` ties, but always pays inclusive score-floor and row-ID resolution costs even when the existing Match WAND result already has a strict kth score boundary.

Linear: https://linear.app/lancedb/issue/OSS-2078

Stack parent: #8702

## How this PR improves performance

For eligible root Match children, this PR runs the existing global Match WAND chain with `k + 1` results and classifies the final boosted scores:

- Fewer than `k + 1` results proves the field result is exhaustive.
- A strict `score[k - 1] > score[k]` gap proves that the first k results cannot depend on a discarded row-ID tie.
- An equal or unsupported boundary is ambiguous and falls back to the existing exact compound scorer.

Each MultiMatch field certifies or falls back independently. The ambiguous path reuses the same opened indices, ready prefilter, and corpus-wide BM25 scorer. The implementation does not change WAND pruning algorithms, external query APIs, or index formats.

The certificate is conservatively disabled for zero/non-finite boosts, `wand_factor != 1`, legacy indices, physical posting schemas without impacts, injected base scorers, zero/non-finite term weights, unbounded queries, and unsupported planner shapes. No-impact postings fall back to the existing exact compound scorer because partition-local candidate pruning cannot certify a corpus-wide score boundary.

## Benchmark results (measured before review fixes)

Environment and methodology:

- 10M-row MMLB dataset
- Two independently indexed text columns
- GCP `c4-highmem-16`
- 8 workers
- 64 GiB index cache
- 250 frozen queries, `k=10/100`
- 5 repetitions
- Two isolated `A1-B1-B2-A2` ABBA blocks
- Measured parent `c581b764b` versus this PR `4eab6d16a`
- Current heads are `3d27cf91f` / `563efebe7`. They add per-field mixed fallback and reject no-impact certificate probes. The measured MMLB corpus uses impact-backed postings, so its fast path is unchanged, but these heads have not been re-benchmarked.
- Ordered row IDs and score signatures verified before timing

Higher QPS is better; lower latency is better.

| Scenario / metric | Parent exact | This PR | Benefit |
| --- | ---: | ---: | ---: |
| `k=10` QPS | 1,615 QPS | 1,761 QPS | 1.09x |
| `k=10` p95 latency | 11.12 ms | 6.84 ms | 1.63x |
| `k=100` QPS | 766 QPS | 1,297 QPS | 1.69x |
| `k=100` p50 latency | 9.97 ms | 5.58 ms | 1.79x |
| `k=100` p95 latency | 19.69 ms | 10.84 ms | 1.82x |
| Fresh-cold `k=10` Q000001 | 679.9 ms | 566.4 ms | 1.20x |
| Fresh-cold `k=100` Q000001 | 729.7 ms | 567.9 ms | 1.28x |

Correctness and determinism:

- Parent and this PR: 500 / 500 oracle cases exact.
- Cross-build row/result differences: 0.
- Timed signature instability: 0.

Certificate census over 250 queries:

| k | Field attempts | Strict | Exhaustive | Fallbacks | Queries with fallback |
| ---: | ---: | ---: | ---: | ---: | ---: |
| 10 | 466 | 229 | 2 | 235 | 232 / 250 |
| 100 | 466 | 449 | 2 | 15 | 15 / 250 |

Metric invariant violations were zero: `attempts == strict + exhaustive + fallbacks` for every query.

Known tradeoff: the rare `k=100` one-field-fallback cohort had about 15% worse warm p95 because it runs WAND and then exact scoring. Overall `k=100` p95 improved 1.82x. Reusing first-pass WAND state for ambiguous fallback is a possible follow-up.

RSS stayed within roughly +0.5% to +3% in the fresh-cold runs.

## Metrics

- `wand_exactness_certificate_attempts`
- `wand_exactness_certificate_strict`
- `wand_exactness_certificate_exhaustive`
- `wand_exactness_certificate_fallbacks`
- `wand_exactness_certificate_candidates`

## Tests and checks

- Added strict, exhaustive, boundary-tie fallback, mixed-field, zero-boost, reversed-segment, and partial-coverage coverage through the real field-local MultiMatch path.
- Added the modern V1 no-impact false-certificate corpus from review, plus mixed-impact rejection and all-impact acceptance controls.
- `cargo fmt --all -- --check`
- `git diff --check`
- Pre-commit fmt and typos checks

Per the requested workflow, I did not run local `cargo test` or `cargo clippy`; CI will run them.
