### PR TITLE
test(index): replace invalid-vector index regression

### DIFF
--- a/rust/lance-index/src/vector/transform.rs
+++ b/rust/lance-index/src/vector/transform.rs
@@ -374,16 +374,17 @@ mod tests {
             Some([f32::NAN, 1.0]),
             Some([f32::INFINITY, 1.0]),
             Some([f32::NEG_INFINITY, 1.0]),
+            Some([1e20, -1e20]),
             Some([3.0, 4.0]),
         ]);
         let output = KeepFiniteVectors::new("v").transform(&batch).unwrap();
 
         let kept = output.column_by_name("v").unwrap().as_fixed_size_list();
-        assert_eq!(kept.len(), 2, "only the two finite rows survive");
+        assert_eq!(kept.len(), 3, "only finite rows survive");
         assert_eq!(kept.null_count(), 0);
         assert_eq!(
             kept.values().as_primitive::<Float32Type>().values(),
-            &[1.0, 2.0, 3.0, 4.0]
+            &[1.0, 2.0, 1e20, -1e20, 3.0, 4.0]
         );
     }
 

--- a/rust/lance-index/src/vector/v3/shuffler.rs
+++ b/rust/lance-index/src/vector/v3/shuffler.rs
@@ -915,6 +915,32 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_two_file_shuffler_empty_first_batch() {
+        let dir = TempStrDir::default();
+        let output_dir = Path::from(dir.as_ref());
+        let empty_batch = make_batch(&[], &[], None);
+        let data_batch = make_batch(&[1, 0, 1], &[10, 20, 30], None);
+
+        let shuffler = TwoFileShuffler::new(output_dir, 2);
+        let stream = batches_to_stream(vec![empty_batch, data_batch]);
+        let reader = shuffler.shuffle(stream).await.unwrap();
+
+        assert_eq!(reader.partition_size(0).unwrap(), 1);
+        assert_eq!(reader.partition_size(1).unwrap(), 2);
+
+        let expected_schema = ArrowSchema::new(vec![Field::new("val", DataType::Int32, false)]);
+        let p0 = collect_partition(reader.as_ref(), 0).await.unwrap();
+        assert_eq!(p0.schema().as_ref(), &expected_schema);
+        let p0_values: &Int32Array = p0["val"].as_primitive();
+        assert_eq!(p0_values.values(), &[20]);
+
+        let p1 = collect_partition(reader.as_ref(), 1).await.unwrap();
+        assert_eq!(p1.schema().as_ref(), &expected_schema);
+        let p1_values: &Int32Array = p1["val"].as_primitive();
+        assert_eq!(p1_values.values(), &[10, 30]);
+    }
+
+    #[tokio::test]
     async fn test_two_file_shuffler_empty_partitions() {
         let dir = TempStrDir::default();
         let output_dir = Path::from(dir.as_ref());

--- a/rust/lance/src/index/vector/ivf/v2.rs
+++ b/rust/lance/src/index/vector/ivf/v2.rs
@@ -5745,58 +5745,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_create_index_with_many_invalid_vectors() {
-        let test_dir = TempStrDir::default();
-        let test_uri = test_dir.as_str();
-
-        // we use 8192 batch size by default, so we need to generate 8192 * 3 vectors to get 3 batches
-        // generate 3 batches, and the first batch's vectors are all with NaN
-        let num_rows = 8192 * 3;
-        let mut vectors = Vec::new();
-        for i in 0..num_rows {
-            if i < 8192 {
-                vectors.extend(std::iter::repeat_n(f32::NAN, DIM));
-            } else if i < 8192 * 2 {
-                vectors.extend(std::iter::repeat_n(rand::random::<f32>(), DIM));
-            } else {
-                vectors.extend(std::iter::repeat_n(rand::random::<f32>() * 1e20, DIM));
-            }
-        }
-        let schema = Schema::new(vec![Field::new(
-            "vector",
-            DataType::FixedSizeList(
-                Arc::new(Field::new("item", DataType::Float32, true)),
-                DIM as i32,
-            ),
-            true,
-        )]);
-        let schema = Arc::new(schema);
-        let batch = RecordBatch::try_new(
-            schema.clone(),
-            vec![Arc::new(
-                FixedSizeListArray::try_new_from_values(Float32Array::from(vectors), DIM as i32)
-                    .unwrap(),
-            )],
-        )
-        .unwrap();
-        let batches = RecordBatchIterator::new(vec![batch].into_iter().map(Ok), schema);
-        let params = WriteParams {
-            mode: WriteMode::Overwrite,
-            ..Default::default()
-        };
-        let mut dataset = Dataset::write(batches, test_uri, Some(params))
-            .await
-            .unwrap();
-
-        let params = VectorIndexParams::ivf_pq(4, 8, DIM / 8, DistanceType::Dot, 50);
-
-        dataset
-            .create_index(&["vector"], IndexType::Vector, None, &params, true)
-            .await
-            .unwrap();
-    }
-
-    #[tokio::test]
     async fn test_compaction_remaps_second_delta_with_shared_partition_topology() {
         const INDEX_NAME: &str = "vector_idx";
         const BASE_ROWS_PER_PARTITION: usize = 2_200;


### PR DESCRIPTION
## What changed

Replace a 24,576-row IVF-PQ build with focused regressions at the actual failure boundaries:

- a shuffler stream whose first batch is empty and whose second batch contains data, with exact schema, partition-size, and value assertions
- a direct `KeepFiniteVectors` assertion that large finite values survive while null/NaN/Inf rows are removed

The previous integration test only asserted that index creation did not fail. Its expensive PQ training did not strengthen either oracle.

## Test runtime

Lower is better. Measured on an Apple M4 (10 cores), macOS 26.6.1, Rust 1.97.0, with prebuilt debug test binaries, `LANCE_CPU_THREADS=4`, and `--test-threads=1`. Results use one warm-up followed by the median of three runs against independent `main` and PR worktrees. The PR value is the combined time of both replacement tests.

| Scenario / metric | Baseline | This PR | Benefit |
| --- | ---: | ---: | ---: |
| Empty-first-batch regression workload | 49.59 s | 0.01 s | 4,959x faster |

## Validation

- `cargo test -p lance-index test_two_file_shuffler_empty_first_batch`
- `cargo test -p lance-index test_keep_finite_vectors_drops_null_and_non_finite_rows`
- `cargo test -p lance test_optimize_with_empty_partition`
- `cargo fmt --all`
- `cargo clippy --all --tests --benches -- -D warnings`
- `git diff --check`
