### PR TITLE
test: reduce slow unit test workloads

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,6 +80,7 @@ Also see directory-specific guidelines: [rust/](rust/AGENTS.md) | [python/](pyth
 ## Testing Standards
 
 - **All bugfixes and features must have corresponding tests. We do not merge code without tests.**
+- Keep local unit tests lightweight: each test case should finish within one second on typical developer hardware. Split independent parameter matrices and use the smallest fixture or model that preserves the asserted behavior; do not relax assertions, coverage, or recall thresholds to meet the budget.
 - Use `rstest` (Rust) or `@pytest.mark.parametrize` (Python) for tests that differ only in inputs. Use `#[case::{name}(...)]` for readable case names.
 - Replace `print()` in tests with `assert` — prints don't catch regressions.
 - Extend existing tests instead of adding overlapping new ones. Add to existing test files.

--- a/rust/lance-encoding/src/array_encoding/logical/blob.rs
+++ b/rust/lance-encoding/src/array_encoding/logical/blob.rs
@@ -430,10 +430,22 @@ mod tests {
             .collect::<HashMap<_, _>>()
     });
 
+    #[rstest::rstest]
     #[test_log::test(tokio::test)]
-    async fn test_basic_blob() {
+    async fn test_basic_blob(
+        #[values(TestEncoding::Array, TestEncoding::StructuralU16)] encoding: TestEncoding,
+        #[values(4096, 1024 * 1024)] page_size: u64,
+        #[values(false, true)] use_slicing: bool,
+    ) {
         let field = Field::new("", DataType::LargeBinary, false).with_metadata(BLOB_META.clone());
-        check_specific_random(field, TestCases::basic().with_array_and_u16_encodings()).await;
+        check_specific_random(
+            field,
+            TestCases::basic()
+                .with_encoding(encoding)
+                .with_page_sizes(vec![page_size])
+                .with_slicing_modes([use_slicing]),
+        )
+        .await;
     }
 
     #[test_log::test(tokio::test)]

--- a/rust/lance-encoding/src/array_encoding/physical/dictionary.rs
+++ b/rust/lance-encoding/src/array_encoding/physical/dictionary.rs
@@ -422,7 +422,10 @@ mod tests {
     use arrow_schema::{DataType, Field};
     use std::{collections::HashMap, sync::Arc, vec};
 
-    use crate::testing::{TestCases, check_basic_random, check_round_trip_encoding_of_data};
+    use crate::testing::{
+        TestCases, TestEncoding, check_basic_random_case, check_round_trip_encoding_of_data,
+    };
+    use rstest::rstest;
 
     use super::encode_dict_indices_and_items;
 
@@ -450,28 +453,29 @@ mod tests {
         assert_eq!(&dict_items, &expected_items);
     }
 
+    #[rstest]
     #[test_log::test(tokio::test)]
-    async fn test_utf8() {
-        let field = Field::new("", DataType::Utf8, false);
-        check_basic_random(field).await;
-    }
-
-    #[test_log::test(tokio::test)]
-    async fn test_binary() {
-        let field = Field::new("", DataType::Binary, false);
-        check_basic_random(field).await;
-    }
-
-    #[test_log::test(tokio::test)]
-    async fn test_large_binary() {
-        let field = Field::new("", DataType::LargeBinary, true);
-        check_basic_random(field).await;
-    }
-
-    #[test_log::test(tokio::test)]
-    async fn test_large_utf8() {
-        let field = Field::new("", DataType::LargeUtf8, true);
-        check_basic_random(field).await;
+    async fn test_random_dictionary(
+        #[values(
+            DataType::Utf8,
+            DataType::Binary,
+            DataType::LargeBinary,
+            DataType::LargeUtf8
+        )]
+        data_type: DataType,
+        #[values(
+            TestEncoding::Array,
+            TestEncoding::StructuralU16,
+            TestEncoding::StructuralU32,
+            TestEncoding::StructuralSparse
+        )]
+        encoding: TestEncoding,
+        #[values(4096, 1024 * 1024)] page_size: u64,
+        #[values(false, true)] use_slicing: bool,
+    ) {
+        let nullable = matches!(data_type, DataType::LargeBinary | DataType::LargeUtf8);
+        let field = Field::new("", data_type, nullable);
+        check_basic_random_case(field, encoding, page_size, use_slicing).await;
     }
 
     #[test_log::test(tokio::test)]
@@ -570,14 +574,25 @@ mod tests {
 
     // These tests cover the case where the input is already dictionary encoded
 
+    #[rstest]
     #[test_log::test(tokio::test)]
-    async fn test_random_dictionary_input() {
+    async fn test_random_dictionary_input(
+        #[values(
+            TestEncoding::Array,
+            TestEncoding::StructuralU16,
+            TestEncoding::StructuralU32,
+            TestEncoding::StructuralSparse
+        )]
+        encoding: TestEncoding,
+        #[values(4096, 1024 * 1024)] page_size: u64,
+        #[values(false, true)] use_slicing: bool,
+    ) {
         let dict_field = Field::new(
             "",
             DataType::Dictionary(Box::new(DataType::UInt16), Box::new(DataType::Utf8)),
             false,
         );
-        check_basic_random(dict_field).await;
+        check_basic_random_case(dict_field, encoding, page_size, use_slicing).await;
     }
 
     #[test_log::test(tokio::test)]

--- a/rust/lance-encoding/src/array_encoding/physical/fixed_size_binary.rs
+++ b/rust/lance-encoding/src/array_encoding/physical/fixed_size_binary.rs
@@ -128,31 +128,35 @@ mod tests {
     use crate::array_encoding::physical::fixed_size_binary::FixedSizeBinaryDecoder;
     use crate::data::{DataBlock, FixedWidthDataBlock};
     use crate::decoder::PrimitivePageDecoder;
-    use crate::testing::{TestCases, check_basic_random, check_round_trip_encoding_of_data};
+    use crate::testing::{
+        TestCases, TestEncoding, check_basic_random_case, check_round_trip_encoding_of_data,
+    };
+    use rstest::rstest;
 
+    #[rstest]
     #[test_log::test(tokio::test)]
-    async fn test_fixed_size_utf8_binary() {
-        let field = Field::new("", DataType::Utf8, false);
-        // This test only generates fixed size binary arrays anyway
-        check_basic_random(field).await;
-    }
-
-    #[test_log::test(tokio::test)]
-    async fn test_fixed_size_binary() {
-        let field = Field::new("", DataType::Binary, false);
-        check_basic_random(field).await;
-    }
-
-    #[test_log::test(tokio::test)]
-    async fn test_fixed_size_large_binary() {
-        let field = Field::new("", DataType::LargeBinary, true);
-        check_basic_random(field).await;
-    }
-
-    #[test_log::test(tokio::test)]
-    async fn test_fixed_size_large_utf8() {
-        let field = Field::new("", DataType::LargeUtf8, true);
-        check_basic_random(field).await;
+    async fn test_fixed_size_random(
+        #[values(
+            DataType::Utf8,
+            DataType::Binary,
+            DataType::LargeBinary,
+            DataType::LargeUtf8
+        )]
+        data_type: DataType,
+        #[values(
+            TestEncoding::Array,
+            TestEncoding::StructuralU16,
+            TestEncoding::StructuralU32,
+            TestEncoding::StructuralSparse
+        )]
+        encoding: TestEncoding,
+        #[values(4096, 1024 * 1024)] page_size: u64,
+        #[values(false, true)] use_slicing: bool,
+    ) {
+        let nullable = matches!(data_type, DataType::LargeBinary | DataType::LargeUtf8);
+        let field = Field::new("", data_type, nullable);
+        // This test only generates fixed-size binary arrays for Utf8 and Binary.
+        check_basic_random_case(field, encoding, page_size, use_slicing).await;
     }
 
     #[test_log::test(tokio::test)]

--- a/rust/lance-encoding/src/array_encoding/physical/fixed_size_list.rs
+++ b/rust/lance-encoding/src/array_encoding/physical/fixed_size_list.rs
@@ -138,18 +138,29 @@ mod tests {
     use arrow_schema::{DataType, Field};
     use lance_datagen::{ArrayGeneratorExt, RowCount, array, gen_array};
 
-    use crate::testing::{TestCases, check_basic_random, check_round_trip_encoding_of_data};
+    use crate::testing::{
+        TestCases, TestEncoding, check_basic_random_case, check_round_trip_encoding_of_data,
+    };
+    use rstest::rstest;
 
-    const PRIMITIVE_TYPES: &[DataType] = &[DataType::Int8, DataType::Float32, DataType::Float64];
-
+    #[rstest]
     #[test_log::test(tokio::test)]
-    async fn test_value_fsl_primitive() {
-        for data_type in PRIMITIVE_TYPES {
-            let inner_field = Field::new("item", data_type.clone(), true);
-            let data_type = DataType::FixedSizeList(Arc::new(inner_field), 16);
-            let field = Field::new("", data_type, false);
-            check_basic_random(field).await;
-        }
+    async fn test_value_fsl_primitive(
+        #[values(DataType::Int8, DataType::Float32, DataType::Float64)] data_type: DataType,
+        #[values(
+            TestEncoding::Array,
+            TestEncoding::StructuralU16,
+            TestEncoding::StructuralU32,
+            TestEncoding::StructuralSparse
+        )]
+        encoding: TestEncoding,
+        #[values(4096, 1024 * 1024)] page_size: u64,
+        #[values(false, true)] use_slicing: bool,
+    ) {
+        let inner_field = Field::new("item", data_type, true);
+        let data_type = DataType::FixedSizeList(Arc::new(inner_field), 16);
+        let field = Field::new("", data_type, false);
+        check_basic_random_case(field, encoding, page_size, use_slicing).await;
     }
 
     #[test_log::test(tokio::test)]

--- a/rust/lance-encoding/src/array_encoding/physical/packed_struct.rs
+++ b/rust/lance-encoding/src/array_encoding/physical/packed_struct.rs
@@ -262,10 +262,23 @@ mod tests {
     use arrow_schema::{DataType, Field, Fields};
     use std::{collections::HashMap, sync::Arc, vec};
 
-    use crate::testing::{TestCases, check_basic_random, check_round_trip_encoding_of_data};
+    use crate::testing::{
+        TestCases, TestEncoding, check_basic_random_case, check_round_trip_encoding_of_data,
+    };
 
+    #[rstest::rstest]
     #[test_log::test(tokio::test)]
-    async fn test_random_packed_struct() {
+    async fn test_random_packed_struct(
+        #[values(
+            TestEncoding::Array,
+            TestEncoding::StructuralU16,
+            TestEncoding::StructuralU32,
+            TestEncoding::StructuralSparse
+        )]
+        encoding: TestEncoding,
+        #[values(4096, 1024 * 1024)] page_size: u64,
+        #[values(false, true)] use_slicing: bool,
+    ) {
         let data_type = DataType::Struct(Fields::from(vec![
             Field::new("a", DataType::UInt64, false),
             Field::new("b", DataType::UInt32, false),
@@ -275,7 +288,7 @@ mod tests {
 
         let field = Field::new("", data_type, false).with_metadata(metadata);
 
-        check_basic_random(field).await;
+        check_basic_random_case(field, encoding, page_size, use_slicing).await;
     }
 
     #[test_log::test(tokio::test)]

--- a/rust/lance-encoding/src/encodings/fuzz_tests.rs
+++ b/rust/lance-encoding/src/encodings/fuzz_tests.rs
@@ -268,7 +268,10 @@ fn test_encoding_round_trip(
     )]
     _shard: usize,
 ) {
-    let rt = tokio::runtime::Runtime::new().unwrap();
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
     let strategy = (encoding_config_strategy(), 100..=1000usize, any::<u64>());
     let mut runner = TestRunner::new(Config {
         cases: 1,
@@ -373,7 +376,10 @@ fn test_fixed_size_list_encoding(
     )]
     encoding: TestEncoding,
 ) {
-    let rt = tokio::runtime::Runtime::new().unwrap();
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
     let strategy = (1..=100i32, 10..=1000usize, any::<u64>());
     let mut runner = TestRunner::new(Config::default());
     runner

--- a/rust/lance-encoding/src/encodings/fuzz_tests.rs
+++ b/rust/lance-encoding/src/encodings/fuzz_tests.rs
@@ -14,8 +14,9 @@ use arrow_array::builder::{Int32Builder, ListBuilder};
 use arrow_array::*;
 use arrow_schema::{DataType, Field};
 use proptest::prelude::*;
+use proptest::test_runner::{Config, TestRunner};
 
-use crate::testing::{TestCases, check_round_trip_encoding_of_data};
+use crate::testing::{TestCases, TestEncoding, check_round_trip_encoding_of_data};
 use lance_core::Result;
 use lance_datagen::{ArrayGenerator, ByteCount, Dimension, RowCount, Seed, array, gen_batch};
 
@@ -252,46 +253,51 @@ fn generate_test_data_for_config(
     Ok(batch.column(0).clone())
 }
 
-// Main property test for encoding round-trip
-proptest! {
-    #![proptest_config(ProptestConfig::with_cases(50))]
+#[rstest::rstest]
+fn test_encoding_round_trip(
+    #[values(
+        TestEncoding::StructuralU16,
+        TestEncoding::StructuralU32,
+        TestEncoding::StructuralSparse
+    )]
+    encoding: TestEncoding,
+    #[values(
+        0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24,
+        25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47,
+        48, 49
+    )]
+    _shard: usize,
+) {
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    let strategy = (encoding_config_strategy(), 100..=1000usize, any::<u64>());
+    let mut runner = TestRunner::new(Config {
+        cases: 1,
+        ..Config::default()
+    });
+    runner
+        .run(&strategy, |(config, num_rows, seed)| {
+            rt.block_on(async {
+                let test_data = generate_test_data_for_config(&config, num_rows, seed)
+                    .expect("Failed to generate test data");
 
-    #[test]
-    fn test_encoding_round_trip(
-        config in encoding_config_strategy(),
-        num_rows in 100..=5000usize,
-        seed in any::<u64>()
-    ) {
-        let rt = tokio::runtime::Runtime::new().unwrap();
+                let _field = config.to_field("test");
 
-        rt.block_on(async {
-            // Generate test data
-            let test_data = generate_test_data_for_config(&config, num_rows, seed)
-                .expect("Failed to generate test data");
+                let mut metadata = HashMap::new();
+                if config.encoding_type == EncodingType::Miniblock {
+                    metadata.insert("encoding_hint".to_string(), "miniblock".to_string());
+                }
 
-            // Set up test cases
-            let _field = config.to_field("test");
+                let test_cases = TestCases::default()
+                    .with_encoding(encoding)
+                    .with_batch_size(100)
+                    .with_range(0..num_rows.min(500) as u64)
+                    .with_indices(vec![0, num_rows as u64 / 2, (num_rows - 1) as u64]);
 
-            let mut metadata = HashMap::new();
-            // Force specific encoding through metadata hints if needed
-            if config.encoding_type == EncodingType::Miniblock {
-                metadata.insert("encoding_hint".to_string(), "miniblock".to_string());
-            }
-
-            let test_cases = TestCases::default()
-                .with_structural_encodings()
-                .with_batch_size(100)
-                .with_range(0..num_rows.min(500) as u64)
-                .with_indices(vec![0, num_rows as u64 / 2, (num_rows - 1) as u64]);
-
-            // Execute round-trip test
-            check_round_trip_encoding_of_data(
-                vec![test_data],
-                &test_cases,
-                metadata
-            ).await;
-        });
-    }
+                check_round_trip_encoding_of_data(vec![test_data], &test_cases, metadata).await;
+            });
+            Ok(())
+        })
+        .unwrap();
 }
 
 #[tokio::test]
@@ -358,37 +364,39 @@ proptest! {
     }
 }
 
