### PR TITLE
perf(fts): defer phrase confirmation with score bounds

### DIFF
--- a/rust/lance-index-core/src/metrics.rs
+++ b/rust/lance-index-core/src/metrics.rs
@@ -20,6 +20,17 @@ pub const COMPOUND_SHOULD_ESSENTIAL_EVALUATIONS_METRIC: &str =
     "compound_should_essential_evaluations";
 pub const COMPOUND_SHOULD_NON_ESSENTIAL_EVALUATIONS_METRIC: &str =
     "compound_should_non_essential_evaluations";
+pub const COMPOUND_PHRASE_EXACT_APPROXIMATIONS_METRIC: &str =
+    "compound_phrase_exact_approximations";
+pub const COMPOUND_PHRASE_SLOPPY_APPROXIMATIONS_METRIC: &str =
+    "compound_phrase_sloppy_approximations";
+pub const COMPOUND_PHRASE_EXACT_CONFIRMATIONS_METRIC: &str = "compound_phrase_exact_confirmations";
+pub const COMPOUND_PHRASE_SLOPPY_CONFIRMATIONS_METRIC: &str =
+    "compound_phrase_sloppy_confirmations";
+pub const COMPOUND_PHRASE_EXACT_CONFIRMATIONS_AVOIDED_METRIC: &str =
+    "compound_phrase_exact_confirmations_avoided";
+pub const COMPOUND_PHRASE_SLOPPY_CONFIRMATIONS_AVOIDED_METRIC: &str =
+    "compound_phrase_sloppy_confirmations_avoided";
 pub const CROSS_COLUMN_STAGED_ATTEMPTS_METRIC: &str = "cross_column_staged_attempts";
 pub const CROSS_COLUMN_STAGED_SUCCESSES_METRIC: &str = "cross_column_staged_successes";
 pub const CROSS_COLUMN_STAGED_FALLBACKS_METRIC: &str = "cross_column_staged_fallbacks";
@@ -149,6 +160,24 @@ pub trait MetricsCollector: Send + Sync {
 
     /// Record non-essential-clause evaluations for pure-SHOULD compound FTS.
     fn record_compound_should_non_essential_evaluations(&self, _num_evaluations: usize) {}
+
+    /// Record exact-phrase documents produced by the posting approximation.
+    fn record_compound_phrase_exact_approximations(&self, _num_approximations: usize) {}
+
+    /// Record sloppy-phrase documents produced by the posting approximation.
+    fn record_compound_phrase_sloppy_approximations(&self, _num_approximations: usize) {}
+
+    /// Record exact-phrase position confirmations.
+    fn record_compound_phrase_exact_confirmations(&self, _num_confirmations: usize) {}
+
+    /// Record sloppy-phrase position confirmations.
+    fn record_compound_phrase_sloppy_confirmations(&self, _num_confirmations: usize) {}
+
+    /// Record exact-phrase position confirmations avoided by a score bound.
+    fn record_compound_phrase_exact_confirmations_avoided(&self, _num_confirmations: usize) {}
+
+    /// Record sloppy-phrase position confirmations avoided by a score bound.
+    fn record_compound_phrase_sloppy_confirmations_avoided(&self, _num_confirmations: usize) {}
 
     /// Record cross-column queries that attempted candidate-driven staging.
     fn record_cross_column_staged_attempts(&self, _num_attempts: usize) {}

--- a/rust/lance-index/src/scalar/inverted/compound.rs
+++ b/rust/lance-index/src/scalar/inverted/compound.rs
@@ -5887,22 +5887,21 @@ mod tests {
             let params = FtsSearchParams::default().with_phrase_slop(Some(slop));
             let metrics = PhraseMetrics::default();
             let phrase = zero_weight_wand(&documents, scorer.clone(), &params, &metrics);
-            // A sum parent retains the shared floor and combines the phrase's
-            // doc-local upper with its sibling instead of pushing the full
-            // threshold into either child WAND cursor.
+            // The high-scoring sibling keeps the shared block competitive, while
+            // doc 0 still has a combined doc-local upper below the score floor.
             let mut phrase = DisjunctionScorer::try_new(
-                vec![phrase, materialized(&[(0, 0.0)])],
+                vec![phrase, materialized(&[(0, 0.0), (1, 2.0)])],
                 DisjunctionScore::Sum,
             )
             .unwrap();
             let competitive_score = Arc::new(CompetitiveScore::default());
             competitive_score.raise(1.0);
 
-            assert!(
+            assert_eq!(
                 TopKCollector::with_competitive_score(1, competitive_score)
                     .collect(&mut phrase)
-                    .unwrap()
-                    .is_empty()
+                    .unwrap(),
+                rows(&[(1, 2.0)])
             );
 
             if slop == 0 {

--- a/rust/lance-index/src/scalar/inverted/compound.rs
+++ b/rust/lance-index/src/scalar/inverted/compound.rs
@@ -273,6 +273,19 @@ pub(super) trait ComposableScorer: Send {
     }
     fn set_min_competitive_score(&mut self, min_score: f32) -> Result<()>;
 
+    /// Conservative score upper bound for the current approximation without
+    /// running two-phase confirmation. `None` disables doc-local pruning.
+    fn current_score_upper_bound(&mut self) -> Result<Option<f32>> {
+        Ok(None)
+    }
+
+    fn supports_doc_local_confirmation_pruning(&self) -> bool {
+        false
+    }
+
+    /// Report pending two-phase confirmations skipped by a doc-local bound.
+    fn record_confirmation_avoided(&mut self) {}
+
     fn matches(&mut self) -> Result<bool> {
         Ok(true)
     }
@@ -777,6 +790,18 @@ impl<D: WandDocuments + Sync> ComposableScorer for WandCursor<'_, D> {
         self.set_min_competitive_score(min_score)
     }
 
+    fn current_score_upper_bound(&mut self) -> Result<Option<f32>> {
+        self.current_score().map(Some)
+    }
+
+    fn supports_doc_local_confirmation_pruning(&self) -> bool {
+        self.match_cost().is_some()
+    }
+
+    fn record_confirmation_avoided(&mut self) {
+        WandCursor::record_confirmation_avoided(self)
+    }
+
     fn matches(&mut self) -> Result<bool> {
         self.matches()
     }
@@ -1020,6 +1045,10 @@ impl ComposableScorer for MaterializedScorer {
         Ok(())
     }
 
+    fn current_score_upper_bound(&mut self) -> Result<Option<f32>> {
+        self.score().map(Some)
+    }
+
     fn scores_non_negative(&self) -> bool {
         self.scores_non_negative
     }
@@ -1243,6 +1272,19 @@ impl ComposableScorer for RowAddressScorer<'_> {
 
     fn set_min_competitive_score(&mut self, min_score: f32) -> Result<()> {
         self.source.set_min_competitive_score(min_score)
+    }
+
+    fn current_score_upper_bound(&mut self) -> Result<Option<f32>> {
+        self.ensure_positioned()?;
+        self.source.current_score_upper_bound()
+    }
+
+    fn supports_doc_local_confirmation_pruning(&self) -> bool {
+        self.source.supports_doc_local_confirmation_pruning()
+    }
+
+    fn record_confirmation_avoided(&mut self) {
+        self.source.record_confirmation_avoided()
     }
 
     fn matches(&mut self) -> Result<bool> {
@@ -1788,6 +1830,22 @@ impl ComposableScorer for RowAddressMergeScorer<'_> {
         Ok(())
     }
 
+    fn current_score_upper_bound(&mut self) -> Result<Option<f32>> {
+        self.current_source_mut()?.current_score_upper_bound()
+    }
+
+    fn supports_doc_local_confirmation_pruning(&self) -> bool {
+        self.sources
+            .iter()
+            .any(|source| source.supports_doc_local_confirmation_pruning())
+    }
+
+    fn record_confirmation_avoided(&mut self) {
+        if let Ok(source) = self.current_source_mut() {
+            source.record_confirmation_avoided();
+        }
+    }
+
     fn matches(&mut self) -> Result<bool> {
         self.current_source_mut()?.matches()
     }
@@ -2060,6 +2118,22 @@ impl<K: Copy + Ord> TopKCollector<K> {
                 continue;
             }
 
+            // Phrase leaves expose their score from posting frequencies before
+            // positions are decoded. Composite scorers combine those doc-local
+            // uppers with sibling residuals, so a strict miss can bypass every
+            // pending position confirmation. Equality remains live because row
+            // id is the final top-k tie breaker.
+            if min_score.is_finite()
+                && scorer.supports_doc_local_confirmation_pruning()
+                && scorer
+                    .current_score_upper_bound()?
+                    .is_some_and(|upper| upper < min_score)
+            {
+                scorer.record_confirmation_avoided();
+                doc = scorer.next()?;
+                continue;
+            }
+
             if let Some(match_cost) = scorer.match_cost()
                 && (!match_cost.is_finite() || match_cost < 0.0)
             {
@@ -2160,6 +2234,10 @@ impl ComposableScorer for EmptyScorer {
         Ok(())
     }
 
+    fn current_score_upper_bound(&mut self) -> Result<Option<f32>> {
+        Ok(Some(0.0))
+    }
+
     fn scores_non_negative(&self) -> bool {
         true
     }
@@ -2255,6 +2333,22 @@ impl ComposableScorer for ScaleScorer<'_> {
         }
         self.last_parent_score_floor = min_score;
         Ok(())
+    }
+
+    fn current_score_upper_bound(&mut self) -> Result<Option<f32>> {
+        Ok(self.child.current_score_upper_bound()?.map(|upper| {
+            ScoreBounds { lower: 0.0, upper }
+                .scale_non_negative(self.factor)
+                .upper
+        }))
+    }
+
+    fn supports_doc_local_confirmation_pruning(&self) -> bool {
+        self.child.supports_doc_local_confirmation_pruning()
+    }
+
+    fn record_confirmation_avoided(&mut self) {
+        self.child.record_confirmation_avoided()
     }
 
     fn matches(&mut self) -> Result<bool> {
@@ -2464,6 +2558,53 @@ impl ComposableScorer for DisjunctionScorer<'_> {
             }
         }
         Ok(())
+    }
+
+    fn current_score_upper_bound(&mut self) -> Result<Option<f32>> {
+        let Some(current) = self.current else {
+            return Ok(None);
+        };
+        let mut upper = 0.0_f32;
+        for child in &mut self.children {
+            if child.doc() != Some(current) {
+                continue;
+            }
+            let Some(child_upper) = child.current_score_upper_bound()? else {
+                return Ok(None);
+            };
+            if !child_upper.is_finite() {
+                return Ok(None);
+            }
+            upper = match self.mode {
+                DisjunctionScore::Sum => {
+                    ScoreBounds { lower: 0.0, upper }
+                        .add(ScoreBounds {
+                            lower: 0.0,
+                            upper: child_upper.max(0.0),
+                        })
+                        .upper
+                }
+                DisjunctionScore::Max => upper.max(child_upper),
+            };
+        }
+        Ok(upper.is_finite().then_some(upper))
+    }
+
+    fn supports_doc_local_confirmation_pruning(&self) -> bool {
+        self.children
+            .iter()
+            .any(|child| child.supports_doc_local_confirmation_pruning())
+    }
+
+    fn record_confirmation_avoided(&mut self) {
+        let Some(current) = self.current else {
+            return;
+        };
+        for child in &mut self.children {
+            if child.doc() == Some(current) {
+                child.record_confirmation_avoided();
+            }
+        }
     }
 
     fn matches(&mut self) -> Result<bool> {
@@ -2710,6 +2851,46 @@ impl ComposableScorer for RequiredConjunctionScorer<'_> {
         Ok(())
     }
 
