### PR TITLE
test(index): consolidate IVF PQ prewarm coverage

### DIFF
--- a/rust/lance/src/index/vector/ivf/v2.rs
+++ b/rust/lance/src/index/vector/ivf/v2.rs
@@ -6576,145 +6576,44 @@ mod tests {
     async fn test_prewarm_ivf_pq() {
         use lance_io::assert_io_eq;
 
+        const INDEX_NAME: &str = "my_idx";
         let test_dir = TempStrDir::default();
         let test_uri = test_dir.as_str();
-        let (mut dataset, _) = generate_test_dataset::<Float32Type>(test_uri, 0.0..1.0).await;
+        let (mut dataset, vectors) = generate_test_dataset::<Float32Type>(test_uri, 0.0..1.0).await;
 
         let params = VectorIndexParams::with_ivf_pq_params(
             DistanceType::L2,
             IvfBuildParams::new(4),
-            PQBuildParams::default(),
+            PQBuildParams::new(4, 4),
         );
         dataset
             .create_index(
                 &["vector"],
                 IndexType::Vector,
-                Some("my_idx".to_owned()),
+                Some(INDEX_NAME.to_owned()),
                 &params,
                 true,
             )
             .await
             .unwrap();
 
-        // Reset IO stats after index creation
-        dataset.object_store.as_ref().io_stats_incremental();
-
-        // Prewarm should perform IO to load all partitions into cache
-        dataset.prewarm_index("my_idx").await.unwrap();
-        let stats = dataset.object_store.as_ref().io_stats_incremental();
-        assert!(
-            stats.read_iops > 0,
-            "prewarm should have read from disk, but read_iops was 0"
-        );
-
-        // Can query index without IO
-        let q = Float32Array::from_iter_values(repeat_n(0.0, DIM));
+        append_dataset::<Float32Type>(&mut dataset, 8, 0.0..1.0).await;
         dataset
-            .scan()
-            .nearest("vector", &q, 10)
-            .unwrap()
-            .project(&["_rowid"])
-            .unwrap()
-            .try_into_batch()
-            .await
-            .unwrap();
-        let stats = dataset.object_store.as_ref().io_stats_incremental();
-        assert_io_eq!(
-            stats,
-            read_iops,
-            0,
-            "query should not perform IO after prewarm"
-        );
-
-        // Second prewarm should not need IO (already cached)
-        dataset.prewarm_index("my_idx").await.unwrap();
-        let stats = dataset.object_store.as_ref().io_stats_incremental();
-        assert_io_eq!(stats, read_iops, 0, "second prewarm should not perform IO");
-    }
-
-    #[tokio::test]
-    async fn test_prewarm_ivf_pq_multiple_deltas() {
-        use lance_io::assert_io_eq;
-
-        const INDEX_NAME: &str = "my_idx";
-        const BASE_ROWS_PER_PARTITION: usize = 3_000;
-        const SMALL_APPEND_ROWS: usize = 64;
-        let offsets = [-50.0, 50.0];
-
-        let test_dir = TempStrDir::default();
-        let test_uri = test_dir.as_str();
-
-        let (batch, schema) = generate_clustered_batch(BASE_ROWS_PER_PARTITION, offsets);
-        let batches = RecordBatchIterator::new(vec![Ok(batch)], schema.clone());
-        let mut dataset = Dataset::write(
-            batches,
-            test_uri,
-            Some(WriteParams {
-                mode: WriteMode::Overwrite,
-                ..Default::default()
-            }),
-        )
-        .await
-        .unwrap();
-
-        let centroids = build_centroids_for_offsets(&offsets);
-        let ivf_params = IvfBuildParams::try_with_centroids(2, centroids).unwrap();
-        let params = VectorIndexParams::with_ivf_pq_params(
-            DistanceType::L2,
-            ivf_params,
-            PQBuildParams::default(),
-        );
-        dataset
-            .create_index(
-                &["vector"],
-                IndexType::Vector,
-                Some(INDEX_NAME.to_string()),
-                &params,
-                true,
-            )
+            .optimize_indices(&OptimizeOptions::append())
             .await
             .unwrap();
 
-        let template_batch = dataset
-            .take_rows(&[0], dataset.schema().clone())
-            .await
-            .unwrap();
-        let template_values = template_batch["vector"]
-            .as_fixed_size_list()
-            .value(0)
-            .as_primitive::<Float32Type>()
-            .values()
-            .to_vec();
-        let mut append_params = WriteParams {
-            max_rows_per_file: 32,
-            max_rows_per_group: 32,
-            ..Default::default()
-        };
-        append_params.mode = WriteMode::Append;
-        append_constant_vector_with_params(
-            &mut dataset,
-            SMALL_APPEND_ROWS,
-            &template_values,
-            Some(append_params),
-        )
-        .await;
-
-        dataset
-            .optimize_indices(&OptimizeOptions::new())
-            .await
-            .unwrap();
-
-        // Reopen dataset to avoid carrying index state in-memory from index creation.
+        // Reopen to avoid carrying index state in memory from index creation.
         let dataset = Dataset::open(test_uri).await.unwrap();
         let indices = dataset.load_indices_by_name(INDEX_NAME).await.unwrap();
-        assert_eq!(indices.len(), 2, "expected two index deltas for my_idx");
+        assert_eq!(indices.len(), 2, "expected two index deltas");
         let unique_uuids: HashSet<_> = indices.iter().map(|meta| meta.uuid).collect();
         assert_eq!(unique_uuids.len(), 2, "expected two unique index UUIDs");
 
-        // Reset IO stats after index creation
+        // Reset IO stats after index creation.
         dataset.object_store.as_ref().io_stats_incremental();
 
-        // Prewarm should perform IO to load all index deltas into cache
+        // Prewarm should perform IO to load all index deltas into cache.
         dataset.prewarm_index(INDEX_NAME).await.unwrap();
         let stats = dataset.object_store.as_ref().io_stats_incremental();
         assert!(
@@ -6722,11 +6621,11 @@ mod tests {
             "prewarm should have read from disk, but read_iops was 0"
         );
 
-        // Query should not perform IO after prewarm of all deltas
-        let q = Float32Array::from(template_values.clone());
+        // Query should not perform IO after prewarming all deltas.
+        let q = vectors.value(0);
         dataset
             .scan()
-            .nearest("vector", &q, 10)
+            .nearest("vector", q.as_primitive::<Float32Type>(), 10)
             .unwrap()
             .project(&["_rowid"])
             .unwrap()
@@ -6741,7 +6640,7 @@ mod tests {
             "query should not perform IO after prewarm"
         );
 
-        // Second prewarm should not need IO (already cached)
+        // Second prewarm should not need IO (already cached).
         dataset.prewarm_index(INDEX_NAME).await.unwrap();
         let stats = dataset.object_store.as_ref().io_stats_incremental();
         assert_io_eq!(stats, read_iops, 0, "second prewarm should not perform IO");


### PR DESCRIPTION
## What changed

Consolidate the single-segment and multi-delta IVF-PQ prewarm tests into one focused test:

- create a 512-row base index with 4-bit PQ and four subvectors
- append eight rows with `OptimizeOptions::append()` so split/join planning cannot interfere
- reopen and assert two unique segment UUIDs
- retain the prewarm-I/O, zero-I/O query, and idempotent second-prewarm assertions

This removes the duplicated 6,000-row setup without weakening the multi-segment cache-residency regression.

## Test runtime

Lower is better. Measured on an Apple M4 (10 cores), macOS 26.6.1, Rust 1.97.0, with prebuilt debug test binaries, `LANCE_CPU_THREADS=4`, and `--test-threads=1`. Results use one warm-up followed by the median of three runs against independent `main` and PR worktrees. The baseline is the combined time of the two tests replaced by the consolidated test.

| Scenario / metric | Baseline | This PR | Benefit |
| --- | ---: | ---: | ---: |
| IVF-PQ prewarm regression workload | 28.16 s | 0.10 s | 282x faster |

## Validation

- `cargo test -p lance --lib index::vector::ivf::v2::tests::test_prewarm_ivf_pq -- --exact`
- `cargo fmt --all`
- `cargo clippy --all --tests --benches -- -D warnings`
- `git diff --check`