-// Test fixed size list encoding
-proptest! {
-    #[test]
-    fn test_fixed_size_list_encoding(
-        list_size in 1..=100i32,
-        num_rows in 10..=1000usize,
-        seed in any::<u64>()
-    ) {
-        let rt = tokio::runtime::Runtime::new().unwrap();
+#[rstest::rstest]
+fn test_fixed_size_list_encoding(
+    #[values(
+        TestEncoding::StructuralU16,
+        TestEncoding::StructuralU32,
+        TestEncoding::StructuralSparse
+    )]
+    encoding: TestEncoding,
+) {
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    let strategy = (1..=100i32, 10..=1000usize, any::<u64>());
+    let mut runner = TestRunner::new(Config::default());
+    runner
+        .run(&strategy, |(list_size, num_rows, seed)| {
+            rt.block_on(async {
+                let config = EncodingTestConfig {
+                    encoding_type: EncodingType::Miniblock,
+                    data_structure: DataStructure::FixedSizeList(list_size),
+                    data_width: DataWidth::Fixed(FixedWidthType::Int32),
+                    nullable: false,
+                };
 
-        rt.block_on(async {
-            let config = EncodingTestConfig {
-                encoding_type: EncodingType::Miniblock,
-                data_structure: DataStructure::FixedSizeList(list_size),
-                data_width: DataWidth::Fixed(FixedWidthType::Int32),
-                nullable: false,
-            };
+                let test_data = generate_test_data_for_config(&config, num_rows, seed)
+                    .expect("Failed to generate test data");
 
-            let test_data = generate_test_data_for_config(&config, num_rows, seed)
-                .expect("Failed to generate test data");
+                let test_cases = TestCases::default().with_encoding(encoding);
 
-            let test_cases = TestCases::default()
-                .with_structural_encodings();
-
-            check_round_trip_encoding_of_data(
-                vec![test_data],
-                &test_cases,
-                HashMap::new()
-            ).await;
-        });
-    }
+                check_round_trip_encoding_of_data(vec![test_data], &test_cases, HashMap::new())
+                    .await;
+            });
+            Ok(())
+        })
+        .unwrap();
 }
 
 #[tokio::test]

--- a/rust/lance-encoding/src/encodings/logical/fixed_size_list.rs
+++ b/rust/lance-encoding/src/encodings/logical/fixed_size_list.rs
@@ -533,7 +533,7 @@ mod tests {
             STRUCTURAL_ENCODING_FULLZIP, STRUCTURAL_ENCODING_META_KEY,
             STRUCTURAL_ENCODING_MINIBLOCK,
         },
-        testing::{TestCases, check_specific_random},
+        testing::{TestCases, TestEncoding, check_specific_random},
     };
 
     fn make_fsl_struct_type(struct_fields: Fields, dimension: i32) -> DataType {
@@ -700,6 +700,11 @@ mod tests {
         #[case] dimension: i32,
         #[values(STRUCTURAL_ENCODING_MINIBLOCK, STRUCTURAL_ENCODING_FULLZIP)]
         structural_encoding: &str,
+        #[values(TestEncoding::StructuralU32, TestEncoding::StructuralSparse)]
+        encoding: TestEncoding,
+        #[values(4096, 1024 * 1024)] page_size: u64,
+        #[values(false, true)] use_slicing: bool,
+        #[values(1, 5, 10)] ingest_batch_count: u32,
     ) {
         let data_type = make_fsl_struct_type(struct_fields, dimension);
         let mut field_metadata = HashMap::new();
@@ -708,7 +713,11 @@ mod tests {
             structural_encoding.into(),
         );
         let field = Field::new("", data_type, true).with_metadata(field_metadata);
-        let test_cases = TestCases::basic().with_u32_structural_encodings();
+        let test_cases = TestCases::basic()
+            .with_encoding(encoding)
+            .with_page_sizes(vec![page_size])
+            .with_slicing_modes([use_slicing])
+            .with_ingest_batch_counts([ingest_batch_count]);
         check_specific_random(field, test_cases).await;
     }
 

--- a/rust/lance-encoding/src/encodings/logical/list.rs
+++ b/rust/lance-encoding/src/encodings/logical/list.rs
@@ -249,11 +249,12 @@ mod tests {
 
     use arrow_buffer::{BooleanBuffer, NullBuffer, OffsetBuffer, ScalarBuffer};
     use arrow_schema::{DataType, Field, Fields};
+    use lance_datagen::{RowCount, Seed, array, gen_batch};
     use rstest::rstest;
 
     use crate::testing::{
-        TestCases, TestEncoding, check_basic_random, check_round_trip_encoding_of_data,
-        create_test_field_encoder, test_encoding_strategy,
+        TestCases, TestEncoding, check_round_trip_encoding_of_data, create_test_field_encoder,
+        test_encoding_strategy,
     };
 
     fn make_list_type(inner_type: DataType) -> DataType {
@@ -262,6 +263,61 @@ mod tests {
 
     fn make_large_list_type(inner_type: DataType) -> DataType {
         DataType::LargeList(Arc::new(Field::new("item", inner_type, true)))
+    }
+
+    #[derive(Clone, Copy)]
+    enum NullPattern {
+        None,
+        Mixed,
+        All,
+    }
+
+    async fn check_nested_type(
+        data_type: DataType,
+        null_pattern: NullPattern,
+        encoding: TestEncoding,
+    ) {
+        check_nested_type_with_metadata(data_type, null_pattern, encoding, HashMap::new()).await;
+    }
+
+    async fn check_nested_type_with_metadata(
+        data_type: DataType,
+        null_pattern: NullPattern,
+        encoding: TestEncoding,
+        field_metadata: HashMap<String, String>,
+    ) {
+        let null_rate = match null_pattern {
+            NullPattern::None => None,
+            NullPattern::Mixed => Some(0.5),
+            NullPattern::All => Some(1.0),
+        };
+        let make_batch = |seed, rows| {
+            let mut generator = gen_batch()
+                .with_seed(Seed::from(seed))
+                .anon_col(array::rand_type(&data_type));
+            if let Some(null_rate) = null_rate {
+                generator.with_random_nulls(null_rate);
+            }
+            generator
+                .into_batch_rows(RowCount::from(rows))
+                .unwrap()
+                .column(0)
+                .clone()
+        };
+
+        // Combine a non-zero-offset slice with an independently generated batch.
+        // This covers both offset rebasing and rep/def accumulation at the ingest
+        // boundary without repeating the full generic random-test matrix.
+        let first = make_batch(0, 513).slice(1, 512);
+        let second = make_batch(1, 513);
+        let test_cases = TestCases::default()
+            .with_page_sizes(vec![4096])
+            .with_encoding(encoding)
+            .with_batch_size(257)
+            .with_range(510..515)
+            .with_indices(vec![0, 511, 512, 1024]);
+
+        check_round_trip_encoding_of_data(vec![first, second], &test_cases, field_metadata).await;
     }
 
     async fn try_encode_v22_pages(
@@ -378,15 +434,28 @@ mod tests {
     async fn test_list(
         #[values(STRUCTURAL_ENCODING_MINIBLOCK, STRUCTURAL_ENCODING_FULLZIP)]
         structural_encoding: &str,
+        #[values(NullPattern::None, NullPattern::Mixed, NullPattern::All)]
+        null_pattern: NullPattern,
+        #[values(
+            TestEncoding::Array,
+            TestEncoding::StructuralU16,
+            TestEncoding::StructuralU32,
+            TestEncoding::StructuralSparse
+        )]
+        encoding: TestEncoding,
     ) {
         let mut field_metadata = HashMap::new();
         field_metadata.insert(
             STRUCTURAL_ENCODING_META_KEY.to_string(),
             structural_encoding.into(),
         );
-        let field =
-            Field::new("", make_list_type(DataType::Int32), true).with_metadata(field_metadata);
-        check_basic_random(field).await;
+        check_nested_type_with_metadata(
+            make_list_type(DataType::Int32),
+            null_pattern,
+            encoding,
+            field_metadata,
+        )
+        .await;
     }
 
     #[rstest]
@@ -394,35 +463,103 @@ mod tests {
     async fn test_deeply_nested_lists(
         #[values(STRUCTURAL_ENCODING_MINIBLOCK, STRUCTURAL_ENCODING_FULLZIP)]
         structural_encoding: &str,
+        #[values(1, 2, 3, 4, 5)] depth: usize,
+        #[values(
+            TestEncoding::Array,
+            TestEncoding::StructuralU16,
+            TestEncoding::StructuralU32,
+            TestEncoding::StructuralSparse
+        )]
+        test_encoding: TestEncoding,
     ) {
-        let mut field_metadata = HashMap::new();
-        field_metadata.insert(
+        let mut data_type = DataType::Int32;
+        for _ in 0..depth {
+            data_type = make_list_type(data_type);
+        }
+
+        let mut generator = gen_batch()
+            .with_seed(Seed::from(depth as u64))
+            .anon_col(array::rand_type(&data_type));
+        generator.with_random_nulls(0.2);
+        let source = generator
+            .into_batch_rows(RowCount::from(1026))
+            .unwrap()
+            .column(0)
+            .clone();
+
+        // Two non-zero-offset slices cover nested offset rebasing across ingest
+        // batches. The selected range and indices straddle that batch boundary.
+        let data = vec![source.slice(1, 512), source.slice(513, 513)];
+        let test_cases = TestCases::default()
+            .with_page_sizes(vec![4096])
+            .with_encoding(test_encoding)
+            .with_batch_size(257)
+            .with_range(510..515)
+            .with_indices(vec![0, 511, 512, 1024]);
+        let field_metadata = HashMap::from([(
             STRUCTURAL_ENCODING_META_KEY.to_string(),
             structural_encoding.into(),
-        );
-        let field = Field::new("item", DataType::Int32, true).with_metadata(field_metadata);
-        for _ in 0..5 {
-            let field = Field::new("", make_list_type(field.data_type().clone()), true);
-            check_basic_random(field).await;
-        }
+        )]);
+
+        check_round_trip_encoding_of_data(data, &test_cases, field_metadata).await;
     }
 
+    #[rstest]
     #[test_log::test(tokio::test)]
-    async fn test_large_list() {
-        let field = Field::new("", make_large_list_type(DataType::Int32), true);
-        check_basic_random(field).await;
+    async fn test_large_list(
+        #[values(NullPattern::None, NullPattern::Mixed, NullPattern::All)]
+        null_pattern: NullPattern,
+        #[values(
+            TestEncoding::Array,
+            TestEncoding::StructuralU16,
+            TestEncoding::StructuralU32,
+            TestEncoding::StructuralSparse
+        )]
+        encoding: TestEncoding,
+    ) {
+        check_nested_type(
+            make_large_list_type(DataType::Int32),
+            null_pattern,
+            encoding,
+        )
+        .await;
     }
 
+    #[rstest]
     #[test_log::test(tokio::test)]
-    async fn test_nested_strings() {
-        let field = Field::new("", make_list_type(DataType::Utf8), true);
-        check_basic_random(field).await;
+    async fn test_nested_strings(
+        #[values(NullPattern::None, NullPattern::Mixed, NullPattern::All)]
+        null_pattern: NullPattern,
+        #[values(
+            TestEncoding::Array,
+            TestEncoding::StructuralU16,
+            TestEncoding::StructuralU32,
+            TestEncoding::StructuralSparse
+        )]
+        encoding: TestEncoding,
+    ) {
+        check_nested_type(make_list_type(DataType::Utf8), null_pattern, encoding).await;
     }
 
+    #[rstest]
     #[test_log::test(tokio::test)]
-    async fn test_nested_list() {
-        let field = Field::new("", make_list_type(make_list_type(DataType::Int32)), true);
-        check_basic_random(field).await;
+    async fn test_nested_list(
+        #[values(NullPattern::None, NullPattern::Mixed, NullPattern::All)]
+        null_pattern: NullPattern,
+        #[values(
+            TestEncoding::Array,
+            TestEncoding::StructuralU16,
+            TestEncoding::StructuralU32,
+            TestEncoding::StructuralSparse
+        )]
+        encoding: TestEncoding,
+    ) {
+        check_nested_type(
+            make_list_type(make_list_type(DataType::Int32)),
+            null_pattern,
+            encoding,
+        )
+        .await;
     }
 
     /// Regression test: a `List<List<Float32>>` column written as MULTIPLE
@@ -448,16 +585,22 @@ mod tests {
     async fn test_multipage_nested_float_list(
         #[values(STRUCTURAL_ENCODING_MINIBLOCK, STRUCTURAL_ENCODING_FULLZIP)]
         structural_encoding: &str,
+        #[values(
+            TestEncoding::StructuralU16,
+            TestEncoding::StructuralU32,
+            TestEncoding::StructuralSparse
+        )]
+        test_encoding: TestEncoding,
     ) {
         use arrow_array::Float32Array;
 
         // Production shape: 3 inner lists per row, 768 floats each.
         let inner_per_row: usize = 3;
         let inner_len: usize = 768;
-        // Two chunks (batches) -> two pages; a read batch that spans the page
-        // boundary is where the multi-page outer-offset bug triggered. A single
-        // [2731] chunk (one page) decodes fine, which is why this needs >= 2.
-        let chunk_rows: &[usize] = &[1366, 1365];
+        // Each chunk contains ~1.38 MiB of leaf values, so both cross the 1 MiB
+        // value-page limit. A read batch that spans the ingest boundary is where
+        // the multi-page outer-offset bug triggered.
+        let chunk_rows: &[usize] = &[150, 149];
 
         let make_chunk = |start_row: usize, num_rows: usize| -> Arc<dyn Array> {
             let total_inner = num_rows * inner_per_row;
@@ -511,28 +654,55 @@ mod tests {
             structural_encoding.into(),
         );
 
-        let test_cases = TestCases::default().with_structural_encodings();
+        let test_cases = TestCases::default()
+            .with_page_sizes(vec![1024 * 1024])
+            .with_encoding(test_encoding)
+            .with_batch_size(151)
+            .with_range(148..152)
+            .with_indices(vec![0, 149, 150, 298]);
         check_round_trip_encoding_of_data(chunks, &test_cases, field_metadata).await;
     }
 
+    #[rstest]
     #[test_log::test(tokio::test)]
-    async fn test_list_struct_list() {
+    async fn test_list_struct_list(
+        #[values(NullPattern::None, NullPattern::Mixed, NullPattern::All)]
+        null_pattern: NullPattern,
+        #[values(
+            TestEncoding::Array,
+            TestEncoding::StructuralU16,
+            TestEncoding::StructuralU32,
+            TestEncoding::StructuralSparse
+        )]
+        encoding: TestEncoding,
+    ) {
         let struct_type = DataType::Struct(Fields::from(vec![Field::new(
             "inner_str",
             DataType::Utf8,
             false,
         )]));
 
-        let field = Field::new("", make_list_type(struct_type), true);
-        check_basic_random(field).await;
+        check_nested_type(make_list_type(struct_type), null_pattern, encoding).await;
     }
 
+    #[rstest]
     #[test_log::test(tokio::test)]
