### PR TITLE
perf(rowids): reuse cursors across sequential batches

### DIFF
--- a/rust/lance-table/Cargo.toml
+++ b/rust/lance-table/Cargo.toml
@@ -75,5 +75,9 @@ harness = false
 name = "manifest_intern"
 harness = false
 
+[[bench]]
+name = "system_columns"
+harness = false
+
 [lints]
 workspace = true

--- a/rust/lance-table/benches/system_columns.rs
+++ b/rust/lance-table/benches/system_columns.rs
@@ -1,0 +1,123 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+use std::{hint::black_box, sync::Arc, time::Duration};
+
+use arrow_array::{RecordBatch, RecordBatchOptions, UInt64Array};
+use arrow_schema::{DataType, Field, Schema};
+use criterion::{BatchSize, BenchmarkId, Criterion, criterion_group, criterion_main};
+use futures::{FutureExt, StreamExt, TryStreamExt, future, stream};
+use lance_io::ReadBatchParams;
+use lance_table::{
+    rowids::RowIdSequence,
+    utils::stream::{
+        ReadBatchTask, ReadBatchTaskStream, RowIdAndDeletesConfig, wrap_with_row_id_and_delete,
+    },
+};
+
+fn make_batch(batch_size: usize, has_payload: bool) -> RecordBatch {
+    if has_payload {
+        RecordBatch::try_new(
+            Arc::new(Schema::new(vec![Field::new(
+                "value",
+                DataType::UInt64,
+                false,
+            )])),
+            vec![Arc::new(UInt64Array::from(vec![0; batch_size]))],
+        )
+        .unwrap()
+    } else {
+        RecordBatch::try_new_with_options(
+            Arc::new(Schema::empty()),
+            Vec::new(),
+            &RecordBatchOptions::new().with_row_count(Some(batch_size)),
+        )
+        .unwrap()
+    }
+}
+
+fn make_tasks(batch: RecordBatch, total_rows: usize, batch_size: usize) -> ReadBatchTaskStream {
+    let tasks = (0..total_rows).step_by(batch_size).map(move |offset| {
+        let num_rows = batch_size.min(total_rows - offset);
+        let batch = if num_rows == batch.num_rows() {
+            batch.clone()
+        } else {
+            batch.slice(0, num_rows)
+        };
+        ReadBatchTask {
+            task: future::ready(Ok(batch)).boxed(),
+            num_rows: num_rows as u32,
+        }
+    });
+    stream::iter(tasks).boxed()
+}
+
+fn make_config(total_rows: usize, sequence: Arc<RowIdSequence>) -> RowIdAndDeletesConfig {
+    RowIdAndDeletesConfig {
+        params: ReadBatchParams::RangeFull,
+        with_row_id: true,
+        with_row_addr: false,
+        with_row_last_updated_at_version: false,
+        with_row_created_at_version: false,
+        deletion_vector: None,
+        row_id_sequence: Some(sequence),
+        last_updated_at_sequence: None,
+        created_at_sequence: None,
+        make_deletions_null: false,
+        total_num_rows: total_rows as u32,
+    }
+}
+
+fn bench_stream_row_ids(c: &mut Criterion) {
+    let total_rows = std::env::var("BENCH_SYSTEM_ROWS")
+        .map(|value| value.parse().unwrap())
+        .unwrap_or(100_000_usize);
+    let batch_size = std::env::var("BENCH_SYSTEM_BATCH_SIZE")
+        .map(|value| value.parse().unwrap())
+        .unwrap_or(1_024_usize)
+        .min(total_rows);
+    let sequence = Arc::new(
+        RowIdSequence::try_from_iter((0_u64..).filter(|value| value % 17 != 0).take(total_rows))
+            .unwrap(),
+    );
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .build()
+        .unwrap();
+
+    let mut group = c.benchmark_group("stream_row_ids");
+    group.sample_size(10);
+    group.warm_up_time(Duration::from_secs(1));
+    group.measurement_time(Duration::from_secs(3));
+    for has_payload in [false, true] {
+        let batch = make_batch(batch_size, has_payload);
+        group.bench_with_input(
+            BenchmarkId::new("payload", has_payload),
+            &has_payload,
+            |b, _| {
+                b.iter_batched(
+                    || {
+                        (
+                            make_tasks(batch.clone(), total_rows, batch_size),
+                            make_config(total_rows, sequence.clone()),
+                        )
+                    },
+                    |(tasks, config)| {
+                        let batches = runtime
+                            .block_on(
+                                wrap_with_row_id_and_delete(tasks, 0, config)
+                                    .buffered(8)
+                                    .try_collect::<Vec<_>>(),
+                            )
+                            .unwrap();
+                        black_box(batches);
+                    },
+                    BatchSize::SmallInput,
+                );
+            },
+        );
+    }
+    group.finish();
+}
+
+criterion_group!(benches, bench_stream_row_ids);
+criterion_main!(benches);

