### PR TITLE
fix(fts): preserve global scoring for no-impact indexes

### DIFF
--- a/rust/lance-index-core/src/metrics.rs
+++ b/rust/lance-index-core/src/metrics.rs
@@ -56,6 +56,7 @@ pub const WAND_TIE_COMPLETION_COMPARISONS_METRIC: &str = "wand_tie_completion_co
 pub const WAND_SEEDED_FALLBACKS_METRIC: &str = "wand_seeded_fallbacks";
 pub const WAND_SEEDED_FALLBACK_MS_METRIC: &str = "wand_seeded_fallback_ms";
 pub const WAND_SEEDED_FALLBACK_COMPARISONS_METRIC: &str = "wand_seeded_fallback_comparisons";
+pub const NO_IMPACT_GLOBAL_SCORER_FALLBACKS_METRIC: &str = "no_impact_global_scorer_fallbacks";
 
 /// A trait used by the index to report metrics
 ///
@@ -220,6 +221,9 @@ pub trait MetricsCollector: Send + Sync {
 
     /// Record exact replays seeded with an inclusive kth-score floor.
     fn record_wand_seeded_fallbacks(&self, _num_fallbacks: usize) {}
+
+    /// Record partitions whose no-impact postings use scorer-derived bounds.
+    fn record_no_impact_global_scorer_fallbacks(&self, _num_fallbacks: usize) {}
 
     /// Returns an optional sink for recording exact I/O statistics (bytes read,
     /// IOPS, and requests) performed on behalf of this collector.

--- a/rust/lance-index/src/scalar/inverted/index/partition.rs
+++ b/rust/lance-index/src/scalar/inverted/index/partition.rs
@@ -519,6 +519,27 @@ fn summarize_position_matches(mut positions: SmallVec<[(u32, bool); 8]>) -> Posi
     }
 }
 
