### PR TITLE
perf(fts): complete ambiguous WAND ties without full replay

### DIFF
--- a/rust/lance-index-core/src/metrics.rs
+++ b/rust/lance-index-core/src/metrics.rs
@@ -32,6 +32,19 @@ pub const WAND_EXACTNESS_CERTIFICATE_FALLBACKS_METRIC: &str =
     "wand_exactness_certificate_fallbacks";
 pub const WAND_EXACTNESS_CERTIFICATE_CANDIDATES_METRIC: &str =
     "wand_exactness_certificate_candidates";
+pub const WAND_EXACTNESS_PROBE_MS_METRIC: &str = "wand_exactness_probe_ms";
+pub const WAND_EXACTNESS_PROBE_COMPARISONS_METRIC: &str = "wand_exactness_probe_comparisons";
+pub const WAND_TIE_COMPLETION_ATTEMPTS_METRIC: &str = "wand_tie_completion_attempts";
+pub const WAND_TIE_COMPLETION_SUCCESSES_METRIC: &str = "wand_tie_completion_successes";
+pub const WAND_TIE_COMPLETION_OVERFLOWS_METRIC: &str = "wand_tie_completion_overflows";
+pub const WAND_TIE_COMPLETION_CANDIDATES_METRIC: &str = "wand_tie_completion_candidates";
+pub const WAND_TIE_COMPLETION_ROW_ID_REPLACEMENTS_METRIC: &str =
+    "wand_tie_completion_row_id_replacements";
+pub const WAND_TIE_COMPLETION_MS_METRIC: &str = "wand_tie_completion_ms";
+pub const WAND_TIE_COMPLETION_COMPARISONS_METRIC: &str = "wand_tie_completion_comparisons";
+pub const WAND_SEEDED_FALLBACKS_METRIC: &str = "wand_seeded_fallbacks";
+pub const WAND_SEEDED_FALLBACK_MS_METRIC: &str = "wand_seeded_fallback_ms";
+pub const WAND_SEEDED_FALLBACK_COMPARISONS_METRIC: &str = "wand_seeded_fallback_comparisons";
 
 /// A trait used by the index to report metrics
 ///
@@ -163,6 +176,21 @@ pub trait MetricsCollector: Send + Sync {
 
     /// Record WAND candidates returned to the certificate classifier.
     fn record_wand_exactness_certificate_candidates(&self, _num_candidates: usize) {}
+
+    /// Record bounded WAND attempts to complete an ambiguous kth-score tie.
+    fn record_wand_tie_completion_attempts(&self, _num_attempts: usize) {}
+
+    /// Record kth-score ties completed without exact replay.
+    fn record_wand_tie_completion_successes(&self, _num_successes: usize) {}
+
+    /// Record kth-score ties that exceeded the bounded completion budget.
+    fn record_wand_tie_completion_overflows(&self, _num_overflows: usize) {}
+
+    /// Record candidates returned by bounded kth-score tie completion.
+    fn record_wand_tie_completion_candidates(&self, _num_candidates: usize) {}
+
+    /// Record exact replays seeded with an inclusive kth-score floor.
+    fn record_wand_seeded_fallbacks(&self, _num_fallbacks: usize) {}
 
     /// Returns an optional sink for recording exact I/O statistics (bytes read,
     /// IOPS, and requests) performed on behalf of this collector.

--- a/rust/lance-index/src/scalar/inverted.rs
+++ b/rust/lance-index/src/scalar/inverted.rs
@@ -23,7 +23,10 @@ use std::sync::Arc;
 use arrow_schema::{DataType, Field};
 use async_trait::async_trait;
 pub use builder::InvertedIndexBuilder;
-pub use compound::{compound_search, compound_search_with_base_scorer};
+pub use compound::{
+    compound_search, compound_search_with_base_scorer,
+    compound_search_with_base_scorer_and_score_floor, exclusive_scaled_score_floor,
+};
 #[doc(hidden)]
 pub use cross_column::cross_column_compound_search;
 use datafusion::execution::SendableRecordBatchStream;

--- a/rust/lance-index/src/scalar/inverted/compound.rs
+++ b/rust/lance-index/src/scalar/inverted/compound.rs
@@ -205,6 +205,37 @@ fn next_down(value: f32) -> f32 {
     }
 }
 
+/// Find the greatest finite non-negative raw score whose actual `f32`
+/// multiplication remains strictly below an inclusive scaled score floor.
+///
+/// Non-negative finite `f32` values have the same order as their bit patterns,
+/// and multiplication by a finite positive factor is monotonic. Binary search
+/// therefore proves the returned exclusive child floor cannot discard a raw
+/// score whose scaled value is equal to `scaled_score_floor`.
+#[doc(hidden)]
+pub fn exclusive_scaled_score_floor(scaled_score_floor: f32, factor: f32) -> Option<f32> {
+    if !scaled_score_floor.is_finite()
+        || scaled_score_floor <= 0.0
+        || !factor.is_finite()
+        || factor <= 0.0
+    {
+        return None;
+    }
+
+    let mut lower_bits = 0_u32;
+    let mut upper_bits = f32::MAX.to_bits();
+    while lower_bits < upper_bits {
+        let midpoint = lower_bits + (upper_bits - lower_bits).div_ceil(2);
+        let raw_score = f32::from_bits(midpoint);
+        if raw_score * factor < scaled_score_floor {
+            lower_bits = midpoint;
+        } else {
+            upper_bits = midpoint - 1;
+        }
+    }
+    Some(f32::from_bits(lower_bits))
+}
+
 fn checked_score(score: f32, context: &str) -> Result<f32> {
     if score.is_finite() {
         Ok(score)
@@ -2137,6 +2168,9 @@ impl ComposableScorer for EmptyScorer {
 struct ScaleScorer<'a> {
     child: BoxScorer<'a>,
     factor: f32,
+    last_parent_score_floor: f32,
+    #[cfg(test)]
+    score_floor_translations: usize,
 }
 
 impl<'a> ScaleScorer<'a> {
@@ -2146,7 +2180,13 @@ impl<'a> ScaleScorer<'a> {
                 "MatchQuery boost must be finite and non-negative, got {factor}"
             )));
         }
-        Ok(Self { child, factor })
+        Ok(Self {
+            child,
+            factor,
+            last_parent_score_floor: f32::NEG_INFINITY,
+            #[cfg(test)]
+            score_floor_translations: 0,
+        })
     }
 }
 
@@ -2198,10 +2238,22 @@ impl ComposableScorer for ScaleScorer<'_> {
     }
 
     fn set_min_competitive_score(&mut self, min_score: f32) -> Result<()> {
-        if self.factor > 0.0 {
-            self.child
-                .set_min_competitive_score(next_down(min_score / self.factor))?;
+        if min_score.is_nan() {
+            return Err(Error::invalid_input(
+                "minimum competitive MatchQuery score cannot be NaN",
+            ));
         }
+        if min_score <= self.last_parent_score_floor {
+            return Ok(());
+        }
+        #[cfg(test)]
+        {
+            self.score_floor_translations += 1;
+        }
+        if let Some(child_floor) = exclusive_scaled_score_floor(min_score, self.factor) {
+            self.child.set_min_competitive_score(child_floor)?;
+        }
+        self.last_parent_score_floor = min_score;
         Ok(())
     }
 
@@ -3904,7 +3956,7 @@ pub async fn compound_search(
     prefilter: Arc<dyn PreFilter>,
     metrics: Arc<dyn MetricsCollector>,
 ) -> Result<(Vec<u64>, Vec<f32>)> {
-    compound_search_impl(indices, query, params, prefilter, metrics, None).await
+    compound_search_impl(indices, query, params, prefilter, metrics, None, None).await
 }
 
 /// Search one-column compound FTS with caller-supplied corpus-wide BM25 statistics.
@@ -3927,6 +3979,33 @@ pub async fn compound_search_with_base_scorer(
         prefilter,
         metrics,
         Some(base_scorer),
+        None,
+    )
+    .await
+}
+
+/// Search one-column compound FTS with corpus-wide BM25 statistics and an
+/// inclusive initial score floor.
+///
+/// The floor may only remove scores strictly below it. Equal-score rows must
+/// still be visited because final ordering uses row id as its secondary key.
+pub async fn compound_search_with_base_scorer_and_score_floor(
+    indices: &[Arc<InvertedIndex>],
+    query: &FtsQuery,
+    params: &FtsSearchParams,
+    prefilter: Arc<dyn PreFilter>,
+    metrics: Arc<dyn MetricsCollector>,
+    base_scorer: Arc<MemBM25Scorer>,
+    score_floor: f32,
+) -> Result<(Vec<u64>, Vec<f32>)> {
+    compound_search_impl(
+        indices,
+        query,
+        params,
+        prefilter,
+        metrics,
+        Some(base_scorer),
+        Some(score_floor),
     )
     .await
 }