--- a/rust/lance-table/src/rowids.rs
+++ b/rust/lance-table/src/rowids.rs
@@ -72,7 +72,7 @@ impl RowIdSequenceCursor {
     }
 
     fn get(&mut self, sequence: &RowIdSequence, index: usize) -> Option<u64> {
-        if self.last_index.is_some_and(|last| index < last) {
+        if index < self.rows_passed || self.last_index.is_some_and(|last| index < last) {
             *self = Self::default();
         }
         self.last_index = Some(index);

--- a/rust/lance-table/src/rowids.rs
+++ b/rust/lance-table/src/rowids.rs
@@ -32,7 +32,7 @@ use lance_select::{RowAddrMask, RowAddrTreeMap, RowSetOps};
 pub use serde::{read_row_ids, write_row_ids};
 
 use crate::utils::LanceIteratorExtension;
-use segment::U64Segment;
+use segment::{SegmentCursorState, U64Segment};
 use tracing::instrument;
 
 /// A sequence of row ids.
@@ -49,6 +49,84 @@ use tracing::instrument;
 /// We can make optimizations that assume uniqueness.
 #[derive(Debug, Clone, DeepSizeOf, PartialEq, Eq, Default)]
 pub struct RowIdSequence(Vec<U64Segment>);
+
+/// Stateful reader for selections that usually advance through a sequence.
+///
+/// Streaming readers reuse this cursor across record batches. If a later
+/// selection moves backwards then the cursor rewinds before continuing.
+#[derive(Debug, Default)]
+pub(crate) struct RowIdSequenceCursor {
+    segment_idx: usize,
+    rows_passed: usize,
+    segment_len: Option<usize>,
+    segment_cursor: SegmentCursorState,
+    last_index: Option<usize>,
+}
+
+impl RowIdSequenceCursor {
+    fn advance_segment(&mut self) {
+        self.rows_passed += self.segment_len.unwrap_or_default();
+        self.segment_idx += 1;
+        self.segment_len = None;
+        self.segment_cursor = SegmentCursorState::default();
+    }
+
+    fn get(&mut self, sequence: &RowIdSequence, index: usize) -> Option<u64> {
+        if self.last_index.is_some_and(|last| index < last) {
+            *self = Self::default();
+        }
+        self.last_index = Some(index);
+
+        loop {
+            let segment = sequence.0.get(self.segment_idx)?;
+            let segment_len = *self.segment_len.get_or_insert_with(|| segment.len());
+            let local_index = index - self.rows_passed;
+            if local_index < segment_len {
+                return self.segment_cursor.get(segment, local_index);
+            }
+            self.advance_segment();
+        }
+    }
+
+    fn extend_range(
+        &mut self,
+        sequence: &RowIdSequence,
+        selection: Range<usize>,
+        row_ids: &mut Vec<u64>,
+    ) {
+        if selection.is_empty() {
+            return;
+        }
+        if selection.start < self.rows_passed
+            || self.last_index.is_some_and(|last| selection.start < last)
+        {
+            *self = Self::default();
+        }
+        self.last_index = Some(selection.end - 1);
+
+        let mut index = selection.start;
+        while index < selection.end {
+            let Some(segment) = sequence.0.get(self.segment_idx) else {
+                break;
+            };
+            let segment_len = *self.segment_len.get_or_insert_with(|| segment.len());
+            let local_start = index - self.rows_passed;
+            if local_start >= segment_len {
+                self.advance_segment();
+                continue;
+            }
+
+            let count = (selection.end - index).min(segment_len - local_start);
+            let local_end = local_start + count;
+            self.segment_cursor
+                .extend_range(segment, local_start..local_end, row_ids);
+            index += count;
+            if local_end == segment_len {
+                self.advance_segment();
+            }
+        }
+    }
+}
 
 impl std::fmt::Display for RowIdSequence {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -385,35 +463,43 @@ impl RowIdSequence {
         &'a self,
         selection: impl Iterator<Item = usize> + 'a,
     ) -> impl Iterator<Item = u64> + 'a {
-        let mut seg_iter = self.0.iter();
-        let mut cur_seg = seg_iter.next();
-        let mut rows_passed = 0;
-        let mut cur_seg_len = cur_seg.map(|seg| seg.len()).unwrap_or(0);
-        let mut cursor = cur_seg.map(|seg| seg.cursor());
-        let mut last_index = 0;
+        let mut cursor = RowIdSequenceCursor::default();
+        let mut last_index = None;
         selection.filter_map(move |index| {
-            if index < last_index {
+            if last_index.is_some_and(|last| index < last) {
                 panic!("Selection is not sorted");
             }
-            last_index = index;
-
-            cur_seg?;
-
-            while (index - rows_passed) >= cur_seg_len {
-                rows_passed += cur_seg_len;
-                cur_seg = seg_iter.next();
-                cur_seg_len = cur_seg?.len();
-                cursor = cur_seg.map(|seg| seg.cursor());
-            }
-
-            let value = cursor.as_mut().unwrap().get(index - rows_passed);
-            debug_assert!(
-                value.is_some(),
-                "segment reported {cur_seg_len} rows but has no value at {}",
-                index - rows_passed
-            );
-            value
+            last_index = Some(index);
+            cursor.get(self, index)
         })
+    }
+
+    pub(crate) fn cursor(&self) -> RowIdSequenceCursor {
+        RowIdSequenceCursor::default()
+    }
+
+    /// Get a contiguous range of row ids while preserving scan state from a
+    /// previous call.
+    pub(crate) fn select_range_with_cursor(
+        &self,
+        cursor: &mut RowIdSequenceCursor,
+        selection: Range<usize>,
+    ) -> Vec<u64> {
+        let mut row_ids = Vec::with_capacity(selection.len());
+        cursor.extend_range(self, selection, &mut row_ids);
+        row_ids
+    }
+
+    /// Get row ids while preserving scan state from a previous call.
+    ///
+    /// Decreasing offsets are supported by rewinding the cursor. This matters
+    /// for take requests, whose indices are not required to be sorted.
+    pub(crate) fn select_with_cursor<'a>(
+        &'a self,
+        cursor: &'a mut RowIdSequenceCursor,
+        selection: impl Iterator<Item = usize> + 'a,
+    ) -> impl Iterator<Item = u64> + 'a {
+        selection.filter_map(move |index| cursor.get(self, index))
     }
 
     /// Given a mask of row ids, calculate the offset ranges of the row ids that are present
@@ -1237,11 +1323,49 @@ mod test {
     fn test_selection() {
         let sequence = RowIdSequence(vec![
             U64Segment::Range(0..5),
-            U64Segment::Range(10..15),
-            U64Segment::Range(20..25),
+            U64Segment::RangeWithHoles {
+                range: 10..16,
+                holes: vec![12].into(),
+            },
+            U64Segment::RangeWithBitmap {
+                range: 20..28,
+                bitmap: [true, false, true, true, false, true, false, true]
+                    .as_slice()
+                    .into(),
+            },
+            U64Segment::SortedArray(vec![40, 42, 45].into()),
+            U64Segment::Array(vec![60, 50, 70].into()),
         ]);
+        let live = sequence.iter().collect::<Vec<_>>();
         let selection = sequence.select(vec![2, 4, 13, 14, 57].into_iter());
-        assert_eq!(selection.collect::<Vec<_>>(), vec![2, 4, 23, 24]);
+        assert_eq!(
+            selection.collect::<Vec<_>>(),
+            vec![live[2], live[4], live[13], live[14]]
+        );
+
+        for chunk_size in [1, 3, 7, 16] {
+            let mut cursor = sequence.cursor();
+            let mut chunked = Vec::new();
+            for start in (0..live.len()).step_by(chunk_size) {
+                let end = (start + chunk_size).min(live.len());
+                chunked.extend(sequence.select_range_with_cursor(&mut cursor, start..end));
+            }
+            assert_eq!(chunked, live);
+        }
+
+        let mut cursor = sequence.cursor();
+        assert_eq!(
+            sequence.select_range_with_cursor(&mut cursor, 6..19),
+            live[6..19]
+        );
+        assert_eq!(
+            sequence.select_range_with_cursor(&mut cursor, 1..8),
+            live[1..8]
+        );
+        assert_eq!(
+            sequence.select_range_with_cursor(&mut cursor, live.len() - 2..live.len() + 5),
+            live[live.len() - 2..]
+        );
     }
 
     #[test]
@@ -1268,6 +1392,17 @@ mod test {
         let got = sequence.select(picks.iter().copied()).collect::<Vec<_>>();
         let want: Vec<u64> = picks.iter().filter_map(|&i| live.get(i).copied()).collect();
         assert_eq!(got, want);
+
+        let mut cursor = sequence.cursor();
+        let mut chunked = Vec::new();
+        for range in [0..7, 7..30, 30..live.len()] {
+            chunked.extend(sequence.select_range_with_cursor(&mut cursor, range));
+        }
+        assert_eq!(chunked, live);
+        assert_eq!(
+            sequence.select_range_with_cursor(&mut cursor, 2..6),
+            live[2..6]
+        );
     }
 
     #[test]
@@ -1301,6 +1436,25 @@ mod test {
         let got = sequence.select(picks.iter().copied()).collect::<Vec<_>>();
         let want: Vec<u64> = picks.iter().filter_map(|&i| live.get(i).copied()).collect();
         assert_eq!(got, want);
+
+        let tail_start = live.len() - 100_000;
+        let mut cursor = sequence.cursor();
+        assert_eq!(
+            sequence.select_range_with_cursor(&mut cursor, tail_start..live.len()),
+            live[tail_start..]
+        );
+
+        for chunk_size in [1, 7, 8, 9, 1_024, 4_097] {
+            let mut cursor = sequence.cursor();
+            let mut chunked = Vec::with_capacity(live.len() - tail_start);
+            let mut start = tail_start;
+            while start < live.len() {
+                let end = (start + chunk_size).min(live.len());
+                chunked.extend(sequence.select_range_with_cursor(&mut cursor, start..end));
+                start = end;
+            }
+            assert_eq!(chunked, live[tail_start..]);
+        }
     }
 
     #[test]

--- a/rust/lance-table/src/rowids/segment.rs
+++ b/rust/lance-table/src/rowids/segment.rs
@@ -385,8 +385,7 @@ impl U64Segment {
     pub fn cursor(&self) -> SegmentCursor<'_> {
         SegmentCursor {
             segment: self,
-            byte_idx: 0,
-            ones_before: 0,
+            state: SegmentCursorState::default(),
         }
     }
 
@@ -650,6 +649,11 @@ impl U64Segment {
 /// Segment reader that keeps its scan position across calls.
 pub struct SegmentCursor<'a> {
     segment: &'a U64Segment,
+    state: SegmentCursorState,
+}
+
+#[derive(Debug, Default)]
+pub(crate) struct SegmentCursorState {
     /// Byte the next select1 scan resumes at.
     byte_idx: usize,
     /// Set bits in `bitmap.data[..byte_idx]`.
@@ -659,8 +663,74 @@ pub struct SegmentCursor<'a> {
 impl SegmentCursor<'_> {
     /// The value at index `i`. A decreasing index rewinds the scan.
     pub fn get(&mut self, i: usize) -> Option<u64> {
-        let U64Segment::RangeWithBitmap { range, bitmap } = self.segment else {
-            return self.segment.get(i);
+        self.state.get(self.segment, i)
+    }
+}
+
+impl SegmentCursorState {
+    /// Append a contiguous range of values while preserving the bitmap scan
+    /// position for the next call.
+    pub(crate) fn extend_range(
+        &mut self,
+        segment: &U64Segment,
+        selection: Range<usize>,
+        values: &mut Vec<u64>,
+    ) {
+        let U64Segment::RangeWithBitmap { range, bitmap } = segment else {
+            match segment {
+                U64Segment::Range(range) => {
+                    let segment_len = (range.end - range.start) as usize;
+                    let end = selection.end.min(segment_len);
+                    if selection.start < end {
+                        values.extend(
+                            (range.start + selection.start as u64)..(range.start + end as u64),
+                        );
+                    }
+                }
+                _ => values.extend(selection.filter_map(|index| segment.get(index))),
+            }
+            return;
+        };
+
+        if selection.start < self.ones_before {
+            self.byte_idx = 0;
+            self.ones_before = 0;
+        }
+        while let Some(&byte) = bitmap.data.get(self.byte_idx) {
+            let ones = byte.count_ones() as usize;
+            let ones_after_byte = self.ones_before + ones;
+            if selection.start >= ones_after_byte {
+                self.ones_before = ones_after_byte;
+                self.byte_idx += 1;
+                continue;
+            }
+
+            let mut remaining_bits = byte;
+            let mut rank = self.ones_before;
+            while remaining_bits != 0 {
+                if rank >= selection.end {
+                    return;
+                }
+                let bit = remaining_bits.trailing_zeros() as usize;
+                if rank >= selection.start {
+                    values.push(range.start + (self.byte_idx * 8 + bit) as u64);
+                }
+                remaining_bits &= remaining_bits - 1;
+                rank += 1;
+            }
+
+            self.ones_before = ones_after_byte;
+            self.byte_idx += 1;
+            if self.ones_before >= selection.end {
+                return;
+            }
+        }
+    }
+
+    /// The value at index `i`. A decreasing index rewinds the scan.
+    pub(crate) fn get(&mut self, segment: &U64Segment, i: usize) -> Option<u64> {
+        let U64Segment::RangeWithBitmap { range, bitmap } = segment else {
+            return segment.get(i);
         };
         if i < self.ones_before {
             self.byte_idx = 0;

--- a/rust/lance-table/src/utils/stream.rs
+++ b/rust/lance-table/src/utils/stream.rs
@@ -547,7 +547,16 @@ pub fn wrap_with_row_id_and_delete(
                                 .collect::<Vec<_>>(),
                         ),
                     };
-                    Arc::new(values)
+                    if values.len() != num_rows as usize {
+                        return Err(Error::corrupt_file_named(
+                            "row ID metadata",
+                            format!(
+                                "decoded row IDs at selected offset {this_offset} contain {} rows, but the current batch requires {num_rows} rows",
+                                values.len()
+                            ),
+                        ));
+                    }
+                    Ok(Arc::new(values))
                 })
             });
             batch_task
@@ -558,7 +567,7 @@ pub fn wrap_with_row_id_and_delete(
                         this_offset,
                         fragment_id,
                         config.as_ref(),
-                        row_ids,
+                        row_ids.transpose()?,
                     )
                 })
                 .boxed()