+pub(super) fn validate_no_impact_scorer_upper_bound(
+    token: &str,
+    scorer: &MemBM25Scorer,
+) -> Result<()> {
+    let query_weight = scorer.query_weight(token);
+    if !query_weight.is_finite() || query_weight < 0.0 {
+        return Err(Error::invalid_input(format!(
+            "global BM25 query weight for token {token:?} must be finite and non-negative, got {query_weight}"
+        )));
+    }
+    let has_finite_bound = scorer.doc_weight_upper_bound().is_some_and(|bound| {
+        bound.is_finite() && bound >= 0.0 && (query_weight * bound).is_finite()
+    });
+    if !has_finite_bound {
+        return Err(Error::invalid_input(format!(
+            "global BM25 scorer cannot provide a finite no-impact upper bound for token {token:?}"
+        )));
+    }
+    Ok(())
+}
+
 fn token_dictionary_may_match(
     dictionary: &TokenSet,
     tokens: &Tokens,
@@ -1093,8 +1114,8 @@ impl InvertedPartition {
     //
     // `force_global_scorer` is used by compound search, where leaf scores and
     // bounds must share corpus-level statistics before the global collector
-    // can safely propagate its threshold. Old posting formats without impacts
-    // fall back to a scorer-derived global upper bound in that mode.
+    // can safely propagate its threshold. Standard leaf search also routes
+    // no-impact postings through scorer-derived corpus-global upper bounds.
     pub(in super::super) async fn load_posting_lists(
         &self,
         tokens: &Tokens,
@@ -1214,13 +1235,20 @@ impl InvertedPartition {
             let impact_safe = loaded_postings
                 .iter()
                 .all(|(_, _, _, posting)| posting.has_impacts());
+            let no_impact_fallback = !impact_safe;
+            if no_impact_fallback {
+                for (_, token, _, posting) in &loaded_postings {
+                    if !posting.has_impacts() {
+                        validate_no_impact_scorer_upper_bound(token, impact_scorer)?;
+                    }
+                }
+            }
+            let exact_scoring_required = exact_scoring_required || no_impact_fallback;
             return Ok(LoadedPostings {
                 postings: loaded_postings
                     .into_iter()
                     .map(|(token_id, token, position, posting)| {
-                        let needs_scorer_upper_bound = (exact_scoring_required
-                            || force_global_scorer)
-                            && !posting.has_impacts();
+                        let needs_scorer_upper_bound = !posting.has_impacts();
                         let query_weight =
                             if impact_safe || exact_scoring_required || force_global_scorer {
                                 impact_scorer.query_weight(&token)
@@ -1245,7 +1273,19 @@ impl InvertedPartition {
                 grouped_expansions: Vec::new(),
                 impact_safe,
                 exact_scoring_required,
+                no_impact_fallback,
             });
+        }
+
+        let no_impact_fallback = loaded_postings
+            .iter()
+            .any(|(_, _, _, posting)| !posting.has_impacts());
+        if no_impact_fallback {
+            for (_, token, _, posting) in &loaded_postings {
+                if !posting.has_impacts() {
+                    validate_no_impact_scorer_upper_bound(token, impact_scorer)?;
+                }
+            }
         }
 
         let docs_for_union = if needs_union {
@@ -1350,6 +1390,7 @@ impl InvertedPartition {
             grouped_expansions,
             impact_safe: false,
             exact_scoring_required: true,
+            no_impact_fallback,
         })
     }
 

--- a/rust/lance-index/src/scalar/inverted/index/search.rs
+++ b/rust/lance-index/src/scalar/inverted/index/search.rs
@@ -567,6 +567,7 @@ impl InvertedIndex {
                                 grouped_expansions,
                                 impact_safe,
                                 exact_scoring_required,
+                                no_impact_fallback,
                             } = part
                                 .load_posting_lists(
                                     tokens.as_ref(),
@@ -579,6 +580,9 @@ impl InvertedIndex {
                                 .await?;
                             if postings.is_empty() {
                                 return Result::Ok(None);
+                            }
+                            if no_impact_fallback {
+                                metrics.record_no_impact_global_scorer_fallbacks(1);
                             }
                             let max_position = postings
                                 .iter()
@@ -823,6 +827,7 @@ impl InvertedIndex {
                                 grouped_expansions,
                                 impact_safe,
                                 exact_scoring_required,
+                                no_impact_fallback,
                             } = part
                                 .load_posting_lists(
                                     tokens.as_ref(),
@@ -835,6 +840,9 @@ impl InvertedIndex {
                                 .await?;
                             if postings.is_empty() {
                                 return Result::Ok(None);
+                            }
+                            if no_impact_fallback {
+                                metrics.record_no_impact_global_scorer_fallbacks(1);
                             }
                             let documents = part.docs.modern().cloned().ok_or_else(|| {
                                 Error::internal("modern index contains legacy partition documents")

--- a/rust/lance-index/src/scalar/inverted/index/search_candidates.rs
+++ b/rust/lance-index/src/scalar/inverted/index/search_candidates.rs
@@ -201,6 +201,7 @@ pub(in super::super) struct LoadedPostings {
     pub(super) grouped_expansions: Vec<GroupedExpansionTerms>,
     pub(super) impact_safe: bool,
     pub(super) exact_scoring_required: bool,
+    pub(super) no_impact_fallback: bool,
 }
 
 pub(super) enum LoadedDocLengths {
@@ -231,6 +232,7 @@ impl LoadedPostings {
             grouped_expansions: Vec::new(),
             impact_safe: false,
             exact_scoring_required: false,
+            no_impact_fallback: false,
         }
     }
 }

--- a/rust/lance-index/src/scalar/inverted/index/tests/scoring.rs
+++ b/rust/lance-index/src/scalar/inverted/index/tests/scoring.rs
@@ -844,7 +844,12 @@ async fn assert_no_impact_bulk_conjunction_preserves_winner(with_phrase: bool) {
     let shared_threshold = Arc::new(AtomicU32::new(f32::NEG_INFINITY.to_bits()));
     let mut results = Vec::new();
     let mut published_floors = Vec::new();
-    for partition in &index.partitions {
+    for partition_id in [0, 1] {
+        let partition = index
+            .partitions
+            .iter()
+            .find(|partition| partition.id() == partition_id)
+            .unwrap();
         let LoadedPostings {
             postings,
             grouped_expansions,

--- a/rust/lance-index/src/scalar/inverted/index/tests/scoring.rs
+++ b/rust/lance-index/src/scalar/inverted/index/tests/scoring.rs
@@ -1,7 +1,26 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright The Lance Authors
 
+use super::super::partition::validate_no_impact_scorer_upper_bound;
 use super::*;
+
+#[derive(Default)]
+struct NoImpactFallbackMetrics {
+    global_scorer_fallbacks: AtomicU64,
+}
+
+impl MetricsCollector for NoImpactFallbackMetrics {
+    fn record_parts_loaded(&self, _num_parts: usize) {}
+
+    fn record_index_loads(&self, _num_indexes: usize) {}
+
+    fn record_comparisons(&self, _num_comparisons: usize) {}
+
+    fn record_no_impact_global_scorer_fallbacks(&self, num_fallbacks: usize) {
+        self.global_scorer_fallbacks
+            .fetch_add(num_fallbacks as u64, Ordering::Relaxed);
+    }
+}
 
 #[tokio::test]
 async fn test_bm25_search_uses_global_idf() {
@@ -88,15 +107,34 @@ async fn test_bm25_search_uses_global_idf() {
 async fn write_test_partition_with_optional_impacts(
     store: &Arc<LanceIndexStore>,
     partition_id: u64,
+    builder: InnerBuilder,
+    token_set_format: TokenSetFormat,
+    with_impacts: bool,
+) {
+    write_test_partition_with_optional_impacts_and_positions(
+        store,
+        partition_id,
+        builder,
+        token_set_format,
+        with_impacts,
+        false,
+    )
+    .await;
+}
+
+async fn write_test_partition_with_optional_impacts_and_positions(
+    store: &Arc<LanceIndexStore>,
+    partition_id: u64,
     mut builder: InnerBuilder,
     token_set_format: TokenSetFormat,
     with_impacts: bool,
+    with_positions: bool,
 ) {
     let format_version = InvertedListFormatVersion::V1;
     let block_size = LEGACY_BLOCK_SIZE;
     let docs = std::mem::take(&mut builder.docs);
     let schema = inverted_list_schema_for_version_with_block_size_and_impacts(
-        false,
+        with_positions,
         format_version,
         block_size,
         with_impacts,
@@ -137,21 +175,31 @@ async fn load_single_partition_test_index(
     builder: InnerBuilder,
     with_impacts: bool,
 ) -> (TempObjDir, Arc<LanceCache>, Arc<InvertedIndex>) {
+    load_test_index(vec![(0, builder, with_impacts)]).await
+}
+
+async fn load_test_index(
+    partitions: Vec<(u64, InnerBuilder, bool)>,
+) -> (TempObjDir, Arc<LanceCache>, Arc<InvertedIndex>) {
     let tmpdir = TempObjDir::default();
     let store = Arc::new(LanceIndexStore::new(
         ObjectStore::local().into(),
         tmpdir.clone(),
         Arc::new(LanceCache::no_cache()),
     ));
-    write_test_partition_with_optional_impacts(
-        &store,
-        0,
-        builder,
-        TokenSetFormat::default(),
-        with_impacts,
-    )
-    .await;
-    write_test_metadata(&store, vec![0], InvertedIndexParams::default()).await;
+    let mut partition_ids = Vec::with_capacity(partitions.len());
+    for (partition_id, builder, with_impacts) in partitions {
+        write_test_partition_with_optional_impacts(
+            &store,
+            partition_id,
+            builder,
+            TokenSetFormat::default(),
+            with_impacts,
+        )
+        .await;
+        partition_ids.push(partition_id);
+    }
+    write_test_metadata(&store, partition_ids, InvertedIndexParams::default()).await;
     let cache = Arc::new(LanceCache::with_capacity(4096));
     let index = InvertedIndex::load(store, None, cache.as_ref())
         .await
@@ -232,37 +280,44 @@ async fn test_wand_exactness_certificate_support_requires_all_impact_postings() 
 }
 
 #[tokio::test]
-async fn test_no_impact_segments_cannot_certify_strict_bounded_candidates() {
+async fn test_no_impact_segments_preserve_global_bm25_top_k() {
     // Segment-local BM25 strongly favors beta in the first segment, while
     // corpus-wide IDF makes every alpha row the true global winner.
-    let mut first_segment = InnerBuilder::new_with_format_version(
+    let mut alpha_partition = InnerBuilder::new_with_format_version(
         0,
         false,
         TokenSetFormat::default(),
         InvertedListFormatVersion::V1,
     );
-    first_segment.tokens.add("alpha".to_owned());
-    first_segment.tokens.add("beta".to_owned());
-    first_segment
-        .posting_lists
-        .push(PostingListBuilder::new_with_posting_tail_codec(
-            false,
-            InvertedListFormatVersion::V1.posting_tail_codec(),
-        ));
-    first_segment
+    alpha_partition.tokens.add("alpha".to_owned());
+    alpha_partition
         .posting_lists
         .push(PostingListBuilder::new_with_posting_tail_codec(
             false,
             InvertedListFormatVersion::V1.posting_tail_codec(),
         ));
     for doc_id in 0_u32..98 {
-        first_segment.posting_lists[0].add(doc_id, PositionRecorder::Count(1));
-        first_segment.docs.append(u64::from(doc_id), 1);
+        alpha_partition.posting_lists[0].add(doc_id, PositionRecorder::Count(1));
+        alpha_partition.docs.append(u64::from(doc_id), 1);
     }
-    first_segment.posting_lists[1].add(98, PositionRecorder::Count(10));
-    first_segment.docs.append(98, 10);
-    first_segment.posting_lists[1].add(99, PositionRecorder::Count(5));
-    first_segment.docs.append(99, 10);
+
+    let mut beta_partition = InnerBuilder::new_with_format_version(
+        1,
+        false,
+        TokenSetFormat::default(),
+        InvertedListFormatVersion::V1,
+    );
+    beta_partition.tokens.add("beta".to_owned());
+    beta_partition
+        .posting_lists
+        .push(PostingListBuilder::new_with_posting_tail_codec(
+            false,
+            InvertedListFormatVersion::V1.posting_tail_codec(),
+        ));
+    beta_partition.posting_lists[0].add(0, PositionRecorder::Count(10));
+    beta_partition.docs.append(98, 10);
+    beta_partition.posting_lists[0].add(1, PositionRecorder::Count(5));
+    beta_partition.docs.append(99, 10);
 
     let mut second_segment = InnerBuilder::new_with_format_version(
         0,
@@ -282,8 +337,10 @@ async fn test_no_impact_segments_cannot_certify_strict_bounded_candidates() {
         second_segment.docs.append(1_001 + u64::from(doc_id), 1);
     }
 
+    // One segment itself mixes a no-impact partition with an impact-backed
+    // partition. The second segment is no-impact, matching a rolling upgrade.
     let (_first_tmpdir, _first_cache, first_index) =
-        load_single_partition_test_index(first_segment, false).await;
+        load_test_index(vec![(0, alpha_partition, false), (1, beta_partition, true)]).await;
     let (_second_tmpdir, _second_cache, second_index) =
         load_single_partition_test_index(second_segment, false).await;
     for index in [&first_index, &second_index] {
@@ -302,14 +359,17 @@ async fn test_no_impact_segments_cannot_certify_strict_bounded_candidates() {
     ));
     let params = Arc::new(FtsSearchParams::new().with_limit(Some(2)));
     let mut candidates = Vec::new();
-    for index in [first_index, second_index] {
+    let metrics = Arc::new(NoImpactFallbackMetrics::default());
+    // Reverse segment visitation so neither the result nor its row-id tie break
+    // can accidentally depend on the physical search order.
+    for index in [second_index, first_index] {
         let (row_ids, scores) = index
             .bm25_search(
                 tokens.clone(),
                 params.clone(),
                 Operator::Or,
                 Arc::new(NoFilter),
-                Arc::new(NoOpMetricsCollector),
+                metrics.clone(),
                 Some(&scorer),
             )
             .await
@@ -324,24 +384,70 @@ async fn test_no_impact_segments_cannot_certify_strict_bounded_candidates() {
     });
     candidates.truncate(2);
 
-    // A k=1 certificate would see this strict returned gap and accept row 98,
-    // even though the omitted alpha tie group has the much larger exact score
-    // and row 0 wins its global `(score DESC, row_id ASC)` tie.
+    // Before the no-impact fallback used the corpus scorer, the bounded
+    // partition-local candidate set was [98, 1001]. It omitted the alpha tie
+    // group even though row 0 is the true global winner.
     assert_eq!(
         candidates
             .iter()
             .map(|candidate| candidate.0)
             .collect::<Vec<_>>(),
-        vec![98, 1_001]
+        vec![0, 1]
     );
-    assert!(candidates[0].1.total_cmp(&candidates[1].1).is_gt());
-    assert!((candidates[0].1 - 0.011_179_519).abs() < 1e-6);
-    assert!((candidates[1].1 - 0.009_806_488).abs() < 1e-6);
+    assert_eq!(candidates[0].1, candidates[1].1);
 
     let exact_winner_score = scorer.query_weight("alpha") * scorer.doc_weight(1, 1);
     assert!((exact_winner_score - 4.633_705).abs() < 1e-5);
-    assert!(exact_winner_score > candidates[0].1);
-    assert!(!candidates.iter().any(|candidate| candidate.0 == 0));
+    assert!((exact_winner_score - candidates[0].1).abs() < 1e-5);
+    assert_eq!(metrics.global_scorer_fallbacks.load(Ordering::Relaxed), 2);
+}
+
+#[test]
+fn test_global_query_weight_validation_rejects_invalid_values() {
+    let scorer = MemBM25Scorer::new(1, 1, HashMap::from([("alpha".to_owned(), 10)]));
+    let error = validate_no_impact_scorer_upper_bound("alpha", &scorer).unwrap_err();
+    assert!(matches!(error, Error::InvalidInput { .. }));
+    let message = error.to_string();
+    assert!(message.contains("token \"alpha\""), "{message}");
+    assert!(message.contains("got -"), "{message}");
+}
+
+#[tokio::test]
+async fn test_no_impact_search_rejects_injected_negative_query_weight() {
+    let mut builder = InnerBuilder::new_with_format_version(
+        0,
+        false,
+        TokenSetFormat::default(),
+        InvertedListFormatVersion::V1,
+    );
+    builder.tokens.add("alpha".to_owned());
+    builder
+        .posting_lists
+        .push(PostingListBuilder::new_with_posting_tail_codec(
+            false,
+            InvertedListFormatVersion::V1.posting_tail_codec(),
+        ));
+    builder.posting_lists[0].add(0, PositionRecorder::Count(1));
+    builder.docs.append(0, 1);
+    let (_tmpdir, _cache, index) = load_single_partition_test_index(builder, false).await;
+    let scorer = MemBM25Scorer::new(1, 1, HashMap::from([("alpha".to_owned(), 10)]));
+    let error = index
+        .bm25_search(
+            Arc::new(Tokens::new(vec!["alpha".to_owned()], DocType::Text)),
+            Arc::new(FtsSearchParams::new().with_limit(Some(1))),
+            Operator::Or,
+            Arc::new(NoFilter),
+            Arc::new(NoOpMetricsCollector),
+            Some(&scorer),
+        )
+        .await
+        .unwrap_err();
+    assert!(matches!(error, Error::InvalidInput { .. }));
+    assert!(
+        error.to_string().contains(
+            "global BM25 query weight for token \"alpha\" must be finite and non-negative"
+        )
+    );
 }
 
 #[tokio::test]
@@ -597,6 +703,7 @@ async fn search_test_impact_partition(
         grouped_expansions,
         impact_safe,
         exact_scoring_required,
+        no_impact_fallback,
     } = partition
         .load_posting_lists(
             tokens,
@@ -610,6 +717,7 @@ async fn search_test_impact_partition(
         .unwrap();
     assert!(impact_safe);
     assert!(!exact_scoring_required);
+    assert!(!no_impact_fallback);
     assert!(grouped_expansions.is_empty());
 
     let documents = partition.docs.modern().unwrap();
@@ -627,6 +735,174 @@ async fn search_test_impact_partition(
             shared_threshold,
         )
         .unwrap()
+}
+
+async fn load_no_impact_bulk_conjunction_test_index(
+    with_positions: bool,
+) -> (TempObjDir, Arc<LanceCache>, Arc<InvertedIndex>) {
+    let tmpdir = TempObjDir::default();
+    let store = Arc::new(LanceIndexStore::new(
+        ObjectStore::local().into(),
+        tmpdir.clone(),
+        Arc::new(LanceCache::no_cache()),
+    ));
+
+    let mut floor_partition = InnerBuilder::new_with_format_version(
+        0,
+        with_positions,
+        TokenSetFormat::default(),
+        InvertedListFormatVersion::V1,
+    );
+    let mut winner_partition = InnerBuilder::new_with_format_version(
+        1,
+        with_positions,
+        TokenSetFormat::default(),
+        InvertedListFormatVersion::V1,
+    );
+    for builder in [&mut floor_partition, &mut winner_partition] {
+        for token in ["lead", "follow"] {
+            builder.tokens.add(token.to_owned());
+            builder
+                .posting_lists
+                .push(PostingListBuilder::new_with_posting_tail_codec(
+                    with_positions,
+                    InvertedListFormatVersion::V1.posting_tail_codec(),
+                ));
+        }
+    }
+
+    if with_positions {
+        floor_partition.posting_lists[0].add(0, PositionRecorder::Position(vec![0].into()));
+        floor_partition.posting_lists[1].add(0, PositionRecorder::Position(vec![1].into()));
+    } else {
+        floor_partition.posting_lists[0].add(0, PositionRecorder::Count(1));
+        floor_partition.posting_lists[1].add(0, PositionRecorder::Count(1));
+    }
+    floor_partition.docs.append(100, 2);
+    for row_id in 101..10_100 {
+        floor_partition.docs.append(row_id, 100);
+    }
+
+    let lead_positions = (0..63).map(|position| position * 2).collect::<Vec<_>>();
+    let follow_positions = (0..63).map(|position| position * 2 + 1).collect::<Vec<_>>();
+    for doc_id in 0_u32..100 {
+        if with_positions {
+            winner_partition.posting_lists[0].add(
+                doc_id,
+                PositionRecorder::Position(lead_positions.clone().into()),
+            );
+            winner_partition.posting_lists[1].add(
+                doc_id,
+                PositionRecorder::Position(follow_positions.clone().into()),
+            );
+        } else {
+            winner_partition.posting_lists[0].add(doc_id, PositionRecorder::Count(63));
+            winner_partition.posting_lists[1].add(doc_id, PositionRecorder::Count(63));
+        }
+        winner_partition
+            .docs
+            .append(20_000 + u64::from(doc_id), 126);
+    }
+
+    for (partition_id, builder) in [(0, floor_partition), (1, winner_partition)] {
+        write_test_partition_with_optional_impacts_and_positions(
+            &store,
+            partition_id,
+            builder,
+            TokenSetFormat::default(),
+            false,
+            with_positions,
+        )
+        .await;
+    }
+    let params = InvertedIndexParams::default().with_position(with_positions);
+    write_test_metadata(&store, vec![0, 1], params).await;
+    let cache = Arc::new(LanceCache::with_capacity(4096));
+    let index = InvertedIndex::load(store, None, cache.as_ref())
+        .await
+        .unwrap();
+    (tmpdir, cache, index)
+}
+
+async fn assert_no_impact_bulk_conjunction_preserves_winner(with_phrase: bool) {
+    let (_tmpdir, _cache, index) = load_no_impact_bulk_conjunction_test_index(with_phrase).await;
+    let tokens = Arc::new(Tokens::new(
+        vec!["lead".to_owned(), "follow".to_owned()],
+        DocType::Text,
+    ));
+    let params = Arc::new(
+        FtsSearchParams::new()
+            .with_limit(Some(1))
+            .with_phrase_slop(with_phrase.then_some(0)),
+    );
+    let scorer = Arc::new(
+        index
+            .bm25_base_scorer(tokens.as_ref(), params.as_ref(), None)
+            .await
+            .unwrap(),
+    );
+    let shared_threshold = Arc::new(AtomicU32::new(f32::NEG_INFINITY.to_bits()));
+    let mut results = Vec::new();
+    let mut published_floors = Vec::new();
+    for partition in &index.partitions {
+        let LoadedPostings {
+            postings,
+            grouped_expansions,
+            impact_safe,
+            exact_scoring_required,
+            no_impact_fallback,
+        } = partition
+            .load_posting_lists(
+                tokens.as_ref(),
+                params.as_ref(),
+                Operator::And,
+                scorer.as_ref(),
+                &NoOpMetricsCollector,
+                false,
+            )
+            .await
+            .unwrap();
+        assert!(!impact_safe);
+        assert!(exact_scoring_required);
+        assert!(no_impact_fallback);
+        assert!(grouped_expansions.is_empty());
+
+        let documents = partition.docs.modern().unwrap();
+        let lengths = documents.lengths().await.unwrap();
+        let visibility = documents.visibility(NoFilter.mask(), false).await.unwrap();
+        results.push(
+            partition
+                .bm25_search_modern(
+                    lengths.as_ref(),
+                    &visibility,
+                    params.as_ref(),
+                    Operator::And,
+                    postings,
+                    Some(scorer.clone()),
+                    &NoOpMetricsCollector,
+                    shared_threshold.clone(),
+                )
+                .unwrap(),
+        );
+        published_floors.push(f32::from_bits(shared_threshold.load(Ordering::Relaxed)));
+    }
+
+    assert_eq!(results[0].len(), 1);
+    assert!(published_floors[0] > 0.0);
+    let winner_score = 2.0 * scorer.query_weight("lead") * scorer.doc_weight(63, 126);
+    assert!(winner_score > published_floors[0]);
+    assert_eq!(results[1].len(), 1);
+    assert_eq!(results[1][0].document, DocId::new(0));
+}
+
+#[tokio::test]
+async fn test_no_impact_bulk_and_uses_global_frequency_clamp_bound() {
+    assert_no_impact_bulk_conjunction_preserves_winner(false).await;
+}
+
+#[tokio::test]
+async fn test_no_impact_bulk_phrase_uses_global_frequency_clamp_bound() {
+    assert_no_impact_bulk_conjunction_preserves_winner(true).await;
 }
 
 #[tokio::test]
@@ -758,13 +1034,14 @@ async fn test_mixed_impact_and_legacy_partitions_use_global_final_scores() {
 
     let tokens = Arc::new(Tokens::new(vec!["alpha".to_string()], DocType::Text));
     let params = Arc::new(FtsSearchParams::new().with_limit(Some(1)));
+    let metrics = Arc::new(NoImpactFallbackMetrics::default());
     let (row_ids, scores) = index
         .bm25_search(
             tokens.clone(),
             params.clone(),
             Operator::Or,
             Arc::new(NoFilter),
-            Arc::new(NoOpMetricsCollector),
+            metrics.clone(),
             None,
         )
         .await
@@ -772,6 +1049,7 @@ async fn test_mixed_impact_and_legacy_partitions_use_global_final_scores() {
 
     assert_eq!(row_ids, vec![200]);
     assert_eq!(row_ids.len(), scores.len());
+    assert_eq!(metrics.global_scorer_fallbacks.load(Ordering::Relaxed), 1);
 
     let scorer = index
         .bm25_base_scorer(tokens.as_ref(), params.as_ref(), None)
@@ -787,9 +1065,9 @@ async fn test_mixed_impact_and_legacy_partitions_use_global_final_scores() {
 }
 
 #[tokio::test]
-async fn test_two_legacy_partitions_keep_private_thresholds() {
-    // Legacy BM25 scores use partition-local statistics, so sharing one
-    // pruning floor across partitions can discard the global winner.
+async fn test_two_no_impact_partitions_share_global_scorer_and_threshold() {
+    // Both no-impact partitions must score and prune in the same corpus-global
+    // space before publishing a shared threshold.
     let (_tmpdir, _cache, index) = load_global_scoring_test_index(false, false).await;
     for partition in index.partitions.iter() {
         let posting = partition
@@ -802,13 +1080,14 @@ async fn test_two_legacy_partitions_keep_private_thresholds() {
 
     let tokens = Arc::new(Tokens::new(vec!["alpha".to_string()], DocType::Text));
     let params = Arc::new(FtsSearchParams::new().with_limit(Some(1)));
+    let metrics = Arc::new(NoImpactFallbackMetrics::default());
     let (row_ids, scores) = index
         .bm25_search(
             tokens.clone(),
             params.clone(),
             Operator::Or,
             Arc::new(NoFilter),
-            Arc::new(NoOpMetricsCollector),
+            metrics.clone(),
             None,
         )
         .await
@@ -816,6 +1095,7 @@ async fn test_two_legacy_partitions_keep_private_thresholds() {
 
     assert_eq!(row_ids, vec![200]);
     assert_eq!(scores.len(), 1);
+    assert_eq!(metrics.global_scorer_fallbacks.load(Ordering::Relaxed), 2);
     let scorer = index
         .bm25_base_scorer(tokens.as_ref(), params.as_ref(), None)
         .await

--- a/rust/lance-index/src/scalar/inverted/wand.rs
+++ b/rust/lance-index/src/scalar/inverted/wand.rs
@@ -927,6 +927,19 @@ impl PostingIterator {
         self.approximate_upper_bound
     }
 
+    /// Upper bound for the frequency clamp used by bulk conjunction search.
+    /// No-impact postings scored in a corpus-global scorer space cannot reuse
+    /// their persisted partition-local maximum. Impact-backed postings retain
+    /// their existing fast path.
+    #[inline]
+    fn frequency_clamp_upper_bound<S: Scorer + ?Sized>(&self, scorer: &S) -> f32 {
+        if self.use_scorer_upper_bound {
+            scorer_upper_bound(self.query_weight, scorer)
+        } else {
+            self.approximate_upper_bound
+        }
+    }
+
     /// Tightest known list-wide score bound. Impact lists answer from the
     /// baked doc-weight slab (the data-driven equivalent of the max_score the
     /// non-impact format bakes at build time); everything else falls back to
@@ -3514,7 +3527,8 @@ impl<'a, S: Scorer, D: WandDocuments> Wand<'a, S, D> {
         }
         // The clamp bucket must bound every frequency it absorbs; the
         // clause-wide sup does.
-        freq_bound_lut[FREQ_LUT_BUCKETS - 1] = self.lead[0].approximate_upper_bound();
+        freq_bound_lut[FREQ_LUT_BUCKETS - 1] =
+            self.lead[0].frequency_clamp_upper_bound(&self.scorer);
 
         // The conjunction can only start at the max of the clauses' first docs.
         let mut target: u64 = 0;

--- a/rust/lance/src/io/exec/fts.rs
+++ b/rust/lance/src/io/exec/fts.rs
@@ -56,15 +56,16 @@ use lance_index::metrics::{
     COMPOUND_SHOULD_NON_ESSENTIAL_EVALUATIONS_METRIC, COMPOUND_SHOULD_SKIPPED_WINDOWS_METRIC,
     CROSS_COLUMN_STAGED_ATTEMPTS_METRIC, CROSS_COLUMN_STAGED_CANDIDATES_METRIC,
     CROSS_COLUMN_STAGED_FALLBACKS_METRIC, CROSS_COLUMN_STAGED_SUCCESSES_METRIC,
-    FREQS_COLLECTED_METRIC, MetricsCollector, WAND_EXACTNESS_CERTIFICATE_ATTEMPTS_METRIC,
-    WAND_EXACTNESS_CERTIFICATE_CANDIDATES_METRIC, WAND_EXACTNESS_CERTIFICATE_EXHAUSTIVE_METRIC,
-    WAND_EXACTNESS_CERTIFICATE_FALLBACKS_METRIC, WAND_EXACTNESS_CERTIFICATE_STRICT_METRIC,
-    WAND_EXACTNESS_PROBE_COMPARISONS_METRIC, WAND_EXACTNESS_PROBE_MS_METRIC,
-    WAND_SEEDED_FALLBACK_COMPARISONS_METRIC, WAND_SEEDED_FALLBACK_MS_METRIC,
-    WAND_SEEDED_FALLBACKS_METRIC, WAND_TIE_COMPLETION_ATTEMPTS_METRIC,
-    WAND_TIE_COMPLETION_CANDIDATES_METRIC, WAND_TIE_COMPLETION_COMPARISONS_METRIC,
-    WAND_TIE_COMPLETION_MS_METRIC, WAND_TIE_COMPLETION_OVERFLOWS_METRIC,
-    WAND_TIE_COMPLETION_ROW_ID_REPLACEMENTS_METRIC, WAND_TIE_COMPLETION_SUCCESSES_METRIC,
+    FREQS_COLLECTED_METRIC, MetricsCollector, NO_IMPACT_GLOBAL_SCORER_FALLBACKS_METRIC,
+    WAND_EXACTNESS_CERTIFICATE_ATTEMPTS_METRIC, WAND_EXACTNESS_CERTIFICATE_CANDIDATES_METRIC,
+    WAND_EXACTNESS_CERTIFICATE_EXHAUSTIVE_METRIC, WAND_EXACTNESS_CERTIFICATE_FALLBACKS_METRIC,
+    WAND_EXACTNESS_CERTIFICATE_STRICT_METRIC, WAND_EXACTNESS_PROBE_COMPARISONS_METRIC,
+    WAND_EXACTNESS_PROBE_MS_METRIC, WAND_SEEDED_FALLBACK_COMPARISONS_METRIC,
+    WAND_SEEDED_FALLBACK_MS_METRIC, WAND_SEEDED_FALLBACKS_METRIC,
+    WAND_TIE_COMPLETION_ATTEMPTS_METRIC, WAND_TIE_COMPLETION_CANDIDATES_METRIC,
+    WAND_TIE_COMPLETION_COMPARISONS_METRIC, WAND_TIE_COMPLETION_MS_METRIC,
+    WAND_TIE_COMPLETION_OVERFLOWS_METRIC, WAND_TIE_COMPLETION_ROW_ID_REPLACEMENTS_METRIC,
+    WAND_TIE_COMPLETION_SUCCESSES_METRIC,
 };
 use lance_index::scalar::inverted::builder::ScoredDoc;
 use lance_index::scalar::inverted::builder::document_input;
@@ -2195,6 +2196,7 @@ pub struct FtsIndexMetrics {
     wand_seeded_fallbacks: Count,
     wand_seeded_fallback_ms: Gauge,
     wand_seeded_fallback_comparisons: Count,
+    no_impact_global_scorer_fallbacks: Count,
     /// Wall time (ms) of the exec-local `build_global_bm25_scorer`
     /// fallback; zero when a preset base scorer was injected.
     scorer_build_ms: Gauge,
@@ -2286,6 +2288,8 @@ impl FtsIndexMetrics {
             wand_seeded_fallback_ms: metrics.new_gauge(WAND_SEEDED_FALLBACK_MS_METRIC, partition),
             wand_seeded_fallback_comparisons: metrics
                 .new_count(WAND_SEEDED_FALLBACK_COMPARISONS_METRIC, partition),
+            no_impact_global_scorer_fallbacks: metrics
+                .new_count(NO_IMPACT_GLOBAL_SCORER_FALLBACKS_METRIC, partition),
             scorer_build_ms: metrics.new_gauge("scorer_build_ms", partition),
             segment_bind_duration: metrics.new_time(FTS_SEGMENT_BIND_DURATION_METRIC, partition),
             baseline_metrics: BaselineMetrics::new(metrics, partition),
@@ -2497,6 +2501,10 @@ impl MetricsCollector for FtsIndexMetrics {
 
     fn record_wand_seeded_fallbacks(&self, num_fallbacks: usize) {
         self.wand_seeded_fallbacks.add(num_fallbacks);
+    }
+
+    fn record_no_impact_global_scorer_fallbacks(&self, num_fallbacks: usize) {
+        self.no_impact_global_scorer_fallbacks.add(num_fallbacks);
     }
 }
 
@@ -5138,6 +5146,15 @@ mod tests {
         assert_eq!(metrics.wand_tie_completion_comparisons.value(), 47);
         assert_eq!(metrics.wand_seeded_fallback_comparisons.value(), 53);
         assert_eq!(metrics.wand_tie_completion_row_id_replacements.value(), 59);
+    }
+
+    #[test]
+    fn test_no_impact_fallback_metrics_are_counted_independently() {
+        let metrics_set = ExecutionPlanMetricsSet::new();
+        let metrics = super::FtsIndexMetrics::new(&metrics_set, 0);
+
+        metrics.record_no_impact_global_scorer_fallbacks(3);
+        assert_eq!(metrics.no_impact_global_scorer_fallbacks.value(), 3);
     }
 
     async fn create_segment_selection_fixture() -> (Arc<Dataset>, Vec<IndexMetadata>, Vec<u32>) {


### PR DESCRIPTION
## What is the bug?

Readable FTS partitions without impact data can select bounded WAND candidates using partition-local BM25 statistics and only rescore the retained candidates with the corpus scorer. Across partitions or segments this can discard the true global top-k result before final scoring.

The regression retained candidates `[98, 1001]` even though exhaustive global BM25 required row `0`.

Linear: https://linear.app/lancedb/issue/OSS-1345

The impact-backed path delivered by #7602 remains unchanged. The older draft #7467 is closed and superseded by this focused current-main fix.

## How does this PR fix the problem?

- Uses the corpus-wide `MemBM25Scorer` for no-impact candidate scores and scorer-derived conservative upper bounds.
- Keeps no-impact partitions in the same score space before sharing a competitive threshold.
- Uses a scorer-aware high-frequency clamp for bulk AND and Phrase paths.
- Explicitly rejects an injected scorer that cannot provide finite, non-negative no-impact bounds instead of performing unsafe or unbounded pruning.
- Applies validation only when an actually loaded posting lacks impacts, so the impact-backed hot path does no additional token validation or allocation.
- Exposes `no_impact_global_scorer_fallbacks` for activation and control measurements.

No writer, index format, or public query API changes.

## Regression coverage

- Mixed impact/no-impact segments where the old bounded candidates omitted row `0`.
- Reversed segment visitation and final row-ID ties.
- Two no-impact partitions sharing the corpus scorer and threshold.
- High-frequency bulk AND and exact Phrase candidates under a positive shared floor.
- Invalid injected BM25 scorer error behavior.
- Fallback metrics and impact-backed controls.

## Validation

- `cargo check -p lance-index --tests`
- `cargo check -p lance --tests`
- `cargo fmt --all -- --check`
- `git diff --check`
- Static correctness review completed with no remaining blocker.

Per the requested workflow, I did not run local `cargo test` or `cargo clippy`; CI will run them.

## Benchmark

Completed on the frozen 10M-row, 42-language MMLB dataset and the same GCP `c4-highmem-16` VM. The no-impact fixture was rebuilt from source version 3 with the pre-impact writer `f0fcb81c5ae0a7bdf49370a4bffa32b716363c7a`; data files are hard-linked and fixture provenance is pinned. Baseline `91aee6f9123d6f955fa4033d427c124e5b4f7cd2` and target `8f1067866d5abebbe637c7d6195dbeaae15b843f` used independently frozen release-with-debug modules. Warm measurements use 250 queries, five repetitions, eight worker threads, four processes per build in two ABBA blocks. Higher QPS is better.

Activation and correctness:

- The no-impact canary recorded 0 fallback activations on baseline and 276 on target; the impact-backed target control recorded 0.
- Each same-fixture baseline/target oracle covered 1,500 cases. Every returned row was an exhaustive-oracle match with its exact score and the exact top-k score multiset.
- Strict `(score DESC, row_id ASC)` checks reported 1,116 equal-score tie mismatches on every build/fixture because of the separate direct-Match issue OSS-2116. These are recorded, not treated as exact passes.
- The benchmark distribution did not reproduce the adversarial omitted-winner unit regression; it validates activation and performance cost, while the targeted regression test covers that bug.
- The historical no-impact writer and current impact-backed writer produce different score statistics/layout, so performance is compared only baseline-vs-target within each fixture.

No-impact warm results:

| Scenario / metric | Baseline | This PR | Benefit |
| --- | ---: | ---: | ---: |
| AND k=10, median process QPS | 2,708.76 query/s | 2,712.15 query/s | 1.001x throughput |
| AND k=100, median process QPS | 2,449.56 query/s | 2,449.17 query/s | 1.000x throughput |
| Match k=10, median process QPS | 2,003.49 query/s | 2,011.06 query/s | 1.004x throughput |
| Match k=100, median process QPS | 1,762.72 query/s | 1,811.75 query/s | 1.028x throughput |
| Phrase k=10, median process QPS | 296.80 query/s | 296.10 query/s | 0.998x throughput |
| Phrase k=100, median process QPS | 289.69 query/s | 286.78 query/s | 0.990x throughput |

Impact-backed warm control:

| Scenario / metric | Baseline | This PR | Benefit |
| --- | ---: | ---: | ---: |
| AND k=10, median process QPS | 2,713.00 query/s | 2,707.02 query/s | 0.998x throughput |
| AND k=100, median process QPS | 2,451.92 query/s | 2,452.30 query/s | 1.000x throughput |
| Match k=10, median process QPS | 2,631.10 query/s | 2,618.19 query/s | 0.995x throughput |
| Match k=100, median process QPS | 2,227.65 query/s | 2,224.04 query/s | 0.998x throughput |
| Phrase k=10, median process QPS | 522.29 query/s | 513.20 query/s | 0.983x throughput |
| Phrase k=100, median process QPS | 394.80 query/s | 394.03 query/s | 0.998x throughput |

No-impact cold Match control (lower latency is better):

| Scenario / metric | Baseline | This PR | Benefit |
| --- | ---: | ---: | ---: |
| k=10, median query latency | 178.08 ms | 176.41 ms | 1.009x speedup |
| k=100, median query latency | 176.33 ms | 177.31 ms | 0.994x speedup (0.56% slower) |

The change is performance-neutral overall. The largest impact-backed warm regression is 1.74% (Phrase k=10), within the 2% boundary; no-impact Match k=100 improved by 1.028x, while the other no-impact cases range from 0.990x to 1.004x.

Artifacts: `/mnt/benchmark-ssd/mmlb-queue/03-oss1345/results`

Artifact fingerprint: `fe42ab376463bd511ec3cd9cde2e8ef13486fc635966f550792a82ebab12d341` (3,373 files, 526,956,111 bytes).
