### PR TITLE
test(index): reduce HNSW PQ test workloads

### DIFF
--- a/rust/lance-index/src/vector/pq/distance.rs
+++ b/rust/lance-index/src/vector/pq/distance.rs
@@ -395,4 +395,81 @@ mod tests {
         );
         assert_eq!(distances, expected);
     }
+
+    #[test]
+    fn test_compute_4bit_bulk_distance_preserves_flat_prefix_middle_and_tail() {
+        const NUM_VECTORS: usize = 227;
+        const NUM_SUB_VECTORS: usize = 4;
+        const NUM_PACKED_CODES: usize = NUM_SUB_VECTORS / 2;
+        const NUM_CENTROIDS: usize = 16;
+
+        let distance_table = (0..NUM_SUB_VECTORS * NUM_CENTROIDS)
+            .map(|value| (value * value + 1) as f32)
+            .collect::<Vec<_>>();
+        let packed_codes = (0..NUM_VECTORS * NUM_PACKED_CODES)
+            .map(|value| {
+                let low = (value % NUM_CENTROIDS) as u8;
+                let high = ((value * 7 + 3) % NUM_CENTROIDS) as u8;
+                low | (high << 4)
+            })
+            .collect::<Vec<_>>();
+        let packed_codes = UInt8Array::from(packed_codes);
+        let transposed = transpose(&packed_codes, NUM_VECTORS, NUM_PACKED_CODES);
+
+        let actual =
+            compute_pq_distance(&distance_table, 4, NUM_SUB_VECTORS, transposed.values(), 10);
+        let expected = packed_codes
+            .values()
+            .chunks_exact(NUM_PACKED_CODES)
+            .map(|codes| {
+                codes
+                    .iter()
+                    .enumerate()
+                    .map(|(byte_idx, code)| {
+                        distance_table[byte_idx * 2 * NUM_CENTROIDS + (code & 0x0f) as usize]
+                            + distance_table
+                                [(byte_idx * 2 + 1) * NUM_CENTROIDS + (code >> 4) as usize]
+                    })
+                    .sum::<f32>()
+            })
+            .collect::<Vec<_>>();
+
+        assert_eq!(actual.len(), NUM_VECTORS);
+        assert_eq!(&actual[..FLAT_NUM_4BIT_PQ], &expected[..FLAT_NUM_4BIT_PQ]);
+        let tail_start = NUM_VECTORS - NUM_VECTORS % NUM_CENTROIDS;
+        assert_eq!(&actual[tail_start..], &expected[tail_start..]);
+
+        let qmax = expected[..FLAT_NUM_4BIT_PQ]
+            .iter()
+            .copied()
+            .max_by(f32::total_cmp)
+            .unwrap();
+        let (qmin, quantized_table) = quantize_distance_table(&distance_table, qmax);
+        let range = (qmax - qmin) / 255.0;
+        for (vector_idx, actual_distance) in actual
+            .iter()
+            .enumerate()
+            .take(tail_start)
+            .skip(FLAT_NUM_4BIT_PQ)
+        {
+            let codes = &packed_codes.values()
+                [vector_idx * NUM_PACKED_CODES..(vector_idx + 1) * NUM_PACKED_CODES];
+            let quantized_sum = codes
+                .iter()
+                .enumerate()
+                .fold(0_u8, |sum, (byte_idx, code)| {
+                    sum.saturating_add(
+                        quantized_table[byte_idx * 2 * NUM_CENTROIDS + (code & 0x0f) as usize],
+                    )
+                    .saturating_add(
+                        quantized_table[(byte_idx * 2 + 1) * NUM_CENTROIDS + (code >> 4) as usize],
+                    )
+                });
+            let reference = quantized_sum as f32 * range + qmin;
+            assert!(
+                (*actual_distance - reference).abs() <= f32::EPSILON,
+                "4-bit bulk distance mismatch at vector {vector_idx}: actual={actual_distance}, reference={reference}"
+            );
+        }
+    }
 }

--- a/rust/lance/src/dataset/optimize.rs
+++ b/rust/lance/src/dataset/optimize.rs
@@ -6967,14 +6967,14 @@ mod tests {
         use arrow_array::types::{Float32Type, Int32Type};
         use lance_datagen::Dimension;
 
-        const DIM: u32 = 32;
+        const DIM: u32 = 8;
         let mut dataset = lance_datagen::gen_batch()
             .col("id", lance_datagen::array::step::<Int32Type>())
             .col(
                 "vec",
                 lance_datagen::array::rand_vec::<Float32Type>(Dimension::from(DIM)),
             )
-            .into_ram_dataset(FragmentCount::from(6), FragmentRowCount::from(1000))
+            .into_ram_dataset(FragmentCount::from(6), FragmentRowCount::from(64))
             .await
             .unwrap();
         dataset
@@ -7014,7 +7014,7 @@ mod tests {
                 }
             }
         }