@@ -796,6 +805,40 @@ mod tests {
             .copied()
             .collect::<Vec<_>>();
         assert_eq!(actual, vec![4, 4, 10]);
+    }
+
+    #[tokio::test]
+    async fn test_truncated_stable_row_ids_returns_error() {
+        let task = ReadBatchTask {
+            num_rows: 10,
+            task: std::future::ready(Ok(
+                arrow_array::record_batch!(("x", Int32, vec![0; 10])).unwrap()
+            ))
+            .boxed(),
+        };
+        let config = RowIdAndDeletesConfig {
+            params: ReadBatchParams::RangeFull,
+            with_row_id: true,
+            with_row_addr: false,
+            with_row_last_updated_at_version: false,
+            with_row_created_at_version: false,
+            deletion_vector: None,
+            row_id_sequence: Some(Arc::new(RowIdSequence::try_from_iter(0_u64..5).unwrap())),
+            last_updated_at_sequence: None,
+            created_at_sequence: None,
+            make_deletions_null: false,
+            total_num_rows: 10,
+        };
+
+        let error = super::wrap_with_row_id_and_delete(stream::iter([task]).boxed(), 0, config)
+            .buffered(1)
+            .try_collect::<Vec<_>>()
+            .await
+            .unwrap_err();
+        assert!(matches!(error, lance_core::Error::CorruptFile { .. }));
+        assert!(error.to_string().contains(
+            "decoded row IDs at selected offset 0 contain 5 rows, but the current batch requires 10 rows"
+        ));
     }
 
     #[tokio::test]

