### PR TITLE
perf(merge_insert): probe the most selective indexed key first and stop early

### DIFF
--- a/rust/lance/src/dataset/write/merge_insert.rs
+++ b/rust/lance/src/dataset/write/merge_insert.rs
@@ -6256,6 +6256,116 @@ mod tests {
         );
     }
 
+    /// The probe loop orders join keys by how many distinct values the source
+    /// batch holds for them, so writing a composite key coarse-to-fine
+    /// (`["bucket", "id"]`) does not make the coarse probe run first and
+    /// materialize a candidate set the size of the table.
+    ///
+    /// Asserted on the emitted candidate count, which is the only observable
+    /// that says which probe ran: `IndexMetrics` has no per-probe counter and
+    /// is shared across lookups. Probing the selective key first leaves 4
+    /// candidates and stops, because 4 is already down to the source batch
+    /// size; following the caller's order instead would probe `bucket` first
+    /// (8 candidates, no stop), then intersect down to the 2 exact matches. So
+    /// the larger count is the cheaper plan — one probe instead of two — and
+    /// the surplus is trimmed by the full-key join downstream. A regression in
+    /// the ordering shows up here as 2.
+    ///
+    /// Sits with the other composite-key merge_insert tests, next to
+    /// `map_index_exec_multi_lookup_plan_shape`: probe ordering only matters on
+    /// the composite-key indexed path, and this is where that path is covered.
+    #[tokio::test]
+    async fn map_index_exec_probes_most_selective_key_first() {
+        use crate::io::exec::scalar_index::{IndexLookup, MapIndexExec};
+        use arrow_array::types::UInt64Type;
+        use datafusion::physical_plan::ExecutionPlan;
+        use lance_datafusion::exec::OneShotExec;
+
+        // `id` is unique; `bucket` takes two values, so a `bucket` probe alone
+        // reaches half the table while pruning almost nothing.
+        let initial = record_batch!(
+            (
+                "id",
+                Int32,
+                [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]
+            ),
+            (
+                "bucket",
+                Int32,
+                [0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1]
+            )
+        )
+        .unwrap();
+        let schema = initial.schema();
+        let mut dataset = Dataset::write(
+            RecordBatchIterator::new(vec![Ok(initial)], schema),
+            "memory://",
+            None,
+        )
+        .await
+        .unwrap();
+
+        let params = ScalarIndexParams::default();
+        for column in ["id", "bucket"] {
+            dataset
+                .create_index(
+                    &[column],
+                    IndexType::Scalar,
+                    Some(format!("{column}_idx")),
+                    &params,
+                    false,
+                )
+                .await
+                .unwrap();
+        }
+
+        // Columns are in lookup order, which is the deliberately bad one: the
+        // coarse key first. Only ids 0 and 2 also sit in bucket 0, so the exact
+        // composite match is 2 rows.
+        let probe =
+            record_batch!(("bucket", Int32, [0, 0, 0, 0]), ("id", Int32, [0, 1, 2, 3])).unwrap();
+        let source_rows = probe.num_rows();
+        let plan = MapIndexExec::new_multi(
+            Arc::new(dataset),
+            vec![
+                IndexLookup::new("bucket", "bucket_idx"),
+                IndexLookup::new("id", "id_idx"),
+            ],
+            Arc::new(OneShotExec::from_batch(probe)),
+        );
+
+        let mut stream = plan
+            .execute(0, Arc::new(datafusion::execution::TaskContext::default()))
+            .unwrap();
+        let mut candidates = Vec::new();
+        while let Some(batch) = stream.next().await {
+            let batch = batch.unwrap();
+            candidates.extend(
+                batch
+                    .column(0)
+                    .as_primitive::<UInt64Type>()
+                    .values()
+                    .iter()
+                    .copied(),
+            );
+        }
+
+        assert_eq!(
+            candidates.len(),
+            source_rows,
+            "the selective key must be probed first and stop the loop, leaving \
+             one candidate per source row; {} means the probes ran in `on` order",
+            candidates.len()
+        );
+        // Whatever the order, the candidate set has to cover the exact matches.
+        for row_addr in [0_u64, 2] {
+            assert!(
+                candidates.contains(&row_addr),
+                "candidate set must contain exact match at row {row_addr}: {candidates:?}"
+            );
+        }
+    }
+
     mod subcols {
         use super::*;
         use rstest::rstest;

--- a/rust/lance/src/io/exec/scalar_index.rs
+++ b/rust/lance/src/io/exec/scalar_index.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright The Lance Authors
 
+use std::collections::HashSet;
 use std::sync::{Arc, LazyLock};
 
 use super::utils::{IndexMetrics, InstrumentedRecordBatchStreamAdapter};
@@ -12,7 +13,7 @@ use crate::{
         scalar_logical::{open_named_scalar_index, scalar_index_fragment_bitmap},
     },
 };