-    async fn test_list_struct_empty() {
+    async fn test_list_struct_empty(
+        #[values(
+            TestEncoding::Array,
+            TestEncoding::StructuralU16,
+            TestEncoding::StructuralU32,
+            TestEncoding::StructuralSparse
+        )]
+        encoding: TestEncoding,
+    ) {
         let fields = Fields::from(vec![Field::new("inner", DataType::UInt64, true)]);
         let items = UInt64Array::from(Vec::<u64>::new());
         let structs = StructArray::new(fields, vec![Arc::new(items)], None);
-        let offsets = OffsetBuffer::new(ScalarBuffer::<i32>::from(vec![0; 2 * 1024 * 1024 + 1]));
+        // Exceed two 1 MiB offset pages so flushing the empty struct child is
+        // still exercised multiple times (the original #2762 regression).
+        let num_rows = 2 * 1024 * 1024 / size_of::<i32>() + 1;
+        let offsets = OffsetBuffer::new(ScalarBuffer::<i32>::from(vec![0; num_rows + 1]));
         let lists = ListArray::new(
             Arc::new(Field::new("item", structs.data_type().clone(), true)),
             offsets,
@@ -542,7 +712,9 @@ mod tests {
 
         check_round_trip_encoding_of_data(
             vec![Arc::new(lists)],
-            &TestCases::default(),
+            &TestCases::default()
+                .with_page_sizes(vec![1024 * 1024])
+                .with_encoding(encoding),
             HashMap::new(),
         )
         .await;
@@ -1142,13 +1314,28 @@ mod tests {
             structural_encoding.into(),
         );
 
+        let list_array = Arc::new(list_array) as ArrayRef;
+        let pages = try_encode_v22_pages_with_metadata(list_array.clone(), field_metadata.clone())
+            .await
+            .unwrap();
+        if structural_encoding == STRUCTURAL_ENCODING_MINIBLOCK {
+            assert_split_miniblock_layout(&pages, 2, true);
+        }
+
+        let chunk_boundary = levels_per_chunk;
         let test_cases = TestCases::default()
-            .with_range(0..1000)
-            .with_range(0..num_rows as u64)
-            .with_indices(vec![0, (step / 2) as u64, num_rows as u64 - 1])
-            .with_dense_encodings();
-        check_round_trip_encoding_of_data(vec![Arc::new(list_array)], &test_cases, field_metadata)
-            .await;
+            .with_range(chunk_boundary - 2..chunk_boundary + 2)
+            .with_indices(vec![
+                0,
+                (step / 2) as u64,
+                chunk_boundary - 1,
+                chunk_boundary,
+                num_rows as u64 - 1,
+            ])
+            .with_batch_size(64 * 1024)
+            .with_page_sizes(vec![1024 * 1024])
+            .with_encoding(TestEncoding::StructuralU32);
+        check_round_trip_encoding_of_data(vec![list_array], &test_cases, field_metadata).await;
     }
 
     #[test_log::test(tokio::test)]
@@ -1230,8 +1417,16 @@ mod tests {
         check_round_trip_encoding_of_data(vec![list_array], &test_cases, HashMap::new()).await;
     }
 
+    #[rstest]
     #[test_log::test(tokio::test)]
-    async fn test_sparse_boolean_list_with_long_null_prefix() {
+    async fn test_sparse_boolean_list_with_long_null_prefix(
+        #[values(
+            TestEncoding::Array,
+            TestEncoding::StructuralU16,
+            TestEncoding::StructuralU32
+        )]
+        encoding: TestEncoding,
+    ) {
         let null_prefix_rows = 70_000usize;
         let trailing_empty_rows = 9usize;
         let booleans_per_list = 8usize;
@@ -1260,7 +1455,7 @@ mod tests {
         let test_cases = TestCases::default()
             .with_range(0..num_rows as u64)
             .with_indices(vec![0, null_prefix_rows as u64, num_rows as u64 - 1])
-            .with_dense_encodings();
+            .with_encoding(encoding);
         let list_array = Arc::new(list_array) as ArrayRef;
         let pages = encode_v22_pages(list_array.clone()).await;
         assert_split_miniblock_layout(&pages, 1, true);
@@ -1373,9 +1568,9 @@ mod tests {
     /// lists. Mirrors `HNSW::schema()` `__neighbors` / `__dists` columns:
     /// dense level-0 lists, then ~6x as many mostly-empty higher-level rows.
     fn make_hnsw_shaped_list_u32() -> ListArray {
-        const DENSE_ROWS: u32 = 40_000;
+        const DENSE_ROWS: u32 = 5_000;
         const NEIGHBORS_PER_ROW: u32 = 32;
-        const EMPTY_TAIL_ROWS: u32 = 240_000;
+        const EMPTY_TAIL_ROWS: u32 = 70_000;
 
         let mut list_builder = ListBuilder::new(UInt32Builder::new());
         let mut next_val: u32 = 0;
@@ -1404,7 +1599,7 @@ mod tests {
     #[test_log::test(tokio::test)]
     async fn test_list_hnsw_shape_splits_to_miniblock_v2_2() {
         let list_array = make_hnsw_shaped_list_u32();
-        let dense_rows: u64 = 40_000;
+        let dense_rows: u64 = 5_000;
         let total_rows = list_array.len() as u64;
 
         let test_cases = TestCases::default()

--- a/rust/lance-encoding/src/encodings/logical/primitive.rs
+++ b/rust/lance-encoding/src/encodings/logical/primitive.rs
@@ -8763,7 +8763,7 @@ mod tests {
         let repeated_strings: Vec<_> = unique_values
             .iter()
             .cycle()
-            .take(100_000)
+            .take(10_000)
             .map(|s| Some(s.as_str()))
             .collect();
 

--- a/rust/lance-encoding/src/encodings/logical/struct.rs
+++ b/rust/lance-encoding/src/encodings/logical/struct.rs
@@ -639,7 +639,9 @@ mod tests {
     use arrow_schema::{DataType, Field, Fields};
 
     use super::StructuralStructDecoder;
-    use crate::testing::{TestCases, check_basic_random, check_round_trip_encoding_of_data};
+    use crate::testing::{
+        TestCases, TestEncoding, check_basic_random_case, check_round_trip_encoding_of_data,
+    };
 
     #[test]
     fn test_zero_dimension_fsl_decoder_errors() {
@@ -666,14 +668,25 @@ mod tests {
         );
     }
 
+    #[rstest::rstest]
     #[test_log::test(tokio::test)]
-    async fn test_simple_struct() {
+    async fn test_simple_struct(
+        #[values(
+            TestEncoding::Array,
+            TestEncoding::StructuralU16,
+            TestEncoding::StructuralU32,
+            TestEncoding::StructuralSparse
+        )]
+        encoding: TestEncoding,
+        #[values(4096, 1024 * 1024)] page_size: u64,
+        #[values(false, true)] use_slicing: bool,
+    ) {
         let data_type = DataType::Struct(Fields::from(vec![
             Field::new("a", DataType::Int32, false),
             Field::new("b", DataType::Int32, false),
         ]));
         let field = Field::new("", data_type, false);
-        check_basic_random(field).await;
+        check_basic_random_case(field, encoding, page_size, use_slicing).await;
     }
 
     #[test_log::test(tokio::test)]
@@ -790,8 +803,19 @@ mod tests {
         .await;
     }
 
+    #[rstest::rstest]
     #[test_log::test(tokio::test)]
-    async fn test_struct_list() {
+    async fn test_struct_list(
+        #[values(
+            TestEncoding::Array,
+            TestEncoding::StructuralU16,
+            TestEncoding::StructuralU32,
+            TestEncoding::StructuralSparse
+        )]
+        encoding: TestEncoding,
+        #[values(4096, 1024 * 1024)] page_size: u64,
+        #[values(false, true)] use_slicing: bool,
+    ) {
         let data_type = DataType::Struct(Fields::from(vec![
             Field::new(
                 "inner_list",
@@ -801,20 +825,42 @@ mod tests {
             Field::new("outer_int", DataType::Int32, true),
         ]));
         let field = Field::new("row", data_type, false);
-        check_basic_random(field).await;
+        check_basic_random_case(field, encoding, page_size, use_slicing).await;
     }
 
+    #[rstest::rstest]
     #[test_log::test(tokio::test)]
-    async fn test_empty_struct() {
+    async fn test_empty_struct(
+        #[values(
+            TestEncoding::Array,
+            TestEncoding::StructuralU16,
+            TestEncoding::StructuralU32,
+            TestEncoding::StructuralSparse
+        )]
+        encoding: TestEncoding,
+        #[values(4096, 1024 * 1024)] page_size: u64,
+        #[values(false, true)] use_slicing: bool,
+    ) {
         // It's technically legal for a struct to have 0 children, need to
         // make sure we support that
         let data_type = DataType::Struct(Fields::from(Vec::<Field>::default()));
         let field = Field::new("row", data_type, false);
-        check_basic_random(field).await;
+        check_basic_random_case(field, encoding, page_size, use_slicing).await;
     }
 
+    #[rstest::rstest]
     #[test_log::test(tokio::test)]
-    async fn test_complicated_struct() {
+    async fn test_complicated_struct(
+        #[values(
+            TestEncoding::Array,
+            TestEncoding::StructuralU16,
+            TestEncoding::StructuralU32,
+            TestEncoding::StructuralSparse
+        )]
+        encoding: TestEncoding,
+        #[values(4096, 1024 * 1024)] page_size: u64,
+        #[values(false, true)] use_slicing: bool,
+    ) {
         let data_type = DataType::Struct(Fields::from(vec![
             Field::new("int", DataType::Int32, true),
             Field::new(
@@ -832,7 +878,7 @@ mod tests {
             Field::new("outer_binary", DataType::Binary, true),
         ]));
         let field = Field::new("row", data_type, false);
-        check_basic_random(field).await;
+        check_basic_random_case(field, encoding, page_size, use_slicing).await;
     }
 
     #[test_log::test(tokio::test)]

--- a/rust/lance-encoding/src/encodings/physical/binary.rs
+++ b/rust/lance-encoding/src/encodings/physical/binary.rs
@@ -735,13 +735,31 @@ mod tests {
     use std::{collections::HashMap, sync::Arc, vec};
 
     use crate::testing::{
-        FnArrayGeneratorProvider, TestCases, check_basic_random, check_round_trip_encoding_of_data,
+        FnArrayGeneratorProvider, TestCases, TestEncoding, check_basic_random_case,
+        check_round_trip_encoding_generated, check_round_trip_encoding_of_data,
     };
 
+    #[rstest]
     #[test_log::test(tokio::test)]
-    async fn test_utf8_binary() {
+    async fn test_utf8_binary(
+        #[values(
+            TestEncoding::StructuralU16,
+            TestEncoding::StructuralU32,
+            TestEncoding::StructuralSparse
+        )]
+        encoding: TestEncoding,
+        #[values(4096, 1024 * 1024)] page_size: u64,
+        #[values(false, true)] use_slicing: bool,
+    ) {
         let field = Field::new("", DataType::Utf8, false);
-        check_specific_random(field, TestCases::basic().with_structural_encodings()).await;
+        check_specific_random(
+            field,
+            TestCases::basic()
+                .with_encoding(encoding)
+                .with_page_sizes(vec![page_size])
+                .with_slicing_modes([use_slicing]),
+        )
+        .await;
     }
 
     #[rstest]
@@ -750,6 +768,15 @@ mod tests {
         #[values(STRUCTURAL_ENCODING_MINIBLOCK, STRUCTURAL_ENCODING_FULLZIP)]
         structural_encoding: &str,
         #[values(DataType::Utf8, DataType::Binary)] data_type: DataType,
+        #[values(
+            TestEncoding::Array,
+            TestEncoding::StructuralU16,
+            TestEncoding::StructuralU32,
+            TestEncoding::StructuralSparse
+        )]
+        encoding: TestEncoding,
+        #[values(4096, 1024 * 1024)] page_size: u64,
+        #[values(false, true)] use_slicing: bool,
     ) {
         let mut field_metadata = HashMap::new();
         field_metadata.insert(
@@ -758,7 +785,7 @@ mod tests {
         );
 
         let field = Field::new("", data_type, false).with_metadata(field_metadata);
-        check_basic_random(field).await;
+        check_basic_random_case(field, encoding, page_size, use_slicing).await;
     }
 
     #[rstest]
@@ -767,6 +794,14 @@ mod tests {
         #[values(STRUCTURAL_ENCODING_MINIBLOCK, STRUCTURAL_ENCODING_FULLZIP)]
         structural_encoding: &str,
         #[values(DataType::Binary, DataType::Utf8)] data_type: DataType,
+        #[values(
+            TestEncoding::StructuralU16,
+            TestEncoding::StructuralU32,
+            TestEncoding::StructuralSparse
+        )]
+        encoding: TestEncoding,
+        #[values(4096, 1024 * 1024)] page_size: u64,
+        #[values(false, true)] use_slicing: bool,
     ) {
         let mut field_metadata = HashMap::new();
         field_metadata.insert(
@@ -776,7 +811,10 @@ mod tests {
         field_metadata.insert(COMPRESSION_META_KEY.to_string(), "fsst".into());
         let field = Field::new("", data_type, true).with_metadata(field_metadata);
         // TODO (https://github.com/lance-format/lance/issues/4783)
-        let test_cases = TestCases::default().with_structural_encodings();
+        let test_cases = TestCases::default()
+            .with_encoding(encoding)
+            .with_page_sizes(vec![page_size])
+            .with_slicing_modes([use_slicing]);
         check_specific_random(field, test_cases).await;
     }
 
@@ -786,6 +824,14 @@ mod tests {
         #[values(STRUCTURAL_ENCODING_MINIBLOCK, STRUCTURAL_ENCODING_FULLZIP)]
         structural_encoding: &str,
         #[values(DataType::LargeBinary, DataType::LargeUtf8)] data_type: DataType,
+        #[values(
+            TestEncoding::StructuralU16,
+            TestEncoding::StructuralU32,
+            TestEncoding::StructuralSparse
+        )]
+        encoding: TestEncoding,
+        #[values(4096, 1024 * 1024)] page_size: u64,
+        #[values(false, true)] use_slicing: bool,
     ) {
         let mut field_metadata = HashMap::new();
         field_metadata.insert(
@@ -794,19 +840,32 @@ mod tests {
         );
         field_metadata.insert(COMPRESSION_META_KEY.to_string(), "fsst".into());
         let field = Field::new("", data_type, true).with_metadata(field_metadata);
-        check_specific_random(field, TestCases::basic().with_structural_encodings()).await;
+        check_specific_random(
+            field,
+            TestCases::basic()
+                .with_encoding(encoding)
+                .with_page_sizes(vec![page_size])
+                .with_slicing_modes([use_slicing]),
+        )
+        .await;
     }
 
+    #[rstest]
     #[test_log::test(tokio::test)]
-    async fn test_large_binary() {
-        let field = Field::new("", DataType::LargeBinary, true);
-        check_basic_random(field).await;
-    }
-
-    #[test_log::test(tokio::test)]
-    async fn test_large_utf8() {
-        let field = Field::new("", DataType::LargeUtf8, true);
-        check_basic_random(field).await;
+    async fn test_large_binary_types(
+        #[values(DataType::LargeBinary, DataType::LargeUtf8)] data_type: DataType,
+        #[values(
+            TestEncoding::Array,
+            TestEncoding::StructuralU16,
+            TestEncoding::StructuralU32,
+            TestEncoding::StructuralSparse
+        )]
+        encoding: TestEncoding,
+        #[values(4096, 1024 * 1024)] page_size: u64,
+        #[values(false, true)] use_slicing: bool,
+    ) {
+        let field = Field::new("", data_type, true);
+        check_basic_random_case(field, encoding, page_size, use_slicing).await;
     }
 
     #[rstest]
@@ -814,20 +873,31 @@ mod tests {
     async fn test_small_strings(
         #[values(STRUCTURAL_ENCODING_MINIBLOCK, STRUCTURAL_ENCODING_FULLZIP)]
         structural_encoding: &str,
+        #[values(
+            TestEncoding::Array,
+            TestEncoding::StructuralU16,
+            TestEncoding::StructuralU32,
+            TestEncoding::StructuralSparse
+        )]
+        encoding: TestEncoding,
+        #[values(4096, 1024 * 1024)] page_size: u64,
+        #[values(false, true)] use_slicing: bool,
     ) {
-        use crate::testing::check_basic_generated;
-
         let mut field_metadata = HashMap::new();
         field_metadata.insert(
             STRUCTURAL_ENCODING_META_KEY.to_string(),
             structural_encoding.into(),
         );
         let field = Field::new("", DataType::Utf8, true).with_metadata(field_metadata);
-        check_basic_generated(
+        check_round_trip_encoding_generated(
             field,
             Box::new(FnArrayGeneratorProvider::new(move || {
                 lance_datagen::array::utf8_prefix_plus_counter("user_", /*is_large=*/ false)
             })),
+            TestCases::basic()
+                .with_encoding(encoding)
+                .with_page_sizes(vec![page_size])
+                .with_slicing_modes([use_slicing]),
         )
         .await;
     }
@@ -878,10 +948,19 @@ mod tests {
         .await;
     }
 
+    #[rstest]
     #[test_log::test(tokio::test)]
-    async fn test_bigger_than_max_page_size() {
-        // Create an array with one single 32MiB string
-        let big_string = String::from_iter((0..(32 * 1024 * 1024)).map(|_| '0'));
+    async fn test_value_bigger_than_max_page_size(
+        #[values(
+            TestEncoding::Array,
+            TestEncoding::StructuralU16,
+            TestEncoding::StructuralU32,
+            TestEncoding::StructuralSparse
+        )]
+        encoding: TestEncoding,
+    ) {
+        // Create one value larger than the configured 1MiB page budget.
+        let big_string = String::from_iter((0..(2 * 1024 * 1024)).map(|_| '0'));
         let string_array = StringArray::from(vec![
             Some(big_string),
             Some("abc".to_string()),
@@ -891,7 +970,9 @@ mod tests {
         ]);
 
         // Drop the max page size to 1MiB
-        let test_cases = TestCases::default().with_max_page_size(1024 * 1024);
+        let test_cases = TestCases::default()
+            .with_max_page_size(1024 * 1024)
+            .with_encoding(encoding);
 
         check_round_trip_encoding_of_data(
             vec![Arc::new(string_array)],
@@ -899,16 +980,29 @@ mod tests {
             HashMap::new(),
         )
         .await;
+    }
 
-        // This is a regression testing the case where a page with X rows is split into Y parts
-        // where the number of parts is not evenly divisible by the number of rows.  In this
-        // case we are splitting 90 rows into 4 parts.
-        let big_string = String::from_iter((0..(1000 * 1000)).map(|_| '0'));
+    #[rstest]
+    #[test_log::test(tokio::test)]
+    async fn test_page_split_parts_do_not_evenly_divide_rows(
+        #[values(
+            TestEncoding::Array,
+            TestEncoding::StructuralU16,
+            TestEncoding::StructuralU32,
+            TestEncoding::StructuralSparse
+        )]
+        encoding: TestEncoding,
+    ) {
+        // Regression: split 90 rows into four parts, where the part count does
+        // not evenly divide the row count.
+        let big_string = String::from_iter((0..45_000).map(|_| '0'));
         let string_array = StringArray::from_iter_values((0..90).map(|_| big_string.clone()));
 
         check_round_trip_encoding_of_data(
             vec![Arc::new(string_array)],
-            &TestCases::default(),
+            &TestCases::default()
+                .with_max_page_size(1024 * 1024)
+                .with_encoding(encoding),
             HashMap::new(),
         )
         .await;

--- a/rust/lance-encoding/src/encodings/physical/block.rs
+++ b/rust/lance-encoding/src/encodings/physical/block.rs
@@ -804,7 +804,10 @@ mod tests {
                 STRUCTURAL_ENCODING_META_KEY,
             },
             encodings::physical::block::lz4::Lz4BufferCompressor,
-            testing::{FnArrayGeneratorProvider, TestCases, check_round_trip_encoding_generated},
+            testing::{
+                FnArrayGeneratorProvider, TestCases, TestEncoding,
+                check_round_trip_encoding_generated,
+            },
         };
 
         #[test]
@@ -823,49 +826,59 @@ mod tests {
             assert_eq!(input_data, decompressed_data.as_slice());
         }
 
+        #[rstest::rstest]
         #[test_log::test(tokio::test)]
-        async fn test_lz4_compress_round_trip() {
-            for data_type in &[
+        async fn test_lz4_compress_round_trip(
+            #[values(
                 DataType::Utf8,
                 DataType::LargeUtf8,
                 DataType::Binary,
-                DataType::LargeBinary,
-            ] {
-                let field = Field::new("", data_type.clone(), false);
-                let mut field_meta = HashMap::new();
-                field_meta.insert(COMPRESSION_META_KEY.to_string(), "lz4".to_string());
-                // Some bad cardinality estimatation causes us to use dictionary encoding currently
-                // which causes the expected encoding check to fail.
-                field_meta.insert(DICT_DIVISOR_META_KEY.to_string(), "100000".to_string());
-                field_meta.insert(DICT_SIZE_RATIO_META_KEY.to_string(), "0.0001".to_string());
-                // Also disable size-based dictionary encoding
-                field_meta.insert(
-                    STRUCTURAL_ENCODING_META_KEY.to_string(),
-                    STRUCTURAL_ENCODING_FULLZIP.to_string(),
-                );
-                let field = field.with_metadata(field_meta);
-                let test_cases = TestCases::basic()
-                    // Need to use large pages as small pages might be too small to compress
-                    .with_page_sizes(vec![1024 * 1024])
-                    .with_expected_encoding("zstd")
-                    .with_structural_encodings();
+                DataType::LargeBinary
+            )]
+            data_type: DataType,
+            #[values(
+                TestEncoding::StructuralU16,
+                TestEncoding::StructuralU32,
+                TestEncoding::StructuralSparse
+            )]
+            encoding: TestEncoding,
+            #[values(false, true)] use_slicing: bool,
+        ) {
+            let field = Field::new("", data_type.clone(), false);
+            let mut field_meta = HashMap::new();
+            field_meta.insert(COMPRESSION_META_KEY.to_string(), "lz4".to_string());
+            // Some bad cardinality estimatation causes us to use dictionary encoding currently
+            // which causes the expected encoding check to fail.
+            field_meta.insert(DICT_DIVISOR_META_KEY.to_string(), "100000".to_string());
+            field_meta.insert(DICT_SIZE_RATIO_META_KEY.to_string(), "0.0001".to_string());
+            // Also disable size-based dictionary encoding
+            field_meta.insert(
+                STRUCTURAL_ENCODING_META_KEY.to_string(),
+                STRUCTURAL_ENCODING_FULLZIP.to_string(),
+            );
+            let field = field.with_metadata(field_meta);
+            let test_cases = TestCases::basic()
+                // Need to use large pages as small pages might be too small to compress
+                .with_page_sizes(vec![1024 * 1024])
+                .with_expected_encoding("zstd")
+                .with_encoding(encoding)
+                .with_slicing_modes([use_slicing]);
 
-                // Can't use the default random provider because random data isn't compressible
-                // and we will fallback to uncompressed encoding
-                let datagen = Box::new(FnArrayGeneratorProvider::new(move || match data_type {
-                    DataType::Utf8 => utf8_prefix_plus_counter("compressme", false),
-                    DataType::Binary => {
-                        binary_prefix_plus_counter(Arc::from(b"compressme".to_owned()), false)
-                    }
-                    DataType::LargeUtf8 => utf8_prefix_plus_counter("compressme", true),
-                    DataType::LargeBinary => {
-                        binary_prefix_plus_counter(Arc::from(b"compressme".to_owned()), true)
-                    }
-                    _ => panic!("Unsupported data type: {:?}", data_type),
-                }));
+            // Can't use the default random provider because random data isn't compressible
+            // and we will fallback to uncompressed encoding
+            let datagen = Box::new(FnArrayGeneratorProvider::new(move || match data_type {
+                DataType::Utf8 => utf8_prefix_plus_counter("compressme", false),
+                DataType::Binary => {
+                    binary_prefix_plus_counter(Arc::from(b"compressme".to_owned()), false)
+                }
+                DataType::LargeUtf8 => utf8_prefix_plus_counter("compressme", true),
+                DataType::LargeBinary => {
+                    binary_prefix_plus_counter(Arc::from(b"compressme".to_owned()), true)
+                }
+                _ => panic!("Unsupported data type: {:?}", data_type),
+            }));
 
-                check_round_trip_encoding_generated(field, datagen, test_cases).await;
-            }
+            check_round_trip_encoding_generated(field, datagen, test_cases).await;
         }
     }
 }