-        let step = (rows.len() / 16).max(1);
+        let step = (rows.len() / 4).max(1);
         let queries: Vec<Vec<f32>> = rows.iter().step_by(step).cloned().collect();
         let mut baseline: Vec<Vec<i32>> = Vec::new();
         for q in &queries {
@@ -7025,7 +7025,7 @@ mod tests {
         let metrics = compact_files(
             &mut dataset,
             CompactionOptions {
-                target_rows_per_fragment: 2_000,
+                target_rows_per_fragment: 128,
                 defer_index_remap: true,
                 ..Default::default()
             },
@@ -7169,10 +7169,15 @@ mod tests {
         let params = VectorIndexParams::with_ivf_hnsw_pq_params(
             DistanceType::L2,
             small_ivf(),
-            HnswBuildParams::default(),
+            HnswBuildParams::default()
+                .max_level(2)
+                .num_edges(4)
+                .ef_construction(16),
             PQBuildParams {
                 max_iters: 2,
                 num_sub_vectors: 2,
+                num_bits: 4,
+                sample_rate: 2,
                 ..Default::default()
             },
         );

--- a/rust/lance/src/dataset/scanner.rs
+++ b/rust/lance/src/dataset/scanner.rs
@@ -10198,22 +10198,42 @@ mod test {
         #[values(false, true)] stable_row_ids: bool,
         #[values(ApproxMode::Normal, ApproxMode::Fast)] approx_mode: ApproxMode,
         #[values(
-            VectorIndexParams::ivf_pq(2, 8, 2, MetricType::L2, 2),
+            VectorIndexParams::ivf_pq(2, 4, 2, MetricType::L2, 2),
             VectorIndexParams::ivf_hnsw(
                 MetricType::L2,
                 IvfBuildParams::new(2),
                 HnswBuildParams::default()
+                    .max_level(2)
+                    .num_edges(4)
+                    .ef_construction(16)
             ),
             VectorIndexParams::with_ivf_hnsw_pq_params(
                 MetricType::L2,
-                IvfBuildParams::new(2),
-                HnswBuildParams::default(),
-                PQBuildParams::new(2, 8)
+                IvfBuildParams {
+                    num_partitions: Some(2),
+                    max_iters: 2,
+                    sample_rate: 2,
+                    ..Default::default()
+                },
+                HnswBuildParams::default()
+                    .max_level(2)
+                    .num_edges(4)
+                    .ef_construction(16),
+                PQBuildParams {
+                    num_sub_vectors: 2,
+                    num_bits: 4,
+                    max_iters: 2,
+                    sample_rate: 2,
+                    ..Default::default()
+                }
             ),
             VectorIndexParams::with_ivf_hnsw_sq_params(
                 MetricType::L2,
                 IvfBuildParams::new(2),
-                HnswBuildParams::default(),
+                HnswBuildParams::default()
+                    .max_level(2)
+                    .num_edges(4)
+                    .ef_construction(16),
                 SQBuildParams::default()
             )
         )]
@@ -10229,13 +10249,13 @@ mod test {
             ArrowField::new("vector", fixed_size_list_type(2, DataType::Float32), true),
         ]));
 
-        let vector_values = Float32Array::from_iter_values((0..600).map(|x| x as f32));
+        let vector_values = Float32Array::from_iter_values((0..64).map(|x| x as f32));
 
         let batches = vec![
             RecordBatch::try_new(
                 schema.clone(),
                 vec![
-                    Arc::new(Int32Array::from_iter_values(0..300)),
+                    Arc::new(Int32Array::from_iter_values(0..32)),
                     Arc::new(FixedSizeListArray::try_new_from_values(vector_values, 2).unwrap()),
                 ],
             )
@@ -10244,7 +10264,7 @@ mod test {
 
         let write_params = WriteParams {
             data_storage_version: Some(data_storage_version),
-            max_rows_per_file: 300, // At least two files to make sure stable row ids make a difference
+            max_rows_per_file: 16, // At least two files to make sure stable row ids make a difference
             enable_stable_row_ids: stable_row_ids,
             ..Default::default()
         };
@@ -10262,8 +10282,8 @@ mod test {
         let mut scan = dataset.scan();
         scan.filter("filterable > 5").unwrap();
         scan.nearest("vector", query_key.as_ref(), 1).unwrap();
-        scan.minimum_nprobes(100);
-        scan.ef(100);
+        scan.minimum_nprobes(2);
+        scan.ef(16);
         scan.approx_mode(approx_mode);
         scan.with_row_id();
 

--- a/rust/lance/src/index/append.rs
+++ b/rust/lance/src/index/append.rs
@@ -2380,29 +2380,37 @@ mod tests {
     #[tokio::test]
     async fn test_query_delta_indices(
         #[values(
-            VectorIndexParams::ivf_pq(2, 8, 4, MetricType::L2, 2),
+            VectorIndexParams::ivf_pq(2, 4, 2, MetricType::L2, 2),
             VectorIndexParams::ivf_rq(2, 1, MetricType::L2),
             VectorIndexParams::ivf_hnsw(
                 MetricType::L2,
                 IvfBuildParams::new(2),
                 HnswBuildParams {
-                    max_level: 3,
-                    m: 12,
-                    ef_construction: 80,
+                    max_level: 2,
+                    m: 4,
+                    ef_construction: 16,
                     prefetch_distance: Some(1),
                 }
             ),
             VectorIndexParams::with_ivf_hnsw_pq_params(
                 MetricType::L2,
-                IvfBuildParams::new(2),
+                IvfBuildParams {
+                    num_partitions: Some(2),
+                    max_iters: 2,
+                    sample_rate: 2,
+                    ..Default::default()
+                },
                 HnswBuildParams {
-                    max_level: 3,
-                    m: 12,
-                    ef_construction: 80,
+                    max_level: 2,
+                    m: 4,
+                    ef_construction: 16,
                     prefetch_distance: Some(1),
                 },
                 PQBuildParams {
-                    num_sub_vectors: 4,
+                    num_sub_vectors: 2,
+                    num_bits: 4,
+                    max_iters: 2,
+                    sample_rate: 2,
                     ..Default::default()
                 }
             ),
@@ -2410,9 +2418,9 @@ mod tests {
                 MetricType::L2,
                 IvfBuildParams::new(2),
                 HnswBuildParams {
-                    max_level: 3,
-                    m: 12,
-                    ef_construction: 80,
+                    max_level: 2,
+                    m: 4,
+                    ef_construction: 16,
                     prefetch_distance: Some(1),
                 },
                 SQBuildParams::default()
@@ -2420,9 +2428,9 @@ mod tests {
         )]
         index_params: VectorIndexParams,
     ) {
-        const DIM: usize = 64;
-        const INITIAL_ROWS: usize = 1000;
-        const APPENDED_ROWS: usize = 64;
+        const DIM: usize = 8;
+        const INITIAL_ROWS: usize = 64;
+        const APPENDED_ROWS: usize = 16;
 
         let test_dir = TempStrDir::default();
         let test_uri = test_dir.as_str();

--- a/rust/lance/src/index/vector.rs
+++ b/rust/lance/src/index/vector.rs
@@ -2264,25 +2264,27 @@ mod tests {
         let uri = format!("{}/ds", test_dir.as_str());
 
         let reader = lance_datagen::gen_batch()
-            .col("vector", array::rand_vec::<Float32Type>(32.into()))
-            .into_reader_rows(RowCount::from(400), BatchCount::from(1));
+            .col("vector", array::rand_vec::<Float32Type>(8.into()))
+            .into_reader_rows(RowCount::from(64), BatchCount::from(1));
         let mut dataset = Dataset::write(reader, &uri, None).await.unwrap();
 
         let params = VectorIndexParams::with_ivf_hnsw_pq_params(
             MetricType::L2,
             IvfBuildParams {
-                num_partitions: Some(8),
+                num_partitions: Some(2),
+                max_iters: 2,
+                sample_rate: 2,
                 ..Default::default()
             },
-            HnswBuildParams {
-                max_level: 6,
-                m: 24,
-                ef_construction: 120,
-                prefetch_distance: None,
-            },
+            HnswBuildParams::default()
+                .max_level(2)
+                .num_edges(4)
+                .ef_construction(16),
             PQBuildParams {
-                num_sub_vectors: 8,
-                num_bits: 8,
+                num_sub_vectors: 2,
+                num_bits: 4,
+                max_iters: 2,
+                sample_rate: 2,
                 ..Default::default()
             },
         );
@@ -3406,29 +3408,33 @@ mod tests {
         let source_uri = format!("{}/source", test_dir.as_str());
         let target_uri = format!("{}/target", test_dir.as_str());
 
-        // Create source dataset with vector column (need at least 256 rows for PQ training)
+        // A 4-bit PQ codebook needs at least 16 training rows.
         let source_reader = lance_datagen::gen_batch()
             .col("id", array::step::<Int32Type>())
-            .col("vector", array::rand_vec::<Float32Type>(32.into()))
-            .into_reader_rows(RowCount::from(400), BatchCount::from(1));
+            .col("vector", array::rand_vec::<Float32Type>(8.into()))
+            .into_reader_rows(RowCount::from(64), BatchCount::from(1));
         let mut source_dataset = Dataset::write(source_reader, &source_uri, None)
             .await
             .unwrap();
 
         // Create IVF_HNSW_PQ index on source with custom HNSW parameters
         let ivf_params = IvfBuildParams {
-            num_partitions: Some(8),
+            num_partitions: Some(2),
+            max_iters: 2,
+            sample_rate: 2,
             ..Default::default()
         };
         let hnsw_params = HnswBuildParams {
-            max_level: 6,
-            m: 24,
-            ef_construction: 120,
+            max_level: 2,
+            m: 4,
+            ef_construction: 16,
             prefetch_distance: None,
         };
         let pq_params = PQBuildParams {
-            num_sub_vectors: 8,
-            num_bits: 8,
+            num_sub_vectors: 2,
+            num_bits: 4,
+            max_iters: 2,
+            sample_rate: 2,
             ..Default::default()
         };
         let params = VectorIndexParams::with_ivf_hnsw_pq_params(
@@ -3460,8 +3466,8 @@ mod tests {
         // Create target dataset with same schema
         let target_reader = lance_datagen::gen_batch()
             .col("id", array::step::<Int32Type>())
-            .col("vector", array::rand_vec::<Float32Type>(32.into()))
-            .into_reader_rows(RowCount::from(100), BatchCount::from(1));
+            .col("vector", array::rand_vec::<Float32Type>(8.into()))
+            .into_reader_rows(RowCount::from(32), BatchCount::from(1));
         let mut target_dataset = Dataset::write(target_reader, &target_uri, None)
             .await
             .unwrap();
@@ -3508,8 +3514,8 @@ mod tests {
         // Check number of partitions
         assert_eq!(
             stats.get("num_partitions").and_then(|v| v.as_u64()),
-            Some(8),
-            "Should have 8 partitions"
+            Some(2),
+            "Should have 2 partitions"
         );
 
         // Verify centroids are shared between source and target indices
@@ -3570,13 +3576,13 @@ mod tests {
         // Verify PQ parameters
         assert_eq!(
             sub_index.get("nbits").and_then(|v| v.as_u64()),
-            Some(8),
-            "PQ should use 8 bits"
+            Some(4),
+            "PQ should use 4 bits"
         );
         assert_eq!(
             sub_index.get("num_sub_vectors").and_then(|v| v.as_u64()),
-            Some(8),
-            "PQ should have 8 sub vectors"
+            Some(2),
+            "PQ should have 2 sub vectors"
         );
 
         // Verify IVF parameters are correctly derived
@@ -3588,8 +3594,8 @@ mod tests {
         );
         assert_eq!(
             target_ivf_params.num_partitions,
-            Some(8),
-            "Should have 8 partitions as configured"
+            Some(2),
+            "Should have 2 partitions as configured"
         );
 
         // Verify PQ parameters are correctly derived
@@ -3610,29 +3616,29 @@ mod tests {
             "PQ num_bits should match"
         );
         assert_eq!(
-            target_pq_params.num_sub_vectors, 8,
-            "PQ should have 8 sub vectors"
+            target_pq_params.num_sub_vectors, 2,
+            "PQ should have 2 sub vectors"
         );
-        assert_eq!(target_pq_params.num_bits, 8, "PQ should use 8 bits");
+        assert_eq!(target_pq_params.num_bits, 4, "PQ should use 4 bits");
 
         // Verify HNSW parameters are extracted and used correctly
         let derived_hnsw_params = derive_hnsw_params(target_vector_index.as_ref());
         assert_eq!(
-            derived_hnsw_params.max_level, 6,
-            "HNSW max_level should be extracted as 6 from source index"
+            derived_hnsw_params.max_level, 2,
+            "HNSW max_level should be extracted as 2 from source index"
         );
         assert_eq!(
-            derived_hnsw_params.m, 24,
-            "HNSW m should be extracted as 24 from source index"
+            derived_hnsw_params.m, 4,
+            "HNSW m should be extracted as 4 from source index"
         );
         assert_eq!(
-            derived_hnsw_params.ef_construction, 120,
-            "HNSW ef_construction should be extracted as 120 from source index"
+            derived_hnsw_params.ef_construction, 16,
+            "HNSW ef_construction should be extracted as 16 from source index"
         );
 
         // Verify the index is functional
         let query_vector = lance_datagen::gen_batch()
-            .anon_col(array::rand_vec::<Float32Type>(32.into()))
+            .anon_col(array::rand_vec::<Float32Type>(8.into()))
             .into_batch_rows(RowCount::from(1))
             .unwrap()
             .column(0)

--- a/rust/lance/src/index/vector/ivf.rs
+++ b/rust/lance/src/index/vector/ivf.rs
@@ -5255,7 +5255,15 @@ mod tests {
         test_uri: &str,
         range: Range<f32>,
     ) -> (Dataset, Arc<FixedSizeListArray>) {
-        let vectors = generate_random_array_with_range::<Float32Type>(1000 * DIM, range);
+        generate_test_dataset_with_rows(test_uri, range, 1000).await
+    }
+
+    async fn generate_test_dataset_with_rows(
+        test_uri: &str,
+        range: Range<f32>,
+        num_rows: usize,
+    ) -> (Dataset, Arc<FixedSizeListArray>) {
+        let vectors = generate_random_array_with_range::<Float32Type>(num_rows * DIM, range);
         let metadata: HashMap<String, String> = vec![("test".to_string(), "ivf_pq".to_string())]
             .into_iter()
             .collect();
@@ -5586,6 +5594,32 @@ mod tests {
         }
     }
 
+    fn fast_ivf_params(num_partitions: usize) -> IvfBuildParams {
+        IvfBuildParams {
+            num_partitions: Some(num_partitions),
+            max_iters: 2,
+            sample_rate: 2,
+            ..Default::default()
+        }
+    }
+
+    fn fast_pq_params(num_sub_vectors: usize, num_bits: usize) -> PQBuildParams {
+        PQBuildParams {
+            num_sub_vectors,
+            num_bits,
+            max_iters: 2,
+            sample_rate: 2,
+            ..Default::default()
+        }
+    }
+
+    fn fast_hnsw_params() -> HnswBuildParams {
+        HnswBuildParams::default()
+            .max_level(3)
+            .num_edges(8)
+            .ef_construction(32)
+    }
+
     // Clippy doesn't like that all start with Ivf but we might have some in the future
     // that _don't_ start with Ivf so I feel it is meaningful to keep the prefix
     #[allow(clippy::enum_variant_names)]
@@ -5624,13 +5658,13 @@ mod tests {
         num_partitions: 2,
         metric_type: MetricType::Dot,
         dimension: 16,
-        index_type: TestIndexType::IvfHnswPq { pq: TestPqParams::small(), num_edges: 100 },
+        index_type: TestIndexType::IvfHnswPq { pq: TestPqParams::small(), num_edges: 4 },
     })]
     #[case::ivf_hnsw_sq(CreateIndexCase {
         metric_type: MetricType::Dot,
         num_partitions: 2,
         dimension: 16,
-        index_type: TestIndexType::IvfHnswSq { num_edges: 100 },
+        index_type: TestIndexType::IvfHnswSq { num_edges: 4 },
     })]
     async fn test_create_index_nulls(
         #[case] test_case: CreateIndexCase,
@@ -5642,36 +5676,37 @@ mod tests {
         let mut index_params = match test_case.index_type {
             TestIndexType::IvfPq { pq } => VectorIndexParams::with_ivf_pq_params(
                 test_case.metric_type,
-                IvfBuildParams::new(test_case.num_partitions),
-                PQBuildParams::new(pq.num_sub_vectors, pq.num_bits),
+                fast_ivf_params(test_case.num_partitions),
+                fast_pq_params(pq.num_sub_vectors, pq.num_bits),
             ),
             TestIndexType::IvfHnswPq { pq, num_edges } => {
                 VectorIndexParams::with_ivf_hnsw_pq_params(
                     test_case.metric_type,
-                    IvfBuildParams::new(test_case.num_partitions),
-                    HnswBuildParams::default().num_edges(num_edges),
-                    PQBuildParams::new(pq.num_sub_vectors, pq.num_bits),
+                    fast_ivf_params(test_case.num_partitions),
+                    fast_hnsw_params().num_edges(num_edges),
+                    fast_pq_params(pq.num_sub_vectors, pq.num_bits),
                 )
             }
-            TestIndexType::IvfFlat => {
-                VectorIndexParams::ivf_flat(test_case.num_partitions, test_case.metric_type)
-            }
+            TestIndexType::IvfFlat => VectorIndexParams::with_ivf_flat_params(
+                test_case.metric_type,
+                fast_ivf_params(test_case.num_partitions),
+            ),
             TestIndexType::IvfHnswSq { num_edges } => VectorIndexParams::with_ivf_hnsw_sq_params(
                 test_case.metric_type,
-                IvfBuildParams::new(test_case.num_partitions),
-                HnswBuildParams::default().num_edges(num_edges),
+                fast_ivf_params(test_case.num_partitions),
+                fast_hnsw_params().num_edges(num_edges),
                 SQBuildParams::default(),
             ),
         };
         index_params.version(index_version);
 
-        let nrows = 2_000;
+        let nrows = 512_usize;
         let data = gen_batch()
             .col(
                 "vec",
                 array::rand_vec::<Float32Type>(Dimension::from(test_case.dimension as u32)),
             )
-            .into_batch_rows(RowCount::from(nrows))
+            .into_batch_rows(RowCount::from(nrows as u64))
             .unwrap();
 
         // Make every other row null
@@ -5704,9 +5739,9 @@ mod tests {
             .collect::<Float32Array>();
         let results = dataset
             .scan()
-            .nearest("vec", &query, 2_000)
+            .nearest("vec", &query, nrows)
             .unwrap()
-            .ef(100_000)
+            .ef(nrows)
             .minimum_nprobes(2)
             .try_into_batch()
             .await
@@ -5715,10 +5750,10 @@ mod tests {
         if is_approximate {
             let recall = results.num_rows() as f32 / num_non_null as f32;
             assert!(
-                recall >= 0.99,
+                recall >= 0.5,
                 "Recall {} below threshold {} ({}/{})",
                 recall,
-                0.99,
+                0.5,
                 results.num_rows(),
                 num_non_null,
             );
@@ -6502,12 +6537,13 @@ mod tests {
         let test_dir = TempStrDir::default();
         let test_uri = test_dir.as_str();
 
-        let nlist = 4;
-        let (mut dataset, vector_array) = generate_test_dataset(test_uri, 0.0..1.0).await;
+        let nlist = 2;
+        let (mut dataset, vector_array) =
+            generate_test_dataset_with_rows(test_uri, 0.0..1.0, 512).await;
 
-        let ivf_params = IvfBuildParams::new(nlist);
-        let pq_params = PQBuildParams::default();
-        let hnsw_params = HnswBuildParams::default();
+        let ivf_params = fast_ivf_params(nlist);
+        let pq_params = fast_pq_params(4, 8);
+        let hnsw_params = fast_hnsw_params();
         let params = VectorIndexParams::with_ivf_hnsw_pq_params(
             MetricType::L2,
             ivf_params,
@@ -6522,23 +6558,20 @@ mod tests {
 
         let query = vector_array.value(0);
         let query = query.as_primitive::<Float32Type>();
-        let k = 100;
+        let k = 20;
         let results = dataset
             .scan()
             .with_row_id()
             .nearest("vector", query, k)
             .unwrap()
             .minimum_nprobes(nlist)
-            .try_into_stream()
-            .await
-            .unwrap()
-            .try_collect::<Vec<_>>()
+            .ef(64)
+            .try_into_batch()
             .await
             .unwrap();
-        assert_eq!(1, results.len());
-        assert_eq!(k, results[0].num_rows());
+        assert_eq!(k, results.num_rows());
 
-        let row_ids = results[0]
+        let row_ids = results
             .column_by_name(ROW_ID)
             .unwrap()
             .as_any()
@@ -6547,7 +6580,7 @@ mod tests {
             .iter()
             .map(|v| v.unwrap() as u32)
             .collect::<Vec<_>>();
-        let dists = results[0]
+        let dists = results
             .column_by_name("_distance")
             .unwrap()
             .as_any()
@@ -6561,10 +6594,19 @@ mod tests {
 
         let results_set = results.iter().map(|r| r.1).collect::<HashSet<_>>();
         let gt_set = gt.iter().map(|r| r.1).collect::<HashSet<_>>();
+        assert_eq!(results_set.len(), k, "search returned duplicate row ids");
+        assert!(
+            results.iter().all(|(distance, _)| distance.is_finite()),
+            "search returned a non-finite distance: {results:?}"
+        );
+        assert!(
+            results.windows(2).all(|pair| pair[0].0 <= pair[1].0),
+            "search distances are not sorted: {results:?}"
+        );
 
         let recall = results_set.intersection(&gt_set).count() as f32 / k as f32;
         assert!(
-            recall >= 0.9,
+            recall >= 0.5,
             "recall: {}\n results: {:?}\n\ngt: {:?}",
             recall,
             results,

--- a/rust/lance/src/index/vector/ivf/io.rs
+++ b/rust/lance/src/index/vector/ivf/io.rs
@@ -975,10 +975,10 @@ mod tests {
             return;
         };
 
-        const DIM: usize = 32;
-        const ROWS: usize = 1024;
-        const NLIST: usize = 4;
-        const NUM_BUILDS: usize = 3;
+        const DIM: usize = 8;
+        const ROWS: usize = 256;
+        const NLIST: usize = 2;
+        const NUM_BUILDS: usize = 2;
 
         // Keep the dataset out of the temp dir's `.tmp*` namespace so the parent
         // never confuses it with a leaked scratch directory.
@@ -996,6 +996,24 @@ mod tests {
             .await
             .unwrap();
 
+        let ivf_params = IvfBuildParams {
+            num_partitions: Some(NLIST),
+            max_iters: 2,
+            sample_rate: 2,
+            ..Default::default()
+        };
+        let hnsw_params = HnswBuildParams::default()
+            .max_level(2)
+            .num_edges(4)
+            .ef_construction(16);
+        let pq_params = PQBuildParams {
+            num_sub_vectors: 2,
+            num_bits: 8,
+            max_iters: 2,
+            sample_rate: 2,
+            ..Default::default()
+        };
+
         for _ in 0..NUM_BUILDS {
             crate::index::vector::ivf::build_ivf_hnsw_pq_index(
                 &ds,
@@ -1003,9 +1021,9 @@ mod tests {
                 "idx",
                 uuid::Uuid::new_v4(),
                 MetricType::L2,
-                &IvfBuildParams::new(NLIST),
-                &HnswBuildParams::default(),
-                &PQBuildParams::new(4, 8),
+                &ivf_params,
+                &hnsw_params,
+                &pq_params,
             )
             .await
             .unwrap();

--- a/rust/lance/src/index/vector/ivf/v2.rs
+++ b/rust/lance/src/index/vector/ivf/v2.rs
@@ -2112,6 +2112,11 @@ mod tests {
 
     const NUM_ROWS: usize = 512;
     const DIM: usize = 32;
+    // An 8-bit PQ codebook has 256 centroids, so this is the smallest valid
+    // training fixture shared by the 8-bit and 4-bit runtime cases.
+    const LIGHTWEIGHT_PQ_ROWS: usize = 256;
+    const LIGHTWEIGHT_PQ_PARTITIONS: usize = 2;
+    const LIGHTWEIGHT_PQ_SUB_VECTORS: usize = 4;
 
     lance_testing::define_stage_event_progress!(RecordingProgress, IndexBuildProgress, Result<()>);
 
@@ -2577,12 +2582,175 @@ mod tests {
 
     fn lightweight_pq_params() -> PQBuildParams {
         PQBuildParams {
-            num_sub_vectors: 4,
+            num_sub_vectors: LIGHTWEIGHT_PQ_SUB_VECTORS,
             num_bits: 4,
             max_iters: 2,
             sample_rate: 16,
             ..Default::default()
         }
+    }
+
+    fn lightweight_pq_params_with_bits(num_bits: usize) -> PQBuildParams {
+        PQBuildParams {
+            num_sub_vectors: LIGHTWEIGHT_PQ_SUB_VECTORS,
+            num_bits,
+            max_iters: 2,
+            sample_rate: 16,
+            ..Default::default()
+        }
+    }
+
+    fn lightweight_hnsw_params() -> HnswBuildParams {
+        HnswBuildParams::default()
+            .max_level(2)
+            .num_edges(4)
+            .ef_construction(16)
+    }
+
+    fn make_seeded_vector_batch(num_rows: usize) -> (RecordBatch, SchemaRef) {
+        let batch = lance_datagen::gen_batch()
+            .with_seed(lance_datagen::Seed::from(42))
+            .col("id", lance_datagen::array::step::<UInt64Type>())
+            .col(
+                "vector",
+                lance_datagen::array::rand_vec::<Float32Type>((DIM as u32).into()),
+            )
+            .into_batch_rows(lance_datagen::RowCount::from(num_rows as u64))
+            .unwrap();
+        let schema = batch.schema();
+        (batch, schema)
+    }
+
+    async fn search_lightweight_pq_index(
+        dataset: &Dataset,
+        query: &dyn Array,
+        k: usize,
+        num_partitions: usize,
+        refine_factor: u32,
+        ef: usize,
+    ) -> RecordBatch {
+        dataset
+            .scan()
+            .nearest("vector", query, k)
+            .unwrap()
+            .minimum_nprobes(num_partitions)
+            .ef(ef)
+            .refine(refine_factor)
+            .with_row_id()
+            .try_into_batch()
+            .await
+            .unwrap()
+    }
+
+    async fn assert_lightweight_pq_index(
+        distance_type: DistanceType,
+        num_bits: usize,
+        use_hnsw: bool,
+    ) {
+        const INDEX_NAME: &str = "test_index";
+        const K: usize = 10;
+
+        let test_dir = TempStrDir::default();
+        let (batch, schema) = make_seeded_vector_batch(LIGHTWEIGHT_PQ_ROWS);
+        let vectors = batch["vector"].as_fixed_size_list().clone();
+        let batches = RecordBatchIterator::new(vec![Ok(batch)], schema);
+        let mut dataset = Dataset::write(batches, test_dir.as_str(), None)
+            .await
+            .unwrap();
+
+        let mut ivf_params = IvfBuildParams::new(LIGHTWEIGHT_PQ_PARTITIONS);
+        ivf_params.max_iters = 2;
+        ivf_params.sample_rate = 16;
+        let pq_params = lightweight_pq_params_with_bits(num_bits);
+        let params = if use_hnsw {
+            VectorIndexParams::with_ivf_hnsw_pq_params(
+                distance_type,
+                ivf_params,
+                lightweight_hnsw_params(),
+                pq_params,
+            )
+        } else {
+            VectorIndexParams::with_ivf_pq_params(distance_type, ivf_params, pq_params)
+        };
+        dataset
+            .create_index(
+                &["vector"],
+                IndexType::Vector,
+                Some(INDEX_NAME.to_owned()),
+                &params,
+                true,
+            )
+            .await
+            .unwrap();
+
+        let stats_json = dataset.index_statistics(INDEX_NAME).await.unwrap();
+        let stats: serde_json::Value = serde_json::from_str(&stats_json).unwrap();
+        let expected_index_type = if use_hnsw { "IVF_HNSW_PQ" } else { "IVF_PQ" };
+        let expected_sub_index = if use_hnsw { "HNSW" } else { "PQ" };
+        assert_eq!(stats["index_type"], expected_index_type);
+        assert_eq!(
+            stats["indices"][0]["num_partitions"],
+            LIGHTWEIGHT_PQ_PARTITIONS
+        );
+        assert_eq!(
+            stats["indices"][0]["sub_index"]["index_type"],
+            expected_sub_index
+        );
+        assert_eq!(stats["indices"][0]["sub_index"]["nbits"], num_bits);
+        assert_eq!(
+            stats["indices"][0]["sub_index"]["num_sub_vectors"],
+            LIGHTWEIGHT_PQ_SUB_VECTORS
+        );
+        if use_hnsw {
+            let hnsw_params = &stats["indices"][0]["sub_index"]["params"];
+            assert_eq!(hnsw_params["max_level"], 2);
+            assert_eq!(hnsw_params["m"], 4);
+            assert_eq!(hnsw_params["ef_construction"], 16);
+        }
+
+        let query = vectors.value(0);
+        let ground_truth = ground_truth(&dataset, "vector", query.as_ref(), K, distance_type).await;
+        let before_reopen = search_lightweight_pq_index(
+            &dataset,
+            query.as_ref(),
+            K,
+            LIGHTWEIGHT_PQ_PARTITIONS,
+            4,
+            64,
+        )
+        .await;
+        assert_eq!(before_reopen.num_rows(), K);
+        let row_ids = before_reopen[ROW_ID].as_primitive::<UInt64Type>().values();
+        assert_eq!(row_ids.iter().copied().collect::<HashSet<_>>().len(), K);
+        let distances = before_reopen[DIST_COL]
+            .as_primitive::<Float32Type>()
+            .values();
+        assert!(distances.iter().all(|distance| distance.is_finite()));
+        assert!(distances.windows(2).all(|pair| pair[0] <= pair[1]));
+        let recall = row_ids
+            .iter()
+            .filter(|row_id| ground_truth.contains(row_id))
+            .count() as f32
+            / K as f32;
+        assert_ge!(recall, 0.5, "recall: {recall}");
+
+        drop(dataset);
+        let reopened = Dataset::open(test_dir.as_str()).await.unwrap();
+        let reopened_stats: serde_json::Value =
+            serde_json::from_str(&reopened.index_statistics(INDEX_NAME).await.unwrap()).unwrap();
+        assert_eq!(reopened_stats, stats);
+        assert_eq!(
+            search_lightweight_pq_index(
+                &reopened,
+                query.as_ref(),
+                K,
+                LIGHTWEIGHT_PQ_PARTITIONS,
+                4,
+                64,
+            )
+            .await,
+            before_reopen
+        );
     }
 
     async fn load_vector_index_context(
@@ -3017,10 +3185,19 @@ mod tests {
         schema: Arc<Schema>,
         batches: Vec<RecordBatch>,
     ) -> Dataset {
+        write_dataset_from_batches_with_max_rows(test_uri, schema, batches, 500).await
+    }
+
+    async fn write_dataset_from_batches_with_max_rows(
+        test_uri: &str,
+        schema: Arc<Schema>,
+        batches: Vec<RecordBatch>,
+        max_rows_per_file: usize,
+    ) -> Dataset {
         let batches = RecordBatchIterator::new(batches.into_iter().map(Ok), schema);
 
         let write_params = WriteParams {
-            max_rows_per_file: 500,
+            max_rows_per_file,
             mode: WriteMode::Overwrite,
             ..Default::default()
         };
@@ -3033,6 +3210,30 @@ mod tests {
     async fn prepare_global_ivf_pq(
         dataset: &Dataset,
         vector_column: &str,
+    ) -> (IvfBuildParams, PQBuildParams) {
+        prepare_ivf_pq(
+            dataset,
+            vector_column,
+            TWO_FRAG_DIM,
+            TWO_FRAG_NUM_PARTITIONS,
+            TWO_FRAG_NUM_SUBVECTORS,
+            TWO_FRAG_NUM_BITS,
+            TWO_FRAG_MAX_ITERS,
+            TWO_FRAG_SAMPLE_RATE,
+        )
+        .await
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    async fn prepare_ivf_pq(
+        dataset: &Dataset,
+        vector_column: &str,
+        expected_dimension: usize,
+        num_partitions: usize,
+        num_sub_vectors: usize,
+        num_bits: usize,
+        max_iters: u32,
+        sample_rate: usize,
     ) -> (IvfBuildParams, PQBuildParams) {
         let batch = dataset
             .scan()
@@ -3047,39 +3248,33 @@ mod tests {
             .as_fixed_size_list();
 
         let dim = vectors.value_length() as usize;
-        assert_eq!(dim, TWO_FRAG_DIM, "unexpected vector dimension");
+        assert_eq!(dim, expected_dimension, "unexpected vector dimension");
 
         let values = vectors.values().as_primitive::<Float32Type>();
 
-        let kmeans_params = KMeansParams::new(None, TWO_FRAG_MAX_ITERS, 1, DistanceType::L2);
-        let kmeans = train_kmeans::<Float32Type>(
-            values,
-            kmeans_params,
-            dim,
-            TWO_FRAG_NUM_PARTITIONS,
-            TWO_FRAG_SAMPLE_RATE,
-        )
-        .unwrap();
+        let kmeans_params = KMeansParams::new(None, max_iters, 1, DistanceType::L2);
+        let kmeans =
+            train_kmeans::<Float32Type>(values, kmeans_params, dim, num_partitions, sample_rate)
+                .unwrap();
 
         let centroids_flat = kmeans.centroids.as_primitive::<Float32Type>().clone();
         let centroids_fsl =
             Arc::new(FixedSizeListArray::try_new_from_values(centroids_flat, dim as i32).unwrap());
         let mut ivf_params =
-            IvfBuildParams::try_with_centroids(TWO_FRAG_NUM_PARTITIONS, centroids_fsl).unwrap();
-        ivf_params.max_iters = TWO_FRAG_MAX_ITERS as usize;
-        ivf_params.sample_rate = TWO_FRAG_SAMPLE_RATE;
+            IvfBuildParams::try_with_centroids(num_partitions, centroids_fsl).unwrap();
+        ivf_params.max_iters = max_iters as usize;
+        ivf_params.sample_rate = sample_rate;
 
-        let mut pq_train_params = PQBuildParams::new(TWO_FRAG_NUM_SUBVECTORS, TWO_FRAG_NUM_BITS);
-        pq_train_params.max_iters = TWO_FRAG_MAX_ITERS as usize;
-        pq_train_params.sample_rate = TWO_FRAG_SAMPLE_RATE;
+        let mut pq_train_params = PQBuildParams::new(num_sub_vectors, num_bits);
+        pq_train_params.max_iters = max_iters as usize;
+        pq_train_params.sample_rate = sample_rate;
 
         let pq = pq_train_params.build(vectors, DistanceType::L2).unwrap();
         let codebook_flat = pq.codebook.values().as_primitive::<Float32Type>().clone();
         let pq_codebook: ArrayRef = Arc::new(codebook_flat);
-        let mut pq_params =
-            PQBuildParams::with_codebook(TWO_FRAG_NUM_SUBVECTORS, TWO_FRAG_NUM_BITS, pq_codebook);
-        pq_params.max_iters = TWO_FRAG_MAX_ITERS as usize;
-        pq_params.sample_rate = TWO_FRAG_SAMPLE_RATE;
+        let mut pq_params = PQBuildParams::with_codebook(num_sub_vectors, num_bits, pq_codebook);
+        pq_params.max_iters = max_iters as usize;
+        pq_params.sample_rate = sample_rate;
 
         (ivf_params, pq_params)
     }
@@ -3818,9 +4013,21 @@ mod tests {
     async fn test_merge_existing_hnsw_segments_rebuilds_graph(#[case] expected_index_type: &str) {
         let test_dir = TempStrDir::default();
         let base_uri = test_dir.as_str();
-        let (schema, batches) = make_two_fragment_batches();
+        let (schema, batches, max_rows_per_file) = if expected_index_type == "IVF_HNSW_PQ" {
+            let (batch, schema) = make_seeded_vector_batch(LIGHTWEIGHT_PQ_ROWS * 2);
+            (schema, vec![batch], LIGHTWEIGHT_PQ_ROWS)
+        } else {
+            let (schema, batches) = make_two_fragment_batches();
+            (schema, batches, 500)
+        };
         let dataset_uri = format!("{}/merge_hnsw_rebuilds_graph", base_uri);
-        let mut dataset = write_dataset_from_batches(&dataset_uri, schema, batches).await;
+        let mut dataset = write_dataset_from_batches_with_max_rows(
+            &dataset_uri,
+            schema,
+            batches,
+            max_rows_per_file,
+        )
+        .await;
 
         let fragments = dataset.get_fragments();
         assert!(fragments.len() >= 2);
@@ -3831,11 +4038,21 @@ mod tests {
                 HnswBuildParams::default(),
             ),
             "IVF_HNSW_PQ" => {
-                let (ivf_params, pq_params) = prepare_global_ivf_pq(&dataset, "vector").await;
+                let (ivf_params, pq_params) = prepare_ivf_pq(
+                    &dataset,
+                    "vector",
+                    DIM,
+                    LIGHTWEIGHT_PQ_PARTITIONS,
+                    LIGHTWEIGHT_PQ_SUB_VECTORS,
+                    8,
+                    2,
+                    16,
+                )
+                .await;
                 VectorIndexParams::with_ivf_hnsw_pq_params(
                     DistanceType::L2,
                     ivf_params,
-                    HnswBuildParams::default(),
+                    lightweight_hnsw_params(),
                     pq_params,
                 )
             }
@@ -4510,26 +4727,12 @@ mod tests {
     }
 
     #[rstest]
-    // Temporarily disable recall checks for 4-bit PQ.
-    #[case(4, DistanceType::L2, 0.0)]
-    #[case(4, DistanceType::Cosine, 0.0)]
-    #[case(4, DistanceType::Dot, 0.0)]
+    #[case::l2(DistanceType::L2)]
+    #[case::cosine(DistanceType::Cosine)]
+    #[case::dot(DistanceType::Dot)]
     #[tokio::test]
-    async fn test_build_ivf_pq_4bit(
-        #[case] nlist: usize,
-        #[case] distance_type: DistanceType,
-        #[case] recall_requirement: f32,
-    ) {
-        let ivf_params = IvfBuildParams::new(nlist);
-        let pq_params = PQBuildParams::new(32, 4);
-        let params = VectorIndexParams::with_ivf_pq_params(distance_type, ivf_params, pq_params);
-        test_index(params.clone(), nlist, recall_requirement, None).await;
-        if distance_type == DistanceType::Cosine {
-            test_index_multivec(params.clone(), nlist, recall_requirement).await;
-        }
-        // PQ performs worse on farther vectors, so if we delete the many nearest vectors, the recall will be lower
-        // lower the recall requirement in remap case for PQ, because it deletes half of the vectors
-        test_remap(params, nlist, recall_requirement * 0.9).await;
+    async fn test_build_ivf_pq_4bit(#[case] distance_type: DistanceType) {
+        assert_lightweight_pq_index(distance_type, 4, false).await;
     }
 
     #[rstest]
@@ -4754,57 +4957,84 @@ mod tests {
     }
 
     #[rstest]
-    #[case(4, DistanceType::L2, 0.9)]
-    #[case(4, DistanceType::Cosine, 0.9)]
-    #[case(4, DistanceType::Dot, 0.85)]
+    #[case::l2(DistanceType::L2)]
+    #[case::cosine(DistanceType::Cosine)]
+    #[case::dot(DistanceType::Dot)]
     #[tokio::test]
-    async fn test_create_ivf_hnsw_pq(
-        #[case] nlist: usize,
-        #[case] distance_type: DistanceType,
-        #[case] recall_requirement: f32,
-    ) {
-        let ivf_params = IvfBuildParams::new(nlist);
-        let pq_params = PQBuildParams::default();
-        let hnsw_params = HnswBuildParams::default();
-        let params = VectorIndexParams::with_ivf_hnsw_pq_params(
-            distance_type,
-            ivf_params,
-            hnsw_params,
-            pq_params,
-        );
-        test_index(params.clone(), nlist, recall_requirement, None).await;
-        if distance_type == DistanceType::Cosine {
-            test_index_multivec(params.clone(), nlist, recall_requirement).await;
-        }
-        // PQ performs worse on farther vectors, so if we delete the many nearest vectors, the recall will be lower
-        // lower the recall requirement in remap case for PQ, because it deletes half of the vectors
-        test_remap(params, nlist, recall_requirement * 0.9).await;
+    async fn test_create_ivf_hnsw_pq(#[case] distance_type: DistanceType) {
+        assert_lightweight_pq_index(distance_type, 8, true).await;
     }
 
     #[rstest]
-    // Temporarily disable recall checks for 4-bit PQ.
-    #[case(4, DistanceType::L2, 0.0)]
-    #[case(4, DistanceType::Cosine, 0.0)]
-    #[case(4, DistanceType::Dot, 0.0)]
+    #[case::l2(DistanceType::L2)]
+    #[case::cosine(DistanceType::Cosine)]
+    #[case::dot(DistanceType::Dot)]
     #[tokio::test]
-    async fn test_create_ivf_hnsw_pq_4bit(
-        #[case] nlist: usize,
-        #[case] distance_type: DistanceType,
-        #[case] recall_requirement: f32,
-    ) {
-        let ivf_params = IvfBuildParams::new(nlist);
-        let pq_params = PQBuildParams::new(32, 4);
-        let hnsw_params = HnswBuildParams::default();
+    async fn test_create_ivf_hnsw_pq_4bit(#[case] distance_type: DistanceType) {
+        assert_lightweight_pq_index(distance_type, 4, true).await;
+    }
+
+    #[tokio::test]
+    async fn test_create_ivf_hnsw_pq_multivec() {
+        const NUM_ROWS: usize = 64;
+        const K: usize = 10;
+
+        let test_dir = TempStrDir::default();
+        let batch = lance_datagen::gen_batch()
+            .with_seed(lance_datagen::Seed::from(42))
+            .col("id", lance_datagen::array::step::<UInt64Type>())
+            .col(
+                "vector",
+                lance_datagen::array::cycle_vec_var(
+                    lance_datagen::array::rand_vec::<Float32Type>((DIM as u32).into()),
+                    3_u32.into(),
+                    4_u32.into(),
+                ),
+            )
+            .into_batch_rows(lance_datagen::RowCount::from(NUM_ROWS as u64))
+            .unwrap();
+        let vectors = batch["vector"].as_list::<i32>().clone();
+        let schema = batch.schema();
+        let batches = RecordBatchIterator::new(vec![Ok(batch)], schema);
+        let mut dataset = Dataset::write(batches, test_dir.as_str(), None)
+            .await
+            .unwrap();
+
+        let mut ivf_params = IvfBuildParams::new(1);
+        ivf_params.max_iters = 2;
+        ivf_params.sample_rate = 16;
         let params = VectorIndexParams::with_ivf_hnsw_pq_params(
-            distance_type,
+            DistanceType::Cosine,
             ivf_params,
-            hnsw_params,
-            pq_params,
+            lightweight_hnsw_params(),
+            lightweight_pq_params(),
         );
-        test_index(params.clone(), nlist, recall_requirement, None).await;
-        if distance_type == DistanceType::Cosine {
-            test_index_multivec(params, nlist, recall_requirement).await;
-        }
+        dataset
+            .create_index(&["vector"], IndexType::Vector, None, &params, true)
+            .await
+            .unwrap();
+
+        let query = vectors.value(0);
+        // Three vectors per query amplify the internal candidate k. This
+        // bounded budget covers all 64 * 3 vector entries in the fixture.
+        let result = search_lightweight_pq_index(&dataset, query.as_ref(), K, 1, 2, 256).await;
+        assert_eq!(result.num_rows(), K);
+        let row_ids = result[ROW_ID].as_primitive::<UInt64Type>().values();
+        assert_eq!(row_ids.iter().copied().collect::<HashSet<_>>().len(), K);
+        let distances = result[DIST_COL].as_primitive::<Float32Type>().values();
+        assert!(distances.iter().all(|distance| distance.is_finite()));
+        assert!(distances.windows(2).all(|pair| pair[0] <= pair[1]));
+
+        let ground_truth = multivec_ground_truth(&vectors, query.as_ref(), K, DistanceType::Cosine)
+            .into_iter()
+            .map(|(_, row_id)| row_id)
+            .collect::<HashSet<_>>();
+        let recall = row_ids
+            .iter()
+            .filter(|row_id| ground_truth.contains(row_id))
+            .count() as f32
+            / K as f32;
+        assert_ge!(recall, 0.5, "recall: {recall}");
     }
 
     // `lance-index` keeps these crate-private; spelling them out here also pins


### PR DESCRIPTION
## Performance issue

The existing IVF_HNSW_PQ and 4-bit IVF_PQ runtime coverage repeatedly builds large F32/F64, multivector, remap, and lifecycle fixtures with default PQ/HNSW training parameters. The feature is still exposed at the public API boundary, so this PR retains its runtime coverage instead of deleting it.

## How this improves the tests

- keep every existing L2/Cosine/Dot HNSW_PQ and 4-bit matrix case
- use deterministic minimum-sized fixtures: 256 rows for the 8-bit codebook, 2 IVF partitions, 4 subvectors, 2 training iterations, and small HNSW graphs
- assert recall >= 0.5, unique row IDs, finite/sorted distances, metadata, and reopen behavior
- retain focused multivector, remap/trim, append, prefilter, initialization, null, distributed merge, and scratch-directory coverage
- add a direct 4-bit bulk-distance oracle for the exact prefix, quantized middle, and exact tail
- make no production-code changes

## Test runtime

Lower is better. Measured on an Apple M4 Mac mini (10 cores, 24 GB), macOS 26.6.1, Rust 1.97.0, with prebuilt debug test binaries, `LANCE_CPU_THREADS=4`, and `--test-threads=1`. Results use one warm-up followed by three alternating baseline/current runs; the table reports the median. Baseline is `53b560d84`; this PR is `0b1cf3d17`.

| Scenario / metric | Baseline | This PR | Benefit |
| --- | ---: | ---: | ---: |
| Unique affected runtime workload (68 baseline-listed tests; 69 PR-listed tests plus the new bulk oracle) | 85.50 s | 5.45 s | 15.7x faster (80.05 s saved) |
| Tests matching `hnsw_pq` | 49.18 s | 1.62 s | 30.4x faster |
| 4-bit IVF_PQ 3-case matrix | 7.34 s | 0.11 s | 66.7x faster |
| Shared null/prefilter/append/remap/file-size filters | 41.59 s | 4.08 s | 10.2x faster |

The diagnostic rows overlap; only the first row is the non-overlapping total. The new direct 4-bit bulk oracle rounds to 0.00 s at the timer's 0.01 s resolution.

## Validation

- `hnsw_pq`: 24 passed, 1 intentionally ignored child process
- HNSW_PQ 8-bit matrix: 3 passed
- HNSW_PQ 4-bit matrix: 3 passed
- IVF_PQ 4-bit matrix: 3 passed
- focused multivector and PQ merge regressions
- null matrix: 10 passed
- ANN prefilter matrix: 32 passed
- delta append matrix: 5 passed
- remap/trim matrix: 6 passed
- initialization, file-size, legacy create, and scratch lifecycle tests
- direct 4-bit bulk-distance oracle
- `cargo fmt --all -- --check`
- `cargo clippy --all --tests --benches -- -D warnings`
- `git diff --check`