@@ -3938,6 +4017,7 @@ async fn compound_search_impl(
     prefilter: Arc<dyn PreFilter>,
     metrics: Arc<dyn MetricsCollector>,
     base_scorer: Option<Arc<MemBM25Scorer>>,
+    initial_score_floor: Option<f32>,
 ) -> Result<(Vec<u64>, Vec<f32>)> {
     let limit = params.limit.unwrap_or(usize::MAX);
     if limit == 0 {
@@ -3947,7 +4027,11 @@ async fn compound_search_impl(
         prepare_compound_query(indices, query, params, metrics.as_ref(), base_scorer).await?;
     prefilter.wait_for_ready().await?;
     let mask = prefilter.mask();
-    let mut collector = TopKCollector::new(limit);
+    let competitive_score = Arc::new(CompetitiveScore::default());
+    if let Some(score_floor) = initial_score_floor {
+        competitive_score.raise(checked_score(score_floor, "initial compound score floor")?);
+    }
+    let mut collector = TopKCollector::with_competitive_score(limit, competitive_score);
 
     for (segment_ordinal, index) in indices.iter().enumerate() {
         let loads =
@@ -4157,6 +4241,77 @@ mod tests {
     }
 
     #[test]
+    fn scaled_score_floor_is_maximal_and_preserves_equalities() {
+        let cases = [
+            (3.75_f32, 2.5_f32),
+            (f32::from_bits(1.0_f32.to_bits() + 1), 1.000_000_2_f32),
+            (2.0_f32, f32::MIN_POSITIVE),
+            (1.0_f32, f32::from_bits(1)),
+        ];
+        for (raw_score, factor) in cases {
+            let scaled_score = raw_score * factor;
+            assert!(scaled_score.is_finite() && scaled_score > 0.0);
+            let child_floor = exclusive_scaled_score_floor(scaled_score, factor).unwrap();
+            assert!(child_floor * factor < scaled_score);
+            assert!(child_floor < raw_score);
+            let next_raw = f32::from_bits(child_floor.to_bits() + 1);
+            assert!(next_raw * factor >= scaled_score);
+
+            let mut scorer = ScaleScorer::try_new(materialized(&[(0, raw_score)]), factor).unwrap();
+            scorer.set_min_competitive_score(scaled_score).unwrap();
+            assert_eq!(scorer.next().unwrap(), Some(0));
+            assert_eq!(scorer.score().unwrap(), scaled_score);
+        }
+
+        let subnormal_factor = f32::from_bits(1);
+        let raw_score = 0.25_f32;
+        let scaled_score = raw_score * subnormal_factor;
+        assert_eq!(scaled_score, 0.0);
+        assert_eq!(
+            exclusive_scaled_score_floor(scaled_score, subnormal_factor),
+            None
+        );
+        let mut scorer =
+            ScaleScorer::try_new(materialized(&[(0, raw_score)]), subnormal_factor).unwrap();
+        scorer.set_min_competitive_score(scaled_score).unwrap();
+        assert_eq!(scorer.next().unwrap(), Some(0));
+        assert_eq!(scorer.score().unwrap(), 0.0);
+    }
+
+    #[test]
+    fn scale_scorer_only_translates_strictly_higher_floors() {
+        let (child, work) = instrumented(materialized(&[(0, 10.0)]));
+        let mut scorer = ScaleScorer::try_new(child, 2.0).unwrap();
+
+        scorer.set_min_competitive_score(4.0).unwrap();
+        scorer.set_min_competitive_score(4.0).unwrap();
+        scorer.set_min_competitive_score(3.0).unwrap();
+        assert_eq!(scorer.score_floor_translations, 1);
+        assert_eq!(work.floors.load(AtomicOrdering::Relaxed), 1);
+
+        scorer.set_min_competitive_score(5.0).unwrap();
+        assert_eq!(scorer.score_floor_translations, 2);
+        assert_eq!(work.floors.load(AtomicOrdering::Relaxed), 2);
+
+        let error = scorer.set_min_competitive_score(f32::NAN).unwrap_err();
+        assert!(matches!(error, Error::InvalidInput { .. }));
+        assert!(error.to_string().contains("cannot be NaN"));
+        assert_eq!(scorer.score_floor_translations, 2);
+
+        let subnormal_factor = f32::from_bits(1);
+        let (child, work) = instrumented(materialized(&[(0, 1.0)]));
+        let mut scorer = ScaleScorer::try_new(child, subnormal_factor).unwrap();
+        scorer.set_min_competitive_score(0.0).unwrap();
+        scorer.set_min_competitive_score(0.0).unwrap();
+        assert_eq!(scorer.score_floor_translations, 1);
+        assert_eq!(work.floors.load(AtomicOrdering::Relaxed), 0);
+
+        scorer.set_min_competitive_score(f32::from_bits(1)).unwrap();
+        assert_eq!(scorer.score_floor_translations, 2);
+        assert_eq!(work.floors.load(AtomicOrdering::Relaxed), 1);
+    }
+
+    #[test]
     fn materialized_scorer_precomputes_multi_block_bounds() {
         assert_eq!(std::mem::size_of::<ScoreBounds>(), 8);
         let values = [
@@ -4222,6 +4377,21 @@ mod tests {
                 }
             ]
         );
+    }
+
+    #[test]
+    fn seeded_collector_keeps_floor_equalities_for_row_id_ordering() {
+        let competitive_score = Arc::new(CompetitiveScore::default());
+        competitive_score.raise(5.0);
+        let mut collector = TopKCollector::with_competitive_score(2, competitive_score);
+
+        let mut later_segment = MaterializedScorer::try_new(rows(&[(2, 4.0), (99, 5.0)])).unwrap();
+        collector.collect_mapped(&mut later_segment, Ok).unwrap();
+        let mut earlier_segment =
+            MaterializedScorer::try_new(rows(&[(1, 5.0), (50, 6.0)])).unwrap();
+        collector.collect_mapped(&mut earlier_segment, Ok).unwrap();
+
+        assert_eq!(collector.into_rows(), rows(&[(50, 6.0), (1, 5.0)]));
     }
 
     #[test]

--- a/rust/lance-index/src/scalar/inverted/index/search.rs
+++ b/rust/lance-index/src/scalar/inverted/index/search.rs
@@ -216,6 +216,68 @@ impl InvertedIndex {
         metrics: Arc<dyn MetricsCollector>,
         base_scorer: Option<&MemBM25Scorer>,
     ) -> Result<Vec<ScoredDoc>> {
+        self.bm25_search_documents_impl(
+            tokens,
+            params,
+            operator,
+            prefilter,
+            metrics,
+            base_scorer,
+            None,
+        )
+        .await
+    }
+
+    /// Search logical FTS documents with an exclusive initial raw-score floor.
+    ///
+    /// This is an internal optimization hook for a repeated bounded WAND pass.
+    /// Callers must round the floor down far enough to retain every candidate
+    /// equal to their inclusive logical threshold.
+    #[doc(hidden)]
+    #[instrument(level = "debug", skip_all)]
+    pub async fn bm25_search_documents_with_score_floor(
+        &self,
+        tokens: Arc<Tokens>,
+        params: Arc<FtsSearchParams>,
+        operator: Operator,
+        prefilter: Arc<dyn PreFilter>,
+        metrics: Arc<dyn MetricsCollector>,
+        base_scorer: Option<&MemBM25Scorer>,
+        initial_score_floor: f32,
+    ) -> Result<Vec<ScoredDoc>> {
+        if self.is_legacy() {
+            return Err(Error::invalid_input(
+                "an initial Match WAND score floor requires a modern FTS index",
+            ));
+        }
+        if !initial_score_floor.is_finite() {
+            return Err(Error::invalid_input(format!(
+                "initial Match WAND score floor must be finite, got {initial_score_floor}"
+            )));
+        }
+        self.bm25_search_documents_impl(
+            tokens,
+            params,
+            operator,
+            prefilter,
+            metrics,
+            base_scorer,
+            Some(initial_score_floor),
+        )
+        .await
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    async fn bm25_search_documents_impl(
+        &self,
+        tokens: Arc<Tokens>,
+        params: Arc<FtsSearchParams>,
+        operator: Operator,
+        prefilter: Arc<dyn PreFilter>,
+        metrics: Arc<dyn MetricsCollector>,
+        base_scorer: Option<&MemBM25Scorer>,
+        initial_score_floor: Option<f32>,
+    ) -> Result<Vec<ScoredDoc>> {
         // Fuzzy expansion runs once here, with the global `max_expansions`
         // budget, instead of once per partition: partitions receive the
         // final token list, so the matched terms cannot depend on how the
@@ -286,6 +348,7 @@ impl InvertedIndex {
                 scorer,
                 impact_scorer,
                 limit,
+                initial_score_floor,
             })
             .await
         }
@@ -541,6 +604,7 @@ impl InvertedIndex {
             scorer,
             impact_scorer,
             limit,
+            initial_score_floor,
         } = request;
         if self.partitions.len() > u32::MAX as usize {
             return Err(Error::index(format!(
@@ -548,7 +612,9 @@ impl InvertedIndex {
                 self.partitions.len()
             )));
         }
-        let impact_shared_threshold = Arc::new(AtomicU32::new(f32::NEG_INFINITY.to_bits()));
+        let impact_shared_threshold = Arc::new(AtomicU32::new(
+            initial_score_floor.unwrap_or(f32::NEG_INFINITY).to_bits(),
+        ));
         let io_parallelism = self.store.io_parallelism();
         let parts = self
             .partitions

--- a/rust/lance-index/src/scalar/inverted/index/search.rs
+++ b/rust/lance-index/src/scalar/inverted/index/search.rs
@@ -235,6 +235,7 @@ impl InvertedIndex {
     /// equal to their inclusive logical threshold.
     #[doc(hidden)]
     #[instrument(level = "debug", skip_all)]
+    #[allow(clippy::too_many_arguments)]
     pub async fn bm25_search_documents_with_score_floor(
         &self,
         tokens: Arc<Tokens>,

--- a/rust/lance-index/src/scalar/inverted/index/search_candidates.rs
+++ b/rust/lance-index/src/scalar/inverted/index/search_candidates.rs
@@ -19,6 +19,8 @@ pub(super) struct ModernSearchRequest<'a> {
     pub(super) scorer: &'a MemBM25Scorer,
     pub(super) impact_scorer: Arc<MemBM25Scorer>,
     pub(super) limit: usize,
+    /// Exclusive raw-score floor used to seed standalone Match WAND.
+    pub(super) initial_score_floor: Option<f32>,
 }
 
 /// Typed identity for one modern candidate after partition-local scoring.

--- a/rust/lance/src/dataset/tests/dataset_index.rs
+++ b/rust/lance/src/dataset/tests/dataset_index.rs
@@ -53,6 +53,10 @@ use lance_index::metrics::{
     CROSS_COLUMN_STAGED_SUCCESSES_METRIC, WAND_EXACTNESS_CERTIFICATE_ATTEMPTS_METRIC,
     WAND_EXACTNESS_CERTIFICATE_CANDIDATES_METRIC, WAND_EXACTNESS_CERTIFICATE_EXHAUSTIVE_METRIC,
     WAND_EXACTNESS_CERTIFICATE_FALLBACKS_METRIC, WAND_EXACTNESS_CERTIFICATE_STRICT_METRIC,
+    WAND_SEEDED_FALLBACK_COMPARISONS_METRIC, WAND_SEEDED_FALLBACKS_METRIC,
+    WAND_TIE_COMPLETION_ATTEMPTS_METRIC, WAND_TIE_COMPLETION_CANDIDATES_METRIC,
+    WAND_TIE_COMPLETION_COMPARISONS_METRIC, WAND_TIE_COMPLETION_OVERFLOWS_METRIC,
+    WAND_TIE_COMPLETION_SUCCESSES_METRIC,
 };
 use lance_index::optimize::OptimizeOptions;
 use lance_index::scalar::inverted::{
@@ -2036,7 +2040,7 @@ async fn test_field_local_match_wand_exactness_certificates() {
     assert_eq!(tied_oracle[0].1, tied_oracle[1].1);
     assert!(tied_oracle[0].0 < tied_oracle[1].0);
     let (tied, stats) = compound_fts_results_with_stats(&dataset, tied_query, 1).await;
-    assert_scored_rows_close("wand_certificate_tie_fallback", &tied, &tied_oracle[..1]);
+    assert_scored_rows_close("wand_certificate_tie_completion", &tied, &tied_oracle[..1]);
     assert_eq!(
         stats
             .all_counts
@@ -2053,13 +2057,13 @@ async fn test_field_local_match_wand_exactness_certificates() {
         stats
             .all_counts
             .get(WAND_EXACTNESS_CERTIFICATE_EXHAUSTIVE_METRIC),
-        Some(&0)
+        Some(&1)
     );
     assert_eq!(
         stats
             .all_counts
             .get(WAND_EXACTNESS_CERTIFICATE_FALLBACKS_METRIC),
-        Some(&1)
+        Some(&0)
     );
     assert_eq!(
         stats
@@ -2067,6 +2071,23 @@ async fn test_field_local_match_wand_exactness_certificates() {
             .get(WAND_EXACTNESS_CERTIFICATE_CANDIDATES_METRIC),
         Some(&2)
     );
+    assert_eq!(
+        stats.all_counts.get(WAND_TIE_COMPLETION_ATTEMPTS_METRIC),
+        Some(&1)
+    );
+    assert_eq!(
+        stats.all_counts.get(WAND_TIE_COMPLETION_SUCCESSES_METRIC),
+        Some(&1)
+    );
+    assert_eq!(
+        stats.all_counts.get(WAND_TIE_COMPLETION_OVERFLOWS_METRIC),
+        Some(&0)
+    );
+    assert_eq!(
+        stats.all_counts.get(WAND_TIE_COMPLETION_CANDIDATES_METRIC),
+        Some(&2)
+    );
+    assert_eq!(stats.all_counts.get(WAND_SEEDED_FALLBACKS_METRIC), Some(&0));
 
     let mixed_query = field_local_query("noise");
     let mixed_oracle =
@@ -2083,7 +2104,7 @@ async fn test_field_local_match_wand_exactness_certificates() {
         stats
             .all_counts
             .get(WAND_EXACTNESS_CERTIFICATE_EXHAUSTIVE_METRIC),
-        Some(&1)
+        Some(&2)
     );
     assert_eq!(
         stats
@@ -2095,7 +2116,7 @@ async fn test_field_local_match_wand_exactness_certificates() {
         stats
             .all_counts
             .get(WAND_EXACTNESS_CERTIFICATE_FALLBACKS_METRIC),
-        Some(&1)
+        Some(&0)
     );
     assert_eq!(
         stats
@@ -2119,6 +2140,122 @@ async fn test_field_local_match_wand_exactness_certificates() {
             .get(WAND_EXACTNESS_CERTIFICATE_ATTEMPTS_METRIC),
         Some(&0),
         "zero-boost fields must use the exact path without attempting a certificate"
+    );
+}
+
+async fn write_wand_tie_dataset(num_ties: usize) -> Dataset {
+    let reader = gen_batch()
+        .col("title", array::fill_utf8("token".to_owned()))
+        .col("body", array::fill_utf8("unrelated".to_owned()))
+        .into_reader_rows(
+            RowCount::from(u64::try_from(num_ties).unwrap()),
+            BatchCount::from(1),
+        );
+    let dataset = Dataset::write(
+        reader,
+        "memory://",
+        Some(WriteParams {
+            max_rows_per_file: num_ties.div_ceil(2),
+            ..Default::default()
+        }),
+    )
+    .await
+    .unwrap();
+    assert_eq!(dataset.get_fragments().len(), 2);
+    dataset
+}
+
+fn wand_tie_multimatch(terms: &str, boost: f32, fuzziness: Option<u32>) -> FtsQuery {
+    let mut query = MultiMatchQuery::try_new(
+        terms.to_owned(),
+        vec!["title".to_owned(), "body".to_owned()],
+    )
+    .unwrap()
+    .try_with_boosts(vec![boost, 1.0])
+    .unwrap();
+    for match_query in &mut query.match_queries {
+        match_query.fuzziness = fuzziness;
+    }
+    query.into()
+}
+
+#[tokio::test]
+async fn test_wand_tie_completion_recovers_reversed_segment_row_id() {
+    let mut dataset = write_wand_tie_dataset(6).await;
+    create_fragmented_fts_index_with_order(&mut dataset, "title", true, true).await;
+    create_fragmented_fts_index_with_order(&mut dataset, "body", true, true).await;
+    let query = wand_tie_multimatch("token", 1.0, Some(0));
+    let oracle = compound_fts_results(&dataset, query.clone(), None).await;
+    assert_eq!(oracle.len(), 6);
+    assert_eq!(oracle[0].0, 0);
+
+    let (actual, stats) = compound_fts_results_with_stats(&dataset, query, 1).await;
+
+    assert_scored_rows_close(
+        "wand_tie_completion_reversed_segments",
+        &actual,
+        &oracle[..1],
+    );
+    assert_eq!(
+        stats.all_counts.get(WAND_TIE_COMPLETION_ATTEMPTS_METRIC),
+        Some(&1)
+    );
+    assert_eq!(
+        stats.all_counts.get(WAND_TIE_COMPLETION_SUCCESSES_METRIC),
+        Some(&1)
+    );
+    assert_eq!(
+        stats.all_counts.get(WAND_TIE_COMPLETION_CANDIDATES_METRIC),
+        Some(&6)
+    );
+    assert_eq!(stats.all_counts.get(WAND_SEEDED_FALLBACKS_METRIC), Some(&0));
+}
+
+#[tokio::test]
+async fn test_wand_tie_overflow_uses_seeded_fuzzy_boosted_fallback() {
+    const NUM_TIES: usize = 131;
+    let mut dataset = write_wand_tie_dataset(NUM_TIES).await;
+    create_fragmented_fts_index_with_order(&mut dataset, "title", true, true).await;
+    create_fragmented_fts_index_with_order(&mut dataset, "body", true, true).await;
+    let query = wand_tie_multimatch("tiken", 2.5, Some(1));
+    let oracle = compound_fts_results(&dataset, query.clone(), None).await;
+    assert_eq!(oracle.len(), NUM_TIES);
+    assert_eq!(oracle[0].0, 0);
+
+    let (actual, stats) = compound_fts_results_with_stats(&dataset, query, 1).await;
+
+    assert_scored_rows_close("wand_tie_seeded_fuzzy_boost", &actual, &oracle[..1]);
+    assert_eq!(
+        stats.all_counts.get(WAND_TIE_COMPLETION_ATTEMPTS_METRIC),
+        Some(&1)
+    );
+    assert_eq!(
+        stats.all_counts.get(WAND_TIE_COMPLETION_OVERFLOWS_METRIC),
+        Some(&1)
+    );
+    assert_eq!(
+        stats.all_counts.get(WAND_TIE_COMPLETION_CANDIDATES_METRIC),
+        Some(&130),
+        "k=1 reserves 128 tie slots plus one lower-score guard slot"
+    );
+    assert_eq!(
+        stats
+            .all_counts
+            .get(WAND_EXACTNESS_CERTIFICATE_FALLBACKS_METRIC),
+        Some(&1)
+    );
+    assert_eq!(stats.all_counts.get(WAND_SEEDED_FALLBACKS_METRIC), Some(&1));
+    assert!(
+        stats
+            .all_counts
+            .get(WAND_TIE_COMPLETION_COMPARISONS_METRIC)
+            .is_some_and(|comparisons| *comparisons > 0)
+    );
+    assert!(
+        stats
+            .all_counts
+            .get(WAND_SEEDED_FALLBACK_COMPARISONS_METRIC)
+            .is_some_and(|comparisons| *comparisons > 0)
     );
 }
 

--- a/rust/lance/src/io/exec/fts.rs
+++ b/rust/lance/src/io/exec/fts.rs
@@ -54,7 +54,13 @@ use lance_index::metrics::{
     CROSS_COLUMN_STAGED_SUCCESSES_METRIC, FREQS_COLLECTED_METRIC, MetricsCollector,
     WAND_EXACTNESS_CERTIFICATE_ATTEMPTS_METRIC, WAND_EXACTNESS_CERTIFICATE_CANDIDATES_METRIC,
     WAND_EXACTNESS_CERTIFICATE_EXHAUSTIVE_METRIC, WAND_EXACTNESS_CERTIFICATE_FALLBACKS_METRIC,
-    WAND_EXACTNESS_CERTIFICATE_STRICT_METRIC,
+    WAND_EXACTNESS_CERTIFICATE_STRICT_METRIC, WAND_EXACTNESS_PROBE_COMPARISONS_METRIC,
+    WAND_EXACTNESS_PROBE_MS_METRIC, WAND_SEEDED_FALLBACK_COMPARISONS_METRIC,
+    WAND_SEEDED_FALLBACK_MS_METRIC, WAND_SEEDED_FALLBACKS_METRIC,
+    WAND_TIE_COMPLETION_ATTEMPTS_METRIC, WAND_TIE_COMPLETION_CANDIDATES_METRIC,
+    WAND_TIE_COMPLETION_COMPARISONS_METRIC, WAND_TIE_COMPLETION_MS_METRIC,
+    WAND_TIE_COMPLETION_OVERFLOWS_METRIC, WAND_TIE_COMPLETION_ROW_ID_REPLACEMENTS_METRIC,
+    WAND_TIE_COMPLETION_SUCCESSES_METRIC,
 };
 use lance_index::scalar::inverted::builder::ScoredDoc;
 use lance_index::scalar::inverted::builder::document_input;
@@ -67,13 +73,18 @@ use lance_index::scalar::inverted::tokenizer::document_tokenizer::TextTokenizer;
 use lance_index::scalar::inverted::{
     DOC_INDEX_COL, DocumentGranularity, FTS_SCHEMA, FlatBm25SearchOptions, InvertedIndex,
     MemBM25Scorer, SCORE_COL, Scorer, build_global_bm25_scorer, compound_search,
-    compound_search_with_base_scorer, cross_column_compound_search,
+    compound_search_with_base_scorer, compound_search_with_base_scorer_and_score_floor,
+    cross_column_compound_search, exclusive_scaled_score_floor,
     flat_bm25_search_stream_with_options_and_scorer, fts_schema,
 };
 use lance_index::{prefilter::PreFilter, scalar::inverted::query::BooleanQuery};
 use lance_tokenizer::{SimpleTokenizer, TextAnalyzer};
 use tracing::instrument;
 use uuid::Uuid;
+
+/// Maximum number of additional kth-score rows retained before exact replay.
+/// One extra probe slot is reserved for the strict lower-score guard.
+const WAND_TIE_COMPLETION_BUDGET: usize = 128;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct TokenWithPosition {
@@ -305,6 +316,7 @@ async fn search_segments(
     pre_filter: Arc<dyn PreFilter>,
     metrics: Arc<FtsIndexMetrics>,
     base_scorer: Arc<MemBM25Scorer>,
+    initial_score_floor: Option<f32>,
 ) -> Result<Vec<ScoredDoc>> {
     let limit = params.limit.unwrap_or(usize::MAX);
     let mut candidates = std::collections::BinaryHeap::new();
@@ -318,16 +330,30 @@ async fn search_segments(
             let metrics = metrics.clone();
             let base_scorer = base_scorer.clone();
             async move {
-                index
-                    .bm25_search_documents(
-                        tokens,
-                        params,
-                        operator,
-                        pre_filter,
-                        metrics,
-                        Some(base_scorer.as_ref()),
-                    )
-                    .await
+                if let Some(initial_score_floor) = initial_score_floor {
+                    index
+                        .bm25_search_documents_with_score_floor(
+                            tokens,
+                            params,
+                            operator,
+                            pre_filter,
+                            metrics,
+                            Some(base_scorer.as_ref()),
+                            initial_score_floor,
+                        )
+                        .await
+                } else {
+                    index
+                        .bm25_search_documents(
+                            tokens,
+                            params,
+                            operator,
+                            pre_filter,
+                            metrics,
+                            Some(base_scorer.as_ref()),
+                        )
+                        .await
+                }
             }
         })
         .collect::<Vec<_>>();
@@ -659,18 +685,22 @@ enum WandExactnessCertificate {
     Ambiguous,
 }
 
-/// Classify a globally merged k+1 Match WAND result.
+/// Classify a globally merged bounded Match WAND result.
 ///
 /// Sorting before classification is essential: per-segment WAND output is not
 /// a final cross-segment ordering. A strict score gap after result k proves
 /// that score-only pruning could not have discarded a row-id tie at the final
-/// boundary. Ties wholly inside top-k remain safe because all members of their
-/// score group are present before the strict boundary.
+/// boundary. Returning fewer rows than requested proves exhaustion. Merely
+/// observing a lower score during collection is not a proof because other
+/// partitions may still contain kth-score ties.
 fn classify_wand_exactness_certificate(
     documents: &mut [ScoredDoc],
     limit: usize,
+    probe_limit: usize,
 ) -> WandExactnessCertificate {
     if limit == 0
+        || probe_limit <= limit
+        || documents.len() > probe_limit
         || documents
             .iter()
             .any(|document| !document.score.0.is_finite())
@@ -684,17 +714,66 @@ fn classify_wand_exactness_certificate(
             .total_cmp(&left.score.0)
             .then_with(|| left.row_id.cmp(&right.row_id))
     });
-    if documents.len() <= limit {
+    if documents.len() < probe_limit {
         WandExactnessCertificate::Exhaustive
-    } else if documents[limit - 1]
-        .score
-        .0
-        .total_cmp(&documents[limit].score.0)
-        == Ordering::Greater
+    } else if documents[limit - 1].score.0.total_cmp(
+        &documents
+            .last()
+            .expect("a full bounded probe has a guard candidate")
+            .score
+            .0,
+    ) == Ordering::Greater
     {
         WandExactnessCertificate::Strict
     } else {
         WandExactnessCertificate::Ambiguous
+    }
+}
+
+fn finish_wand_documents(mut documents: Vec<ScoredDoc>, limit: usize) -> (Vec<u64>, Vec<f32>) {
+    documents.truncate(limit);
+    documents
+        .into_iter()
+        .map(|document| (document.row_id, document.score.0))
+        .unzip()
+}
+
+fn count_smaller_row_id_replacements(
+    initial: &[ScoredDoc],
+    completion: &[ScoredDoc],
+    limit: usize,
+) -> usize {
+    initial
+        .iter()
+        .zip(completion)
+        .take(limit)
+        .filter(|(initial, completed)| completed.row_id < initial.row_id)
+        .count()
+}
+
+async fn exact_match_fallback(
+    indices: &[Arc<InvertedIndex>],
+    query: &FtsQuery,
+    params: &FtsSearchParams,
+    prefilter: Arc<dyn PreFilter>,
+    metrics: Arc<FtsIndexMetrics>,
+    base_scorer: Arc<MemBM25Scorer>,
+    score_floor: Option<f32>,
+) -> Result<(Vec<u64>, Vec<f32>)> {
+    if let Some(score_floor) = score_floor {
+        compound_search_with_base_scorer_and_score_floor(
+            indices,
+            query,
+            params,
+            prefilter,
+            metrics,
+            base_scorer,
+            score_floor,
+        )
+        .await
+    } else {
+        compound_search_with_base_scorer(indices, query, params, prefilter, metrics, base_scorer)
+            .await
     }
 }
 
@@ -881,16 +960,17 @@ impl ExecutionPlan for CompoundQueryExec {
                 })?;
                 let mut tokenizer =
                     tokenizer_for_match_query(first_index.as_ref(), match_query.fuzziness);
-                let tokens = collect_query_tokens(&match_query.terms, &mut tokenizer);
-                let wand_params = MatchQueryExec::effective_params(&match_query, params.clone())
-                    .with_phrase_slop(None)
-                    .with_limit(Some(wand_limit));
+                let tokens = Arc::new(collect_query_tokens(&match_query.terms, &mut tokenizer));
+                let base_wand_params =
+                    MatchQueryExec::effective_params(&match_query, params.clone())
+                        .with_phrase_slop(None)
+                        .with_limit(Some(wand_limit));
                 let scorer_start = std::time::Instant::now();
                 let base_scorer = Arc::new(
                     build_global_bm25_scorer(
                         &indices,
-                        &tokens,
-                        &wand_params,
+                        tokens.as_ref(),
+                        &base_wand_params,
                         Some(metrics.as_ref()),
                     )
                     .await?,
@@ -917,48 +997,174 @@ impl ExecutionPlan for CompoundQueryExec {
                 } else {
                     metrics.record_wand_exactness_certificate_attempts(1);
                     prefilter.wait_for_ready().await?;
+                    let probe_start = std::time::Instant::now();
+                    let probe_comparisons = metrics.index_metrics.comparisons();
                     let mut documents = search_segments(
                         &indices,
-                        Arc::new(tokens),
-                        Arc::new(wand_params),
+                        tokens.clone(),
+                        Arc::new(base_wand_params.clone()),
                         match_query.operator,
                         prefilter.clone(),
                         metrics.clone(),
                         base_scorer.clone(),
+                        None,
                     )
                     .await?;
+                    metrics.record_wand_exactness_probe(probe_start.elapsed());
+                    metrics.record_wand_exactness_probe_comparisons(
+                        metrics
+                            .index_metrics
+                            .comparisons()
+                            .saturating_sub(probe_comparisons),
+                    );
                     documents.iter_mut().for_each(|document| {
                         document.score.0 *= match_query.boost;
                     });
                     metrics.record_wand_exactness_certificate_candidates(documents.len());
-                    match classify_wand_exactness_certificate(&mut documents, limit) {
+                    match classify_wand_exactness_certificate(&mut documents, limit, wand_limit) {
                         WandExactnessCertificate::Exhaustive => {
                             metrics.record_wand_exactness_certificate_exhaustive(1);
-                            documents.truncate(limit);
-                            documents
-                                .into_iter()
-                                .map(|document| (document.row_id, document.score.0))
-                                .unzip()
+                            finish_wand_documents(documents, limit)
                         }
                         WandExactnessCertificate::Strict => {
                             metrics.record_wand_exactness_certificate_strict(1);
-                            documents.truncate(limit);
-                            documents
-                                .into_iter()
-                                .map(|document| (document.row_id, document.score.0))
-                                .unzip()
+                            finish_wand_documents(documents, limit)
                         }
                         WandExactnessCertificate::Ambiguous => {
-                            metrics.record_wand_exactness_certificate_fallbacks(1);
-                            compound_search_with_base_scorer(
-                                &indices,
-                                &query,
-                                &params,
-                                prefilter,
-                                metrics.clone(),
-                                base_scorer,
-                            )
-                            .await?
+                            let score_floor = documents
+                                .get(limit - 1)
+                                .map(|document| document.score.0)
+                                .filter(|score| score.is_finite());
+                            let completion_limit = limit
+                                .checked_add(WAND_TIE_COMPLETION_BUDGET)
+                                .and_then(|limit| limit.checked_add(1));
+                            if let (Some(score_floor), Some(completion_limit)) =
+                                (score_floor, completion_limit)
+                            {
+                                metrics.record_wand_tie_completion_attempts(1);
+                                let completion_params = Arc::new(
+                                    base_wand_params.clone().with_limit(Some(completion_limit)),
+                                );
+                                let completion_start = std::time::Instant::now();
+                                let completion_comparisons = metrics.index_metrics.comparisons();
+                                let raw_score_floor =
+                                    exclusive_scaled_score_floor(score_floor, match_query.boost);
+                                let mut completion = search_segments(
+                                    &indices,
+                                    tokens,
+                                    completion_params,
+                                    match_query.operator,
+                                    prefilter.clone(),
+                                    metrics.clone(),
+                                    base_scorer.clone(),
+                                    raw_score_floor,
+                                )
+                                .await?;
+                                metrics.record_wand_tie_completion(completion_start.elapsed());
+                                metrics.record_wand_tie_completion_comparisons(
+                                    metrics
+                                        .index_metrics
+                                        .comparisons()
+                                        .saturating_sub(completion_comparisons),
+                                );
+                                completion.iter_mut().for_each(|document| {
+                                    document.score.0 *= match_query.boost;
+                                });
+                                metrics.record_wand_tie_completion_candidates(completion.len());
+                                match classify_wand_exactness_certificate(
+                                    &mut completion,
+                                    limit,
+                                    completion_limit,
+                                ) {
+                                    WandExactnessCertificate::Exhaustive => {
+                                        metrics.record_wand_tie_completion_successes(1);
+                                        metrics.record_wand_tie_completion_row_id_replacements(
+                                            count_smaller_row_id_replacements(
+                                                &documents,
+                                                &completion,
+                                                limit,
+                                            ),
+                                        );
+                                        metrics.record_wand_exactness_certificate_exhaustive(1);
+                                        finish_wand_documents(completion, limit)
+                                    }
+                                    WandExactnessCertificate::Strict => {
+                                        metrics.record_wand_tie_completion_successes(1);
+                                        metrics.record_wand_tie_completion_row_id_replacements(
+                                            count_smaller_row_id_replacements(
+                                                &documents,
+                                                &completion,
+                                                limit,
+                                            ),
+                                        );
+                                        metrics.record_wand_exactness_certificate_strict(1);
+                                        finish_wand_documents(completion, limit)
+                                    }
+                                    WandExactnessCertificate::Ambiguous => {
+                                        let seeded_floor = completion
+                                            .iter()
+                                            .all(|document| document.score.0.is_finite())
+                                            .then_some(score_floor);
+                                        metrics.record_wand_exactness_certificate_fallbacks(1);
+                                        if seeded_floor.is_some() {
+                                            metrics.record_wand_tie_completion_overflows(1);
+                                            metrics.record_wand_seeded_fallbacks(1);
+                                        }
+                                        let fallback_start = std::time::Instant::now();
+                                        let fallback_comparisons =
+                                            metrics.index_metrics.comparisons();
+                                        let results = exact_match_fallback(
+                                            &indices,
+                                            &query,
+                                            &params,
+                                            prefilter,
+                                            metrics.clone(),
+                                            base_scorer,
+                                            seeded_floor,
+                                        )
+                                        .await?;
+                                        if seeded_floor.is_some() {
+                                            metrics.record_wand_seeded_fallback(
+                                                fallback_start.elapsed(),
+                                            );
+                                            metrics.record_wand_seeded_fallback_comparisons(
+                                                metrics
+                                                    .index_metrics
+                                                    .comparisons()
+                                                    .saturating_sub(fallback_comparisons),
+                                            );
+                                        }
+                                        results
+                                    }
+                                }
+                            } else {
+                                metrics.record_wand_exactness_certificate_fallbacks(1);
+                                if score_floor.is_some() {
+                                    metrics.record_wand_seeded_fallbacks(1);
+                                }
+                                let fallback_start = std::time::Instant::now();
+                                let fallback_comparisons = metrics.index_metrics.comparisons();
+                                let results = exact_match_fallback(
+                                    &indices,
+                                    &query,
+                                    &params,
+                                    prefilter,
+                                    metrics.clone(),
+                                    base_scorer,
+                                    score_floor,
+                                )
+                                .await?;
+                                if score_floor.is_some() {
+                                    metrics.record_wand_seeded_fallback(fallback_start.elapsed());
+                                    metrics.record_wand_seeded_fallback_comparisons(
+                                        metrics
+                                            .index_metrics
+                                            .comparisons()
+                                            .saturating_sub(fallback_comparisons),
+                                    );
+                                }
+                                results
+                            }
                         }
                     }
                 }
@@ -1756,6 +1962,18 @@ pub struct FtsIndexMetrics {
     wand_exactness_certificate_exhaustive: Count,
     wand_exactness_certificate_fallbacks: Count,
     wand_exactness_certificate_candidates: Count,
+    wand_exactness_probe_ms: Gauge,
+    wand_exactness_probe_comparisons: Count,
+    wand_tie_completion_attempts: Count,
+    wand_tie_completion_successes: Count,
+    wand_tie_completion_overflows: Count,
+    wand_tie_completion_candidates: Count,
+    wand_tie_completion_row_id_replacements: Count,
+    wand_tie_completion_ms: Gauge,
+    wand_tie_completion_comparisons: Count,
+    wand_seeded_fallbacks: Count,
+    wand_seeded_fallback_ms: Gauge,
+    wand_seeded_fallback_comparisons: Count,
     /// Wall time (ms) of the exec-local `build_global_bm25_scorer`
     /// fallback; zero when a preset base scorer was injected.
     scorer_build_ms: Gauge,
@@ -1811,6 +2029,26 @@ impl FtsIndexMetrics {
                 .new_count(WAND_EXACTNESS_CERTIFICATE_FALLBACKS_METRIC, partition),
             wand_exactness_certificate_candidates: metrics
                 .new_count(WAND_EXACTNESS_CERTIFICATE_CANDIDATES_METRIC, partition),
+            wand_exactness_probe_ms: metrics.new_gauge(WAND_EXACTNESS_PROBE_MS_METRIC, partition),
+            wand_exactness_probe_comparisons: metrics
+                .new_count(WAND_EXACTNESS_PROBE_COMPARISONS_METRIC, partition),
+            wand_tie_completion_attempts: metrics
+                .new_count(WAND_TIE_COMPLETION_ATTEMPTS_METRIC, partition),
+            wand_tie_completion_successes: metrics
+                .new_count(WAND_TIE_COMPLETION_SUCCESSES_METRIC, partition),
+            wand_tie_completion_overflows: metrics
+                .new_count(WAND_TIE_COMPLETION_OVERFLOWS_METRIC, partition),
+            wand_tie_completion_candidates: metrics
+                .new_count(WAND_TIE_COMPLETION_CANDIDATES_METRIC, partition),
+            wand_tie_completion_row_id_replacements: metrics
+                .new_count(WAND_TIE_COMPLETION_ROW_ID_REPLACEMENTS_METRIC, partition),
+            wand_tie_completion_ms: metrics.new_gauge(WAND_TIE_COMPLETION_MS_METRIC, partition),
+            wand_tie_completion_comparisons: metrics
+                .new_count(WAND_TIE_COMPLETION_COMPARISONS_METRIC, partition),
+            wand_seeded_fallbacks: metrics.new_count(WAND_SEEDED_FALLBACKS_METRIC, partition),
+            wand_seeded_fallback_ms: metrics.new_gauge(WAND_SEEDED_FALLBACK_MS_METRIC, partition),
+            wand_seeded_fallback_comparisons: metrics
+                .new_count(WAND_SEEDED_FALLBACK_COMPARISONS_METRIC, partition),
             scorer_build_ms: metrics.new_gauge("scorer_build_ms", partition),
             segment_bind_duration: metrics.new_time(FTS_SEGMENT_BIND_DURATION_METRIC, partition),
             baseline_metrics: BaselineMetrics::new(metrics, partition),
@@ -1823,6 +2061,38 @@ impl FtsIndexMetrics {
 
     pub fn record_scorer_build(&self, elapsed: std::time::Duration) {
         self.scorer_build_ms.set(elapsed.as_millis() as usize);
+    }
+
+    fn record_wand_exactness_probe(&self, elapsed: std::time::Duration) {
+        self.wand_exactness_probe_ms
+            .set(elapsed.as_millis() as usize);
+    }
+
+    fn record_wand_exactness_probe_comparisons(&self, comparisons: usize) {
+        self.wand_exactness_probe_comparisons.add(comparisons);
+    }
+
+    fn record_wand_tie_completion(&self, elapsed: std::time::Duration) {
+        self.wand_tie_completion_ms
+            .set(elapsed.as_millis() as usize);
+    }
+
+    fn record_wand_tie_completion_comparisons(&self, comparisons: usize) {
+        self.wand_tie_completion_comparisons.add(comparisons);
+    }
+
+    fn record_wand_tie_completion_row_id_replacements(&self, replacements: usize) {
+        self.wand_tie_completion_row_id_replacements
+            .add(replacements);
+    }
+
+    fn record_wand_seeded_fallback(&self, elapsed: std::time::Duration) {
+        self.wand_seeded_fallback_ms
+            .set(elapsed.as_millis() as usize);
+    }
+
+    fn record_wand_seeded_fallback_comparisons(&self, comparisons: usize) {
+        self.wand_seeded_fallback_comparisons.add(comparisons);
     }
 }
 
@@ -1940,6 +2210,26 @@ impl MetricsCollector for FtsIndexMetrics {
     fn record_wand_exactness_certificate_candidates(&self, num_candidates: usize) {
         self.wand_exactness_certificate_candidates
             .add(num_candidates);
+    }
+
+    fn record_wand_tie_completion_attempts(&self, num_attempts: usize) {
+        self.wand_tie_completion_attempts.add(num_attempts);
+    }
+
+    fn record_wand_tie_completion_successes(&self, num_successes: usize) {
+        self.wand_tie_completion_successes.add(num_successes);
+    }
+
+    fn record_wand_tie_completion_overflows(&self, num_overflows: usize) {
+        self.wand_tie_completion_overflows.add(num_overflows);
+    }
+
+    fn record_wand_tie_completion_candidates(&self, num_candidates: usize) {
+        self.wand_tie_completion_candidates.add(num_candidates);
+    }
+
+    fn record_wand_seeded_fallbacks(&self, num_fallbacks: usize) {
+        self.wand_seeded_fallbacks.add(num_fallbacks);
     }
 }
 
@@ -2421,6 +2711,7 @@ impl ExecutionPlan for MatchQueryExec {
                 pre_filter,
                 metrics.clone(),
                 base_scorer,
+                None,
             )
             .await?;
             documents.iter_mut().for_each(|document| {
@@ -3719,6 +4010,7 @@ impl ExecutionPlan for PhraseQueryExec {
                 pre_filter,
                 metrics.clone(),
                 base_scorer,
+                None,
             )
             .await?;
             metrics.baseline_metrics.record_output(documents.len());
@@ -4304,8 +4596,9 @@ mod tests {
     use super::{
         BoolSlot, BoostQueryExec, CompoundQueryExec, CrossColumnCompoundQueryExec,
         FTS_SEGMENT_BIND_DURATION_METRIC, FlatMatchFilterExec, FlatMatchQueryExec, MatchQueryExec,
-        PhraseQueryExec, WandExactnessCertificate, build_boolean_query_children,
-        classify_wand_exactness_certificate, default_text_tokenizer, open_fts_segments,
+        PhraseQueryExec, WAND_TIE_COMPLETION_BUDGET, WandExactnessCertificate,
+        build_boolean_query_children, classify_wand_exactness_certificate,
+        count_smaller_row_id_replacements, default_text_tokenizer, open_fts_segments,
     };
     use crate::io::exec::utils::IndexMetrics;
     use datafusion::physical_plan::empty::EmptyExec;
@@ -4376,13 +4669,13 @@ mod tests {
 
         let mut exhaustive = documents(&[3.0, 2.0]);
         assert_eq!(
-            classify_wand_exactness_certificate(&mut exhaustive, 3),
+            classify_wand_exactness_certificate(&mut exhaustive, 3, 4),
             WandExactnessCertificate::Exhaustive
         );
 
         let mut strict = documents(&[4.0, 3.0, 3.0, 1.0]);
         assert_eq!(
-            classify_wand_exactness_certificate(&mut strict, 3),
+            classify_wand_exactness_certificate(&mut strict, 3, 4),
             WandExactnessCertificate::Strict
         );
         assert_eq!(
@@ -4396,20 +4689,73 @@ mod tests {
 
         let mut ambiguous = documents(&[4.0, 3.0, 2.0, 2.0]);
         assert_eq!(
-            classify_wand_exactness_certificate(&mut ambiguous, 3),
+            classify_wand_exactness_certificate(&mut ambiguous, 3, 4),
             WandExactnessCertificate::Ambiguous
         );
 
         let mut non_finite = documents(&[4.0, f32::INFINITY]);
         assert_eq!(
-            classify_wand_exactness_certificate(&mut non_finite, 1),
+            classify_wand_exactness_certificate(&mut non_finite, 1, 2),
             WandExactnessCertificate::Ambiguous
         );
 
         let mut zero_limit = documents(&[1.0]);
         assert_eq!(
-            classify_wand_exactness_certificate(&mut zero_limit, 0),
+            classify_wand_exactness_certificate(&mut zero_limit, 0, 1),
             WandExactnessCertificate::Ambiguous
+        );
+
+        let mut reversed_segments = vec![
+            ScoredDoc::new(99, 2.0),
+            ScoredDoc::new(50, 3.0),
+            ScoredDoc::new(1, 2.0),
+        ];
+        assert_eq!(
+            classify_wand_exactness_certificate(&mut reversed_segments, 2, 4),
+            WandExactnessCertificate::Exhaustive
+        );
+        assert_eq!(
+            reversed_segments
+                .iter()
+                .map(|document| document.row_id)
+                .collect::<Vec<_>>(),
+            vec![50, 1, 99],
+            "completed ties must use final row-id order, not segment arrival order"
+        );
+
+        let completion_limit = 1 + WAND_TIE_COMPLETION_BUDGET + 1;
+        let mut at_budget = (0..=WAND_TIE_COMPLETION_BUDGET)
+            .rev()
+            .map(|row_id| ScoredDoc::new(row_id as u64, 2.0))
+            .chain(std::iter::once(ScoredDoc::new(u64::MAX, 1.0)))
+            .collect::<Vec<_>>();
+        assert_eq!(at_budget.len(), completion_limit);
+        assert_eq!(
+            classify_wand_exactness_certificate(&mut at_budget, 1, completion_limit),
+            WandExactnessCertificate::Strict,
+            "the completion budget includes a slot for a strict lower-score guard"
+        );
+        assert_eq!(at_budget[0].row_id, 0);
+
+        let mut overflow = (0..completion_limit)
+            .rev()
+            .map(|row_id| ScoredDoc::new(row_id as u64, 2.0))
+            .collect::<Vec<_>>();
+        assert_eq!(
+            classify_wand_exactness_certificate(&mut overflow, 1, completion_limit),
+            WandExactnessCertificate::Ambiguous,
+            "a full probe with no lower-score guard must replay exactly"
+        );
+
+        let initial = vec![ScoredDoc::new(50, 3.0), ScoredDoc::new(99, 2.0)];
+        let completed = vec![ScoredDoc::new(50, 3.0), ScoredDoc::new(1, 2.0)];
+        assert_eq!(
+            count_smaller_row_id_replacements(&initial, &completed, 2),
+            1
+        );
+        assert_eq!(
+            count_smaller_row_id_replacements(&completed, &initial, 2),
+            0
         );
     }
 
@@ -4423,12 +4769,36 @@ mod tests {
         metrics.record_wand_exactness_certificate_exhaustive(5);
         metrics.record_wand_exactness_certificate_fallbacks(7);
         metrics.record_wand_exactness_certificate_candidates(11);
+        metrics.record_wand_tie_completion_attempts(13);
+        metrics.record_wand_tie_completion_successes(17);
+        metrics.record_wand_tie_completion_overflows(19);
+        metrics.record_wand_tie_completion_candidates(23);
+        metrics.record_wand_seeded_fallbacks(29);
+        metrics.record_wand_exactness_probe(std::time::Duration::from_millis(31));
+        metrics.record_wand_tie_completion(std::time::Duration::from_millis(37));
+        metrics.record_wand_seeded_fallback(std::time::Duration::from_millis(41));
+        metrics.record_wand_exactness_probe_comparisons(43);
+        metrics.record_wand_tie_completion_comparisons(47);
+        metrics.record_wand_seeded_fallback_comparisons(53);
+        metrics.record_wand_tie_completion_row_id_replacements(59);
 
         assert_eq!(metrics.wand_exactness_certificate_attempts.value(), 2);
         assert_eq!(metrics.wand_exactness_certificate_strict.value(), 3);
         assert_eq!(metrics.wand_exactness_certificate_exhaustive.value(), 5);
         assert_eq!(metrics.wand_exactness_certificate_fallbacks.value(), 7);
         assert_eq!(metrics.wand_exactness_certificate_candidates.value(), 11);
+        assert_eq!(metrics.wand_tie_completion_attempts.value(), 13);
+        assert_eq!(metrics.wand_tie_completion_successes.value(), 17);
+        assert_eq!(metrics.wand_tie_completion_overflows.value(), 19);
+        assert_eq!(metrics.wand_tie_completion_candidates.value(), 23);
+        assert_eq!(metrics.wand_seeded_fallbacks.value(), 29);
+        assert_eq!(metrics.wand_exactness_probe_ms.value(), 31);
+        assert_eq!(metrics.wand_tie_completion_ms.value(), 37);
+        assert_eq!(metrics.wand_seeded_fallback_ms.value(), 41);
+        assert_eq!(metrics.wand_exactness_probe_comparisons.value(), 43);
+        assert_eq!(metrics.wand_tie_completion_comparisons.value(), 47);
+        assert_eq!(metrics.wand_seeded_fallback_comparisons.value(), 53);
+        assert_eq!(metrics.wand_tie_completion_row_id_replacements.value(), 59);
     }
 
     async fn create_segment_selection_fixture() -> (Arc<Dataset>, Vec<IndexMetadata>, Vec<u32>) {

--- a/rust/lance/src/io/exec/fts.rs
+++ b/rust/lance/src/io/exec/fts.rs
@@ -308,6 +308,7 @@ async fn open_fts_segments(
     .await
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn search_segments(
     indices: &[Arc<InvertedIndex>],
     tokens: Arc<Tokens>,

--- a/rust/lance/src/io/exec/utils.rs
+++ b/rust/lance/src/io/exec/utils.rs
@@ -585,6 +585,11 @@ impl IndexMetrics {
     pub fn flush_io(&self) {
         self.io_metrics.record_stats(self.io_stats.snapshot());
     }
+
+    /// Return the cumulative comparison count for phase-level deltas.
+    pub fn comparisons(&self) -> usize {
+        self.index_comparisons.value()
+    }
 }
 
 impl MetricsCollector for IndexMetrics {


### PR DESCRIPTION
## Performance issue

The exact `k + 1` WAND certificate for fully indexed top-level `MultiMatch` fields returns immediately on a strict score boundary, but an equal kth-score boundary currently restarts the exact compound scorer from the beginning. On the frozen 10M-row broad-250 workload, this affected 232/250 `k=10` queries in the previous certificate census.

Linear: https://linear.app/lancedb/issue/OSS-2100/complete-ambiguous-multimatch-wand-ties-without-full-replay

## How this improves it

- Run a bounded `k + 128 + 1` completion pass only for ambiguous kth-score ties.
- Seed the completion WAND with an inclusive score floor from the initial probe.
- Resolve final row IDs and select exact `(score DESC, row_id ASC)` top-k when the bounded tie state closes with a strict guard.
- Fall back to the exact compound scorer if the tie state overflows, seeded with the best proven inclusive floor.
- Reuse opened indices, tokenization, prefilter state, and the corpus-wide BM25 scorer.
- Record completion attempts, successes, overflows, candidates, comparisons, duration, and row-ID replacements separately.

The score-floor conversion uses the greatest raw `f32` whose actual scaled value is strictly below the inclusive parent floor. This preserves every equal-score candidate, including tiny/subnormal boost cases. The shared conversion is cached in `ScaleScorer`, so an unchanged competitive floor does not repeat the bit-domain search per candidate.

The final-row-ID ordering rule follows Lucene's composite score/doc-ID collector model, while retaining a score-only inclusive floor where Lance cannot prove posting-order and final-row-ID equivalence.

## Correctness coverage

Added coverage for tie groups below/at/above the budget, reversed multi-segment row-ID order, boosted fuzzy overflow, seeded replay, strict equality, normal and subnormal scale conversion, and deterministic replacement accounting. An independent static review found no remaining correctness or performance blocker.

## Validation

- `cargo check -p lance-index -p lance`
- `cargo check -p lance --tests`
- `cargo fmt --all -- --check`
- `git diff --check`

Per request, test binaries and clippy were not run locally; CI runs them. The latest CI clippy, format, and JNI Rust lint checks pass.

## Benchmark

Environment: GCP `c4-highmem-16` (16 vCPUs, 121 GiB RAM), `us-central1-c`, `release-with-debug`. Dataset: frozen MMLB code-columns snapshot with 10,000,000 rows, 10 fragments, and the existing `full_content` / `summary` FTS indices. Query manifest: frozen broad-250, SHA-256 `b4094da9...64fab`. Baseline: main `91aee6f91`, module `121aa0e...743`; this PR: `45436fe3c`, module `e6196649...ebcfa`.

Both builds matched the frozen exhaustive ordered `(score DESC, row_id ASC)` oracle in all 500/500 bounded cases (`k=10` and `k=100`). All process-level row-ID and result signatures were stable and identical across builds.

Warm methodology: 64 GiB index cache, 8 query workers, 250 queries × 5 repetitions per process, two independent A-B-B-A blocks (four process samples per build). QPS is the median across processes; latency percentiles pool all process samples.

| Scenario / metric | Baseline | This PR | Benefit |
| --- | ---: | ---: | ---: |
| `k=10` throughput (higher is better) | 1,789.45 q/s | 2,171.50 q/s | **1.214x speedup** |
| `k=10` p50 latency (lower is better) | 4.245 ms | 3.589 ms | **1.183x faster** |
| `k=10` p95 latency (lower is better) | 6.797 ms | 5.053 ms | **1.345x faster** |
| `k=100` throughput (higher is better) | 1,332.42 q/s | 1,430.29 q/s | **1.073x speedup** |
| `k=100` p50 latency (lower is better) | 5.297 ms | 5.295 ms | 1.000x |
| `k=100` p95 latency (lower is better) | 11.215 ms | 8.651 ms | **1.296x faster** |

Activation/cost evidence across the 500 cases:

- Exact full compound replays: `250 -> 3` (**83.3x fewer**).
- Row addresses resolved by exact replay: `53,762 -> 800` (**67.2x fewer**).
- Bounded tie completion: 250 attempts, 247 successes, 3 overflows.
- The 3 seeded overflow fallbacks performed 800 comparisons; completion passes performed 4,464,504 comparisons.

True-cold methodology: one query per fresh process, page cache dropped before every process, no prewarm, two A-B-B-A blocks for each k.

| Scenario / metric | Baseline | This PR | Benefit |
| --- | ---: | ---: | ---: |
| cold `k=10` query latency (lower is better) | 569.694 ms | 558.559 ms | **1.020x faster** |
| cold `k=10` process wall time (lower is better) | 14.565 s | 13.420 s | **1.085x faster** |
| cold `k=100` query latency (lower is better) | 582.448 ms | 580.370 ms | **1.004x faster** |
| cold `k=100` process wall time (lower is better) | 14.100 s | 13.375 s | **1.054x faster** |

Cold peak RSS ratios (this PR / baseline) were `0.986x` for `k=10` and `0.997x` for `k=100`; file-input ratios were both approximately `1.000x`.
