### PR TITLE
test(python): reduce slow test workloads

### DIFF
--- a/python/python/tests/test_dataset.py
+++ b/python/python/tests/test_dataset.py
@@ -1754,6 +1754,27 @@ def test_cleanup_with_older_than_and_retain_versions(tmp_path: Path):
     assert ds.count_rows() == len(ds.to_table())
 
 
+def _wait_until_latest_version_is_older_than(dataset, older_than_seconds):
+    latest_timestamp = dataset.versions()[-1]["timestamp"]
+    threshold = latest_timestamp + timedelta(seconds=older_than_seconds)
+    deadline = time.monotonic() + older_than_seconds + 1
+
+    while True:
+        now = (
+            datetime.now(latest_timestamp.tzinfo)
+            if latest_timestamp.tzinfo is not None
+            else datetime.now()
+        )
+        remaining = (threshold - now).total_seconds()
+        if remaining < 0:
+            return
+
+        timeout_remaining = deadline - time.monotonic()
+        if timeout_remaining <= 0:
+            pytest.fail("latest dataset version did not pass the cleanup age threshold")
+        time.sleep(min(remaining + 0.05, timeout_remaining))
+
+
 def test_auto_cleanup(tmp_path):
     table = pa.Table.from_pydict({"a": range(100), "b": range(100)})
     base_dir = tmp_path / "test"
@@ -1768,11 +1789,11 @@ def test_auto_cleanup(tmp_path):
     lance.write_dataset(table, base_dir, mode="append")
     lance.write_dataset(table, base_dir, mode="append")
 
-    time.sleep(5)
+    dataset = lance.dataset(base_dir)
+    _wait_until_latest_version_is_older_than(dataset, 1)
 
     # trigger cleanup
     lance.write_dataset(table, base_dir, mode="append")
-    dataset = lance.dataset(base_dir)
     assert len(dataset.versions()) == 2
 
 
@@ -1787,7 +1808,7 @@ def test_config_update_auto_cleanup(tmp_path):
     lance.write_dataset(table, base_dir, mode="append")
     lance.write_dataset(table, base_dir, mode="append")
 
-    time.sleep(5)
+    _wait_until_latest_version_is_older_than(ds, 0.001)
 
     # trigger cleanup
     lance.write_dataset(table, base_dir, mode="append")
@@ -1823,12 +1844,13 @@ def test_auto_cleanup_invalid(tmp_path):
         table, base_dir, auto_cleanup_options=auto_cleanup_options, mode="append"
     )
 
-    time.sleep(3)
+    dataset = lance.dataset(base_dir)
+    assert "lance.auto_cleanup.interval" not in dataset.config()
+    assert "lance.auto_cleanup.older_than" not in dataset.config()
 
     lance.write_dataset(
         table, base_dir, auto_cleanup_options=auto_cleanup_options, mode="append"
     )
-    dataset = lance.dataset(base_dir)
     assert len(dataset.versions()) == 4
 
 
@@ -1846,7 +1868,7 @@ def test_enable_disable_auto_cleanup(tmp_path):
     lance.write_dataset(table, base_dir, mode="append")
     lance.write_dataset(table, base_dir, mode="append")
 
-    time.sleep(5)
+    _wait_until_latest_version_is_older_than(ds, 1)
 
     # trigger cleanup
     lance.write_dataset(table, base_dir, mode="append")
@@ -1854,12 +1876,14 @@ def test_enable_disable_auto_cleanup(tmp_path):
 
     # this is a transactional commit, so will increase a version
     ds.optimize.disable_auto_cleanup()
+    assert "lance.auto_cleanup.interval" not in ds.config()
+    assert "lance.auto_cleanup.older_than" not in ds.config()
 
     lance.write_dataset(table, base_dir, mode="append")
     lance.write_dataset(table, base_dir, mode="append")
     lance.write_dataset(table, base_dir, mode="append")
 
-    time.sleep(5)
+    _wait_until_latest_version_is_older_than(ds, 1)
 
     # wait to see if cleanup would be trigger
     lance.write_dataset(table, base_dir, mode="append")

--- a/python/python/tests/test_file.py
+++ b/python/python/tests/test_file.py
@@ -482,18 +482,27 @@ def test_write_read_additional_schema_metadata(tmp_path):
 
 
 def test_writer_maintains_order(tmp_path):
-    # 100Ki strings, each string is a couple of KiBs
-    big_strings = [f"{i}" * 1024 for i in range(100 * 1024)]
-    table = pa.table({"big_strings": big_strings})
+    row_ids = list(range(8))
+    payloads = ["0123456789abcdef" * (64 * 1024)] + [
+        f"page-{row_id}" for row_id in row_ids[1:]
+    ]
+    table = pa.table({"payload": payloads, "row_id": row_ids})
+    path = tmp_path / "ordered-pages.lance"
 
-    for i in range(4):
-        path = tmp_path / f"foo-{i}.lance"
-        with LanceFileWriter(str(path)) as writer:
-            writer.write_batch(table)
+    # Before #2836, the seven cheap pages could finish encoding before the
+    # expensive first page and be written out of order.
+    with LanceFileWriter(
+        str(path),
+        table.schema,
+        version="2.0",
+        data_cache_bytes=1,
+        max_page_bytes=64 * 1024,
+    ) as writer:
+        writer.write_batch(table)
 
-        reader = LanceFileReader(str(path))
-        result = reader.read_all().to_table()
-        assert result == table
+    reader = LanceFileReader(str(path))
+    assert [len(column.pages) for column in reader.metadata().columns] == [8, 1]
+    assert reader.read_all().to_table() == table
 
 
 def test_compression(tmp_path):

--- a/python/python/tests/test_indices.py
+++ b/python/python/tests/test_indices.py
@@ -11,35 +11,37 @@ import pytest
 from lance.file import LanceFileReader, LanceFileWriter
 from lance.indices import IndicesBuilder, IvfModel, PqModel
 
-NUM_ROWS_PER_FRAGMENT = 10000
 DIMENSION = 128
 NUM_SUBVECTORS = 8
 NUM_FRAGMENTS = 3
-NUM_ROWS = NUM_ROWS_PER_FRAGMENT * NUM_FRAGMENTS
-NUM_PARTITIONS = round(np.sqrt(NUM_ROWS))
-
-
 SMALL_ROWS_PER_FRAGMENT = 100
 SMALL_NUM_ROWS = SMALL_ROWS_PER_FRAGMENT * NUM_FRAGMENTS
+SMALL_NUM_PARTITIONS = round(np.sqrt(SMALL_NUM_ROWS))
+PQ_ROWS_PER_FRAGMENT = 512
+PQ_NUM_ROWS = PQ_ROWS_PER_FRAGMENT * NUM_FRAGMENTS
+MOSTLY_NULL_ROWS_PER_FRAGMENT = 2000
+MOSTLY_NULL_NUM_ROWS = MOSTLY_NULL_ROWS_PER_FRAGMENT * NUM_FRAGMENTS
+MOSTLY_NULL_NUM_PARTITIONS = round(np.sqrt(MOSTLY_NULL_NUM_ROWS))
+TRAINING_SAMPLE_RATE = 2
+TRAINING_MAX_ITERS = 2
 
 
-def make_ds(num_rows: int, rows_per_frag: int, tmpdir: pathlib.Path, dtype: str):
-    vectors = np.random.randn(num_rows, DIMENSION).astype(dtype)
+def make_ds(
+    num_rows: int,
+    rows_per_frag: int,
+    tmpdir: pathlib.Path,
+    dtype: str,
+    name: str = "dataset",
+):
+    vectors = np.random.default_rng(42).standard_normal((num_rows, DIMENSION))
+    vectors = vectors.astype(dtype)
     vectors = vectors.reshape(-1)
     vectors = pa.FixedSizeListArray.from_arrays(vectors, DIMENSION)
     table = pa.Table.from_arrays([vectors], names=["vectors"])
-    uri = str(tmpdir / "dataset")
+    uri = str(tmpdir / name)
 
     ds = lance.write_dataset(table, uri, max_rows_per_file=rows_per_frag)
     return ds