+    fn current_score_upper_bound(&mut self) -> Result<Option<f32>> {
+        let Some(current) = self.current else {
+            return Ok(None);
+        };
+        let mut bounds = ScoreBounds::ZERO;
+        for child in &mut self.children {
+            if child.doc() != Some(current) {
+                return Ok(None);
+            }
+            let Some(upper) = child.current_score_upper_bound()? else {
+                return Ok(None);
+            };
+            if !upper.is_finite() {
+                return Ok(None);
+            }
+            bounds = bounds.add(ScoreBounds {
+                lower: 0.0,
+                upper: upper.max(0.0),
+            });
+        }
+        Ok(bounds.upper.is_finite().then_some(bounds.upper))
+    }
+
+    fn supports_doc_local_confirmation_pruning(&self) -> bool {
+        self.children
+            .iter()
+            .any(|child| child.supports_doc_local_confirmation_pruning())
+    }
+
+    fn record_confirmation_avoided(&mut self) {
+        let Some(current) = self.current else {
+            return;
+        };
+        for child in &mut self.children {
+            if child.doc() == Some(current) {
+                child.record_confirmation_avoided();
+            }
+        }
+    }
+
     fn matches(&mut self) -> Result<bool> {
         self.ensure_confirmed()
     }
@@ -2837,6 +3018,22 @@ impl ComposableScorer for BoostScorer<'_> {
             self.positive.set_min_competitive_score(min_score)?;
         }
         Ok(())
+    }
+
+    fn current_score_upper_bound(&mut self) -> Result<Option<f32>> {
+        if self.negative.scores_non_negative() {
+            self.positive.current_score_upper_bound()
+        } else {
+            Ok(None)
+        }
+    }
+
+    fn supports_doc_local_confirmation_pruning(&self) -> bool {
+        self.positive.supports_doc_local_confirmation_pruning()
+    }
+
+    fn record_confirmation_avoided(&mut self) {
+        self.positive.record_confirmation_avoided()
     }
 
     fn matches(&mut self) -> Result<bool> {
@@ -3165,6 +3362,60 @@ impl ComposableScorer for ReqOptScorer<'_> {
         Ok(())
     }
 
+    fn current_score_upper_bound(&mut self) -> Result<Option<f32>> {
+        let Some(current) = self.current else {
+            return Ok(None);
+        };
+        let Some(required_upper) = self.required.current_score_upper_bound()? else {
+            return Ok(None);
+        };
+        if !required_upper.is_finite() {
+            return Ok(None);
+        }
+        if required_upper >= self.min_competitive_score {
+            // The required side alone keeps this document competitive. Keep
+            // the optional iterator lazy; scoring will align it only for a
+            // surviving candidate.
+            return Ok(Some(f32::INFINITY));
+        }
+        let optional_upper = if self.ensure_optional_at_or_after(current)? == Some(current) {
+            let Some(optional_upper) = self.optional.current_score_upper_bound()? else {
+                return Ok(None);
+            };
+            if !optional_upper.is_finite() {
+                return Ok(None);
+            }
+            optional_upper.max(0.0)
+        } else {
+            0.0
+        };
+        let upper = ScoreBounds {
+            lower: 0.0,
+            upper: required_upper.max(0.0),
+        }
+        .add(ScoreBounds {
+            lower: 0.0,
+            upper: optional_upper,
+        })
+        .upper;
+        Ok(upper.is_finite().then_some(upper))
+    }
+
+    fn supports_doc_local_confirmation_pruning(&self) -> bool {
+        self.required.supports_doc_local_confirmation_pruning()
+            || self.optional.supports_doc_local_confirmation_pruning()
+    }
+
+    fn record_confirmation_avoided(&mut self) {
+        let Some(current) = self.current else {
+            return;
+        };
+        self.required.record_confirmation_avoided();
+        if self.optional.doc() == Some(current) {
+            self.optional.record_confirmation_avoided();
+        }
+    }
+
     fn matches(&mut self) -> Result<bool> {
         self.ensure_confirmed()
     }
@@ -3188,7 +3439,10 @@ pub(super) struct BooleanScorer<'a> {
     optional: Option<BoxScorer<'a>>,
     prohibited: Option<BoxScorer<'a>>,
     current: Option<u64>,
+    confirmed_doc: Option<u64>,
+    confirmed: bool,
     optional_matches: bool,
+    defer_confirmation: bool,
 }
 
 impl<'a> BooleanScorer<'a> {
@@ -3254,26 +3508,57 @@ impl<'a> BooleanScorer<'a> {
                     as BoxScorer<'a>,
             )
         };
