### PR TITLE
fix: delete data files when cleanup retains an older tag

### DIFF
--- a/rust/lance/src/dataset/cleanup.rs
+++ b/rust/lance/src/dataset/cleanup.rs
@@ -312,6 +312,32 @@ struct CleanupInspection {
     tagged_old_versions: HashSet<u64>,
     /// The earliest timestamp of all retained manifests.
     earliest_retained_manifest_time: Option<DateTime<Utc>>,
+    /// The latest timestamp of all manifests that will be removed.
+    latest_deleted_manifest_time: Option<DateTime<Utc>>,
+}
+
+impl CleanupInspection {
+    /// Cutoff for `read_dir_all(..., unmodified_since)`.
+    ///
+    /// Listing only files with `last_modified <= earliest_retained` is valid
+    /// when the working set is a time suffix: every retained version is newer
+    /// than every deleted one. A tagged old version (or any other sparse
+    /// retain) pulls that cutoff backwards, so files from newer deleted
+    /// versions are never listed. Their manifests are still removed, which
+    /// permanently orphans the data files ([#8705](https://github.com/lance-format/lance/issues/8705)).
+    ///
+    /// When a deleted manifest is newer than the earliest retained one, drop
+    /// the cutoff and scan the whole subtree — the same approach already used
+    /// for `_indices/`.
+    fn listing_unmodified_since(&self) -> Option<DateTime<Utc>> {
+        match (
+            self.earliest_retained_manifest_time,
+            self.latest_deleted_manifest_time,
+        ) {
+            (Some(retained), Some(deleted)) if deleted > retained => None,
+            (retained, _) => retained,
+        }
+    }
 }
 
 /// If a file cannot be verified then it will only be deleted if it is at least
@@ -561,18 +587,19 @@ impl<'a> CleanupTask<'a> {
         }
 
         self.process_manifest(&manifest, &indexes, in_working_set, &mut inspection)?;
+        let commit_ts = manifest.timestamp();
         if !in_working_set {
             inspection
                 .old_manifests
                 .insert(location.path.clone(), manifest.version);
+            match inspection.latest_deleted_manifest_time {
+                Some(ts) if commit_ts <= ts => {}
+                _ => inspection.latest_deleted_manifest_time = Some(commit_ts),
+            }
         } else {
-            let commit_ts = manifest.timestamp();
-            if let Some(ts) = inspection.earliest_retained_manifest_time {
-                if commit_ts < ts {
-                    inspection.earliest_retained_manifest_time = Some(commit_ts);
-                }
-            } else {
-                inspection.earliest_retained_manifest_time = Some(commit_ts);
+            match inspection.earliest_retained_manifest_time {
+                Some(ts) if commit_ts >= ts => {}
+                _ => inspection.earliest_retained_manifest_time = Some(commit_ts),
             }
         }
         Ok(())
@@ -688,7 +715,10 @@ impl<'a> CleanupTask<'a> {
         };
 
         // Restrict scanning to Lance-managed subtrees for safety and performance.
-        let unmodified_since = inspection.earliest_retained_manifest_time;
+        // Drop the retained-manifest cutoff when a sparse retain (e.g. a tag)
+        // would hide files that belong to newer deleted versions. See
+        // [`CleanupInspection::listing_unmodified_since`].
+        let unmodified_since = inspection.listing_unmodified_since();
         let streams = vec![
             build_listing_stream(self.dataset.versions_dir(), unmodified_since),
             build_listing_stream(self.dataset.transactions_dir(), unmodified_since),
@@ -2428,6 +2458,49 @@ mod tests {
             .unwrap();
 
         assert_eq!(removed.old_versions, 1);
+    }
+
+    #[tokio::test]
+    async fn cleanup_deletes_data_files_newer_than_tagged_version() {
+        // A tag on an old version must not prevent cleanup from deleting data
+        // files that belong only to newer, untagged versions. The listing
+        // cutoff used to be the earliest retained manifest time; with a tag
+        // that pulled the cutoff backwards and skipped those newer files.
+        // After their manifests were removed they became permanent orphans
+        // (https://github.com/lance-format/lance/issues/8705).
+        MockClock::set_system_time(std::time::Duration::from_secs(0));
+        let fixture = MockDatasetFixture::try_new().unwrap();
+        fixture.create_some_data().await.unwrap();
+        MockClock::set_system_time(TimeDelta::try_days(1).unwrap().to_std().unwrap());
+        fixture.overwrite_some_data().await.unwrap();
+        MockClock::set_system_time(TimeDelta::try_days(2).unwrap().to_std().unwrap());
+        fixture.overwrite_some_data().await.unwrap();
+
+        let dataset = *(fixture.open().await.unwrap());
+        dataset.tags().create("keep-v1", 1).await.unwrap();
+
+        MockClock::set_system_time(TimeDelta::try_days(10).unwrap().to_std().unwrap());
+
+        let before_count = fixture.count_files().await.unwrap();
+        assert_eq!(before_count.num_data_files, 3);
+        assert_eq!(before_count.num_manifest_files, 3);
+
+        let removed = fixture
+            .run_cleanup_with_override(
+                utc_now() - TimeDelta::try_days(8).unwrap(),
+                None,
+                Some(false),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(removed.old_versions, 1);
+        assert_eq!(removed.data_files_removed, 1);
+
+        let after_count = fixture.count_files().await.unwrap();
+        assert_eq!(after_count.num_manifest_files, 2);
+        assert_eq!(after_count.num_data_files, 2);
+        assert_eq!(after_count.num_tx_files, 2);
     }
 
     // Helper function to check that the number of files is correct.


### PR DESCRIPTION
## Summary
- `cleanup_old_versions` used the earliest retained manifest time as the `read_dir_all` cutoff. A tag on an old version pulled that cutoff backwards, so data files from newer deleted versions were never listed.
- After those versions' manifests were removed, the skipped data files became permanent orphans. Same hole already existed for `_indices/` and was fixed there; this applies the same rule to data / tx / deletions.
- When a deleted manifest is newer than the earliest retained one, drop the cutoff and scan the subtree. Suffix-only cleanup keeps the original listing optimization.

Fixes #8705

```mermaid
flowchart TD
    A[cleanup_old_versions] --> B{Working set is a time suffix?}
    B -->|Yes: keep latest N versions| C[Scan files with last_modified <= earliest retained]
    C --> D[Delete unreferenced data / tx / deletions]
    B -->|No: tag keeps an older version| E[Deleted versions can be newer than the tag]
    E --> F[Old cutoff skips those newer data files]
    F --> G[Manifests are still removed]
    G --> H[Data files become permanent orphans]
    E --> I[New: drop unmodified_since cutoff]
    I --> D
```

## Test plan
- [x] `cleanup_deletes_data_files_newer_than_tagged_version` — overwrite replaces files, tag v1, cleanup deletes the intermediate version's data file
- [x] `dataset::cleanup::tests` (43 tests)
- [x] `cargo fmt --all`
- [x] `cargo check -p lance --tests`
- [x] `cargo clippy -p lance --tests --benches -- -D warnings`