-
-
-@pytest.fixture(
-    params=[np.float16, np.float32, np.float64],
-    ids=["f16", "f32", "f64"],
-)
-def rand_dataset(tmpdir, request):
-    return make_ds(NUM_ROWS, NUM_ROWS_PER_FRAGMENT, tmpdir, request.param)
 
 
 @pytest.fixture(
@@ -51,17 +53,53 @@ def small_rand_dataset(tmpdir, request):
 
 
 @pytest.fixture
-def mostly_null_dataset(tmpdir, request):
-    vectors = np.random.randn(NUM_ROWS, DIMENSION).astype(np.float32)
-    vectors = vectors.reshape(-1)
-    vectors = pa.FixedSizeListArray.from_arrays(vectors, DIMENSION)
-    vectors = vectors.to_pylist()
-    vectors = [vec if i % 10 == 0 else None for i, vec in enumerate(vectors)]
-    vectors = pa.array(vectors, pa.list_(pa.float32(), DIMENSION))
+def small_float32_dataset(tmpdir):
+    return make_ds(SMALL_NUM_ROWS, SMALL_ROWS_PER_FRAGMENT, tmpdir, np.float32)
+
+
+@pytest.fixture(
+    params=[np.float16, np.float32, np.float64],
+    ids=["f16", "f32", "f64"],
+)
+def pq_rand_dataset(tmpdir, request):
+    return make_ds(
+        PQ_NUM_ROWS,
+        PQ_ROWS_PER_FRAGMENT,
+        tmpdir,
+        request.param,
+        name="pq_dataset",
+    )
+
+
+@pytest.fixture
+def pq_float32_dataset(tmpdir):
+    return make_ds(
+        PQ_NUM_ROWS,
+        PQ_ROWS_PER_FRAGMENT,
+        tmpdir,
+        np.float32,
+        name="pq_dataset",
+    )
+
+
+@pytest.fixture
+def mostly_null_dataset(tmpdir):
+    values = np.random.default_rng(42).standard_normal(MOSTLY_NULL_NUM_ROWS * DIMENSION)
+    values = pa.array(values.astype(np.float32))
+    null_mask = pa.array(np.arange(MOSTLY_NULL_NUM_ROWS) % 10 != 0)
+    vectors = pa.FixedSizeListArray.from_arrays(
+        values,
+        DIMENSION,
+        mask=null_mask,
+    )
     table = pa.Table.from_arrays([vectors], names=["vectors"])
 
     uri = str(tmpdir / "nulls_dataset")
-    ds = lance.write_dataset(table, uri, max_rows_per_file=NUM_ROWS_PER_FRAGMENT)
+    ds = lance.write_dataset(
+        table,
+        uri,
+        max_rows_per_file=MOSTLY_NULL_ROWS_PER_FRAGMENT,
+    )
     return ds
 
 
@@ -91,11 +129,14 @@ def make_multivector_dataset(tmpdir):
     return ds, dimension
 
 
-def test_ivf_centroids(tmpdir, rand_dataset):
-    ivf = IndicesBuilder(rand_dataset, "vectors").train_ivf(sample_rate=16)
+def test_ivf_centroids(tmpdir, small_rand_dataset):
+    ivf = IndicesBuilder(small_rand_dataset, "vectors").train_ivf(
+        sample_rate=TRAINING_SAMPLE_RATE,
+        max_iters=TRAINING_MAX_ITERS,
+    )
 
     assert ivf.distance_type == "l2"
-    assert len(ivf.centroids) == NUM_PARTITIONS
+    assert len(ivf.centroids) == SMALL_NUM_PARTITIONS
 
     ivf.save(str(tmpdir / "ivf"))
     reloaded = IvfModel.load(str(tmpdir / "ivf"))
@@ -104,18 +145,25 @@ def test_ivf_centroids(tmpdir, rand_dataset):
 
 
 def test_ivf_centroids_hamming(tmpdir):
-    num_rows = NUM_ROWS
-    vectors = np.random.randint(0, 256, size=(num_rows, DIMENSION), dtype=np.uint8)
+    num_rows = SMALL_NUM_ROWS
+    vectors = np.random.default_rng(42).integers(
+        0,
+        256,
+        size=(num_rows, DIMENSION),
+        dtype=np.uint8,
+    )
     vectors_flat = vectors.reshape(-1)
     vectors_arr = pa.FixedSizeListArray.from_arrays(
         pa.array(vectors_flat, type=pa.uint8()), DIMENSION
     )
     table = pa.Table.from_arrays([vectors_arr], names=["vectors"])
     uri = str(tmpdir / "hamming_dataset")
-    ds = lance.write_dataset(table, uri, max_rows_per_file=NUM_ROWS_PER_FRAGMENT)
+    ds = lance.write_dataset(table, uri, max_rows_per_file=SMALL_ROWS_PER_FRAGMENT)
 
     ivf = IndicesBuilder(ds, "vectors").train_ivf(
-        sample_rate=16, distance_type="hamming"
+        sample_rate=TRAINING_SAMPLE_RATE,
+        max_iters=TRAINING_MAX_ITERS,
+        distance_type="hamming",
     )
 
     assert ivf.distance_type == "hamming"
@@ -131,40 +179,49 @@ def test_ivf_centroids_hamming(tmpdir):
 @pytest.mark.parametrize("distance_type", ["l2", "cosine", "dot"])
 def test_ivf_centroids_mostly_null(mostly_null_dataset, distance_type):
     ivf = IndicesBuilder(mostly_null_dataset, "vectors").train_ivf(
-        sample_rate=16, distance_type=distance_type
+        sample_rate=TRAINING_SAMPLE_RATE,
+        max_iters=TRAINING_MAX_ITERS,
+        distance_type=distance_type,
     )
 
     assert ivf.distance_type == distance_type
-    assert len(ivf.centroids) == NUM_PARTITIONS
+    assert len(ivf.centroids) == MOSTLY_NULL_NUM_PARTITIONS
 
 
 @pytest.mark.cuda
-def test_ivf_centroids_cuda(rand_dataset):
-    ivf = IndicesBuilder(rand_dataset, "vectors").train_ivf(
-        sample_rate=16, accelerator="cuda"
+def test_ivf_centroids_cuda(small_rand_dataset):
+    ivf = IndicesBuilder(small_rand_dataset, "vectors").train_ivf(
+        sample_rate=TRAINING_SAMPLE_RATE,
+        max_iters=TRAINING_MAX_ITERS,
+        accelerator="cuda",
     )
 
     assert ivf.distance_type == "l2"
-    # Can't use NUM_PARTITIONS here because
+    # Can't use SMALL_NUM_PARTITIONS here because
     # CUDA uses math.ceil and CPU uses round to calc. num_partitions
-    assert len(ivf.centroids) == math.ceil(np.sqrt(NUM_ROWS))
+    assert len(ivf.centroids) == math.ceil(np.sqrt(SMALL_NUM_ROWS))
 
 
 @pytest.mark.cuda
 @pytest.mark.parametrize("distance_type", ["l2", "cosine", "dot"])
 def test_ivf_centroids_mostly_null_cuda(mostly_null_dataset, distance_type):
     ivf = IndicesBuilder(mostly_null_dataset, "vectors").train_ivf(
-        sample_rate=16, accelerator="cuda", distance_type=distance_type
+        sample_rate=TRAINING_SAMPLE_RATE,
+        max_iters=TRAINING_MAX_ITERS,
+        accelerator="cuda",
+        distance_type=distance_type,
     )
 
     assert ivf.distance_type == distance_type
-    assert len(ivf.centroids) == NUM_PARTITIONS
+    assert len(ivf.centroids) == MOSTLY_NULL_NUM_PARTITIONS
 
 
-def test_ivf_centroids_distance_type(tmpdir, rand_dataset):
+def test_ivf_centroids_distance_type(tmpdir, small_float32_dataset):
     def check(distance_type):
-        ivf = IndicesBuilder(rand_dataset, "vectors").train_ivf(
-            sample_rate=16, distance_type=distance_type
+        ivf = IndicesBuilder(small_float32_dataset, "vectors").train_ivf(
+            sample_rate=TRAINING_SAMPLE_RATE,
+            max_iters=TRAINING_MAX_ITERS,
+            distance_type=distance_type,
         )
         assert ivf.distance_type == distance_type
         ivf.save(str(tmpdir / "ivf"))
@@ -176,31 +233,44 @@ def test_ivf_centroids_distance_type(tmpdir, rand_dataset):
     check("dot")
 
 
-def test_num_partitions(rand_dataset):
-    ivf = IndicesBuilder(rand_dataset, "vectors").train_ivf(
-        sample_rate=16, num_partitions=10
+def test_num_partitions(small_float32_dataset):
+    ivf = IndicesBuilder(small_float32_dataset, "vectors").train_ivf(
+        sample_rate=TRAINING_SAMPLE_RATE,
+        max_iters=TRAINING_MAX_ITERS,
+        num_partitions=10,
     )
     assert ivf.num_partitions == 10
 
 
 @pytest.fixture
-def rand_ivf(rand_dataset):
-    dtype = rand_dataset.schema.field("vectors").type.value_type.to_pandas_dtype()
-    centroids = np.random.rand(DIMENSION * 100).astype(dtype)
+def small_rand_ivf(small_rand_dataset):
+    dtype = small_rand_dataset.schema.field("vectors").type.value_type.to_pandas_dtype()
+    centroids = np.random.default_rng(42).random(DIMENSION * 100).astype(dtype)
     centroids = pa.FixedSizeListArray.from_arrays(centroids, DIMENSION)
     return IvfModel(centroids, "l2")
 
 
 @pytest.fixture
-def small_rand_ivf(small_rand_dataset):
-    dtype = small_rand_dataset.schema.field("vectors").type.value_type.to_pandas_dtype()
-    centroids = np.random.rand(DIMENSION * 100).astype(dtype)
+def pq_rand_ivf(pq_rand_dataset):
+    dtype = pq_rand_dataset.schema.field("vectors").type.value_type.to_pandas_dtype()
+    centroids = np.random.default_rng(42).random(DIMENSION * 100).astype(dtype)
     centroids = pa.FixedSizeListArray.from_arrays(centroids, DIMENSION)
     return IvfModel(centroids, "l2")
 
 
-def test_gen_pq(tmpdir, rand_dataset, rand_ivf):
-    pq = IndicesBuilder(rand_dataset, "vectors").train_pq(rand_ivf, sample_rate=2)
+@pytest.fixture
+def small_float32_ivf(small_float32_dataset):
+    centroids = np.random.default_rng(42).random(DIMENSION * 100).astype(np.float32)
+    centroids = pa.FixedSizeListArray.from_arrays(centroids, DIMENSION)
+    return IvfModel(centroids, "l2")
+
+
+def test_gen_pq(tmpdir, pq_rand_dataset, pq_rand_ivf):
+    pq = IndicesBuilder(pq_rand_dataset, "vectors").train_pq(
+        pq_rand_ivf,
+        sample_rate=TRAINING_SAMPLE_RATE,
+        max_iters=TRAINING_MAX_ITERS,
+    )
     assert pq.dimension == DIMENSION
     assert pq.num_subvectors == NUM_SUBVECTORS
 
@@ -209,9 +279,10 @@ def test_gen_pq(tmpdir, rand_dataset, rand_ivf):
     assert pq.dimension == reloaded.dimension
     assert pq.codebook == reloaded.codebook
 
-    pq_4bit = IndicesBuilder(rand_dataset, "vectors").train_pq(
-        rand_ivf,
-        sample_rate=2,
+    pq_4bit = IndicesBuilder(pq_rand_dataset, "vectors").train_pq(
+        pq_rand_ivf,
+        sample_rate=TRAINING_SAMPLE_RATE,
+        max_iters=TRAINING_MAX_ITERS,
         num_bits=4,
     )
     assert pq_4bit.num_bits == 4
@@ -254,10 +325,16 @@ def test_ivf_centroids_fragment_ids(tmpdir):
     fragment_ids = [fragment.fragment_id for fragment in ds.get_fragments()]
 
     first_ivf = IndicesBuilder(ds, "vectors").train_ivf(
-        num_partitions=1, sample_rate=2, fragment_ids=[fragment_ids[0]]
+        num_partitions=1,
+        sample_rate=TRAINING_SAMPLE_RATE,
+        max_iters=TRAINING_MAX_ITERS,
+        fragment_ids=[fragment_ids[0]],
     )
     second_ivf = IndicesBuilder(ds, "vectors").train_ivf(
-        num_partitions=1, sample_rate=2, fragment_ids=[fragment_ids[1]]
+        num_partitions=1,
+        sample_rate=TRAINING_SAMPLE_RATE,
+        max_iters=TRAINING_MAX_ITERS,
+        fragment_ids=[fragment_ids[1]],
     )
 
     first_centroid = first_ivf.centroids.values.to_numpy().reshape(-1, DIMENSION)[0]
@@ -349,17 +426,19 @@ def test_indices_builder_multivector_distributed_dimensions(tmpdir, monkeypatch)
     }
 
 
-def test_pq_fragment_ids(rand_dataset):
-    fragment_id = rand_dataset.get_fragments()[0].fragment_id
-    ivf = IndicesBuilder(rand_dataset, "vectors").train_ivf(
+def test_pq_fragment_ids(pq_float32_dataset):
+    fragment_id = pq_float32_dataset.get_fragments()[0].fragment_id
+    ivf = IndicesBuilder(pq_float32_dataset, "vectors").train_ivf(
         num_partitions=4,
-        sample_rate=16,
+        sample_rate=TRAINING_SAMPLE_RATE,
+        max_iters=TRAINING_MAX_ITERS,
         fragment_ids=[fragment_id],
     )
 
-    pq = IndicesBuilder(rand_dataset, "vectors").train_pq(
+    pq = IndicesBuilder(pq_float32_dataset, "vectors").train_pq(
         ivf,
-        sample_rate=2,
+        sample_rate=TRAINING_SAMPLE_RATE,
+        max_iters=TRAINING_MAX_ITERS,
         fragment_ids=[fragment_id],
     )
 
@@ -367,31 +446,41 @@ def test_pq_fragment_ids(rand_dataset):
     assert pq.num_subvectors == NUM_SUBVECTORS
 
 
-def test_pq_invalid_sub_vectors(tmpdir, rand_dataset, rand_ivf):
+def test_pq_invalid_sub_vectors(
+    small_float32_dataset,
+    small_float32_ivf,
+):
     with pytest.raises(
         ValueError,
         match="must be divisible by num_subvectors .* without remainder",
     ):
-        IndicesBuilder(rand_dataset, "vectors").train_pq(
-            rand_ivf, sample_rate=2, num_subvectors=5
+        IndicesBuilder(small_float32_dataset, "vectors").train_pq(
+            small_float32_ivf,
+            sample_rate=TRAINING_SAMPLE_RATE,
+            max_iters=TRAINING_MAX_ITERS,
+            num_subvectors=5,
         )
 
 
 def test_gen_pq_mostly_null(mostly_null_dataset):
-    centroids = np.random.rand(DIMENSION * 100).astype(np.float32)
+    centroids = np.random.default_rng(42).random(DIMENSION * 100).astype(np.float32)
     centroids = pa.FixedSizeListArray.from_arrays(centroids, DIMENSION)
     ivf = IvfModel(centroids, "l2")
 
-    pq = IndicesBuilder(mostly_null_dataset, "vectors").train_pq(ivf, sample_rate=2)
+    pq = IndicesBuilder(mostly_null_dataset, "vectors").train_pq(
+        ivf,
+        sample_rate=TRAINING_SAMPLE_RATE,
+        max_iters=TRAINING_MAX_ITERS,
+    )
     assert pq.dimension == DIMENSION
     assert pq.num_subvectors == NUM_SUBVECTORS
 
 
 @pytest.mark.cuda
-def test_assign_partitions(rand_dataset, rand_ivf):
-    builder = IndicesBuilder(rand_dataset, "vectors")
+def test_assign_partitions(small_rand_dataset, small_rand_ivf):
+    builder = IndicesBuilder(small_rand_dataset, "vectors")
 
-    partitions_uri = builder.assign_ivf_partitions(rand_ivf, accelerator="cuda")
+    partitions_uri = builder.assign_ivf_partitions(small_rand_ivf, accelerator="cuda")
 
     partitions = lance.dataset(partitions_uri)
     found_row_ids = set()
@@ -402,13 +491,13 @@ def test_assign_partitions(rand_dataset, rand_ivf):
         part_ids = batch["partition"]
         for part_id in part_ids:
             assert part_id.as_py() < 100
-    assert len(found_row_ids) == rand_dataset.count_rows()
+    assert len(found_row_ids) == small_rand_dataset.count_rows()
 
 
 @pytest.mark.cuda
 @pytest.mark.parametrize("distance_type", ["l2", "cosine", "dot"])
 def test_assign_partitions_mostly_null(mostly_null_dataset, distance_type):
-    centroids = np.random.rand(DIMENSION * 100).astype(np.float32)
+    centroids = np.random.default_rng(42).random(DIMENSION * 100).astype(np.float32)
     centroids = pa.FixedSizeListArray.from_arrays(centroids, DIMENSION)
     ivf = IvfModel(centroids, distance_type)
 
@@ -431,7 +520,7 @@ def test_assign_partitions_mostly_null(mostly_null_dataset, distance_type):
 @pytest.fixture
 def small_rand_pq(small_rand_dataset, small_rand_ivf):
     dtype = small_rand_dataset.schema.field("vectors").type.value_type.to_pandas_dtype()
-    codebook = np.random.rand(DIMENSION * 256).astype(dtype)
+    codebook = np.random.default_rng(42).random(DIMENSION * 256).astype(dtype)
     codebook = pa.FixedSizeListArray.from_arrays(codebook, DIMENSION)
     pq = PqModel(NUM_SUBVECTORS, codebook)
     return pq

--- a/python/python/tests/test_scalar_index.py
+++ b/python/python/tests/test_scalar_index.py
@@ -134,19 +134,26 @@ def test_create_scalar_index_rejects_invalid_uuid(tmp_path):
 def btree_comparison_datasets(tmp_path):
     """Setup datasets for B-tree comparison tests"""
     num_fragments = 3
-    rows_per_fragment = 10000
+    rows_per_fragment = 100
     total_rows = num_fragments * rows_per_fragment
 
+    fragment_path = tmp_path / "fragment"
     fragment_ds = generate_multi_fragment_dataset(
-        tmp_path / "fragment",
+        fragment_path,
         num_fragments=num_fragments,
         rows_per_fragment=rows_per_fragment,
     )
 
-    complete_ds = generate_multi_fragment_dataset(
-        tmp_path / "complete",
-        num_fragments=num_fragments,
-        rows_per_fragment=rows_per_fragment,
+    complete_path = tmp_path / "complete"
+    shutil.copytree(fragment_path, complete_path)
+    complete_ds = lance.dataset(complete_path)
+    fragment_count = len(fragment_ds.get_fragments())
+    complete_count = len(complete_ds.get_fragments())
+    assert fragment_count == num_fragments, (
+        f"Expected {num_fragments} segmented fragments, got {fragment_count}"
+    )
+    assert complete_count == num_fragments, (
+        f"Expected {num_fragments} complete-index fragments, got {complete_count}"
     )
 
     fragment_ds_committed = _commit_segmented_btree_index(
@@ -5368,74 +5375,98 @@ def test_btree_fragment_ids_parameter_validation(tmp_path):
     assert segment.fragment_ids == {valid_fragment_id}
 
 
-@pytest.mark.parametrize(
-    "test_name,filter_expr",
-    [
-        # Test 1: Boundary values at fragment edges
-        ("First value", "id = 0"),
-        ("Fragment 0 last value", "id = 9999"),
-        ("Fragment 1 first value", "id = 10000"),
-        ("Fragment 1 last value", "id = 19999"),
-        ("Fragment 2 first value", "id = 20000"),
-        ("Last value", "id = 29999"),
-        # Test 2: Values in the middle of fragments
-        ("Fragment 0 middle", "id = 5000"),
-        ("Fragment 1 middle", "id = 15000"),
-        ("Fragment 2 middle", "id = 25000"),
-        # Test 3: Range queries within single fragments
-        ("Range within fragment 0", "id >= 10 AND id < 20"),
-        ("Range within fragment 1", "id >= 10010 AND id < 10020"),
-        ("Range within fragment 2", "id >= 20010 AND id < 20020"),
-        # Test 4: Range queries spanning multiple fragments
-        ("Cross fragment 0-1", "id >= 9995 AND id < 10005"),
-        ("Cross fragment 1-2", "id >= 19995 AND id < 20005"),
-        ("Cross all fragments", "id >= 5000 AND id < 25000"),
-        # Test 5: Edge cases
-        ("Non-existent small value", "id = -1"),
-        ("Non-existent large value", "id = 30100"),
-        ("Large range", "id >= 0 AND id < 30000"),
-        # Test 6: Comparison operators
-        ("Less than boundary", "id < 10000"),
-        ("Greater than boundary", "id > 19999"),
-        ("Less than or equal", "id <= 10050"),
-        ("Greater than or equal", "id >= 10050"),
-    ],
-)
-def test_btree_query_comparison_parametrized(
-    btree_comparison_datasets, test_name, filter_expr
-):
+def test_btree_query_comparison(btree_comparison_datasets):
     """
-    Parametrized B-tree index query comparison test.
+    B-tree index query comparison test covering representative query shapes.
 
     Compares segmented fragment-built BTree results with a complete BTree index.
     """
     fragment_ds = btree_comparison_datasets["fragment_ds"]
     complete_ds = btree_comparison_datasets["complete_ds"]
+    rows_per_fragment = btree_comparison_datasets["rows_per_fragment"]
+    total_rows = btree_comparison_datasets["total_rows"]
+    fragment_starts = [idx * rows_per_fragment for idx in range(3)]
+    fragment_ends = [start + rows_per_fragment - 1 for start in fragment_starts]
+    fragment_middles = [start + rows_per_fragment // 2 for start in fragment_starts]
+    range_start_offset = rows_per_fragment // 10
+    range_end_offset = range_start_offset * 2
+    cross_fragment_margin = rows_per_fragment // 20
 
-    fragment_results = fragment_ds.scanner(
-        filter=filter_expr,
-        columns=["id", "text"],
-    ).to_table()
+    cases = [
+        # Boundary values at fragment edges
+        ("First value", f"id = {fragment_starts[0]}"),
+        ("Fragment 0 last value", f"id = {fragment_ends[0]}"),
+        ("Fragment 1 first value", f"id = {fragment_starts[1]}"),
+        ("Fragment 1 last value", f"id = {fragment_ends[1]}"),
+        ("Fragment 2 first value", f"id = {fragment_starts[2]}"),
+        ("Last value", f"id = {total_rows - 1}"),
+        # Values in the middle of fragments
+        ("Fragment 0 middle", f"id = {fragment_middles[0]}"),
+        ("Fragment 1 middle", f"id = {fragment_middles[1]}"),
+        ("Fragment 2 middle", f"id = {fragment_middles[2]}"),
+        # Range queries within single fragments
+        (
+            "Range within fragment 0",
+            f"id >= {fragment_starts[0] + range_start_offset} "
+            f"AND id < {fragment_starts[0] + range_end_offset}",
+        ),
+        (
+            "Range within fragment 1",
+            f"id >= {fragment_starts[1] + range_start_offset} "
+            f"AND id < {fragment_starts[1] + range_end_offset}",
+        ),
+        (
+            "Range within fragment 2",
+            f"id >= {fragment_starts[2] + range_start_offset} "
+            f"AND id < {fragment_starts[2] + range_end_offset}",
+        ),
+        # Range queries spanning multiple fragments
+        (
+            "Cross fragment 0-1",
+            f"id >= {fragment_ends[0] - cross_fragment_margin + 1} "
+            f"AND id < {fragment_starts[1] + cross_fragment_margin}",
+        ),
+        (
+            "Cross fragment 1-2",
+            f"id >= {fragment_ends[1] - cross_fragment_margin + 1} "
+            f"AND id < {fragment_starts[2] + cross_fragment_margin}",
+        ),
+        (
+            "Cross all fragments",
+            f"id >= {fragment_middles[0]} AND id < {fragment_middles[2]}",
+        ),
+        # Missing values and the full indexed range
+        ("Non-existent small value", f"id = {fragment_starts[0] - 1}"),
+        (
+            "Non-existent large value",
+            f"id = {total_rows + rows_per_fragment}",
+        ),
+        (
+            "Large range",
+            f"id >= {fragment_starts[0]} AND id < {total_rows}",
+        ),
+        # Comparison operators
+        ("Less than boundary", f"id < {fragment_starts[1]}"),
+        ("Greater than boundary", f"id > {fragment_ends[1]}"),
+        ("Less than or equal", f"id <= {fragment_middles[1]}"),
+        ("Greater than or equal", f"id >= {fragment_middles[1]}"),
+    ]
 
-    complete_results = complete_ds.scanner(
-        filter=filter_expr,
-        columns=["id", "text"],
-    ).to_table()
+    for test_name, filter_expr in cases:
+        fragment_results = fragment_ds.scanner(
+            filter=filter_expr,
+            columns=["id", "text"],
+        ).to_table()
+        complete_results = complete_ds.scanner(
+            filter=filter_expr,
+            columns=["id", "text"],
+        ).to_table()
 
-    assert fragment_results.num_rows == complete_results.num_rows, (
-        f"Test '{test_name}' failed: Fragment index "
-        f"returned {fragment_results.num_rows} rows, "
-        f"but complete index returned {complete_results.num_rows}"
-        f" rows for filter: {filter_expr}"
-    )
-
-    if fragment_results.num_rows > 0:
-        fragment_ids = sorted(fragment_results.column("id").to_pylist())
-        complete_ids = sorted(complete_results.column("id").to_pylist())
-
-        assert fragment_ids == complete_ids, (
-            f"Test '{test_name}' failed: Fragment index "
-            f"and complete index returned different results for filter: {filter_expr}"
+        fragment_results = fragment_results.sort_by([("id", "ascending")])
+        complete_results = complete_results.sort_by([("id", "ascending")])
+        assert fragment_results.equals(complete_results), (
+            f"Test '{test_name}' failed: segmented and complete BTree indexes returned "
+            f"different results for filter: {filter_expr}"
         )
 
 

--- a/python/python/tests/test_vector_index.py
+++ b/python/python/tests/test_vector_index.py
@@ -2823,7 +2823,7 @@ def assert_distributed_vector_consistency(
        preprocessed artifacts
     5) For each query, compute ground-truth TopK IDs using exact search
        (use_index=False), then compute TopK using single index and the distributed
-       index with consistent nearest settings (refine_factor=10; IVF probes all
+       index with consistent nearest settings (refine_factor=100; IVF probes all
        fixture partitions)
     6) Compute recall for single and distributed, require each to be >= 0.5,
        and bound their absolute difference with similarity_threshold.
@@ -2947,7 +2947,7 @@ def assert_distributed_vector_consistency(
         gt_ids.append(np.array(gt_tbl["id"].to_pylist(), dtype=np.int64))
 
         # Consistent nearest settings for index-based search
-        nearest = {"column": column, "q": q, "k": topk, "refine_factor": 10}
+        nearest = {"column": column, "q": q, "k": topk, "refine_factor": 100}
         if "IVF" in index_type:
             nearest["nprobes"] = int(index_params.get("num_partitions", 4))
         if "HNSW" in index_type:

--- a/python/python/tests/test_vector_index.py
+++ b/python/python/tests/test_vector_index.py
@@ -60,18 +60,26 @@ def create_table(nvec=1000, ndim=128, nans=0, nullify=False, dtype=np.float32):
 
 
 def create_multivec_table(
-    nvec=1000, nvec_per_row=5, ndim=128, nans=0, nullify=False, dtype=np.float32
+    nvec=1000,
+    nvec_per_row=5,
+    ndim=128,
+    nans=0,
+    nullify=False,
+    dtype=np.float32,
+    seed=None,
 ):
-    mat = np.random.randn(nvec, nvec_per_row, ndim)
+    rng = np.random.default_rng(seed)
+    text_rng = random.Random(seed)
+    mat = rng.standard_normal((nvec, nvec_per_row, ndim))
     if nans > 0:
         nans_mat = np.empty((nans, ndim))
         nans_mat[:] = np.nan
         mat = np.concatenate((mat, nans_mat), axis=0)
     mat = mat.astype(dtype)
-    price = np.random.rand(nvec + nans) * 100
+    price = rng.random(nvec + nans) * 100
 
     def gen_str(n):
-        return "".join(random.choices(string.ascii_letters + string.digits, k=n))
+        return "".join(text_rng.choices(string.ascii_letters + string.digits, k=n))
 
     meta = np.array([gen_str(100) for _ in range(nvec + nans)])
 
@@ -112,13 +120,20 @@ def indexed_dataset(tmp_path):
     tbl = create_table()
     dataset = lance.write_dataset(tbl, tmp_path)
     yield dataset.create_index(
-        "vector", index_type="IVF_PQ", num_partitions=4, num_sub_vectors=16
+        "vector",
+        index_type="IVF_PQ",
+        num_partitions=4,
+        num_sub_vectors=16,
+        max_iters=2,
+        sample_rate=2,
     )
 
 
 @pytest.fixture()
 def multivec_dataset():
-    tbl = create_multivec_table()
+    # Keep at least 100 logical rows for the top-k assertions below. Five
+    # vectors per row still exercises multivector deduplication and fanout.
+    tbl = create_multivec_table(nvec=128, seed=42)
     yield lance.write_dataset(tbl, "memory://")
 
 
@@ -127,8 +142,11 @@ def indexed_multivec_dataset(multivec_dataset):
     yield multivec_dataset.create_index(
         "vector",
         index_type="IVF_PQ",
-        num_partitions=4,
-        num_sub_vectors=16,
+        num_partitions=1,
+        num_sub_vectors=4,
+        num_bits=4,
+        max_iters=2,
+        sample_rate=2,
         metric="cosine",
     )
 
@@ -371,13 +389,19 @@ def test_distributed_ivf_pq_partition_window_env_override(tmp_path, monkeypatch)
     monkeypatch.setenv("LANCE_IVF_PQ_MERGE_PARTITION_WINDOW_SIZE", "4")
     monkeypatch.setenv("LANCE_IVF_PQ_MERGE_PARTITION_PREFETCH_WINDOW_COUNT", "2")
 
-    data = create_table(nvec=3000, ndim=128)
-    q = np.random.randn(128).astype(np.float32)
+    rng = np.random.default_rng(42)
+    matrix = rng.standard_normal((640, 32), dtype=np.float32)
+    data = vec_to_table(data=matrix).append_column("id", pa.array(range(640)))
+    q = rng.standard_normal(32).astype(np.float32)
     assert_distributed_vector_consistency(
         data,
         "vector",
         index_type="IVF_PQ",
-        index_params={"num_partitions": 10, "num_sub_vectors": 16},
+        index_params={
+            "num_partitions": 10,
+            "num_sub_vectors": 4,
+            "max_iters": 2,
+        },
         queries=[q],
         topk=10,
         world=2,
@@ -404,7 +428,7 @@ def test_distributed_vector(
     request, fixture_name, index_type, index_params, similarity_threshold
 ):
     ds = request.getfixturevalue(fixture_name)
-    q = np.random.randn(128).astype(np.float32)
+    q = np.random.default_rng(42).standard_normal(128).astype(np.float32)
     assert_distributed_vector_consistency(
         ds.to_table(),
         "vector",
@@ -502,20 +526,20 @@ def test_f16_cuda(tmp_path):
     "index_file_version", [IndexFileVersion.V3, IndexFileVersion.LEGACY]
 )
 def test_index_with_nans(tmp_path, index_file_version):
-    # 1024 rows, the entire table should be sampled
-    tbl = create_table(nvec=1000, nans=24)
+    tbl = create_table(nvec=256, ndim=32, nans=8)
 
     dataset = lance.write_dataset(tbl, tmp_path)
     dataset = dataset.create_index(
         "vector",
         index_type="IVF_PQ",
-        num_partitions=4,
-        num_sub_vectors=16,
+        num_partitions=1,
+        num_sub_vectors=4,
+        max_iters=2,
         index_file_version=index_file_version,
     )
     idx_stats = dataset.stats.index_stats("vector_idx")
     assert idx_stats["indices"][0]["index_file_version"] == index_file_version
-    validate_vector_index(dataset, "vector")
+    validate_vector_index(dataset, "vector", sample_size=16)
 
 
 @pytest.mark.parametrize(
@@ -524,22 +548,22 @@ def test_index_with_nans(tmp_path, index_file_version):
 def test_torch_index_with_nans(tmp_path, index_file_version):
     torch = pytest.importorskip("torch")
 
-    # 1024 rows, the entire table should be sampled
-    tbl = create_table(nvec=1000, nans=24)
+    tbl = create_table(nvec=256, ndim=32, nans=8)
 
     dataset = lance.write_dataset(tbl, tmp_path)
     dataset = dataset.create_index(
         "vector",
         index_type="IVF_PQ",
-        num_partitions=4,
-        num_sub_vectors=16,
+        num_partitions=1,
+        num_sub_vectors=4,
+        max_iters=2,
         accelerator=torch.device("cpu"),
         one_pass_ivfpq=True,
         index_file_version=index_file_version,
     )
     idx_stats = dataset.stats.index_stats("vector_idx")
     assert idx_stats["indices"][0]["index_file_version"] == index_file_version
-    validate_vector_index(dataset, "vector")
+    validate_vector_index(dataset, "vector", sample_size=16)
 
 
 def test_index_with_no_centroid_movement(tmp_path):
@@ -548,7 +572,8 @@ def test_index_with_no_centroid_movement(tmp_path):
     # this test makes the centroids essentially [1..]
     # this makes sure the early stop condition in the index building code
     # doesn't do divide by zero
-    mat = np.concatenate([np.ones((256, 32))])
+    # Torch one-pass PQ emits an 8-bit codebook, which requires 256 rows.
+    mat = np.ones((256, 16), dtype=np.float32)
 
     tbl = vec_to_table(data=mat)
 
@@ -558,27 +583,37 @@ def test_index_with_no_centroid_movement(tmp_path):
         index_type="IVF_PQ",
         num_partitions=1,
         num_sub_vectors=4,
+        max_iters=2,
         accelerator=torch.device("cpu"),
     )
-    validate_vector_index(dataset, "vector")
+    validate_vector_index(dataset, "vector", sample_size=8)
 
 
 def test_index_with_pq_codebook(tmp_path):
-    tbl = create_table(nvec=1024, ndim=128)
+    dim = 16
+    rng = np.random.default_rng(42)
+    # Eight-bit PQ still requires its 256 centroid training rows even when the
+    # initial codebook is supplied; reducing the dimension keeps this fixture small.
+    vectors = rng.standard_normal((256, dim), dtype=np.float32)
+    tbl = vec_to_table(data=vectors)
     dataset = lance.write_dataset(tbl, tmp_path)
-    pq_codebook = np.random.randn(4, 256, 128 // 4).astype(np.float32)
+    pq_codebook = rng.standard_normal((4, 256, dim // 4), dtype=np.float32)
+    ivf_centroids = rng.standard_normal((1, dim), dtype=np.float32)
 
     dataset = dataset.create_index(
         "vector",
         index_type="IVF_PQ",
         num_partitions=1,
         num_sub_vectors=4,
-        ivf_centroids=np.random.randn(1, 128).astype(np.float32),
+        max_iters=2,
+        ivf_centroids=ivf_centroids,
         pq_codebook=pq_codebook,
     )
     index = dataset.stats.index_stats("vector_idx")
     assert index["indices"][0]["sub_index"]["nbits"] == 8
-    validate_vector_index(dataset, "vector", refine_factor=10, pass_threshold=0.99)
+    validate_vector_index(
+        dataset, "vector", refine_factor=256, sample_size=8, pass_threshold=0.99
+    )
 
     pq_codebook = pa.FixedShapeTensorArray.from_numpy_ndarray(pq_codebook)
 
@@ -587,17 +622,23 @@ def test_index_with_pq_codebook(tmp_path):
         index_type="IVF_PQ",
         num_partitions=1,
         num_sub_vectors=4,
-        ivf_centroids=np.random.randn(1, 128).astype(np.float32),
+        max_iters=2,
+        ivf_centroids=ivf_centroids,
         pq_codebook=pq_codebook,
         replace=True,
     )
-    validate_vector_index(dataset, "vector", refine_factor=10, pass_threshold=0.99)
+    validate_vector_index(
+        dataset, "vector", refine_factor=256, sample_size=8, pass_threshold=0.99
+    )
 
 
 def test_index_with_4bit_numpy_pq_codebook(tmp_path):
-    tbl = create_table(nvec=1024, ndim=128)
+    dim = 32
+    rng = np.random.default_rng(42)
+    vectors = rng.standard_normal((32, dim), dtype=np.float32)
+    tbl = vec_to_table(data=vectors)
     dataset = lance.write_dataset(tbl, tmp_path)
-    pq_codebook = np.random.randn(4, 16, 128 // 4).astype(np.float32)
+    pq_codebook = rng.standard_normal((4, 16, dim // 4), dtype=np.float32)
 
     dataset = dataset.create_index(
         "vector",
@@ -605,7 +646,8 @@ def test_index_with_4bit_numpy_pq_codebook(tmp_path):
         num_partitions=1,
         num_sub_vectors=4,
         num_bits=4,
-        ivf_centroids=np.random.randn(1, 128).astype(np.float32),
+        max_iters=2,
+        ivf_centroids=rng.standard_normal((1, dim), dtype=np.float32),
         pq_codebook=pq_codebook,
     )
 
@@ -615,7 +657,7 @@ def test_index_with_4bit_numpy_pq_codebook(tmp_path):
     result = dataset.to_table(
         nearest={
             "column": "vector",
-            "q": np.random.randn(128).astype(np.float32),
+            "q": vectors[0],
             "k": 10,
         }
     )
@@ -623,13 +665,15 @@ def test_index_with_4bit_numpy_pq_codebook(tmp_path):
 
 
 def test_index_with_pq_codebook_rejects_wrong_num_bits_shape(tmp_path):
-    tbl = create_table(nvec=8, ndim=128)
+    dim = 16
+    rng = np.random.default_rng(42)
+    tbl = vec_to_table(data=rng.standard_normal((8, dim), dtype=np.float32))
     dataset = lance.write_dataset(tbl, tmp_path)
-    pq_codebook = np.random.randn(4, 256, 128 // 4).astype(np.float32)
+    pq_codebook = rng.standard_normal((4, 256, dim // 4), dtype=np.float32)
 
     with pytest.raises(
         ValueError,
-        match=r"\(sub_vectors, 16, dim\) for num_bits=4, got \(4, 256, 32\)",
+        match=r"\(sub_vectors, 16, dim\) for num_bits=4, got \(4, 256, 4\)",
     ):
         dataset.create_index(
             "vector",
@@ -637,7 +681,7 @@ def test_index_with_pq_codebook_rejects_wrong_num_bits_shape(tmp_path):
             num_partitions=1,
             num_sub_vectors=4,
             num_bits=4,
-            ivf_centroids=np.random.randn(1, 128).astype(np.float32),
+            ivf_centroids=rng.standard_normal((1, dim), dtype=np.float32),
             pq_codebook=pq_codebook,
         )
 
@@ -739,14 +783,18 @@ def test_create_index_unsupported_accelerator(tmp_path):
 
 
 def test_create_index_accelerator_fallback(tmp_path, caplog):
-    tbl = create_table()
+    tbl = create_table(nvec=64, ndim=32)
     dataset = lance.write_dataset(tbl, tmp_path)
 
     with caplog.at_level(logging.WARNING):
         dataset = dataset.create_index(
             "vector",
             index_type="IVF_HNSW_SQ",
-            num_partitions=4,
+            num_partitions=1,
+            max_iters=2,
+            max_level=2,
+            m=4,
+            ef_construction=16,
             accelerator="cuda",
         )
 
@@ -816,62 +864,106 @@ def test_has_index(dataset, tmp_path):
     assert ann_ds.describe_indices()[0].field_names == ["vector"]
 
 
-def test_index_type(dataset, tmp_path):
-    ann_ds = lance.write_dataset(dataset.to_table(), tmp_path / "indexed.lance")
+def test_index_type(tmp_path):
+    index_cases = [
+        ("IVF_PQ", {"num_sub_vectors": 4, "num_bits": 4}),
+        (
+            "IVF_HNSW_SQ",
+            {"max_level": 2, "m": 4, "ef_construction": 16},
+        ),
+        (
+            "IVF_HNSW_PQ",
+            {
+                "num_sub_vectors": 4,
+                "num_bits": 4,
+                "max_level": 2,
+                "m": 4,
+                "ef_construction": 16,
+            },
+        ),
+        (
+            "IVF_HNSW_FLAT",
+            {"max_level": 2, "m": 4, "ef_construction": 16},
+        ),
+    ]
+    rng = np.random.default_rng(42)
+    vectors = rng.standard_normal((64, 32), dtype=np.float32)
+    table = vec_to_table(data=vectors).append_column("id", pa.array(range(64)))
+    ann_ds = lance.write_dataset(table, tmp_path / "replace_index_type")
+    assert not ann_ds.has_index
 
+    for case_index, (index_type, index_options) in enumerate(index_cases):
+        ann_ds = ann_ds.create_index(
+            "vector",
+            index_type=index_type,
+            num_partitions=1,
+            max_iters=2,
+            sample_rate=2,
+            replace=case_index > 0,
+            **index_options,
+        )
+        stats = ann_ds.stats.index_stats("vector_idx")
+        assert stats["index_type"] == index_type
+        assert stats["num_indices"] == 1
+        indices = ann_ds.describe_indices()
+        assert len(indices) == 1
+        assert indices[0].field_names == ["vector"]
+
+        nearest = {
+            "column": "vector",
+            "q": vectors[0],
+            "k": 10,
+            "nprobes": 1,
+            "refine_factor": 4,
+        }
+        if "HNSW" in index_type:
+            nearest["ef"] = 64
+        actual = ann_ds.to_table(columns=["id"], nearest=nearest)
+        expected = ann_ds.to_table(
+            columns=["id"],
+            nearest={
+                "column": "vector",
+                "q": vectors[0],
+                "k": 10,
+                "use_index": False,
+            },
+        )
+        actual_ids = set(actual["id"].to_pylist())
+        expected_ids = set(expected["id"].to_pylist())
+        assert actual.num_rows == 10
+        assert len(actual_ids) == 10
+        assert len(actual_ids & expected_ids) / len(expected_ids) >= 0.5
+
+
+def test_create_dot_index(tmp_path):
+    rng = np.random.default_rng(42)
+    table = vec_to_table(data=rng.standard_normal((64, 32), dtype=np.float32))
+    ann_ds = lance.write_dataset(table, tmp_path / "indexed.lance")
+    assert not ann_ds.has_index
     ann_ds = ann_ds.create_index(
         "vector",
         index_type="IVF_PQ",
-        num_partitions=4,
-        num_sub_vectors=16,
-        replace=True,
-    )
-    stats = ann_ds.stats.index_stats("vector_idx")
-    assert stats["index_type"] == "IVF_PQ"
-
-    ann_ds = ann_ds.create_index(
-        "vector",
-        index_type="IVF_HNSW_SQ",
-        num_partitions=4,
-        num_sub_vectors=16,
-        replace=True,
-    )
-    stats = ann_ds.stats.index_stats("vector_idx")
-    assert stats["index_type"] == "IVF_HNSW_SQ"
-
-    ann_ds = ann_ds.create_index(
-        "vector",
-        index_type="IVF_HNSW_PQ",
-        num_partitions=4,
-        num_sub_vectors=16,
-        replace=True,
-    )
-    stats = ann_ds.stats.index_stats("vector_idx")
-    assert stats["index_type"] == "IVF_HNSW_PQ"
-
-
-def test_create_dot_index(dataset, tmp_path):
-    assert not dataset.has_index
-    ann_ds = lance.write_dataset(dataset.to_table(), tmp_path / "indexed.lance")
-    ann_ds = ann_ds.create_index(
-        "vector",
-        index_type="IVF_PQ",
-        num_partitions=4,
-        num_sub_vectors=16,
+        num_partitions=1,
+        num_sub_vectors=4,
+        num_bits=4,
+        max_iters=2,
         metric="dot",
     )
     assert ann_ds.has_index
 
 
-def test_create_4bit_ivf_pq_index(dataset, tmp_path):
-    assert not dataset.has_index
-    ann_ds = lance.write_dataset(dataset.to_table(), tmp_path / "indexed.lance")
+def test_create_4bit_ivf_pq_index(tmp_path):
+    rng = np.random.default_rng(42)
+    table = vec_to_table(data=rng.standard_normal((32, 32), dtype=np.float32))
+    ann_ds = lance.write_dataset(table, tmp_path / "indexed.lance")
+    assert not ann_ds.has_index
     ann_ds = ann_ds.create_index(
         "vector",
         index_type="IVF_PQ",
         num_partitions=1,
-        num_sub_vectors=16,
+        num_sub_vectors=4,
         num_bits=4,
+        max_iters=2,
         metric="l2",
     )
     index = ann_ds.stats.index_stats("vector_idx")
@@ -1215,53 +1307,31 @@ def test_create_ivf_rq_mostly_null():
     assert result.num_rows == 10
 
 
-def test_create_ivf_hnsw_pq_index(dataset, tmp_path):
-    assert not dataset.has_index
-    ann_ds = lance.write_dataset(dataset.to_table(), tmp_path / "indexed.lance")
-    ann_ds = ann_ds.create_index(
-        "vector",
-        index_type="IVF_HNSW_PQ",
-        num_partitions=4,
-        num_sub_vectors=16,
-    )
-    assert ann_ds.describe_indices()[0].field_names == ["vector"]
-
-
-def test_create_ivf_hnsw_sq_index(dataset, tmp_path):
-    assert not dataset.has_index
-    ann_ds = lance.write_dataset(dataset.to_table(), tmp_path / "indexed.lance")
-    ann_ds = ann_ds.create_index(
-        "vector",
-        index_type="IVF_HNSW_SQ",
-        num_partitions=4,
-        num_sub_vectors=16,
-    )
-    assert ann_ds.describe_indices()[0].field_names == ["vector"]
-
-
-def test_create_ivf_hnsw_flat_index(dataset, tmp_path):
-    assert not dataset.has_index
-    ann_ds = lance.write_dataset(dataset.to_table(), tmp_path / "indexed.lance")
-    ann_ds = ann_ds.create_index(
-        "vector",
-        index_type="IVF_HNSW_FLAT",
-        num_partitions=4,
-        num_sub_vectors=16,
-    )
-    assert ann_ds.describe_indices()[0].field_names == ["vector"]
-
-
 def test_multivec_ann(indexed_multivec_dataset: lance.LanceDataset):
-    query = np.random.rand(5, 128)
+    rng = np.random.default_rng(42)
+    query = rng.random((5, 128))
     results = indexed_multivec_dataset.scanner(
-        nearest={"column": "vector", "q": query, "k": 100}
+        nearest={
+            "column": "vector",
+            "q": query,
+            "k": 100,
+            "nprobes": 1,
+            "refine_factor": 2,
+        }
     ).to_table()
     assert results.num_rows == 100
     assert results["vector"].type == pa.list_(pa.list_(pa.float32(), 128))
     assert len(results["vector"][0]) == 5
+    ground_truth = indexed_multivec_dataset.to_table(
+        columns=["id"],
+        nearest={"column": "vector", "q": query, "k": 100, "use_index": False},
+    )
+    actual_ids = set(results["id"].to_pylist())
+    expected_ids = set(ground_truth["id"].to_pylist())
+    assert len(actual_ids & expected_ids) / len(expected_ids) >= 0.5
 
     # query with single vector also works
-    query = np.random.rand(128)
+    query = rng.random(128)
     results = indexed_multivec_dataset.to_table(
         nearest={"column": "vector", "q": query, "k": 100}
     )
@@ -1282,14 +1352,14 @@ def test_multivec_ann(indexed_multivec_dataset: lance.LanceDataset):
         )
 
     # query with a vector that dim not match
-    query = np.random.rand(256)
+    query = rng.random(256)
     with pytest.raises(ValueError, match="does not match index column size"):
         indexed_multivec_dataset.to_table(
             nearest={"column": "vector", "q": query, "k": 100}
         )
 
     # query with a list of vectors that some dim not match
-    query = [np.random.rand(128)] * 5 + [np.random.rand(256)]
+    query = [rng.random(128)] * 5 + [rng.random(256)]
     with pytest.raises(ValueError, match="All query vectors must have the same length"):
         indexed_multivec_dataset.to_table(
             nearest={"column": "vector", "q": query, "k": 100}
@@ -1703,17 +1773,23 @@ def test_index_cache_size_deprecation(tmp_path):
 
 
 def test_f16_index(tmp_path: Path):
-    DIM = 64
+    DIM = 32
+    total = 256
     uri = tmp_path / "f16data.lance"
-    f16_data = np.random.uniform(0, 1, 2048 * DIM).astype(np.float16)
+    rng = np.random.default_rng(42)
+    f16_data = rng.uniform(0, 1, total * DIM).astype(np.float16)
     fsl = pa.FixedSizeListArray.from_arrays(f16_data, DIM)
     tbl = pa.Table.from_pydict({"vector": fsl})
     dataset = lance.write_dataset(tbl, uri)
     dataset.create_index(
-        "vector", index_type="IVF_PQ", num_partitions=4, num_sub_vectors=2
+        "vector",
+        index_type="IVF_PQ",
+        num_partitions=1,
+        num_sub_vectors=4,
+        max_iters=2,
     )
 
-    q = np.random.uniform(0, 1, DIM).astype(np.float16)
+    q = rng.uniform(0, 1, DIM).astype(np.float16)
     rst = dataset.to_table(
         nearest={
             "column": "vector",
@@ -1728,8 +1804,9 @@ def test_f16_index(tmp_path: Path):
 
 def test_vector_with_nans(tmp_path: Path):
     DIM = 32
-    TOTAL = 2048
-    data = np.random.uniform(0, 1, TOTAL * DIM).astype(np.float32)
+    TOTAL = 320
+    rng = np.random.default_rng(42)
+    data = rng.uniform(0, 1, TOTAL * DIM).astype(np.float32)
 
     # Put the 1st vector as NaN.
     np.put(data, range(DIM, 2 * DIM), np.nan)
@@ -1743,12 +1820,13 @@ def test_vector_with_nans(tmp_path: Path):
     ds = dataset.create_index(
         "vector",
         index_type="IVF_PQ",
-        num_partitions=2,
-        num_sub_vectors=2,
+        num_partitions=1,
+        num_sub_vectors=4,
+        max_iters=2,
         replace=True,
     )
     tbl = ds.to_table(
-        nearest={"column": "vector", "q": data[0:DIM], "k": TOTAL, "nprobes": 2},
+        nearest={"column": "vector", "q": data[0:DIM], "k": TOTAL, "nprobes": 1},
         with_row_id=True,
     )
     assert len(tbl) == TOTAL - 1
@@ -1804,14 +1882,18 @@ def test_dynamic_projection_with_vectors_index(tmp_path: Path):
 def test_index_cast_centroids(tmp_path):
     torch = pytest.importorskip("torch")
 
-    tbl = create_table(nvec=1000)
+    dim = 16
+    rng = np.random.default_rng(42)
+    # Torch one-pass PQ emits an 8-bit codebook, which requires 256 rows.
+    tbl = vec_to_table(data=rng.standard_normal((256, dim), dtype=np.float32))
 
     dataset = lance.write_dataset(tbl, tmp_path)
     dataset = dataset.create_index(
         "vector",
         index_type="IVF_PQ",
-        num_partitions=4,
-        num_sub_vectors=16,
+        num_partitions=2,
+        num_sub_vectors=4,
+        max_iters=2,
         accelerator=torch.device("cpu"),
     )
 
@@ -1820,18 +1902,19 @@ def test_index_cast_centroids(tmp_path):
     index_stats = dataset.stats.index_stats(index_name)
     centroids = index_stats["indices"][0]["centroids"]
     values = pa.array([x for arr in centroids for x in arr], pa.float32())
-    centroids = pa.FixedSizeListArray.from_arrays(values, 128)
+    centroids = pa.FixedSizeListArray.from_arrays(values, dim)
 
     # Cast invalidates the attached index; drop it first per the new contract.
     dataset.drop_index(index_name)
-    dataset.alter_columns(dict(path="vector", data_type=pa.list_(pa.float16(), 128)))
+    dataset.alter_columns(dict(path="vector", data_type=pa.list_(pa.float16(), dim)))
 
     # centroids are f32, but the column is now f16
     dataset = dataset.create_index(
         "vector",
         index_type="IVF_PQ",
-        num_partitions=4,
-        num_sub_vectors=16,
+        num_partitions=2,
+        num_sub_vectors=4,
+        max_iters=2,
         accelerator=torch.device("cpu"),
         ivf_centroids=centroids,
     )
@@ -2723,17 +2806,16 @@ def assert_distributed_vector_consistency(
     """Recall-only consistency check between single-machine and distributed indices.
 
     This helper keeps the original signature for compatibility but ignores
-    similarity_metric/similarity_threshold. It compares recall@K against a ground
-    truth computed via exact search (use_index=False) on the single dataset and
-    asserts that the recall difference between single-machine and distributed
-    indices is within 10%.
+    similarity_metric. It compares recall@K against a ground truth computed via
+    exact search (use_index=False), requires both indices to reach at least 0.5
+    recall, and bounds their recall difference with similarity_threshold.
 
     Steps
     -----
     1) Write `data` to two URIs (single, distributed); ensure distributed has >=2
        fragments (rewrite with max_rows_per_file if needed)
     2) Build a single-machine index via `create_index`
-    3) Global training (IVF/PQ) using `IndicesBuilder.prepare_global_ivfpq` when
+    3) Global training (IVF/PQ) using `IndicesBuilder.prepare_global_ivf_pq` when
        appropriate; for IVF_FLAT/SQ variants, train IVF centroids via
        `IndicesBuilder.train_ivf`
     4) Build the distributed index via
@@ -2741,11 +2823,12 @@ def assert_distributed_vector_consistency(
        preprocessed artifacts
     5) For each query, compute ground-truth TopK IDs using exact search
        (use_index=False), then compute TopK using single index and the distributed
-       index with consistent nearest settings (refine_factor=1; IVF uses nprobes)
-    6) Compute recall for single and distributed using the provided formula and
-       assert the absolute difference is <= 0.10. Also print the recalls.
+       index with consistent nearest settings (refine_factor=10; IVF probes all
+       fixture partitions)
+    6) Compute recall for single and distributed, require each to be >= 0.5,
+       and bound their absolute difference with similarity_threshold.
     """
-    # Keep signature compatibility but ignore similarity_metric/threshold
+    # Keep signature compatibility but ignore the superseded metric selector.
     _ = similarity_metric
 
     index_params = index_params or {}
@@ -2771,33 +2854,37 @@ def assert_distributed_vector_consistency(
             data, dist_uri, mode="overwrite", max_rows_per_file=500
         )
 
+    num_rows = single_ds.count_rows()
+    nparts = index_params.get("num_partitions", None)
+    is_pq = index_type in {"IVF_PQ", "IVF_HNSW_PQ"}
+    # Eight-bit PQ needs at least 256 centroids and sample_rate >= 2.
+    sample_rate = 2 if is_pq else min(8, num_rows // max(1, nparts or 1))
+    max_iters = index_params.get("max_iters", 5)
+    build_params = dict(index_params)
+    build_params.setdefault("sample_rate", sample_rate)
+    build_params.setdefault("max_iters", max_iters)
+
     # Build single-machine index
     single_ds = single_ds.create_index(
         column=column,
         index_type=index_type,
-        **index_params,
+        **build_params,
     )
 
     # Global training / preparation for distributed build
     preprocessed = None
     builder = IndicesBuilder(single_ds, column)
-    nparts = index_params.get("num_partitions", None)
     nsub = index_params.get("num_sub_vectors", None)
     dist_type = index_params.get("metric", "l2")
-    num_rows = single_ds.count_rows()
 
-    # Choose a safe sample_rate that satisfies IVF (nparts*sr <= rows) and PQ
-    # (256*sr <= rows). Minimum 2 as required by builder verification.
-    safe_sr_ivf = num_rows // max(1, nparts or 1)
-    safe_sr_pq = num_rows // 256
-    safe_sr = max(2, min(safe_sr_ivf, safe_sr_pq))
-
-    if index_type in {"IVF_PQ", "IVF_HNSW_PQ"}:
+    if is_pq:
+        assert num_rows >= 512, "8-bit PQ training requires at least 512 rows"
         preprocessed = builder.prepare_global_ivf_pq(
             nparts,
             nsub,
             distance_type=dist_type,
-            sample_rate=safe_sr,
+            sample_rate=sample_rate,
+            max_iters=max_iters,
         )
     elif (
         ("IVF_FLAT" in index_type)
@@ -2807,7 +2894,8 @@ def assert_distributed_vector_consistency(
         ivf_model = builder.train_ivf(
             nparts,
             distance_type=dist_type,
-            sample_rate=safe_sr,
+            sample_rate=sample_rate,
+            max_iters=max_iters,
         )
         preprocessed = {"ivf_centroids": ivf_model.centroids}
 
@@ -2859,9 +2947,9 @@ def assert_distributed_vector_consistency(
         gt_ids.append(np.array(gt_tbl["id"].to_pylist(), dtype=np.int64))
 
         # Consistent nearest settings for index-based search
-        nearest = {"column": column, "q": q, "k": topk, "refine_factor": 100}
+        nearest = {"column": column, "q": q, "k": topk, "refine_factor": 10}
         if "IVF" in index_type:
-            nearest["nprobes"] = max(16, int(index_params.get("num_partitions", 4)) * 4)
+            nearest["nprobes"] = int(index_params.get("num_partitions", 4))
         if "HNSW" in index_type:
             # Ensure ef is large enough even when refine_factor multiplies k for HNSW
             effective_k = topk * int(
@@ -2889,10 +2977,18 @@ def assert_distributed_vector_consistency(
     rs = compute_recall(gt_ids, single_ids)
     rd = compute_recall(gt_ids, dist_ids)
 
-    # Assert recall difference within 10%
-    assert abs(rs - rd) <= 1 - similarity_threshold, (
+    assert rs >= 0.5, (
+        f"Single-machine {index_type} recall below 0.5: recall={rs:.3f}, "
+        f"num_partitions={nparts}, topk={topk}, queries={len(queries)}"
+    )
+    assert rd >= 0.5, (
+        f"Distributed {index_type} recall below 0.5: recall={rd:.3f}, "
+        f"num_partitions={nparts}, topk={topk}, queries={len(queries)}"
+    )
+    max_recall_difference = 1 - similarity_threshold
+    assert abs(rs - rd) <= max_recall_difference, (
         f"Recall difference too large: single={rs:.3f}, distributed={rd:.3f}, "
-        f"diff={abs(rs - rd):.3f} (> {similarity_threshold})"
+        f"diff={abs(rs - rd):.3f} (> {max_recall_difference:.3f})"
     )
 
     # Cleanup temporary directory if used
@@ -2911,324 +3007,88 @@ def _make_sample_dataset_base(
     max_rows_per_file: int = 500,
 ):
     """Common helper to construct sample datasets for distributed index tests."""
-    mat = np.random.rand(n_rows, dim).astype(np.float32)
+    mat = np.random.default_rng(42).random((n_rows, dim), dtype=np.float32)
     ids = np.arange(n_rows)
-    arr = pa.array(mat.tolist(), type=pa.list_(pa.float32(), dim))
+    arr = pa.FixedSizeListArray.from_arrays(pa.array(mat.reshape(-1)), dim)
     tbl = pa.table({"id": ids, "vector": arr})
     return lance.write_dataset(
         tbl, tmp_path / name, max_rows_per_file=max_rows_per_file
     )
 
 
-def test_prepared_global_ivfpq_distributed_merge_and_search(tmp_path: Path):
-    ds = _make_sample_dataset_base(tmp_path, "preproc_ds", 2000, 128)
-
-    # Global preparation
-    builder = IndicesBuilder(ds, "vector")
-    preprocessed = builder.prepare_global_ivf_pq(
-        num_partitions=4,
-        num_subvectors=4,
-        distance_type="l2",
-        sample_rate=3,
-        max_iters=20,
+@pytest.mark.parametrize(
+    "index_type",
+    [
+        "IVF_FLAT",
+        "IVF_PQ",
+        "IVF_SQ",
+    ],
+)
+def test_distributed_ivf_two_shard_build_merge_and_search(tmp_path, index_type):
+    dim = 32
+    num_partitions = 2
+    ds = _make_sample_dataset_base(
+        tmp_path,
+        f"dist_{index_type.lower()}",
+        n_rows=640,
+        dim=dim,
+        max_rows_per_file=320,
     )
-
-    # Distributed build using prepared centroids/codebook
-    ds = build_distributed_vector_index(
-        ds,
-        "vector",
-        index_type="IVF_PQ",
-        num_partitions=4,
-        num_sub_vectors=4,
-        world=2,
-        ivf_centroids=preprocessed["ivf_centroids"],
-        pq_codebook=preprocessed["pq_codebook"],
-    )
-
-    # Query sanity
-    q = np.random.rand(128).astype(np.float32)
-    results = ds.to_table(nearest={"column": "vector", "q": q, "k": 10})
-    assert 0 < len(results) <= 10
-
-
-def test_consistency_improves_with_preprocessed_centroids(tmp_path: Path):
-    ds = _make_sample_dataset_base(tmp_path, "preproc_ds", 2000, 128)
-
-    builder = IndicesBuilder(ds, "vector")
-    pre = builder.prepare_global_ivf_pq(
-        num_partitions=4,
-        num_subvectors=16,
-        distance_type="l2",
-        sample_rate=7,
-        max_iters=20,
-    )
-
-    # Build single-machine index as ground truth target index
-    single_ds = lance.write_dataset(ds.to_table(), tmp_path / "single_ivfpq")
-    single_ds = single_ds.create_index(
-        column="vector",
-        index_type="IVF_PQ",
-        num_partitions=4,
-        num_sub_vectors=16,
-    )
-
-    # Distributed with preprocessed IVF centroids
-    dist_pre = lance.write_dataset(ds.to_table(), tmp_path / "dist_pre")
-    dist_pre = build_distributed_vector_index(
-        dist_pre,
-        "vector",
-        index_type="IVF_PQ",
-        num_partitions=4,
-        num_sub_vectors=16,
-        world=2,
-        ivf_centroids=pre["ivf_centroids"],
-        pq_codebook=pre["pq_codebook"],
-    )
-
-    # Evaluate recall vs exact search
-    q = np.random.rand(128).astype(np.float32)
-    topk = 10
-    gt = single_ds.to_table(
-        nearest={"column": "vector", "q": q, "k": topk, "use_index": False}
-    )
-    res_pre = dist_pre.to_table(nearest={"column": "vector", "q": q, "k": topk})
-
-    gt_ids = gt["id"].to_pylist()
-    pre_ids = res_pre["id"].to_pylist()
-
-    def _recall(gt_ids, res_ids):
-        s = set(int(x) for x in gt_ids)
-        d = set(int(x) for x in res_ids)
-        return len(s & d) / max(1, len(s))
-
-    recall_pre = _recall(gt_ids, pre_ids)
-
-    # Expect some non-zero recall with preprocessed IVF centroids
-    if recall_pre < 0.10:
-        pytest.skip(
-            "Distributed IVF_PQ recall below threshold in current "
-            "environment - known issue"
-        )
-    assert recall_pre >= 0.10
-
-
-def test_metadata_merge_pq_success(tmp_path):
-    ds = _make_sample_dataset_base(tmp_path, "dist_ds", 2000, 128)
     frags = ds.get_fragments()
-    assert len(frags) >= 2, "Need at least 2 fragments for distributed testing"
-    mid = max(1, len(frags) // 2)
-    node1 = [f.fragment_id for f in frags[:mid]]
-    node2 = [f.fragment_id for f in frags[mid:]]
+    assert len(frags) == 2
+    fragment_groups = [[fragment.fragment_id] for fragment in frags]
     builder = IndicesBuilder(ds, "vector")
-    pre = builder.prepare_global_ivf_pq(
-        num_partitions=8,
-        num_subvectors=16,
-        distance_type="l2",
-        sample_rate=7,
-        max_iters=20,
-    )
-    try:
-        segments = _build_segments(
-            ds,
-            "vector",
-            "IVF_PQ",
-            [node1, node2],
-            index_name="vector_idx",
-            num_partitions=8,
-            num_sub_vectors=16,
-            ivf_centroids=pre["ivf_centroids"],
-            pq_codebook=pre["pq_codebook"],
+    build_kwargs = {"num_partitions": num_partitions}
+    if index_type == "IVF_PQ":
+        preprocessed = builder.prepare_global_ivf_pq(
+            num_partitions=num_partitions,
+            num_subvectors=4,
+            distance_type="l2",
+            sample_rate=2,
+            max_iters=2,
         )
-        ds = _commit_segments_helper(ds, segments, "vector")
-        q = np.random.rand(128).astype(np.float32)
-        results = ds.to_table(nearest={"column": "vector", "q": q, "k": 10})
-        assert 0 < len(results) <= 10
-    except ValueError as e:
-        raise e
-
-
-def test_distributed_workflow_merge_and_search(tmp_path):
-    """End-to-end: build IVF_PQ on two groups, merge, and verify search returns
-    results."""
-    ds = _make_sample_dataset_base(tmp_path, "dist_ds", 2000, 128)
-    frags = ds.get_fragments()
-    if len(frags) < 2:
-        pytest.skip("Need at least 2 fragments for distributed testing")
-    mid = len(frags) // 2
-    node1 = [f.fragment_id for f in frags[:mid]]
-    node2 = [f.fragment_id for f in frags[mid:]]
-    builder = IndicesBuilder(ds, "vector")
-    pre = builder.prepare_global_ivf_pq(
-        num_partitions=4,
-        num_subvectors=4,
-        distance_type="l2",
-        sample_rate=7,
-        max_iters=20,
-    )
-    try:
-        segments = _build_segments(
-            ds,
-            "vector",
-            "IVF_PQ",
-            [node1, node2],
-            index_name="vector_idx",
-            num_partitions=4,
+        assert set(preprocessed) == {"ivf_centroids", "pq_codebook"}
+        assert len(preprocessed["ivf_centroids"]) == num_partitions
+        assert preprocessed["ivf_centroids"].type.list_size == dim
+        assert len(preprocessed["pq_codebook"]) > 0
+        assert preprocessed["pq_codebook"].type.list_size == dim
+        build_kwargs.update(
             num_sub_vectors=4,
-            ivf_centroids=pre["ivf_centroids"],
-            pq_codebook=pre["pq_codebook"],
+            ivf_centroids=preprocessed["ivf_centroids"],
+            pq_codebook=preprocessed["pq_codebook"],
         )
-        ds = _commit_segments_helper(ds, segments, "vector")
-        q = np.random.rand(128).astype(np.float32)
-        results = ds.to_table(nearest={"column": "vector", "q": q, "k": 10})
-        assert 0 < len(results) <= 10
-    except ValueError as e:
-        raise e
-
-
-def test_vector_merge_two_shards_success_flat(tmp_path):
-    ds = _make_sample_dataset_base(tmp_path, "dist_ds", 1000, 128)
-    frags = ds.get_fragments()
-    assert len(frags) >= 2
-    shard1 = [frags[0].fragment_id]
-    shard2 = [frags[1].fragment_id]
-    # Global preparation
-    builder = IndicesBuilder(ds, "vector")
-    preprocessed = builder.prepare_global_ivf_pq(
-        num_partitions=4,
-        num_subvectors=4,
-        distance_type="l2",
-        sample_rate=3,
-        max_iters=20,
-    )
+    else:
+        ivf_model = builder.train_ivf(
+            num_partitions=num_partitions,
+            distance_type="l2",
+            sample_rate=8,
+            max_iters=2,
+        )
+        build_kwargs["ivf_centroids"] = ivf_model.centroids
 
     segments = _build_segments(
         ds,
         "vector",
-        "IVF_FLAT",
-        [shard1, shard2],
+        index_type,
+        fragment_groups,
         index_name="vector_idx",
-        num_partitions=4,
-        num_sub_vectors=128,
-        ivf_centroids=preprocessed["ivf_centroids"],
-        pq_codebook=preprocessed["pq_codebook"],
+        **build_kwargs,
     )
-    ds = _commit_segments_helper(ds, segments, column="vector")
-    q = np.random.rand(128).astype(np.float32)
-    result = ds.to_table(nearest={"column": "vector", "q": q, "k": 5})
-    assert 0 < len(result) <= 5
-
-
-@pytest.mark.parametrize(
-    "index_type,num_sub_vectors",
-    [
-        ("IVF_PQ", 4),
-        ("IVF_FLAT", 128),
-    ],
-)
-def test_distributed_ivf_parameterized(tmp_path, index_type, num_sub_vectors):
-    ds = _make_sample_dataset_base(tmp_path, "dist_ds", 2000, 128)
-    frags = ds.get_fragments()
-    assert len(frags) >= 2
-    mid = len(frags) // 2
-    node1 = [f.fragment_id for f in frags[:mid]]
-    node2 = [f.fragment_id for f in frags[mid:]]
-    builder = IndicesBuilder(ds, "vector")
-    pre = builder.prepare_global_ivf_pq(
-        num_partitions=4,
-        num_subvectors=num_sub_vectors,
-        distance_type="l2",
-        sample_rate=7,
-        max_iters=20,
-    )
-
-    try:
-        base_kwargs = dict(
-            column="vector",
-            index_type=index_type,
-            num_partitions=4,
-            num_sub_vectors=num_sub_vectors,
-        )
-
-        kwargs1 = dict(base_kwargs, fragment_ids=node1)
-        kwargs2 = dict(base_kwargs, fragment_ids=node2)
-
-        if pre is not None:
-            kwargs1.update(
-                ivf_centroids=pre["ivf_centroids"], pq_codebook=pre["pq_codebook"]
-            )
-            kwargs2.update(
-                ivf_centroids=pre["ivf_centroids"], pq_codebook=pre["pq_codebook"]
-            )
-
-        segments = [
-            ds.create_index_uncommitted(**kwargs1),
-            ds.create_index_uncommitted(**kwargs2),
-        ]
-        ds = _commit_segments_helper(ds, segments, "vector")
-
-        q = np.random.rand(128).astype(np.float32)
-        results = ds.to_table(nearest={"column": "vector", "q": q, "k": 10})
-        assert 0 < len(results) <= 10
-    except ValueError as e:
-        raise e
-
-
-@pytest.mark.parametrize(
-    "index_type,num_sub_vectors",
-    [
-        ("IVF_PQ", 128),
-        ("IVF_SQ", None),
-    ],
-)
-def test_merge_two_shards_parameterized(tmp_path, index_type, num_sub_vectors):
-    ds = _make_sample_dataset_base(tmp_path, "dist_ds2", 2000, 128)
-    frags = ds.get_fragments()
-    assert len(frags) >= 2
-    shard1 = [frags[0].fragment_id]
-    shard2 = [frags[1].fragment_id]
-    builder = IndicesBuilder(ds, "vector")
-    pre = builder.prepare_global_ivf_pq(
-        num_partitions=4,
-        num_subvectors=num_sub_vectors,
-        distance_type="l2",
-        sample_rate=7,
-        max_iters=20,
-    )
-
-    base_kwargs = {
-        "column": "vector",
-        "index_type": index_type,
-        "num_partitions": 4,
-    }
-
-    # first shard
-    kwargs1 = dict(base_kwargs)
-    kwargs1["fragment_ids"] = shard1
-    if num_sub_vectors is not None:
-        kwargs1["num_sub_vectors"] = num_sub_vectors
-    if pre is not None:
-        kwargs1["ivf_centroids"] = pre["ivf_centroids"]
-        # only PQ has pq_codebook
-        if "pq_codebook" in pre:
-            kwargs1["pq_codebook"] = pre["pq_codebook"]
-    segment1 = ds.create_index_uncommitted(**kwargs1)
-
-    # second shard
-    kwargs2 = dict(base_kwargs)
-    kwargs2["fragment_ids"] = shard2
-    if num_sub_vectors is not None:
-        kwargs2["num_sub_vectors"] = num_sub_vectors
-    if pre is not None:
-        kwargs2["ivf_centroids"] = pre["ivf_centroids"]
-        if "pq_codebook" in pre:
-            kwargs2["pq_codebook"] = pre["pq_codebook"]
-    segment2 = ds.create_index_uncommitted(**kwargs2)
-
-    segments = [segment1, segment2]
+    assert len(segments) == 2
     ds = _commit_segments_helper(ds, segments, column="vector")
 
-    q = np.random.rand(128).astype(np.float32)
-    results = ds.to_table(nearest={"column": "vector", "q": q, "k": 5})
+    stats = ds.stats.index_stats("vector_idx")
+    assert stats["index_type"] == index_type
+    q = np.random.default_rng(43).random(dim, dtype=np.float32)
+    results = ds.to_table(
+        nearest={
+            "column": "vector",
+            "q": q,
+            "k": 5,
+            "nprobes": num_partitions,
+            "refine_factor": 10,
+        }
+    )
     assert 0 < len(results) <= 5
 
 
@@ -3243,6 +3103,7 @@ def test_commit_existing_index_segments_accepts_index_metadata(tmp_path):
         num_partitions=2,
         distance_type="l2",
         sample_rate=8,
+        max_iters=2,
     )
     base_kwargs = {
         "column": "vector",
@@ -3285,6 +3146,7 @@ def test_distributed_ivf_rq_shared_rotation(tmp_path):
         num_partitions=2,
         distance_type="l2",
         sample_rate=8,
+        max_iters=2,
     )
     rabitq_model = indices.build_rq_model(dimension=dim, num_bits=1)
     base_kwargs = {
@@ -3313,16 +3175,21 @@ def test_distributed_ivf_rq_shared_rotation(tmp_path):
 
 
 def test_commit_existing_index_segments_accepts_uncommitted_vector_segments(tmp_path):
-    ds = _make_sample_dataset_base(tmp_path, "segment_commit_ds", 2000, 128)
+    dim = 32
+    ds = _make_sample_dataset_base(
+        tmp_path,
+        "segment_commit_ds",
+        n_rows=512,
+        dim=dim,
+        max_rows_per_file=256,
+    )
     frags = ds.get_fragments()
-    assert len(frags) >= 2
-    builder = IndicesBuilder(ds, "vector")
-    preprocessed = builder.prepare_global_ivf_pq(
-        num_partitions=4,
-        num_subvectors=4,
+    assert len(frags) == 2
+    ivf_model = IndicesBuilder(ds, "vector").train_ivf(
+        num_partitions=2,
         distance_type="l2",
-        sample_rate=7,
-        max_iters=20,
+        sample_rate=8,
+        max_iters=2,
     )
 
     segments = [
@@ -3332,62 +3199,60 @@ def test_commit_existing_index_segments_accepts_uncommitted_vector_segments(tmp_
             name="vector_idx",
             train=True,
             fragment_ids=[fragment.fragment_id],
-            num_partitions=4,
-            num_sub_vectors=128,
-            ivf_centroids=preprocessed["ivf_centroids"],
-            pq_codebook=preprocessed["pq_codebook"],
+            num_partitions=2,
+            ivf_centroids=ivf_model.centroids,
         )
-        for fragment in frags[:2]
+        for fragment in frags
     ]
 
     assert len(segments) == 2
     ds = ds.commit_existing_index_segments("vector_idx", "vector", segments)
 
-    q = np.random.rand(128).astype(np.float32)
+    q = np.random.rand(dim).astype(np.float32)
     results = ds.to_table(nearest={"column": "vector", "q": q, "k": 5})
     assert 0 < len(results) <= 5
 
 
 def test_distributed_ivf_pq_order_invariance(tmp_path: Path):
     """Ensure distributed IVF_PQ build is invariant to shard build order."""
-    ds = _make_sample_dataset_base(tmp_path, "dist_ds", 2000, 128)
+    dim = 32
+    ds = _make_sample_dataset_base(
+        tmp_path, "dist_ds", n_rows=640, dim=dim, max_rows_per_file=320
+    )
 
     # Global IVF+PQ training once; artifacts are reused across shard orders.
     builder = IndicesBuilder(ds, "vector")
     pre = builder.prepare_global_ivf_pq(
-        num_partitions=4,
-        num_subvectors=16,
+        num_partitions=2,
+        num_subvectors=4,
         distance_type="l2",
-        sample_rate=7,
+        sample_rate=2,
+        max_iters=2,
     )
 
     # Copy the dataset twice so index manifests do not clash and we can vary
     # the shard build order independently on identical data.
     ds_order_12 = lance.write_dataset(
-        ds.to_table(), tmp_path / "pq_order_node1_node2", max_rows_per_file=500
+        ds.to_table(), tmp_path / "pq_order_node1_node2", max_rows_per_file=320
     )
     ds_order_21 = lance.write_dataset(
-        ds.to_table(), tmp_path / "pq_order_node2_node1", max_rows_per_file=500
+        ds.to_table(), tmp_path / "pq_order_node2_node1", max_rows_per_file=320
     )
 
     # For each copy, derive two shard groups from its own fragments.
     frags_12 = ds_order_12.get_fragments()
-    if len(frags_12) < 2:
-        pytest.skip("Need at least 2 fragments for distributed indexing (order_12)")
+    assert len(frags_12) == 2
     mid_12 = len(frags_12) // 2
     node1_12 = [f.fragment_id for f in frags_12[:mid_12]]
     node2_12 = [f.fragment_id for f in frags_12[mid_12:]]
-    if not node1_12 or not node2_12:
-        pytest.skip("Failed to split fragments into two non-empty groups (order_12)")
+    assert node1_12 and node2_12
 
     frags_21 = ds_order_21.get_fragments()
-    if len(frags_21) < 2:
-        pytest.skip("Need at least 2 fragments for distributed indexing (order_21)")
+    assert len(frags_21) == 2
     mid_21 = len(frags_21) // 2
     node1_21 = [f.fragment_id for f in frags_21[:mid_21]]
     node2_21 = [f.fragment_id for f in frags_21[mid_21:]]
-    if not node1_21 or not node2_21:
-        pytest.skip("Failed to split fragments into two non-empty groups (order_21)")
+    assert node1_21 and node2_21
 
     def build_distributed_ivf_pq(ds_copy, shard_order):
         try:
@@ -3397,8 +3262,8 @@ def test_distributed_ivf_pq_order_invariance(tmp_path: Path):
                 "IVF_PQ",
                 shard_order,
                 index_name="vector_idx",
-                num_partitions=4,
-                num_sub_vectors=16,
+                num_partitions=2,
+                num_sub_vectors=4,
                 ivf_centroids=pre["ivf_centroids"],
                 pq_codebook=pre["pq_codebook"],
             )
@@ -3411,11 +3276,8 @@ def test_distributed_ivf_pq_order_invariance(tmp_path: Path):
 
     # Sample queries once from the original dataset and reuse for both index builds
     # to check order invariance under distributed PQ training and merging.
-    k = 10
-    sample_tbl = ds.sample(10, columns=["vector"])
-    queries = [
-        np.asarray(v, dtype=np.float32) for v in sample_tbl["vector"].to_pylist()
-    ]
+    k = 5
+    queries = np.random.default_rng(43).random((3, dim), dtype=np.float32)
 
     def collect_ids_and_distances(ds_with_index):
         ids_per_query = []
@@ -3427,8 +3289,8 @@ def test_distributed_ivf_pq_order_invariance(tmp_path: Path):
                     "column": "vector",
                     "q": q,
                     "k": k,
-                    "nprobes": 16,
-                    "refine_factor": 100,
+                    "nprobes": 2,
+                    "refine_factor": 10,
                 },
             )
             ids_per_query.append([int(x) for x in tbl["id"].to_pylist()])

--- a/python/python/tests/test_vector_index.py
+++ b/python/python/tests/test_vector_index.py
@@ -548,7 +548,9 @@ def test_index_with_nans(tmp_path, index_file_version):
 def test_torch_index_with_nans(tmp_path, index_file_version):
     torch = pytest.importorskip("torch")
 
-    tbl = create_table(nvec=256, ndim=32, nans=8)
+    # Torch PQ initialization samples 256 valid residuals. Keep a small margin
+    # after NaN filtering so every platform can produce a complete sample batch.
+    tbl = create_table(nvec=320, ndim=32, nans=8)
 
     dataset = lance.write_dataset(tbl, tmp_path)
     dataset = dataset.create_index(


### PR DESCRIPTION
## Performance issue

The Python suite repeatedly trains large vector indices, rebuilds identical BTree fixtures, waits on fixed cleanup sleeps, and uses a multi-GB probabilistic file-writer ordering regression. The slowest individual tests reach 1–2 minutes on CI, while several parameter matrices repeat setup rather than distinct contracts.

## How this improves the tests

- replace the 100K-string x4 writer soak with an 8-row deterministic v2.0 write-side page-order regression that asserts 8 payload pages, 1 row-id page, and exact cross-column order
- split IVF/PQ dtype and metric axes, use deterministic minimum-safe multi-fragment fixtures, Arrow-native null masks, and 2 training iterations
- bound vector validation samples; shrink NaN, codebook, Torch, f16, multivector, and HNSW/PQ smoke fixtures while preserving Legacy/V3 and recall >= 0.5
- preserve cross-index-type `replace=True` coverage in one small IVF_PQ -> HNSW_SQ -> HNSW_PQ -> HNSW_FLAT sequence
- consolidate 9 overlapping distributed two-shard nodes into 3 IVF_FLAT/PQ/SQ cases, eliminate unused PQ training for IVF_FLAT/SQ, and require both single/distributed recall >= 0.5
- build the segmented/full BTree comparison once while retaining all 22 named boundary/range/comparison cases
- replace 23 seconds of fixed auto-cleanup sleeps with waits derived from manifest timestamps; keep the intentional delete-rate-limit test unchanged
- make no production-code changes

## Test runtime

Lower is better. The CI rows compare the same GitHub Actions Python workflow, runner label, pytest command (`-n auto --dist loadgroup`), and dependency set. Baseline is [`91aee6f91`](https://github.com/lance-format/lance/commit/91aee6f9123d6f955fa4033d427c124e5b4f7cd2) in [run 32823596075](https://github.com/lance-format/lance/actions/runs/32823596075); this PR is [`9417bbdae`](https://github.com/lance-format/lance/commit/9417bbdae6bd0b443bff3997069c69101588cd95) in [run 32846789759](https://github.com/lance-format/lance/actions/runs/32846789759). The suite has 38 fewer pytest nodes because repeated parameterized setup is consolidated into internal named cases; the behavioral cases described above remain covered.

| Scenario / metric | Baseline | This PR | Benefit |
| --- | ---: | ---: | ---: |
| Full Python suite, macOS ARM / Python 3.14 | 346.31 s | 82.60 s | 4.2x faster (263.71 s saved) |
| Full Python suite, Linux ARM / Python 3.14 | 400.73 s | 114.35 s | 3.5x faster (286.38 s saved) |
| Full Python suite, Windows / Python 3.12 | 244.68 s | 79.01 s | 3.1x faster (165.67 s saved) |
| Full Python suite, Linux x86_64 / Python 3.10 | 309.62 s | 131.01 s | 2.4x faster (178.61 s saved) |
| Full Python suite, Linux x86_64 / Python 3.13 | 285.41 s | 125.60 s | 2.3x faster (159.81 s saved) |
| Full Python suite, Linux x86_64 / Python 3.14 | 264.93 s | 124.23 s | 2.1x faster (140.70 s saved) |

The focused local rows below were measured on an Apple M4 Mac mini (10 cores, 24 GB), macOS 26.6.1, Python 3.13.14, PyArrow 25.0.1, and the same release-mode local `pylance` extension. Results use serial pytest, one warm-up, and three alternating baseline/current runs; the table reports the median.

| Scenario / metric | Baseline | This PR | Benefit |
| --- | ---: | ---: | ---: |
| Stable measured union below | 54.39 s | 14.12 s | 3.9x faster (40.27 s saved) |
| Writer page-order regression | 19.23 s | 2.68 s | 7.2x faster |
| Four auto-cleanup tests | 25.73 s | 5.62 s | 4.6x faster |
| `test_indices.py` | 6.20 s | 2.85 s | 2.2x faster |
| BTree comparison workload | 3.23 s | 2.97 s | 1.1x faster; setup count drops from 22 to 1 |

The local union is the sum of independently measured, non-overlapping median groups. The BTree wall time is dominated by pytest startup and 44 retained scans even though index-build work drops from 88 builds to 4.

## Coverage and validation

- final CI: macOS ARM, Linux ARM, Windows, Linux x86_64 Python 3.10/3.13/3.14, AWS integration tests, compatibility tests, lint, wheel build, and memtest pass
- file writer ordering: 1 passed, with physical page-count assertions
- auto-cleanup: 4 passed
- indices builder file: 27 passed, 15 expected CUDA skips
- vector-index focused cases: 22 passed, including both Torch NaN versions
- distributed vector cases: 11 passed
- BTree comparison: all 22 internal cases passed in one test
- Windows sample-margin fix: both Torch NaN versions passed in three consecutive local runs
- full vector-index file excluding the known local callback race: 90 passed, 5 expected skips
- the excluded progress-callback test fails identically from unmodified main on this fast local build; the full CI lane remains authoritative for it
- `uv run make format`
- `uv run make lint` (Ruff, Pyright with 0 errors, Rust fmt/clippy)
- `git diff --check`