+        let scores_non_negative = driver.scores_non_negative()
+            && optional
+                .as_ref()
+                .is_none_or(|optional| optional.scores_non_negative());
+        let has_doc_local_confirmation = driver.supports_doc_local_confirmation_pruning()
+            || optional
+                .as_ref()
+                .is_some_and(|optional| optional.supports_doc_local_confirmation_pruning())
+            || prohibited
+                .as_ref()
+                .is_some_and(|prohibited| prohibited.supports_doc_local_confirmation_pruning());
         Ok(Self {
             driver,
             optional,
             prohibited,
             current: None,
+            confirmed_doc: None,
+            confirmed: false,
             optional_matches: false,
+            defer_confirmation: scores_non_negative && has_doc_local_confirmation,
         })
     }
 
-    fn accept_driver_doc(&mut self) -> Result<bool> {
-        let Some(current) = self.driver.doc() else {
+    fn set_current(&mut self, current: Option<u64>) -> Option<u64> {
+        if self.current != current {
+            self.confirmed_doc = None;
+            self.confirmed = false;
+            self.optional_matches = false;
+        }
+        self.current = current;
+        current
+    }
+
+    fn ensure_confirmed(&mut self) -> Result<bool> {
+        let Some(current) = self.current else {
             return Ok(false);
         };
+        if self.confirmed_doc == Some(current) {
+            return Ok(self.confirmed);
+        }
         if !self.driver.matches()? {
+            self.confirmed_doc = Some(current);
+            self.confirmed = false;
             return Ok(false);
         }
         if let Some(prohibited) = &mut self.prohibited
             && prohibited.advance(current)? == Some(current)
             && prohibited.matches()?
         {
+            self.confirmed_doc = Some(current);
+            self.confirmed = false;
             return Ok(false);
         }
         self.optional_matches = if let Some(optional) = &mut self.optional {
@@ -3281,24 +3566,23 @@ impl<'a> BooleanScorer<'a> {
         } else {
             false
         };
-        self.current = Some(current);
+        self.confirmed_doc = Some(current);
+        self.confirmed = true;
         Ok(true)
     }
 
-    fn next_accepted(&mut self, target: Option<u64>) -> Result<Option<u64>> {
-        let mut doc = match target {
+    fn next_candidate(&mut self, target: Option<u64>) -> Result<Option<u64>> {
+        let mut candidate = match target {
             Some(target) => self.driver.advance(target)?,
             None => self.driver.next()?,
         };
-        while doc.is_some() {
-            if self.accept_driver_doc()? {
+        loop {
+            self.set_current(candidate);
+            if self.defer_confirmation || candidate.is_none() || self.ensure_confirmed()? {
                 return Ok(self.current);
             }
-            doc = self.driver.next()?;
+            candidate = self.driver.next()?;
         }
-        self.current = None;
-        self.optional_matches = false;
-        Ok(None)
     }
 }
 
@@ -3312,14 +3596,14 @@ impl ComposableScorer for BooleanScorer<'_> {
     }
 
     fn next(&mut self) -> Result<Option<u64>> {
-        self.next_accepted(None)
+        self.next_candidate(None)
     }
 
     fn advance(&mut self, target: u64) -> Result<Option<u64>> {
         if self.current.is_some_and(|current| current >= target) {
             return Ok(self.current);
         }
-        self.next_accepted(Some(target))
+        self.next_candidate(Some(target))
     }
 
     fn cost(&self) -> usize {
@@ -3327,9 +3611,9 @@ impl ComposableScorer for BooleanScorer<'_> {
     }
 
     fn score(&mut self) -> Result<f32> {
-        if self.current.is_none() {
+        if !self.ensure_confirmed()? {
             return Err(Error::internal(
-                "Boolean FTS scorer is not positioned on a document",
+                "Boolean FTS score requested for an unconfirmed document",
             ));
         }
         let mut score = self.driver.score()?;
@@ -3393,8 +3677,86 @@ impl ComposableScorer for BooleanScorer<'_> {
         Ok(())
     }
 
+    fn current_score_upper_bound(&mut self) -> Result<Option<f32>> {
+        let Some(current) = self.current else {
+            return Ok(None);
+        };
+        if !self.scores_non_negative() {
+            return Ok(None);
+        }
+        let Some(driver_upper) = self.driver.current_score_upper_bound()? else {
+            return Ok(None);
+        };
+        if !driver_upper.is_finite() {
+            return Ok(None);
+        }
+        let optional_upper = if let Some(optional) = &mut self.optional {
+            if optional.advance(current)? == Some(current) {
+                let Some(optional_upper) = optional.current_score_upper_bound()? else {
+                    return Ok(None);
+                };
+                if !optional_upper.is_finite() {
+                    return Ok(None);
+                }
+                optional_upper.max(0.0)
+            } else {
+                0.0
+            }
+        } else {
+            0.0
+        };
+        let upper = ScoreBounds {
+            lower: 0.0,
+            upper: driver_upper,
+        }
+        .add(ScoreBounds {
+            lower: 0.0,
+            upper: optional_upper,
+        })
+        .upper;
+        Ok(upper.is_finite().then_some(upper))
+    }
+
+    fn supports_doc_local_confirmation_pruning(&self) -> bool {
+        self.defer_confirmation
+    }
+
+    fn record_confirmation_avoided(&mut self) {
+        let Some(current) = self.current else {
+            return;
+        };
+        self.driver.record_confirmation_avoided();
+        if let Some(optional) = &mut self.optional
+            && optional.doc() == Some(current)
+        {
+            optional.record_confirmation_avoided();
+        }
+        if let Some(prohibited) = &mut self.prohibited
+            && prohibited.doc() == Some(current)
+        {
+            prohibited.record_confirmation_avoided();
+        }
+    }
+
     fn matches(&mut self) -> Result<bool> {
-        Ok(self.current.is_some())
+        self.ensure_confirmed()
+    }
+
+    fn match_cost(&self) -> Option<f32> {
+        self.driver
+            .match_cost()
+            .into_iter()
+            .chain(
+                self.optional
+                    .as_ref()
+                    .and_then(|optional| optional.match_cost()),
+            )
+            .chain(
+                self.prohibited
+                    .as_ref()
+                    .and_then(|prohibited| prohibited.match_cost()),
+            )
+            .reduce(|left, right| left + right)
     }
 
     fn scores_non_negative(&self) -> bool {
@@ -4179,6 +4541,54 @@ mod tests {
         non_essential_evaluations: AtomicUsize,
     }
 
+    #[derive(Default)]
+    struct PhraseMetrics {
+        exact_approximations: AtomicUsize,
+        sloppy_approximations: AtomicUsize,
+        exact_confirmations: AtomicUsize,
+        sloppy_confirmations: AtomicUsize,
+        exact_confirmations_avoided: AtomicUsize,
+        sloppy_confirmations_avoided: AtomicUsize,
+    }
+
+    impl MetricsCollector for PhraseMetrics {
+        fn record_parts_loaded(&self, _num_parts: usize) {}
+
+        fn record_index_loads(&self, _num_loads: usize) {}
+
+        fn record_comparisons(&self, _num_comparisons: usize) {}
+
+        fn record_compound_phrase_exact_approximations(&self, num_approximations: usize) {
+            self.exact_approximations
+                .fetch_add(num_approximations, AtomicOrdering::Relaxed);
+        }
+
+        fn record_compound_phrase_sloppy_approximations(&self, num_approximations: usize) {
+            self.sloppy_approximations
+                .fetch_add(num_approximations, AtomicOrdering::Relaxed);
+        }
+
+        fn record_compound_phrase_exact_confirmations(&self, num_confirmations: usize) {
+            self.exact_confirmations
+                .fetch_add(num_confirmations, AtomicOrdering::Relaxed);
+        }
+
+        fn record_compound_phrase_sloppy_confirmations(&self, num_confirmations: usize) {
+            self.sloppy_confirmations
+                .fetch_add(num_confirmations, AtomicOrdering::Relaxed);
+        }
+
+        fn record_compound_phrase_exact_confirmations_avoided(&self, num_confirmations: usize) {
+            self.exact_confirmations_avoided
+                .fetch_add(num_confirmations, AtomicOrdering::Relaxed);
+        }
+
+        fn record_compound_phrase_sloppy_confirmations_avoided(&self, num_confirmations: usize) {
+            self.sloppy_confirmations_avoided
+                .fetch_add(num_confirmations, AtomicOrdering::Relaxed);
+        }
+    }
+
     impl MetricsCollector for ShouldMetrics {
         fn record_parts_loaded(&self, _num_parts: usize) {}
 
@@ -4446,8 +4856,10 @@ mod tests {
         inner: MaterializedScorer,
         accepted: Vec<u64>,
         match_cost: Option<f32>,
+        has_doc_upper: bool,
         approximations: Arc<AtomicUsize>,
         confirmations: Arc<AtomicUsize>,
+        confirmations_avoided: Arc<AtomicUsize>,
     }
 
     impl ComposableScorer for TwoPhaseScorer {
@@ -4495,6 +4907,23 @@ mod tests {
             self.inner.set_min_competitive_score(min_score)
         }
 
+        fn current_score_upper_bound(&mut self) -> Result<Option<f32>> {
+            if self.has_doc_upper {
+                self.inner.score().map(Some)
+            } else {
+                Ok(None)
+            }
+        }
+
+        fn supports_doc_local_confirmation_pruning(&self) -> bool {
+            true
+        }
+
+        fn record_confirmation_avoided(&mut self) {
+            self.confirmations_avoided
+                .fetch_add(1, AtomicOrdering::Relaxed);
+        }
+
         fn matches(&mut self) -> Result<bool> {
             self.confirmations.fetch_add(1, AtomicOrdering::Relaxed);
             Ok(self
@@ -4520,16 +4949,68 @@ mod tests {
         Arc<AtomicUsize>,
         Arc<AtomicUsize>,
     ) {
+        let (scorer, approximations, confirmations, _) =
+            two_phase_with_avoided(values, accepted, match_cost);
+        (scorer, approximations, confirmations)
+    }
+
+    fn two_phase_with_avoided(
+        values: &[(u64, f32)],
+        accepted: Vec<u64>,
+        match_cost: Option<f32>,
+    ) -> (
+        Box<dyn ComposableScorer>,
+        Arc<AtomicUsize>,
+        Arc<AtomicUsize>,
+        Arc<AtomicUsize>,
+    ) {
         let approximations = Arc::new(AtomicUsize::new(0));
         let confirmations = Arc::new(AtomicUsize::new(0));
+        let confirmations_avoided = Arc::new(AtomicUsize::new(0));
         let scorer = TwoPhaseScorer {
             inner: MaterializedScorer::try_new(rows(values)).unwrap(),
             accepted,
             match_cost,
+            has_doc_upper: true,
             approximations: approximations.clone(),
             confirmations: confirmations.clone(),
+            confirmations_avoided: confirmations_avoided.clone(),
         };
-        (Box::new(scorer), approximations, confirmations)
+        (
+            Box::new(scorer),
+            approximations,
+            confirmations,
+            confirmations_avoided,
+        )
+    }
+
+    fn two_phase_without_doc_upper(
+        values: &[(u64, f32)],
+        accepted: Vec<u64>,
+    ) -> (
+        Box<dyn ComposableScorer>,
+        Arc<AtomicUsize>,
+        Arc<AtomicUsize>,
+        Arc<AtomicUsize>,
+    ) {
+        let approximations = Arc::new(AtomicUsize::new(0));
+        let confirmations = Arc::new(AtomicUsize::new(0));
+        let confirmations_avoided = Arc::new(AtomicUsize::new(0));
+        let scorer = TwoPhaseScorer {
+            inner: MaterializedScorer::try_new(rows(values)).unwrap(),
+            accepted,
+            match_cost: Some(1.0),
+            has_doc_upper: false,
+            approximations: approximations.clone(),
+            confirmations: confirmations.clone(),
+            confirmations_avoided: confirmations_avoided.clone(),
+        };
+        (
+            Box::new(scorer),
+            approximations,
+            confirmations,
+            confirmations_avoided,
+        )
     }
 
     #[derive(Default)]
@@ -4598,6 +5079,18 @@ mod tests {
         fn set_min_competitive_score(&mut self, min_score: f32) -> Result<()> {
             self.work.floors.fetch_add(1, AtomicOrdering::Relaxed);
             self.inner.set_min_competitive_score(min_score)
+        }
+
+        fn current_score_upper_bound(&mut self) -> Result<Option<f32>> {
+            self.inner.current_score_upper_bound()
+        }
+
+        fn supports_doc_local_confirmation_pruning(&self) -> bool {
+            self.inner.supports_doc_local_confirmation_pruning()
+        }
+
+        fn record_confirmation_avoided(&mut self) {
+            self.inner.record_confirmation_avoided()
         }
 
         fn matches(&mut self) -> Result<bool> {
@@ -5383,6 +5876,233 @@ mod tests {
     }
 
     #[test]
+    fn phrase_doc_bound_records_exact_and_sloppy_confirmation_avoidance() {
+        let mut token_docs = HashMap::new();
+        token_docs.insert("common".to_owned(), 10_000_000);
+        let scorer = Arc::new(MemBM25Scorer::new(10_000_000, 10_000_000, token_docs));
+        let mut documents = DocSet::default();
+        documents.append(0, 1);
+
+        for slop in [0, 2] {
+            let params = FtsSearchParams::default().with_phrase_slop(Some(slop));
+            let metrics = PhraseMetrics::default();
+            let phrase = zero_weight_wand(&documents, scorer.clone(), &params, &metrics);
+            // A sum parent retains the shared floor and combines the phrase's
+            // doc-local upper with its sibling instead of pushing the full
+            // threshold into either child WAND cursor.
+            let mut phrase = DisjunctionScorer::try_new(
+                vec![phrase, materialized(&[(0, 0.0)])],
+                DisjunctionScore::Sum,
+            )
+            .unwrap();
+            let competitive_score = Arc::new(CompetitiveScore::default());
+            competitive_score.raise(1.0);
+
+            assert!(
+                TopKCollector::with_competitive_score(1, competitive_score)
+                    .collect(&mut phrase)
+                    .unwrap()
+                    .is_empty()
+            );
+
+            if slop == 0 {
+                assert_eq!(
+                    metrics.exact_approximations.load(AtomicOrdering::Relaxed),
+                    1
+                );
+                assert_eq!(metrics.exact_confirmations.load(AtomicOrdering::Relaxed), 0);
+                assert_eq!(
+                    metrics
+                        .exact_confirmations_avoided
+                        .load(AtomicOrdering::Relaxed),
+                    1
+                );
+            } else {
+                assert_eq!(
+                    metrics.sloppy_approximations.load(AtomicOrdering::Relaxed),
+                    1
+                );
+                assert_eq!(
+                    metrics.sloppy_confirmations.load(AtomicOrdering::Relaxed),
+                    0
+                );
+                assert_eq!(
+                    metrics
+                        .sloppy_confirmations_avoided
+                        .load(AtomicOrdering::Relaxed),
+                    1
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn phrase_positive_boost_uses_positive_upper_before_confirmation() {
+        let (phrase, _, confirmations, confirmations_avoided) =
+            two_phase_with_avoided(&[(0, 2.0), (1, 10.0)], vec![1], Some(1.0));
+        let mut scorer = BoostScorer::try_new(phrase, materialized(&[(1, 1.0)]), 0.5).unwrap();
+        let competitive_score = Arc::new(CompetitiveScore::default());
+        competitive_score.raise(9.5);
+
+        assert_eq!(
+            TopKCollector::with_competitive_score(1, competitive_score)
+                .collect(&mut scorer)
+                .unwrap(),
+            rows(&[(1, 9.5)])
+        );
+        assert_eq!(confirmations.load(AtomicOrdering::Relaxed), 1);
+        assert_eq!(confirmations_avoided.load(AtomicOrdering::Relaxed), 1);
+    }
+
+    #[test]
+    fn phrase_must_not_never_contributes_to_score_upper_bound() {
+        let (prohibited, approximations, confirmations, confirmations_avoided) =
+            two_phase_with_avoided(&[(0, 100.0)], Vec::new(), Some(1.0));
+        let mut scorer = BooleanScorer::try_new(
+            Vec::new(),
+            vec![materialized(&[(0, 1.0), (1, 10.0)])],
+            vec![prohibited],
+        )
+        .unwrap();
+        let competitive_score = Arc::new(CompetitiveScore::default());
+        competitive_score.raise(10.0);
+
+        assert_eq!(
+            TopKCollector::with_competitive_score(1, competitive_score)
+                .collect(&mut scorer)
+                .unwrap(),
+            rows(&[(1, 10.0)])
+        );
+        // Doc 0 is rejected from the positive score alone. The prohibited
+        // phrase is never advanced, so it cannot inflate that upper bound.
+        assert_eq!(approximations.load(AtomicOrdering::Relaxed), 0);
+        assert_eq!(confirmations.load(AtomicOrdering::Relaxed), 0);
+        assert_eq!(confirmations_avoided.load(AtomicOrdering::Relaxed), 0);
+    }
+
+    #[test]
+    fn signed_and_unknown_doc_bounds_use_exact_confirmation_fallback() {
+        let (signed_phrase, _, signed_confirmations, signed_avoided) =
+            two_phase_with_avoided(&[(0, 2.0)], vec![0], Some(1.0));
+        let signed_optional =
+            Box::new(BoostScorer::try_new(signed_phrase, materialized(&[(0, 2.0)]), 2.0).unwrap());
+        let mut signed = BooleanScorer::try_new(
+            vec![signed_optional],
+            vec![materialized(&[(0, 1.0)])],
+            Vec::new(),
+        )
+        .unwrap();
+        let competitive_score = Arc::new(CompetitiveScore::default());
+        competitive_score.raise(10.0);
+
+        assert!(
+            TopKCollector::with_competitive_score(1, competitive_score)
+                .collect(&mut signed)
+                .unwrap()
+                .is_empty()
+        );
+        assert_eq!(signed_confirmations.load(AtomicOrdering::Relaxed), 1);
+        assert_eq!(signed_avoided.load(AtomicOrdering::Relaxed), 0);
+
+        let (unknown_phrase, approximations, confirmations, confirmations_avoided) =
+            two_phase_without_doc_upper(&[(0, 1.0), (1, 100.0)], vec![1]);
+        let mut unknown = BooleanScorer::try_new(
+            vec![unknown_phrase, materialized(&[(0, 0.0), (1, 0.0)])],
+            Vec::new(),
+            Vec::new(),
+        )
+        .unwrap();
+        let competitive_score = Arc::new(CompetitiveScore::default());
+        competitive_score.raise(50.0);
+
+        assert_eq!(
+            TopKCollector::with_competitive_score(1, competitive_score)
+                .collect(&mut unknown)
+                .unwrap(),
+            rows(&[(1, 100.0)])
+        );
+        assert_eq!(approximations.load(AtomicOrdering::Relaxed), 2);
+        assert_eq!(confirmations.load(AtomicOrdering::Relaxed), 2);
+        assert_eq!(confirmations_avoided.load(AtomicOrdering::Relaxed), 0);
+    }
+
+    #[test]
+    fn row_address_merge_forwards_phrase_doc_bound_and_avoidance() {
+        // Cross-column eager execution maps each leaf into row-address space
+        // and merges disjoint sources through this same wrapper stack.
+        let (phrase, approximations, confirmations, confirmations_avoided) =
+            two_phase_with_avoided(&[(0, 2.0), (1, 10.0)], vec![1], Some(1.0));
+        let mapped_phrase = Box::new(RowAddressScorer::new(
+            phrase,
+            ordered_row_address_projection_for_test(vec![100, 200]),
+        ));
+        let mut scorer = RowAddressMergeScorer::try_new(vec![
+            RowAddressSource::new(100, mapped_phrase),
+            row_address_source(&[(300, 100.0)]),
+        ])
+        .unwrap();
+        let competitive_score = Arc::new(CompetitiveScore::default());
+        competitive_score.raise(10.0);
+
+        assert_eq!(
+            TopKCollector::with_competitive_score(2, competitive_score)
+                .collect(&mut scorer)
+                .unwrap(),
+            rows(&[(300, 100.0), (200, 10.0)])
+        );
+        assert_eq!(approximations.load(AtomicOrdering::Relaxed), 2);
+        assert_eq!(confirmations.load(AtomicOrdering::Relaxed), 1);
+        assert_eq!(confirmations_avoided.load(AtomicOrdering::Relaxed), 1);
+    }
+
+    #[test]
+    fn phrase_outward_upper_equal_to_ulp_floor_still_confirms() {
+        let exact_score = next_down(1.0);
+        let floor = 1.0;
+        assert_eq!(
+            ScoreBounds::ZERO
+                .add(ScoreBounds::point(exact_score).unwrap())
+                .upper(),
+            floor
+        );
+        let (phrase, _, confirmations, confirmations_avoided) =
+            two_phase_with_avoided(&[(7, exact_score)], vec![7], Some(1.0));
+        let mut phrase = DisjunctionScorer::try_new(vec![phrase], DisjunctionScore::Sum).unwrap();
+        let competitive_score = Arc::new(CompetitiveScore::default());
+        competitive_score.raise(floor);
+
+        assert!(
+            TopKCollector::with_competitive_score(1, competitive_score)
+                .collect(&mut phrase)
+                .unwrap()
+                .is_empty()
+        );
+        assert_eq!(confirmations.load(AtomicOrdering::Relaxed), 1);
+        assert_eq!(confirmations_avoided.load(AtomicOrdering::Relaxed), 0);
+    }
+
+    #[test]
+    fn surviving_nested_phrase_is_confirmed_exactly_once() {
+        let (phrase, _, confirmations, confirmations_avoided) =
+            two_phase_with_avoided(&[(3, 5.0)], vec![3], Some(1.0));
+        let nested = Box::new(
+            DisjunctionScorer::try_new(
+                vec![phrase, materialized(&[(3, 0.0)])],
+                DisjunctionScore::Sum,
+            )
+            .unwrap(),
+        );
+        let mut scorer = BooleanScorer::try_new(vec![nested], Vec::new(), Vec::new()).unwrap();
+
+        assert_eq!(
+            TopKCollector::new(1).collect(&mut scorer).unwrap(),
+            rows(&[(3, 5.0)])
+        );
+        assert_eq!(confirmations.load(AtomicOrdering::Relaxed), 1);
+        assert_eq!(confirmations_avoided.load(AtomicOrdering::Relaxed), 0);
+    }
+
+    #[test]
     fn reqopt_delays_sparse_optional_probes() {
         let values = (0..100).map(|doc| (doc, 1.0)).collect::<Vec<_>>();
         let build = || {
@@ -5406,7 +6126,10 @@ mod tests {
             optional: Some(optional),
             prohibited: None,
             current: None,
+            confirmed_doc: None,
+            confirmed: false,
             optional_matches: false,
+            defer_confirmation: false,
         };
         let eager_results = TopKCollector::new(1).collect(&mut eager).unwrap();
 
@@ -5772,6 +6495,85 @@ mod tests {
 
     fn plan_leaf(index: usize) -> CompoundScorerPlan {
         CompoundScorerPlan::Leaf { index, boost: 1.0 }
+    }
+
+    #[test]
+    fn phrase_doc_bounds_match_exhaustive_oracle_across_boolean_shapes() {
+        // Leaf 0 models an exact phrase and leaf 1 a sloppy phrase. Their
+        // approximation scores include false position candidates, including a
+        // high-scoring false candidate at doc 4. Docs 1 and 3 deliberately tie.
+        let exact_approximations = [(0, 2.0), (1, 4.0), (2, 3.0), (3, 4.0), (4, 100.0)];
+        let sloppy_approximations = [(0, 1.0), (1, 2.0), (2, 3.0), (3, 2.0), (4, 1.0)];
+        let exact_matches = HashMap::from([(1, 4.0), (3, 4.0)]);
+        let sloppy_matches = HashMap::from([(1, 2.0), (2, 3.0), (3, 2.0)]);
+        let optional = HashMap::from([(0, 1.0), (1, 4.0), (2, 2.0), (3, 4.0), (4, 1.0)]);
+        let required = HashMap::from([(0, 1.0), (1, 1.0), (2, 1.0), (3, 1.0), (4, 1.0)]);
+        let oracle_leaves = vec![exact_matches, sloppy_matches, optional.clone(), required];
+
+        let pure_should = CompoundScorerPlan::Boolean {
+            should: vec![plan_leaf(0), plan_leaf(1), plan_leaf(2)],
+            must: Vec::new(),
+            must_not: Vec::new(),
+        };
+        let must_should = CompoundScorerPlan::Boolean {
+            should: vec![plan_leaf(0), plan_leaf(1), plan_leaf(2)],
+            must: vec![plan_leaf(3)],
+            must_not: Vec::new(),
+        };
+        let nested = CompoundScorerPlan::Boolean {
+            should: vec![pure_should.clone()],
+            must: vec![plan_leaf(3)],
+            must_not: Vec::new(),
+        };
+
+        for (shape, plan, floor) in [
+            ("should", pure_should, 10.0),
+            ("must_should", must_should, 11.0),
+            ("nested", nested, 11.0),
+        ] {
+            let (exact, _, exact_confirmations, exact_avoided) =
+                two_phase_with_avoided(&exact_approximations, vec![1, 3], Some(1.0));
+            let (sloppy, _, sloppy_confirmations, sloppy_avoided) =
+                two_phase_with_avoided(&sloppy_approximations, vec![1, 2, 3], Some(2.0));
+            let mut leaves = vec![
+                Some(exact),
+                Some(sloppy),
+                Some(materialized(
+                    &optional
+                        .iter()
+                        .map(|(doc, score)| (*doc, *score))
+                        .collect::<Vec<_>>(),
+                )),
+                Some(materialized(&[
+                    (0, 1.0),
+                    (1, 1.0),
+                    (2, 1.0),
+                    (3, 1.0),
+                    (4, 1.0),
+                ])),
+            ];
+            let mut scorer = plan.build(&mut leaves, &NoOpMetricsCollector).unwrap();
+            let competitive_score = Arc::new(CompetitiveScore::default());
+            competitive_score.raise(floor);
+            let actual = TopKCollector::with_competitive_score(2, competitive_score)
+                .collect(scorer.as_mut())
+                .unwrap();
+            let expected = exhaustive_compound_top_k(&plan, &oracle_leaves, 2);
+
+            assert_eq!(actual, expected, "shape={shape}");
+            assert_eq!(actual, rows(&[(1, floor), (3, floor)]), "shape={shape}");
+            assert!(
+                exact_avoided.load(AtomicOrdering::Relaxed)
+                    + sloppy_avoided.load(AtomicOrdering::Relaxed)
+                    > 0,
+                "shape={shape} should avoid at least one position confirmation"
+            );
+            assert!(
+                exact_confirmations.load(AtomicOrdering::Relaxed) > 0
+                    && sloppy_confirmations.load(AtomicOrdering::Relaxed) > 0,
+                "shape={shape} must confirm surviving equal-floor phrase candidates"
+            );
+        }
     }
 
     fn plan_input(possible: bool, cost: usize, lower: f32, upper: f32) -> CompoundLeafPlanInput {

--- a/rust/lance-index/src/scalar/inverted/compound/should_maxscore.rs
+++ b/rust/lance-index/src/scalar/inverted/compound/should_maxscore.rs
@@ -552,6 +552,79 @@ impl ComposableScorer for ShouldMaxScoreScorer<'_> {
         Ok(())
     }
 
+    fn current_score_upper_bound(&mut self) -> Result<Option<f32>> {
+        let Some(current) = self.current else {
+            return Ok(None);
+        };
+        self.child_scores.fill(None);
+        for (index, child) in self.children.iter_mut().enumerate() {
+            if self.essential[index] {
+                if child.doc() != Some(current) {
+                    self.child_scores[index] = Some(0.0);
+                    continue;
+                }
+                let Some(upper) = child.current_score_upper_bound()? else {
+                    return Ok(None);
+                };
+                if !upper.is_finite() {
+                    return Ok(None);
+                }
+                self.child_scores[index] = Some(upper.max(0.0));
+            }
+        }
+        let mut upper = self.partial_score_upper();
+        if upper < self.min_competitive_score {
+            return Ok(Some(upper));
+        }
+
+        // The residual range bound was inconclusive. Tighten it with each
+        // non-essential posting approximation for this document, largest
+        // global bound first. Stop as soon as the unresolved residual can no
+        // longer reach the floor, still without touching phrase positions.
+        for index in self.bound_order.iter().rev().copied() {
+            if self.essential[index] {
+                continue;
+            }
+            let child = &mut self.children[index];
+            if child.doc().is_some_and(|doc| doc < current) {
+                child.advance(current)?;
+            }
+            self.child_scores[index] = if child.doc() == Some(current) {
+                let Some(upper) = child.current_score_upper_bound()? else {
+                    return Ok(None);
+                };
+                if !upper.is_finite() {
+                    return Ok(None);
+                }
+                Some(upper.max(0.0))
+            } else {
+                Some(0.0)
+            };
+            upper = self.partial_score_upper();
+            if upper < self.min_competitive_score {
+                return Ok(Some(upper));
+            }
+        }
+        Ok(upper.is_finite().then_some(upper))
+    }
+
+    fn supports_doc_local_confirmation_pruning(&self) -> bool {
+        self.children
+            .iter()
+            .any(|child| child.supports_doc_local_confirmation_pruning())
+    }
+
+    fn record_confirmation_avoided(&mut self) {
+        let Some(current) = self.current else {
+            return;
+        };
+        for child in &mut self.children {
+            if child.doc() == Some(current) {
+                child.record_confirmation_avoided();
+            }
+        }
+    }
+
     fn matches(&mut self) -> Result<bool> {
         self.ensure_confirmed()
     }

--- a/rust/lance-index/src/scalar/inverted/wand.rs
+++ b/rust/lance-index/src/scalar/inverted/wand.rs
@@ -4755,6 +4755,11 @@ impl<'a, D: WandDocuments> WandCursor<'a, D> {
             self.current_document_key = Some(document_key);
             self.current_score = score;
             self.confirmation = self.phrase_slop.is_none().then_some(true);
+            match self.phrase_slop {
+                Some(0) => self.metrics.record_compound_phrase_exact_approximations(1),
+                Some(_) => self.metrics.record_compound_phrase_sloppy_approximations(1),
+                None => {}
+            }
             self.shallow = None;
             return Ok(Some(doc_id));
         }
@@ -4805,9 +4810,29 @@ impl<'a, D: WandDocuments> WandCursor<'a, D> {
         let phrase_slop = self.phrase_slop.ok_or_else(|| {
             Error::internal("posting FTS scorer requires phrase slop for position confirmation")
         })?;
+        if phrase_slop == 0 {
+            self.metrics.record_compound_phrase_exact_confirmations(1);
+        } else {
+            self.metrics.record_compound_phrase_sloppy_confirmations(1);
+        }
         let confirmed = self.wand.check_positions(phrase_slop as i32)?;
         self.confirmation = Some(confirmed);
         Ok(confirmed)
+    }
+
+    pub(super) fn record_confirmation_avoided(&self) {
+        if self.confirmation.is_some() {
+            return;
+        }
+        match self.phrase_slop {
+            Some(0) => self
+                .metrics
+                .record_compound_phrase_exact_confirmations_avoided(1),
+            Some(_) => self
+                .metrics
+                .record_compound_phrase_sloppy_confirmations_avoided(1),
+            None => {}
+        }
     }
 
     pub(super) fn match_cost(&self) -> Option<f32> {

--- a/rust/lance/src/io/exec/fts.rs
+++ b/rust/lance/src/io/exec/fts.rs
@@ -47,20 +47,24 @@ use lance_index::metrics::{
     AND_CANDIDATES_PRUNED_BEFORE_RETURN_METRIC, AND_CANDIDATES_SEEN_METRIC, AND_FULL_SCORES_METRIC,
     COMPOUND_ADDRESS_RESOLUTION_BATCHES_METRIC, COMPOUND_ADDRESSES_RESOLVED_METRIC,
     COMPOUND_PEAK_ADDRESS_RESOLUTION_BATCH_SIZE_METRIC, COMPOUND_PEAK_BUFFERED_CANDIDATES_METRIC,
-    COMPOUND_SCORE_FLOOR_OVERFLOWS_METRIC, COMPOUND_SHOULD_BOUND_RECOMPUTATIONS_METRIC,
-    COMPOUND_SHOULD_ESSENTIAL_EVALUATIONS_METRIC, COMPOUND_SHOULD_NON_ESSENTIAL_EVALUATIONS_METRIC,
-    COMPOUND_SHOULD_SKIPPED_WINDOWS_METRIC, CROSS_COLUMN_STAGED_ATTEMPTS_METRIC,
-    CROSS_COLUMN_STAGED_CANDIDATES_METRIC, CROSS_COLUMN_STAGED_FALLBACKS_METRIC,
-    CROSS_COLUMN_STAGED_SUCCESSES_METRIC, FREQS_COLLECTED_METRIC, MetricsCollector,
-    WAND_EXACTNESS_CERTIFICATE_ATTEMPTS_METRIC, WAND_EXACTNESS_CERTIFICATE_CANDIDATES_METRIC,
-    WAND_EXACTNESS_CERTIFICATE_EXHAUSTIVE_METRIC, WAND_EXACTNESS_CERTIFICATE_FALLBACKS_METRIC,
-    WAND_EXACTNESS_CERTIFICATE_STRICT_METRIC, WAND_EXACTNESS_PROBE_COMPARISONS_METRIC,
-    WAND_EXACTNESS_PROBE_MS_METRIC, WAND_SEEDED_FALLBACK_COMPARISONS_METRIC,
-    WAND_SEEDED_FALLBACK_MS_METRIC, WAND_SEEDED_FALLBACKS_METRIC,
-    WAND_TIE_COMPLETION_ATTEMPTS_METRIC, WAND_TIE_COMPLETION_CANDIDATES_METRIC,
-    WAND_TIE_COMPLETION_COMPARISONS_METRIC, WAND_TIE_COMPLETION_MS_METRIC,
-    WAND_TIE_COMPLETION_OVERFLOWS_METRIC, WAND_TIE_COMPLETION_ROW_ID_REPLACEMENTS_METRIC,
-    WAND_TIE_COMPLETION_SUCCESSES_METRIC,
+    COMPOUND_PHRASE_EXACT_APPROXIMATIONS_METRIC,
+    COMPOUND_PHRASE_EXACT_CONFIRMATIONS_AVOIDED_METRIC, COMPOUND_PHRASE_EXACT_CONFIRMATIONS_METRIC,
+    COMPOUND_PHRASE_SLOPPY_APPROXIMATIONS_METRIC,
+    COMPOUND_PHRASE_SLOPPY_CONFIRMATIONS_AVOIDED_METRIC,
+    COMPOUND_PHRASE_SLOPPY_CONFIRMATIONS_METRIC, COMPOUND_SCORE_FLOOR_OVERFLOWS_METRIC,
+    COMPOUND_SHOULD_BOUND_RECOMPUTATIONS_METRIC, COMPOUND_SHOULD_ESSENTIAL_EVALUATIONS_METRIC,
+    COMPOUND_SHOULD_NON_ESSENTIAL_EVALUATIONS_METRIC, COMPOUND_SHOULD_SKIPPED_WINDOWS_METRIC,
+    CROSS_COLUMN_STAGED_ATTEMPTS_METRIC, CROSS_COLUMN_STAGED_CANDIDATES_METRIC,
+    CROSS_COLUMN_STAGED_FALLBACKS_METRIC, CROSS_COLUMN_STAGED_SUCCESSES_METRIC,
+    FREQS_COLLECTED_METRIC, MetricsCollector, WAND_EXACTNESS_CERTIFICATE_ATTEMPTS_METRIC,
+    WAND_EXACTNESS_CERTIFICATE_CANDIDATES_METRIC, WAND_EXACTNESS_CERTIFICATE_EXHAUSTIVE_METRIC,
+    WAND_EXACTNESS_CERTIFICATE_FALLBACKS_METRIC, WAND_EXACTNESS_CERTIFICATE_STRICT_METRIC,
+    WAND_EXACTNESS_PROBE_COMPARISONS_METRIC, WAND_EXACTNESS_PROBE_MS_METRIC,
+    WAND_SEEDED_FALLBACK_COMPARISONS_METRIC, WAND_SEEDED_FALLBACK_MS_METRIC,
+    WAND_SEEDED_FALLBACKS_METRIC, WAND_TIE_COMPLETION_ATTEMPTS_METRIC,
+    WAND_TIE_COMPLETION_CANDIDATES_METRIC, WAND_TIE_COMPLETION_COMPARISONS_METRIC,
+    WAND_TIE_COMPLETION_MS_METRIC, WAND_TIE_COMPLETION_OVERFLOWS_METRIC,
+    WAND_TIE_COMPLETION_ROW_ID_REPLACEMENTS_METRIC, WAND_TIE_COMPLETION_SUCCESSES_METRIC,
 };
 use lance_index::scalar::inverted::builder::ScoredDoc;
 use lance_index::scalar::inverted::builder::document_input;
@@ -1954,6 +1958,12 @@ pub struct FtsIndexMetrics {
     compound_should_bound_recomputations: Count,
     compound_should_essential_evaluations: Count,
     compound_should_non_essential_evaluations: Count,
+    compound_phrase_exact_approximations: Count,
+    compound_phrase_sloppy_approximations: Count,
+    compound_phrase_exact_confirmations: Count,
+    compound_phrase_sloppy_confirmations: Count,
+    compound_phrase_exact_confirmations_avoided: Count,
+    compound_phrase_sloppy_confirmations_avoided: Count,
     cross_column_staged_attempts: Count,
     cross_column_staged_successes: Count,
     cross_column_staged_fallbacks: Count,
@@ -2012,6 +2022,22 @@ impl FtsIndexMetrics {
                 .new_count(COMPOUND_SHOULD_ESSENTIAL_EVALUATIONS_METRIC, partition),
             compound_should_non_essential_evaluations: metrics
                 .new_count(COMPOUND_SHOULD_NON_ESSENTIAL_EVALUATIONS_METRIC, partition),
+            compound_phrase_exact_approximations: metrics
+                .new_count(COMPOUND_PHRASE_EXACT_APPROXIMATIONS_METRIC, partition),
+            compound_phrase_sloppy_approximations: metrics
+                .new_count(COMPOUND_PHRASE_SLOPPY_APPROXIMATIONS_METRIC, partition),
+            compound_phrase_exact_confirmations: metrics
+                .new_count(COMPOUND_PHRASE_EXACT_CONFIRMATIONS_METRIC, partition),
+            compound_phrase_sloppy_confirmations: metrics
+                .new_count(COMPOUND_PHRASE_SLOPPY_CONFIRMATIONS_METRIC, partition),
+            compound_phrase_exact_confirmations_avoided: metrics.new_count(
+                COMPOUND_PHRASE_EXACT_CONFIRMATIONS_AVOIDED_METRIC,
+                partition,
+            ),
+            compound_phrase_sloppy_confirmations_avoided: metrics.new_count(
+                COMPOUND_PHRASE_SLOPPY_CONFIRMATIONS_AVOIDED_METRIC,
+                partition,
+            ),
             cross_column_staged_attempts: metrics
                 .new_count(CROSS_COLUMN_STAGED_ATTEMPTS_METRIC, partition),
             cross_column_staged_successes: metrics
@@ -2173,6 +2199,36 @@ impl MetricsCollector for FtsIndexMetrics {
     fn record_compound_should_non_essential_evaluations(&self, num_evaluations: usize) {
         self.compound_should_non_essential_evaluations
             .add(num_evaluations);
+    }
+
+    fn record_compound_phrase_exact_approximations(&self, num_approximations: usize) {
+        self.compound_phrase_exact_approximations
+            .add(num_approximations);
+    }
+
+    fn record_compound_phrase_sloppy_approximations(&self, num_approximations: usize) {
+        self.compound_phrase_sloppy_approximations
+            .add(num_approximations);
+    }
+
+    fn record_compound_phrase_exact_confirmations(&self, num_confirmations: usize) {
+        self.compound_phrase_exact_confirmations
+            .add(num_confirmations);
+    }
+
+    fn record_compound_phrase_sloppy_confirmations(&self, num_confirmations: usize) {
+        self.compound_phrase_sloppy_confirmations
+            .add(num_confirmations);
+    }
+
+    fn record_compound_phrase_exact_confirmations_avoided(&self, num_confirmations: usize) {
+        self.compound_phrase_exact_confirmations_avoided
+            .add(num_confirmations);
+    }
+
+    fn record_compound_phrase_sloppy_confirmations_avoided(&self, num_confirmations: usize) {
+        self.compound_phrase_sloppy_confirmations_avoided
+            .add(num_confirmations);
     }
 
     fn record_cross_column_staged_attempts(&self, num_attempts: usize) {
@@ -4639,6 +4695,32 @@ mod tests {
         assert_eq!(metrics.compound_should_bound_recomputations.value(), 3);
         assert_eq!(metrics.compound_should_essential_evaluations.value(), 5);
         assert_eq!(metrics.compound_should_non_essential_evaluations.value(), 7);
+    }
+
+    #[test]
+    fn test_compound_phrase_metrics_separate_exact_and_sloppy_work() {
+        let metrics_set = ExecutionPlanMetricsSet::new();
+        let metrics = super::FtsIndexMetrics::new(&metrics_set, 0);
+
+        metrics.record_compound_phrase_exact_approximations(2);
+        metrics.record_compound_phrase_sloppy_approximations(3);
+        metrics.record_compound_phrase_exact_confirmations(5);
+        metrics.record_compound_phrase_sloppy_confirmations(7);
+        metrics.record_compound_phrase_exact_confirmations_avoided(11);
+        metrics.record_compound_phrase_sloppy_confirmations_avoided(13);
+
+        assert_eq!(metrics.compound_phrase_exact_approximations.value(), 2);
+        assert_eq!(metrics.compound_phrase_sloppy_approximations.value(), 3);
+        assert_eq!(metrics.compound_phrase_exact_confirmations.value(), 5);
+        assert_eq!(metrics.compound_phrase_sloppy_confirmations.value(), 7);
+        assert_eq!(
+            metrics.compound_phrase_exact_confirmations_avoided.value(),
+            11
+        );
+        assert_eq!(
+            metrics.compound_phrase_sloppy_confirmations_avoided.value(),
+            13
+        );
     }
 
     #[test]


### PR DESCRIPTION
## What is the performance issue?

Compound Phrase clauses can confirm positions before the scorer knows whether the candidate can still reach the current competitive score floor. ReqOpt, pure-SHOULD/MAXSCORE, and nested Boolean queries can therefore decode and align candidate positions that score bounds would reject.

Linear: https://linear.app/lancedb/issue/OSS-1708

## How does this PR improve performance?

- Exposes a conservative current-document score upper bound before two-phase confirmation.
- Combines pending Phrase upper bounds with sibling residual bounds using outward-rounded `ScoreBounds` arithmetic.
- Skips position confirmation only when the complete document upper bound is strictly below the competitive floor; equality remains eligible for final row-ID tie resolution.
- Propagates the capability through conjunction, ReqOpt, pure-SHOULD MAXSCORE, nested Boolean, positive Boost, and row-address wrappers.
- Falls back to exact confirmation for signed, unknown, non-finite, or otherwise unsupported bounds.
- Caches confirmation state so a surviving candidate is confirmed at most once.
- Records exact/sloppy approximations, confirmations, and confirmations avoided.

The design follows Lucene's two-phase boundary in `PhraseScorer`, which checks a document-local Phrase upper bound before resetting and reading positions:

https://github.com/apache/lucene/blob/2822b28b5ab042672d6cb569589128e5dcafa648/lucene/core/src/java/org/apache/lucene/search/PhraseScorer.java#L50-L95

Lance's current Phrase score is the term-sum BM25 already computed by the approximation. Position confirmation determines membership but does not increase that score, so the pre-confirmation value is a safe document-local upper bound.

This PR avoids per-candidate position decoding/alignment. It does not claim to avoid loading the Phrase posting's position stream at leaf-open time.

## Correctness coverage

- Exact and sloppy Phrase.
- Pure SHOULD and MAXSCORE residual bounds.
- MUST+SHOULD / ReqOpt transitions.
- Nested Boolean and multiple Phrase clauses.
- Phrase-positive Boost and signed/unknown fallback.
- Phrase MUST_NOT exclusion semantics.
- RowAddressScorer and cross-column eager wrapper forwarding.
- Equal-floor and ULP boundary behavior.
- Confirmation exactly once for surviving candidates.
- Phrase-free controls retain the original eager path.

## Validation

- Current-head CI is green, including Rust clippy/fmt, Python, Java, compatibility, platform builds, and Lance Gatekeeper.
- Exact benchmark oracle: baseline `1500/1500` cases and target `1500/1500` cases passed; the full cross-build ordered row-ID and f32-score comparison passed.
- Target activation canary observed 53,079,101 exact approximations with 31,133,423 confirmations avoided, and 47,049,262 sloppy approximations with 29,370,370 confirmations avoided. The Match-only control emitted no Phrase metrics.
- Timed result and row-ID digests had zero within-build instability and zero cross-build differences.

Per the requested workflow, I did not run local `cargo test` or `cargo clippy`; CI ran the required checks.

## Benchmark

Environment: one dedicated GCP `c4-highmem-16` VM (16 vCPU, 121 GiB RAM), with no concurrent build or benchmark load. Dataset: 10,000,000-row MMLB code corpus, 42 languages, 10 shards, using the `full_content` FTS index with positions.

The exact/sloppy workloads are pure-SHOULD Boolean queries containing a high-frequency Match, a source-text Match, and a three-repeat high-frequency Phrase with slop 0 or 2. The control contains the same two Match clauses without the Phrase.

Warm protocol: frozen 250-query manifest, k=10/100, 8 query threads, 5 repetitions, four baseline and four target process blocks in forward/reverse ABBA order. Values are the median process QPS across the four blocks; higher is better.

| Scenario / metric | Baseline | This PR | Benefit |
| --- | ---: | ---: | ---: |
| Exact Phrase, k=10, warm throughput | 197.69 q/s | 266.86 q/s | 1.350x speedup |
| Exact Phrase, k=100, warm throughput | 43.33 q/s | 65.77 q/s | 1.518x speedup |
| Sloppy Phrase, k=10, warm throughput | 211.51 q/s | 295.51 q/s | 1.397x speedup |
| Sloppy Phrase, k=100, warm throughput | 46.68 q/s | 76.36 q/s | 1.636x speedup |
| Match-only control, k=10, warm throughput | 117.46 q/s | 117.00 q/s | 1.004x slower |
| Match-only control, k=100, warm throughput | 113.98 q/s | 114.29 q/s | 1.003x speedup |

The k=10 Phrase process blocks had more spread than k=100, but all four target blocks were faster than the corresponding four baseline blocks. The Match-only k=10 control changed by -0.39%, within the 2% guardrail.

Cold protocol: page cache dropped before every process, four baseline and four target ABBA blocks per shape/k. Q000073 was selected before timing because it activated both paths (925,978 exact and 832,517 sloppy confirmations avoided). Query latency excludes fixed process/index-open setup; lower is better.

| Scenario / metric | Baseline | This PR | Benefit |
| --- | ---: | ---: | ---: |
| Exact Phrase, k=10, cold query latency | 1409.68 ms | 1407.79 ms | 1.001x speedup |
| Exact Phrase, k=100, cold query latency | 2094.45 ms | 1812.79 ms | 1.155x speedup |
| Sloppy Phrase, k=10, cold query latency | 1409.32 ms | 1392.52 ms | 1.012x speedup |
| Sloppy Phrase, k=100, cold query latency | 2117.50 ms | 1745.27 ms | 1.213x speedup |

Cold file input was matched within 1.0005x and max RSS stayed within -0.79% to +0.83%. Full cold-process wall time was dominated by roughly 14 seconds of fixed startup/index-open work and was effectively neutral to slightly slower (0.6% to 2.7%); this PR's measured cold benefit is in the query segment, not process startup.

Compared commits: baseline `91aee6f9123d6f955fa4033d427c124e5b4f7cd2`; target `c8816cdddb7219a501cb9c468e22538ffedbaef1`. Target module SHA-256: `89923df38c1575d90b7833c4bda968cec7e669efdeaaab4c4bd7cfdecfadcbab`. Phrase benchmark adapter SHA-256: `85e4907d85f5563bc4fdaa3c685133c42d41f5338ad4261d568d46be6dedd803`.

The final result tree contains 1,827 files and 2,576,968,905 bytes with tree SHA-256 `36c5f00101723358b729333fee535243534e47234f5f16a1fc35467a411926e4`. The first cold-fixture attempt retained Q000073 inside a one-line manifest and was rejected by the contiguous-ID guard before any valid timing; it was archived outside the result tree. The final fixture preserves the source query provenance while locally renumbering it to Q000001.