--- a/rust/lance-encoding/src/encodings/physical/fsst.rs
+++ b/rust/lance-encoding/src/encodings/physical/fsst.rs
@@ -396,13 +396,22 @@ mod tests {
     use lance_datagen::{ByteCount, RowCount};
 
     use super::map_fsst_error;
-    use crate::testing::{TestCases, check_round_trip_encoding_of_data};
+    use crate::testing::{TestCases, TestEncoding, check_round_trip_encoding_of_data};
 
+    #[rstest::rstest]
     #[test_log::test(tokio::test)]
-    async fn test_fsst() {
+    async fn test_fsst(
+        #[values(false, true)] explicit: bool,
+        #[values(
+            TestEncoding::StructuralU16,
+            TestEncoding::StructuralU32,
+            TestEncoding::StructuralSparse
+        )]
+        encoding: TestEncoding,
+    ) {
         let test_cases = TestCases::default()
             .with_expected_encoding("fsst")
-            .with_structural_encodings();
+            .with_encoding(encoding);
 
         // Generate data suitable for FSST (large strings, total size > 32KB)
         let arr = lance_datagen::gen_batch()
@@ -412,15 +421,13 @@ mod tests {
             .column(0)
             .clone();
 
-        // Test both explicit metadata and automatic selection
-        // 1. Test with explicit FSST metadata
-        let metadata_explicit =
-            HashMap::from([("lance-encoding:compression".to_string(), "fsst".to_string())]);
-        check_round_trip_encoding_of_data(vec![arr.clone()], &test_cases, metadata_explicit).await;
-
-        // 2. Test automatic FSST selection based on data characteristics
-        // FSST should be chosen automatically: max_len >= 5 and total_size >= 32KB
-        check_round_trip_encoding_of_data(vec![arr], &test_cases, HashMap::new()).await;
+        let metadata = if explicit {
+            HashMap::from([("lance-encoding:compression".to_string(), "fsst".to_string())])
+        } else {
+            // Automatic selection requires max_len >= 5 and total_size >= 32KB.
+            HashMap::new()
+        };
+        check_round_trip_encoding_of_data(vec![arr], &test_cases, metadata).await;
     }
 
     #[test]

--- a/rust/lance-encoding/src/encodings/physical/value.rs
+++ b/rust/lance-encoding/src/encodings/physical/value.rs
@@ -782,10 +782,7 @@ impl PerValueCompressor for ValueEncoder {
 // public tests module because we share the PRIMITIVE_TYPES constant with fixed_size_list
 #[cfg(test)]
 mod tests {
-    use std::{
-        collections::HashMap,
-        sync::{Arc, LazyLock},
-    };
+    use std::{collections::HashMap, sync::Arc};
 
     use arrow_array::{
         Array, ArrayRef, Decimal128Array, FixedSizeListArray, Int32Array, ListArray, UInt8Array,
@@ -807,8 +804,7 @@ mod tests {
         },
         format::pb21::compressive_encoding::Compression,
         testing::{
-            FnArrayGeneratorProvider, TestCases, check_basic_random,
-            check_round_trip_encoding_generated, check_round_trip_encoding_of_data,
+            TestCases, TestEncoding, check_basic_random_case, check_round_trip_encoding_of_data,
         },
     };
 
@@ -905,75 +901,83 @@ mod tests {
         }
     }
 
-    static LARGE_TYPES: LazyLock<Vec<DataType>> = LazyLock::new(|| {
-        vec![DataType::FixedSizeList(
-            Arc::new(Field::new("", DataType::Int32, false)),
-            128,
-        )]
-    });
-
+    #[rstest::rstest]
     #[test_log::test(tokio::test)]
-    async fn test_large_primitive() {
-        for data_type in LARGE_TYPES.iter() {
-            log::info!("Testing encoding for {:?}", data_type);
-            let field = Field::new("", data_type.clone(), false);
-            check_basic_random(field).await;
-        }
+    async fn test_large_primitive(
+        #[values(
+            TestEncoding::Array,
+            TestEncoding::StructuralU16,
+            TestEncoding::StructuralU32,
+            TestEncoding::StructuralSparse
+        )]
+        encoding: TestEncoding,
+        #[values(4096, 1024 * 1024)] page_size: u64,
+        #[values(false, true)] use_slicing: bool,
+    ) {
+        let data_type =
+            DataType::FixedSizeList(Arc::new(Field::new("", DataType::Int32, false)), 128);
+        let field = Field::new("", data_type, false);
+        check_basic_random_case(field, encoding, page_size, use_slicing).await;
     }
 
+    #[rstest::rstest]
     #[test_log::test(tokio::test)]
-    async fn test_decimal128_dictionary_encoding() {
-        let test_cases = TestCases::default().with_structural_encodings();
+    async fn test_decimal128_dictionary_encoding(
+        #[values(
+            TestEncoding::StructuralU16,
+            TestEncoding::StructuralU32,
+            TestEncoding::StructuralSparse
+        )]
+        encoding: TestEncoding,
+    ) {
+        let test_cases = TestCases::default()
+            .with_encoding(encoding)
+            .with_expected_encoding("dictionary");
         let decimals: Vec<i32> = (0..100).collect();
         let repeated_strings: Vec<_> = decimals
             .iter()
             .cycle()
-            .take(decimals.len() * 10000)
+            .take(decimals.len() * 1000)
             .map(|&v| Some(v as i128))
             .collect();
         let decimal_array = Arc::new(Decimal128Array::from(repeated_strings)) as ArrayRef;
         check_round_trip_encoding_of_data(vec![decimal_array], &test_cases, HashMap::new()).await;
     }
 
+    #[rstest::rstest]
     #[test_log::test(tokio::test)]
-    async fn test_miniblock_stress() {
+    async fn test_miniblock_stress(
+        #[values(false, true)] mixed_validity: bool,
+        #[values(10, 100, 1500, 15000)] batch_size: u32,
+        #[values(1000, 2000, 3000, 60000)] page_size: u64,
+        #[values(
+            TestEncoding::StructuralU16,
+            TestEncoding::StructuralU32,
+            TestEncoding::StructuralSparse
+        )]
+        encoding: TestEncoding,
+    ) {
         // Tests for strange page sizes and batch sizes and validity scenarios for miniblock
 
-        // 10K integers, 100 per array, all valid
-        let data1 = (0..100)
-            .map(|_| Arc::new(Int32Array::from_iter_values(0..100)) as Arc<dyn Array>)
-            .collect::<Vec<_>>();
-
-        // Same as above but with mixed validity
-        let data2 = (0..100)
+        // 10K integers, 100 per array, either all valid or mixed validity.
+        let data = (0..100)
             .map(|_| {
-                Arc::new(Int32Array::from_iter(
-                    (0..100).map(|i| if i % 2 == 0 { Some(i) } else { None }),
-                )) as Arc<dyn Array>
+                if mixed_validity {
+                    Arc::new(Int32Array::from_iter(
+                        (0..100).map(|i| if i % 2 == 0 { Some(i) } else { None }),
+                    )) as Arc<dyn Array>
+                } else {
+                    Arc::new(Int32Array::from_iter_values(0..100)) as Arc<dyn Array>
+                }
             })
             .collect::<Vec<_>>();
 
-        // Same as above but with all null for first half then all valid
-        // TODO: Re-enable once the all-null path is complete
-        let _data3 = (0..100)
-            .map(|chunk_idx| {
-                Arc::new(Int32Array::from_iter(
-                    (0..100).map(|i| if chunk_idx < 50 { None } else { Some(i) }),
-                )) as Arc<dyn Array>
-            })
-            .collect::<Vec<_>>();
+        let test_cases = TestCases::default()
+            .with_page_sizes(vec![page_size])
+            .with_batch_size(batch_size)
+            .with_encoding(encoding);
 
-        for data in [data1, data2 /*data3*/] {
-            for batch_size in [10, 100, 1500, 15000] {
-                // 40000 bytes of data
-                let test_cases = TestCases::default()
-                    .with_page_sizes(vec![1000, 2000, 3000, 60000])
-                    .with_batch_size(batch_size)
-                    .with_structural_encodings();
-
-                check_round_trip_encoding_of_data(data.clone(), &test_cases, HashMap::new()).await;
-            }
-        }
+        check_round_trip_encoding_of_data(data, &test_cases, HashMap::new()).await;
     }
 
     fn create_simple_fsl() -> FixedSizeListArray {
@@ -1250,18 +1254,43 @@ mod tests {
         assert_eq!(decompressed.as_ref(), sample_array.as_ref());
     }
 
+    #[rstest::rstest]
     #[test_log::test(tokio::test)]
-    async fn test_fsl_nullable_items() {
-        let datagen = Box::new(FnArrayGeneratorProvider::new(move || {
-            lance_datagen::array::rand_vec_nullable::<UInt32Type>(Dimension::from(128), 0.5)
-        }));
+    async fn test_fsl_nullable_items(
+        #[values(
+            TestEncoding::Array,
+            TestEncoding::StructuralU16,
+            TestEncoding::StructuralU32,
+            TestEncoding::StructuralSparse
+        )]
+        encoding: TestEncoding,
+    ) {
+        let mut generator =
+            gen_batch()
+                .with_seed(Seed::from(0))
+                .anon_col(array::rand_vec_nullable::<UInt32Type>(
+                    Dimension::from(128),
+                    0.5,
+                ));
+        generator.with_random_nulls(0.2);
+        let source = generator
+            .into_batch_rows(RowCount::from(1026))
+            .unwrap()
+            .column(0)
+            .clone();
+        let test_cases = TestCases::default()
+            .with_page_sizes(vec![4096])
+            .with_encoding(encoding)
+            .with_batch_size(257)
+            .with_range(510..515)
+            .with_indices(vec![0, 511, 512, 1024]);
 
-        let field = Field::new(
-            "",
-            DataType::FixedSizeList(Arc::new(Field::new("item", DataType::UInt32, true)), 128),
-            false,
-        );
-        check_round_trip_encoding_generated(field, datagen, TestCases::default()).await;
+        check_round_trip_encoding_of_data(
+            vec![source.slice(1, 512), source.slice(513, 513)],
+            &test_cases,
+            HashMap::new(),
+        )
+        .await;
     }
 
     #[test_log::test(tokio::test)]