-use arrow_array::{Array, RecordBatch, UInt64Array, cast::AsArray, types::UInt64Type};
+use arrow_array::{Array, ArrayRef, RecordBatch, UInt64Array, cast::AsArray, types::UInt64Type};
 use arrow_schema::{Schema, SchemaRef};
 use async_recursion::async_recursion;
 use async_trait::async_trait;
@@ -400,11 +401,13 @@ impl IndexLookup {
 ///
 /// Multiple `(column, index_name)` lookups can be supplied: the operator
 /// expects one input column per lookup (in matching order) and emits the
-/// row addresses where every column's value is present in its respective
-/// index — that is, the AND of the per-column index probes. This lets a
-/// composite-key join trim the candidate row set with every available
-/// scalar index before the downstream take. A row address reached by more
-/// than one input batch is emitted only once.
+/// row addresses that could match on every column. The result is an upper
+/// bound, not an exact set — the probes are evaluated one key at a time,
+/// most-selective first, and stop as soon as the candidate set is no larger
+/// than the input batch, so a caller must still filter on the full key.
+/// This lets a composite-key join trim the candidate row set before the
+/// downstream take without paying for a probe that prunes nothing. A row
+/// address reached by more than one input batch is emitted only once.
 #[derive(Debug)]
 pub struct MapIndexExec {
     dataset: Arc<Dataset>,
@@ -451,9 +454,10 @@ impl MapIndexExec {
         )
     }
 
-    /// Build a `MapIndexExec` that probes one or more scalar indices and
-    /// emits the AND of their results. `lookups` must be non-empty and
-    /// `input` must produce one column per lookup, in the same order.
+    /// Build a `MapIndexExec` that probes one or more scalar indices and emits
+    /// an upper bound on the row addresses matching every one of them (see the
+    /// type docs). `lookups` must be non-empty and `input` must produce one
+    /// column per lookup, in the same order.
     pub fn new_multi(
         dataset: Arc<Dataset>,
         lookups: Vec<IndexLookup>,
@@ -491,6 +495,15 @@ impl MapIndexExec {
         // fragment covered by *every* index in `lookups`; restrict the
         // deletion mask to that intersection so we only filter deletes we
         // could actually see.
+        //
+        // This loop must keep covering every lookup even though `map_batch`
+        // may skip some probes. A skipped probe leaves candidates from
+        // fragments that its index does not cover, and the restricted mask is
+        // the only thing that then blocks them. Those fragments are read
+        // separately by the unindexed-fragment scan in
+        // `create_indexed_scan_joined_stream`, so letting candidates through
+        // would feed the same target row into the join twice, which the
+        // default `SourceDedupeBehavior::Fail` reports as an error.
         let mut fragment_bitmap: Option<RoaringBitmap> = None;
         for lookup in &lookups {
             let bm = scalar_index_fragment_bitmap(&dataset, &lookup.column, &lookup.index_name)
@@ -558,32 +571,43 @@ impl MapIndexExec {
         )))
     }
 
-    /// Build the AND-of-IsIn `ScalarIndexExpr` describing this batch's
-    /// composite lookup: each input column contributes one `IsIn` query
-    /// against its matching index.
-    fn build_query(
-        lookups: &[IndexLookup],
-        batch: &RecordBatch,
-    ) -> datafusion::error::Result<ScalarIndexExpr> {
-        let per_column = lookups.iter().enumerate().map(|(idx, lookup)| {
-            let column = batch.column(idx);
-            let values = (0..column.len())
-                .map(|row| ScalarValue::try_from_array(column, row))
-                .collect::<datafusion::error::Result<Vec<_>>>()?;
-            Ok::<_, datafusion::error::DataFusionError>(ScalarIndexExpr::Query(ScalarIndexSearch {
-                column: lookup.column.clone(),
-                index_name: lookup.index_name.clone(),
-                // Internal IndexedLookup-style query — type is unknown at this layer
-                index_type: String::new(),
-                query: Arc::new(SargableQuery::IsIn(values)),
-                needs_recheck: false,
-                fragment_bitmap: None,
-            }))
-        });
+    /// The values of one input column, deduped when `dedupe` is set.
+    ///
+    /// Deduping earns its keep once there is more than one key: the distinct
+    /// count doubles as the probe-ordering signal in [`Self::map_batch`], and a
+    /// repeated value only adds an `IsIn` entry that re-selects index pages
+    /// already selected. With a single key there is nothing to order, so
+    /// hashing every value would be pure overhead on the most common path.
+    ///
+    /// One NULL survives dedupe on purpose: an index reads a NULL in the list
+    /// as "also match null rows", which is a flag rather than a count.
+    fn key_values(column: &ArrayRef, dedupe: bool) -> datafusion::error::Result<Vec<ScalarValue>> {
+        let mut values = Vec::with_capacity(column.len());
+        let mut seen = HashSet::with_capacity(if dedupe { column.len() } else { 0 });
+        for row in 0..column.len() {
+            let value = ScalarValue::try_from_array(column, row)?;
+            if dedupe {
+                if seen.contains(&value) {
+                    continue;
+                }
+                seen.insert(value.clone());
+            }
+            values.push(value);
+        }
+        Ok(values)
+    }
 
-        per_column
-            .reduce(|lhs, rhs| Ok(ScalarIndexExpr::And(Box::new(lhs?), Box::new(rhs?))))
-            .expect("MapIndexExec built with no lookups")
+    /// Build the `IsIn` query for one join key against its matching index.
+    fn build_key_query(lookup: &IndexLookup, values: Vec<ScalarValue>) -> ScalarIndexExpr {
+        ScalarIndexExpr::Query(ScalarIndexSearch {
+            column: lookup.column.clone(),
+            index_name: lookup.index_name.clone(),
+            // Internal IndexedLookup-style query — type is unknown at this layer
+            index_type: String::new(),
+            query: Arc::new(SargableQuery::IsIn(values)),
+            needs_recheck: false,
+            fragment_bitmap: None,
+        })
     }
 
     async fn map_batch(
@@ -593,12 +617,89 @@ impl MapIndexExec {
         batch: RecordBatch,
         metrics: Arc<IndexMetrics>,
     ) -> datafusion::error::Result<RecordBatch> {
-        let query = Self::build_query(&lookups, &batch)?;
-        let query_result = query.evaluate(dataset.as_ref(), metrics.as_ref()).await?;
-        if !query_result.is_exact() {
-            todo!("Support for non-exact query results as input for merge_insert")
+        // The operator's contract is one input column per lookup, in order (see
+        // `new_multi`). Check it here rather than letting `batch.column` panic
+        // deep inside a DataFusion stream, and check it before the probe loop:
+        // the loop can skip the offending lookup, which would turn a broken
+        // plan into a failure that depends on the data.
+        if lookups.len() != batch.num_columns() {
+            return Err(datafusion::error::DataFusionError::Internal(format!(
+                "MapIndexExec has {} lookups but its input produced {} columns",
+                lookups.len(),
+                batch.num_columns()
+            )));
         }
-        let mut row_addr_mask = query_result.upper;
+
+        // Probe the keys one at a time and intersect, rather than evaluating an
+        // AND of every probe at once. A join key whose values repeat across the
+        // target (a bucket or status column) matches most of the table, so its
+        // probe materializes a candidate set the size of the dataset while
+        // pruning almost nothing: on a 10M-row table, probing a 1024-distinct
+        // key asked for 2.4 GB of candidates.
+        // With one key there is nothing to order and nothing a second probe
+        // could intersect away, so that path stays exactly as it was.
+        let several_keys = lookups.len() > 1;
+        let mut values_per_key = Vec::with_capacity(lookups.len());
+        for column in batch.columns() {
+            values_per_key.push(Self::key_values(column, several_keys)?);
+        }
+
+        // Probe the most selective key first. The key with the most distinct
+        // source values partitions the target most finely, so its probe is the
+        // one most likely to leave a candidate set small enough to skip the
+        // rest. Following the caller's `on` order instead would run the
+        // expensive probe first, because the natural way to write a composite
+        // key is coarse-to-fine (`["tenant_id", "row_id"]`). The distinct count
+        // is a source-side proxy for target-side selectivity, and it only knows
+        // how many values a probe will look up, not how many target rows each
+        // of them matches. A skewed batch — many distinct values that each
+        // match many rows, sitting next to few values that each match few —
+        // can therefore be ordered worse than the caller wrote it. The floor is
+        // the old behaviour's probe set — run sequentially, see below — because
+        // the break only ever removes probes.
+        let mut probe_order: Vec<usize> = (0..lookups.len()).collect();
+        if several_keys {
+            // Stable, so keys with equally distinct values keep `on` order.
+            probe_order.sort_by_key(|&idx| std::cmp::Reverse(values_per_key[idx].len()));
+        }
+
+        // Stop once the candidate set is no larger than the source batch. A
+        // further probe could still remove false positives, but what is left to
+        // remove is bounded by the source batch, so it cannot save more work
+        // downstream than the probe itself costs. That bound is the point: per
+        // batch the emitted set is either the full intersection or at most
+        // `batch.num_rows()` rows, which is also what keeps the cross-batch
+        // candidate set in `DistinctRowAddrs` bounded.
+        //
+        // Skipping a probe only leaves extra candidates, never drops a match:
+        // the downstream hash join filters on the full composite key (see
+        // `create_indexed_scan_joined_stream`), the same reason an unindexed
+        // `on` column is allowed to prune nothing. Extra candidates stay inside
+        // the index-covered fragments because the restricted deletion mask
+        // applied below is built from *every* lookup's fragment bitmap.
+        //
+        // The probes run in sequence where the old `ScalarIndexExpr::And` ran
+        // them concurrently. That is the price of being able to stop, and it
+        // shows up only when no probe is skipped and the index cache is cold.
+        let source_rows = batch.num_rows() as u64;
+        // `all_rows()` is the identity for `intersect`, so the first probe
+        // needs no special case.
+        let mut row_addr_mask = RowAddrMask::all_rows();
+        for idx in probe_order {
+            if row_addr_mask
+                .max_len()
+                .is_some_and(|len| len <= source_rows)
+            {
+                break;
+            }
+            let values = std::mem::take(&mut values_per_key[idx]);
+            let query = Self::build_key_query(&lookups[idx], values);
+            let query_result = query.evaluate(dataset.as_ref(), metrics.as_ref()).await?;
+            if !query_result.is_exact() {
+                todo!("Support for non-exact query results as input for merge_insert")
+            }
+            row_addr_mask = row_addr_mask.intersect(query_result.upper);
+        }
 
         if let Some(deletion_mask) = deletion_mask.as_ref() {
             row_addr_mask = row_addr_mask & deletion_mask.as_ref().clone();


### PR DESCRIPTION
## What this changes

`MapIndexExec::map_batch` probed every indexed join key as one `ScalarIndexExpr::And` and evaluated the whole expression, so a low-cardinality key materialized a candidate set the size of the table while pruning almost nothing (#8718).

It now probes one key at a time, intersects as it goes, and stops once the candidate set is no larger than the source batch. Keys are ordered by how many distinct values the source batch holds for them, so a caller who writes a composite key coarse-to-fine (`["tenant_id", "row_id"]`) does not pay for the coarse probe first. `IsIn` lists are deduplicated. Both the ordering and the dedup are gated on having more than one lookup, so the single-key path behaves as before.

Skipping a probe widens the candidate set, which is safe because the downstream join filters on the full composite key; the file already documents that the probe result is a super-set. Extra candidates stay inside index-covered fragments because the restricted deletion mask is still built from every lookup's fragment bitmap. That coupling is now stated in a comment, because relaxing it would feed the same target row into the join twice and the default `SourceDedupeBehavior::Fail` would abort the merge.

## Numbers

Same dataset as the issue. Baseline and patched were measured in one sitting about twenty minutes apart, swapping only the binary: the patch was reverse-applied for the baseline, then re-applied. Release build, warm index cache, median of 5 runs.

| case | main | this PR |
| --- | --- | --- |
| `on = ["composite_a", "composite_b"]` | 198.9 ms | 10.2 ms |
| `on = ["composite_b", "composite_a"]` | 199.4 ms | 10.5 ms |
| `on = ["composite_a"]`, single key | 10.2 ms | 9.8 ms |
| `conditional_update`, single key | 11.1 ms | 10.1 ms |
| `id_int`, single key | 10.9 ms | 9.9 ms |
| `id_uuid4` 100k, single key | 1132.5 ms | 1114.5 ms |
| `composite` v2 hash path (control) | 128.7 ms | 124.3 ms |
| `id_uuid4` v2 hash path (control) | 228.6 ms | 221.3 ms |

The two controls do not touch `MapIndexExec` and moved by 3.2% and 3.4%, so the two sides are comparable. The single-key shapes moved by 1.6% to 9.2%, which lands inside this script's run-to-run spread once the control drift is subtracted; that path is meant to be unchanged.

## What this does not fix

A single low-cardinality key still materializes the whole candidate set. There is no second key to intersect with and no reason for the loop to stop, so `on = ["composite_b"]` alone still exhausts the default pool, before and after this change. Bounding it needs a budget inside the index probe, and `merge_insert` would first need to accept a non-exact result, which it currently `todo!()`s. Related: #1983.

The distinct count is a source-side proxy for target-side selectivity. A skewed batch, with many distinct values that each match many target rows, can be ordered worse than the caller wrote it; the floor is the old behaviour of probing every key.

Probes now run in sequence where the old `And` ran them concurrently through `try_join!`. That is what makes stopping possible. Measured on the case where no probe can be skipped, a 100-row source with `on = ["composite_b", "composite_a"]` so that the coarse key probes first and returns roughly 976k candidates: 36.6 ms to 43.4 ms on a cold index cache, 10.6 ms to 11.6 ms warm, so 19% and 9%. The same construction with the columns swapped stops after one probe and goes from 37.1 ms to 3.5 ms cold.

## Test plan

- New `map_index_exec_probes_most_selective_key_first` asserts the emitted candidate count, which is the only observable that reveals which probe ran: `IndexMetrics` has no per-probe counter and one collector is shared across lookups. Reverting the ordering makes it fail with `left: 2, right: 4`.
- `cargo test -p lance --lib merge_insert -- --test-threads=1`: 219 pass.
- `cargo fmt --all`, `cargo clippy --all --tests --benches -- -D warnings`.
- Benchmark numbers above.

## Follow-up note

The route gate comment at `merge_insert.rs:1432` says a partially-indexed composite key "under-matches" on the indexed path. The mechanism is the opposite: each column's `IsIn` is a super-set, uncovered fragments go through the union scan, and the full-key join trims. Left alone to keep this diff to the two files it needs.

Closes #8718
