### PR TITLE
perf(scan): reduce system column pipeline overhead

### DIFF
--- a/rust/lance-table/benches/system_columns.rs
+++ b/rust/lance-table/benches/system_columns.rs
@@ -52,13 +52,17 @@ fn make_tasks(batch: RecordBatch, total_rows: usize, batch_size: usize) -> ReadB
     stream::iter(tasks).boxed()
 }
 
-fn make_config(total_rows: usize, sequence: Arc<RowIdSequence>) -> RowIdAndDeletesConfig {
+fn make_config(
+    total_rows: usize,
+    sequence: Arc<RowIdSequence>,
+    with_all_system_columns: bool,
+) -> RowIdAndDeletesConfig {
     RowIdAndDeletesConfig {
         params: ReadBatchParams::RangeFull,
         with_row_id: true,
-        with_row_addr: false,
-        with_row_last_updated_at_version: false,
-        with_row_created_at_version: false,
+        with_row_addr: with_all_system_columns,
+        with_row_last_updated_at_version: with_all_system_columns,
+        with_row_created_at_version: with_all_system_columns,
         deletion_vector: None,
         row_id_sequence: Some(sequence),
         last_updated_at_sequence: None,
@@ -94,33 +98,45 @@ fn bench_stream_row_ids(c: &mut Criterion) {
             .unwrap(),
         );
         for has_payload in [false, true] {
-            let batch = make_batch(batch_size, has_payload);
-            let parameter = format!("holes_{hole_stride}/payload_{has_payload}");
-            group.bench_with_input(
-                BenchmarkId::new("shape", parameter),
-                &has_payload,
-                |b, _| {
-                    b.iter_batched(
-                        || {
-                            (
-                                make_tasks(batch.clone(), total_rows, batch_size),
-                                make_config(total_rows, sequence.clone()),
-                            )
-                        },
-                        |(tasks, config)| {
-                            let batches = runtime
-                                .block_on(
-                                    wrap_with_row_id_and_delete(tasks, 0, config)
-                                        .buffered(8)
-                                        .try_collect::<Vec<_>>(),
+            for with_all_system_columns in [false, true] {
+                let batch = make_batch(batch_size, has_payload);
+                let system_columns = if with_all_system_columns {
+                    "all"
+                } else {
+                    "row_id"
+                };
+                let parameter =
+                    format!("holes_{hole_stride}/payload_{has_payload}/system_{system_columns}");
+                group.bench_with_input(
+                    BenchmarkId::new("shape", parameter),
+                    &has_payload,
+                    |b, _| {
+                        b.iter_batched(
+                            || {
+                                (
+                                    make_tasks(batch.clone(), total_rows, batch_size),
+                                    make_config(
+                                        total_rows,
+                                        sequence.clone(),
+                                        with_all_system_columns,
+                                    ),
                                 )
-                                .unwrap();
-                            black_box(batches);
-                        },
-                        BatchSize::SmallInput,
-                    );
-                },
-            );
+                            },
+                            |(tasks, config)| {
+                                let batches = runtime
+                                    .block_on(
+                                        wrap_with_row_id_and_delete(tasks, 0, config)
+                                            .buffered(8)
+                                            .try_collect::<Vec<_>>(),
+                                    )
+                                    .unwrap();
+                                black_box(batches);
+                            },
+                            BatchSize::SmallInput,
+                        );
+                    },
+                );
+            }
         }
     }
     group.finish();

--- a/rust/lance-table/benches/system_columns.rs
+++ b/rust/lance-table/benches/system_columns.rs
@@ -36,18 +36,35 @@ fn make_batch(batch_size: usize, has_payload: bool) -> RecordBatch {
     }
 }
 
-fn make_tasks(batch: RecordBatch, total_rows: usize, batch_size: usize) -> ReadBatchTaskStream {
-    let tasks = (0..total_rows).step_by(batch_size).map(move |offset| {
-        let num_rows = batch_size.min(total_rows - offset);
+fn make_tasks(
+    batch: RecordBatch,
+    total_rows: usize,
+    batch_size: usize,
+    variable_batches: bool,
+) -> ReadBatchTaskStream {
+    let mut offset = 0;
+    let mut use_short_batch = true;
+    let tasks = std::iter::from_fn(move || {
+        if offset == total_rows {
+            return None;
+        }
+        let requested = if variable_batches && use_short_batch {
+            batch_size.saturating_sub(1).max(1)
+        } else {
+            batch_size
+        };
+        use_short_batch = !use_short_batch;
+        let num_rows = requested.min(total_rows - offset);
+        offset += num_rows;
         let batch = if num_rows == batch.num_rows() {
             batch.clone()
         } else {
             batch.slice(0, num_rows)
         };
-        ReadBatchTask {
+        Some(ReadBatchTask {
             task: future::ready(Ok(batch)).boxed(),
             num_rows: num_rows as u32,
-        }
+        })
     });
     stream::iter(tasks).boxed()
 }
@@ -80,6 +97,9 @@ fn bench_stream_row_ids(c: &mut Criterion) {
         .map(|value| value.parse().unwrap())
         .unwrap_or(1_024_usize)
         .min(total_rows);
+    let variable_batches = std::env::var("BENCH_SYSTEM_VARIABLE_BATCHES")
+        .map(|value| value == "1")
+        .unwrap_or(false);
     let runtime = tokio::runtime::Builder::new_current_thread()
         .build()
         .unwrap();
@@ -105,8 +125,9 @@ fn bench_stream_row_ids(c: &mut Criterion) {
                 } else {
                     "row_id"
                 };
-                let parameter =
-                    format!("holes_{hole_stride}/payload_{has_payload}/system_{system_columns}");
+                let parameter = format!(
+                    "holes_{hole_stride}/payload_{has_payload}/system_{system_columns}/variable_{variable_batches}"
+                );
                 group.bench_with_input(
                     BenchmarkId::new("shape", parameter),
                     &has_payload,
@@ -114,7 +135,12 @@ fn bench_stream_row_ids(c: &mut Criterion) {
                         b.iter_batched(
                             || {
                                 (
-                                    make_tasks(batch.clone(), total_rows, batch_size),
+                                    make_tasks(
+                                        batch.clone(),
+                                        total_rows,
+                                        batch_size,
+                                        variable_batches,
+                                    ),
                                     make_config(
                                         total_rows,
                                         sequence.clone(),

--- a/rust/lance-table/src/utils/stream.rs
+++ b/rust/lance-table/src/utils/stream.rs
@@ -388,6 +388,10 @@ struct CachedOutputSchema {
 }
 
 impl PrecomputedRowIdChunk {
+    fn end_offset(&self) -> usize {
+        self.logical_offset + self.values.len()
+    }
+
     fn slice(&self, logical_offset: usize, num_rows: usize) -> Option<Arc<UInt64Array>> {
         let offset_in_chunk = logical_offset.checked_sub(self.logical_offset)?;
         if offset_in_chunk + num_rows > self.values.len() {
@@ -398,6 +402,50 @@ impl PrecomputedRowIdChunk {
         }
         Some(Arc::new(self.values.slice(offset_in_chunk, num_rows)))
     }
+}
+
+fn decode_row_id_chunk<const USE_DENSE_ROW_ID_EXPANSION: bool>(
+    sequence: &RowIdSequence,
+    cursor: &mut RowIdSequenceCursor,
+    params: &ReadBatchParams,
+    logical_offset: usize,
+    chunk_len: usize,
+) -> Result<PrecomputedRowIdChunk> {
+    let selection = params
+        .slice(logical_offset, chunk_len)
+        .unwrap()
+        .to_ranges()
+        .unwrap();
+    let values = match selection.as_slice() {
+        [range] if USE_DENSE_ROW_ID_EXPANSION => UInt64Array::from(
+            sequence
+                .select_dense_range_with_cursor(cursor, range.start as usize..range.end as usize),
+        ),
+        [range] => UInt64Array::from(
+            sequence.select_range_with_cursor(cursor, range.start as usize..range.end as usize),
+        ),
+        _ => sequence
+            .select_with_cursor(
+                cursor,
+                selection
+                    .iter()
+                    .flat_map(|range| range.start as usize..range.end as usize),
+            )
+            .collect::<UInt64Array>(),
+    };
+    if values.len() != chunk_len {
+        return Err(Error::corrupt_file_named(
+            "row ID metadata",
+            format!(
+                "decoded row ID chunk at selected offset {logical_offset} contains {} rows, but the selection requires {chunk_len} rows",
+                values.len()
+            ),
+        ));
+    }
+    Ok(PrecomputedRowIdChunk {
+        logical_offset,
+        values: Arc::new(values),
+    })
 }
 
 fn selected_row_count(params: &ReadBatchParams, total_num_rows: usize) -> usize {
@@ -661,48 +709,48 @@ fn wrap_with_row_id_and_delete_impl<const USE_DENSE_ROW_ID_EXPANSION: bool>(
                         return Ok(row_ids);
                     }
 
-                    let batches_per_chunk = ROW_ID_READ_AHEAD_ROWS.div_ceil(num_rows);
-                    let chunk_len = (num_rows * batches_per_chunk)
-                        .min(selected_rows.saturating_sub(logical_offset));
-                    let selection = config
-                        .params
-                        .slice(logical_offset, chunk_len)
-                        .unwrap()
-                        .to_ranges()
-                        .unwrap();
-                    let values = match selection.as_slice() {
-                        [range] if USE_DENSE_ROW_ID_EXPANSION => {
-                            UInt64Array::from(sequence.select_dense_range_with_cursor(
-                                cursor,
-                                range.start as usize..range.end as usize,
-                            ))
+                    let prefix = row_id_chunk.as_ref().and_then(|chunk| {
+                        let prefix_len = chunk.end_offset().checked_sub(logical_offset)?;
+                        if prefix_len == 0 {
+                            None
+                        } else {
+                            chunk.slice(logical_offset, prefix_len)
                         }
-                        [range] => UInt64Array::from(sequence.select_range_with_cursor(
-                            cursor,
-                            range.start as usize..range.end as usize,
-                        )),
-                        _ => sequence
-                            .select_with_cursor(
-                                cursor,
-                                selection
-                                    .iter()
-                                    .flat_map(|range| range.start as usize..range.end as usize),
-                            )
-                            .collect::<UInt64Array>(),
-                    };
-                    let chunk = PrecomputedRowIdChunk {
-                        logical_offset,
-                        values: Arc::new(values),
-                    };
-                    let row_ids = chunk.slice(logical_offset, num_rows).ok_or_else(|| {
+                    });
+                    let decode_offset = logical_offset
+                        + prefix
+                            .as_ref()
+                            .map(|row_ids| row_ids.len())
+                            .unwrap_or_default();
+                    let required_end = logical_offset + num_rows;
+                    let missing_rows = required_end.saturating_sub(decode_offset);
+                    let chunk_len = missing_rows
+                        .max(ROW_ID_READ_AHEAD_ROWS)
+                        .min(selected_rows.saturating_sub(decode_offset));
+                    let chunk = decode_row_id_chunk::<USE_DENSE_ROW_ID_EXPANSION>(
+                        sequence,
+                        cursor,
+                        &config.params,
+                        decode_offset,
+                        chunk_len,
+                    )?;
+                    let suffix = chunk.slice(decode_offset, missing_rows).ok_or_else(|| {
                         Error::corrupt_file_named(
                             "row ID metadata",
                             format!(
-                                "decoded row ID chunk at selected offset {logical_offset} contains {} rows, but the current batch requires {num_rows} rows",
+                                "decoded row ID chunk at selected offset {decode_offset} contains {} rows, but the current batch requires {missing_rows} more rows",
                                 chunk.values.len()
                             ),
                         )
                     })?;
+                    let row_ids = if let Some(prefix) = prefix {
+                        let mut values = Vec::with_capacity(num_rows);
+                        values.extend_from_slice(prefix.values());
+                        values.extend_from_slice(suffix.values());
+                        Arc::new(UInt64Array::from(values))
+                    } else {
+                        suffix
+                    };
                     row_id_chunk = Some(chunk);
                     Ok(row_ids)
                 })
@@ -1043,11 +1091,11 @@ mod tests {
             batch[ROW_ID].as_primitive::<UInt64Type>()
         }
         assert_eq!(
-            row_ids(&batches[63]).values().as_ptr(),
+            row_ids(&batches[62]).values().as_ptr(),
             row_ids(&batches[0])
                 .values()
                 .as_ptr()
-                .wrapping_add(63 * 1_025)
+                .wrapping_add(62 * 1_025)
         );
         assert_eq!(
             row_ids(&batches[68]).values().as_ptr(),
@@ -1133,8 +1181,95 @@ mod tests {
             .unwrap_err();
         assert!(matches!(error, lance_core::Error::CorruptFile { .. }));
         assert!(error.to_string().contains(
-            "decoded row ID chunk at selected offset 0 contains 5 rows, but the current batch requires 10 rows"
+            "decoded row ID chunk at selected offset 0 contains 5 rows, but the selection requires 10 rows"
         ));
+    }
+
+    #[tokio::test]
+    async fn test_truncated_stable_row_ids_with_unsorted_indices_returns_error() {
+        let tasks = (0..4).map(|_| ReadBatchTask {
+            num_rows: 1,
+            task: std::future::ready(Ok(
+                arrow_array::record_batch!(("x", Int32, vec![0])).unwrap()
+            ))
+            .boxed(),
+        });
+        let config = RowIdAndDeletesConfig {
+            params: ReadBatchParams::Indices(UInt32Array::from(vec![0, 5, 1, 2])),
+            with_row_id: true,
+            with_row_addr: false,
+            with_row_last_updated_at_version: false,
+            with_row_created_at_version: false,
+            deletion_vector: None,
+            row_id_sequence: Some(Arc::new(RowIdSequence::try_from_iter(0_u64..5).unwrap())),
+            last_updated_at_sequence: None,
+            created_at_sequence: None,
+            make_deletions_null: false,
+            total_num_rows: 6,
+        };
+
+        let error = super::wrap_with_row_id_and_delete(stream::iter(tasks).boxed(), 0, config)
+            .buffered(1)
+            .try_collect::<Vec<_>>()
+            .await
+            .unwrap_err();
+        assert!(matches!(error, lance_core::Error::CorruptFile { .. }));
+    }
+
+    #[tokio::test]
+    async fn test_stable_row_id_read_ahead_with_variable_task_boundaries() {
+        let total_rows = super::ROW_ID_READ_AHEAD_ROWS * 3 + 41;
+        let expected = (0_u64..)
+            .filter(|row_id| row_id % 17 != 0)
+            .take(total_rows)
+            .collect::<Vec<_>>();
+        let mut remaining = total_rows;
+        let mut use_short_task = true;
+        let tasks = std::iter::from_fn(move || {
+            if remaining == 0 {
+                return None;
+            }
+            let requested = if use_short_task { 32_768 } else { 32_769 };
+            use_short_task = !use_short_task;
+            let num_rows = remaining.min(requested);
+            remaining -= num_rows;
+            Some(ReadBatchTask {
+                num_rows: num_rows as u32,
+                task: std::future::ready(Ok(arrow_array::record_batch!((
+                    "x",
+                    Int32,
+                    vec![0; num_rows]
+                ))
+                .unwrap()))
+                .boxed(),
+            })
+        });
+        let config = RowIdAndDeletesConfig {
+            params: ReadBatchParams::RangeFull,
+            with_row_id: true,
+            with_row_addr: false,
+            with_row_last_updated_at_version: false,
+            with_row_created_at_version: false,
+            deletion_vector: None,
+            row_id_sequence: Some(Arc::new(
+                RowIdSequence::try_from_iter(expected.clone()).unwrap(),
+            )),
+            last_updated_at_sequence: None,
+            created_at_sequence: None,
+            make_deletions_null: false,
+            total_num_rows: total_rows as u32,
+        };
+
+        let actual = super::wrap_with_row_id_and_delete(stream::iter(tasks).boxed(), 0, config)
+            .buffered(3)
+            .try_collect::<Vec<_>>()
+            .await
+            .unwrap()
+            .iter()
+            .flat_map(|batch| batch[ROW_ID].as_primitive::<UInt64Type>().values())
+            .copied()
+            .collect::<Vec<_>>();
+        assert_eq!(actual, expected);
     }
 
     #[tokio::test]

--- a/rust/lance-table/src/utils/stream.rs
+++ b/rust/lance-table/src/utils/stream.rs
@@ -592,7 +592,7 @@ fn apply_row_id_and_deletes_with_system_columns(
 
     let batch = if system_columns.is_empty() {
         batch
-    } else {
+    } else if let Some(output_schema_cache) = output_schema_cache {
         let input_schema = batch.schema();
         let make_output_schema = || {
             let mut fields = input_schema
@@ -606,21 +606,17 @@ fn apply_row_id_and_deletes_with_system_columns(
                 input_schema.metadata().clone(),
             ))
         };
-        let output_schema = output_schema_cache
-            .map(|cache| {
-                let cached = cache.get_or_init(|| CachedOutputSchema {
-                    input: input_schema.clone(),
-                    output: make_output_schema(),
-                });
-                if Arc::ptr_eq(&cached.input, &input_schema)
-                    || cached.input.as_ref() == input_schema.as_ref()
-                {
-                    cached.output.clone()
-                } else {
-                    make_output_schema()
-                }
-            })
-            .unwrap_or_else(make_output_schema);
+        let cached = output_schema_cache.get_or_init(|| CachedOutputSchema {
+            input: input_schema.clone(),
+            output: make_output_schema(),
+        });
+        let output_schema = if Arc::ptr_eq(&cached.input, &input_schema)
+            || cached.input.as_ref() == input_schema.as_ref()
+        {
+            cached.output.clone()
+        } else {
+            make_output_schema()
+        };
         let mut columns = Vec::with_capacity(batch.num_columns() + system_columns.len());
         columns.extend_from_slice(batch.columns());
         columns.extend(system_columns.into_iter().map(|(_, array)| array));
@@ -629,6 +625,12 @@ fn apply_row_id_and_deletes_with_system_columns(
             columns,
             &RecordBatchOptions::new().with_row_count(Some(batch.num_rows())),
         )?
+    } else {
+        system_columns
+            .into_iter()
+            .try_fold(batch, |batch, (field, array)| {
+                batch.try_with_column(field, array)
+            })?
     };
 
     match (deletion_mask, config.make_deletions_null) {
@@ -698,9 +700,9 @@ fn wrap_with_row_id_and_delete_impl<const USE_DENSE_ROW_ID_EXPANSION: bool>(
             if num_rows_usize != 0 && use_uniform_batch_fast_paths {
                 if let Some(batch_size) = uniform_batch_size {
                     // A shorter final batch is expected. Any other task-size change can
-                    // repeatedly straddle read-ahead boundaries and makes shared schema
-                    // lifetimes counterproductive for large buffers. Drain the current
-                    // row-ID cache, then use exact per-task work from this point forward.
+                    // repeatedly straddle read-ahead boundaries. Drain the current row-ID
+                    // cache, then use exact per-task decoding and the original incremental
+                    // system-column assembly from this point forward.
                     if num_rows_usize != batch_size
                         && logical_offset + num_rows_usize < selected_rows
                     {

--- a/rust/lance-table/src/utils/stream.rs
+++ b/rust/lance-table/src/utils/stream.rs
@@ -370,7 +370,7 @@ pub fn apply_row_id_and_deletes(
 
 #[derive(Default)]
 struct PrecomputedSystemColumns {
-    row_ids: Option<Arc<UInt64Array>>,
+    row_ids: Option<Result<Arc<UInt64Array>>>,
     last_updated_versions: Option<Result<Arc<UInt64Array>>>,
     created_versions: Option<Result<Arc<UInt64Array>>>,
 }
@@ -468,6 +468,7 @@ fn apply_row_id_and_deletes_with_system_columns(
     let row_ids = if config.with_row_id {
         let _rowids = tracing::span!(tracing::Level::DEBUG, "fetch_row_ids").entered();
         if let Some(row_ids) = precomputed_row_ids {
+            let row_ids = row_ids?;
             debug_assert_eq!(row_ids.len(), num_rows as usize);
             Some(row_ids)
         } else if let Some(row_id_sequence) = &config.row_id_sequence {
@@ -745,7 +746,7 @@ fn wrap_with_row_id_and_delete_impl<const USE_DENSE_ROW_ID_EXPANSION: bool>(
                         fragment_id,
                         config.as_ref(),
                         PrecomputedSystemColumns {
-                            row_ids: row_ids.transpose()?,
+                            row_ids,
                             last_updated_versions,
                             created_versions,
                         },
@@ -990,40 +991,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_truncated_stable_row_ids_returns_error() {
-        let task = ReadBatchTask {
-            num_rows: 10,
-            task: std::future::ready(Ok(
-                arrow_array::record_batch!(("x", Int32, vec![0; 10])).unwrap()
-            ))
-            .boxed(),
-        };
-        let config = RowIdAndDeletesConfig {
-            params: ReadBatchParams::RangeFull,
-            with_row_id: true,
-            with_row_addr: false,
-            with_row_last_updated_at_version: false,
-            with_row_created_at_version: false,
-            deletion_vector: None,
-            row_id_sequence: Some(Arc::new(RowIdSequence::try_from_iter(0_u64..5).unwrap())),
-            last_updated_at_sequence: None,
-            created_at_sequence: None,
-            make_deletions_null: false,
-            total_num_rows: 10,
-        };
-
-        let error = super::wrap_with_row_id_and_delete(stream::iter([task]).boxed(), 0, config)
-            .buffered(1)
-            .try_collect::<Vec<_>>()
-            .await
-            .unwrap_err();
-        assert!(matches!(error, lance_core::Error::CorruptFile { .. }));
-        assert!(error.to_string().contains(
-            "decoded row ID chunk at selected offset 0 contains 5 rows, but the current batch requires 10 rows"
-        ));
-    }
-
-    #[tokio::test]
     async fn test_stable_row_id_read_ahead_range_boundary_and_tail() {
         let all_row_ids = (10_000..120_000)
             .filter(|row_id| row_id % 11 != 0)
@@ -1134,6 +1101,40 @@ mod tests {
             batches[1][ROW_ID].as_primitive::<UInt64Type>().values(),
             &[42]
         );
+    }
+
+    #[tokio::test]
+    async fn test_truncated_stable_row_ids_returns_error() {
+        let task = ReadBatchTask {
+            num_rows: 10,
+            task: std::future::ready(Ok(
+                arrow_array::record_batch!(("x", Int32, vec![0; 10])).unwrap()
+            ))
+            .boxed(),
+        };
+        let config = RowIdAndDeletesConfig {
+            params: ReadBatchParams::RangeFull,
+            with_row_id: true,
+            with_row_addr: false,
+            with_row_last_updated_at_version: false,
+            with_row_created_at_version: false,
+            deletion_vector: None,
+            row_id_sequence: Some(Arc::new(RowIdSequence::try_from_iter(0_u64..5).unwrap())),
+            last_updated_at_sequence: None,
+            created_at_sequence: None,
+            make_deletions_null: false,
+            total_num_rows: 10,
+        };
+
+        let error = super::wrap_with_row_id_and_delete(stream::iter([task]).boxed(), 0, config)
+            .buffered(1)
+            .try_collect::<Vec<_>>()
+            .await
+            .unwrap_err();
+        assert!(matches!(error, lance_core::Error::CorruptFile { .. }));
+        assert!(error.to_string().contains(
+            "decoded row ID chunk at selected offset 0 contains 5 rows, but the current batch requires 10 rows"
+        ));
     }
 
     #[tokio::test]

--- a/rust/lance-table/src/utils/stream.rs
+++ b/rust/lance-table/src/utils/stream.rs
@@ -673,6 +673,8 @@ fn wrap_with_row_id_and_delete_impl<const USE_DENSE_ROW_ID_EXPANSION: bool>(
     let config = Arc::new(config);
     let output_schema_cache = Arc::new(OnceLock::new());
     let mut row_id_chunk: Option<PrecomputedRowIdChunk> = None;
+    let mut uniform_batch_size = None;
+    let mut use_uniform_batch_fast_paths = true;
     let selected_rows = selected_row_count(&config.params, config.total_num_rows as usize);
     let mut last_updated_cursor = config
         .last_updated_at_sequence
@@ -688,23 +690,54 @@ fn wrap_with_row_id_and_delete_impl<const USE_DENSE_ROW_ID_EXPANSION: bool>(
     stream
         .map(move |batch_task| {
             let config = config.clone();
-            let output_schema_cache = output_schema_cache.clone();
             let this_offset = offset;
             let num_rows = batch_task.num_rows;
             offset += num_rows;
+            let logical_offset = this_offset as usize;
+            let num_rows_usize = num_rows as usize;
+            if num_rows_usize != 0 && use_uniform_batch_fast_paths {
+                if let Some(batch_size) = uniform_batch_size {
+                    // A shorter final batch is expected. Any other task-size change can
+                    // repeatedly straddle read-ahead boundaries and makes shared schema
+                    // lifetimes counterproductive for large buffers. Drain the current
+                    // row-ID cache, then use exact per-task work from this point forward.
+                    if num_rows_usize != batch_size
+                        && logical_offset + num_rows_usize < selected_rows
+                    {
+                        use_uniform_batch_fast_paths = false;
+                    }
+                } else {
+                    uniform_batch_size = Some(num_rows_usize);
+                }
+            }
+            let output_schema_cache = use_uniform_batch_fast_paths
+                .then(|| output_schema_cache.clone());
             // Build row ids while pulling the ordered task stream, before the
             // batch futures can run concurrently. Adjacent batches share a
             // bounded chunk and take zero-copy Arrow slices from it.
             let row_ids = config.row_id_sequence.as_ref().and_then(|sequence| {
                 row_id_cursor.as_mut().map(|cursor| {
-                    let logical_offset = this_offset as usize;
-                    let num_rows = num_rows as usize;
-                    if num_rows == 0 {
+                    if num_rows_usize == 0 {
                         return Ok(Arc::new(UInt64Array::from(Vec::<u64>::new())));
+                    }
+                    if !use_uniform_batch_fast_paths
+                        && row_id_chunk
+                            .as_ref()
+                            .is_none_or(|chunk| chunk.end_offset() <= logical_offset)
+                    {
+                        row_id_chunk = None;
+                        return decode_row_id_chunk::<USE_DENSE_ROW_ID_EXPANSION>(
+                            sequence,
+                            cursor,
+                            &config.params,
+                            logical_offset,
+                            num_rows_usize,
+                        )
+                        .map(|chunk| chunk.values);
                     }
                     if let Some(row_ids) = row_id_chunk
                         .as_ref()
-                        .and_then(|chunk| chunk.slice(logical_offset, num_rows))
+                        .and_then(|chunk| chunk.slice(logical_offset, num_rows_usize))
                     {
                         return Ok(row_ids);
                     }
@@ -722,11 +755,17 @@ fn wrap_with_row_id_and_delete_impl<const USE_DENSE_ROW_ID_EXPANSION: bool>(
                             .as_ref()
                             .map(|row_ids| row_ids.len())
                             .unwrap_or_default();
-                    let required_end = logical_offset + num_rows;
+                    let required_end = logical_offset + num_rows_usize;
                     let missing_rows = required_end.saturating_sub(decode_offset);
-                    let chunk_len = missing_rows
-                        .max(ROW_ID_READ_AHEAD_ROWS)
-                        .min(selected_rows.saturating_sub(decode_offset));
+                    let chunk_len = if use_uniform_batch_fast_paths {
+                        let batch_size = uniform_batch_size.unwrap_or(num_rows_usize);
+                        let batches_per_chunk = (ROW_ID_READ_AHEAD_ROWS / batch_size).max(1);
+                        let chunk_rows = batch_size.saturating_mul(batches_per_chunk);
+                        missing_rows.max(chunk_rows)
+                    } else {
+                        missing_rows
+                    }
+                    .min(selected_rows.saturating_sub(decode_offset));
                     let chunk = decode_row_id_chunk::<USE_DENSE_ROW_ID_EXPANSION>(
                         sequence,
                         cursor,
@@ -744,7 +783,7 @@ fn wrap_with_row_id_and_delete_impl<const USE_DENSE_ROW_ID_EXPANSION: bool>(
                         )
                     })?;
                     let row_ids = if let Some(prefix) = prefix {
-                        let mut values = Vec::with_capacity(num_rows);
+                        let mut values = Vec::with_capacity(num_rows_usize);
                         values.extend_from_slice(prefix.values());
                         values.extend_from_slice(suffix.values());
                         Arc::new(UInt64Array::from(values))
@@ -798,7 +837,7 @@ fn wrap_with_row_id_and_delete_impl<const USE_DENSE_ROW_ID_EXPANSION: bool>(
                             last_updated_versions,
                             created_versions,
                         },
-                        Some(output_schema_cache.as_ref()),
+                        output_schema_cache.as_deref(),
                     )
                 })
                 .boxed()
@@ -1260,11 +1299,16 @@ mod tests {
             total_num_rows: total_rows as u32,
         };
 
-        let actual = super::wrap_with_row_id_and_delete(stream::iter(tasks).boxed(), 0, config)
+        let batches = super::wrap_with_row_id_and_delete(stream::iter(tasks).boxed(), 0, config)
             .buffered(3)
             .try_collect::<Vec<_>>()
             .await
-            .unwrap()
+            .unwrap();
+        let second_schema = batches[1].schema();
+        let third_schema = batches[2].schema();
+        assert!(!Arc::ptr_eq(&second_schema, &third_schema));
+
+        let actual = batches
             .iter()
             .flat_map(|batch| batch[ROW_ID].as_primitive::<UInt64Type>().values())
             .copied()

--- a/rust/lance-table/src/utils/stream.rs
+++ b/rust/lance-table/src/utils/stream.rs
@@ -1,10 +1,16 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright The Lance Authors
 
-use std::{fmt, sync::Arc};
+use std::{
+    fmt,
+    sync::{Arc, OnceLock},
+};
 
-use arrow_array::{BooleanArray, RecordBatch, RecordBatchOptions, UInt64Array, make_array};
+use arrow_array::{
+    ArrayRef, BooleanArray, RecordBatch, RecordBatchOptions, UInt64Array, make_array,
+};
 use arrow_buffer::NullBuffer;
+use arrow_schema::{Field, Schema, SchemaRef};
 use futures::{
     FutureExt, Stream, StreamExt,
     future::{BoxFuture, Shared},
@@ -358,6 +364,7 @@ pub fn apply_row_id_and_deletes(
         fragment_id,
         config,
         PrecomputedSystemColumns::default(),
+        None,
     )
 }
 
@@ -368,6 +375,45 @@ struct PrecomputedSystemColumns {
     created_versions: Option<Result<Arc<UInt64Array>>>,
 }
 
+const ROW_ID_READ_AHEAD_ROWS: usize = 64 * 1024;
+
+struct PrecomputedRowIdChunk {
+    logical_offset: usize,
+    values: Arc<UInt64Array>,
+}
+
+struct CachedOutputSchema {
+    input: SchemaRef,
+    output: SchemaRef,
+}
+
+impl PrecomputedRowIdChunk {
+    fn slice(&self, logical_offset: usize, num_rows: usize) -> Option<Arc<UInt64Array>> {
+        let offset_in_chunk = logical_offset.checked_sub(self.logical_offset)?;
+        if offset_in_chunk + num_rows > self.values.len() {
+            return None;
+        }
+        if offset_in_chunk == 0 && num_rows == self.values.len() {
+            return Some(self.values.clone());
+        }
+        Some(Arc::new(self.values.slice(offset_in_chunk, num_rows)))
+    }
+}
+
+fn selected_row_count(params: &ReadBatchParams, total_num_rows: usize) -> usize {
+    match params {
+        ReadBatchParams::Range(range) => range.len(),
+        ReadBatchParams::Ranges(ranges) => ranges
+            .iter()
+            .map(|range| (range.end - range.start) as usize)
+            .sum(),
+        ReadBatchParams::RangeFull => total_num_rows,
+        ReadBatchParams::RangeTo(range) => range.end,
+        ReadBatchParams::RangeFrom(range) => total_num_rows.saturating_sub(range.start),
+        ReadBatchParams::Indices(indices) => indices.len(),
+    }
+}
+
 #[instrument(name = "apply_row_id_and_deletes", level = "debug", skip_all)]
 fn apply_row_id_and_deletes_with_system_columns(
     batch: RecordBatch,
@@ -375,6 +421,7 @@ fn apply_row_id_and_deletes_with_system_columns(
     fragment_id: u32,
     config: &RowIdAndDeletesConfig,
     precomputed: PrecomputedSystemColumns,
+    output_schema_cache: Option<&OnceLock<CachedOutputSchema>>,
 ) -> Result<RecordBatch> {
     let PrecomputedSystemColumns {
         row_ids: precomputed_row_ids,
@@ -454,62 +501,85 @@ fn apply_row_id_and_deletes_with_system_columns(
         v.build_predicate(row_addrs.iter())
     });
 
-    let batch = if config.with_row_id {
-        let row_id_arr = row_ids.unwrap();
-        batch.try_with_column(ROW_ID_FIELD.clone(), row_id_arr)?
-    } else {
-        batch
-    };
+    let mut system_columns: Vec<(Field, ArrayRef)> = Vec::with_capacity(4);
+    if config.with_row_id {
+        system_columns.push((ROW_ID_FIELD.clone(), row_ids.unwrap()));
+    }
+    if config.with_row_addr {
+        system_columns.push((ROW_ADDR_FIELD.clone(), row_addrs.unwrap()));
+    }
+    if config.with_row_last_updated_at_version {
+        let version_arr = if let Some(version_arr) = last_updated_versions {
+            version_arr?
+        } else if let Some(sequence) = &config.last_updated_at_sequence {
+            Arc::new(UInt64Array::from(version_values_for_selection(
+                sequence,
+                &config.params,
+                batch_offset,
+                num_rows,
+            )?))
+        } else {
+            // Default to version 1 if sequence not provided
+            Arc::new(UInt64Array::from(vec![1u64; num_rows as usize]))
+        };
+        system_columns.push((ROW_LAST_UPDATED_AT_VERSION_FIELD.clone(), version_arr));
+    }
+    if config.with_row_created_at_version {
+        let version_arr = if let Some(version_arr) = created_versions {
+            version_arr?
+        } else if let Some(sequence) = &config.created_at_sequence {
+            Arc::new(UInt64Array::from(version_values_for_selection(
+                sequence,
+                &config.params,
+                batch_offset,
+                num_rows,
+            )?))
+        } else {
+            // Default to version 1 if sequence not provided
+            Arc::new(UInt64Array::from(vec![1u64; num_rows as usize]))
+        };
+        system_columns.push((ROW_CREATED_AT_VERSION_FIELD.clone(), version_arr));
+    }
 
-    let batch = if config.with_row_addr {
-        let row_addr_arr = row_addrs.unwrap();
-        batch.try_with_column(ROW_ADDR_FIELD.clone(), row_addr_arr)?
-    } else {
-        batch
-    };
-
-    // Add version columns if requested
-    let batch = if config.with_row_last_updated_at_version || config.with_row_created_at_version {
-        let mut batch = batch;
-
-        if config.with_row_last_updated_at_version {
-            let version_arr = if let Some(version_arr) = last_updated_versions {
-                version_arr?
-            } else if let Some(sequence) = &config.last_updated_at_sequence {
-                Arc::new(UInt64Array::from(version_values_for_selection(
-                    sequence,
-                    &config.params,
-                    batch_offset,
-                    num_rows,
-                )?))
-            } else {
-                // Default to version 1 if sequence not provided
-                Arc::new(UInt64Array::from(vec![1u64; num_rows as usize]))
-            };
-            batch =
-                batch.try_with_column(ROW_LAST_UPDATED_AT_VERSION_FIELD.clone(), version_arr)?;
-        }
-
-        if config.with_row_created_at_version {
-            let version_arr = if let Some(version_arr) = created_versions {
-                version_arr?
-            } else if let Some(sequence) = &config.created_at_sequence {
-                Arc::new(UInt64Array::from(version_values_for_selection(
-                    sequence,
-                    &config.params,
-                    batch_offset,
-                    num_rows,
-                )?))
-            } else {
-                // Default to version 1 if sequence not provided
-                Arc::new(UInt64Array::from(vec![1u64; num_rows as usize]))
-            };
-            batch = batch.try_with_column(ROW_CREATED_AT_VERSION_FIELD.clone(), version_arr)?;
-        }
-
+    let batch = if system_columns.is_empty() {
         batch
     } else {
-        batch
+        let input_schema = batch.schema();
+        let make_output_schema = || {
+            let mut fields = input_schema
+                .fields()
+                .iter()
+                .map(|field| field.as_ref().clone())
+                .collect::<Vec<_>>();
+            fields.extend(system_columns.iter().map(|(field, _)| field.clone()));
+            Arc::new(Schema::new_with_metadata(
+                fields,
+                input_schema.metadata().clone(),
+            ))
+        };
+        let output_schema = output_schema_cache
+            .map(|cache| {
+                let cached = cache.get_or_init(|| CachedOutputSchema {
+                    input: input_schema.clone(),
+                    output: make_output_schema(),
+                });
+                if Arc::ptr_eq(&cached.input, &input_schema)
+                    || cached.input.as_ref() == input_schema.as_ref()
+                {
+                    cached.output.clone()
+                } else {
+                    make_output_schema()
+                }
+            })
+            .unwrap_or_else(make_output_schema);
+        let mut columns = Vec::with_capacity(batch.num_columns() + system_columns.len());
+        columns.extend_from_slice(batch.columns());
+        columns.extend(system_columns.into_iter().map(|(_, array)| array));
+        RecordBatch::try_new_with_options(
+            output_schema,
+            columns,
+            &RecordBatchOptions::new().with_row_count(Some(batch.num_rows())),
+        )?
     };
 
     match (deletion_mask, config.make_deletions_null) {
@@ -552,6 +622,9 @@ fn wrap_with_row_id_and_delete_impl<const USE_DENSE_ROW_ID_EXPANSION: bool>(
     mut row_id_cursor: Option<RowIdSequenceCursor>,
 ) -> ReadBatchFutStream {
     let config = Arc::new(config);
+    let output_schema_cache = Arc::new(OnceLock::new());
+    let mut row_id_chunk: Option<PrecomputedRowIdChunk> = None;
+    let selected_rows = selected_row_count(&config.params, config.total_num_rows as usize);
     let mut last_updated_cursor = config
         .last_updated_at_sequence
         .as_ref()
@@ -566,18 +639,33 @@ fn wrap_with_row_id_and_delete_impl<const USE_DENSE_ROW_ID_EXPANSION: bool>(
     stream
         .map(move |batch_task| {
             let config = config.clone();
+            let output_schema_cache = output_schema_cache.clone();
             let this_offset = offset;
             let num_rows = batch_task.num_rows;
             offset += num_rows;
-            // Materialize row ids while polling the ordered task stream. Batch
-            // futures may complete concurrently, so doing this inside the
-            // future would require locking the shared cursor or would reorder
-            // its accesses.
+            // Build row ids while pulling the ordered task stream, before the
+            // batch futures can run concurrently. Adjacent batches share a
+            // bounded chunk and take zero-copy Arrow slices from it.
             let row_ids = config.row_id_sequence.as_ref().and_then(|sequence| {
                 row_id_cursor.as_mut().map(|cursor| {
+                    let logical_offset = this_offset as usize;
+                    let num_rows = num_rows as usize;
+                    if num_rows == 0 {
+                        return Ok(Arc::new(UInt64Array::from(Vec::<u64>::new())));
+                    }
+                    if let Some(row_ids) = row_id_chunk
+                        .as_ref()
+                        .and_then(|chunk| chunk.slice(logical_offset, num_rows))
+                    {
+                        return Ok(row_ids);
+                    }
+
+                    let batches_per_chunk = ROW_ID_READ_AHEAD_ROWS.div_ceil(num_rows);
+                    let chunk_len = (num_rows * batches_per_chunk)
+                        .min(selected_rows.saturating_sub(logical_offset));
                     let selection = config
                         .params
-                        .slice(this_offset as usize, num_rows as usize)
+                        .slice(logical_offset, chunk_len)
                         .unwrap()
                         .to_ranges()
                         .unwrap();
@@ -592,27 +680,30 @@ fn wrap_with_row_id_and_delete_impl<const USE_DENSE_ROW_ID_EXPANSION: bool>(
                             cursor,
                             range.start as usize..range.end as usize,
                         )),
-                        _ => UInt64Array::from(
-                            sequence
-                                .select_with_cursor(
-                                    cursor,
-                                    selection
-                                        .iter()
-                                        .flat_map(|range| range.start as usize..range.end as usize),
-                                )
-                                .collect::<Vec<_>>(),
-                        ),
+                        _ => sequence
+                            .select_with_cursor(
+                                cursor,
+                                selection
+                                    .iter()
+                                    .flat_map(|range| range.start as usize..range.end as usize),
+                            )
+                            .collect::<UInt64Array>(),
                     };
-                    if values.len() != num_rows as usize {
-                        return Err(Error::corrupt_file_named(
+                    let chunk = PrecomputedRowIdChunk {
+                        logical_offset,
+                        values: Arc::new(values),
+                    };
+                    let row_ids = chunk.slice(logical_offset, num_rows).ok_or_else(|| {
+                        Error::corrupt_file_named(
                             "row ID metadata",
                             format!(
-                                "decoded row IDs at selected offset {this_offset} contain {} rows, but the current batch requires {num_rows} rows",
-                                values.len()
+                                "decoded row ID chunk at selected offset {logical_offset} contains {} rows, but the current batch requires {num_rows} rows",
+                                chunk.values.len()
                             ),
-                        ));
-                    }
-                    Ok(Arc::new(values))
+                        )
+                    })?;
+                    row_id_chunk = Some(chunk);
+                    Ok(row_ids)
                 })
             });
             let last_updated_versions =
@@ -658,6 +749,7 @@ fn wrap_with_row_id_and_delete_impl<const USE_DENSE_ROW_ID_EXPANSION: bool>(
                             last_updated_versions,
                             created_versions,
                         },
+                        Some(output_schema_cache.as_ref()),
                     )
                 })
                 .boxed()
@@ -927,8 +1019,184 @@ mod tests {
             .unwrap_err();
         assert!(matches!(error, lance_core::Error::CorruptFile { .. }));
         assert!(error.to_string().contains(
-            "decoded row IDs at selected offset 0 contain 5 rows, but the current batch requires 10 rows"
+            "decoded row ID chunk at selected offset 0 contains 5 rows, but the current batch requires 10 rows"
         ));
+    }
+
+    #[tokio::test]
+    async fn test_stable_row_id_read_ahead_range_boundary_and_tail() {
+        let all_row_ids = (10_000..120_000)
+            .filter(|row_id| row_id % 11 != 0)
+            .collect::<Vec<u64>>();
+        let selection = 1_234..71_237;
+        let selected_len = selection.len();
+        let mut remaining = selected_len;
+        let tasks = std::iter::from_fn(move || {
+            if remaining == 0 {
+                return None;
+            }
+            let num_rows = remaining.min(1_025);
+            remaining -= num_rows;
+            Some(ReadBatchTask {
+                num_rows: num_rows as u32,
+                task: std::future::ready(Ok(arrow_array::record_batch!((
+                    "x",
+                    Int32,
+                    vec![0; num_rows]
+                ))
+                .unwrap()))
+                .boxed(),
+            })
+        });
+        let config = RowIdAndDeletesConfig {
+            params: ReadBatchParams::Range(selection.clone()),
+            with_row_id: true,
+            with_row_addr: false,
+            with_row_last_updated_at_version: false,
+            with_row_created_at_version: false,
+            deletion_vector: None,
+            row_id_sequence: Some(Arc::new(
+                RowIdSequence::try_from_iter(all_row_ids.clone()).unwrap(),
+            )),
+            last_updated_at_sequence: None,
+            created_at_sequence: None,
+            make_deletions_null: false,
+            total_num_rows: all_row_ids.len() as u32,
+        };
+
+        let batches = super::wrap_with_row_id_and_delete(stream::iter(tasks).boxed(), 3, config)
+            .buffered(8)
+            .try_collect::<Vec<_>>()
+            .await
+            .unwrap();
+        assert_eq!(batches.len(), 69);
+        assert_eq!(batches.last().unwrap().num_rows(), 303);
+
+        fn row_ids(batch: &RecordBatch) -> &arrow_array::UInt64Array {
+            batch[ROW_ID].as_primitive::<UInt64Type>()
+        }
+        assert_eq!(
+            row_ids(&batches[63]).values().as_ptr(),
+            row_ids(&batches[0])
+                .values()
+                .as_ptr()
+                .wrapping_add(63 * 1_025)
+        );
+        assert_eq!(
+            row_ids(&batches[68]).values().as_ptr(),
+            row_ids(&batches[64])
+                .values()
+                .as_ptr()
+                .wrapping_add(4 * 1_025)
+        );
+
+        let actual = batches
+            .iter()
+            .flat_map(|batch| row_ids(batch).values())
+            .copied()
+            .collect::<Vec<_>>();
+        assert_eq!(actual, all_row_ids[selection]);
+    }
+
+    #[tokio::test]
+    async fn test_stable_row_id_read_ahead_empty_task() {
+        let tasks = [0_u32, 1].into_iter().map(|num_rows| ReadBatchTask {
+            num_rows,
+            task: std::future::ready(Ok(arrow_array::record_batch!((
+                "x",
+                Int32,
+                vec![0; num_rows as usize]
+            ))
+            .unwrap()))
+            .boxed(),
+        });
+        let config = RowIdAndDeletesConfig {
+            params: ReadBatchParams::RangeFull,
+            with_row_id: true,
+            with_row_addr: false,
+            with_row_last_updated_at_version: false,
+            with_row_created_at_version: false,
+            deletion_vector: None,
+            row_id_sequence: Some(Arc::new(RowIdSequence::try_from_iter([42]).unwrap())),
+            last_updated_at_sequence: None,
+            created_at_sequence: None,
+            make_deletions_null: false,
+            total_num_rows: 1,
+        };
+
+        let batches = super::wrap_with_row_id_and_delete(stream::iter(tasks).boxed(), 0, config)
+            .buffered(2)
+            .try_collect::<Vec<_>>()
+            .await
+            .unwrap();
+        assert_eq!(batches[0].num_rows(), 0);
+        assert_eq!(
+            batches[1][ROW_ID].as_primitive::<UInt64Type>().values(),
+            &[42]
+        );
+    }
+
+    #[tokio::test]
+    async fn test_system_columns_share_schema_for_equivalent_payload_batches() {
+        let batches = (0..3)
+            .map(|batch_index| {
+                arrow_array::record_batch!((
+                    "payload",
+                    Int32,
+                    (batch_index * 10..(batch_index + 1) * 10).collect::<Vec<_>>()
+                ))
+                .unwrap()
+            })
+            .collect::<Vec<_>>();
+        assert!(!Arc::ptr_eq(&batches[0].schema(), &batches[1].schema()));
+        let tasks = batches.into_iter().map(|batch| ReadBatchTask {
+            num_rows: batch.num_rows() as u32,
+            task: std::future::ready(Ok(batch)).boxed(),
+        });
+        let config = RowIdAndDeletesConfig {
+            params: ReadBatchParams::RangeFull,
+            with_row_id: true,
+            with_row_addr: true,
+            with_row_last_updated_at_version: true,
+            with_row_created_at_version: true,
+            deletion_vector: None,
+            row_id_sequence: Some(Arc::new(
+                RowIdSequence::try_from_iter((0..30).map(|row_id| 100 + row_id + row_id / 7))
+                    .unwrap(),
+            )),
+            last_updated_at_sequence: None,
+            created_at_sequence: None,
+            make_deletions_null: false,
+            total_num_rows: 30,
+        };
+
+        let batches = super::wrap_with_row_id_and_delete(stream::iter(tasks).boxed(), 7, config)
+            .buffered(3)
+            .try_collect::<Vec<_>>()
+            .await
+            .unwrap();
+        let expected_fields = [
+            "payload",
+            lance_core::ROW_ID,
+            lance_core::ROW_ADDR,
+            lance_core::ROW_LAST_UPDATED_AT_VERSION,
+            lance_core::ROW_CREATED_AT_VERSION,
+        ];
+        assert_eq!(
+            batches[0]
+                .schema()
+                .fields()
+                .iter()
+                .map(|field| field.name().as_str())
+                .collect::<Vec<_>>(),
+            expected_fields
+        );
+        assert!(
+            batches
+                .windows(2)
+                .all(|pair| Arc::ptr_eq(&pair[0].schema(), &pair[1].schema()))
+        );
+        assert!(batches.iter().all(|batch| batch.num_columns() == 5));
     }
 
     #[tokio::test]

--- a/rust/lance/src/dataset/fragment.rs
+++ b/rust/lance/src/dataset/fragment.rs
@@ -15,7 +15,8 @@ use arrow::compute::concat_batches;
 use arrow_array::cast::as_primitive_array;
 use arrow_array::types::UInt64Type;
 use arrow_array::{
-    Array, RecordBatch, RecordBatchReader, StructArray, UInt32Array, UInt64Array, new_null_array,
+    Array, RecordBatch, RecordBatchOptions, RecordBatchReader, StructArray, UInt32Array,
+    UInt64Array, new_null_array,
 };
 use arrow_schema::{DataType, Field as ArrowField, Fields as ArrowFields, Schema as ArrowSchema};
 use datafusion::logical_expr::Expr;
@@ -3232,13 +3233,29 @@ impl FragmentReader {
         //
         // We could potentially delete the support for no-columns in the wrap function or
         // we can delete this path once we migrate away from any support of v1.
-        let merged = if self.num_system_cols() == self.output_schema.fields.len() {
+        let system_columns_only = self.num_system_cols() == self.output_schema.fields.len();
+        let merged = if system_columns_only {
             let selected_rows = params.to_offsets_total(total_num_rows).len();
+            let empty_schema = Arc::new(ArrowSchema::empty());
+            let full_batch = RecordBatch::try_new_with_options(
+                empty_schema.clone(),
+                Vec::new(),
+                &RecordBatchOptions::new().with_row_count(Some(batch_size as usize)),
+            )?;
             let tasks = (0..selected_rows)
                 .step_by(batch_size as usize)
                 .map(move |offset| {
                     let num_rows = (batch_size as usize).min(selected_rows - offset);
-                    let batch = RecordBatch::from(StructArray::new_empty_fields(num_rows, None));
+                    let batch = if num_rows == batch_size as usize {
+                        full_batch.clone()
+                    } else {
+                        RecordBatch::try_new_with_options(
+                            empty_schema.clone(),
+                            Vec::new(),
+                            &RecordBatchOptions::new().with_row_count(Some(num_rows)),
+                        )
+                        .expect("an empty schema accepts an explicit row count")
+                    };
                     ReadBatchTask {
                         task: std::future::ready(Ok(batch)).boxed(),
                         num_rows: num_rows as u32,
@@ -3295,9 +3312,14 @@ impl FragmentReader {
                     let output_schema = output_schema.clone();
                     batch_fut
                         .map(move |batch| {
-                            batch?
-                                .project_by_schema(&output_schema)
-                                .map_err(Error::from)
+                            let batch = batch?;
+                            if system_columns_only
+                                && batch.schema().as_ref() == output_schema.as_ref()
+                            {
+                                Ok(batch)
+                            } else {
+                                batch.project_by_schema(&output_schema).map_err(Error::from)
+                            }
                         })
                         .boxed()
                 })
@@ -3414,13 +3436,28 @@ impl FragmentReader {
             num_requested_rows += range.end - range.start;
         }
 
-        let merged_stream = if self.num_system_cols() == self.output_schema.fields.len() {
+        let system_columns_only = self.num_system_cols() == self.output_schema.fields.len();
+        let merged_stream = if system_columns_only {
+            let empty_schema = Arc::new(ArrowSchema::empty());
+            let full_batch = RecordBatch::try_new_with_options(
+                empty_schema.clone(),
+                Vec::new(),
+                &RecordBatchOptions::new().with_row_count(Some(batch_size as usize)),
+            )?;
             let tasks = (0..num_requested_rows)
                 .step_by(batch_size as usize)
                 .map(move |offset| {
                     let num_rows = (batch_size as u64).min(num_requested_rows - offset);
-                    let batch =
-                        RecordBatch::from(StructArray::new_empty_fields(num_rows as usize, None));
+                    let batch = if num_rows == batch_size as u64 {
+                        full_batch.clone()
+                    } else {
+                        RecordBatch::try_new_with_options(
+                            empty_schema.clone(),
+                            Vec::new(),
+                            &RecordBatchOptions::new().with_row_count(Some(num_rows as usize)),
+                        )
+                        .expect("an empty schema accepts an explicit row count")
+                    };
                     ReadBatchTask {
                         task: std::future::ready(Ok(batch)).boxed(),
                         num_rows: num_rows as u32,
@@ -3470,9 +3507,14 @@ impl FragmentReader {
                     let output_schema = output_schema.clone();
                     batch_fut
                         .map(move |batch| {
-                            batch?
-                                .project_by_schema(&output_schema)
-                                .map_err(Error::from)
+                            let batch = batch?;
+                            if system_columns_only
+                                && batch.schema().as_ref() == output_schema.as_ref()
+                            {
+                                Ok(batch)
+                            } else {
+                                batch.project_by_schema(&output_schema).map_err(Error::from)
+                            }
                         })
                         .boxed()
                 })
@@ -3615,6 +3657,7 @@ impl RecordBatchReader for JsonConvertingReader {
 #[cfg(test)]
 mod tests {
     use arrow_arith::numeric::mul;
+    use arrow_array::cast::AsArray;
     use arrow_array::{
         ArrayRef, BooleanArray, Int32Array, Int64Array, RecordBatchIterator, StringArray,
     };
@@ -5764,6 +5807,175 @@ mod tests {
                 assert!(reader.read_range(invalid_range, 100).await.is_err());
             }
         }
+    }
+
+    #[tokio::test]
+    async fn test_mixed_payload_and_system_columns_preserve_schema_and_order() {
+        let test_dir = TempStrDir::default();
+        let schema = Arc::new(ArrowSchema::new(vec![
+            ArrowField::new("i", DataType::Int32, false),
+            ArrowField::new("s", DataType::Utf8, false),
+        ]));
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(Int32Array::from_iter_values(0..23)),
+                Arc::new(StringArray::from_iter_values(
+                    (0..23).map(|value| format!("s-{value}")),
+                )),
+            ],
+        )
+        .unwrap();
+        let write_params = WriteParams {
+            data_storage_version: Some(LanceFileVersion::Stable),
+            enable_stable_row_ids: true,
+            max_rows_per_file: 23,
+            max_rows_per_group: 7,
+            ..Default::default()
+        };
+        let dataset = Dataset::write(
+            RecordBatchIterator::new([Ok(batch)], schema),
+            test_dir.as_ref(),
+            Some(write_params),
+        )
+        .await
+        .unwrap();
+        let fragment = dataset.get_fragment(0).unwrap();
+        let projection = fragment.schema().project(&["s", "i"]).unwrap();
+        let reader = fragment
+            .open(
+                &projection,
+                FragReadConfig::default()
+                    .with_row_id(true)
+                    .with_row_address(true)
+                    .with_row_last_updated_at_version(true)
+                    .with_row_created_at_version(true),
+            )
+            .await
+            .unwrap();
+
+        let ranges: Arc<[Range<u64>]> = Arc::from([2..6, 10..13]);
+        let batches = reader
+            .read_ranges(ranges, 3)
+            .await
+            .unwrap()
+            .buffered(3)
+            .try_collect::<Vec<_>>()
+            .await
+            .unwrap();
+        assert_eq!(batches.iter().map(RecordBatch::num_rows).sum::<usize>(), 7);
+        assert!(
+            batches
+                .windows(2)
+                .all(|pair| pair[0].schema().as_ref() == pair[1].schema().as_ref())
+        );
+        let expected_fields = [
+            "s",
+            "i",
+            ROW_ID,
+            ROW_ADDR,
+            lance_core::ROW_LAST_UPDATED_AT_VERSION,
+            lance_core::ROW_CREATED_AT_VERSION,
+        ];
+        assert_eq!(
+            batches[0]
+                .schema()
+                .fields()
+                .iter()
+                .map(|field| field.name().as_str())
+                .collect::<Vec<_>>(),
+            expected_fields
+        );
+
+        let selected_offsets = [2_u64, 3, 4, 5, 10, 11, 12];
+        let actual_row_ids = batches
+            .iter()
+            .flat_map(|batch| batch[ROW_ID].as_primitive::<UInt64Type>().values())
+            .copied()
+            .collect::<Vec<_>>();
+        let actual_row_addrs = batches
+            .iter()
+            .flat_map(|batch| batch[ROW_ADDR].as_primitive::<UInt64Type>().values())
+            .copied()
+            .collect::<Vec<_>>();
+        assert_eq!(actual_row_ids, selected_offsets);
+        assert_eq!(actual_row_addrs, selected_offsets);
+        for version_column in [
+            lance_core::ROW_LAST_UPDATED_AT_VERSION,
+            lance_core::ROW_CREATED_AT_VERSION,
+        ] {
+            assert!(batches.iter().all(|batch| {
+                batch[version_column]
+                    .as_primitive::<UInt64Type>()
+                    .values()
+                    .iter()
+                    .all(|version| *version == 1)
+            }));
+        }
+
+        let range_batches = reader
+            .read_range(1..8, 3)
+            .await
+            .unwrap()
+            .buffered(3)
+            .try_collect::<Vec<_>>()
+            .await
+            .unwrap();
+        assert_eq!(
+            range_batches
+                .iter()
+                .flat_map(|batch| batch[ROW_ID].as_primitive::<UInt64Type>().values())
+                .copied()
+                .collect::<Vec<_>>(),
+            (1..8).collect::<Vec<_>>()
+        );
+        assert_eq!(range_batches.last().unwrap().num_rows(), 1);
+
+        let empty_projection = fragment.schema().project::<&str>(&[]).unwrap();
+        let system_reader = fragment
+            .open(
+                &empty_projection,
+                FragReadConfig::default()
+                    .with_row_id(true)
+                    .with_row_address(true),
+            )
+            .await
+            .unwrap();
+        let system_batches = system_reader
+            .read_all(7)
+            .await
+            .unwrap()
+            .buffered(4)
+            .try_collect::<Vec<_>>()
+            .await
+            .unwrap();
+        assert_eq!(
+            system_batches
+                .iter()
+                .map(RecordBatch::num_rows)
+                .collect::<Vec<_>>(),
+            [7, 7, 7, 2]
+        );
+        assert!(
+            system_batches
+                .windows(2)
+                .all(|pair| Arc::ptr_eq(&pair[0].schema(), &pair[1].schema()))
+        );
+
+        let system_ranges: Arc<[Range<u64>]> = Arc::from([2..6, 10..13]);
+        let system_range_batches = system_reader
+            .read_ranges(system_ranges, 3)
+            .await
+            .unwrap()
+            .buffered(3)
+            .try_collect::<Vec<_>>()
+            .await
+            .unwrap();
+        assert!(
+            system_range_batches
+                .windows(2)
+                .all(|pair| Arc::ptr_eq(&pair[0].schema(), &pair[1].schema()))
+        );
     }
 
     #[rstest]


### PR DESCRIPTION
## Summary

Reduce fixed per-batch work in the system-column scan pipeline after the row-ID and version cursors have removed decoder prefix scans.

This supersedes #8717, which was merged into its temporary integration base while the dependency stack was being refreshed. No version of #8717 was merged into `main`.

This change:

- reads stable row IDs ahead in batch-aligned chunks and serves uniform adjacent batches as zero-copy Arrow slices;
- validates the complete prefetched selection before exposing or caching it;
- drains the current row-ID chunk and falls back to exact per-task decoding when non-final task sizes vary, avoiding repeated boundary copies or cursor rewinds;
- assembles all requested system columns into one `RecordBatch` for uniform task streams, while variable task streams retain the prior incremental assembly;
- caches structurally equivalent schemas for uniform task streams, not only pointer-identical `Arc<Schema>` values, and disables that cache after task sizes vary;
- reuses a full-size zero-column batch template;
- skips no-op projections for system-only reads only when schemas are strictly equal;
- bounds read-ahead by the actual range selection, including empty and tail reads.

For batches up to 64K rows, each cached row-ID chunk is at most 64K `u64` values (512 KiB). A larger batch is decoded as one batch without additional read-ahead. Zero-copy slices can keep a chunk alive until adjacent batches are released; an irregular stream can make one boundary copy while draining the existing chunk.

## Performance

Benchmarks compare `main` at `a8bec27d5` (including #8716) with this branch, use `release-with-debug`, pin both revisions to the same CPU, and run each case in a fresh process.

The 100K-row uniform-task matrix improved all 16 combinations of batch size (64/1024), bitmap density (holes every 2/17 values), payload (absent/present), and system columns (`_rowid`/all):

- batch size 64: `_rowid` improved 30.3%-33.7%; all system columns improved 51.4%-56.8%;
- batch size 1024: `_rowid` improved 13.1%-26.5%; all system columns improved 29.5%-36.7%.

A standard Criterion run for the representative batch-size-64, holes-17, zero-payload, all-system-columns case measured 3.7000 ms on `main` and 1.7455 ms here (-52.8%). CPU profiles attribute the change: `RecordBatchExt::try_with_column` (7.47% self time on `main`) and `SchemaExt::try_with_column` (4.59%) both fell below the 0.1% reporting threshold.

The review reproducer uses 10M rows, holes-17, one payload column, `_rowid`, and alternating 32,768/32,769-row tasks. With isolated base/head target directories, standard Criterion measured 10.387-10.468 ms on `main` and 10.449-10.499 ms here (+0.51% by point estimate, within run noise). A second pair under `perf record` measured 10.699-10.746 ms and 10.652-10.724 ms, respectively. Profiles show the same dominant workload (`SegmentCursorState::extend_dense_range`, 42.17% / 42.22% self time); `RecordBatchExt::try_with_column` was only 0.16% / 0.10%, and schema reconstruction and boundary copying were not hotspots.

## Validation

- `cargo test -p lance-table --lib` (384 passed)
- `cargo test -p lance --lib dataset::fragment` (108 passed)
- `cargo check -p lance-table --tests --benches`
- `cargo clippy --all --tests --benches -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`
- Python integration: `test_to_batches_with_partial_last_batch`, `test_to_batches`, `test_scan_no_columns`, and `test_roundtrip_reader` (4 passed)
- read-only production-scale matrix: 32/32 cases passed against an independent metadata oracle, with the dataset version asserted unchanged before and after

Targeted regressions cover mixed payload + all-system projection schema/order, uniform structurally equal schemas with different `Arc`s, variable-task fallback, stable-row-ID unsorted indices and metadata underfill, read-ahead tail/chunk boundaries, empty tasks, and system-only `read_all` / `read_ranges`.

Dependencies #8713, #8715, and #8716 are merged into `main`. This PR's diff is limited to the system-column benchmark and the two implementation files.
