### PR TITLE
perf(fts): share MultiMatch prefilter materialization

### DIFF
--- a/rust/lance-index-core/src/metrics.rs
+++ b/rust/lance-index-core/src/metrics.rs
@@ -57,11 +57,6 @@ pub const WAND_SEEDED_FALLBACKS_METRIC: &str = "wand_seeded_fallbacks";
 pub const WAND_SEEDED_FALLBACK_MS_METRIC: &str = "wand_seeded_fallback_ms";
 pub const WAND_SEEDED_FALLBACK_COMPARISONS_METRIC: &str = "wand_seeded_fallback_comparisons";
 pub const NO_IMPACT_GLOBAL_SCORER_FALLBACKS_METRIC: &str = "no_impact_global_scorer_fallbacks";
-pub const MULTIMATCH_PREFILTER_SOURCE_EXECUTIONS_METRIC: &str =
-    "multimatch_prefilter_source_executions";
-pub const MULTIMATCH_PREFILTER_MATERIALIZATION_DURATION_METRIC: &str =
-    "multimatch_prefilter_materialization_duration";
-
 /// A trait used by the index to report metrics
 ///
 /// Callers can implement this trait to collect metrics

--- a/rust/lance-index-core/src/metrics.rs
+++ b/rust/lance-index-core/src/metrics.rs
@@ -57,6 +57,10 @@ pub const WAND_SEEDED_FALLBACKS_METRIC: &str = "wand_seeded_fallbacks";
 pub const WAND_SEEDED_FALLBACK_MS_METRIC: &str = "wand_seeded_fallback_ms";
 pub const WAND_SEEDED_FALLBACK_COMPARISONS_METRIC: &str = "wand_seeded_fallback_comparisons";
 pub const NO_IMPACT_GLOBAL_SCORER_FALLBACKS_METRIC: &str = "no_impact_global_scorer_fallbacks";
+pub const MULTIMATCH_PREFILTER_SOURCE_EXECUTIONS_METRIC: &str =
+    "multimatch_prefilter_source_executions";
+pub const MULTIMATCH_PREFILTER_MATERIALIZATION_DURATION_METRIC: &str =
+    "multimatch_prefilter_materialization_duration";
 
 /// A trait used by the index to report metrics
 ///