--- a/rust/lance-table/src/utils/stream.rs
+++ b/rust/lance-table/src/utils/stream.rs
@@ -345,12 +345,22 @@ impl RowIdAndDeletesConfig {
     }
 }
 
-#[instrument(level = "debug", skip_all)]
 pub fn apply_row_id_and_deletes(
     batch: RecordBatch,
     batch_offset: u32,
     fragment_id: u32,
     config: &RowIdAndDeletesConfig,
+) -> Result<RecordBatch> {
+    apply_row_id_and_deletes_with_row_ids(batch, batch_offset, fragment_id, config, None)
+}
+
+#[instrument(name = "apply_row_id_and_deletes", level = "debug", skip_all)]
+fn apply_row_id_and_deletes_with_row_ids(
+    batch: RecordBatch,
+    batch_offset: u32,
+    fragment_id: u32,
+    config: &RowIdAndDeletesConfig,
+    precomputed_row_ids: Option<Arc<UInt64Array>>,
 ) -> Result<RecordBatch> {
     let mut deletion_vector = config.deletion_vector.as_ref();
     // Convert Some(NoDeletions) into None to simplify logic below
@@ -391,7 +401,10 @@ pub fn apply_row_id_and_deletes(
 
     let row_ids = if config.with_row_id {
         let _rowids = tracing::span!(tracing::Level::DEBUG, "fetch_row_ids").entered();
-        if let Some(row_id_sequence) = &config.row_id_sequence {
+        if let Some(row_ids) = precomputed_row_ids {
+            debug_assert_eq!(row_ids.len(), num_rows as usize);
+            Some(row_ids)
+        } else if let Some(row_id_sequence) = &config.row_id_sequence {
             let selection = config
                 .params
                 .slice(batch_offset as usize, num_rows as usize)
@@ -494,6 +507,11 @@ pub fn wrap_with_row_id_and_delete(
     config: RowIdAndDeletesConfig,
 ) -> ReadBatchFutStream {
     let config = Arc::new(config);
+    let mut row_id_cursor = config
+        .row_id_sequence
+        .as_ref()
+        .filter(|_| config.with_row_id)
+        .map(|sequence| sequence.cursor());
     let mut offset = 0;
     stream
         .map(move |batch_task| {
@@ -501,10 +519,47 @@ pub fn wrap_with_row_id_and_delete(
             let this_offset = offset;
             let num_rows = batch_task.num_rows;
             offset += num_rows;
+            // Materialize row ids while polling the ordered task stream. Batch
+            // futures may complete concurrently, so doing this inside the
+            // future would require locking the shared cursor or would reorder
+            // its accesses.
+            let row_ids = config.row_id_sequence.as_ref().and_then(|sequence| {
+                row_id_cursor.as_mut().map(|cursor| {
+                    let selection = config
+                        .params
+                        .slice(this_offset as usize, num_rows as usize)
+                        .unwrap()
+                        .to_ranges()
+                        .unwrap();
+                    let values = match selection.as_slice() {
+                        [range] => UInt64Array::from(sequence.select_range_with_cursor(
+                            cursor,
+                            range.start as usize..range.end as usize,
+                        )),
+                        _ => UInt64Array::from(
+                            sequence
+                                .select_with_cursor(
+                                    cursor,
+                                    selection
+                                        .iter()
+                                        .flat_map(|range| range.start as usize..range.end as usize),
+                                )
+                                .collect::<Vec<_>>(),
+                        ),
+                    };
+                    Arc::new(values)
+                })
+            });
             batch_task
                 .task
                 .map(move |batch| {
-                    apply_row_id_and_deletes(batch?, this_offset, fragment_id, config.as_ref())
+                    apply_row_id_and_deletes_with_row_ids(
+                        batch?,
+                        this_offset,
+                        fragment_id,
+                        config.as_ref(),
+                        row_ids,
+                    )
                 })
                 .boxed()
         })
@@ -530,7 +585,7 @@ mod tests {
     use lance_io::{ReadBatchParams, stream::arrow_stream_to_lance_stream};
     use roaring::RoaringBitmap;
 
-    use crate::utils::stream::ReadBatchTask;
+    use crate::{rowids::RowIdSequence, utils::stream::ReadBatchTask};
 
     use super::RowIdAndDeletesConfig;
 
@@ -574,6 +629,133 @@ mod tests {
             .collect::<Result<Vec<_>, ArrowError>>()
             .unwrap();
         assert_eq!(merged, expected);
+    }
+
+    #[tokio::test]
+    async fn test_stable_row_ids_across_concurrent_batches_and_deletes() {
+        let expected = (10_000..120_000)
+            .filter(|row_id| row_id % 13 != 0)
+            .collect::<Vec<u64>>();
+        let row_id_sequence = Arc::new(RowIdSequence::try_from_iter(expected.clone()).unwrap());
+        let deletion_offsets = (0..expected.len() as u32).step_by(997).collect::<Vec<_>>();
+        let deletion_vector = Some(Arc::new(DeletionVector::Bitmap(
+            deletion_offsets.iter().copied().collect(),
+        )));
+
+        let batches = expected
+            .chunks(257)
+            .map(|chunk| arrow_array::record_batch!(("x", Int32, vec![0; chunk.len()])).unwrap())
+            .map(Ok)
+            .collect::<Vec<std::result::Result<RecordBatch, ArrowError>>>();
+        let data = batch_task_stream(stream::iter(batches).boxed());
+        let config = RowIdAndDeletesConfig {
+            params: ReadBatchParams::RangeFull,
+            with_row_id: true,
+            with_row_addr: true,
+            with_row_last_updated_at_version: false,
+            with_row_created_at_version: false,
+            deletion_vector,
+            row_id_sequence: Some(row_id_sequence),
+            last_updated_at_sequence: None,
+            created_at_sequence: None,
+            make_deletions_null: false,
+            total_num_rows: expected.len() as u32,
+        };
+
+        let batches = super::wrap_with_row_id_and_delete(data, 7, config)
+            .buffered(8)
+            .try_collect::<Vec<_>>()
+            .await
+            .unwrap();
+        let actual_row_ids = batches
+            .iter()
+            .flat_map(|batch| batch[ROW_ID].as_primitive::<UInt64Type>().values())
+            .copied()
+            .collect::<Vec<_>>();
+        let actual_row_addrs = batches
+            .iter()
+            .flat_map(|batch| {
+                batch[lance_core::ROW_ADDR]
+                    .as_primitive::<UInt64Type>()
+                    .values()
+            })
+            .copied()
+            .collect::<Vec<_>>();
+        let expected_survivors = expected
+            .iter()
+            .enumerate()
+            .filter(|(offset, _)| deletion_offsets.binary_search(&(*offset as u32)).is_err())
+            .map(|(offset, row_id)| {
+                (
+                    *row_id,
+                    u64::from(RowAddress::new_from_parts(7, offset as u32)),
+                )
+            })
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            actual_row_ids,
+            expected_survivors
+                .iter()
+                .map(|(row_id, _)| *row_id)
+                .collect::<Vec<_>>()
+        );
+        assert_eq!(
+            actual_row_addrs,
+            expected_survivors
+                .iter()
+                .map(|(_, row_addr)| *row_addr)
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_stable_row_ids_with_unsorted_indices() {
+        let expected = (100..140)
+            .filter(|row_id| row_id % 3 != 0)
+            .collect::<Vec<u64>>();
+        let indices = UInt32Array::from(vec![8, 2, 9, 1, 6]);
+        let batches = [2, 2, 1].into_iter().map(|num_rows| ReadBatchTask {
+            num_rows,
+            task: std::future::ready(Ok(arrow_array::record_batch!((
+                "x",
+                Int32,
+                vec![0; num_rows as usize]
+            ))
+            .unwrap()))
+            .boxed(),
+        });
+        let config = RowIdAndDeletesConfig {
+            params: ReadBatchParams::Indices(indices.clone()),
+            with_row_id: true,
+            with_row_addr: false,
+            with_row_last_updated_at_version: false,
+            with_row_created_at_version: false,
+            deletion_vector: None,
+            row_id_sequence: Some(Arc::new(
+                RowIdSequence::try_from_iter(expected.clone()).unwrap(),
+            )),
+            last_updated_at_sequence: None,
+            created_at_sequence: None,
+            make_deletions_null: false,
+            total_num_rows: expected.len() as u32,
+        };
+
+        let actual = super::wrap_with_row_id_and_delete(stream::iter(batches).boxed(), 7, config)
+            .buffered(3)
+            .try_collect::<Vec<_>>()
+            .await
+            .unwrap()
+            .iter()
+            .flat_map(|batch| batch[ROW_ID].as_primitive::<UInt64Type>().values())
+            .copied()
+            .collect::<Vec<_>>();
+        let expected = indices
+            .values()
+            .iter()
+            .map(|index| expected[*index as usize])
+            .collect::<Vec<_>>();
+        assert_eq!(actual, expected);
     }
 
     #[tokio::test]

--- a/rust/lance-table/src/utils/stream.rs
+++ b/rust/lance-table/src/utils/stream.rs
@@ -759,6 +759,46 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_repeated_row_id_after_bulk_segment_boundary() {
+        let mut row_ids = RowIdSequence::from(0..5);
+        row_ids.extend(RowIdSequence::from(10..20));
+        let batches = [1_u32, 2].into_iter().map(|num_rows| ReadBatchTask {
+            num_rows,
+            task: std::future::ready(Ok(arrow_array::record_batch!((
+                "x",
+                Int32,
+                vec![0; num_rows as usize]
+            ))
+            .unwrap()))
+            .boxed(),
+        });
+        let config = RowIdAndDeletesConfig {
+            params: ReadBatchParams::Indices(UInt32Array::from(vec![4, 4, 5])),
+            with_row_id: true,
+            with_row_addr: false,
+            with_row_last_updated_at_version: false,
+            with_row_created_at_version: false,
+            deletion_vector: None,
+            row_id_sequence: Some(Arc::new(row_ids)),
+            last_updated_at_sequence: None,
+            created_at_sequence: None,
+            make_deletions_null: false,
+            total_num_rows: 15,
+        };
+
+        let actual = super::wrap_with_row_id_and_delete(stream::iter(batches).boxed(), 0, config)
+            .buffered(1)
+            .try_collect::<Vec<_>>()
+            .await
+            .unwrap()
+            .iter()
+            .flat_map(|batch| batch[ROW_ID].as_primitive::<UInt64Type>().values())
+            .copied()
+            .collect::<Vec<_>>();
+        assert_eq!(actual, vec![4, 4, 10]);
+    }
+
+    #[tokio::test]
     async fn test_zip_with_different_batch_boundaries() {
         let left_batch =
             arrow_array::record_batch!(("x", Int32, (0..10).collect::<Vec<_>>())).unwrap();


### PR DESCRIPTION
## Summary

Reuse a stable row-ID cursor across ordered record-batch tasks and bulk-decode range-backed segments.

Stable row IDs represented as `RangeWithBitmap` / `RangeWithHoles` previously rebuilt selection state for every batch. Sequential scans therefore rescanned an ever-growing prefix, approaching quadratic work as batch count increased.

This change:

- persists `RowIdSequenceCursor` across ordered tasks and caches segment lengths;
- adds an exact-capacity contiguous-range path;
- adds `SegmentCursorState::extend_range` for bulk expansion of range and bitmap segments;
- preserves the direct/random selection fallback and rejects unsorted indices explicitly;
- reports truncated stable row-ID metadata as `CorruptFile` instead of panicking or returning a short batch.

## Performance

100K-row synthetic sequential scan, identical Criterion harness:

| Batch size | `main` | This PR | Speedup |
|---:|---:|---:|---:|
| 64 | 17.177 ms | 1.174 ms | 14.6x |
| 1024 | 1.868 ms | 236.16 us | 7.9x |

CPU profiling on `main` attributed 51.73% to `RowIdSequence::select` and 33.45% to `U64Segment::len`, matching repeated prefix traversal. After this change those hotspots are replaced by `SegmentCursorState::extend_range`; remaining time is fixed allocation/schema work.

## Validation

- `cargo test -p lance-table --lib` (336 passed)
- `cargo check -p lance-table --tests --benches`
- `cargo clippy -p lance-table --all-targets --no-deps -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`

This is the root of the row-ID optimization stack and has no dependency on the bitmap or version-cursor follow-ups.

Follow-up PRs:

- #8715: dense / near-dense bitmap decode paths
- #8716: dataset-version RLE cursor
- #8747: system-column scan pipeline fixed-cost reduction
