### PR TITLE
perf(rowids): accelerate dense bitmap decoding

### DIFF
--- a/rust/lance-table/benches/system_columns.rs
+++ b/rust/lance-table/benches/system_columns.rs
@@ -76,10 +76,6 @@ fn bench_stream_row_ids(c: &mut Criterion) {
         .map(|value| value.parse().unwrap())
         .unwrap_or(1_024_usize)
         .min(total_rows);
-    let sequence = Arc::new(
-        RowIdSequence::try_from_iter((0_u64..).filter(|value| value % 17 != 0).take(total_rows))
-            .unwrap(),
-    );
     let runtime = tokio::runtime::Builder::new_current_thread()
         .build()
         .unwrap();
@@ -88,33 +84,44 @@ fn bench_stream_row_ids(c: &mut Criterion) {
     group.sample_size(10);
     group.warm_up_time(Duration::from_secs(1));
     group.measurement_time(Duration::from_secs(3));
-    for has_payload in [false, true] {
-        let batch = make_batch(batch_size, has_payload);
-        group.bench_with_input(
-            BenchmarkId::new("payload", has_payload),
-            &has_payload,
-            |b, _| {
-                b.iter_batched(
-                    || {
-                        (
-                            make_tasks(batch.clone(), total_rows, batch_size),
-                            make_config(total_rows, sequence.clone()),
-                        )
-                    },
-                    |(tasks, config)| {
-                        let batches = runtime
-                            .block_on(
-                                wrap_with_row_id_and_delete(tasks, 0, config)
-                                    .buffered(8)
-                                    .try_collect::<Vec<_>>(),
-                            )
-                            .unwrap();
-                        black_box(batches);
-                    },
-                    BatchSize::SmallInput,
-                );
-            },
+    for hole_stride in [2_u64, 17] {
+        let sequence = Arc::new(
+            RowIdSequence::try_from_iter(
+                (0_u64..)
+                    .filter(|value| value % hole_stride != 0)
+                    .take(total_rows),
+            )
+            .unwrap(),
         );
+        for has_payload in [false, true] {
+            let batch = make_batch(batch_size, has_payload);
+            let parameter = format!("holes_{hole_stride}/payload_{has_payload}");
+            group.bench_with_input(
+                BenchmarkId::new("shape", parameter),
+                &has_payload,
+                |b, _| {
+                    b.iter_batched(
+                        || {
+                            (
+                                make_tasks(batch.clone(), total_rows, batch_size),
+                                make_config(total_rows, sequence.clone()),
+                            )
+                        },
+                        |(tasks, config)| {
+                            let batches = runtime
+                                .block_on(
+                                    wrap_with_row_id_and_delete(tasks, 0, config)
+                                        .buffered(8)
+                                        .try_collect::<Vec<_>>(),
+                                )
+                                .unwrap();
+                            black_box(batches);
+                        },
+                        BatchSize::SmallInput,
+                    );
+                },
+            );
+        }
     }
     group.finish();
 }

--- a/rust/lance-table/src/rowids.rs
+++ b/rust/lance-table/src/rowids.rs
@@ -59,6 +59,7 @@ pub(crate) struct RowIdSequenceCursor {
     segment_idx: usize,
     rows_passed: usize,
     segment_len: Option<usize>,
+    use_dense_range_expansion: Option<bool>,
     segment_cursor: SegmentCursorState,
     last_index: Option<usize>,
 }
@@ -68,6 +69,7 @@ impl RowIdSequenceCursor {
         self.rows_passed += self.segment_len.unwrap_or_default();
         self.segment_idx += 1;
         self.segment_len = None;
+        self.use_dense_range_expansion = None;
         self.segment_cursor = SegmentCursorState::default();
     }
 
@@ -118,8 +120,16 @@ impl RowIdSequenceCursor {
 
             let count = (selection.end - index).min(segment_len - local_start);
             let local_end = local_start + count;
-            self.segment_cursor
-                .extend_range(segment, local_start..local_end, row_ids);
+            let use_dense_range_expansion = *self
+                .use_dense_range_expansion
+                .get_or_insert_with(|| segment.use_dense_range_expansion());
+            if use_dense_range_expansion {
+                self.segment_cursor
+                    .extend_dense_range(segment, local_start..local_end, row_ids);
+            } else {
+                self.segment_cursor
+                    .extend_range(segment, local_start..local_end, row_ids);
+            }
             index += count;
             if local_end == segment_len {
                 self.advance_segment();

--- a/rust/lance-table/src/rowids.rs
+++ b/rust/lance-table/src/rowids.rs
@@ -122,7 +122,7 @@ impl RowIdSequenceCursor {
             let local_end = local_start + count;
             let use_dense_range_expansion = *self
                 .use_dense_range_expansion
-                .get_or_insert_with(|| segment.use_dense_range_expansion());
+                .get_or_insert_with(|| segment.use_dense_range_expansion(segment_len));
             if use_dense_range_expansion {
                 self.segment_cursor
                     .extend_dense_range(segment, local_start..local_end, row_ids);

--- a/rust/lance-table/src/rowids.rs
+++ b/rust/lance-table/src/rowids.rs
@@ -59,7 +59,6 @@ pub(crate) struct RowIdSequenceCursor {
     segment_idx: usize,
     rows_passed: usize,
     segment_len: Option<usize>,
-    use_dense_range_expansion: Option<bool>,
     segment_cursor: SegmentCursorState,
     last_index: Option<usize>,
 }
@@ -69,7 +68,6 @@ impl RowIdSequenceCursor {
         self.rows_passed += self.segment_len.unwrap_or_default();
         self.segment_idx += 1;
         self.segment_len = None;
-        self.use_dense_range_expansion = None;
         self.segment_cursor = SegmentCursorState::default();
     }
 
@@ -120,16 +118,49 @@ impl RowIdSequenceCursor {
 
             let count = (selection.end - index).min(segment_len - local_start);
             let local_end = local_start + count;
-            let use_dense_range_expansion = *self
-                .use_dense_range_expansion
-                .get_or_insert_with(|| segment.use_dense_range_expansion(segment_len));
-            if use_dense_range_expansion {
-                self.segment_cursor
-                    .extend_dense_range(segment, local_start..local_end, row_ids);
-            } else {
-                self.segment_cursor
-                    .extend_range(segment, local_start..local_end, row_ids);
+            self.segment_cursor
+                .extend_range(segment, local_start..local_end, row_ids);
+            index += count;
+            if local_end == segment_len {
+                self.advance_segment();
             }
+        }
+    }
+
+    // Keep the sparse loop in `extend_range` unchanged. Sharing this loop with
+    // the dense decoder measurably slows sparse system-only scans.
+    fn extend_dense_range(
+        &mut self,
+        sequence: &RowIdSequence,
+        selection: Range<usize>,
+        row_ids: &mut Vec<u64>,
+    ) {
+        if selection.is_empty() {
+            return;
+        }
+        if selection.start < self.rows_passed
+            || self.last_index.is_some_and(|last| selection.start < last)
+        {
+            *self = Self::default();
+        }
+        self.last_index = Some(selection.end - 1);
+
+        let mut index = selection.start;
+        while index < selection.end {
+            let Some(segment) = sequence.0.get(self.segment_idx) else {
+                break;
+            };
+            let segment_len = *self.segment_len.get_or_insert_with(|| segment.len());
+            let local_start = index - self.rows_passed;
+            if local_start >= segment_len {
+                self.advance_segment();
+                continue;
+            }
+
+            let count = (selection.end - index).min(segment_len - local_start);
+            let local_end = local_start + count;
+            self.segment_cursor
+                .extend_dense_range(segment, local_start..local_end, row_ids);
             index += count;
             if local_end == segment_len {
                 self.advance_segment();
@@ -488,6 +519,23 @@ impl RowIdSequence {
         RowIdSequenceCursor::default()
     }
 
+    /// Choose the dense decoder once for a stream and reuse its cardinality.
+    ///
+    /// A stream uses one decoder for its lifetime, so multi-segment sequences
+    /// conservatively retain the sparse path. For a single bitmap segment, the
+    /// cardinality computed for the density decision seeds the cursor instead
+    /// of scanning the bitmap again on the first batch.
+    pub(crate) fn cursor_with_dense_range_expansion(&self) -> (RowIdSequenceCursor, bool) {
+        let mut cursor = self.cursor();
+        let [segment @ U64Segment::RangeWithBitmap { .. }] = self.0.as_slice() else {
+            return (cursor, false);
+        };
+        let segment_len = segment.len();
+        cursor.segment_len = Some(segment_len);
+        let use_dense_range_expansion = segment.use_dense_range_expansion(segment_len);
+        (cursor, use_dense_range_expansion)
+    }
+
     /// Get a contiguous range of row ids while preserving scan state from a
     /// previous call.
     pub(crate) fn select_range_with_cursor(
@@ -497,6 +545,17 @@ impl RowIdSequence {
     ) -> Vec<u64> {
         let mut row_ids = Vec::with_capacity(selection.len());
         cursor.extend_range(self, selection, &mut row_ids);
+        row_ids
+    }
+
+    /// Get a contiguous range from a sequence whose bitmap segments are dense.
+    pub(crate) fn select_dense_range_with_cursor(
+        &self,
+        cursor: &mut RowIdSequenceCursor,
+        selection: Range<usize>,
+    ) -> Vec<u64> {
+        let mut row_ids = Vec::with_capacity(selection.len());
+        cursor.extend_dense_range(self, selection, &mut row_ids);
         row_ids
     }
 
@@ -1413,6 +1472,51 @@ mod test {
             sequence.select_range_with_cursor(&mut cursor, 2..6),
             live[2..6]
         );
+    }
+
+    #[test]
+    fn test_dense_range_cursor_selection() {
+        let mut bitmap = Bitmap::new_full(40);
+        for hole in [3, 4, 17, 39] {
+            bitmap.clear(hole);
+        }
+        let sequence = RowIdSequence(vec![U64Segment::RangeWithBitmap {
+            range: 100..140,
+            bitmap,
+        }]);
+        let expected = sequence.iter().collect::<Vec<_>>();
+        let (mut cursor, use_dense_range_expansion) = sequence.cursor_with_dense_range_expansion();
+        assert!(use_dense_range_expansion);
+        assert_eq!(cursor.segment_len, Some(expected.len()));
+
+        let mut actual = Vec::new();
+        for selection in [0..7, 7..8, 8..31, 31..expected.len() + 5] {
+            actual.extend(sequence.select_dense_range_with_cursor(&mut cursor, selection));
+        }
+        assert_eq!(actual, expected);
+        assert_eq!(
+            sequence.select_dense_range_with_cursor(&mut cursor, 2..9),
+            expected[2..9]
+        );
+
+        let mut sparse_bitmap = Bitmap::new_empty(40);
+        for value in (0..40).step_by(2) {
+            sparse_bitmap.set(value);
+        }
+        let sparse = RowIdSequence(vec![U64Segment::RangeWithBitmap {
+            range: 0..40,
+            bitmap: sparse_bitmap,
+        }]);
+        let (sparse_cursor, use_dense_range_expansion) = sparse.cursor_with_dense_range_expansion();
+        assert!(!use_dense_range_expansion);
+        assert_eq!(sparse_cursor.segment_len, Some(20));
+
+        let mut multiple_segments = sequence.clone();
+        multiple_segments.extend(RowIdSequence::from(200..205));
+        let (multiple_cursor, use_dense_range_expansion) =
+            multiple_segments.cursor_with_dense_range_expansion();
+        assert!(!use_dense_range_expansion);
+        assert_eq!(multiple_cursor.segment_len, None);
     }
 
     #[test]

--- a/rust/lance-table/src/rowids/bitmap.rs
+++ b/rust/lance-table/src/rowids/bitmap.rs
@@ -1,12 +1,44 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright The Lance Authors
 
+use std::sync::OnceLock;
+
 use lance_core::deepsize::DeepSizeOf;
 
-#[derive(PartialEq, Eq, Clone, DeepSizeOf)]
 pub struct Bitmap {
-    pub data: Vec<u8>,
-    pub len: usize,
+    data: Vec<u8>,
+    len: usize,
+    count_ones: OnceLock<usize>,
+}
+
+impl Clone for Bitmap {
+    fn clone(&self) -> Self {
+        let count_ones = OnceLock::new();
+        if let Some(&count) = self.count_ones.get() {
+            count_ones
+                .set(count)
+                .expect("new count cache should be empty");
+        }
+        Self {
+            data: self.data.clone(),
+            len: self.len,
+            count_ones,
+        }
+    }
+}
+
+impl PartialEq for Bitmap {
+    fn eq(&self, other: &Self) -> bool {
+        self.data == other.data && self.len == other.len
+    }
+}
+
+impl Eq for Bitmap {}
+
+impl DeepSizeOf for Bitmap {
+    fn deep_size_of_children(&self, context: &mut lance_core::deepsize::Context) -> usize {
+        self.data.deep_size_of_children(context)
+    }
 }
 
 /// Set bits in `data`, counted a word at a time.
@@ -37,7 +69,7 @@ impl std::fmt::Debug for Bitmap {
 impl Bitmap {
     pub fn new_empty(len: usize) -> Self {
         let data = vec![0; len.div_ceil(8)];
-        Self { data, len }
+        Self::from_parts(data, len)
     }
 
     pub fn new_full(len: usize) -> Self {
@@ -52,15 +84,34 @@ impl Bitmap {
                 *last_byte &= !(1 << i);
             }
         }
-        Self { data, len }
+        Self::from_parts(data, len)
+    }
+
+    pub(crate) fn from_parts(data: Vec<u8>, len: usize) -> Self {
+        Self {
+            data,
+            len,
+            count_ones: OnceLock::new(),
+        }
+    }
+
+    #[inline]
+    pub(crate) fn bytes(&self) -> &[u8] {
+        &self.data
+    }
+
+    pub(crate) fn into_bytes(self) -> Vec<u8> {
+        self.data
     }
 
     pub fn set(&mut self, i: usize) {
         self.data[i / 8] |= 1 << (i % 8);
+        self.count_ones.take();
     }
 
     pub fn clear(&mut self, i: usize) {
         self.data[i / 8] &= !(1 << (i % 8));
+        self.count_ones.take();
     }
 
     pub fn get(&self, i: usize) -> bool {
@@ -80,7 +131,7 @@ impl Bitmap {
     }
 
     pub fn count_ones(&self) -> usize {
-        count_ones(&self.data)
+        *self.count_ones.get_or_init(|| count_ones(&self.data))
     }
 
     pub fn count_zeros(&self) -> usize {
@@ -212,6 +263,28 @@ mod tests {
             }
             assert_eq!(bitmap.count_ones(), len.div_ceil(3), "len {len}");
         }
+    }
+
+    #[test]
+    fn test_count_ones_cache_tracks_clone_and_mutation() {
+        let mut bitmap = Bitmap::new_empty(10_000);
+        bitmap.set(3);
+        bitmap.set(9_999);
+        assert_eq!(bitmap.count_ones(), 2);
+        assert_eq!(bitmap.count_ones.get(), Some(&2));
+
+        let clone = bitmap.clone();
+        assert_eq!(clone.count_ones.get(), Some(&2));
+        assert_eq!(clone.count_ones(), 2);
+
+        bitmap.set(8);
+        assert!(bitmap.count_ones.get().is_none());
+        assert_eq!(bitmap.count_ones(), 3);
+
+        bitmap.clear(3);
+        assert!(bitmap.count_ones.get().is_none());
+        assert_eq!(bitmap.count_ones(), 2);
+        assert_eq!(clone.count_ones(), 2);
     }
 
     #[test]

--- a/rust/lance-table/src/rowids/bitmap.rs
+++ b/rust/lance-table/src/rowids/bitmap.rs
@@ -1,44 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright The Lance Authors
 
-use std::sync::OnceLock;
-
 use lance_core::deepsize::DeepSizeOf;
 
+#[derive(PartialEq, Eq, Clone, DeepSizeOf)]
 pub struct Bitmap {
-    data: Vec<u8>,
-    len: usize,
-    count_ones: OnceLock<usize>,
-}
-
-impl Clone for Bitmap {
-    fn clone(&self) -> Self {
-        let count_ones = OnceLock::new();
-        if let Some(&count) = self.count_ones.get() {
-            count_ones
-                .set(count)
-                .expect("new count cache should be empty");
-        }
-        Self {
-            data: self.data.clone(),
-            len: self.len,
-            count_ones,
-        }
-    }
-}
-
-impl PartialEq for Bitmap {
-    fn eq(&self, other: &Self) -> bool {
-        self.data == other.data && self.len == other.len
-    }
-}
-
-impl Eq for Bitmap {}
-
-impl DeepSizeOf for Bitmap {
-    fn deep_size_of_children(&self, context: &mut lance_core::deepsize::Context) -> usize {
-        self.data.deep_size_of_children(context)
-    }
+    pub data: Vec<u8>,
+    pub len: usize,
 }
 
 /// Set bits in `data`, counted a word at a time.
@@ -88,11 +56,7 @@ impl Bitmap {
     }
 
     pub(crate) fn from_parts(data: Vec<u8>, len: usize) -> Self {
-        Self {
-            data,
-            len,
-            count_ones: OnceLock::new(),
-        }
+        Self { data, len }
     }
 
     #[inline]
@@ -106,12 +70,10 @@ impl Bitmap {
 
     pub fn set(&mut self, i: usize) {
         self.data[i / 8] |= 1 << (i % 8);
-        self.count_ones.take();
     }
 
     pub fn clear(&mut self, i: usize) {
         self.data[i / 8] &= !(1 << (i % 8));
-        self.count_ones.take();
     }
 
     pub fn get(&self, i: usize) -> bool {
@@ -131,7 +93,7 @@ impl Bitmap {
     }
 
     pub fn count_ones(&self) -> usize {
-        *self.count_ones.get_or_init(|| count_ones(&self.data))
+        count_ones(&self.data)
     }
 
     pub fn count_zeros(&self) -> usize {
@@ -266,25 +228,15 @@ mod tests {
     }
 
     #[test]
-    fn test_count_ones_cache_tracks_clone_and_mutation() {
-        let mut bitmap = Bitmap::new_empty(10_000);
-        bitmap.set(3);
-        bitmap.set(9_999);
-        assert_eq!(bitmap.count_ones(), 2);
-        assert_eq!(bitmap.count_ones.get(), Some(&2));
+    fn test_count_ones_tracks_direct_data_mutation() {
+        let mut bitmap = Bitmap::new_empty(16);
+        assert_eq!(bitmap.count_ones(), 0);
 
-        let clone = bitmap.clone();
-        assert_eq!(clone.count_ones.get(), Some(&2));
-        assert_eq!(clone.count_ones(), 2);
+        bitmap.data[0] = 0b1010_0101;
+        assert_eq!(bitmap.count_ones(), 4);
 
-        bitmap.set(8);
-        assert!(bitmap.count_ones.get().is_none());
-        assert_eq!(bitmap.count_ones(), 3);
-
-        bitmap.clear(3);
-        assert!(bitmap.count_ones.get().is_none());
-        assert_eq!(bitmap.count_ones(), 2);
-        assert_eq!(clone.count_ones(), 2);
+        bitmap.data[1] = 0xff;
+        assert_eq!(bitmap.count_ones(), 12);
     }
 
     #[test]

--- a/rust/lance-table/src/rowids/segment.rs
+++ b/rust/lance-table/src/rowids/segment.rs
@@ -873,6 +873,21 @@ mod test {
     use super::*;
 
     #[test]
+    fn test_range_with_bitmap_data_remains_publicly_mutable() {
+        let mut segment = U64Segment::RangeWithBitmap {
+            range: 0..8,
+            bitmap: Bitmap::new_empty(8),
+        };
+        let U64Segment::RangeWithBitmap { bitmap, .. } = &mut segment else {
+            unreachable!();
+        };
+
+        bitmap.data[0] = 0b1010_0101;
+        assert_eq!(bitmap.len, 8);
+        assert_eq!(bitmap.count_ones(), 4);
+    }
+
+    #[test]
     fn test_extend_range_over_full_and_near_dense_bitmap_bytes() {
         let mut bitmap = Bitmap::new_full(24);
         bitmap.clear(10);

--- a/rust/lance-table/src/rowids/segment.rs
+++ b/rust/lance-table/src/rowids/segment.rs
@@ -277,6 +277,16 @@ impl U64Segment {
         }
     }
 
+    pub(crate) fn use_dense_range_expansion(&self) -> bool {
+        let Self::RangeWithBitmap { bitmap, .. } = self else {
+            return false;
+        };
+        // Keep sparse segments on the compact per-bit decoder. Contiguous-run
+        // expansion pays off when dense bytes dominate the segment.
+        let dense_threshold = bitmap.len().saturating_sub(bitmap.len() / 4);
+        bitmap.count_ones() >= dense_threshold
+    }
+
     pub fn is_empty(&self) -> bool {
         self.len() == 0
     }
@@ -656,7 +666,7 @@ pub struct SegmentCursor<'a> {
 pub(crate) struct SegmentCursorState {
     /// Byte the next select1 scan resumes at.
     byte_idx: usize,
-    /// Set bits in `bitmap.data[..byte_idx]`.
+    /// Set bits in the bitmap bytes before `byte_idx`.
     ones_before: usize,
 }
 
@@ -696,7 +706,21 @@ impl SegmentCursorState {
             self.byte_idx = 0;
             self.ones_before = 0;
         }
-        while let Some(&byte) = bitmap.data.get(self.byte_idx) {
+
+        let range_start = range.start;
+        let bitmap_bytes = bitmap.bytes();
+        self.extend_sparse_bitmap_range(range_start, bitmap_bytes, selection, values);
+    }
+
+    #[inline(never)]
+    fn extend_sparse_bitmap_range(
+        &mut self,
+        range_start: u64,
+        bitmap_bytes: &[u8],
+        selection: Range<usize>,
+        values: &mut Vec<u64>,
+    ) {
+        while let Some(&byte) = bitmap_bytes.get(self.byte_idx) {
             let ones = byte.count_ones() as usize;
             let ones_after_byte = self.ones_before + ones;
             if selection.start >= ones_after_byte {
@@ -713,7 +737,92 @@ impl SegmentCursorState {
                 }
                 let bit = remaining_bits.trailing_zeros() as usize;
                 if rank >= selection.start {
-                    values.push(range.start + (self.byte_idx * 8 + bit) as u64);
+                    values.push(range_start + (self.byte_idx * 8 + bit) as u64);
+                }
+                remaining_bits &= remaining_bits - 1;
+                rank += 1;
+            }
+
+            self.ones_before = ones_after_byte;
+            self.byte_idx += 1;
+            if self.ones_before >= selection.end {
+                return;
+            }
+        }
+    }
+
+    pub(crate) fn extend_dense_range(
+        &mut self,
+        segment: &U64Segment,
+        selection: Range<usize>,
+        values: &mut Vec<u64>,
+    ) {
+        let U64Segment::RangeWithBitmap { range, bitmap } = segment else {
+            self.extend_range(segment, selection, values);
+            return;
+        };
+        if selection.start < self.ones_before {
+            self.byte_idx = 0;
+            self.ones_before = 0;
+        }
+        self.extend_dense_bitmap_range(range.start, bitmap.bytes(), selection, values);
+    }
+
+    #[inline(never)]
+    fn extend_dense_bitmap_range(
+        &mut self,
+        range_start: u64,
+        bitmap_bytes: &[u8],
+        selection: Range<usize>,
+        values: &mut Vec<u64>,
+    ) {
+        while let Some(&byte) = bitmap_bytes.get(self.byte_idx) {
+            let ones = byte.count_ones() as usize;
+            let ones_after_byte = self.ones_before + ones;
+            if selection.start >= ones_after_byte {
+                self.ones_before = ones_after_byte;
+                self.byte_idx += 1;
+                continue;
+            }
+
+            let includes_entire_byte =
+                selection.start <= self.ones_before && selection.end >= ones_after_byte;
+            if includes_entire_byte && ones >= 6 {
+                let byte_start = range_start + (self.byte_idx * 8) as u64;
+                if byte == u8::MAX {
+                    values.extend(byte_start..byte_start + 8);
+                } else {
+                    let mut remaining_bits = byte;
+                    let mut bit_offset = 0_u64;
+                    while remaining_bits != 0 {
+                        let zeros = remaining_bits.trailing_zeros();
+                        remaining_bits >>= zeros;
+                        bit_offset += u64::from(zeros);
+                        let run = remaining_bits.trailing_ones();
+                        values.extend(
+                            (byte_start + bit_offset)..(byte_start + bit_offset + u64::from(run)),
+                        );
+                        remaining_bits >>= run;
+                        bit_offset += u64::from(run);
+                    }
+                }
+                self.ones_before = ones_after_byte;
+                self.byte_idx += 1;
+                if self.ones_before >= selection.end {
+                    return;
+                }
+                continue;
+            }
+
+            let mut remaining_bits = byte;
+            let mut rank = self.ones_before;
+            while remaining_bits != 0 {
+                if rank >= selection.end {
+                    return;
+                }
+                let bit = remaining_bits.trailing_zeros() as usize;
+                if rank >= selection.start {
+                    values.push(range_start + (self.byte_idx * 8 + bit) as u64);
                 }
                 remaining_bits &= remaining_bits - 1;
                 rank += 1;
@@ -739,7 +848,9 @@ impl SegmentCursorState {
         // Deserialization rejects a bitmap whose padding bits are set, so
         // popcount counts only valid positions.
         let mut remaining = i - self.ones_before;
-        while let Some(&byte) = bitmap.data.get(self.byte_idx) {
+        let range_start = range.start;
+        let bitmap_bytes = bitmap.bytes();
+        while let Some(&byte) = bitmap_bytes.get(self.byte_idx) {
             let ones = byte.count_ones() as usize;
             if remaining < ones {
                 let mut b = byte;
@@ -747,7 +858,7 @@ impl SegmentCursorState {
                     b &= b - 1; // clear lowest set bit
                 }
                 let bit = b.trailing_zeros() as usize;
-                return Some(range.start + (self.byte_idx * 8 + bit) as u64);
+                return Some(range_start + (self.byte_idx * 8 + bit) as u64);
             }
             remaining -= ones;
             self.ones_before += ones;
@@ -760,6 +871,32 @@ impl SegmentCursorState {
 #[cfg(test)]
 mod test {
     use super::*;
+
+    #[test]
+    fn test_extend_range_over_full_and_near_dense_bitmap_bytes() {
+        let mut bitmap = Bitmap::new_full(24);
+        bitmap.clear(10);
+        bitmap.clear(17);
+        bitmap.clear(22);
+        let segment = U64Segment::RangeWithBitmap {
+            range: 100..124,
+            bitmap,
+        };
+        assert!(segment.use_dense_range_expansion());
+        let expected = segment.iter().collect::<Vec<_>>();
+
+        let mut state = SegmentCursorState::default();
+        let mut actual = Vec::new();
+        for selection in [0..8, 8..15, 15..21] {
+            state.extend_dense_range(&segment, selection, &mut actual);
+        }
+        assert_eq!(actual, expected);
+
+        let mut state = SegmentCursorState::default();
+        let mut partial = Vec::new();
+        state.extend_dense_range(&segment, 9..20, &mut partial);
+        assert_eq!(partial, expected[9..20]);
+    }
 
     #[test]
     fn test_segments() {

--- a/rust/lance-table/src/rowids/segment.rs
+++ b/rust/lance-table/src/rowids/segment.rs
@@ -707,20 +707,7 @@ impl SegmentCursorState {
             self.ones_before = 0;
         }
 
-        let range_start = range.start;
-        let bitmap_bytes = bitmap.bytes();
-        self.extend_sparse_bitmap_range(range_start, bitmap_bytes, selection, values);
-    }
-
-    #[inline(never)]
-    fn extend_sparse_bitmap_range(
-        &mut self,
-        range_start: u64,
-        bitmap_bytes: &[u8],
-        selection: Range<usize>,
-        values: &mut Vec<u64>,
-    ) {
-        while let Some(&byte) = bitmap_bytes.get(self.byte_idx) {
+        while let Some(&byte) = bitmap.data.get(self.byte_idx) {
             let ones = byte.count_ones() as usize;
             let ones_after_byte = self.ones_before + ones;
             if selection.start >= ones_after_byte {
@@ -737,7 +724,7 @@ impl SegmentCursorState {
                 }
                 let bit = remaining_bits.trailing_zeros() as usize;
                 if rank >= selection.start {
-                    values.push(range_start + (self.byte_idx * 8 + bit) as u64);
+                    values.push(range.start + (self.byte_idx * 8 + bit) as u64);
                 }
                 remaining_bits &= remaining_bits - 1;
                 rank += 1;
@@ -768,7 +755,7 @@ impl SegmentCursorState {
         self.extend_dense_bitmap_range(range.start, bitmap.bytes(), selection, values);
     }
 
-    #[inline(never)]
+    #[inline]
     fn extend_dense_bitmap_range(
         &mut self,
         range_start: u64,

--- a/rust/lance-table/src/rowids/segment.rs
+++ b/rust/lance-table/src/rowids/segment.rs
@@ -277,14 +277,14 @@ impl U64Segment {
         }
     }
 
-    pub(crate) fn use_dense_range_expansion(&self) -> bool {
+    pub(crate) fn use_dense_range_expansion(&self, segment_len: usize) -> bool {
         let Self::RangeWithBitmap { bitmap, .. } = self else {
             return false;
         };
         // Keep sparse segments on the compact per-bit decoder. Contiguous-run
         // expansion pays off when dense bytes dominate the segment.
         let dense_threshold = bitmap.len().saturating_sub(bitmap.len() / 4);
-        bitmap.count_ones() >= dense_threshold
+        segment_len >= dense_threshold
     }
 
     pub fn is_empty(&self) -> bool {
@@ -897,7 +897,17 @@ mod test {
             range: 100..124,
             bitmap,
         };
-        assert!(segment.use_dense_range_expansion());
+        assert!(segment.use_dense_range_expansion(segment.len()));
+
+        let mut sparse_bitmap = Bitmap::new_empty(24);
+        for i in [0, 8, 16] {
+            sparse_bitmap.set(i);
+        }
+        let sparse_segment = U64Segment::RangeWithBitmap {
+            range: 0..24,
+            bitmap: sparse_bitmap,
+        };
+        assert!(!sparse_segment.use_dense_range_expansion(sparse_segment.len()));
         let expected = segment.iter().collect::<Vec<_>>();
 
         let mut state = SegmentCursorState::default();

--- a/rust/lance-table/src/rowids/serde.rs
+++ b/rust/lance-table/src/rowids/serde.rs
@@ -331,7 +331,7 @@ mod test {
     use super::*;
 
     #[test]
-    fn test_cached_bitmap_popcount_does_not_change_serialization() {
+    fn test_bitmap_serialization_is_byte_exact() {
         let mut bitmap = Bitmap::new_full(10);
         bitmap.clear(2);
         let segment = U64Segment::RangeWithBitmap {

--- a/rust/lance-table/src/rowids/serde.rs
+++ b/rust/lance-table/src/rowids/serde.rs
@@ -146,10 +146,7 @@ impl TryFrom<pb::U64Segment> for U64Segment {
                 }
                 Ok(Self::RangeWithBitmap {
                     range: start..end,
-                    bitmap: Bitmap {
-                        data: bitmap,
-                        len: range_len,
-                    },
+                    bitmap: Bitmap::from_parts(bitmap, range_len),
                 })
             }
             Some(SortedArray(array)) => {
@@ -258,7 +255,7 @@ impl From<U64Segment> for pb::U64Segment {
                     pb::u64_segment::RangeWithBitmap {
                         start: range.start,
                         end: range.end,
-                        bitmap: bitmap.data,
+                        bitmap: bitmap.into_bytes(),
                     },
                 )),
             },
@@ -327,11 +324,29 @@ pub fn read_row_ids(reader: &[u8]) -> Result<RowIdSequence> {
 
 #[cfg(test)]
 mod test {
-    use super::*;
     use pretty_assertions::assert_eq;
     use proptest::prelude::*;
     use rstest::rstest;
 
+    use super::*;
+
+    #[test]
+    fn test_cached_bitmap_popcount_does_not_change_serialization() {
+        let mut bitmap = Bitmap::new_full(10);
+        bitmap.clear(2);
+        let segment = U64Segment::RangeWithBitmap {
+            range: 100..110,
+            bitmap,
+        };
+        assert_eq!(segment.len(), 9);
+
+        let serialized = pb::U64Segment::from(segment.clone());
+        let Some(pb::u64_segment::Segment::RangeWithBitmap(encoded)) = &serialized.segment else {
+            panic!("expected bitmap segment");
+        };
+        assert_eq!(encoded.bitmap, vec![0xfb, 0x03]);
+        assert_eq!(U64Segment::try_from(serialized).unwrap(), segment);
+    }
     fn read_segment(segment: pb::u64_segment::Segment) -> Result<RowIdSequence> {
         let sequence = pb::RowIdSequence {
             segments: vec![pb::U64Segment {

--- a/rust/lance-table/src/utils/stream.rs
+++ b/rust/lance-table/src/utils/stream.rs
@@ -19,7 +19,7 @@ use lance_core::{
 use lance_io::ReadBatchParams;
 use tracing::instrument;
 
-use crate::rowids::RowIdSequence;
+use crate::rowids::{RowIdSequence, RowIdSequenceCursor};
 
 pub type ReadBatchFut = BoxFuture<'static, Result<RecordBatch>>;
 /// A task, emitted by a file reader, that will produce a batch (of the
@@ -506,12 +506,29 @@ pub fn wrap_with_row_id_and_delete(
     fragment_id: u32,
     config: RowIdAndDeletesConfig,
 ) -> ReadBatchFutStream {
-    let config = Arc::new(config);
-    let mut row_id_cursor = config
+    let (row_id_cursor, use_dense_row_id_expansion) = config
         .row_id_sequence
         .as_ref()
         .filter(|_| config.with_row_id)
-        .map(|sequence| sequence.cursor());
+        .map(|sequence| {
+            let (cursor, use_dense_range_expansion) = sequence.cursor_with_dense_range_expansion();
+            (Some(cursor), use_dense_range_expansion)
+        })
+        .unwrap_or((None, false));
+    if use_dense_row_id_expansion {
+        wrap_with_row_id_and_delete_impl::<true>(stream, fragment_id, config, row_id_cursor)
+    } else {
+        wrap_with_row_id_and_delete_impl::<false>(stream, fragment_id, config, row_id_cursor)
+    }
+}
+
+fn wrap_with_row_id_and_delete_impl<const USE_DENSE_ROW_ID_EXPANSION: bool>(
+    stream: ReadBatchTaskStream,
+    fragment_id: u32,
+    config: RowIdAndDeletesConfig,
+    mut row_id_cursor: Option<RowIdSequenceCursor>,
+) -> ReadBatchFutStream {
+    let config = Arc::new(config);
     let mut offset = 0;
     stream
         .map(move |batch_task| {
@@ -532,6 +549,12 @@ pub fn wrap_with_row_id_and_delete(
                         .to_ranges()
                         .unwrap();
                     let values = match selection.as_slice() {
+                        [range] if USE_DENSE_ROW_ID_EXPANSION => {
+                            UInt64Array::from(sequence.select_dense_range_with_cursor(
+                                cursor,
+                                range.start as usize..range.end as usize,
+                            ))
+                        }
                         [range] => UInt64Array::from(sequence.select_range_with_cursor(
                             cursor,
                             range.start as usize..range.end as usize,


### PR DESCRIPTION
## Summary

Add dense and near-dense bitmap decode paths.

This follows #8713 and targets `RangeWithBitmap` segments after the sequential cursor has removed repeated prefix scans.

The decoder now:

- emits a full `0xff` byte as one contiguous eight-value range;
- expands full bytes with at least six set bits as contiguous runs;
- selects the specialized dense stream once for a single bitmap segment;
- seeds the cursor with the cardinality used for that decision, avoiding a second bitmap scan;
- keeps multi-segment sequences on the existing sparse path because one stream-wide decoder cannot safely assume that every segment has the same density.

The sparse cursor and bitmap loop remain separate and source-equivalent to `main`. This avoids the measurable fallback regression caused by performing adaptive dispatch in every batch.

`Bitmap.data` and `Bitmap.len` remain publicly accessible for source compatibility. A proposed popcount cache was removed because direct mutation of the public byte vector could otherwise make the cached cardinality stale. The on-disk encoding remains byte-for-byte unchanged.

## Performance

Measured on Linux x86_64 with `release-with-debug`, 1,000,000 output rows, batch size 1,024, 10 Criterion samples, 1 second warm-up, and 3 seconds measurement. Both binaries used the same benchmark source. Baseline was current `main` at `d57d0fb42`; candidate was `fbde7d600`.

| Shape | Payload | `main` | This PR | Change |
|---|---:|---:|---:|---:|
| 50% density (`holes_2`) | no | 2.243 ms | 2.274 ms | +0.96% (within Criterion noise threshold) |
| 50% density (`holes_2`) | yes | 2.600 ms | 2.594 ms | -0.22% (no significant change) |
| ~94% density (`holes_17`) | no | 2.484 ms | 1.600 ms | **-35.58%** |
| ~94% density (`holes_17`) | yes | 2.592 ms | 1.677 ms | **-35.14%** |

Linux `perf` attributes the dense-shape improvement to the intended decoder change: on `main`, `SegmentCursorState::extend_range` accounts for 68.17% of CPU samples; this PR moves that work to `SegmentCursorState::extend_dense_range` (48.61% of samples) while reducing end-to-end time by 35.58%. For the 50%-density fallback, both `main` and this PR remain in `SegmentCursorState::extend_range` (66.83% and 70.13% respectively); no adaptive-dispatch helper appears in the hot path.

## Validation

- `cargo test -p lance-table --lib` (365 passed)
- `cargo clippy --all --tests --benches -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`
- full-width-byte regression coverage, including the previous shift-by-8 panic
- dense sequential cursor coverage across batch and byte boundaries, tail reads, past-end reads, and rewind
- sparse and multi-segment fallback coverage
- concurrent multi-batch stable row-ID coverage with deletions
- unsorted stable row-ID index coverage
- direct public-byte mutation cardinality coverage
- public-field source-compatibility coverage through `U64Segment::RangeWithBitmap`
- byte-exact serde coverage

Dependency #8713 is merged. This PR targets `main` directly and contains only the bitmap follow-up.