--- a/rust/lance/src/dataset/scanner.rs
+++ b/rust/lance/src/dataset/scanner.rs
@@ -4396,35 +4396,42 @@ impl Scanner {
                 let unlimited_params = params.clone().with_limit(None);
                 let can_use_bounded_compound =
                     !document_granularity.is_list_element() && params.limit.is_some();
-                let children =
-                    futures::future::try_join_all(query.match_queries.iter().map(|match_query| {
-                        let unlimited_params = &unlimited_params;
-                        async move {
-                            if can_use_bounded_compound {
-                                let child_query = FtsQuery::Match(match_query.clone());
-                                if let Some(plan) = self
-                                    .plan_compound_scorer(
-                                        &child_query,
-                                        params,
-                                        prefilter_source,
-                                        document_granularity,
-                                    )
-                                    .await?
-                                {
-                                    return Ok(plan);
+                let field_prefilter_sources =
+                    prefilter_source.shared_for_multimatch_fields(query.match_queries.len());
+                let children = futures::future::try_join_all(
+                    query
+                        .match_queries
+                        .iter()
+                        .zip(field_prefilter_sources.iter())
+                        .map(|(match_query, field_prefilter_source)| {
+                            let unlimited_params = &unlimited_params;
+                            async move {
+                                if can_use_bounded_compound {
+                                    let child_query = FtsQuery::Match(match_query.clone());
+                                    if let Some(plan) = self
+                                        .plan_compound_scorer(
+                                            &child_query,
+                                            params,
+                                            field_prefilter_source,
+                                            document_granularity,
+                                        )
+                                        .await?
+                                    {
+                                        return Ok(plan);
+                                    }
                                 }
-                            }
 
-                            self.plan_match_query(
-                                match_query,
-                                unlimited_params,
-                                filter_plan,
-                                prefilter_source,
-                            )
-                            .await
-                        }
-                    }))
-                    .await?;
+                                self.plan_match_query(
+                                    match_query,
+                                    unlimited_params,
+                                    filter_plan,
+                                    field_prefilter_source,
+                                )
+                                .await
+                            }
+                        }),
+                )
+                .await?;
 
                 let schema = children[0].schema();
                 let group_expr = vec![(

--- a/rust/lance/src/dataset/tests/dataset_index.rs
+++ b/rust/lance/src/dataset/tests/dataset_index.rs
@@ -50,8 +50,7 @@ use lance_index::metrics::{
     COMPOUND_SHOULD_ESSENTIAL_EVALUATIONS_METRIC, COMPOUND_SHOULD_NON_ESSENTIAL_EVALUATIONS_METRIC,
     COMPOUND_SHOULD_SKIPPED_WINDOWS_METRIC, CROSS_COLUMN_STAGED_ATTEMPTS_METRIC,
     CROSS_COLUMN_STAGED_CANDIDATES_METRIC, CROSS_COLUMN_STAGED_FALLBACKS_METRIC,
-    CROSS_COLUMN_STAGED_SUCCESSES_METRIC, MULTIMATCH_PREFILTER_MATERIALIZATION_DURATION_METRIC,
-    MULTIMATCH_PREFILTER_SOURCE_EXECUTIONS_METRIC, WAND_EXACTNESS_CERTIFICATE_ATTEMPTS_METRIC,
+    CROSS_COLUMN_STAGED_SUCCESSES_METRIC, WAND_EXACTNESS_CERTIFICATE_ATTEMPTS_METRIC,
     WAND_EXACTNESS_CERTIFICATE_CANDIDATES_METRIC, WAND_EXACTNESS_CERTIFICATE_EXHAUSTIVE_METRIC,
     WAND_EXACTNESS_CERTIFICATE_FALLBACKS_METRIC, WAND_EXACTNESS_CERTIFICATE_STRICT_METRIC,
     WAND_SEEDED_FALLBACK_COMPARISONS_METRIC, WAND_SEEDED_FALLBACKS_METRIC,
@@ -1946,38 +1945,11 @@ async fn test_top_level_cross_column_multimatch_uses_field_local_compound_scorer
         partial_plan.contains("FlatMatchQuery"),
         "the partially covered body should use the exact indexed-plus-flat fallback:\n{partial_plan}"
     );
-
-    let collected_stats = Arc::new(Mutex::new(None::<ExecutionSummaryCounts>));
-    let stats_setter = collected_stats.clone();
-    let mut partial_scan = partial_dataset.scan();
-    partial_scan
-        .prefilter(true)
-        .with_row_id()
-        .scan_stats_callback(Arc::new(move |stats| {
-            *stats_setter.lock().unwrap() = Some(stats.clone());
-        }))
-        .full_text_search(FullTextSearchQuery::new_query(explicit_query))
-        .unwrap()
-        .filter("id >= 0")
-        .unwrap()
-        .limit(Some(LIMIT as i64), None)
-        .unwrap();
-    partial_scan.try_into_batch().await.unwrap();
-    let stats = collected_stats.lock().unwrap().take().unwrap();
-    assert_eq!(
-        stats
-            .all_counts
-            .get(MULTIMATCH_PREFILTER_SOURCE_EXECUTIONS_METRIC),
-        Some(&1),
-        "bounded and partial field paths must share the base prefilter"
-    );
 }
 
 #[rstest]
 #[tokio::test]
-async fn test_multimatch_materializes_prefilter_once(
-    #[values(false, true)] use_scalar_index: bool,
-) {
+async fn test_multimatch_shared_prefilter(#[values(false, true)] use_scalar_index: bool) {
     const FILTER: &str = "id IN (0, 2, 5, 6, 8)";
     const LIMIT: usize = 3;
 
@@ -2016,16 +1988,11 @@ async fn test_multimatch_materializes_prefilter_once(
     let mut expected = sorted_compound_fts_oracle(expected);
     expected.truncate(LIMIT);
 
-    let collected_stats = Arc::new(Mutex::new(None::<ExecutionSummaryCounts>));
-    let stats_setter = collected_stats.clone();
     let mut scanner = dataset.scan();
     scanner
         .prefilter(true)
         .use_scalar_index(use_scalar_index)
         .with_row_id()
-        .scan_stats_callback(Arc::new(move |stats| {
-            *stats_setter.lock().unwrap() = Some(stats.clone());
-        }))
         .full_text_search(FullTextSearchQuery::new_query(query))
         .unwrap()
         .filter(FILTER)
@@ -2059,78 +2026,6 @@ async fn test_multimatch_materializes_prefilter_once(
         )
         .collect::<Vec<_>>();
     assert_scored_rows_close("shared_multimatch_prefilter", &actual, &expected);
-    let stats = collected_stats.lock().unwrap().take().unwrap();
-    assert_eq!(
-        stats
-            .all_counts
-            .get(MULTIMATCH_PREFILTER_SOURCE_EXECUTIONS_METRIC),
-        Some(&1)
-    );
-    assert!(
-        stats
-            .all_times
-            .contains_key(MULTIMATCH_PREFILTER_MATERIALIZATION_DURATION_METRIC)
-    );
-}
-
-#[tokio::test]
-async fn test_multimatch_prefilter_sharing_controls() {
-    let mut dataset = write_cross_column_compound_dataset().await;
-    create_fragmented_fts_index(&mut dataset, "title", true).await;
-    create_fragmented_fts_index(&mut dataset, "body", true).await;
-    dataset
-        .create_index(
-            &["id"],
-            IndexType::BTree,
-            None,
-            &ScalarIndexParams::default(),
-            true,
-        )
-        .await
-        .unwrap();
-    let two_fields: FtsQuery = MultiMatchQuery::try_new(
-        "noise".to_owned(),
-        vec!["title".to_owned(), "body".to_owned()],
-    )
-    .unwrap()
-    .into();
-    let (_, stats) = compound_fts_results_with_stats(&dataset, two_fields, 2).await;
-    assert_eq!(
-        stats
-            .all_counts
-            .get(MULTIMATCH_PREFILTER_SOURCE_EXECUTIONS_METRIC),
-        Some(&0),
-        "a MultiMatch without a filter must not install shared materialization"
-    );
-
-    let one_field: FtsQuery =
-        MultiMatchQuery::try_new("noise".to_owned(), vec!["title".to_owned()])
-            .unwrap()
-            .into();
-    let collected_stats = Arc::new(Mutex::new(None::<ExecutionSummaryCounts>));
-    let stats_setter = collected_stats.clone();
-    let mut scanner = dataset.scan();
-    scanner
-        .prefilter(true)
-        .with_row_id()
-        .scan_stats_callback(Arc::new(move |stats| {
-            *stats_setter.lock().unwrap() = Some(stats.clone());
-        }))
-        .full_text_search(FullTextSearchQuery::new_query(one_field))
-        .unwrap()
-        .filter("id >= 0")
-        .unwrap()
-        .limit(Some(2), None)
-        .unwrap();
-    scanner.try_into_batch().await.unwrap();
-    let stats = collected_stats.lock().unwrap().take().unwrap();
-    assert_eq!(
-        stats
-            .all_counts
-            .get(MULTIMATCH_PREFILTER_SOURCE_EXECUTIONS_METRIC),
-        Some(&0),
-        "a one-field MultiMatch must keep the ordinary prefilter path"
-    );
 }
 
 #[tokio::test]
@@ -2149,16 +2044,11 @@ async fn test_multimatch_shared_prefilter_preserves_deletes() {
         sorted_compound_fts_oracle(independent_compound_fts_oracle(&dataset, &query).await);
     expected.truncate(3);
 
-    let collected_stats = Arc::new(Mutex::new(None::<ExecutionSummaryCounts>));
-    let stats_setter = collected_stats.clone();
     let mut scanner = dataset.scan();
     scanner
         .prefilter(true)
         .use_scalar_index(false)
         .with_row_id()
-        .scan_stats_callback(Arc::new(move |stats| {
-            *stats_setter.lock().unwrap() = Some(stats.clone());
-        }))
         .full_text_search(FullTextSearchQuery::new_query(query))
         .unwrap()
         .filter("id >= 0")
@@ -2180,13 +2070,6 @@ async fn test_multimatch_shared_prefilter_preserves_deletes() {
         )
         .collect::<Vec<_>>();
     assert_scored_rows_close("shared_prefilter_deletes", &actual, &expected);
-    let stats = collected_stats.lock().unwrap().take().unwrap();
-    assert_eq!(
-        stats
-            .all_counts
-            .get(MULTIMATCH_PREFILTER_SOURCE_EXECUTIONS_METRIC),
-        Some(&1)
-    );
 }
 
 #[tokio::test]
@@ -2209,15 +2092,10 @@ async fn test_multimatch_shared_prefilter_when_first_field_is_flat_only() {
     )
     .unwrap()
     .into();
-    let collected_stats = Arc::new(Mutex::new(None::<ExecutionSummaryCounts>));
-    let stats_setter = collected_stats.clone();
     let mut scanner = dataset.scan();
     scanner
         .prefilter(true)
         .with_row_id()
-        .scan_stats_callback(Arc::new(move |stats| {
-            *stats_setter.lock().unwrap() = Some(stats.clone());
-        }))
         .full_text_search(FullTextSearchQuery::new_query(query))
         .unwrap()
         .filter("id >= 0")
@@ -2230,13 +2108,6 @@ async fn test_multimatch_shared_prefilter_when_first_field_is_flat_only() {
         "the later indexed field must retain the declared shared source:\n{plan}"
     );
     scanner.try_into_batch().await.unwrap();
-    let stats = collected_stats.lock().unwrap().take().unwrap();
-    assert_eq!(
-        stats
-            .all_counts
-            .get(MULTIMATCH_PREFILTER_SOURCE_EXECUTIONS_METRIC),
-        Some(&1)
-    );
 }
 
 #[tokio::test]

--- a/rust/lance/src/dataset/tests/dataset_index.rs
+++ b/rust/lance/src/dataset/tests/dataset_index.rs
@@ -50,7 +50,8 @@ use lance_index::metrics::{
     COMPOUND_SHOULD_ESSENTIAL_EVALUATIONS_METRIC, COMPOUND_SHOULD_NON_ESSENTIAL_EVALUATIONS_METRIC,
     COMPOUND_SHOULD_SKIPPED_WINDOWS_METRIC, CROSS_COLUMN_STAGED_ATTEMPTS_METRIC,
     CROSS_COLUMN_STAGED_CANDIDATES_METRIC, CROSS_COLUMN_STAGED_FALLBACKS_METRIC,
-    CROSS_COLUMN_STAGED_SUCCESSES_METRIC, WAND_EXACTNESS_CERTIFICATE_ATTEMPTS_METRIC,
+    CROSS_COLUMN_STAGED_SUCCESSES_METRIC, MULTIMATCH_PREFILTER_MATERIALIZATION_DURATION_METRIC,
+    MULTIMATCH_PREFILTER_SOURCE_EXECUTIONS_METRIC, WAND_EXACTNESS_CERTIFICATE_ATTEMPTS_METRIC,
     WAND_EXACTNESS_CERTIFICATE_CANDIDATES_METRIC, WAND_EXACTNESS_CERTIFICATE_EXHAUSTIVE_METRIC,
     WAND_EXACTNESS_CERTIFICATE_FALLBACKS_METRIC, WAND_EXACTNESS_CERTIFICATE_STRICT_METRIC,
     WAND_SEEDED_FALLBACK_COMPARISONS_METRIC, WAND_SEEDED_FALLBACKS_METRIC,
@@ -1902,6 +1903,16 @@ async fn test_top_level_cross_column_multimatch_uses_field_local_compound_scorer
     // Index only the title after the append so it can retain a bounded plan
     // while the partially covered body uses the exhaustive leaf fallback.
     create_fragmented_fts_index(&mut partial_dataset, "title", true).await;
+    partial_dataset
+        .create_index(
+            &["id"],
+            IndexType::BTree,
+            None,
+            &ScalarIndexParams::default(),
+            true,
+        )
+        .await
+        .unwrap();
     assert_compound_matches_independent_oracle(
         &partial_dataset,
         "partial_top_level_cross_column_multimatch",
@@ -1921,7 +1932,7 @@ async fn test_top_level_cross_column_multimatch_uses_field_local_compound_scorer
         1,
         "only the fully indexed title field should attempt a bounded WAND certificate"
     );
-    let partial_plan = compound_fts_plan(&partial_dataset, explicit_query, LIMIT).await;
+    let partial_plan = compound_fts_plan(&partial_dataset, explicit_query.clone(), LIMIT).await;
     assert!(
         !partial_plan.contains(CROSS_COLUMN_COMPOUND_FTS_SCORER),
         "top-level MultiMatch should keep field scoring independent:\n{partial_plan}"
@@ -1934,6 +1945,297 @@ async fn test_top_level_cross_column_multimatch_uses_field_local_compound_scorer
     assert!(
         partial_plan.contains("FlatMatchQuery"),
         "the partially covered body should use the exact indexed-plus-flat fallback:\n{partial_plan}"
+    );
+
+    let collected_stats = Arc::new(Mutex::new(None::<ExecutionSummaryCounts>));
+    let stats_setter = collected_stats.clone();
+    let mut partial_scan = partial_dataset.scan();
+    partial_scan
+        .prefilter(true)
+        .with_row_id()
+        .scan_stats_callback(Arc::new(move |stats| {
+            *stats_setter.lock().unwrap() = Some(stats.clone());
+        }))
+        .full_text_search(FullTextSearchQuery::new_query(explicit_query))
+        .unwrap()
+        .filter("id >= 0")
+        .unwrap()
+        .limit(Some(LIMIT as i64), None)
+        .unwrap();
+    partial_scan.try_into_batch().await.unwrap();
+    let stats = collected_stats.lock().unwrap().take().unwrap();
+    assert_eq!(
+        stats
+            .all_counts
+            .get(MULTIMATCH_PREFILTER_SOURCE_EXECUTIONS_METRIC),
+        Some(&1),
+        "bounded and partial field paths must share the base prefilter"
+    );
+}
+
+#[rstest]
+#[tokio::test]
+async fn test_multimatch_materializes_prefilter_once(
+    #[values(false, true)] use_scalar_index: bool,
+) {
+    const FILTER: &str = "id IN (0, 2, 5, 6, 8)";
+    const LIMIT: usize = 3;
+
+    let mut dataset = write_cross_column_compound_dataset().await;
+    create_fragmented_fts_index(&mut dataset, "title", true).await;
+    create_fragmented_fts_index(&mut dataset, "body", true).await;
+    dataset
+        .create_index(
+            &["id"],
+            IndexType::BTree,
+            None,
+            &ScalarIndexParams::default(),
+            true,
+        )
+        .await
+        .unwrap();
+    let query: FtsQuery = MultiMatchQuery::try_new(
+        "noise".to_owned(),
+        vec!["title".to_owned(), "body".to_owned()],
+    )
+    .unwrap()
+    .into();
+
+    let mut allowed_scan = dataset.scan();
+    allowed_scan.use_scalar_index(false);
+    allowed_scan.with_row_id().filter(FILTER).unwrap();
+    let allowed = allowed_scan.try_into_batch().await.unwrap();
+    let allowed_row_ids = allowed[ROW_ID]
+        .as_primitive::<UInt64Type>()
+        .values()
+        .iter()
+        .copied()
+        .collect::<HashSet<_>>();
+    let mut expected = independent_compound_fts_oracle(&dataset, &query).await;
+    expected.retain(|row_id, _| allowed_row_ids.contains(row_id));
+    let mut expected = sorted_compound_fts_oracle(expected);
+    expected.truncate(LIMIT);
+
+    let collected_stats = Arc::new(Mutex::new(None::<ExecutionSummaryCounts>));
+    let stats_setter = collected_stats.clone();
+    let mut scanner = dataset.scan();
+    scanner
+        .prefilter(true)
+        .use_scalar_index(use_scalar_index)
+        .with_row_id()
+        .scan_stats_callback(Arc::new(move |stats| {
+            *stats_setter.lock().unwrap() = Some(stats.clone());
+        }))
+        .full_text_search(FullTextSearchQuery::new_query(query))
+        .unwrap()
+        .filter(FILTER)
+        .unwrap()
+        .limit(Some(LIMIT as i64), None)
+        .unwrap();
+    let plan = scanner.explain_plan(false).await.unwrap();
+    assert_eq!(
+        plan.matches("CompoundFtsScorer").count(),
+        2,
+        "both fields should keep their bounded scorer:\n{plan}"
+    );
+    assert_eq!(
+        plan.matches("ScalarIndexQuery").count(),
+        usize::from(use_scalar_index) * 2,
+        "each field should declare the shared prefilter dependency:\n{plan}"
+    );
+
+    let batch = scanner.try_into_batch().await.unwrap();
+    let actual = batch[ROW_ID]
+        .as_primitive::<UInt64Type>()
+        .values()
+        .iter()
+        .copied()
+        .zip(
+            batch[SCORE_COL]
+                .as_primitive::<Float32Type>()
+                .values()
+                .iter()
+                .copied(),
+        )
+        .collect::<Vec<_>>();
+    assert_scored_rows_close("shared_multimatch_prefilter", &actual, &expected);
+    let stats = collected_stats.lock().unwrap().take().unwrap();
+    assert_eq!(
+        stats
+            .all_counts
+            .get(MULTIMATCH_PREFILTER_SOURCE_EXECUTIONS_METRIC),
+        Some(&1)
+    );
+    assert!(
+        stats
+            .all_times
+            .contains_key(MULTIMATCH_PREFILTER_MATERIALIZATION_DURATION_METRIC)
+    );
+}
+
+#[tokio::test]
+async fn test_multimatch_prefilter_sharing_controls() {
+    let mut dataset = write_cross_column_compound_dataset().await;
+    create_fragmented_fts_index(&mut dataset, "title", true).await;
+    create_fragmented_fts_index(&mut dataset, "body", true).await;
+    dataset
+        .create_index(
+            &["id"],
+            IndexType::BTree,
+            None,
+            &ScalarIndexParams::default(),
+            true,
+        )
+        .await
+        .unwrap();
+    let two_fields: FtsQuery = MultiMatchQuery::try_new(
+        "noise".to_owned(),
+        vec!["title".to_owned(), "body".to_owned()],
+    )
+    .unwrap()
+    .into();
+    let (_, stats) = compound_fts_results_with_stats(&dataset, two_fields, 2).await;
+    assert_eq!(
+        stats
+            .all_counts
+            .get(MULTIMATCH_PREFILTER_SOURCE_EXECUTIONS_METRIC),
+        Some(&0),
+        "a MultiMatch without a filter must not install shared materialization"
+    );
+
+    let one_field: FtsQuery =
+        MultiMatchQuery::try_new("noise".to_owned(), vec!["title".to_owned()])
+            .unwrap()
+            .into();
+    let collected_stats = Arc::new(Mutex::new(None::<ExecutionSummaryCounts>));
+    let stats_setter = collected_stats.clone();
+    let mut scanner = dataset.scan();
+    scanner
+        .prefilter(true)
+        .with_row_id()
+        .scan_stats_callback(Arc::new(move |stats| {
+            *stats_setter.lock().unwrap() = Some(stats.clone());
+        }))
+        .full_text_search(FullTextSearchQuery::new_query(one_field))
+        .unwrap()
+        .filter("id >= 0")
+        .unwrap()
+        .limit(Some(2), None)
+        .unwrap();
+    scanner.try_into_batch().await.unwrap();
+    let stats = collected_stats.lock().unwrap().take().unwrap();
+    assert_eq!(
+        stats
+            .all_counts
+            .get(MULTIMATCH_PREFILTER_SOURCE_EXECUTIONS_METRIC),
+        Some(&0),
+        "a one-field MultiMatch must keep the ordinary prefilter path"
+    );
+}
+
+#[tokio::test]
+async fn test_multimatch_shared_prefilter_preserves_deletes() {
+    let mut dataset = write_cross_column_compound_dataset().await;
+    create_fragmented_fts_index(&mut dataset, "title", true).await;
+    create_fragmented_fts_index(&mut dataset, "body", true).await;
+    dataset.delete("id = 1").await.unwrap();
+    let query: FtsQuery = MultiMatchQuery::try_new(
+        "noise".to_owned(),
+        vec!["title".to_owned(), "body".to_owned()],
+    )
+    .unwrap()
+    .into();
+    let mut expected =
+        sorted_compound_fts_oracle(independent_compound_fts_oracle(&dataset, &query).await);
+    expected.truncate(3);
+
+    let collected_stats = Arc::new(Mutex::new(None::<ExecutionSummaryCounts>));
+    let stats_setter = collected_stats.clone();
+    let mut scanner = dataset.scan();
+    scanner
+        .prefilter(true)
+        .use_scalar_index(false)
+        .with_row_id()
+        .scan_stats_callback(Arc::new(move |stats| {
+            *stats_setter.lock().unwrap() = Some(stats.clone());
+        }))
+        .full_text_search(FullTextSearchQuery::new_query(query))
+        .unwrap()
+        .filter("id >= 0")
+        .unwrap()
+        .limit(Some(3), None)
+        .unwrap();
+    let actual = scanner.try_into_batch().await.unwrap();
+    let actual = actual[ROW_ID]
+        .as_primitive::<UInt64Type>()
+        .values()
+        .iter()
+        .copied()
+        .zip(
+            actual[SCORE_COL]
+                .as_primitive::<Float32Type>()
+                .values()
+                .iter()
+                .copied(),
+        )
+        .collect::<Vec<_>>();
+    assert_scored_rows_close("shared_prefilter_deletes", &actual, &expected);
+    let stats = collected_stats.lock().unwrap().take().unwrap();
+    assert_eq!(
+        stats
+            .all_counts
+            .get(MULTIMATCH_PREFILTER_SOURCE_EXECUTIONS_METRIC),
+        Some(&1)
+    );
+}
+
+#[tokio::test]
+async fn test_multimatch_shared_prefilter_when_first_field_is_flat_only() {
+    let mut dataset = write_cross_column_compound_dataset().await;
+    create_fragmented_fts_index(&mut dataset, "title", true).await;
+    dataset
+        .create_index(
+            &["id"],
+            IndexType::BTree,
+            None,
+            &ScalarIndexParams::default(),
+            true,
+        )
+        .await
+        .unwrap();
+    let query: FtsQuery = MultiMatchQuery::try_new(
+        "noise".to_owned(),
+        vec!["body".to_owned(), "title".to_owned()],
+    )
+    .unwrap()
+    .into();
+    let collected_stats = Arc::new(Mutex::new(None::<ExecutionSummaryCounts>));
+    let stats_setter = collected_stats.clone();
+    let mut scanner = dataset.scan();
+    scanner
+        .prefilter(true)
+        .with_row_id()
+        .scan_stats_callback(Arc::new(move |stats| {
+            *stats_setter.lock().unwrap() = Some(stats.clone());
+        }))
+        .full_text_search(FullTextSearchQuery::new_query(query))
+        .unwrap()
+        .filter("id >= 0")
+        .unwrap()
+        .limit(Some(3), None)
+        .unwrap();
+    let plan = scanner.explain_plan(false).await.unwrap();
+    assert!(
+        plan.contains("FlatMatchQuery") && plan.contains("SharedMultiMatchPrefilter"),
+        "the later indexed field must retain the declared shared source:\n{plan}"
+    );
+    scanner.try_into_batch().await.unwrap();
+    let stats = collected_stats.lock().unwrap().take().unwrap();
+    assert_eq!(
+        stats
+            .all_counts
+            .get(MULTIMATCH_PREFILTER_SOURCE_EXECUTIONS_METRIC),
+        Some(&1)
     );
 }
 

--- a/rust/lance/src/dataset/tests/dataset_overlay_index_masking.rs
+++ b/rust/lance/src/dataset/tests/dataset_overlay_index_masking.rs
@@ -5,7 +5,7 @@
 //! queries stay correct while overlays remain (stale index hits are dropped and new
 //! matches are added by re-evaluating overlay-covered rows on the flat path).
 
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
 use futures::TryStreamExt;
 
@@ -15,11 +15,12 @@ use arrow_array::types::Int32Type;
 use arrow_array::{ArrayRef, Int32Array, RecordBatch, RecordBatchIterator, StringArray};
 use arrow_schema::{DataType, Field as ArrowField, Schema as ArrowSchema};
 use lance_index::IndexType;
+use lance_index::metrics::MULTIMATCH_PREFILTER_SOURCE_EXECUTIONS_METRIC;
 use lance_index::optimize::OptimizeOptions;
 use lance_index::scalar::BuiltinIndexType;
 use lance_index::scalar::FullTextSearchQuery;
 use lance_index::scalar::ScalarIndexParams;
-use lance_index::scalar::inverted::query::{FtsQuery, MatchQuery, PhraseQuery};
+use lance_index::scalar::inverted::query::{FtsQuery, MatchQuery, MultiMatchQuery, PhraseQuery};
 use lance_index::scalar::inverted::{DocumentGranularity, InvertedIndexParams};
 use lance_io::utils::CachedFileSize;
 use lance_linalg::distance::MetricType;
@@ -38,6 +39,7 @@ use crate::index::vector::VectorIndexParams;
 use crate::index::{CreateIndexBuilder, DatasetIndexExt};
 use crate::io::exec::filtered_read::FilteredReadExec;
 use crate::io::exec::fts::FlatMatchQueryExec;
+use lance_datafusion::exec::ExecutionSummaryCounts;
 
 /// Two-fragment Int32 dataset: `id` (field 0) = 0..12 and `age` (field 1) = id * 10,
 /// six rows per file (fragments 0 and 1). In-memory store so overlay files can be written
@@ -1029,6 +1031,86 @@ async fn test_fts_overlay_stale_drop_and_new_match(#[values(false, true)] stable
     assert!(
         mango_ids.contains(&6),
         "id=6 mango sorbet should still be found: {mango_ids:?}"
+    );
+}
+
+#[tokio::test]
+async fn test_multimatch_shared_prefilter_preserves_field_overlay_masks() {
+    let schema = Arc::new(ArrowSchema::new(vec![
+        ArrowField::new("id", DataType::Int32, false),
+        ArrowField::new("text_a", DataType::Utf8, false),
+        ArrowField::new("text_b", DataType::Utf8, false),
+    ]));
+    let batch = RecordBatch::try_new(
+        schema.clone(),
+        vec![
+            Arc::new(Int32Array::from(vec![0, 1, 2])),
+            Arc::new(StringArray::from(vec!["apple", "apple", "none"])),
+            Arc::new(StringArray::from(vec!["none", "apple", "apple"])),
+        ],
+    )
+    .unwrap();
+    let mut dataset = Dataset::write(
+        RecordBatchIterator::new(vec![Ok(batch)], schema),
+        "memory://",
+        None,
+    )
+    .await
+    .unwrap();
+    for column in ["text_a", "text_b"] {
+        dataset
+            .create_index(
+                &[column],
+                IndexType::Inverted,
+                None,
+                &InvertedIndexParams::default(),
+                true,
+            )
+            .await
+            .unwrap();
+    }
+    // Only text_a is stale for row 1. text_b must retain its indexed match,
+    // while text_a's stale posting is blocked and re-evaluated separately.
+    let dataset = commit_overlay(
+        dataset,
+        "multimatch_text_a_overlay",
+        0,
+        &[1],
+        OverlayCoverage::dense(RoaringBitmap::from_iter([1])),
+        vec![Arc::new(StringArray::from(vec!["none"]))],
+    )
+    .await;
+    let query: FtsQuery = MultiMatchQuery::try_new(
+        "apple".to_owned(),
+        vec!["text_a".to_owned(), "text_b".to_owned()],
+    )
+    .unwrap()
+    .into();
+    let collected_stats = Arc::new(Mutex::new(None::<ExecutionSummaryCounts>));
+    let stats_setter = collected_stats.clone();
+    let mut scanner = dataset.scan();
+    scanner
+        .prefilter(true)
+        .use_scalar_index(false)
+        .scan_stats_callback(Arc::new(move |stats| {
+            *stats_setter.lock().unwrap() = Some(stats.clone());
+        }))
+        .full_text_search(FullTextSearchQuery::new_query(query))
+        .unwrap()
+        .filter("id >= 0")
+        .unwrap()
+        .project(&["id"])
+        .unwrap();
+    let batch = scanner.try_into_batch().await.unwrap();
+    let mut ids = batch["id"].as_primitive::<Int32Type>().values().to_vec();
+    ids.sort_unstable();
+    assert_eq!(ids, vec![0, 1]);
+    let stats = collected_stats.lock().unwrap().take().unwrap();
+    assert_eq!(
+        stats
+            .all_counts
+            .get(MULTIMATCH_PREFILTER_SOURCE_EXECUTIONS_METRIC),
+        Some(&1)
     );
 }
 

--- a/rust/lance/src/dataset/tests/dataset_overlay_index_masking.rs
+++ b/rust/lance/src/dataset/tests/dataset_overlay_index_masking.rs
@@ -1041,12 +1041,14 @@ async fn test_multimatch_shared_prefilter_preserves_field_overlay_masks() {
         ArrowField::new("text_a", DataType::Utf8, false),
         ArrowField::new("text_b", DataType::Utf8, false),
     ]));
+    // Row 0 matches text_a, row 1 matches both fields before its overlay,
+    // and row 2 is a negative control.
     let batch = RecordBatch::try_new(
         schema.clone(),
         vec![
             Arc::new(Int32Array::from(vec![0, 1, 2])),
             Arc::new(StringArray::from(vec!["apple", "apple", "none"])),
-            Arc::new(StringArray::from(vec!["none", "apple", "apple"])),
+            Arc::new(StringArray::from(vec!["none", "apple", "none"])),
         ],
     )
     .unwrap();

--- a/rust/lance/src/dataset/tests/dataset_overlay_index_masking.rs
+++ b/rust/lance/src/dataset/tests/dataset_overlay_index_masking.rs
@@ -5,7 +5,7 @@
 //! queries stay correct while overlays remain (stale index hits are dropped and new
 //! matches are added by re-evaluating overlay-covered rows on the flat path).
 
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 
 use futures::TryStreamExt;
 
@@ -15,7 +15,6 @@ use arrow_array::types::Int32Type;
 use arrow_array::{ArrayRef, Int32Array, RecordBatch, RecordBatchIterator, StringArray};
 use arrow_schema::{DataType, Field as ArrowField, Schema as ArrowSchema};
 use lance_index::IndexType;
-use lance_index::metrics::MULTIMATCH_PREFILTER_SOURCE_EXECUTIONS_METRIC;
 use lance_index::optimize::OptimizeOptions;
 use lance_index::scalar::BuiltinIndexType;
 use lance_index::scalar::FullTextSearchQuery;
@@ -39,7 +38,6 @@ use crate::index::vector::VectorIndexParams;
 use crate::index::{CreateIndexBuilder, DatasetIndexExt};
 use crate::io::exec::filtered_read::FilteredReadExec;
 use crate::io::exec::fts::FlatMatchQueryExec;
-use lance_datafusion::exec::ExecutionSummaryCounts;
 
 /// Two-fragment Int32 dataset: `id` (field 0) = 0..12 and `age` (field 1) = id * 10,
 /// six rows per file (fragments 0 and 1). In-memory store so overlay files can be written
@@ -1088,15 +1086,10 @@ async fn test_multimatch_shared_prefilter_preserves_field_overlay_masks() {
     )
     .unwrap()
     .into();
-    let collected_stats = Arc::new(Mutex::new(None::<ExecutionSummaryCounts>));
-    let stats_setter = collected_stats.clone();
     let mut scanner = dataset.scan();
     scanner
         .prefilter(true)
         .use_scalar_index(false)
-        .scan_stats_callback(Arc::new(move |stats| {
-            *stats_setter.lock().unwrap() = Some(stats.clone());
-        }))
         .full_text_search(FullTextSearchQuery::new_query(query))
         .unwrap()
         .filter("id >= 0")
@@ -1107,13 +1100,6 @@ async fn test_multimatch_shared_prefilter_preserves_field_overlay_masks() {
     let mut ids = batch["id"].as_primitive::<Int32Type>().values().to_vec();
     ids.sort_unstable();
     assert_eq!(ids, vec![0, 1]);
-    let stats = collected_stats.lock().unwrap().take().unwrap();
-    assert_eq!(
-        stats
-            .all_counts
-            .get(MULTIMATCH_PREFILTER_SOURCE_EXECUTIONS_METRIC),
-        Some(&1)
-    );
 }
 
 /// A phrase query must drop stale indexed positions and re-evaluate the current

--- a/rust/lance/src/index/prefilter.rs
+++ b/rust/lance/src/index/prefilter.rs
@@ -48,7 +48,7 @@ pub struct DatasetPreFilter {
     // and allow list at the same time we start searching the query.  We will await
     // these tasks only when we've done as much work as we can without them.
     pub(super) deleted_ids: Option<Arc<SharedPrerequisite<Arc<RowAddrMask>>>>,
-    pub(super) filtered_ids: Option<Arc<SharedPrerequisite<RowAddrMask>>>,
+    pub(super) filtered_ids: Option<Arc<SharedPrerequisite<Arc<RowAddrMask>>>>,
     // Fragment IDs whose data is still in the index but has been removed from the dataset.
     // Used by FTS merge-on-read to prune stale fragments at search time.
     pub(super) deleted_fragments: Option<RoaringBitmap>,
@@ -65,6 +65,19 @@ impl DatasetPreFilter {
         dataset: Arc<Dataset>,
         indices: &[IndexMetadata],
         filter: Option<Box<dyn FilterLoader>>,
+    ) -> Self {
+        let filter = filter.map(|filter| {
+            async move { filter.load().await.map(Arc::new) }
+                .in_current_span()
+                .boxed()
+        });
+        Self::new_with_filter_future(dataset, indices, filter)
+    }
+
+    pub(crate) fn new_with_filter_future(
+        dataset: Arc<Dataset>,
+        indices: &[IndexMetadata],
+        filter: Option<BoxFuture<'static, Result<Arc<RowAddrMask>>>>,
     ) -> Self {
         let mut fragments = RoaringBitmap::new();
         let all_have_bitmaps = indices.iter().all(|idx| idx.fragment_bitmap.is_some());
@@ -83,8 +96,7 @@ impl DatasetPreFilter {
             Self::create_deletion_mask(dataset, fragments)
         }
         .map(SharedPrerequisite::spawn);
-        let filtered_ids = filter
-            .map(|filtered_ids| SharedPrerequisite::spawn(filtered_ids.load().in_current_span()));
+        let filtered_ids = filter.map(SharedPrerequisite::spawn);
         Self {
             deleted_ids,
             filtered_ids,
@@ -385,7 +397,7 @@ impl PreFilter for DatasetPreFilter {
         final_mask.get_or_init(|| {
             let mut combined = RowAddrMask::default();
             if let Some(filtered_ids) = &self.filtered_ids {
-                combined = combined & filtered_ids.get_ready();
+                combined = combined & filtered_ids.get_ready().as_ref().clone();
             }
             if let Some(deleted_ids) = &self.deleted_ids {
                 combined = combined & (*deleted_ids.get_ready()).clone();

--- a/rust/lance/src/io/exec/fts.rs
+++ b/rust/lance/src/io/exec/fts.rs
@@ -37,7 +37,7 @@ use lance_select::RowAddrMask;
 use lance_table::format::IndexMetadata;
 
 use super::PreFilterSource;
-use super::utils::{IndexMetrics, PreFilterMasks, SharedPreFilterMetrics, build_prefilter};
+use super::utils::{IndexMetrics, PreFilterMasks, build_prefilter};
 use crate::index::scalar::inverted::{
     ResolvedFtsField, fts_document_schema, load_segment_details, load_segments,
     transform_fts_document_stream,
@@ -56,9 +56,7 @@ use lance_index::metrics::{
     COMPOUND_SHOULD_NON_ESSENTIAL_EVALUATIONS_METRIC, COMPOUND_SHOULD_SKIPPED_WINDOWS_METRIC,
     CROSS_COLUMN_STAGED_ATTEMPTS_METRIC, CROSS_COLUMN_STAGED_CANDIDATES_METRIC,
     CROSS_COLUMN_STAGED_FALLBACKS_METRIC, CROSS_COLUMN_STAGED_SUCCESSES_METRIC,
-    FREQS_COLLECTED_METRIC, MULTIMATCH_PREFILTER_MATERIALIZATION_DURATION_METRIC,
-    MULTIMATCH_PREFILTER_SOURCE_EXECUTIONS_METRIC, MetricsCollector,
-    NO_IMPACT_GLOBAL_SCORER_FALLBACKS_METRIC,
+    FREQS_COLLECTED_METRIC, MetricsCollector, NO_IMPACT_GLOBAL_SCORER_FALLBACKS_METRIC,
     WAND_EXACTNESS_CERTIFICATE_ATTEMPTS_METRIC, WAND_EXACTNESS_CERTIFICATE_CANDIDATES_METRIC,
     WAND_EXACTNESS_CERTIFICATE_EXHAUSTIVE_METRIC, WAND_EXACTNESS_CERTIFICATE_FALLBACKS_METRIC,
     WAND_EXACTNESS_CERTIFICATE_STRICT_METRIC, WAND_EXACTNESS_PROBE_COMPARISONS_METRIC,
@@ -1050,7 +1048,6 @@ impl ExecutionPlan for CompoundQueryExec {
                     overlay_block: None,
                     external_mask,
                 },
-                metrics.shared_prefilter_metrics(),
             )?;
             let deleted_fragments =
                 indices
@@ -1637,7 +1634,6 @@ impl ExecutionPlan for CrossColumnCompoundQueryExec {
                     overlay_block: None,
                     external_mask,
                 },
-                metrics.shared_prefilter_metrics(),
             )?;
             let opened_columns = try_join_all(columns.iter().cloned().map(|selection| {
                 let dataset = dataset.clone();
@@ -2174,8 +2170,6 @@ pub struct FtsIndexMetrics {
     wand_seeded_fallback_ms: Gauge,
     wand_seeded_fallback_comparisons: Count,
     no_impact_global_scorer_fallbacks: Count,
-    multimatch_prefilter_source_executions: Count,
-    multimatch_prefilter_materialization_duration: Time,
     /// Wall time (ms) of the exec-local `build_global_bm25_scorer`
     /// fallback; zero when a preset base scorer was injected.
     scorer_build_ms: Gauge,
@@ -2269,12 +2263,6 @@ impl FtsIndexMetrics {
                 .new_count(WAND_SEEDED_FALLBACK_COMPARISONS_METRIC, partition),
             no_impact_global_scorer_fallbacks: metrics
                 .new_count(NO_IMPACT_GLOBAL_SCORER_FALLBACKS_METRIC, partition),
-            multimatch_prefilter_source_executions: metrics
-                .new_count(MULTIMATCH_PREFILTER_SOURCE_EXECUTIONS_METRIC, partition),
-            multimatch_prefilter_materialization_duration: metrics.new_time(
-                MULTIMATCH_PREFILTER_MATERIALIZATION_DURATION_METRIC,
-                partition,
-            ),
             scorer_build_ms: metrics.new_gauge("scorer_build_ms", partition),
             segment_bind_duration: metrics.new_time(FTS_SEGMENT_BIND_DURATION_METRIC, partition),
             baseline_metrics: BaselineMetrics::new(metrics, partition),
@@ -2319,13 +2307,6 @@ impl FtsIndexMetrics {
 
     fn record_wand_seeded_fallback_comparisons(&self, comparisons: usize) {
         self.wand_seeded_fallback_comparisons.add(comparisons);
-    }
-
-    fn shared_prefilter_metrics(&self) -> SharedPreFilterMetrics {
-        SharedPreFilterMetrics {
-            source_executions: self.multimatch_prefilter_source_executions.clone(),
-            materialization_duration: self.multimatch_prefilter_materialization_duration.clone(),
-        }
     }
 }
 
@@ -2946,7 +2927,6 @@ impl ExecutionPlan for MatchQueryExec {
                     overlay_block,
                     external_mask,
                 },
-                metrics.shared_prefilter_metrics(),
             )?;
             let deleted_fragments =
                 indices
@@ -4246,7 +4226,6 @@ impl ExecutionPlan for PhraseQueryExec {
                     overlay_block,
                     external_mask,
                 },
-                metrics.shared_prefilter_metrics(),
             )?;
             let deleted_fragments =
                 indices

--- a/rust/lance/src/io/exec/fts.rs
+++ b/rust/lance/src/io/exec/fts.rs
@@ -37,7 +37,7 @@ use lance_select::RowAddrMask;
 use lance_table::format::IndexMetadata;
 
 use super::PreFilterSource;
-use super::utils::{IndexMetrics, build_prefilter};
+use super::utils::{IndexMetrics, SharedPreFilterMetrics, build_prefilter};
 use crate::index::scalar::inverted::{
     ResolvedFtsField, fts_document_schema, load_segment_details, load_segments,
     transform_fts_document_stream,
@@ -56,7 +56,9 @@ use lance_index::metrics::{
     COMPOUND_SHOULD_NON_ESSENTIAL_EVALUATIONS_METRIC, COMPOUND_SHOULD_SKIPPED_WINDOWS_METRIC,
     CROSS_COLUMN_STAGED_ATTEMPTS_METRIC, CROSS_COLUMN_STAGED_CANDIDATES_METRIC,
     CROSS_COLUMN_STAGED_FALLBACKS_METRIC, CROSS_COLUMN_STAGED_SUCCESSES_METRIC,
-    FREQS_COLLECTED_METRIC, MetricsCollector, NO_IMPACT_GLOBAL_SCORER_FALLBACKS_METRIC,
+    FREQS_COLLECTED_METRIC, MULTIMATCH_PREFILTER_MATERIALIZATION_DURATION_METRIC,
+    MULTIMATCH_PREFILTER_SOURCE_EXECUTIONS_METRIC, MetricsCollector,
+    NO_IMPACT_GLOBAL_SCORER_FALLBACKS_METRIC,
     WAND_EXACTNESS_CERTIFICATE_ATTEMPTS_METRIC, WAND_EXACTNESS_CERTIFICATE_CANDIDATES_METRIC,
     WAND_EXACTNESS_CERTIFICATE_EXHAUSTIVE_METRIC, WAND_EXACTNESS_CERTIFICATE_FALLBACKS_METRIC,
     WAND_EXACTNESS_CERTIFICATE_STRICT_METRIC, WAND_EXACTNESS_PROBE_COMPARISONS_METRIC,
@@ -933,12 +935,7 @@ impl ExecutionPlan for CompoundQueryExec {
     }
 
     fn children(&self) -> Vec<&Arc<dyn ExecutionPlan>> {
-        match &self.prefilter_source {
-            PreFilterSource::None => vec![],
-            PreFilterSource::FilteredRowIds(source) | PreFilterSource::ScalarIndexQuery(source) => {
-                vec![source]
-            }
-        }
+        self.prefilter_source.execution_plan().into_iter().collect()
     }
 
     fn required_input_distribution(&self) -> Vec<Distribution> {
@@ -960,17 +957,7 @@ impl ExecutionPlan for CompoundQueryExec {
                         "compound FTS lost its prefilter child".to_string(),
                     ));
                 };
-                match &self.prefilter_source {
-                    PreFilterSource::FilteredRowIds(_) => PreFilterSource::FilteredRowIds(source),
-                    PreFilterSource::ScalarIndexQuery(_) => {
-                        PreFilterSource::ScalarIndexQuery(source)
-                    }
-                    PreFilterSource::None => {
-                        return Err(DataFusionError::Internal(
-                            "compound FTS received an unexpected prefilter child".to_string(),
-                        ));
-                    }
-                }
+                self.prefilter_source.with_execution_plan(source)?
             }
             count => {
                 return Err(DataFusionError::Internal(format!(
@@ -1061,6 +1048,7 @@ impl ExecutionPlan for CompoundQueryExec {
                 &segments,
                 None,
                 external_mask,
+                metrics.shared_prefilter_metrics(),
             )?;
             let deleted_fragments =
                 indices
@@ -1553,12 +1541,7 @@ impl ExecutionPlan for CrossColumnCompoundQueryExec {
     }
 
     fn children(&self) -> Vec<&Arc<dyn ExecutionPlan>> {
-        match &self.prefilter_source {
-            PreFilterSource::None => vec![],
-            PreFilterSource::FilteredRowIds(source) | PreFilterSource::ScalarIndexQuery(source) => {
-                vec![source]
-            }
-        }
+        self.prefilter_source.execution_plan().into_iter().collect()
     }
 
     fn required_input_distribution(&self) -> Vec<Distribution> {
@@ -1580,18 +1563,7 @@ impl ExecutionPlan for CrossColumnCompoundQueryExec {
                         "cross-column compound FTS lost its prefilter child".to_string(),
                     ));
                 };
-                match &self.prefilter_source {
-                    PreFilterSource::FilteredRowIds(_) => PreFilterSource::FilteredRowIds(source),
-                    PreFilterSource::ScalarIndexQuery(_) => {
-                        PreFilterSource::ScalarIndexQuery(source)
-                    }
-                    PreFilterSource::None => {
-                        return Err(DataFusionError::Internal(
-                            "cross-column compound FTS received an unexpected prefilter child"
-                                .to_string(),
-                        ));
-                    }
-                }
+                self.prefilter_source.with_execution_plan(source)?
             }
             count => {
                 return Err(DataFusionError::Internal(format!(
@@ -1661,6 +1633,7 @@ impl ExecutionPlan for CrossColumnCompoundQueryExec {
                 &selected_segments,
                 None,
                 external_mask,
+                metrics.shared_prefilter_metrics(),
             )?;
             let opened_columns = try_join_all(columns.iter().cloned().map(|selection| {
                 let dataset = dataset.clone();
@@ -2197,6 +2170,8 @@ pub struct FtsIndexMetrics {
     wand_seeded_fallback_ms: Gauge,
     wand_seeded_fallback_comparisons: Count,
     no_impact_global_scorer_fallbacks: Count,
+    multimatch_prefilter_source_executions: Count,
+    multimatch_prefilter_materialization_duration: Time,
     /// Wall time (ms) of the exec-local `build_global_bm25_scorer`
     /// fallback; zero when a preset base scorer was injected.
     scorer_build_ms: Gauge,
@@ -2290,6 +2265,12 @@ impl FtsIndexMetrics {
                 .new_count(WAND_SEEDED_FALLBACK_COMPARISONS_METRIC, partition),
             no_impact_global_scorer_fallbacks: metrics
                 .new_count(NO_IMPACT_GLOBAL_SCORER_FALLBACKS_METRIC, partition),
+            multimatch_prefilter_source_executions: metrics
+                .new_count(MULTIMATCH_PREFILTER_SOURCE_EXECUTIONS_METRIC, partition),
+            multimatch_prefilter_materialization_duration: metrics.new_time(
+                MULTIMATCH_PREFILTER_MATERIALIZATION_DURATION_METRIC,
+                partition,
+            ),
             scorer_build_ms: metrics.new_gauge("scorer_build_ms", partition),
             segment_bind_duration: metrics.new_time(FTS_SEGMENT_BIND_DURATION_METRIC, partition),
             baseline_metrics: BaselineMetrics::new(metrics, partition),
@@ -2334,6 +2315,13 @@ impl FtsIndexMetrics {
 
     fn record_wand_seeded_fallback_comparisons(&self, comparisons: usize) {
         self.wand_seeded_fallback_comparisons.add(comparisons);
+    }
+
+    fn shared_prefilter_metrics(&self) -> SharedPreFilterMetrics {
+        SharedPreFilterMetrics {
+            source_executions: self.multimatch_prefilter_source_executions.clone(),
+            materialization_duration: self.multimatch_prefilter_materialization_duration.clone(),
+        }
     }
 }
 
@@ -2825,11 +2813,7 @@ impl ExecutionPlan for MatchQueryExec {
     }
 
     fn children(&self) -> Vec<&Arc<dyn ExecutionPlan>> {
-        match &self.prefilter_source {
-            PreFilterSource::None => vec![],
-            PreFilterSource::FilteredRowIds(src) => vec![&src],
-            PreFilterSource::ScalarIndexQuery(src) => vec![&src],
-        }
+        self.prefilter_source.execution_plan().into_iter().collect()
     }
 
     fn required_input_distribution(&self) -> Vec<Distribution> {
@@ -2872,19 +2856,7 @@ impl ExecutionPlan for MatchQueryExec {
             }
             1 => {
                 let src = children.pop().unwrap();
-                let prefilter_source = match &self.prefilter_source {
-                    PreFilterSource::FilteredRowIds(_) => {
-                        PreFilterSource::FilteredRowIds(src.clone())
-                    }
-                    PreFilterSource::ScalarIndexQuery(_) => {
-                        PreFilterSource::ScalarIndexQuery(src.clone())
-                    }
-                    PreFilterSource::None => {
-                        return Err(DataFusionError::Internal(
-                            "Unexpected prefilter source".to_string(),
-                        ));
-                    }
-                };
+                let prefilter_source = self.prefilter_source.with_execution_plan(src)?;
 
                 Self {
                     dataset: self.dataset.clone(),
@@ -2968,6 +2940,7 @@ impl ExecutionPlan for MatchQueryExec {
                 &segments,
                 overlay_block,
                 external_mask,
+                metrics.shared_prefilter_metrics(),
             )?;
             let deleted_fragments =
                 indices
@@ -4153,11 +4126,7 @@ impl ExecutionPlan for PhraseQueryExec {
     }
 
     fn children(&self) -> Vec<&Arc<dyn ExecutionPlan>> {
-        match &self.prefilter_source {
-            PreFilterSource::None => vec![],
-            PreFilterSource::FilteredRowIds(src) => vec![&src],
-            PreFilterSource::ScalarIndexQuery(src) => vec![&src],
-        }
+        self.prefilter_source.execution_plan().into_iter().collect()
     }
 
     fn required_input_distribution(&self) -> Vec<Distribution> {
@@ -4173,37 +4142,32 @@ impl ExecutionPlan for PhraseQueryExec {
         mut children: Vec<Arc<dyn ExecutionPlan>>,
     ) -> DataFusionResult<Arc<dyn ExecutionPlan>> {
         let plan = match children.len() {
-            0 => Self {
-                dataset: self.dataset.clone(),
-                query: self.query.clone(),
-                tokenized_query: self.tokenized_query.clone(),
-                params: self.params.clone(),
-                prefilter_source: PreFilterSource::None,
-                base_scorer: self.base_scorer.clone(),
-                shared_scorer: self.shared_scorer.clone(),
-                segment_selection: self.segment_selection.clone(),
-                overlay_block: self.overlay_block.clone(),
-                document_granularity: self.document_granularity,
-                schema: self.schema.clone(),
-                external_mask: self.external_mask.clone(),
-                properties: self.properties.clone(),
-                metrics: ExecutionPlanMetricsSet::new(),
-            },
+            0 => {
+                if !matches!(self.prefilter_source, PreFilterSource::None) {
+                    return Err(DataFusionError::Internal(
+                        "Unexpected prefilter source".to_string(),
+                    ));
+                }
+                Self {
+                    dataset: self.dataset.clone(),
+                    query: self.query.clone(),
+                    tokenized_query: self.tokenized_query.clone(),
+                    params: self.params.clone(),
+                    prefilter_source: PreFilterSource::None,
+                    base_scorer: self.base_scorer.clone(),
+                    shared_scorer: self.shared_scorer.clone(),
+                    segment_selection: self.segment_selection.clone(),
+                    overlay_block: self.overlay_block.clone(),
+                    document_granularity: self.document_granularity,
+                    schema: self.schema.clone(),
+                    external_mask: self.external_mask.clone(),
+                    properties: self.properties.clone(),
+                    metrics: ExecutionPlanMetricsSet::new(),
+                }
+            }
             1 => {
                 let src = children.pop().unwrap();
-                let prefilter_source = match &self.prefilter_source {
-                    PreFilterSource::FilteredRowIds(_) => {
-                        PreFilterSource::FilteredRowIds(src.clone())
-                    }
-                    PreFilterSource::ScalarIndexQuery(_) => {
-                        PreFilterSource::ScalarIndexQuery(src.clone())
-                    }
-                    PreFilterSource::None => {
-                        return Err(DataFusionError::Internal(
-                            "Unexpected prefilter source".to_string(),
-                        ));
-                    }
-                };
+                let prefilter_source = self.prefilter_source.with_execution_plan(src)?;
                 Self {
                     dataset: self.dataset.clone(),
                     query: self.query.clone(),
@@ -4274,6 +4238,7 @@ impl ExecutionPlan for PhraseQueryExec {
                 &segments,
                 overlay_block,
                 external_mask,
+                metrics.shared_prefilter_metrics(),
             )?;
             let deleted_fragments =
                 indices

--- a/rust/lance/src/io/exec/fts.rs
+++ b/rust/lance/src/io/exec/fts.rs
@@ -37,7 +37,7 @@ use lance_select::RowAddrMask;
 use lance_table::format::IndexMetadata;
 
 use super::PreFilterSource;
-use super::utils::{IndexMetrics, SharedPreFilterMetrics, build_prefilter};
+use super::utils::{IndexMetrics, PreFilterMasks, SharedPreFilterMetrics, build_prefilter};
 use crate::index::scalar::inverted::{
     ResolvedFtsField, fts_document_schema, load_segment_details, load_segments,
     transform_fts_document_stream,
@@ -1046,8 +1046,10 @@ impl ExecutionPlan for CompoundQueryExec {
                 &prefilter_source,
                 dataset,
                 &segments,
-                None,
-                external_mask,
+                PreFilterMasks {
+                    overlay_block: None,
+                    external_mask,
+                },
                 metrics.shared_prefilter_metrics(),
             )?;
             let deleted_fragments =
@@ -1631,8 +1633,10 @@ impl ExecutionPlan for CrossColumnCompoundQueryExec {
                 &prefilter_source,
                 dataset.clone(),
                 &selected_segments,
-                None,
-                external_mask,
+                PreFilterMasks {
+                    overlay_block: None,
+                    external_mask,
+                },
                 metrics.shared_prefilter_metrics(),
             )?;
             let opened_columns = try_join_all(columns.iter().cloned().map(|selection| {
@@ -2938,8 +2942,10 @@ impl ExecutionPlan for MatchQueryExec {
                 &prefilter_source,
                 ds,
                 &segments,
-                overlay_block,
-                external_mask,
+                PreFilterMasks {
+                    overlay_block,
+                    external_mask,
+                },
                 metrics.shared_prefilter_metrics(),
             )?;
             let deleted_fragments =
@@ -4236,8 +4242,10 @@ impl ExecutionPlan for PhraseQueryExec {
                 &prefilter_source,
                 ds,
                 &segments,
-                overlay_block,
-                external_mask,
+                PreFilterMasks {
+                    overlay_block,
+                    external_mask,
+                },
                 metrics.shared_prefilter_metrics(),
             )?;
             let deleted_fragments =

--- a/rust/lance/src/io/exec/utils.rs
+++ b/rust/lance/src/io/exec/utils.rs
@@ -10,6 +10,7 @@ use lance_index::metrics::MetricsCollector;
 use lance_io::scheduler::{IoStats, ScanScheduler, ScanStats};
 use lance_table::format::IndexMetadata;
 use pin_project::pin_project;
+use std::collections::HashMap;
 use std::future::Future;
 use std::pin::Pin;
 use std::sync::{Arc, Mutex};
@@ -21,11 +22,15 @@ use async_trait::async_trait;
 use datafusion::common::runtime::SpawnedTask;
 use datafusion::error::{DataFusionError, Result as DataFusionResult};
 use datafusion::physical_plan::metrics::{
-    BaselineMetrics, Count, ExecutionPlanMetricsSet, Gauge, MetricBuilder, MetricValue,
+    BaselineMetrics, Count, ExecutionPlanMetricsSet, Gauge, MetricBuilder, MetricValue, Time,
 };
 use datafusion::physical_plan::{
-    DisplayAs, DisplayFormatType, ExecutionPlan, RecordBatchStream, SendableRecordBatchStream,
+    DisplayAs, DisplayFormatType, ExecutionPlan, PlanProperties, RecordBatchStream,
+    SendableRecordBatchStream,
 };
+use datafusion_physical_expr::{Distribution, EquivalenceProperties, Partitioning};
+use datafusion_physical_plan::execution_plan::{Boundedness, EmissionType};
+use futures::future::{BoxFuture, Shared};
 use futures::stream::FuturesUnordered;
 use futures::{FutureExt, Stream, StreamExt, TryStreamExt};
 use lance_core::error::{CloneableResult, Error};
@@ -71,6 +76,299 @@ pub enum PreFilterSource {
     None,
 }
 
+type SharedPreFilterFuture = Shared<BoxFuture<'static, CloneableResult<Arc<RowAddrMask>>>>;
+
+struct SharedPreFilterEntry {
+    context: std::sync::Weak<datafusion::execution::TaskContext>,
+    future: SharedPreFilterFuture,
+    waiters: usize,
+    is_complete: bool,
+    generation: u64,
+}
+
+/// Query-plan-local materialization state for a MultiMatch base prefilter.
+///
+/// Entries are keyed by task-context identity and partition. This prevents a
+/// reused physical plan from carrying a mask into a later query and keeps an
+/// accidental multi-partition execution from sharing across input partitions.
+/// The mutex is held only while installing or cloning a future; prefilter
+/// execution never runs under it.
+struct SharedPreFilterMaterialization {
+    queries: Mutex<HashMap<(usize, usize), SharedPreFilterEntry>>,
+    next_generation: std::sync::atomic::AtomicU64,
+}
+
+impl std::fmt::Debug for SharedPreFilterMaterialization {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let queries = self
+            .queries
+            .lock()
+            .map(|queries| queries.len())
+            .unwrap_or_default();
+        f.debug_struct("SharedPreFilterMaterialization")
+            .field("queries", &queries)
+            .finish()
+    }
+}
+
+impl SharedPreFilterMaterialization {
+    fn new() -> Self {
+        Self {
+            queries: Mutex::new(HashMap::new()),
+            next_generation: std::sync::atomic::AtomicU64::new(0),
+        }
+    }
+}
+
+#[derive(Debug)]
+struct SharedPreFilterExec {
+    source: Arc<dyn ExecutionPlan>,
+    materialization: Arc<SharedPreFilterMaterialization>,
+    properties: Arc<PlanProperties>,
+}
+
+impl SharedPreFilterExec {
+    fn new(
+        source: Arc<dyn ExecutionPlan>,
+        materialization: Arc<SharedPreFilterMaterialization>,
+    ) -> Self {
+        Self {
+            properties: Arc::new(PlanProperties::new(
+                EquivalenceProperties::new(source.schema()),
+                Partitioning::UnknownPartitioning(1),
+                EmissionType::Final,
+                Boundedness::Bounded,
+            )),
+            source,
+            materialization,
+        }
+    }
+}
+
+impl DisplayAs for SharedPreFilterExec {
+    fn fmt_as(&self, _t: DisplayFormatType, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "SharedMultiMatchPrefilter")
+    }
+}
+
+impl ExecutionPlan for SharedPreFilterExec {
+    fn name(&self) -> &str {
+        "SharedPreFilterExec"
+    }
+
+    fn children(&self) -> Vec<&Arc<dyn ExecutionPlan>> {
+        vec![&self.source]
+    }
+
+    fn required_input_distribution(&self) -> Vec<Distribution> {
+        self.children()
+            .iter()
+            .map(|_| Distribution::SinglePartition)
+            .collect()
+    }
+
+    fn with_new_children(
+        self: Arc<Self>,
+        mut children: Vec<Arc<dyn ExecutionPlan>>,
+    ) -> DataFusionResult<Arc<dyn ExecutionPlan>> {
+        let source = match children.len() {
+            1 => children.pop().ok_or_else(|| {
+                DataFusionError::Internal(
+                    "shared MultiMatch prefilter lost its source child".to_string(),
+                )
+            })?,
+            count => {
+                return Err(DataFusionError::Internal(format!(
+                    "shared MultiMatch prefilter expected one child, got {count}"
+                )));
+            }
+        };
+        Ok(Arc::new(Self::new(source, self.materialization.clone())))
+    }
+
+    fn execute(
+        &self,
+        _partition: usize,
+        _context: Arc<datafusion::execution::TaskContext>,
+    ) -> DataFusionResult<SendableRecordBatchStream> {
+        Err(DataFusionError::Internal(
+            "shared MultiMatch prefilter must be materialized by its FTS consumer".to_string(),
+        ))
+    }
+
+    fn properties(&self) -> &Arc<PlanProperties> {
+        &self.properties
+    }
+}
+
+#[derive(Clone)]
+pub(crate) struct SharedPreFilterMetrics {
+    pub source_executions: Count,
+    pub materialization_duration: Time,
+}
+
+impl PreFilterSource {
+    /// Return a plan-local shared form for a MultiMatch with multiple fields.
+    /// No-filter and already-shared sources retain their existing identity.
+    pub(crate) fn shared_for_multimatch_fields(&self, field_count: usize) -> Vec<Self> {
+        if field_count <= 1 {
+            return vec![self.clone(); field_count];
+        }
+        match self {
+            Self::FilteredRowIds(source) | Self::ScalarIndexQuery(source) => {
+                let materialization = Arc::new(SharedPreFilterMaterialization::new());
+                (0..field_count)
+                    .map(|_| {
+                        let shared = Arc::new(SharedPreFilterExec::new(
+                            source.clone(),
+                            materialization.clone(),
+                        ));
+                        if matches!(self, Self::FilteredRowIds(_)) {
+                            Self::FilteredRowIds(shared)
+                        } else {
+                            Self::ScalarIndexQuery(shared)
+                        }
+                    })
+                    .collect()
+            }
+            Self::None => vec![self.clone(); field_count],
+        }
+    }
+
+    pub(crate) fn execution_plan(&self) -> Option<&Arc<dyn ExecutionPlan>> {
+        match self {
+            Self::FilteredRowIds(source) | Self::ScalarIndexQuery(source) => Some(source),
+            Self::None => None,
+        }
+    }
+
+    pub(crate) fn with_execution_plan(
+        &self,
+        source: Arc<dyn ExecutionPlan>,
+    ) -> DataFusionResult<Self> {
+        match self {
+            Self::FilteredRowIds(_) => Ok(Self::FilteredRowIds(source)),
+            Self::ScalarIndexQuery(_) => Ok(Self::ScalarIndexQuery(source)),
+            Self::None => Err(DataFusionError::Internal(
+                "prefilter source received an unexpected execution-plan child".to_string(),
+            )),
+        }
+    }
+}
+
+struct SharedPreFilterWaiter {
+    materialization: Arc<SharedPreFilterMaterialization>,
+    key: (usize, usize),
+    generation: u64,
+}
+
+impl SharedPreFilterWaiter {
+    fn mark_complete(&self) {
+        if let Ok(mut queries) = self.materialization.queries.lock()
+            && let Some(entry) = queries.get_mut(&self.key)
+            && entry.generation == self.generation
+        {
+            entry.is_complete = true;
+        }
+    }
+}
+
+impl Drop for SharedPreFilterWaiter {
+    fn drop(&mut self) {
+        let Ok(mut queries) = self.materialization.queries.lock() else {
+            return;
+        };
+        let should_remove = if let Some(entry) = queries.get_mut(&self.key)
+            && entry.generation == self.generation
+        {
+            let Some(waiters) = entry.waiters.checked_sub(1) else {
+                debug_assert!(false, "shared prefilter waiter count underflowed");
+                return;
+            };
+            entry.waiters = waiters;
+            entry.waiters == 0 && !entry.is_complete
+        } else {
+            false
+        };
+        if should_remove {
+            queries.remove(&self.key);
+        }
+    }
+}
+
+fn shared_prefilter_future(
+    materialization: Arc<SharedPreFilterMaterialization>,
+    source: Arc<dyn ExecutionPlan>,
+    is_scalar_index_query: bool,
+    context: Arc<datafusion::execution::TaskContext>,
+    partition: usize,
+    metrics: SharedPreFilterMetrics,
+) -> BoxFuture<'static, Result<Arc<RowAddrMask>>> {
+    async move {
+        let context_id = Arc::as_ptr(&context) as usize;
+        let key = (context_id, partition);
+        let (future, generation) = {
+            let mut queries = materialization.queries.lock().map_err(|_| {
+                Error::internal("MultiMatch prefilter materialization lock was poisoned")
+            })?;
+            queries.retain(|_, entry| entry.context.strong_count() > 0);
+            if let Some(entry) = queries.get_mut(&key) {
+                entry.waiters = entry.waiters.checked_add(1).ok_or_else(|| {
+                    Error::internal("MultiMatch prefilter waiter count overflowed")
+                })?;
+                (entry.future.clone(), entry.generation)
+            } else {
+                let generation = materialization
+                    .next_generation
+                    .fetch_update(
+                        std::sync::atomic::Ordering::Relaxed,
+                        std::sync::atomic::Ordering::Relaxed,
+                        |generation| generation.checked_add(1),
+                    )
+                    .map_err(|_| {
+                        Error::internal("MultiMatch prefilter generation counter overflowed")
+                    })?;
+                let entry = SharedPreFilterEntry {
+                    context: Arc::downgrade(&context),
+                    future: {
+                        async move {
+                            metrics.source_executions.add(1);
+                            let _timer = metrics.materialization_duration.timer();
+                            let result = async move {
+                                let stream = source.execute(partition, context)?;
+                                if is_scalar_index_query {
+                                    Box::new(SelectionVectorToPrefilter(stream)).load().await
+                                } else {
+                                    Box::new(FilteredRowIdsToPrefilter(stream)).load().await
+                                }
+                            }
+                            .await;
+                            CloneableResult::from(result.map(Arc::new))
+                        }
+                        .boxed()
+                        .shared()
+                    },
+                    waiters: 1,
+                    is_complete: false,
+                    generation,
+                };
+                let future = entry.future.clone();
+                queries.insert(key, entry);
+                (future, generation)
+            }
+        };
+        let waiter = SharedPreFilterWaiter {
+            materialization,
+            key,
+            generation,
+        };
+        let CloneableResult(result) = future.await;
+        waiter.mark_complete();
+        result.map_err(|error| error.0)
+    }
+    .boxed()
+}
+
 pub(crate) fn build_prefilter(
     context: Arc<datafusion::execution::TaskContext>,
     partition: usize,
@@ -79,15 +377,41 @@ pub(crate) fn build_prefilter(
     index_meta: &[IndexMetadata],
     overlay_block: Option<RowAddrMask>,
     external_mask: Option<Arc<RowAddrMask>>,
+    shared_metrics: SharedPreFilterMetrics,
 ) -> Result<Arc<DatasetPreFilter>> {
+    let mut shared_filter = None;
     let prefilter_loader = match &prefilter_source {
         PreFilterSource::FilteredRowIds(src_node) => {
-            let stream = src_node.execute(partition, context)?;
-            Some(Box::new(FilteredRowIdsToPrefilter(stream)) as Box<dyn FilterLoader>)
+            if let Some(shared) = src_node.downcast_ref::<SharedPreFilterExec>() {
+                shared_filter = Some(shared_prefilter_future(
+                    shared.materialization.clone(),
+                    shared.source.clone(),
+                    false,
+                    context,
+                    partition,
+                    shared_metrics,
+                ));
+                None
+            } else {
+                let stream = src_node.execute(partition, context)?;
+                Some(Box::new(FilteredRowIdsToPrefilter(stream)) as Box<dyn FilterLoader>)
+            }
         }
         PreFilterSource::ScalarIndexQuery(src_node) => {
-            let stream = src_node.execute(partition, context)?;
-            Some(Box::new(SelectionVectorToPrefilter(stream)) as Box<dyn FilterLoader>)
+            if let Some(shared) = src_node.downcast_ref::<SharedPreFilterExec>() {
+                shared_filter = Some(shared_prefilter_future(
+                    shared.materialization.clone(),
+                    shared.source.clone(),
+                    true,
+                    context,
+                    partition,
+                    shared_metrics,
+                ));
+                None
+            } else {
+                let stream = src_node.execute(partition, context)?;
+                Some(Box::new(SelectionVectorToPrefilter(stream)) as Box<dyn FilterLoader>)
+            }
         }
         PreFilterSource::None => None,
     };
@@ -95,13 +419,26 @@ pub(crate) fn build_prefilter(
     // filter produced, so an FTS prefilter restricts BM25 scoring to masked rows
     // (mirrors the ANN path). Independent of `overlay_block`, which the prefilter
     // applies separately to drop index entries staled by a data overlay.
-    let prefilter_loader = match external_mask {
-        Some(mask) => {
-            Some(Box::new(MaskAndLoader::new(mask, prefilter_loader)) as Box<dyn FilterLoader>)
-        }
-        None => prefilter_loader,
+    let mut prefilter = if let Some(shared_filter) = shared_filter {
+        let shared_filter = match external_mask {
+            Some(mask) => async move {
+                Ok(Arc::new(
+                    mask.as_ref().clone() & shared_filter.await?.as_ref().clone(),
+                ))
+            }
+            .boxed(),
+            None => shared_filter,
+        };
+        DatasetPreFilter::new_with_filter_future(ds, index_meta, Some(shared_filter))
+    } else {
+        let prefilter_loader = match external_mask {
+            Some(mask) => {
+                Some(Box::new(MaskAndLoader::new(mask, prefilter_loader)) as Box<dyn FilterLoader>)
+            }
+            None => prefilter_loader,
+        };
+        DatasetPreFilter::new(ds, index_meta, prefilter_loader)
     };
-    let mut prefilter = DatasetPreFilter::new(ds, index_meta, prefilter_loader);
     if let Some(overlay_block) = overlay_block {
         prefilter = prefilter.with_overlay_block(overlay_block);
     }
@@ -618,9 +955,11 @@ mod tests {
 
     use std::sync::Arc;
 
-    use arrow_array::{RecordBatchReader, types::UInt32Type};
-    use arrow_schema::SortOptions;
+    use arrow_array::{RecordBatch, RecordBatchReader, UInt64Array, types::UInt32Type};
+    use arrow_schema::{DataType, Field, Schema, SortOptions};
     use datafusion::common::NullEquality;
+    use datafusion::error::{DataFusionError, Result as DataFusionResult};
+    use datafusion::physical_plan::metrics::{Count, Time};
     use datafusion::{
         logical_expr::JoinType,
         physical_expr::expressions::Column,
@@ -628,12 +967,297 @@ mod tests {
             ExecutionPlan, joins::SortMergeJoinExec, stream::RecordBatchStreamAdapter,
         },
     };
-    use futures::{StreamExt, TryStreamExt};
-    use lance_core::utils::futures::Capacity;
+    use futures::{StreamExt, TryStreamExt, stream};
+    use lance_core::{ROW_ID, utils::futures::Capacity};
     use lance_datafusion::exec::OneShotExec;
     use lance_datagen::{BatchCount, RowCount, array};
+    use lance_select::result::IndexExprResultWireFormat;
+    use lance_select::{RowAddrMask, RowAddrTreeMap, RowSetOps, result::IndexExprResult};
+    use roaring::RoaringBitmap;
+    use rstest::rstest;
 
-    use super::{InstrumentedChildInputStream, ReplayExec};
+    use super::{
+        InstrumentedChildInputStream, PreFilterSource, ReplayExec, SharedPreFilterExec,
+        SharedPreFilterMaterialization, SharedPreFilterMetrics, shared_prefilter_future,
+    };
+
+    fn prefilter_metrics() -> SharedPreFilterMetrics {
+        SharedPreFilterMetrics {
+            source_executions: Count::new(),
+            materialization_duration: Time::new(),
+        }
+    }
+
+    fn prefilter_source(is_scalar_index_query: bool, is_empty: bool) -> PreFilterSource {
+        let mask = if is_empty {
+            RowAddrMask::allow_nothing()
+        } else {
+            RowAddrMask::from_allowed(RowAddrTreeMap::from_iter(0_u64..4))
+        };
+        let batch = if is_scalar_index_query {
+            IndexExprResult::exact(mask)
+                .serialize(
+                    &RoaringBitmap::from_iter([0_u32]),
+                    IndexExprResultWireFormat::TwoMask,
+                )
+                .unwrap()
+        } else {
+            let row_ids = if is_empty {
+                UInt64Array::from(Vec::<u64>::new())
+            } else {
+                UInt64Array::from_iter_values(0_u64..4)
+            };
+            RecordBatch::try_new(
+                Arc::new(Schema::new(vec![Field::new(
+                    ROW_ID,
+                    DataType::UInt64,
+                    false,
+                )])),
+                vec![Arc::new(row_ids)],
+            )
+            .unwrap()
+        };
+        let source = Arc::new(OneShotExec::from_batch(batch));
+        if is_scalar_index_query {
+            PreFilterSource::ScalarIndexQuery(source)
+        } else {
+            PreFilterSource::FilteredRowIds(source)
+        }
+    }
+
+    fn shared_materialization(source: &PreFilterSource) -> Arc<SharedPreFilterMaterialization> {
+        match source {
+            PreFilterSource::FilteredRowIds(source) | PreFilterSource::ScalarIndexQuery(source) => {
+                source
+                    .downcast_ref::<SharedPreFilterExec>()
+                    .expect("expected a shared prefilter source")
+                    .materialization
+                    .clone()
+            }
+            _ => panic!("expected a shared prefilter source"),
+        }
+    }
+
+    fn shared_source(source: &PreFilterSource) -> Arc<dyn ExecutionPlan> {
+        match source {
+            PreFilterSource::FilteredRowIds(source) | PreFilterSource::ScalarIndexQuery(source) => {
+                source
+                    .downcast_ref::<SharedPreFilterExec>()
+                    .expect("expected a shared prefilter source")
+                    .source
+                    .clone()
+            }
+            _ => panic!("expected a shared prefilter source"),
+        }
+    }
+
+    #[rstest]
+    #[case::two_fields(2)]
+    #[case::four_fields(4)]
+    #[case::eight_fields(8)]
+    #[tokio::test]
+    async fn shared_multimatch_prefilter_materializes_once(
+        #[case] field_count: usize,
+        #[values(false, true)] is_scalar_index_query: bool,
+        #[values(false, true)] is_empty: bool,
+    ) {
+        let shared_sources = prefilter_source(is_scalar_index_query, is_empty)
+            .shared_for_multimatch_fields(field_count);
+        assert_eq!(
+            shared_sources
+                .iter()
+                .filter(|source| source.execution_plan().is_some())
+                .count(),
+            field_count,
+            "every field must declare its shared source dependency"
+        );
+        let metrics = prefilter_metrics();
+        let context = Arc::new(datafusion::execution::TaskContext::default());
+        let masks = futures::future::try_join_all(shared_sources.iter().map(|source| {
+            shared_prefilter_future(
+                shared_materialization(source),
+                shared_source(source),
+                is_scalar_index_query,
+                context.clone(),
+                0,
+                metrics.clone(),
+            )
+        }))
+        .await
+        .unwrap();
+
+        assert_eq!(metrics.source_executions.value(), 1);
+        assert!(masks.windows(2).all(|pair| Arc::ptr_eq(&pair[0], &pair[1])));
+        assert_eq!(masks[0].allow_list().unwrap().is_empty(), is_empty);
+    }
+
+    #[test]
+    fn no_filter_and_single_field_do_not_install_sharing() {
+        let no_filter = PreFilterSource::None.shared_for_multimatch_fields(8);
+        assert!(
+            no_filter
+                .iter()
+                .all(|source| matches!(source, PreFilterSource::None))
+        );
+
+        let single = prefilter_source(false, false).shared_for_multimatch_fields(1);
+        assert!(matches!(
+            single.as_slice(),
+            [PreFilterSource::FilteredRowIds(_)]
+        ));
+    }
+
+    #[tokio::test]
+    async fn shared_multimatch_prefilter_caches_source_error() {
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            ROW_ID,
+            DataType::UInt64,
+            false,
+        )]));
+        let stream = Box::pin(RecordBatchStreamAdapter::new(
+            schema,
+            stream::iter(vec![Err(DataFusionError::Execution(
+                "shared prefilter failure".to_string(),
+            ))]),
+        ));
+        let source = PreFilterSource::FilteredRowIds(Arc::new(OneShotExec::new(stream)));
+        let shared_sources = source.shared_for_multimatch_fields(2);
+        let metrics = prefilter_metrics();
+        let context = Arc::new(datafusion::execution::TaskContext::default());
+        let left = shared_prefilter_future(
+            shared_materialization(&shared_sources[0]),
+            shared_source(&shared_sources[0]),
+            false,
+            context.clone(),
+            0,
+            metrics.clone(),
+        );
+        let right = shared_prefilter_future(
+            shared_materialization(&shared_sources[1]),
+            shared_source(&shared_sources[1]),
+            false,
+            context,
+            0,
+            metrics.clone(),
+        );
+        let (left, right) = tokio::join!(left, right);
+
+        assert!(
+            left.unwrap_err()
+                .to_string()
+                .contains("shared prefilter failure")
+        );
+        assert!(
+            right
+                .unwrap_err()
+                .to_string()
+                .contains("shared prefilter failure")
+        );
+        assert_eq!(metrics.source_executions.value(), 1);
+    }
+
+    #[tokio::test]
+    async fn shared_multimatch_prefilter_survives_waiter_cancellation() {
+        let batch = RecordBatch::try_new(
+            Arc::new(Schema::new(vec![Field::new(
+                ROW_ID,
+                DataType::UInt64,
+                false,
+            )])),
+            vec![Arc::new(UInt64Array::from_iter_values(0_u64..4))],
+        )
+        .unwrap();
+        let schema = batch.schema();
+        let (release, wait) = tokio::sync::oneshot::channel::<()>();
+        let stream = Box::pin(RecordBatchStreamAdapter::new(
+            schema,
+            stream::once(async move {
+                wait.await.map_err(|error| {
+                    DataFusionError::Execution(format!(
+                        "shared prefilter release sender dropped: {error}"
+                    ))
+                })?;
+                Ok(batch)
+            }),
+        ));
+        let source = PreFilterSource::FilteredRowIds(Arc::new(OneShotExec::new(stream)));
+        let shared_sources = source.shared_for_multimatch_fields(2);
+        let materialization = shared_materialization(&shared_sources[0]);
+        let metrics = prefilter_metrics();
+        let context = Arc::new(datafusion::execution::TaskContext::default());
+        let first = tokio::spawn(shared_prefilter_future(
+            materialization.clone(),
+            shared_source(&shared_sources[0]),
+            false,
+            context.clone(),
+            0,
+            metrics.clone(),
+        ));
+        while metrics.source_executions.value() == 0 {
+            tokio::task::yield_now().await;
+        }
+        let second = tokio::spawn(shared_prefilter_future(
+            materialization.clone(),
+            shared_source(&shared_sources[1]),
+            false,
+            context,
+            0,
+            metrics.clone(),
+        ));
+        loop {
+            let waiters = materialization
+                .queries
+                .lock()
+                .unwrap()
+                .values()
+                .map(|entry| entry.waiters)
+                .sum::<usize>();
+            if waiters == 2 {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+        first.abort();
+        release.send(()).unwrap();
+        let mask = tokio::time::timeout(std::time::Duration::from_secs(5), second)
+            .await
+            .expect("replacement waiter should resume the shared source")
+            .unwrap()
+            .unwrap();
+        assert_eq!(mask.allow_list().unwrap().len(), Some(4));
+        assert_eq!(metrics.source_executions.value(), 1);
+    }
+
+    #[tokio::test]
+    async fn shared_multimatch_prefilter_drops_fully_canceled_query() {
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            ROW_ID,
+            DataType::UInt64,
+            false,
+        )]));
+        let stream = Box::pin(RecordBatchStreamAdapter::new(
+            schema,
+            stream::pending::<DataFusionResult<RecordBatch>>(),
+        ));
+        let source = PreFilterSource::FilteredRowIds(Arc::new(OneShotExec::new(stream)));
+        let shared_sources = source.shared_for_multimatch_fields(2);
+        let materialization = shared_materialization(&shared_sources[0]);
+        let metrics = prefilter_metrics();
+        let waiter = tokio::spawn(shared_prefilter_future(
+            materialization.clone(),
+            shared_source(&shared_sources[0]),
+            false,
+            Arc::new(datafusion::execution::TaskContext::default()),
+            0,
+            metrics.clone(),
+        ));
+        while metrics.source_executions.value() == 0 {
+            tokio::task::yield_now().await;
+        }
+        waiter.abort();
+        assert!(waiter.await.unwrap_err().is_cancelled());
+        assert!(materialization.queries.lock().unwrap().is_empty());
+    }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn instrumented_child_input_stream_excludes_child_poll_time() {

--- a/rust/lance/src/io/exec/utils.rs
+++ b/rust/lance/src/io/exec/utils.rs
@@ -22,7 +22,7 @@ use async_trait::async_trait;
 use datafusion::common::runtime::SpawnedTask;
 use datafusion::error::{DataFusionError, Result as DataFusionResult};
 use datafusion::physical_plan::metrics::{
-    BaselineMetrics, Count, ExecutionPlanMetricsSet, Gauge, MetricBuilder, MetricValue, Time,
+    BaselineMetrics, Count, ExecutionPlanMetricsSet, Gauge, MetricBuilder, MetricValue,
 };
 use datafusion::physical_plan::{
     DisplayAs, DisplayFormatType, ExecutionPlan, PlanProperties, RecordBatchStream,
@@ -201,12 +201,6 @@ impl ExecutionPlan for SharedPreFilterExec {
     }
 }
 
-#[derive(Clone)]
-pub(crate) struct SharedPreFilterMetrics {
-    pub source_executions: Count,
-    pub materialization_duration: Time,
-}
-
 pub(crate) struct PreFilterMasks {
     pub overlay_block: Option<RowAddrMask>,
     pub external_mask: Option<Arc<RowAddrMask>>,
@@ -307,7 +301,6 @@ fn shared_prefilter_future(
     is_scalar_index_query: bool,
     context: Arc<datafusion::execution::TaskContext>,
     partition: usize,
-    metrics: SharedPreFilterMetrics,
 ) -> BoxFuture<'static, Result<Arc<RowAddrMask>>> {
     async move {
         let context_id = Arc::as_ptr(&context) as usize;
@@ -337,8 +330,6 @@ fn shared_prefilter_future(
                     context: Arc::downgrade(&context),
                     future: {
                         async move {
-                            metrics.source_executions.add(1);
-                            let _timer = metrics.materialization_duration.timer();
                             let result = async move {
                                 let stream = source.execute(partition, context)?;
                                 if is_scalar_index_query {
@@ -381,7 +372,6 @@ pub(crate) fn build_prefilter(
     ds: Arc<Dataset>,
     index_meta: &[IndexMetadata],
     masks: PreFilterMasks,
-    shared_metrics: SharedPreFilterMetrics,
 ) -> Result<Arc<DatasetPreFilter>> {
     let mut shared_filter = None;
     let prefilter_loader = match &prefilter_source {
@@ -393,7 +383,6 @@ pub(crate) fn build_prefilter(
                     false,
                     context,
                     partition,
-                    shared_metrics,
                 ));
                 None
             } else {
@@ -409,7 +398,6 @@ pub(crate) fn build_prefilter(
                     true,
                     context,
                     partition,
-                    shared_metrics,
                 ));
                 None
             } else {
@@ -963,7 +951,6 @@ mod tests {
     use arrow_schema::{DataType, Field, Schema, SortOptions};
     use datafusion::common::NullEquality;
     use datafusion::error::{DataFusionError, Result as DataFusionResult};
-    use datafusion::physical_plan::metrics::{Count, Time};
     use datafusion::{
         logical_expr::JoinType,
         physical_expr::expressions::Column,
@@ -982,15 +969,8 @@ mod tests {
 
     use super::{
         InstrumentedChildInputStream, PreFilterSource, ReplayExec, SharedPreFilterExec,
-        SharedPreFilterMaterialization, SharedPreFilterMetrics, shared_prefilter_future,
+        SharedPreFilterMaterialization, shared_prefilter_future,
     };
-
-    fn prefilter_metrics() -> SharedPreFilterMetrics {
-        SharedPreFilterMetrics {
-            source_executions: Count::new(),
-            materialization_duration: Time::new(),
-        }
-    }
 
     fn prefilter_source(is_scalar_index_query: bool, is_empty: bool) -> PreFilterSource {
         let mask = if is_empty {
@@ -1021,6 +1001,8 @@ mod tests {
             )
             .unwrap()
         };
+        // A duplicate source execution fails, so successful concurrent
+        // materialization verifies sharing without production metrics.
         let source = Arc::new(OneShotExec::from_batch(batch));
         if is_scalar_index_query {
             PreFilterSource::ScalarIndexQuery(source)
@@ -1075,7 +1057,6 @@ mod tests {
             field_count,
             "every field must declare its shared source dependency"
         );
-        let metrics = prefilter_metrics();
         let context = Arc::new(datafusion::execution::TaskContext::default());
         let masks = futures::future::try_join_all(shared_sources.iter().map(|source| {
             shared_prefilter_future(
@@ -1084,13 +1065,11 @@ mod tests {
                 is_scalar_index_query,
                 context.clone(),
                 0,
-                metrics.clone(),
             )
         }))
         .await
         .unwrap();
 
-        assert_eq!(metrics.source_executions.value(), 1);
         assert!(masks.windows(2).all(|pair| Arc::ptr_eq(&pair[0], &pair[1])));
         assert_eq!(masks[0].allow_list().unwrap().is_empty(), is_empty);
     }
@@ -1126,7 +1105,6 @@ mod tests {
         ));
         let source = PreFilterSource::FilteredRowIds(Arc::new(OneShotExec::new(stream)));
         let shared_sources = source.shared_for_multimatch_fields(2);
-        let metrics = prefilter_metrics();
         let context = Arc::new(datafusion::execution::TaskContext::default());
         let left = shared_prefilter_future(
             shared_materialization(&shared_sources[0]),
@@ -1134,7 +1112,6 @@ mod tests {
             false,
             context.clone(),
             0,
-            metrics.clone(),
         );
         let right = shared_prefilter_future(
             shared_materialization(&shared_sources[1]),
@@ -1142,7 +1119,6 @@ mod tests {
             false,
             context,
             0,
-            metrics.clone(),
         );
         let (left, right) = tokio::join!(left, right);
 
@@ -1157,7 +1133,6 @@ mod tests {
                 .to_string()
                 .contains("shared prefilter failure")
         );
-        assert_eq!(metrics.source_executions.value(), 1);
     }
 
     #[tokio::test]
@@ -1172,10 +1147,16 @@ mod tests {
         )
         .unwrap();
         let schema = batch.schema();
+        let (started, has_started) = tokio::sync::oneshot::channel::<()>();
         let (release, wait) = tokio::sync::oneshot::channel::<()>();
         let stream = Box::pin(RecordBatchStreamAdapter::new(
             schema,
             stream::once(async move {
+                started.send(()).map_err(|_| {
+                    DataFusionError::Execution(
+                        "shared prefilter startup receiver dropped".to_string(),
+                    )
+                })?;
                 wait.await.map_err(|error| {
                     DataFusionError::Execution(format!(
                         "shared prefilter release sender dropped: {error}"
@@ -1187,7 +1168,6 @@ mod tests {
         let source = PreFilterSource::FilteredRowIds(Arc::new(OneShotExec::new(stream)));
         let shared_sources = source.shared_for_multimatch_fields(2);
         let materialization = shared_materialization(&shared_sources[0]);
-        let metrics = prefilter_metrics();
         let context = Arc::new(datafusion::execution::TaskContext::default());
         let first = tokio::spawn(shared_prefilter_future(
             materialization.clone(),
@@ -1195,18 +1175,17 @@ mod tests {
             false,
             context.clone(),
             0,
-            metrics.clone(),
         ));
-        while metrics.source_executions.value() == 0 {
-            tokio::task::yield_now().await;
-        }
+        tokio::time::timeout(std::time::Duration::from_secs(5), has_started)
+            .await
+            .expect("shared prefilter source should start")
+            .expect("shared prefilter startup sender should remain alive");
         let second = tokio::spawn(shared_prefilter_future(
             materialization.clone(),
             shared_source(&shared_sources[1]),
             false,
             context,
             0,
-            metrics.clone(),
         ));
         loop {
             let waiters = materialization
@@ -1229,7 +1208,6 @@ mod tests {
             .unwrap()
             .unwrap();
         assert_eq!(mask.allow_list().unwrap().len(), Some(4));
-        assert_eq!(metrics.source_executions.value(), 1);
     }
 
     #[tokio::test]
@@ -1239,25 +1217,32 @@ mod tests {
             DataType::UInt64,
             false,
         )]));
+        let (started, has_started) = tokio::sync::oneshot::channel::<()>();
         let stream = Box::pin(RecordBatchStreamAdapter::new(
             schema,
-            stream::pending::<DataFusionResult<RecordBatch>>(),
+            stream::once(async move {
+                started.send(()).map_err(|_| {
+                    DataFusionError::Execution(
+                        "shared prefilter startup receiver dropped".to_string(),
+                    )
+                })?;
+                std::future::pending::<DataFusionResult<RecordBatch>>().await
+            }),
         ));
         let source = PreFilterSource::FilteredRowIds(Arc::new(OneShotExec::new(stream)));
         let shared_sources = source.shared_for_multimatch_fields(2);
         let materialization = shared_materialization(&shared_sources[0]);
-        let metrics = prefilter_metrics();
         let waiter = tokio::spawn(shared_prefilter_future(
             materialization.clone(),
             shared_source(&shared_sources[0]),
             false,
             Arc::new(datafusion::execution::TaskContext::default()),
             0,
-            metrics.clone(),
         ));
-        while metrics.source_executions.value() == 0 {
-            tokio::task::yield_now().await;
-        }
+        tokio::time::timeout(std::time::Duration::from_secs(5), has_started)
+            .await
+            .expect("shared prefilter source should start")
+            .expect("shared prefilter startup sender should remain alive");
         waiter.abort();
         assert!(waiter.await.unwrap_err().is_cancelled());
         assert!(materialization.queries.lock().unwrap().is_empty());

--- a/rust/lance/src/io/exec/utils.rs
+++ b/rust/lance/src/io/exec/utils.rs
@@ -207,6 +207,11 @@ pub(crate) struct SharedPreFilterMetrics {
     pub materialization_duration: Time,
 }
 
+pub(crate) struct PreFilterMasks {
+    pub overlay_block: Option<RowAddrMask>,
+    pub external_mask: Option<Arc<RowAddrMask>>,
+}
+
 impl PreFilterSource {
     /// Return a plan-local shared form for a MultiMatch with multiple fields.
     /// No-filter and already-shared sources retain their existing identity.
@@ -375,8 +380,7 @@ pub(crate) fn build_prefilter(
     prefilter_source: &PreFilterSource,
     ds: Arc<Dataset>,
     index_meta: &[IndexMetadata],
-    overlay_block: Option<RowAddrMask>,
-    external_mask: Option<Arc<RowAddrMask>>,
+    masks: PreFilterMasks,
     shared_metrics: SharedPreFilterMetrics,
 ) -> Result<Arc<DatasetPreFilter>> {
     let mut shared_filter = None;
@@ -420,7 +424,7 @@ pub(crate) fn build_prefilter(
     // (mirrors the ANN path). Independent of `overlay_block`, which the prefilter
     // applies separately to drop index entries staled by a data overlay.
     let mut prefilter = if let Some(shared_filter) = shared_filter {
-        let shared_filter = match external_mask {
+        let shared_filter = match masks.external_mask {
             Some(mask) => async move {
                 Ok(Arc::new(
                     mask.as_ref().clone() & shared_filter.await?.as_ref().clone(),
@@ -431,7 +435,7 @@ pub(crate) fn build_prefilter(
         };
         DatasetPreFilter::new_with_filter_future(ds, index_meta, Some(shared_filter))
     } else {
-        let prefilter_loader = match external_mask {
+        let prefilter_loader = match masks.external_mask {
             Some(mask) => {
                 Some(Box::new(MaskAndLoader::new(mask, prefilter_loader)) as Box<dyn FilterLoader>)
             }
@@ -439,7 +443,7 @@ pub(crate) fn build_prefilter(
         };
         DatasetPreFilter::new(ds, index_meta, prefilter_loader)
     };
-    if let Some(overlay_block) = overlay_block {
+    if let Some(overlay_block) = masks.overlay_block {
         prefilter = prefilter.with_overlay_block(overlay_block);
     }
     Ok(Arc::new(prefilter))


### PR DESCRIPTION
## Performance issue

Top-level `MultiMatch` plans one field-local FTS scorer per field. With a prefiltered scan, every scorer currently executes the same `FilteredRowIds` or `ScalarIndexQuery` source and materializes the same base row mask before applying field-local exclusions. An N-field query can therefore repeat expensive prefilter work N times.

Linear: https://linear.app/lancedb/issue/OSS-2101/share-multimatch-prefilter-evaluation-across-field-scorers

## How this improves it

- Materialize the immutable dataset-level prefilter once per DataFusion task context and partition.
- Share the ready `Arc<RowAddrMask>` across all field-local FTS consumers.
- Keep segment coverage, deleted fragments, row overlays, and external masks field-local.
- Preserve the physical-plan child dependency through optimizer rewrites.
- Isolate errors and cancellation with generation-aware waiter accounting.
- Record source execution count and materialization duration.

This follows Lucene's separation between a shared required filter and field-local scoring state, while retaining Lance's independent per-field index domains.

## Correctness coverage

Added coverage for 2/4/8 fields, both prefilter source types, empty and non-empty masks, flat-first planning, partial coverage, deletes, overlays, errors, and waiter cancellation. An independent static review found no correctness or liveness blocker.

## Validation

- Current-head CI is green, including Rust clippy/fmt, Python, Java, compatibility, platform builds, and Lance Gatekeeper.
- Exact benchmark oracle: baseline `1500/1500` cases and target `1500/1500` cases passed; the full cross-build ordered row-ID and f32-score comparison passed.
- Activation canary: target 2/4/8-field filtered queries each recorded exactly one shared prefilter source execution; 1-field and no-filter controls recorded zero.
- Timed result and row-ID digests had zero within-build instability and zero cross-build differences.

## Benchmark

Environment: one dedicated GCP `c4-highmem-16` VM (16 vCPU, 121 GiB RAM), with no concurrent build or benchmark load. Dataset: 10,000,000-row MMLB code corpus, 42 languages, 10 shards, with `full_content` and `summary` FTS indices. The filter was `row_index < 1000000` (10% selectivity) and `prefilter=True`. MultiMatch field entries alternated the two indexed columns so 1/2/4/8-field cases isolate repeated prefilter materialization while preserving DisMax semantics.

Warm protocol: frozen 250-query broad-term manifest, k=10/100, 8 query threads, 5 repetitions, four baseline and four target process blocks in forward/reverse ABBA order. Values are the median process QPS across the four blocks; higher is better.

| Scenario / metric | Baseline | This PR | Benefit |
| --- | ---: | ---: | ---: |
| Filtered 1 field, k=10, warm throughput | 121.81 q/s | 121.97 q/s | 1.001x speedup |
| Filtered 1 field, k=100, warm throughput | 107.60 q/s | 108.32 q/s | 1.007x speedup |
| Filtered 2 fields, k=10, warm throughput | 86.40 q/s | 126.77 q/s | 1.467x speedup |
| Filtered 2 fields, k=100, warm throughput | 80.42 q/s | 117.36 q/s | 1.459x speedup |
| Filtered 4 fields, k=10, warm throughput | 47.87 q/s | 123.91 q/s | 2.589x speedup |
| Filtered 4 fields, k=100, warm throughput | 44.80 q/s | 111.24 q/s | 2.483x speedup |
| Filtered 8 fields, k=10, warm throughput | 23.95 q/s | 116.18 q/s | 4.851x speedup |
| Filtered 8 fields, k=100, warm throughput | 22.54 q/s | 97.50 q/s | 4.325x speedup |
| No-filter 8-field control, k=10, warm throughput | 741.11 q/s | 743.34 q/s | 1.003x speedup |
| No-filter 8-field control, k=100, warm throughput | 515.49 q/s | 517.32 q/s | 1.004x speedup |

Cold protocol: one frozen broad query, 8-field filtered shape, page cache dropped before every process, four baseline and four target blocks per k. Values are medians; latency and RSS are lower-is-better. File input was matched within 1.0001x.

| Scenario / metric | Baseline | This PR | Benefit |
| --- | ---: | ---: | ---: |
| Filtered 8 fields, k=10, cold query latency | 636.27 ms | 590.46 ms | 1.078x speedup |
| Filtered 8 fields, k=100, cold query latency | 639.20 ms | 595.13 ms | 1.074x speedup |
| Filtered 8 fields, k=10, cold max RSS | 1256.86 MiB | 1112.84 MiB | 1.129x lower RSS |
| Filtered 8 fields, k=100, cold max RSS | 1259.95 MiB | 1122.86 MiB | 1.122x lower RSS |

Compared commits: baseline `91aee6f9123d6f955fa4033d427c124e5b4f7cd2`; target `13f9b0899c3ac577988418155f1d7e4fc73569d2`. Target module SHA-256: `871d121682833cf2e35891b9a12f6392e761890771dd059f1ff46f088fddb538`. Final prefilter-aware harness SHA-256: `8f60b08b188c4fabe20fcdfa9b22d754cf7f576a66a012c91f825abe18707d73`.

The final result tree contains 1,795 files and 927,098,904 bytes with tree SHA-256 `0e40078620700553ebac8bc46b1d35eb47f843cec2e608cfcdc0ba798165e77e`. An initial preflight accidentally exercised the default postfilter behavior; it was rejected by the exact oracle, archived outside the result tree, and is not included in any reported measurement.