--- a/rust/lance-encoding/src/testing.rs
+++ b/rust/lance-encoding/src/testing.rs
@@ -612,6 +612,27 @@ pub async fn check_basic_random(field: Field) {
     check_specific_random(field, TestCases::basic()).await;
 }
 
+/// Runs one independently schedulable slice of [`check_basic_random`].
+///
+/// The complete matrix is the Cartesian product of all encodings, page sizes,
+/// and slicing modes.  Keeping these axes outside the helper lets expensive
+/// data types preserve the full matrix without concentrating it in one test.
+pub async fn check_basic_random_case(
+    field: Field,
+    encoding: TestEncoding,
+    page_size: u64,
+    use_slicing: bool,
+) {
+    check_specific_random(
+        field,
+        TestCases::basic()
+            .with_encoding(encoding)
+            .with_page_sizes(vec![page_size])
+            .with_slicing_modes([use_slicing]),
+    )
+    .await;
+}
+
 pub async fn check_specific_random(field: Field, test_cases: TestCases) {
     let array_generator_provider = RandomArrayGeneratorProvider {
         field: field.clone(),
@@ -715,6 +736,8 @@ pub struct TestCases {
     skip_validation: bool,
     max_page_size: Option<u64>,
     page_sizes: Vec<u64>,
+    slicing_modes: Vec<bool>,
+    ingest_batch_counts: Vec<u32>,
     encodings: Vec<TestEncoding>,
     verify_encoding: Option<Arc<EncodingVerificationFn>>,
     expected_encoding: Option<Vec<String>>,
@@ -729,6 +752,8 @@ impl Default for TestCases {
             skip_validation: false,
             max_page_size: None,
             page_sizes: vec![4096, 1024 * 1024],
+            slicing_modes: vec![false, true],
+            ingest_batch_counts: vec![1, 5, 10],
             encodings: TestEncoding::all().collect(),
             verify_encoding: None,
             expected_encoding: None,
@@ -808,6 +833,19 @@ impl TestCases {
 
     pub fn with_page_sizes(mut self, page_sizes: Vec<u64>) -> Self {
         self.page_sizes = page_sizes;
+        self
+    }
+
+    pub fn with_slicing_modes(mut self, slicing_modes: impl IntoIterator<Item = bool>) -> Self {
+        self.slicing_modes = slicing_modes.into_iter().collect();
+        self
+    }
+
+    pub fn with_ingest_batch_counts(
+        mut self,
+        ingest_batch_counts: impl IntoIterator<Item = u32>,
+    ) -> Self {
+        self.ingest_batch_counts = ingest_batch_counts.into_iter().collect();
         self
     }
 
@@ -1445,7 +1483,7 @@ async fn check_round_trip_random(
     test_cases: &TestCases,
 ) {
     for null_rate in [None, Some(0.5), Some(1.0)] {
-        for use_slicing in [false, true] {
+        for use_slicing in test_cases.slicing_modes.iter().copied() {
             for encoding in test_cases.encodings() {
                 if null_rate != Some(1.0) && matches!(field.data_type(), DataType::Null) {
                     continue;
@@ -1460,7 +1498,7 @@ async fn check_round_trip_random(
                     field.clone().with_nullable(false)
                 };
 
-                for num_ingest_batches in [1, 5, 10] {
+                for num_ingest_batches in test_cases.ingest_batch_counts.iter().copied() {
                     let rows_per_batch = NUM_RANDOM_ROWS / num_ingest_batches;
                     let mut data = Vec::new();
 

--- a/rust/lance-linalg/src/distance/cosine.rs
+++ b/rust/lance-linalg/src/distance/cosine.rs
@@ -1413,6 +1413,7 @@ mod tests {
 
     use crate::test_utils::{
         arbitrary_bf16, arbitrary_f16, arbitrary_f32, arbitrary_f64, arbitrary_vector_pair,
+        dimension_shard, run_vector_pair_proptest,
     };
     use approx::assert_relative_eq;
     use num_traits::AsPrimitive;
@@ -1500,6 +1501,78 @@ mod tests {
         Ok(())
     }
 
+    #[rstest::rstest]
+    fn test_cosine_f32(
+        #[values(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)] shard: usize,
+    ) {
+        run_vector_pair_proptest(arbitrary_f32, dimension_shard(shard), |x, y| {
+            prop_assume!(norm_l2(&x) > 1e-10);
+            prop_assume!(norm_l2(&y) > 1e-10);
+            do_cosine_test(&x, &y)
+        });
+    }
+
+    #[rstest::rstest]
+    fn test_cosine_f64(
+        #[values(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)] shard: usize,
+    ) {
+        run_vector_pair_proptest(arbitrary_f64, dimension_shard(shard), |x, y| {
+            prop_assume!(norm_l2(&x) > 1e-20);
+            prop_assume!(norm_l2(&y) > 1e-20);
+            do_cosine_test(&x, &y)
+        });
+    }
+
+    #[rstest::rstest]
+    fn test_cosine_fast_f32_scalar_simd_parity(
+        #[values(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)] shard: usize,
+    ) {
+        run_vector_pair_proptest(arbitrary_f32, dimension_shard(shard), |x, y| {
+            prop_assume!(norm_l2(&x) > 1e-10);
+            prop_assume!(norm_l2(&y) > 1e-10);
+            let x_norm = norm_l2(&x);
+            let x_f64: Vec<f64> = x.iter().map(|&v| v as f64).collect();
+            let y_f64: Vec<f64> = y.iter().map(|&v| v as f64).collect();
+            let scalar = cosine_fast_scalar(&x_f64, x_norm, &y_f64);
+            let simd = <f32 as Cosine>::cosine_fast(&x, x_norm, &y);
+            prop_assert!(approx::relative_eq!(scalar, simd, max_relative = 1e-3));
+            Ok(())
+        });
+    }
+
+    #[rstest::rstest]
+    fn test_cosine_with_norms_f32_scalar_simd_parity(
+        #[values(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)] shard: usize,
+    ) {
+        run_vector_pair_proptest(arbitrary_f32, dimension_shard(shard), |x, y| {
+            prop_assume!(norm_l2(&x) > 1e-10);
+            prop_assume!(norm_l2(&y) > 1e-10);
+            let x_norm = norm_l2(&x);
+            let y_norm = norm_l2(&y);
+            let x_f64: Vec<f64> = x.iter().map(|&v| v as f64).collect();
+            let y_f64: Vec<f64> = y.iter().map(|&v| v as f64).collect();
+            let scalar = cosine_with_norms_scalar(&x_f64, x_norm, y_norm, &y_f64);
+            let simd = <f32 as Cosine>::cosine_with_norms(&x, x_norm, y_norm, &y);
+            prop_assert!(approx::relative_eq!(scalar, simd, max_relative = 1e-3));
+            Ok(())
+        });
+    }
+
+    #[rstest::rstest]
+    fn test_cosine_fast_f64_scalar_simd_parity(
+        #[values(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)] shard: usize,
+    ) {
+        run_vector_pair_proptest(arbitrary_f64, dimension_shard(shard), |x, y| {
+            prop_assume!(norm_l2(&x) > 1e-20);
+            prop_assume!(norm_l2(&y) > 1e-20);
+            let x_norm = norm_l2(&x);
+            let scalar = cosine_fast_scalar(&x, x_norm, &y);
+            let simd = <f64 as Cosine>::cosine_fast(&x, x_norm, &y);
+            prop_assert!(approx::relative_eq!(scalar, simd, max_relative = 1e-3));
+            Ok(())
+        });
+    }
+
     proptest::proptest! {
         #[test]
         fn test_cosine_f16((x, y) in arbitrary_vector_pair(arbitrary_f16, 4..4048)) {
@@ -1514,37 +1587,6 @@ mod tests {
             prop_assume!(norm_l2(&x) > 1e-6);
             prop_assume!(norm_l2(&y) > 1e-6);
             do_cosine_test(&x, &y)?;
-        }
-
-        #[test]
-        fn test_cosine_f32((x, y) in arbitrary_vector_pair(arbitrary_f32, 4..4048)){
-            prop_assume!(norm_l2(&x) > 1e-10);
-            prop_assume!(norm_l2(&y) > 1e-10);
-            do_cosine_test(&x, &y)?;
-        }
-
-        #[test]
-        fn test_cosine_f64((x, y) in arbitrary_vector_pair(arbitrary_f64, 4..4048)){
-            prop_assume!(norm_l2(&x) > 1e-20);
-            prop_assume!(norm_l2(&y) > 1e-20);
-            do_cosine_test(&x, &y)?;
-        }
-
-        /// Cross-backend parity for the f32 cosine_fast kernel. Exercises the
-        /// scalar fallback (`cosine_scalar`) against the dispatched SIMD path
-        /// so the runtime fallback is exercised even on AVX2-capable CI hosts.
-        #[test]
-        fn test_cosine_fast_f32_scalar_simd_parity(
-            (x, y) in arbitrary_vector_pair(arbitrary_f32, 4..4048)
-        ) {
-            prop_assume!(norm_l2(&x) > 1e-10);
-            prop_assume!(norm_l2(&y) > 1e-10);
-            let x_norm = norm_l2(&x);
-            let x_f64: Vec<f64> = x.iter().map(|&v| v as f64).collect();
-            let y_f64: Vec<f64> = y.iter().map(|&v| v as f64).collect();
-            let scalar = cosine_fast_scalar(&x_f64, x_norm, &y_f64);
-            let simd = <f32 as Cosine>::cosine_fast(&x, x_norm, &y);
-            prop_assert!(approx::relative_eq!(scalar, simd, max_relative = 1e-3));
         }
 
         /// AVX-512-direct parity for the f32 cosine_fast kernel. Early-returns
@@ -1601,25 +1643,6 @@ mod tests {
             let scalar = cosine_scalar(&x, x_norm, &y);
             let avx = unsafe { f32_x86::cosine_fast_avx(&x, x_norm, &y) };
             prop_assert!(approx::relative_eq!(scalar, avx, max_relative = 1e-5));
-        }
-
-        /// Cross-backend parity for the f32 cosine_with_norms kernel.
-        /// Exercises the scalar fallback (`cosine_scalar_fast`) against the
-        /// dispatched SIMD path so the runtime fallback is exercised even on
-        /// AVX2-capable CI hosts.
-        #[test]
-        fn test_cosine_with_norms_f32_scalar_simd_parity(
-            (x, y) in arbitrary_vector_pair(arbitrary_f32, 4..4048)
-        ) {
-            prop_assume!(norm_l2(&x) > 1e-10);
-            prop_assume!(norm_l2(&y) > 1e-10);
-            let x_norm = norm_l2(&x);
-            let y_norm = norm_l2(&y);
-            let x_f64: Vec<f64> = x.iter().map(|&v| v as f64).collect();
-            let y_f64: Vec<f64> = y.iter().map(|&v| v as f64).collect();
-            let scalar = cosine_with_norms_scalar(&x_f64, x_norm, y_norm, &y_f64);
-            let simd = <f32 as Cosine>::cosine_with_norms(&x, x_norm, y_norm, &y);
-            prop_assert!(approx::relative_eq!(scalar, simd, max_relative = 1e-3));
         }
 
         /// AVX-512-direct parity for the f32 cosine_with_norms kernel.
@@ -1679,22 +1702,6 @@ mod tests {
             let scalar = cosine_scalar_fast(&x, x_norm, &y, y_norm);
             let avx = unsafe { f32_x86::cosine_with_norms_avx(&x, x_norm, y_norm, &y) };
             prop_assert!(approx::relative_eq!(scalar, avx, max_relative = 1e-5));
-        }
-
-        /// Cross-backend parity for the f64 cosine_fast kernel. Uses the
-        /// hand-rolled `cosine_fast_scalar` (not the trait-routed
-        /// `cosine_scalar`, which would itself dispatch through `dot::<f64>`)
-        /// so the reference stays free of any AVX path on AVX2-capable hosts.
-        #[test]
-        fn test_cosine_fast_f64_scalar_simd_parity(
-            (x, y) in arbitrary_vector_pair(arbitrary_f64, 4..4048)
-        ) {
-            prop_assume!(norm_l2(&x) > 1e-20);
-            prop_assume!(norm_l2(&y) > 1e-20);
-            let x_norm = norm_l2(&x);
-            let scalar = cosine_fast_scalar(&x, x_norm, &y);
-            let simd = <f64 as Cosine>::cosine_fast(&x, x_norm, &y);
-            prop_assert!(approx::relative_eq!(scalar, simd, max_relative = 1e-3));
         }
 
         /// AVX-512-direct parity for the f64 cosine_fast kernel. Early-returns

--- a/rust/lance-linalg/src/distance/dot.rs
+++ b/rust/lance-linalg/src/distance/dot.rs
@@ -838,6 +838,7 @@ mod tests {
     use super::*;
     use crate::test_utils::{
         arbitrary_bf16, arbitrary_f16, arbitrary_f32, arbitrary_f64, arbitrary_vector_pair,
+        dimension_shard, run_vector_pair_proptest,
     };
     use num_traits::{Float, FromPrimitive};
     use proptest::prelude::*;
@@ -949,6 +950,39 @@ mod tests {
         Ok(())
     }
 
+    #[rstest::rstest]
+    fn test_dot_f32(#[values(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)] shard: usize) {
+        run_vector_pair_proptest(arbitrary_f32, dimension_shard(shard), |x, y| {
+            do_dot_test(&x, &y)
+        });
+    }
+
+    #[rstest::rstest]
+    fn test_dot_f64(#[values(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)] shard: usize) {
+        run_vector_pair_proptest(arbitrary_f64, dimension_shard(shard), |x, y| {
+            do_dot_test(&x, &y)
+        });
+    }
+
+    #[rstest::rstest]
+    fn test_dot_f32_scalar_simd_parity(
+        #[values(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)] shard: usize,
+    ) {
+        run_vector_pair_proptest(arbitrary_f32, dimension_shard(shard), |x, y| {
+            let x_f64: Vec<f64> = x.iter().map(|&v| v as f64).collect();
+            let y_f64: Vec<f64> = y.iter().map(|&v| v as f64).collect();
+            let scalar = x_f64
+                .iter()
+                .zip(y_f64.iter())
+                .map(|(&a, &b)| a * b)
+                .sum::<f64>() as f32;
+            let simd = <f32 as Dot>::dot(&x, &y);
+            let max_error = max_error::<f32>(&x_f64, &y_f64);
+            prop_assert!(approx::relative_eq!(scalar, simd, epsilon = max_error));
+            Ok(())
+        });
+    }
+
     proptest::proptest! {
         #[test]
         fn test_dot_f16((x, y) in arbitrary_vector_pair(arbitrary_f16, 4..4048)) {
@@ -957,16 +991,6 @@ mod tests {
 
         #[test]
         fn test_dot_bf16((x, y) in arbitrary_vector_pair(arbitrary_bf16, 4..4048)){
-            do_dot_test(&x, &y)?;
-        }
-
-        #[test]
-        fn test_dot_f32((x, y) in arbitrary_vector_pair(arbitrary_f32, 4..4048)){
-            do_dot_test(&x, &y)?;
-        }
-
-        #[test]
-        fn test_dot_f64((x, y) in arbitrary_vector_pair(arbitrary_f64, 4..4048)){
             do_dot_test(&x, &y)?;
         }
 
@@ -982,28 +1006,6 @@ mod tests {
             let scalar = dot_f64_scalar(&x, &y);
             let simd = dot_f64_simd(&x, &y);
             let max_error = max_error::<f64>(&x, &y);
-            prop_assert!(approx::relative_eq!(scalar, simd, epsilon = max_error));
-        }
-
-        /// Parity check for `dot_f32_dispatched` (Branch B exclusive: the
-        /// auto-vectorised scalar dot path). The dispatched kernel must
-        /// agree with a portable f64-precision scalar reference within
-        /// numerical tolerance. The reference is hand-rolled here to keep
-        /// this test architecture-agnostic (the x86_64-only `dot_f64_scalar`
-        /// helper is gated above).
-        #[test]
-        fn test_dot_f32_scalar_simd_parity(
-            (x, y) in arbitrary_vector_pair(arbitrary_f32, 4..4048)
-        ) {
-            let x_f64: Vec<f64> = x.iter().map(|&v| v as f64).collect();
-            let y_f64: Vec<f64> = y.iter().map(|&v| v as f64).collect();
-            let scalar = x_f64
-                .iter()
-                .zip(y_f64.iter())
-                .map(|(&a, &b)| a * b)
-                .sum::<f64>() as f32;
-            let simd = <f32 as Dot>::dot(&x, &y);
-            let max_error = max_error::<f32>(&x_f64, &y_f64);
             prop_assert!(approx::relative_eq!(scalar, simd, epsilon = max_error));
         }
 

--- a/rust/lance-linalg/src/distance/l2.rs
+++ b/rust/lance-linalg/src/distance/l2.rs
@@ -1021,6 +1021,7 @@ mod tests {
 
     use crate::test_utils::{
         arbitrary_bf16, arbitrary_f16, arbitrary_f32, arbitrary_f64, arbitrary_vector_pair,
+        dimension_shard, run_vector_pair_proptest,
     };
 
     #[test]
@@ -1158,6 +1159,40 @@ mod tests {
         do_l2_test(&x, &y).unwrap();
     }
 
+    #[rstest::rstest]
+    fn test_l2_distance_f32(
+        #[values(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)] shard: usize,
+    ) {
+        run_vector_pair_proptest(arbitrary_f32, dimension_shard(shard), |x, y| {
+            do_l2_test(&x, &y)
+        });
+    }
+
+    #[rstest::rstest]
+    fn test_l2_distance_f64(
+        #[values(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)] shard: usize,
+    ) {
+        run_vector_pair_proptest(arbitrary_f64, dimension_shard(shard), |x, y| {
+            do_l2_test(&x, &y)
+        });
+    }
+
+    #[rstest::rstest]
+    fn test_l2_f32_scalar_simd_parity(
+        #[values(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)] shard: usize,
+    ) {
+        run_vector_pair_proptest(arbitrary_f32, dimension_shard(shard), |x, y| {
+            let scalar = x
+                .iter()
+                .zip(y.iter())
+                .map(|(&a, &b)| ((a as f64) - (b as f64)).powi(2))
+                .sum::<f64>() as f32;
+            let simd = <f32 as L2>::l2(&x, &y);
+            prop_assert!(approx::relative_eq!(scalar, simd, max_relative = 1e-3));
+            Ok(())
+        });
+    }
+
     // Test L2 distance over different types.
     // * L2 is valid over the entire range of f16.
     // * L2 is valid over f32 and bf16 in the range of +-1e12.
@@ -1173,16 +1208,6 @@ mod tests {
             do_l2_test(&x, &y)?;
         }
 
-        #[test]
-        fn test_l2_distance_f32((x, y) in arbitrary_vector_pair(arbitrary_f32, 4..4048)){
-            do_l2_test(&x, &y)?;
-        }
-
-        #[test]
-        fn test_l2_distance_f64((x, y) in arbitrary_vector_pair(arbitrary_f64, 4..4048)){
-            do_l2_test(&x, &y)?;
-        }
-
         /// Cross-backend parity: scalar fallback must match the dispatched
         /// SIMD path within numerical tolerance. Exercises `l2_f64_scalar`
         /// directly so the runtime fallback is exercised even on AVX2-capable
@@ -1195,25 +1220,6 @@ mod tests {
             let scalar = l2_f64_scalar(&x, &y);
             let simd = l2_f64_simd(&x, &y);
             prop_assert!(approx::relative_eq!(scalar, simd, max_relative = 1e-6));
-        }
-
-        /// Parity check for `l2_f32_dispatched` (Branch B exclusive: the
-        /// auto-vectorised scalar L2 path). The dispatched kernel must
-        /// agree with a portable f64-precision scalar reference within
-        /// numerical tolerance. The reference is hand-rolled here to keep
-        /// this test architecture-agnostic (the x86_64-only `l2_f64_scalar`
-        /// helper is gated above).
-        #[test]
-        fn test_l2_f32_scalar_simd_parity(
-            (x, y) in arbitrary_vector_pair(arbitrary_f32, 4..4048)
-        ) {
-            let scalar = x
-                .iter()
-                .zip(y.iter())
-                .map(|(&a, &b)| ((a as f64) - (b as f64)).powi(2))
-                .sum::<f64>() as f32;
-            let simd = <f32 as L2>::l2(&x, &y);
-            prop_assert!(approx::relative_eq!(scalar, simd, max_relative = 1e-3));
         }
 
         /// AVX-512-direct parity: explicitly compares the scalar fallback

--- a/rust/lance-linalg/src/distance/norm_l2.rs
+++ b/rust/lance-linalg/src/distance/norm_l2.rs
@@ -472,7 +472,10 @@ pub fn norm_squared_fsl(fsl: &FixedSizeListArray) -> Vec<f32> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_utils::{arbitrary_bf16, arbitrary_f16, arbitrary_f32, arbitrary_f64};
+    use crate::test_utils::{
+        arbitrary_bf16, arbitrary_f16, arbitrary_f32, arbitrary_f64, dimension_shard,
+        run_vector_proptest,
+    };
     use arrow_array::{Float16Array, Float64Array, UInt8Array};
     use lance_arrow::FixedSizeListArrayExt;
     use num_traits::ToPrimitive;
@@ -498,6 +501,36 @@ mod tests {
         Ok(())
     }
 
+    #[rstest::rstest]
+    fn test_l2_norm_f32(
+        #[values(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)] shard: usize,
+    ) {
+        run_vector_proptest(arbitrary_f32, dimension_shard(shard), |data| {
+            do_norm_l2_test(&data)
+        });
+    }
+
+    #[rstest::rstest]
+    fn test_l2_norm_f64(
+        #[values(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)] shard: usize,
+    ) {
+        run_vector_proptest(arbitrary_f64, dimension_shard(shard), |data| {
+            do_norm_l2_test(&data)
+        });
+    }
+
+    #[rstest::rstest]
+    fn test_l2_norm_f32_scalar_simd_parity(
+        #[values(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)] shard: usize,
+    ) {
+        run_vector_proptest(arbitrary_f32, dimension_shard(shard), |data| {
+            let scalar = data.iter().map(|&v| (v as f64).powi(2)).sum::<f64>().sqrt() as f32;
+            let simd = <f32 as Normalize>::norm_l2(&data);
+            prop_assert!(approx::relative_eq!(scalar, simd, max_relative = 1e-3));
+            Ok(())
+        });
+    }
+
     proptest::proptest! {
         #[test]
         fn test_l2_norm_f16(data in prop::collection::vec(arbitrary_f16(), 4..4048)) {
@@ -506,16 +539,6 @@ mod tests {
 
         #[test]
         fn test_l2_norm_bf16(data in prop::collection::vec(arbitrary_bf16(), 4..4048)){
-            do_norm_l2_test(&data)?;
-        }
-
-        #[test]
-        fn test_l2_norm_f32(data in prop::collection::vec(arbitrary_f32(), 4..4048)){
-            do_norm_l2_test(&data)?;
-        }
-
-        #[test]
-        fn test_l2_norm_f64(data in prop::collection::vec(arbitrary_f64(), 4..4048)){
             do_norm_l2_test(&data)?;
         }
 
@@ -531,21 +554,6 @@ mod tests {
             let scalar = norm_l2_f64_scalar(&data);
             let simd = norm_l2_f64_simd(&data);
             prop_assert!(approx::relative_eq!(scalar, simd, max_relative = 1e-6));
-        }
-
-        /// Parity check for `norm_l2_f32_dispatched` (Branch B exclusive: the
-        /// auto-vectorised scalar L2-norm path). The dispatched kernel must
-        /// agree with a portable f64-precision scalar reference within
-        /// numerical tolerance. The reference is hand-rolled here to keep this
-        /// test architecture-agnostic (the x86_64-only `norm_l2_f64_scalar`
-        /// helper is gated above).
-        #[test]
-        fn test_l2_norm_f32_scalar_simd_parity(
-            data in prop::collection::vec(arbitrary_f32(), 4..4048)
-        ) {
-            let scalar = data.iter().map(|&v| (v as f64).powi(2)).sum::<f64>().sqrt() as f32;
-            let simd = <f32 as Normalize>::norm_l2(&data);
-            prop_assert!(approx::relative_eq!(scalar, simd, max_relative = 1e-3));
         }
 
         /// AVX-512-direct parity: explicitly compares the scalar fallback

--- a/rust/lance-linalg/src/test_utils.rs
+++ b/rust/lance-linalg/src/test_utils.rs
@@ -3,6 +3,24 @@
 
 use half::{bf16, f16};
 use proptest::prelude::*;
+use proptest::test_runner::{Config, TestCaseResult, TestRunner};
+use std::ops::Range;
+
+const CASES_PER_DIMENSION_SHARD: u32 = 16;
+const MIN_TEST_DIMENSION: usize = 4;
+const MAX_TEST_DIMENSION: usize = 4048;
+const NUM_DIMENSION_SHARDS: usize = 16;
+
+pub fn dimension_shard(shard: usize) -> Range<usize> {
+    let dimensions_per_shard = (MAX_TEST_DIMENSION - MIN_TEST_DIMENSION) / NUM_DIMENSION_SHARDS;
+    let start = MIN_TEST_DIMENSION + shard * dimensions_per_shard;
+    let end = if shard + 1 == NUM_DIMENSION_SHARDS {
+        MAX_TEST_DIMENSION
+    } else {
+        start + dimensions_per_shard
+    };
+    start..end
+}
 
 /// Arbitrary finite f16 value.
 pub fn arbitrary_f16() -> impl Strategy<Value = f16> {
@@ -78,4 +96,32 @@ where
         let y = prop::collection::vec(values(), dim);
         (x, y)
     })
+}
+
+pub fn run_vector_pair_proptest<T, S, F>(values: fn() -> S, dim_range: Range<usize>, property: F)
+where
+    T: std::fmt::Debug,
+    S: Strategy<Value = T> + 'static,
+    F: Fn(Vec<T>, Vec<T>) -> TestCaseResult,
+{
+    let strategy = arbitrary_vector_pair(values, dim_range);
+    let mut runner = TestRunner::new(Config {
+        cases: CASES_PER_DIMENSION_SHARD,
+        ..Config::default()
+    });
+    runner.run(&strategy, |(x, y)| property(x, y)).unwrap();
+}
+
+pub fn run_vector_proptest<T, S, F>(values: fn() -> S, dim_range: Range<usize>, property: F)
+where
+    T: std::fmt::Debug,
+    S: Strategy<Value = T>,
+    F: Fn(Vec<T>) -> TestCaseResult,
+{
+    let strategy = prop::collection::vec(values(), dim_range);
+    let mut runner = TestRunner::new(Config {
+        cases: CASES_PER_DIMENSION_SHARD,
+        ..Config::default()
+    });
+    runner.run(&strategy, property).unwrap();
 }

--- a/rust/lance/src/dataset/blob.rs
+++ b/rust/lance/src/dataset/blob.rs
@@ -4386,7 +4386,7 @@ mod tests {
             let data = lance_datagen::gen_batch()
                 .col("filterme", array::step::<UInt64Type>())
                 .col("blobs", array::blob())
-                .into_reader_rows(RowCount::from(10), BatchCount::from(10))
+                .into_reader_rows(RowCount::from(10), BatchCount::from(4))
                 .map(|batch| Ok(batch?))
                 .collect::<Result<Vec<_>>>()
                 .unwrap();
@@ -4533,19 +4533,19 @@ mod tests {
             .scan()
             .project::<String>(&[])
             .unwrap()
-            .filter("filterme >= 50")
+            .filter("filterme >= 10")
             .unwrap()
             .with_row_id()
             .try_into_batch()
             .await
             .unwrap();
         let row_ids = row_ids.column(0).as_primitive::<UInt64Type>().values();
-        let row_ids = vec![row_ids[5], row_ids[17], row_ids[33]];
+        let row_ids = vec![row_ids[5], row_ids[17], row_ids[23]];
 
         let blobs = fixture.dataset.take_blobs(&row_ids, "blobs").await.unwrap();
 
         for (actual_idx, (expected_batch_idx, expected_row_idx)) in
-            [(5, 5), (6, 7), (8, 3)].iter().enumerate()
+            [(1, 5), (2, 7), (3, 3)].iter().enumerate()
         {
             let val = blobs[actual_idx].as_ref().unwrap().read().await.unwrap();
             let expected = fixture.data[*expected_batch_idx]
@@ -4613,7 +4613,7 @@ mod tests {
         indices.pop();
 
         // Row indices
-        assert_eq!(indices, [2, 12, 22, 32, 42, 52, 62, 72, 82]);
+        assert_eq!(indices, [2, 12, 22]);
         let blobs = fixture
             .dataset
             .take_blobs_by_indices(&indices, "blobs")
@@ -4826,7 +4826,7 @@ mod tests {
 
         let batches = batches.try_collect::<Vec<_>>().await.unwrap();
 
-        assert_eq!(batches.len(), 10);
+        assert_eq!(batches.len(), 4);
         for batch in batches.iter() {
             assert_eq!(batch.num_columns(), 1);
             assert!(batch.column(0).data_type().is_struct());
@@ -4838,7 +4838,7 @@ mod tests {
             .scan()
             .project(&["blobs"])
             .unwrap()
-            .filter("filterme = 50")
+            .filter("filterme = 30")
             .unwrap()
             .try_into_stream()
             .await

--- a/rust/lance/src/dataset/cleanup.rs
+++ b/rust/lance/src/dataset/cleanup.rs
@@ -4866,7 +4866,7 @@ mod tests {
         );
     }
 
-    #[tokio::test]
+    #[tokio::test(start_paused = true)]
     async fn test_cleanup_with_rate_limit() {
         // Create multiple versions with data files that will be deleted.
         let fixture = MockDatasetFixture::try_new().unwrap();
@@ -4885,7 +4885,7 @@ mod tests {
             .unwrap()
             .build();
 
-        let start = std::time::Instant::now();
+        let start = tokio::time::Instant::now();
         let db = fixture.open().await.unwrap();
         let stats = cleanup_old_versions(&db, policy).await.unwrap();
         let elapsed = start.elapsed();

--- a/rust/lance/src/dataset/delta.rs
+++ b/rust/lance/src/dataset/delta.rs
@@ -2072,10 +2072,10 @@ mod tests {
         use lance_datafusion::exec::LanceExecutionOptions;
 
         let schema = Arc::new(arrow_schema::Schema::new(vec![ROW_ID_FIELD.clone()]));
-        // ~16 MB of candidates against a 2 MB pool: the sorts must spill,
+        // ~8 MB of candidates against a 2 MB pool: the sorts must spill,
         // and the pool still clears DataFusion's fixed merge reservations.
-        let candidate_ids: Vec<u64> = (0..2_000_000).collect();
-        let live_ids: Vec<u64> = (0..2_000_000).filter(|id| id % 3 == 0).collect();
+        let candidate_ids: Vec<u64> = (0..1_000_000).collect();
+        let live_ids: Vec<u64> = (0..1_000_000).filter(|id| id % 3 == 0).collect();
         let expected = candidate_ids.len() - live_ids.len();
         let as_stream = |ids: Vec<u64>| -> datafusion::physical_plan::SendableRecordBatchStream {
             let batches: Vec<_> = ids
@@ -2098,7 +2098,7 @@ mod tests {
             as_stream(live_ids),
             LanceExecutionOptions {
                 use_spilling: true,
-                mem_pool_size: Some(4 * 1024 * 1024),
+                mem_pool_size: Some(2 * 1024 * 1024),
                 ..Default::default()
             },
         )

--- a/rust/lance/src/dataset/mem_wal/write.rs
+++ b/rust/lance/src/dataset/mem_wal/write.rs
@@ -5379,8 +5379,8 @@ mod tests {
         );
     }
 
-    /// Same as the local-fs test but against memory:// — closer to S3
-    /// semantics (conditional PUT, list-prefix consistency).
+    /// Regression for #6713 against memory://, which is closer to S3
+    /// semantics (conditional PUT and list-prefix consistency).
     #[tokio::test]
     async fn test_shard_writer_auto_flush_repeatedly_memory_store() {
         let base_uri = "memory:///bench_test_flush";
@@ -5405,17 +5405,20 @@ mod tests {
 
         let initial_gen = writer.memtable_stats().await.unwrap().generation;
 
-        for i in 0..1000 {
+        // The bug appeared on the second generation because repeated flushes
+        // reused the generation-1 path. Queue several flushes before draining
+        // so both path uniqueness and background sequencing are exercised.
+        for i in 0..8 {
             let batch = create_test_batch(&schema, i * 10, 10);
             writer.put(vec![batch]).await.unwrap();
         }
 
-        tokio::time::sleep(tokio::time::Duration::from_secs(2)).await;
+        writer.wait_for_flush_drain().await.unwrap();
 
         let stats = writer.memtable_stats().await.unwrap();
         assert!(
-            stats.generation >= initial_gen + 50,
-            "expected many flushes; generation went {} → {}",
+            stats.generation >= initial_gen + 3,
+            "expected repeated successful flushes; generation went {} → {}",
             initial_gen,
             stats.generation
         );
@@ -5428,7 +5431,7 @@ mod tests {
     /// hit "Dataset already exists: …_gen_1" once the second flush
     /// started.
     #[tokio::test]
-    async fn test_shard_writer_auto_flush_repeatedly_stress() {
+    async fn test_shard_writer_auto_flush_repeatedly_local_store() {
         let (store, base_path, base_uri, _temp_dir) = create_local_store().await;
         let schema = create_test_schema();
 
@@ -5450,21 +5453,20 @@ mod tests {
 
         let initial_gen = writer.memtable_stats().await.unwrap().generation;
 
-        // Every put crosses the size threshold, so each one queues a
-        // freeze. We want to catch any bug where two flushes collide on
-        // path/generation. Drive 1000 puts so we get ≥ 100 flushes —
-        // enough rope for the bug to show up.
-        for i in 0..1000 {
+        // Queue multiple generations before waiting. The original failure was
+        // deterministic on the second flush, so three committed generations
+        // are sufficient to prove that paths and generation IDs advance.
+        for i in 0..8 {
             let batch = create_test_batch(&schema, i * 10, 10);
             writer.put(vec![batch]).await.unwrap();
         }
 
-        tokio::time::sleep(tokio::time::Duration::from_secs(2)).await;
+        writer.wait_for_flush_drain().await.unwrap();
 
         let stats = writer.memtable_stats().await.unwrap();
         assert!(
-            stats.generation >= initial_gen + 50,
-            "expected many successful auto-flushes; generation went {} → {}",
+            stats.generation >= initial_gen + 3,
+            "expected repeated successful flushes; generation went {} → {}",
             initial_gen,
             stats.generation
         );
@@ -5615,58 +5617,6 @@ mod tests {
             task_executor.tasks.read().unwrap().is_empty(),
             "close must join background tasks before returning an error"
         );
-    }
-
-    /// Regression: the memtable flush should successfully fire many
-    /// times in a row. A bug where every flush wrote the same path was
-    /// caught by lance-format/lance#6713.
-    #[tokio::test]
-    async fn test_shard_writer_auto_flush_repeatedly() {
-        let (store, base_path, base_uri, _temp_dir) = create_local_store().await;
-        let schema = create_test_schema();
-
-        // durable_write=true matches the LSM `merge_insert` defaults and
-        // is the configuration that surfaced #6713 in the wild.
-        let config = ShardWriterConfig {
-            shard_id: Uuid::new_v4(),
-            shard_spec_id: 0,
-            durable_write: true,
-            max_wal_buffer_size: 1024 * 1024,
-            max_wal_flush_interval: Some(Duration::from_millis(10)),
-            // Tiny size threshold so a few batches cross it.
-            max_memtable_size: 1024,
-            manifest_scan_batch_size: 2,
-            ..Default::default()
-        };
-
-        let writer = ShardWriter::open(store, base_path, base_uri, config, schema.clone(), vec![])
-            .await
-            .unwrap();
-
-        let initial_gen = writer.memtable_stats().await.unwrap().generation;
-
-        // Drive enough write traffic to trigger several auto-flushes.
-        // durable_write=true means each put waits for the WAL flush, so
-        // we don't need explicit yields between puts.
-        for i in 0..200 {
-            let batch = create_test_batch(&schema, i * 10, 10);
-            writer.put(vec![batch]).await.unwrap();
-        }
-
-        // Wait for the background memtable flushes to drain.
-        tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
-
-        // Generation should have advanced by at least 3 — i.e. we want to
-        // confirm multiple flushes succeeded back to back, not just one.
-        let stats = writer.memtable_stats().await.unwrap();
-        assert!(
-            stats.generation >= initial_gen + 3,
-            "expected ≥ 3 successful auto-flushes; generation went {} → {}",
-            initial_gen,
-            stats.generation
-        );
-
-        writer.close().await.unwrap();
     }
 
     #[tokio::test]
@@ -7809,7 +7759,7 @@ mod tests {
             max_memtable_size: 64 * 1024 * 1024,
             manifest_scan_batch_size: 2,
             // Short grace so the sweep is observable without a slow test.
-            frozen_memtable_grace: Duration::from_secs(1),
+            frozen_memtable_grace: Duration::from_millis(50),
             ..Default::default()
         };
         let writer = ShardWriter::open(store, base_path, base_uri, config, schema.clone(), vec![])
@@ -7843,7 +7793,7 @@ mod tests {
         );
 
         // After the grace elapses (plus a sweep tick) the handle is evicted.
-        tokio::time::sleep(Duration::from_millis(1_500)).await;
+        tokio::time::sleep(Duration::from_millis(250)).await;
         let refs = writer.in_memory_memtable_refs().await.unwrap();
         assert!(
             refs.frozen.is_empty(),

--- a/rust/lance/src/dataset/optimize/tests/binary_copy.rs
+++ b/rust/lance/src/dataset/optimize/tests/binary_copy.rs
@@ -253,11 +253,14 @@ async fn do_test_binary_copy_with_defer_remap(version: LanceFileVersion) {
     assert_eq!(before_batch, after_batch);
 }
 
+#[rstest::rstest]
+#[case(LanceFileVersion::V2_0)]
+#[case(LanceFileVersion::V2_1)]
+#[case(LanceFileVersion::V2_2)]
+#[case(LanceFileVersion::V2_3)]
 #[tokio::test]
-async fn test_binary_copy_preserves_stable_row_ids() {
-    for version in NON_LEGACY_VERSIONS {
-        do_binary_copy_preserves_stable_row_ids(version).await;
-    }
+async fn test_binary_copy_preserves_stable_row_ids(#[case] version: LanceFileVersion) {
+    do_binary_copy_preserves_stable_row_ids(version).await;
 }
 
 async fn do_binary_copy_preserves_stable_row_ids(version: LanceFileVersion) {
@@ -269,17 +272,18 @@ async fn do_binary_copy_preserves_stable_row_ids(version: LanceFileVersion) {
         .col(Box::new(IncrementingInt32::new().named("i".to_owned())));
 
     let mut dataset = Dataset::write(
-        data_gen.batch(4_000),
+        data_gen.batch(1_024),
         format!("memory://test/binary_copy_stable_row_ids_{}", version).as_str(),
         Some(WriteParams {
             enable_stable_row_ids: true,
             data_storage_version: Some(version),
-            max_rows_per_file: 500,
+            max_rows_per_file: 256,
             ..Default::default()
         }),
     )
     .await
     .unwrap();
+    assert_eq!(dataset.get_fragments().len(), 4);
 
     dataset
         .create_index(
@@ -344,7 +348,7 @@ async fn do_binary_copy_preserves_stable_row_ids(version: LanceFileVersion) {
         .unwrap();
 
     let options = CompactionOptions {
-        target_rows_per_fragment: 2_000,
+        target_rows_per_fragment: 512,
         compaction_mode: Some(CompactionMode::ForceBinaryCopy),
         ..Default::default()
     };
@@ -386,11 +390,14 @@ async fn do_binary_copy_preserves_stable_row_ids(version: LanceFileVersion) {
     assert_eq!(before, after);
 }
 
+#[rstest::rstest]
+#[case(LanceFileVersion::V2_0)]
+#[case(LanceFileVersion::V2_1)]
+#[case(LanceFileVersion::V2_2)]
+#[case(LanceFileVersion::V2_3)]
 #[tokio::test]
-async fn test_binary_copy_remaps_unstable_row_ids() {
-    for version in NON_LEGACY_VERSIONS {
-        do_binary_copy_remaps_unstable_row_ids(version).await;
-    }
+async fn test_binary_copy_remaps_unstable_row_ids(#[case] version: LanceFileVersion) {
+    do_binary_copy_remaps_unstable_row_ids(version).await;
 }
 
 async fn do_binary_copy_remaps_unstable_row_ids(version: LanceFileVersion) {
@@ -401,17 +408,18 @@ async fn do_binary_copy_remaps_unstable_row_ids(version: LanceFileVersion) {
         .col(Box::new(IncrementingInt32::new().named("i".to_owned())));
 
     let mut dataset = Dataset::write(
-        data_gen.batch(4_000),
-        "memory://test/binary_copy_no_stable",
+        data_gen.batch(1_024),
+        format!("memory://test/binary_copy_no_stable_{version}").as_str(),
         Some(WriteParams {
             enable_stable_row_ids: false,
             data_storage_version: Some(version),
-            max_rows_per_file: 500,
+            max_rows_per_file: 256,
             ..Default::default()
         }),
     )
     .await
     .unwrap();
+    assert_eq!(dataset.get_fragments().len(), 4);
 
     dataset
         .create_index(
@@ -463,7 +471,7 @@ async fn do_binary_copy_remaps_unstable_row_ids(version: LanceFileVersion) {
         .unwrap();
 
     let options = CompactionOptions {
-        target_rows_per_fragment: 2_000,
+        target_rows_per_fragment: 512,
         compaction_mode: Some(CompactionMode::ForceBinaryCopy),
         ..Default::default()
     };

--- a/rust/lance/src/dataset/scanner.rs
+++ b/rust/lance/src/dataset/scanner.rs
@@ -8271,9 +8271,9 @@ mod test {
         // smaller scale): a large leading block of matches, a large gap of
         // non-matches, then a small trailing match. Single fragment.
         let batches = vec![
-            make_batch(0, 100_000, 7),
-            make_batch(100_000, 400_000, 1),
-            make_batch(500_000, 7_300, 7),
+            make_batch(0, 20_000, 7),
+            make_batch(20_000, 80_000, 1),
+            make_batch(100_000, 1_500, 7),
         ];
 
         let reader = RecordBatchIterator::new(batches.into_iter().map(Ok), schema.clone());
@@ -8307,7 +8307,7 @@ mod test {
         scan.project(&["id", "items"]).unwrap();
         scan.materialization_style(MaterializationStyle::AllEarlyExcept(vec![items_b_field_id]));
         let result = scan.try_into_batch().await.unwrap();
-        assert_eq!(result.num_rows(), 107_300);
+        assert_eq!(result.num_rows(), 21_500);
     }
 
     #[tokio::test]
@@ -8527,7 +8527,7 @@ mod test {
         // Make the store slow so that if we don't cancel the scan, it will take a loooong time.
         let throttled = Arc::new(ThrottledStoreWrapper {
             config: ThrottleConfig {
-                wait_get_per_call: Duration::from_secs(1),
+                wait_get_per_call: Duration::from_millis(100),
                 ..Default::default()
             },
         });
@@ -8566,8 +8566,8 @@ mod test {
 
         // This test is a timing test, which is unfortunate, as it may be flaky.  I'm hoping
         // we have enough wiggle room here.  The failure case is 30s on my machine and the pass
-        // case is 2-3s.
-        assert!(duration < Duration::from_secs(10));
+        // case is a few hundred milliseconds.
+        assert!(duration < Duration::from_secs(3));
     }
 
     #[rstest]
@@ -11360,6 +11360,8 @@ mod test {
         #[values(LanceFileVersion::Legacy, LanceFileVersion::Stable)]
         data_storage_version: LanceFileVersion,
         #[values(false, true)] use_stable_row_ids: bool,
+        #[values(false, true)] use_index: bool,
+        #[values(false, true)] use_projection: bool,
     ) {
         let fixture = Box::pin(ScalarIndexTestFixture::new(
             data_storage_version,
@@ -11367,42 +11369,36 @@ mod test {
         ))
         .await;
 
-        for use_index in [false, true] {
-            for use_projection in [false, true] {
-                for use_deleted_data in [false, true] {
-                    for use_new_data in [false, true] {
-                        // Don't test compaction in conjunction with deletion and new data, it's too
-                        // many combinations with no clear benefit.  Feel free to update if there is
-                        // a need
-                        // TODO: enable compaction for stable row id once supported.
-                        let compaction_choices =
-                            if use_deleted_data || use_new_data || use_stable_row_ids {
-                                vec![false]
-                            } else {
-                                vec![false, true]
+        for use_deleted_data in [false, true] {
+            for use_new_data in [false, true] {
+                // Don't test compaction in conjunction with deletion and new data, it's too
+                // many combinations with no clear benefit.  Feel free to update if there is
+                // a need
+                // TODO: enable compaction for stable row id once supported.
+                let compaction_choices = if use_deleted_data || use_new_data || use_stable_row_ids {
+                    vec![false]
+                } else {
+                    vec![false, true]
+                };
+                for use_compaction in compaction_choices {
+                    let updated_choices = if use_deleted_data || use_new_data || use_compaction {
+                        vec![false]
+                    } else {
+                        vec![false, true]
+                    };
+                    for use_updated in updated_choices {
+                        for with_row_id in [false, true] {
+                            let params = ScalarTestParams {
+                                use_index,
+                                use_projection,
+                                use_deleted_data,
+                                use_new_data,
+                                with_row_id,
+                                use_compaction,
+                                use_updated,
                             };
-                        for use_compaction in compaction_choices {
-                            let updated_choices =
-                                if use_deleted_data || use_new_data || use_compaction {
-                                    vec![false]
-                                } else {
-                                    vec![false, true]
-                                };
-                            for use_updated in updated_choices {
-                                for with_row_id in [false, true] {
-                                    let params = ScalarTestParams {
-                                        use_index,
-                                        use_projection,
-                                        use_deleted_data,
-                                        use_new_data,
-                                        with_row_id,
-                                        use_compaction,
-                                        use_updated,
-                                    };
-                                    fixture.check_vector_queries(&params).await;
-                                    fixture.check_simple_queries(&params).await;
-                                }
-                            }
+                            fixture.check_vector_queries(&params).await;
+                            fixture.check_simple_queries(&params).await;
                         }
                     }
                 }
@@ -11467,7 +11463,7 @@ mod test {
             .col("ngram", array::rand_utf8(ByteCount::from(5), false))
             .col("exact", array::rand_type(&DataType::UInt32))
             .col("no_index", array::rand_type(&DataType::UInt32))
-            .into_reader_rows(RowCount::from(1000), BatchCount::from(5));
+            .into_reader_rows(RowCount::from(32), BatchCount::from(2));
 
         let mut dataset = Dataset::write(data, "memory://test", None).await.unwrap();
         dataset

--- a/rust/lance/src/dataset/schema_evolution.rs
+++ b/rust/lance/src/dataset/schema_evolution.rs
@@ -3252,8 +3252,9 @@ mod test {
         )
         .await?;
 
-        // Build an IVF_PQ index on the vector column.
-        let params = VectorIndexParams::ivf_pq(4, 8, 8, MetricType::L2, 50);
+        // Any attached vector index blocks the cast; IVF_FLAT exercises that
+        // ownership contract without unrelated quantizer training.
+        let params = VectorIndexParams::ivf_flat(1, MetricType::L2);
         dataset
             .create_index(&["vec"], IndexType::Vector, None, &params, false)
             .await?;

--- a/rust/lance/src/dataset/tests/dataset_index.rs
+++ b/rust/lance/src/dataset/tests/dataset_index.rs
@@ -4311,11 +4311,11 @@ async fn test_fts_phrase_query() {
     let words = ["lance", "full", "text", "search"];
     let mut lance_search_count = 0;
     let mut full_text_count = 0;
-    let mut doc_array = (0..4096)
+    let mut doc_array = (0..256)
         .map(|_| {
             let mut rng = rand::rng();
-            let mut text = String::with_capacity(512);
-            let len = rng.random_range(127..512);
+            let mut text = String::with_capacity(128);
+            let len = rng.random_range(31..128);
             for i in 0..len {
                 if i > 0 {
                     text.push(' ');

--- a/rust/lance/src/dataset/write/commit.rs
+++ b/rust/lance/src/dataset/write/commit.rs
@@ -925,7 +925,7 @@ mod tests {
         );
     }
 
-    #[tokio::test]
+    #[tokio::test(start_paused = true)]
     async fn test_commit_timeout_triggers() {
         let throttled = Arc::new(ThrottledStoreWrapper {
             config: ThrottleConfig {
@@ -964,7 +964,7 @@ mod tests {
         assert!(matches!(&err, Error::Timeout { .. }), "got {err:?}");
     }
 
-    #[tokio::test]
+    #[tokio::test(start_paused = true)]
     async fn test_commit_timeout_applies_to_execute_batch() {
         let throttled = Arc::new(ThrottledStoreWrapper {
             config: ThrottleConfig {
@@ -1008,7 +1008,7 @@ mod tests {
     /// `with_timeout(None)` must let a commit run unbounded. Uses a throttled
     /// store so the commit takes real wall-clock time — long enough that the
     /// 50ms timeout in `test_commit_timeout_triggers` would have fired.
-    #[tokio::test]
+    #[tokio::test(start_paused = true)]
     async fn test_commit_timeout_none_disables() {
         let throttled = Arc::new(ThrottledStoreWrapper {
             config: ThrottleConfig {
@@ -1150,7 +1150,7 @@ mod tests {
 
     /// On non-lexically-ordered stores (e.g. S3 Express) a commit should use the
     /// version hint (a few HEAD probes, O(k)) instead of a full O(n) listing.
-    #[tokio::test]
+    #[tokio::test(start_paused = true)]
     async fn test_commit_uses_version_hint_on_non_lexical_store() {
         // Make `list` artificially slow per entry so a full listing would be
         // obvious; HEAD/GET/PUT stay fast.

--- a/rust/lance/src/dataset/write/merge_insert.rs
+++ b/rust/lance/src/dataset/write/merge_insert.rs
@@ -8333,7 +8333,7 @@ mod tests {
     #[rstest::rstest]
     #[case::all_success(Duration::from_secs(100_000))]
     #[case::timeout(Duration::from_millis(200))]
-    #[tokio::test]
+    #[tokio::test(start_paused = true)]
     async fn test_merge_insert_concurrency(#[case] timeout: Duration) {
         let schema = Arc::new(Schema::new(vec![
             Field::new("id", DataType::UInt32, false),

--- a/rust/lance/src/dataset/write/update.rs
+++ b/rust/lance/src/dataset/write/update.rs
@@ -1111,8 +1111,8 @@ mod tests {
         // Increase likelihood of contention by throttling the store
         let throttled = Arc::new(ThrottledStoreWrapper {
             config: ThrottleConfig {
-                wait_list_per_call: Duration::from_millis(10),
-                wait_get_per_call: Duration::from_millis(10),
+                wait_list_per_call: Duration::from_millis(1),
+                wait_get_per_call: Duration::from_millis(1),
                 ..Default::default()
             },
         });

--- a/rust/lance/src/index/vector/pq.rs
+++ b/rust/lance/src/index/vector/pq.rs
@@ -770,7 +770,11 @@ mod tests {
         let centroids = generate_random_array_with_range::<Float32Type>(4 * DIM, -1.0..1.0);
         let fsl = FixedSizeListArray::try_new_from_values(centroids, DIM as i32).unwrap();
         let ivf = IvfModel::new(fsl, None);
-        let params = PQBuildParams::new(16, 8);
+        let params = PQBuildParams {
+            max_iters: 2,
+            sample_rate: 4,
+            ..PQBuildParams::new(16, 8)
+        };
         let pq = build_pq_model(&dataset, "vector", DIM, MetricType::L2, &params, Some(&ivf))
             .await
             .unwrap();
@@ -810,7 +814,11 @@ mod tests {
         )
         .await
         .unwrap();
-        let params = PQBuildParams::new(16, 8);
+        let params = PQBuildParams {
+            max_iters: 2,
+            sample_rate: 4,
+            ..PQBuildParams::new(16, 8)
+        };
         let pq = build_pq_model(
             &dataset,
             "vector",

--- a/rust/lance/src/io/commit/external_manifest.rs
+++ b/rust/lance/src/io/commit/external_manifest.rs
@@ -4,10 +4,10 @@
 /// Keep the tests in `lance` crate because it has dependency on [Dataset].
 #[cfg(test)]
 mod test {
+    use std::collections::HashMap;
     use std::ops::Range;
     use std::sync::Arc;
     use std::sync::atomic::{AtomicUsize, Ordering};
-    use std::{collections::HashMap, time::Duration};
 
     use async_trait::async_trait;
     use bytes::Bytes;
@@ -26,7 +26,7 @@ mod test {
         ObjectStore as OSObjectStore, ObjectStoreExt, PutMultipartOptions, PutOptions, PutPayload,
         PutResult, RenameOptions, Result as OSResult, local::LocalFileSystem, path::Path,
     };
-    use tokio::sync::Mutex;
+    use tokio::sync::{Barrier, Mutex};
 
     use crate::dataset::builder::DatasetBuilder;
     use crate::{
@@ -35,22 +35,30 @@ mod test {
     };
     use lance_core::utils::tempfile::TempStrDir;
 
-    // sleep for 1 second to simulate a slow external store on write
     #[derive(Debug)]
-    struct SleepyExternalManifestStore {
+    struct TestExternalManifestStore {
         store: Arc<Mutex<HashMap<(String, u64), String>>>,
+        contention: Option<(u64, Arc<Barrier>)>,
     }
 
-    impl SleepyExternalManifestStore {
+    impl TestExternalManifestStore {
         fn new() -> Self {
             Self {
                 store: Arc::new(Mutex::new(HashMap::new())),
+                contention: None,
+            }
+        }
+
+        fn with_contention(version: u64, participants: usize) -> Self {
+            Self {
+                contention: Some((version, Arc::new(Barrier::new(participants)))),
+                ..Self::new()
             }
         }
     }
 
     #[async_trait]
-    impl ExternalManifestStore for SleepyExternalManifestStore {
+    impl ExternalManifestStore for TestExternalManifestStore {
         /// Get the manifest path for a given uri and version
         async fn get(&self, uri: &str, version: u64) -> Result<String> {
             let store = self.store.lock().await;
@@ -86,7 +94,14 @@ mod test {
             _size: u64,
             _e_tag: Option<String>,
         ) -> Result<()> {
-            tokio::time::sleep(Duration::from_millis(100)).await;
+            if let Some((contended_version, barrier)) = &self.contention
+                && version == *contended_version
+            {
+                // Every writer reaches the external compare-and-set with the same
+                // proposed version before any writer can publish it. This forces
+                // the retry path deterministically instead of relying on sleeps.
+                barrier.wait().await;
+            }
 
             let mut store = self.store.lock().await;
             match store.get(&(uri.to_string(), version)) {
@@ -110,8 +125,6 @@ mod test {
             _size: u64,
             _e_tag: Option<String>,
         ) -> Result<()> {
-            tokio::time::sleep(Duration::from_millis(100)).await;
-
             let mut store = self.store.lock().await;
             match store.get(&(uri.to_string(), version)) {
                 Some(_) => {
@@ -215,7 +228,7 @@ mod test {
 
     #[tokio::test]
     async fn finalized_external_manifest_location_is_head_checked() {
-        let sleepy_store = SleepyExternalManifestStore::new();
+        let sleepy_store = TestExternalManifestStore::new();
         let inner_store = sleepy_store.store.clone();
         let handler = ExternalManifestCommitHandler {
             external_manifest_store: Arc::new(sleepy_store),
@@ -248,7 +261,7 @@ mod test {
 
     #[tokio::test]
     async fn finalized_external_manifest_location_falls_back_to_v1() {
-        let sleepy_store = SleepyExternalManifestStore::new();
+        let sleepy_store = TestExternalManifestStore::new();
         let inner_store = sleepy_store.store.clone();
         let handler = ExternalManifestCommitHandler {
             external_manifest_store: Arc::new(sleepy_store),
@@ -470,7 +483,7 @@ mod test {
         Dataset::write(reader, ds_uri, None).await.unwrap();
 
         // Then try to load the dataset with external store handler set
-        let sleepy_store = SleepyExternalManifestStore::new();
+        let sleepy_store = TestExternalManifestStore::new();
         let handler = Arc::new(ExternalManifestCommitHandler {
             external_manifest_store: Arc::new(sleepy_store),
         });
@@ -497,7 +510,7 @@ mod test {
     #[tokio::test]
     #[cfg(not(windows))]
     async fn test_can_create_dataset_with_external_store() {
-        let sleepy_store = SleepyExternalManifestStore::new();
+        let sleepy_store = TestExternalManifestStore::new();
         let handler = ExternalManifestCommitHandler {
             external_manifest_store: Arc::new(sleepy_store),
         };
@@ -524,96 +537,96 @@ mod test {
     #[cfg(not(windows))]
     #[tokio::test]
     async fn test_concurrent_commits_are_okay() {
-        // Run test 20 times to have a higher chance of catching race conditions
-        for _ in 0..20 {
-            let sleepy_store = SleepyExternalManifestStore::new();
-            let handler = ExternalManifestCommitHandler {
-                external_manifest_store: Arc::new(sleepy_store),
-            };
-            let handler = Arc::new(handler);
+        const NUM_WRITERS: usize = 5;
+        const CONTENDED_VERSION: u64 = 2;
+        let external_store =
+            TestExternalManifestStore::with_contention(CONTENDED_VERSION, NUM_WRITERS);
+        let handler = Arc::new(ExternalManifestCommitHandler {
+            external_manifest_store: Arc::new(external_store),
+        });
 
-            let mut data_gen =
-                BatchGenerator::new().col(Box::new(IncrementingInt32::new().named("x".to_owned())));
-            let dir = TempStrDir::default();
-            let ds_uri = &dir;
+        let mut data_gen =
+            BatchGenerator::new().col(Box::new(IncrementingInt32::new().named("x".to_owned())));
+        let dir = TempStrDir::default();
+        let ds_uri = &dir;
 
-            Dataset::write(
-                data_gen.batch(10),
-                ds_uri,
-                Some(write_params(handler.clone())),
-            )
+        Dataset::write(
+            data_gen.batch(10),
+            ds_uri,
+            Some(write_params(handler.clone())),
+        )
+        .await
+        .unwrap();
+
+        // All writers first attempt version 2. One succeeds and the rest must
+        // observe the conflict, refresh, and commit distinct later versions.
+        let write_futs = (0..NUM_WRITERS)
+            .map(|_| data_gen.batch(10))
+            .map(|data| {
+                let mut params = write_params(handler.clone());
+                params.mode = WriteMode::Append;
+                Dataset::write(data, ds_uri, Some(params))
+            })
+            .collect::<Vec<_>>();
+
+        let res = join_all(write_futs).await;
+
+        let errors = res
+            .into_iter()
+            .filter(|r| r.is_err())
+            .map(|r| r.unwrap_err())
+            .collect::<Vec<_>>();
+
+        assert!(errors.is_empty(), "{:?}", errors);
+
+        let ds = DatasetBuilder::from_uri(ds_uri)
+            .with_read_params(read_params(handler))
+            .load()
             .await
             .unwrap();
+        assert_eq!(ds.count_rows(None).await.unwrap(), 60);
+        assert_eq!(ds.version().version, (NUM_WRITERS + 1) as u64);
 
-            // we have 5 retries by default, more than this will just fail
-            let write_futs = (0..5)
-                .map(|_| data_gen.batch(10))
-                .map(|data| {
-                    let mut params = write_params(handler.clone());
-                    params.mode = WriteMode::Append;
-                    Dataset::write(data, ds_uri, Some(params))
-                })
-                .collect::<Vec<_>>();
-
-            let res = join_all(write_futs).await;
-
-            let errors = res
-                .into_iter()
-                .filter(|r| r.is_err())
-                .map(|r| r.unwrap_err())
-                .collect::<Vec<_>>();
-
-            assert!(errors.is_empty(), "{:?}", errors);
-
-            // load the data and check the content
-            let ds = DatasetBuilder::from_uri(ds_uri)
-                .with_read_params(read_params(handler))
-                .load()
-                .await
-                .unwrap();
-            assert_eq!(ds.count_rows(None).await.unwrap(), 60);
-
-            // No temporary manifests left over
-            let manifest_path = format!("{}/{}", dir, "_versions/");
-            let unexpected_entries = std::fs::read_dir(manifest_path)
-                .unwrap()
-                .filter(|entry| {
-                    let entry = entry.as_ref().unwrap();
-                    !entry
-                        .file_name()
-                        .as_os_str()
-                        .to_string_lossy()
-                        .ends_with(".manifest")
-                })
-                // There is a bug in local fs where concurrent commits can leave behind
-                // temporary `x.manifest#n` files. This might be a bug in object-store.
-                // TODO: fix this.
-                .filter(|entry| {
-                    let entry = entry.as_ref().unwrap();
-                    !entry
-                        .file_name()
-                        .as_os_str()
-                        .to_string_lossy()
-                        .contains(".manifest#")
-                })
-                // The version hint file is expected to be present.
-                .filter(|entry| {
-                    let entry = entry.as_ref().unwrap();
-                    !entry
-                        .file_name()
-                        .as_os_str()
-                        .to_string_lossy()
-                        .starts_with("latest_version_hint")
-                })
-                .collect::<Vec<_>>();
-            assert!(unexpected_entries.is_empty(), "{:?}", unexpected_entries);
-        }
+        // No temporary manifests left over.
+        let manifest_path = format!("{}/{}", dir, "_versions/");
+        let unexpected_entries = std::fs::read_dir(manifest_path)
+            .unwrap()
+            .filter(|entry| {
+                let entry = entry.as_ref().unwrap();
+                !entry
+                    .file_name()
+                    .as_os_str()
+                    .to_string_lossy()
+                    .ends_with(".manifest")
+            })
+            // There is a bug in local fs where concurrent commits can leave behind
+            // temporary `x.manifest#n` files. This might be a bug in object-store.
+            // TODO: fix this.
+            .filter(|entry| {
+                let entry = entry.as_ref().unwrap();
+                !entry
+                    .file_name()
+                    .as_os_str()
+                    .to_string_lossy()
+                    .contains(".manifest#")
+            })
+            // The version hint file is expected to be present.
+            .filter(|entry| {
+                let entry = entry.as_ref().unwrap();
+                !entry
+                    .file_name()
+                    .as_os_str()
+                    .to_string_lossy()
+                    .starts_with("latest_version_hint")
+            })
+            .collect::<Vec<_>>();
+        assert!(unexpected_entries.is_empty(), "{:?}", unexpected_entries);
     }
 
     #[tokio::test]
     #[cfg(not(windows))]
     async fn test_out_of_sync_dataset_can_recover() {
-        let sleepy_store = SleepyExternalManifestStore::new();
+        let sleepy_store = TestExternalManifestStore::new();
         let inner_store = sleepy_store.store.clone();
         let handler = ExternalManifestCommitHandler {
             external_manifest_store: Arc::new(sleepy_store),
@@ -934,7 +947,7 @@ mod test {
 
         // Spin up an ExternalManifestStore and drive `put` (the same code
         // path the failing CTAS hits via ExternalManifestCommitHandler).
-        let external = SleepyExternalManifestStore::new();
+        let external = TestExternalManifestStore::new();
         let head_meta = capped.head(&staging_path).await.unwrap();
         let final_path = ManifestNamingScheme::V2.manifest_path(&base_path, 1);
         // The fixture stores only a tiny body, so its source-size override must
@@ -1010,7 +1023,7 @@ mod test {
         // well below the 5 GB cap, so copy_size_aware must take the fast
         // path.
 
-        let external = SleepyExternalManifestStore::new();
+        let external = TestExternalManifestStore::new();
         let head_meta = capped.head(&staging_path).await.unwrap();
 
         external


### PR DESCRIPTION
Large cross-product test loops, oversized fixtures, and real-time waits make local unit-test feedback unnecessarily slow and leave individual cases above the one-second target.

This change shards independent parameter matrices into named test cases while preserving their original axes and assertions, keeps the same property-test sample budget across dimension shards, uses virtual time where elapsed wall-clock time is not the behavior under test, and selects smaller fixtures or models only where scale is outside the tested contract. Recall thresholds, encoding combinations, boundary conditions, concurrency semantics, and end-to-end lifecycle assertions remain intact.

The tests continue to run under the normal runner configuration; this does not add resource locks or scheduling constraints to hide contention.
