### PR TITLE
test(encoding): reduce primitive value test matrix

### DIFF
--- a/rust/lance-encoding/src/encodings/physical/value.rs
+++ b/rust/lance-encoding/src/encodings/physical/value.rs
@@ -789,7 +789,7 @@ mod tests {
     };
     use arrow_buffer::{BooleanBuffer, NullBuffer, OffsetBuffer, ScalarBuffer};
     use arrow_schema::{DataType, Field, TimeUnit};
-    use lance_datagen::{ArrayGeneratorExt, Dimension, RowCount, array, gen_batch};
+    use lance_datagen::{ArrayGeneratorExt, Dimension, RowCount, Seed, array, gen_batch};
 
     use crate::{
         compression::{FixedPerValueDecompressor, MiniBlockDecompressor},
@@ -877,10 +877,27 @@ mod tests {
 
     #[test_log::test(tokio::test)]
     async fn test_value_primitive() {
-        for data_type in PRIMITIVE_TYPES {
+        const NUM_ROWS: u32 = 1025;
+
+        let test_cases = TestCases::default()
+            .with_batch_size(NUM_ROWS)
+            .with_page_sizes(vec![4096])
+            .with_expected_encoding("flat");
+        let value_metadata =
+            HashMap::from([("lance-encoding:compression".to_string(), "none".to_string())]);
+
+        for (seed, data_type) in PRIMITIVE_TYPES.iter().enumerate() {
             log::info!("Testing encoding for {:?}", data_type);
-            let field = Field::new("", data_type.clone(), false);
-            check_basic_random(field).await;
+            let data = gen_batch()
+                .with_seed(Seed::from(seed as u64))
+                .anon_col(array::rand_type(data_type))
+                .into_batch_rows(RowCount::from(NUM_ROWS as u64))
+                .unwrap()
+                .column(0)
+                .clone();
+
+            check_round_trip_encoding_of_data(vec![data], &test_cases, value_metadata.clone())
+                .await;
         }
     }
 


### PR DESCRIPTION
## What changed

Keep smoke coverage for all 21 primitive Arrow types while removing the generic random-test Cartesian product. Each type now uses a deterministic 1,025-row input, one 4 KiB page size, one full read per supported format, and explicit flat-encoding verification.

Targeted null, slicing, ingest-batch, and page-boundary behavior remains covered by the adjacent value/miniblock tests.

## Test runtime

Lower is better. Measured on an Apple M4 (10 cores), macOS 26.6.1, Rust 1.97.0, with prebuilt debug test binaries, `LANCE_CPU_THREADS=4`, and `--test-threads=1`. Results use one warm-up followed by the median of three runs against independent `main` and PR worktrees.

| Scenario / metric | Baseline | This PR | Benefit |
| --- | ---: | ---: | ---: |
| `test_value_primitive` time | 14.17 s | 0.02 s | 709x faster |

The number of complete round trips drops from 2,928 to 84 while preserving the logical-type surface.

## Validation

- `cargo test -p lance-encoding test_value_primitive -- --nocapture`
- `cargo fmt --all`
- `cargo clippy --all --tests --benches -- -D warnings`
- `git diff --check`
