### PR TITLE
perf(fts): bound partial MultiMatch field fallbacks

### DIFF
--- a/rust/lance-index/src/scalar/inverted/index/flat_search.rs
+++ b/rust/lance-index/src/scalar/inverted/index/flat_search.rs
@@ -862,6 +862,57 @@ pub async fn flat_bm25_search_stream_with_options_and_scorer(
     base_scorer: Option<MemBM25Scorer>,
     options: FlatBm25SearchOptions,
 ) -> DataFusionResult<(SendableRecordBatchStream, MemBM25Scorer)> {
+    flat_bm25_search_stream_with_scorer_mode(
+        input,
+        doc_col,
+        query,
+        tokenizer,
+        FlatScorerMode::Extend(base_scorer),
+        options,
+    )
+    .await
+}
+
+/// Run a flat BM25 search with fixed corpus-wide statistics.
+///
+/// Unlike [`flat_bm25_search_stream_with_options_and_scorer`], documents in
+/// `input` are scored but are not added to the supplied scorer. This is used
+/// when corpus statistics were collected from an unfiltered stream while the
+/// candidate stream has already applied a query filter.
+#[doc(hidden)]
+pub async fn flat_bm25_search_stream_with_options_and_fixed_scorer(
+    input: SendableRecordBatchStream,
+    doc_col: String,
+    query: String,
+    tokenizer: Box<dyn LanceTokenizer>,
+    scorer: MemBM25Scorer,
+    options: FlatBm25SearchOptions,
+) -> DataFusionResult<SendableRecordBatchStream> {
+    Ok(flat_bm25_search_stream_with_scorer_mode(
+        input,
+        doc_col,
+        query,
+        tokenizer,
+        FlatScorerMode::Fixed(scorer),
+        options,
+    )
+    .await?
+    .0)
+}
+
+enum FlatScorerMode {
+    Extend(Option<MemBM25Scorer>),
+    Fixed(MemBM25Scorer),
+}
+
+async fn flat_bm25_search_stream_with_scorer_mode(
+    input: SendableRecordBatchStream,
+    doc_col: String,
+    query: String,
+    tokenizer: Box<dyn LanceTokenizer>,
+    scorer_mode: FlatScorerMode,
+    options: FlatBm25SearchOptions,
+) -> DataFusionResult<(SendableRecordBatchStream, MemBM25Scorer)> {
     let FlatBm25SearchOptions {
         target_batch_size,
         elapsed_compute,
@@ -882,7 +933,12 @@ pub async fn flat_bm25_search_stream_with_options_and_scorer(
     // proceeding. This mirrors the indexed search path, which already
     // short-circuits on empty query tokens.
     if query_tokens.is_empty() {
-        let scorer = base_scorer.unwrap_or_else(|| MemBM25Scorer::new(0, 0, HashMap::new()));
+        let scorer = match scorer_mode {
+            FlatScorerMode::Extend(base_scorer) => {
+                base_scorer.unwrap_or_else(|| MemBM25Scorer::new(0, 0, HashMap::new()))
+            }
+            FlatScorerMode::Fixed(scorer) => scorer,
+        };
         return Ok((
             Box::pin(RecordBatchStreamAdapter::new(
                 output_schema,
@@ -936,7 +992,12 @@ pub async fn flat_bm25_search_stream_with_options_and_scorer(
     // Phase 3 - Calculate final scores (this is fairly cheap, probably don't need to parallelize).
     // All post-await work is synchronous; time the scorer + score + slicing loop together.
     let post_await_start = std::time::Instant::now();
-    let scorer = initialize_scorer(base_scorer.as_ref(), query_tokens.as_ref(), &counted_input);
+    let scorer = match scorer_mode {
+        FlatScorerMode::Extend(base_scorer) => {
+            initialize_scorer(base_scorer.as_ref(), query_tokens.as_ref(), &counted_input)
+        }
+        FlatScorerMode::Fixed(scorer) => scorer,
+    };
     let scores = flat_bm25_score(
         query_tokens.as_ref(),
         &counted_input,

--- a/rust/lance/src/dataset/scanner.rs
+++ b/rust/lance/src/dataset/scanner.rs
@@ -77,7 +77,7 @@ use lance_index::scalar::inverted::query::{
 };
 use lance_index::scalar::inverted::{
     DOC_INDEX_COL, DOC_INDEX_FIELD, DocumentGranularity, INVERTED_INDEX_VERSION_V2,
-    INVERTED_INDEX_VERSION_V3, SCORE_COL, SCORE_FIELD, fts_schema,
+    INVERTED_INDEX_VERSION_V3, MemBM25Scorer, SCORE_COL, SCORE_FIELD, fts_schema,
 };
 use lance_index::scalar::registry::VALUE_COLUMN_NAME;
 use lance_index::vector::{ApproxMode, DEFAULT_QUERY_PARALLELISM, DIST_COL, Query};
@@ -113,8 +113,11 @@ use crate::io::exec::filtered_read::{
     FilteredReadExec, FilteredReadOptions, FilteredReadThreadingMode,
 };
 use crate::io::exec::fts::{
-    BoostQueryExec, CompoundQueryExec, CrossColumnCompoundQueryExec, FlatMatchFilterExec,
-    FlatMatchQueryExec, FtsDocumentExec, MatchQueryExec, PhraseQueryExec, SharedFtsScorer,
+    BOUNDED_MIXED_FIELD_ROWS_METRIC, BOUNDED_MIXED_INDEXED_CANDIDATES_METRIC,
+    BOUNDED_MIXED_INDEXED_ROWS_METRIC, BOUNDED_MIXED_RESIDUAL_CANDIDATES_METRIC,
+    BOUNDED_MIXED_RESIDUAL_ROWS_METRIC, BoostQueryExec, BoundedMixedFtsMetricsExec,
+    CompoundQueryExec, CrossColumnCompoundQueryExec, FlatMatchFilterExec, FlatMatchQueryExec,
+    FtsDocumentExec, MatchQueryExec, PhraseQueryExec, SharedFtsScorer,
 };
 use crate::io::exec::knn::MultivectorScoringExec;
 use crate::io::exec::scalar_index::{MaterializeIndexExec, ScalarIndexExec};
@@ -167,6 +170,43 @@ enum FtsOverlayPlan {
         segments: Vec<IndexMetadata>,
     },
     FullScan,
+}
+
+enum BoundedMixedFtsFieldPlan {
+    NotApplicable,
+    Bounded(Arc<dyn ExecutionPlan>),
+    ExhaustiveFallback(&'static str),
+    TargetFlatFallback(&'static str),
+}
+
+const BOUNDED_MIXED_FUZZY_FALLBACK_METRIC: &str = "fts_bounded_mixed_fallback_fuzzy";
+const BOUNDED_MIXED_FULL_SCAN_FALLBACK_METRIC: &str = "fts_bounded_mixed_fallback_full_scan";
+const BOUNDED_MIXED_UNKNOWN_COVERAGE_FALLBACK_METRIC: &str =
+    "fts_bounded_mixed_fallback_unknown_coverage";
+const BOUNDED_MIXED_OVERLAP_FALLBACK_METRIC: &str =
+    "fts_bounded_mixed_fallback_overlapping_coverage";
+const BOUNDED_MIXED_LEGACY_FALLBACK_METRIC: &str = "fts_bounded_mixed_fallback_legacy";
+
+fn bounded_mixed_overlay_fallback(plan: &FtsOverlayPlan) -> Option<&'static str> {
+    matches!(plan, FtsOverlayPlan::FullScan).then_some(BOUNDED_MIXED_FULL_SCAN_FALLBACK_METRIC)
+}
+
+fn bounded_mixed_indexed_coverage<'a>(
+    segment_coverages: impl IntoIterator<Item = Option<&'a RoaringBitmap>>,
+    target_fragment_ids: &RoaringBitmap,
+) -> std::result::Result<RoaringBitmap, &'static str> {
+    let mut indexed_fragment_ids = RoaringBitmap::new();
+    for segment_fragment_ids in segment_coverages {
+        let Some(segment_fragment_ids) = segment_fragment_ids else {
+            return Err(BOUNDED_MIXED_UNKNOWN_COVERAGE_FALLBACK_METRIC);
+        };
+        let covered_target_ids = segment_fragment_ids & target_fragment_ids;
+        if !(&indexed_fragment_ids & &covered_target_ids).is_empty() {
+            return Err(BOUNDED_MIXED_OVERLAP_FALLBACK_METRIC);
+        }
+        indexed_fragment_ids |= covered_target_ids;
+    }
+    Ok(indexed_fragment_ids)
 }
 
 fn collect_fts_columns_in_order(query: &FtsQuery) -> Vec<String> {
@@ -4304,6 +4344,7 @@ impl Scanner {
     ) -> Result<Arc<dyn ExecutionPlan>> {
         let document_granularity = self.fts_document_granularity(query)?;
         if !document_granularity.is_list_element()
+            && !matches!(query, FtsQuery::MultiMatch(_))
             && supports_compound_scorer(query)
             && let Some(plan) = self
                 .plan_compound_scorer(query, params, prefilter_source, document_granularity)
@@ -4355,8 +4396,9 @@ impl Scanner {
                 // A top-level cross-column MultiMatch scores each field independently and takes
                 // the maximum score for each row. A field's bounded compound top-k is therefore
                 // sufficient to determine the global top-k independently of the other fields.
-                // Preserve that bounded plan for every eligible field, while planning only
-                // partial-index and overlay-backed fields through the exhaustive leaf fallback.
+                // Preserve that bounded plan for every eligible field. Mixed modern fields use
+                // their own bounded indexed-live and residual sources; unsupported shapes retain
+                // the exhaustive leaf fallback.
                 let unlimited_params = params.clone().with_limit(None);
                 let can_use_bounded_compound =
                     !document_granularity.is_list_element() && params.limit.is_some();
@@ -4366,6 +4408,53 @@ impl Scanner {
                         async move {
                             if can_use_bounded_compound {
                                 let child_query = FtsQuery::Match(match_query.clone());
+                                match self
+                                    .plan_bounded_mixed_multimatch_field(
+                                        match_query,
+                                        params,
+                                        filter_plan,
+                                        prefilter_source,
+                                    )
+                                    .await?
+                                {
+                                    BoundedMixedFtsFieldPlan::Bounded(plan) => {
+                                        return Ok((plan, true));
+                                    }
+                                    BoundedMixedFtsFieldPlan::ExhaustiveFallback(metric) => {
+                                        let plan = self
+                                            .plan_match_query(
+                                                match_query,
+                                                unlimited_params,
+                                                filter_plan,
+                                                prefilter_source,
+                                            )
+                                            .await?;
+                                        return Ok((
+                                            Arc::new(BoundedMixedFtsMetricsExec::new_event(
+                                                plan, metric,
+                                            ))
+                                                as Arc<dyn ExecutionPlan>,
+                                            false,
+                                        ));
+                                    }
+                                    BoundedMixedFtsFieldPlan::TargetFlatFallback(metric) => {
+                                        let plan = self
+                                            .plan_target_flat_match_query(
+                                                match_query,
+                                                unlimited_params,
+                                                filter_plan,
+                                            )
+                                            .await?;
+                                        return Ok((
+                                            Arc::new(BoundedMixedFtsMetricsExec::new_event(
+                                                plan, metric,
+                                            ))
+                                                as Arc<dyn ExecutionPlan>,
+                                            false,
+                                        ));
+                                    }
+                                    BoundedMixedFtsFieldPlan::NotApplicable => {}
+                                }
                                 if let Some(plan) = self
                                     .plan_compound_scorer(
                                         &child_query,
@@ -4375,20 +4464,36 @@ impl Scanner {
                                     )
                                     .await?
                                 {
-                                    return Ok(plan);
+                                    return Ok((plan, true));
                                 }
                             }
 
-                            self.plan_match_query(
-                                match_query,
-                                unlimited_params,
-                                filter_plan,
-                                prefilter_source,
-                            )
-                            .await
+                            let plan = self
+                                .plan_match_query(
+                                    match_query,
+                                    unlimited_params,
+                                    filter_plan,
+                                    prefilter_source,
+                                )
+                                .await?;
+                            Ok::<(Arc<dyn ExecutionPlan>, bool), Error>((plan, false))
                         }
                     }))
                     .await?;
+
+                let mut children = children;
+                if children.len() == 1
+                    && children
+                        .first()
+                        .is_some_and(|(_, is_exact_top_k)| *is_exact_top_k)
+                    && let Some((plan, _)) = children.pop()
+                {
+                    return Ok(plan);
+                }
+                let children = children
+                    .into_iter()
+                    .map(|(plan, _)| plan)
+                    .collect::<Vec<_>>();
 
                 let schema = children[0].schema();
                 let group_expr = vec![(
@@ -4584,6 +4689,7 @@ impl Scanner {
                             &flat_params,
                             filter_plan,
                             None,
+                            None,
                         )
                         .await?;
                     return Self::combine_fts_leaf_plans(None, Some(flat_phrase_plan), params);
@@ -4609,6 +4715,7 @@ impl Scanner {
                                 &flat_query,
                                 &flat_params,
                                 filter_plan,
+                                None,
                                 None,
                             )
                             .await?;
@@ -4661,6 +4768,7 @@ impl Scanner {
                             &flat_params,
                             filter_plan,
                             shared_scorer,
+                            None,
                         )
                         .await?,
                     )
@@ -4683,6 +4791,7 @@ impl Scanner {
                         &flat_query,
                         &flat_params,
                         filter_plan,
+                        None,
                         None,
                     )
                     .await?;
@@ -4750,6 +4859,7 @@ impl Scanner {
                             params,
                             filter_plan,
                             None,
+                            None,
                         )
                         .await?;
                     return Self::combine_fts_leaf_plans(None, Some(flat_match_plan), params);
@@ -4776,11 +4886,22 @@ impl Scanner {
                                 params,
                                 filter_plan,
                                 None,
+                                None,
                             )
                             .await?;
                         return Self::combine_fts_leaf_plans(None, Some(flat_match_plan), params);
                     }
                 };
+                if !self.fast_search
+                    && document_granularity == DocumentGranularity::Row
+                    && query.fuzziness == Some(0)
+                    && !stale_rows.is_empty()
+                {
+                    let plan = self
+                        .plan_target_flat_match_query(query, params, filter_plan)
+                        .await?;
+                    return Self::combine_fts_leaf_plans(None, Some(plan), params);
+                }
                 let overlay_block = self.stale_rows_block_mask(&stale_rows).await?;
                 let has_flat_path = !self.fast_search
                     && (!unindexed_fragments.is_empty() || !stale_rows.is_empty());
@@ -4820,6 +4941,7 @@ impl Scanner {
                             params,
                             filter_plan,
                             shared_scorer,
+                            None,
                         )
                         .await?,
                     )
@@ -4844,6 +4966,7 @@ impl Scanner {
                         params,
                         filter_plan,
                         None,
+                        None,
                     )
                     .await?;
                 (None, Some(flat_match_plan))
@@ -4851,6 +4974,237 @@ impl Scanner {
         };
 
         Self::combine_fts_leaf_plans(match_plan, flat_match_plan, params)
+    }
+
+    /// Bound one top-level MultiMatch field whose live rows are split between
+    /// a modern posting index and exact residual evaluation.
+    ///
+    /// The optimization is deliberately narrower than the ordinary Match
+    /// fallback. Known fragment coverage proves that indexed and unindexed
+    /// sources do not overlap, while the overlay block removes stale rows from
+    /// the indexed source before their current values are evaluated by the
+    /// residual source. Unknown or overlapping coverage and legacy postings
+    /// retain the exhaustive plan.
+    async fn plan_bounded_mixed_multimatch_field(
+        &self,
+        query: &MatchQuery,
+        params: &FtsSearchParams,
+        filter_plan: &ExprFilterPlan,
+        prefilter_source: &PreFilterSource,
+    ) -> Result<BoundedMixedFtsFieldPlan> {
+        let Some(limit) = params.limit else {
+            return Ok(BoundedMixedFtsFieldPlan::NotApplicable);
+        };
+        if limit == 0 || query.document_granularity != Some(DocumentGranularity::Row) {
+            return Ok(BoundedMixedFtsFieldPlan::NotApplicable);
+        }
+        if self.fast_search {
+            return Ok(BoundedMixedFtsFieldPlan::NotApplicable);
+        }
+        let column = query.column.as_ref().ok_or_else(|| {
+            Error::invalid_input("the column must be specified in the query".to_string())
+        })?;
+        resolve_fts_field(self.dataset.schema(), column, DocumentGranularity::Row)?;
+
+        let Some(_) = self
+            .dataset
+            .load_scalar_index(
+                IndexCriteria::default()
+                    .for_column(column)
+                    .supports_fts()
+                    .with_fts_document_granularity(DocumentGranularity::Row),
+            )
+            .await?
+        else {
+            return Ok(BoundedMixedFtsFieldPlan::NotApplicable);
+        };
+        let target_fragments: &[Fragment] = self
+            .fragments
+            .as_deref()
+            .unwrap_or_else(|| self.dataset.fragments());
+        if target_fragments.is_empty() {
+            return Ok(BoundedMixedFtsFieldPlan::NotApplicable);
+        }
+        let Some(loaded_segments) =
+            load_segments(&self.dataset, column, DocumentGranularity::Row).await?
+        else {
+            return Ok(BoundedMixedFtsFieldPlan::NotApplicable);
+        };
+        let is_explicit_exact = query.fuzziness == Some(0);
+        let overlay_plan = self
+            .fts_overlay_plan(column, DocumentGranularity::Row, target_fragments)
+            .await?;
+        if let Some(metric) = bounded_mixed_overlay_fallback(&overlay_plan) {
+            if !is_explicit_exact {
+                return Err(Error::not_supported(format!(
+                    "MultiMatch fuzzy field {column} cannot be evaluated safely when FTS overlay coverage requires a full scan"
+                )));
+            }
+            return Ok(BoundedMixedFtsFieldPlan::TargetFlatFallback(metric));
+        }
+        let (stale_rows, segments) = match overlay_plan {
+            FtsOverlayPlan::Unchanged(Some(segments)) => (HashMap::new(), segments),
+            FtsOverlayPlan::Unchanged(None) => (HashMap::new(), loaded_segments),
+            FtsOverlayPlan::RowLevel {
+                stale_rows,
+                segments,
+            } => (stale_rows, segments),
+            FtsOverlayPlan::FullScan => {
+                return Ok(BoundedMixedFtsFieldPlan::TargetFlatFallback(
+                    BOUNDED_MIXED_FULL_SCAN_FALLBACK_METRIC,
+                ));
+            }
+        };
+        let target_fragment_ids =
+            RoaringBitmap::from_iter(target_fragments.iter().map(|fragment| fragment.id as u32));
+        let indexed_fragment_ids = match bounded_mixed_indexed_coverage(
+            segments
+                .iter()
+                .map(|segment| segment.fragment_bitmap.as_ref()),
+            &target_fragment_ids,
+        ) {
+            Ok(indexed_fragment_ids) => indexed_fragment_ids,
+            Err(metric) => {
+                if !is_explicit_exact {
+                    return Err(Error::not_supported(format!(
+                        "MultiMatch fuzzy field {column} cannot be evaluated safely with unknown or overlapping FTS fragment coverage"
+                    )));
+                }
+                return Ok(BoundedMixedFtsFieldPlan::TargetFlatFallback(metric));
+            }
+        };
+        let unindexed_fragment_ids = &target_fragment_ids - &indexed_fragment_ids;
+        let unindexed_fragments = target_fragments
+            .iter()
+            .filter(|fragment| unindexed_fragment_ids.contains(fragment.id as u32))
+            .cloned()
+            .collect::<Vec<_>>();
+        if !stale_rows.is_empty() {
+            if !is_explicit_exact {
+                return Ok(BoundedMixedFtsFieldPlan::ExhaustiveFallback(
+                    BOUNDED_MIXED_FUZZY_FALLBACK_METRIC,
+                ));
+            }
+            // Persisted statistics cannot subtract the old value of a stale
+            // row safely (including zero-token documents). Re-score the
+            // target field from current values instead of merging two corpus
+            // domains or losing a newly matching overlay value.
+            return Ok(BoundedMixedFtsFieldPlan::TargetFlatFallback(
+                BOUNDED_MIXED_FULL_SCAN_FALLBACK_METRIC,
+            ));
+        }
+        if unindexed_fragments.is_empty() {
+            return Ok(BoundedMixedFtsFieldPlan::NotApplicable);
+        }
+        if !is_explicit_exact {
+            // `None` is public API auto-fuzziness, although the current index
+            // implementation treats it as exact. Preserve that existing
+            // executable route here; OSS-2103 tracks aligning the behavior.
+            return Ok(BoundedMixedFtsFieldPlan::ExhaustiveFallback(
+                BOUNDED_MIXED_FUZZY_FALLBACK_METRIC,
+            ));
+        }
+
+        let details = futures::future::try_join_all(
+            segments
+                .iter()
+                .map(|segment| load_physical_fts_details(&self.dataset, column, segment)),
+        )
+        .await?;
+        if details.iter().any(|details| {
+            !matches!(
+                details.posting_format_version,
+                Some(INVERTED_INDEX_VERSION_V2 | INVERTED_INDEX_VERSION_V3)
+            )
+        }) {
+            return Ok(BoundedMixedFtsFieldPlan::ExhaustiveFallback(
+                BOUNDED_MIXED_LEGACY_FALLBACK_METRIC,
+            ));
+        }
+
+        let shared_scorer = Arc::new(SharedFtsScorer::new());
+        let indexed_exec = CompoundQueryExec::new_with_segments(
+            self.dataset.clone(),
+            FtsQuery::Match(query.clone()),
+            params.clone(),
+            prefilter_source.clone(),
+            segments,
+        )
+        .with_shared_scorer(shared_scorer.clone())
+        .with_external_mask(self.external_row_mask.clone());
+        let indexed_plan = Arc::new(indexed_exec) as Arc<dyn ExecutionPlan>;
+        let flat_plan = self
+            .plan_flat_match_query(
+                unindexed_fragments,
+                stale_rows,
+                query,
+                params,
+                filter_plan,
+                Some(shared_scorer),
+                None,
+            )
+            .await?;
+
+        Ok(BoundedMixedFtsFieldPlan::Bounded(
+            Self::combine_bounded_fts_sources(indexed_plan, flat_plan, limit)?,
+        ))
+    }
+
+    fn fts_top_k(plan: Arc<dyn ExecutionPlan>, limit: usize) -> Result<Arc<dyn ExecutionPlan>> {
+        let plan = Arc::new(RepartitionExec::try_new(
+            plan,
+            Partitioning::RoundRobinBatch(1),
+        )?);
+        let sort_exprs = [
+            PhysicalSortExpr {
+                expr: expressions::col(SCORE_COL, plan.schema().as_ref())?,
+                options: SortOptions {
+                    descending: true,
+                    nulls_first: false,
+                },
+            },
+            PhysicalSortExpr {
+                expr: expressions::col(ROW_ID, plan.schema().as_ref())?,
+                options: SortOptions {
+                    descending: false,
+                    nulls_first: false,
+                },
+            },
+        ];
+        Ok(Arc::new(
+            SortExec::new(sort_exprs.into(), plan).with_fetch(Some(limit)),
+        ))
+    }
+
+    fn combine_bounded_fts_sources(
+        indexed_plan: Arc<dyn ExecutionPlan>,
+        flat_plan: Arc<dyn ExecutionPlan>,
+        limit: usize,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        let indexed_plan = Arc::new(BoundedMixedFtsMetricsExec::new(
+            indexed_plan,
+            BOUNDED_MIXED_INDEXED_CANDIDATES_METRIC,
+        ));
+        let indexed_plan = Self::fts_top_k(indexed_plan, limit)?;
+        let indexed_plan = Arc::new(BoundedMixedFtsMetricsExec::new(
+            indexed_plan,
+            BOUNDED_MIXED_INDEXED_ROWS_METRIC,
+        ));
+        let flat_plan = Arc::new(BoundedMixedFtsMetricsExec::new(
+            flat_plan,
+            BOUNDED_MIXED_RESIDUAL_CANDIDATES_METRIC,
+        ));
+        let flat_plan = Self::fts_top_k(flat_plan, limit)?;
+        let flat_plan = Arc::new(BoundedMixedFtsMetricsExec::new(
+            flat_plan,
+            BOUNDED_MIXED_RESIDUAL_ROWS_METRIC,
+        ));
+        let sources = UnionExec::try_new(vec![indexed_plan, flat_plan])?;
+        let field = Self::fts_top_k(sources, limit)?;
+        Ok(Arc::new(BoundedMixedFtsMetricsExec::new(
+            field,
+            BOUNDED_MIXED_FIELD_ROWS_METRIC,
+        )))
     }
 
     fn combine_fts_leaf_plans(
@@ -4887,6 +5241,51 @@ impl Scanner {
         ))
     }
 
+    /// Execute a field entirely from current data values while retaining the
+    /// index tokenizer. This is the fail-closed path when segment coverage or
+    /// overlay ownership cannot prove disjoint indexed and residual sources.
+    async fn plan_target_flat_match_query(
+        &self,
+        query: &MatchQuery,
+        params: &FtsSearchParams,
+        filter_plan: &ExprFilterPlan,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        let target_fragments = self
+            .fragments
+            .as_deref()
+            .unwrap_or_else(|| self.dataset.fragments())
+            .to_vec();
+        if target_fragments.is_empty() {
+            return Ok(Arc::new(EmptyExec::new(fts_schema(
+                DocumentGranularity::Row,
+            ))));
+        }
+        let (candidate_input, document_column) = self
+            .plan_flat_match_input(target_fragments.clone(), HashMap::new(), query, filter_plan)
+            .await?;
+        let mut exec = FlatMatchQueryExec::new_with_document_granularity(
+            self.dataset.clone(),
+            query.clone(),
+            params.clone(),
+            candidate_input,
+            DocumentGranularity::Row,
+            document_column,
+        )
+        .with_base_scorer(Arc::new(MemBM25Scorer::new(0, 0, HashMap::new())));
+        if !filter_plan.is_empty() {
+            let corpus_filter_plan = ExprFilterPlan::default();
+            let (corpus_stats_input, _) = self
+                .plan_flat_match_input(target_fragments, HashMap::new(), query, &corpus_filter_plan)
+                .await?;
+            exec = exec.with_corpus_stats_input(corpus_stats_input);
+        }
+        let plan: Arc<dyn ExecutionPlan> = Arc::new(exec);
+        if let Some(mask) = self.external_row_mask.clone() {
+            return Ok(Arc::new(RowAddrMaskFilterExec::new(plan, mask)));
+        }
+        Ok(plan)
+    }
+
     /// Plan match query on unindexed fragments
     async fn plan_flat_match_query(
         &self,
@@ -4896,18 +5295,71 @@ impl Scanner {
         params: &FtsSearchParams,
         filter_plan: &ExprFilterPlan,
         shared_scorer: Option<Arc<SharedFtsScorer>>,
+        corpus_stats_input: Option<Arc<dyn ExecutionPlan>>,
     ) -> Result<Arc<dyn ExecutionPlan>> {
-        let column = query
-            .column
-            .as_ref()
-            .ok_or(Error::invalid_input(
-                "the column must be specified in the query".to_string(),
-            ))?
-            .clone();
         let document_granularity = query.document_granularity.ok_or_else(|| {
             Error::internal("FTS Match query granularity was not resolved".to_string())
         })?;
-        let resolved = resolve_fts_field(self.dataset.schema(), &column, document_granularity)?;
+        let stats_fragments = fragments.clone();
+        let stats_stale_rows = stale_rows.clone();
+        let (plan, document_column) = self
+            .plan_flat_match_input(fragments, stale_rows, query, filter_plan)
+            .await?;
+        let corpus_stats_input =
+            if corpus_stats_input.is_some() || shared_scorer.is_none() || filter_plan.is_empty() {
+                corpus_stats_input
+            } else {
+                let corpus_filter_plan = ExprFilterPlan::default();
+                Some(
+                    self.plan_flat_match_input(
+                        stats_fragments,
+                        stats_stale_rows,
+                        query,
+                        &corpus_filter_plan,
+                    )
+                    .await?
+                    .0,
+                )
+            };
+        let mut flat_match_plan = FlatMatchQueryExec::new_with_document_granularity(
+            self.dataset.clone(),
+            query.clone(),
+            params.clone(),
+            plan,
+            document_granularity,
+            document_column,
+        );
+        if let Some(shared_scorer) = shared_scorer {
+            flat_match_plan = flat_match_plan.with_shared_scorer(shared_scorer);
+        }
+        if let Some(corpus_stats_input) = corpus_stats_input {
+            flat_match_plan = flat_match_plan.with_corpus_stats_input(corpus_stats_input);
+        }
+        let flat_match_plan: Arc<dyn ExecutionPlan> = Arc::new(flat_match_plan);
+        // Unindexed fragments and stale rows never reach the index-side prefilter,
+        // so apply the external row-address mask to the flat FTS results here
+        // (mirrors the ANN flat branch). Applied before the caller's top-k so
+        // masked-out rows do not consume result slots.
+        if let Some(mask) = self.external_row_mask.clone() {
+            return Ok(Arc::new(RowAddrMaskFilterExec::new(flat_match_plan, mask)));
+        }
+        Ok(flat_match_plan)
+    }
+
+    async fn plan_flat_match_input(
+        &self,
+        fragments: Vec<Fragment>,
+        stale_rows: HashMap<u32, RoaringBitmap>,
+        query: &MatchQuery,
+        filter_plan: &ExprFilterPlan,
+    ) -> Result<(Arc<dyn ExecutionPlan>, String)> {
+        let column = query.column.as_ref().ok_or_else(|| {
+            Error::invalid_input("the column must be specified in the query".to_string())
+        })?;
+        let document_granularity = query.document_granularity.ok_or_else(|| {
+            Error::internal("FTS Match query granularity was not resolved".to_string())
+        })?;
+        let resolved = resolve_fts_field(self.dataset.schema(), column, document_granularity)?;
         let scan_column = if resolved.has_lists() {
             resolved.root_column.clone()
         } else {
@@ -4976,26 +5428,7 @@ impl Scanner {
         } else {
             plan = self.ensure_column_alias(plan, &document_column)?;
         }
-        let mut flat_match_plan = FlatMatchQueryExec::new_with_document_granularity(
-            self.dataset.clone(),
-            query.clone(),
-            params.clone(),
-            plan,
-            document_granularity,
-            document_column,
-        );
-        if let Some(shared_scorer) = shared_scorer {
-            flat_match_plan = flat_match_plan.with_shared_scorer(shared_scorer);
-        }
-        let flat_match_plan: Arc<dyn ExecutionPlan> = Arc::new(flat_match_plan);
-        // Unindexed fragments and stale rows never reach the index-side prefilter,
-        // so apply the external row-address mask to the flat FTS results here
-        // (mirrors the ANN flat branch). Applied before the caller's top-k so
-        // masked-out rows do not consume result slots.
-        if let Some(mask) = self.external_row_mask.clone() {
-            return Ok(Arc::new(RowAddrMaskFilterExec::new(flat_match_plan, mask)));
-        }
-        Ok(flat_match_plan)
+        Ok((plan, document_column))
     }
 
     // ANN/KNN search execution node with optional prefilter
@@ -7131,6 +7564,34 @@ mod test {
     use crate::utils::test::{
         DatagenExt, FragmentCount, FragmentRowCount, ThrottledStoreWrapper, assert_plan_node_equals,
     };
+
+    #[test]
+    fn test_bounded_mixed_fallback_classification() {
+        assert_eq!(
+            bounded_mixed_overlay_fallback(&FtsOverlayPlan::FullScan),
+            Some(BOUNDED_MIXED_FULL_SCAN_FALLBACK_METRIC)
+        );
+
+        let target = RoaringBitmap::from_iter([0, 1, 2]);
+        assert_eq!(
+            bounded_mixed_indexed_coverage(std::iter::once(None), &target),
+            Err(BOUNDED_MIXED_UNKNOWN_COVERAGE_FALLBACK_METRIC)
+        );
+
+        let first = RoaringBitmap::from_iter([0, 1]);
+        let overlapping = RoaringBitmap::from_iter([1]);
+        assert_eq!(
+            bounded_mixed_indexed_coverage([Some(&first), Some(&overlapping)], &target),
+            Err(BOUNDED_MIXED_OVERLAP_FALLBACK_METRIC)
+        );
+
+        let first = RoaringBitmap::from_iter([0]);
+        let second = RoaringBitmap::from_iter([1]);
+        assert_eq!(
+            bounded_mixed_indexed_coverage([Some(&first), Some(&second)], &target),
+            Ok(RoaringBitmap::from_iter([0, 1]))
+        );
+    }
 
     #[test]
     fn test_fts_query_contract_rejects_invalid_values() {

--- a/rust/lance/src/dataset/scanner.rs
+++ b/rust/lance/src/dataset/scanner.rs
@@ -179,13 +179,6 @@ enum BoundedMixedFtsFieldPlan {
     TargetFlatFallback(&'static str),
 }
 
-#[derive(Default)]
-struct FlatMatchScorerInputs {
-    shared_scorer: Option<Arc<SharedFtsScorer>>,
-    corpus_stats_input: Option<Arc<dyn ExecutionPlan>>,
-    base_scorer: Option<Arc<MemBM25Scorer>>,
-}
-
 const BOUNDED_MIXED_FUZZY_FALLBACK_METRIC: &str = "fts_bounded_mixed_fallback_fuzzy";
 const BOUNDED_MIXED_FULL_SCAN_FALLBACK_METRIC: &str = "fts_bounded_mixed_fallback_full_scan";
 const BOUNDED_MIXED_UNKNOWN_COVERAGE_FALLBACK_METRIC: &str =
@@ -4695,7 +4688,7 @@ impl Scanner {
                             &flat_query,
                             &flat_params,
                             filter_plan,
-                            FlatMatchScorerInputs::default(),
+                            None,
                         )
                         .await?;
                     return Self::combine_fts_leaf_plans(None, Some(flat_phrase_plan), params);
@@ -4721,7 +4714,7 @@ impl Scanner {
                                 &flat_query,
                                 &flat_params,
                                 filter_plan,
-                                FlatMatchScorerInputs::default(),
+                                None,
                             )
                             .await?;
                         return Self::combine_fts_leaf_plans(None, Some(flat_phrase_plan), params);
@@ -4772,10 +4765,7 @@ impl Scanner {
                             &flat_query,
                             &flat_params,
                             filter_plan,
-                            FlatMatchScorerInputs {
-                                shared_scorer,
-                                ..Default::default()
-                            },
+                            shared_scorer,
                         )
                         .await?,
                     )
@@ -4798,7 +4788,7 @@ impl Scanner {
                         &flat_query,
                         &flat_params,
                         filter_plan,
-                        FlatMatchScorerInputs::default(),
+                        None,
                     )
                     .await?;
                 (None, Some(flat_phrase_plan))
@@ -4864,7 +4854,7 @@ impl Scanner {
                             query,
                             params,
                             filter_plan,
-                            FlatMatchScorerInputs::default(),
+                            None,
                         )
                         .await?;
                     return Self::combine_fts_leaf_plans(None, Some(flat_match_plan), params);
@@ -4890,7 +4880,7 @@ impl Scanner {
                                 query,
                                 params,
                                 filter_plan,
-                                FlatMatchScorerInputs::default(),
+                                None,
                             )
                             .await?;
                         return Self::combine_fts_leaf_plans(None, Some(flat_match_plan), params);
@@ -4899,32 +4889,8 @@ impl Scanner {
                 let overlay_block = self.stale_rows_block_mask(&stale_rows).await?;
                 let has_flat_path = !self.fast_search
                     && (!unindexed_fragments.is_empty() || !stale_rows.is_empty());
-                let uses_current_row_scorer = has_flat_path
-                    && document_granularity == DocumentGranularity::Row
-                    && query.fuzziness == Some(0)
-                    && !stale_rows.is_empty();
-                let can_share_scorer = document_granularity.is_list_element()
-                    || (document_granularity == DocumentGranularity::Row
-                        && query.fuzziness == Some(0));
-                let shared_scorer =
-                    (has_flat_path && can_share_scorer).then(|| Arc::new(SharedFtsScorer::new()));
-                let (corpus_stats_input, flat_base_scorer) = if uses_current_row_scorer {
-                    let corpus_filter_plan = ExprFilterPlan::default();
-                    let (input, _) = self
-                        .plan_flat_match_input(
-                            target_fragments.to_vec(),
-                            HashMap::new(),
-                            query,
-                            &corpus_filter_plan,
-                        )
-                        .await?;
-                    (
-                        Some(input),
-                        Some(Arc::new(MemBM25Scorer::new(0, 0, HashMap::new()))),
-                    )
-                } else {
-                    (None, None)
-                };
+                let shared_scorer = (has_flat_path && document_granularity.is_list_element())
+                    .then(|| Arc::new(SharedFtsScorer::new()));
                 let mut match_exec = match preset_segments {
                     Some(segments) => MatchQueryExec::new_with_segments_and_document_granularity(
                         self.dataset.clone(),
@@ -4958,11 +4924,7 @@ impl Scanner {
                             query,
                             params,
                             filter_plan,
-                            FlatMatchScorerInputs {
-                                shared_scorer,
-                                corpus_stats_input,
-                                base_scorer: flat_base_scorer,
-                            },
+                            shared_scorer,
                         )
                         .await?,
                     )
@@ -4986,7 +4948,7 @@ impl Scanner {
                         query,
                         params,
                         filter_plan,
-                        FlatMatchScorerInputs::default(),
+                        None,
                     )
                     .await?;
                 (None, Some(flat_match_plan))
@@ -5133,26 +5095,7 @@ impl Scanner {
             ));
         }
 
-        let shared_scorer = Arc::new(SharedFtsScorer::new());
-        let uses_current_corpus = !stale_rows.is_empty();
         let overlay_block = self.stale_rows_block_mask(&stale_rows).await?;
-        let (corpus_stats_input, flat_base_scorer) = if uses_current_corpus {
-            let corpus_filter_plan = ExprFilterPlan::default();
-            let (input, _) = self
-                .plan_flat_match_input(
-                    target_fragments.to_vec(),
-                    HashMap::new(),
-                    query,
-                    &corpus_filter_plan,
-                )
-                .await?;
-            (
-                Some(input),
-                Some(Arc::new(MemBM25Scorer::new(0, 0, HashMap::new()))),
-            )
-        } else {
-            (None, None)
-        };
         let mut indexed_exec = CompoundQueryExec::new_with_segments(
             self.dataset.clone(),
             FtsQuery::Match(query.clone()),
@@ -5160,7 +5103,6 @@ impl Scanner {
             prefilter_source.clone(),
             segments,
         )
-        .with_shared_scorer(shared_scorer.clone())
         .with_external_mask(self.external_row_mask.clone());
         if let Some(overlay_block) = overlay_block {
             indexed_exec = indexed_exec.with_overlay_block(overlay_block);
@@ -5173,11 +5115,7 @@ impl Scanner {
                 query,
                 params,
                 filter_plan,
-                FlatMatchScorerInputs {
-                    shared_scorer: Some(shared_scorer),
-                    corpus_stats_input,
-                    base_scorer: flat_base_scorer,
-                },
+                None,
             )
             .await?;
 
@@ -5330,13 +5268,8 @@ impl Scanner {
         query: &MatchQuery,
         params: &FtsSearchParams,
         filter_plan: &ExprFilterPlan,
-        scorer_inputs: FlatMatchScorerInputs,
+        shared_scorer: Option<Arc<SharedFtsScorer>>,
     ) -> Result<Arc<dyn ExecutionPlan>> {
-        let FlatMatchScorerInputs {
-            shared_scorer,
-            corpus_stats_input,
-            base_scorer,
-        } = scorer_inputs;
         let document_granularity = query.document_granularity.ok_or_else(|| {
             Error::internal("FTS Match query granularity was not resolved".to_string())
         })?;
@@ -5348,32 +5281,24 @@ impl Scanner {
         if plan.properties().output_partitioning().partition_count() > 1 {
             plan = Arc::new(CoalescePartitionsExec::new(plan));
         }
-        let corpus_stats_input =
-            if corpus_stats_input.is_some() || shared_scorer.is_none() || filter_plan.is_empty() {
-                corpus_stats_input
-            } else {
-                let corpus_filter_plan = ExprFilterPlan::default();
-                let mut input = self
-                    .plan_flat_match_input(
-                        stats_fragments,
-                        stats_stale_rows,
-                        query,
-                        &corpus_filter_plan,
-                    )
-                    .await?
-                    .0;
-                if input.properties().output_partitioning().partition_count() > 1 {
-                    input = Arc::new(CoalescePartitionsExec::new(input));
-                }
-                Some(input)
-            };
-        let corpus_stats_input = corpus_stats_input.map(|input| {
+        let corpus_stats_input = if shared_scorer.is_some() && !filter_plan.is_empty() {
+            let corpus_filter_plan = ExprFilterPlan::default();
+            let mut input = self
+                .plan_flat_match_input(
+                    stats_fragments,
+                    stats_stale_rows,
+                    query,
+                    &corpus_filter_plan,
+                )
+                .await?
+                .0;
             if input.properties().output_partitioning().partition_count() > 1 {
-                Arc::new(CoalescePartitionsExec::new(input)) as Arc<dyn ExecutionPlan>
-            } else {
-                input
+                input = Arc::new(CoalescePartitionsExec::new(input));
             }
-        });
+            Some(input)
+        } else {
+            None
+        };
         let mut flat_match_plan = FlatMatchQueryExec::new_with_document_granularity(
             self.dataset.clone(),
             query.clone(),
@@ -5384,9 +5309,6 @@ impl Scanner {
         );
         if let Some(shared_scorer) = shared_scorer {
             flat_match_plan = flat_match_plan.with_shared_scorer(shared_scorer);
-        }
-        if let Some(base_scorer) = base_scorer {
-            flat_match_plan = flat_match_plan.with_base_scorer(base_scorer);
         }
         if let Some(corpus_stats_input) = corpus_stats_input {
             flat_match_plan = flat_match_plan.with_corpus_stats_input(corpus_stats_input);

--- a/rust/lance/src/dataset/scanner.rs
+++ b/rust/lance/src/dataset/scanner.rs
@@ -179,6 +179,13 @@ enum BoundedMixedFtsFieldPlan {
     TargetFlatFallback(&'static str),
 }
 
+#[derive(Default)]
+struct FlatMatchScorerInputs {
+    shared_scorer: Option<Arc<SharedFtsScorer>>,
+    corpus_stats_input: Option<Arc<dyn ExecutionPlan>>,
+    base_scorer: Option<Arc<MemBM25Scorer>>,
+}
+
 const BOUNDED_MIXED_FUZZY_FALLBACK_METRIC: &str = "fts_bounded_mixed_fallback_fuzzy";
 const BOUNDED_MIXED_FULL_SCAN_FALLBACK_METRIC: &str = "fts_bounded_mixed_fallback_full_scan";
 const BOUNDED_MIXED_UNKNOWN_COVERAGE_FALLBACK_METRIC: &str =
@@ -4688,8 +4695,7 @@ impl Scanner {
                             &flat_query,
                             &flat_params,
                             filter_plan,
-                            None,
-                            None,
+                            FlatMatchScorerInputs::default(),
                         )
                         .await?;
                     return Self::combine_fts_leaf_plans(None, Some(flat_phrase_plan), params);
@@ -4715,8 +4721,7 @@ impl Scanner {
                                 &flat_query,
                                 &flat_params,
                                 filter_plan,
-                                None,
-                                None,
+                                FlatMatchScorerInputs::default(),
                             )
                             .await?;
                         return Self::combine_fts_leaf_plans(None, Some(flat_phrase_plan), params);
@@ -4767,8 +4772,10 @@ impl Scanner {
                             &flat_query,
                             &flat_params,
                             filter_plan,
-                            shared_scorer,
-                            None,
+                            FlatMatchScorerInputs {
+                                shared_scorer,
+                                ..Default::default()
+                            },
                         )
                         .await?,
                     )
@@ -4791,8 +4798,7 @@ impl Scanner {
                         &flat_query,
                         &flat_params,
                         filter_plan,
-                        None,
-                        None,
+                        FlatMatchScorerInputs::default(),
                     )
                     .await?;
                 (None, Some(flat_phrase_plan))
@@ -4858,8 +4864,7 @@ impl Scanner {
                             query,
                             params,
                             filter_plan,
-                            None,
-                            None,
+                            FlatMatchScorerInputs::default(),
                         )
                         .await?;
                     return Self::combine_fts_leaf_plans(None, Some(flat_match_plan), params);
@@ -4885,28 +4890,41 @@ impl Scanner {
                                 query,
                                 params,
                                 filter_plan,
-                                None,
-                                None,
+                                FlatMatchScorerInputs::default(),
                             )
                             .await?;
                         return Self::combine_fts_leaf_plans(None, Some(flat_match_plan), params);
                     }
                 };
-                if !self.fast_search
-                    && document_granularity == DocumentGranularity::Row
-                    && query.fuzziness == Some(0)
-                    && !stale_rows.is_empty()
-                {
-                    let plan = self
-                        .plan_target_flat_match_query(query, params, filter_plan)
-                        .await?;
-                    return Self::combine_fts_leaf_plans(None, Some(plan), params);
-                }
                 let overlay_block = self.stale_rows_block_mask(&stale_rows).await?;
                 let has_flat_path = !self.fast_search
                     && (!unindexed_fragments.is_empty() || !stale_rows.is_empty());
-                let shared_scorer = (has_flat_path && document_granularity.is_list_element())
-                    .then(|| Arc::new(SharedFtsScorer::new()));
+                let uses_current_row_scorer = has_flat_path
+                    && document_granularity == DocumentGranularity::Row
+                    && query.fuzziness == Some(0)
+                    && !stale_rows.is_empty();
+                let can_share_scorer = document_granularity.is_list_element()
+                    || (document_granularity == DocumentGranularity::Row
+                        && query.fuzziness == Some(0));
+                let shared_scorer =
+                    (has_flat_path && can_share_scorer).then(|| Arc::new(SharedFtsScorer::new()));
+                let (corpus_stats_input, flat_base_scorer) = if uses_current_row_scorer {
+                    let corpus_filter_plan = ExprFilterPlan::default();
+                    let (input, _) = self
+                        .plan_flat_match_input(
+                            target_fragments.to_vec(),
+                            HashMap::new(),
+                            query,
+                            &corpus_filter_plan,
+                        )
+                        .await?;
+                    (
+                        Some(input),
+                        Some(Arc::new(MemBM25Scorer::new(0, 0, HashMap::new()))),
+                    )
+                } else {
+                    (None, None)
+                };
                 let mut match_exec = match preset_segments {
                     Some(segments) => MatchQueryExec::new_with_segments_and_document_granularity(
                         self.dataset.clone(),
@@ -4940,8 +4958,11 @@ impl Scanner {
                             query,
                             params,
                             filter_plan,
-                            shared_scorer,
-                            None,
+                            FlatMatchScorerInputs {
+                                shared_scorer,
+                                corpus_stats_input,
+                                base_scorer: flat_base_scorer,
+                            },
                         )
                         .await?,
                     )
@@ -4965,8 +4986,7 @@ impl Scanner {
                         query,
                         params,
                         filter_plan,
-                        None,
-                        None,
+                        FlatMatchScorerInputs::default(),
                     )
                     .await?;
                 (None, Some(flat_match_plan))
@@ -5085,15 +5105,8 @@ impl Scanner {
                     BOUNDED_MIXED_FUZZY_FALLBACK_METRIC,
                 ));
             }
-            // Persisted statistics cannot subtract the old value of a stale
-            // row safely (including zero-token documents). Re-score the
-            // target field from current values instead of merging two corpus
-            // domains or losing a newly matching overlay value.
-            return Ok(BoundedMixedFtsFieldPlan::TargetFlatFallback(
-                BOUNDED_MIXED_FULL_SCAN_FALLBACK_METRIC,
-            ));
         }
-        if unindexed_fragments.is_empty() {
+        if unindexed_fragments.is_empty() && stale_rows.is_empty() {
             return Ok(BoundedMixedFtsFieldPlan::NotApplicable);
         }
         if !is_explicit_exact {
@@ -5123,7 +5136,26 @@ impl Scanner {
         }
 
         let shared_scorer = Arc::new(SharedFtsScorer::new());
-        let indexed_exec = CompoundQueryExec::new_with_segments(
+        let uses_current_corpus = !stale_rows.is_empty();
+        let overlay_block = self.stale_rows_block_mask(&stale_rows).await?;
+        let (corpus_stats_input, flat_base_scorer) = if uses_current_corpus {
+            let corpus_filter_plan = ExprFilterPlan::default();
+            let (input, _) = self
+                .plan_flat_match_input(
+                    target_fragments.to_vec(),
+                    HashMap::new(),
+                    query,
+                    &corpus_filter_plan,
+                )
+                .await?;
+            (
+                Some(input),
+                Some(Arc::new(MemBM25Scorer::new(0, 0, HashMap::new()))),
+            )
+        } else {
+            (None, None)
+        };
+        let mut indexed_exec = CompoundQueryExec::new_with_segments(
             self.dataset.clone(),
             FtsQuery::Match(query.clone()),
             params.clone(),
@@ -5132,6 +5164,9 @@ impl Scanner {
         )
         .with_shared_scorer(shared_scorer.clone())
         .with_external_mask(self.external_row_mask.clone());
+        if let Some(overlay_block) = overlay_block {
+            indexed_exec = indexed_exec.with_overlay_block(overlay_block);
+        }
         let indexed_plan = Arc::new(indexed_exec) as Arc<dyn ExecutionPlan>;
         let flat_plan = self
             .plan_flat_match_query(
@@ -5140,8 +5175,11 @@ impl Scanner {
                 query,
                 params,
                 filter_plan,
-                Some(shared_scorer),
-                None,
+                FlatMatchScorerInputs {
+                    shared_scorer: Some(shared_scorer),
+                    corpus_stats_input,
+                    base_scorer: flat_base_scorer,
+                },
             )
             .await?;
 
@@ -5294,9 +5332,13 @@ impl Scanner {
         query: &MatchQuery,
         params: &FtsSearchParams,
         filter_plan: &ExprFilterPlan,
-        shared_scorer: Option<Arc<SharedFtsScorer>>,
-        corpus_stats_input: Option<Arc<dyn ExecutionPlan>>,
+        scorer_inputs: FlatMatchScorerInputs,
     ) -> Result<Arc<dyn ExecutionPlan>> {
+        let FlatMatchScorerInputs {
+            shared_scorer,
+            corpus_stats_input,
+            base_scorer,
+        } = scorer_inputs;
         let document_granularity = query.document_granularity.ok_or_else(|| {
             Error::internal("FTS Match query granularity was not resolved".to_string())
         })?;
@@ -5331,6 +5373,9 @@ impl Scanner {
         );
         if let Some(shared_scorer) = shared_scorer {
             flat_match_plan = flat_match_plan.with_shared_scorer(shared_scorer);
+        }
+        if let Some(base_scorer) = base_scorer {
+            flat_match_plan = flat_match_plan.with_base_scorer(base_scorer);
         }
         if let Some(corpus_stats_input) = corpus_stats_input {
             flat_match_plan = flat_match_plan.with_corpus_stats_input(corpus_stats_input);

--- a/rust/lance/src/dataset/scanner.rs
+++ b/rust/lance/src/dataset/scanner.rs
@@ -14700,10 +14700,8 @@ full_filter=name LIKE Utf8(\"test%2\"), refine_filter=name LIKE Utf8(\"test%2\")
         log::info!("Test case: Full text search with unindexed rows and prefilter");
         // After routing flat FTS through `FilteredReadExec`, the BTree on `i`
         // pushes into the unindexed-fragment scan too — no more `FilterExec` on
-        // top of an unfiltered `LanceScan`. A second unfiltered child collects
-        // corpus statistics so candidate filtering cannot change BM25 scores.
-        // Legacy uses the `MaterializeIndex` shape, v2 uses `LanceRead` with
-        // `full_filter` set on the candidate child only.
+        // top of an unfiltered `LanceScan`. Legacy uses the `MaterializeIndex`
+        // shape, v2 uses `LanceRead` with `full_filter` set.
         let expected = if data_storage_version == LanceFileVersion::Legacy {
             r#"ProjectionExec: expr=[s@2 as s, _score@1 as _score, _rowid@0 as _rowid]
   Take: columns="_rowid, _score, (s)"
@@ -14726,8 +14724,7 @@ full_filter=name LIKE Utf8(\"test%2\"), refine_filter=name LIKE Utf8(\"test%2\")
                       MaterializeIndex: query=[i > 10]@i_idx(BTree)
                   ProjectionExec: expr=[_rowid@2 as _rowid, s@1 as s]
                     FilterExec: i@0 > 10
-                      LanceScan: uri=..., projection=[i, s], row_id=true, row_addr=false, ordered=false, range=None
-              LanceScan: uri=..., projection=[s], row_id=true, row_addr=false, ordered=true, range=None"#
+                      LanceScan: uri=..., projection=[i, s], row_id=true, row_addr=false, ordered=false, range=None"#
         } else {
             r#"ProjectionExec: expr=[s@2 as s, _score@1 as _score, _rowid@0 as _rowid]
   LanceRead: uri=..., projection=[s], source=stream(_rowid)
@@ -14739,8 +14736,7 @@ full_filter=name LIKE Utf8(\"test%2\"), refine_filter=name LIKE Utf8(\"test%2\")
               ScalarIndexQuery: query=[i > 10]@i_idx(BTree)
           FlatMatchQuery: column=s, query=hello
             LanceRead: uri=..., projection=[s], num_fragments=1, range_before=None, range_after=None, row_id=true, row_addr=false, full_filter=i > Int32(10), refine_filter=--
-              ScalarIndexQuery: query=[i > 10]@i_idx(BTree)
-            LanceRead: uri=..., projection=[s], num_fragments=1, range_before=None, range_after=None, row_id=true, row_addr=false, full_filter=--, refine_filter=--"#
+              ScalarIndexQuery: query=[i > 10]@i_idx(BTree)"#
         };
         assert_plan_equals(
             &dataset.dataset,

--- a/rust/lance/src/dataset/scanner.rs
+++ b/rust/lance/src/dataset/scanner.rs
@@ -5099,12 +5099,10 @@ impl Scanner {
             .filter(|fragment| unindexed_fragment_ids.contains(fragment.id as u32))
             .cloned()
             .collect::<Vec<_>>();
-        if !stale_rows.is_empty() {
-            if !is_explicit_exact {
-                return Ok(BoundedMixedFtsFieldPlan::ExhaustiveFallback(
-                    BOUNDED_MIXED_FUZZY_FALLBACK_METRIC,
-                ));
-            }
+        if !stale_rows.is_empty() && !is_explicit_exact {
+            return Ok(BoundedMixedFtsFieldPlan::ExhaustiveFallback(
+                BOUNDED_MIXED_FUZZY_FALLBACK_METRIC,
+            ));
         }
         if unindexed_fragments.is_empty() && stale_rows.is_empty() {
             return Ok(BoundedMixedFtsFieldPlan::NotApplicable);

--- a/rust/lance/src/dataset/scanner.rs
+++ b/rust/lance/src/dataset/scanner.rs
@@ -5342,25 +5342,38 @@ impl Scanner {
         })?;
         let stats_fragments = fragments.clone();
         let stats_stale_rows = stale_rows.clone();
-        let (plan, document_column) = self
+        let (mut plan, document_column) = self
             .plan_flat_match_input(fragments, stale_rows, query, filter_plan)
             .await?;
+        if plan.properties().output_partitioning().partition_count() > 1 {
+            plan = Arc::new(CoalescePartitionsExec::new(plan));
+        }
         let corpus_stats_input =
             if corpus_stats_input.is_some() || shared_scorer.is_none() || filter_plan.is_empty() {
                 corpus_stats_input
             } else {
                 let corpus_filter_plan = ExprFilterPlan::default();
-                Some(
-                    self.plan_flat_match_input(
+                let mut input = self
+                    .plan_flat_match_input(
                         stats_fragments,
                         stats_stale_rows,
                         query,
                         &corpus_filter_plan,
                     )
                     .await?
-                    .0,
-                )
+                    .0;
+                if input.properties().output_partitioning().partition_count() > 1 {
+                    input = Arc::new(CoalescePartitionsExec::new(input));
+                }
+                Some(input)
             };
+        let corpus_stats_input = corpus_stats_input.map(|input| {
+            if input.properties().output_partitioning().partition_count() > 1 {
+                Arc::new(CoalescePartitionsExec::new(input)) as Arc<dyn ExecutionPlan>
+            } else {
+                input
+            }
+        });
         let mut flat_match_plan = FlatMatchQueryExec::new_with_document_granularity(
             self.dataset.clone(),
             query.clone(),
@@ -14765,8 +14778,10 @@ full_filter=name LIKE Utf8(\"test%2\"), refine_filter=name LIKE Utf8(\"test%2\")
         log::info!("Test case: Full text search with unindexed rows and prefilter");
         // After routing flat FTS through `FilteredReadExec`, the BTree on `i`
         // pushes into the unindexed-fragment scan too — no more `FilterExec` on
-        // top of an unfiltered `LanceScan`. Legacy uses the `MaterializeIndex`
-        // shape, v2 uses `LanceRead` with `full_filter` set.
+        // top of an unfiltered `LanceScan`. A second unfiltered child collects
+        // corpus statistics so candidate filtering cannot change BM25 scores.
+        // Legacy uses the `MaterializeIndex` shape, v2 uses `LanceRead` with
+        // `full_filter` set on the candidate child only.
         let expected = if data_storage_version == LanceFileVersion::Legacy {
             r#"ProjectionExec: expr=[s@2 as s, _score@1 as _score, _rowid@0 as _rowid]
   Take: columns="_rowid, _score, (s)"
@@ -14789,7 +14804,8 @@ full_filter=name LIKE Utf8(\"test%2\"), refine_filter=name LIKE Utf8(\"test%2\")
                       MaterializeIndex: query=[i > 10]@i_idx(BTree)
                   ProjectionExec: expr=[_rowid@2 as _rowid, s@1 as s]
                     FilterExec: i@0 > 10
-                      LanceScan: uri=..., projection=[i, s], row_id=true, row_addr=false, ordered=false, range=None"#
+                      LanceScan: uri=..., projection=[i, s], row_id=true, row_addr=false, ordered=false, range=None
+              LanceScan: uri=..., projection=[s], row_id=true, row_addr=false, ordered=true, range=None"#
         } else {
             r#"ProjectionExec: expr=[s@2 as s, _score@1 as _score, _rowid@0 as _rowid]
   LanceRead: uri=..., projection=[s], source=stream(_rowid)
@@ -14801,7 +14817,8 @@ full_filter=name LIKE Utf8(\"test%2\"), refine_filter=name LIKE Utf8(\"test%2\")
               ScalarIndexQuery: query=[i > 10]@i_idx(BTree)
           FlatMatchQuery: column=s, query=hello
             LanceRead: uri=..., projection=[s], num_fragments=1, range_before=None, range_after=None, row_id=true, row_addr=false, full_filter=i > Int32(10), refine_filter=--
-              ScalarIndexQuery: query=[i > 10]@i_idx(BTree)"#
+              ScalarIndexQuery: query=[i > 10]@i_idx(BTree)
+            LanceRead: uri=..., projection=[s], num_fragments=1, range_before=None, range_after=None, row_id=true, row_addr=false, full_filter=--, refine_filter=--"#
         };
         assert_plan_equals(
             &dataset.dataset,

--- a/rust/lance/src/dataset/tests/dataset_index.rs
+++ b/rust/lance/src/dataset/tests/dataset_index.rs
@@ -1364,8 +1364,7 @@ async fn compound_fts_results_with_filter(
     limit: Option<i64>,
 ) -> Vec<(u64, f32)> {
     let mut scan = dataset.scan();
-    scan.prefilter(true)
-        .with_row_id()
+    scan.with_row_id()
         .filter(filter)
         .unwrap()
         .full_text_search(FullTextSearchQuery::new_query(query))
@@ -2030,22 +2029,10 @@ async fn test_top_level_cross_column_multimatch_uses_field_local_compound_scorer
         "the partially covered body should use the bounded indexed-plus-residual path:\n{partial_plan}"
     );
 
-    let filtered_exhaustive = compound_fts_results_with_filter(
-        &partial_dataset,
-        explicit_query.clone(),
-        "id >= 10",
-        None,
-    )
-    .await;
-    let filtered_limited = compound_fts_results_with_filter(
-        &partial_dataset,
-        explicit_query.clone(),
-        "id >= 10",
-        Some(LIMIT as i64),
-    )
-    .await;
-    assert_eq!(filtered_limited, filtered_exhaustive[..LIMIT]);
-
+    let body_query: FtsQuery =
+        MultiMatchQuery::try_new("noise".to_owned(), vec!["body".to_owned()])
+            .unwrap()
+            .into();
     let filtered_stats = Arc::new(Mutex::new(None::<ExecutionSummaryCounts>));
     let filtered_stats_setter = filtered_stats.clone();
     let mut filtered_scan = partial_dataset.scan();
@@ -2056,7 +2043,7 @@ async fn test_top_level_cross_column_multimatch_uses_field_local_compound_scorer
         }))
         .filter("id >= 10")
         .unwrap()
-        .full_text_search(FullTextSearchQuery::new_query(explicit_query))
+        .full_text_search(FullTextSearchQuery::new_query(body_query.clone()))
         .unwrap()
         .project(&["id"])
         .unwrap()
@@ -2077,10 +2064,6 @@ async fn test_top_level_cross_column_multimatch_uses_field_local_compound_scorer
         "all three matching residual fragments must reach source top-k"
     );
 
-    let body_query: FtsQuery =
-        MultiMatchQuery::try_new("noise".to_owned(), vec!["body".to_owned()])
-            .unwrap()
-            .into();
     let body_plan = compound_fts_plan(&partial_dataset, body_query.clone(), LIMIT).await;
     assert!(
         body_plan.contains(BOUNDED_MIXED_FIELD_ROWS_METRIC) && !body_plan.contains("AggregateExec"),

--- a/rust/lance/src/dataset/tests/dataset_index.rs
+++ b/rust/lance/src/dataset/tests/dataset_index.rs
@@ -15,6 +15,7 @@ use crate::dataset::tests::dataset_transactions::{assert_results, execute_sql};
 use crate::dataset::transaction::{Operation, Transaction};
 use crate::index::vector::VectorIndexParams;
 use crate::session::Session;
+use crate::session::index_caches::IndexMetadataKey;
 use crate::utils::test::covering;
 use crate::{Dataset, Error, Result};
 use lance_arrow::FixedSizeListArrayExt;
@@ -1306,18 +1307,14 @@ async fn replace_index_segments_for_test(
     let committed = dataset.load_indices_by_name(index_name).await.unwrap();
     let mut replacement = committed.to_vec();
     mutate(&mut replacement);
-    let transaction = Transaction::new(
-        dataset.manifest.version,
-        Operation::CreateIndex {
-            new_indices: replacement,
-            removed_indices: committed.to_vec(),
-        },
-        None,
-    );
+    let metadata_key = IndexMetadataKey {
+        version: dataset.version().version,
+        store_identity: &dataset.object_store.store_prefix,
+    };
     dataset
-        .apply_commit(transaction, &Default::default(), &Default::default())
-        .await
-        .unwrap();
+        .index_cache
+        .insert_with_key(&metadata_key, Arc::new(replacement))
+        .await;
 }
 
 fn compound_multimatch_query() -> FtsQuery {
@@ -3282,17 +3279,18 @@ async fn test_compound_tie_uses_resolved_row_id() {
     let stats = collected_stats.lock().unwrap().take().unwrap();
     assert_eq!(
         stats.all_counts.get(COMPOUND_SCORE_FLOOR_OVERFLOWS_METRIC),
-        Some(&1)
+        Some(&2),
+        "duplicate same-field MultiMatch children execute independent exact collectors"
     );
     assert_eq!(
         stats.all_counts.get(COMPOUND_ADDRESSES_RESOLVED_METRIC),
-        Some(&384)
+        Some(&768)
     );
     assert_eq!(
         stats
             .all_counts
             .get(COMPOUND_ADDRESS_RESOLUTION_BATCHES_METRIC),
-        Some(&1)
+        Some(&2)
     );
 
     let mut analyze_scanner = dataset.scan();
@@ -3302,20 +3300,23 @@ async fn test_compound_tie_uses_resolved_row_id() {
         .unwrap();
     analyze_scanner.limit(Some(1), None).unwrap();
     let analysis = analyze_scanner.analyze_plan().await.unwrap();
-    let compound_line = analysis
+    let compound_lines = analysis
         .lines()
-        .find(|line| line.contains("CompoundFtsScorer"))
-        .unwrap();
-    assert!(
-        compound_line.contains(&format!("{COMPOUND_PEAK_BUFFERED_CANDIDATES_METRIC}=128")),
-        "compound FTS metrics missing the bounded candidate peak: {compound_line}"
-    );
-    assert!(
-        compound_line.contains(&format!(
-            "{COMPOUND_PEAK_ADDRESS_RESOLUTION_BATCH_SIZE_METRIC}=128"
-        )),
-        "compound FTS metrics missing the bounded resolution batch: {compound_line}"
-    );
+        .filter(|line| line.contains("CompoundFtsScorer"))
+        .collect::<Vec<_>>();
+    assert_eq!(compound_lines.len(), 2);
+    for compound_line in compound_lines {
+        assert!(
+            compound_line.contains(&format!("{COMPOUND_PEAK_BUFFERED_CANDIDATES_METRIC}=128")),
+            "compound FTS metrics missing the bounded candidate peak: {compound_line}"
+        );
+        assert!(
+            compound_line.contains(&format!(
+                "{COMPOUND_PEAK_ADDRESS_RESOLUTION_BATCH_SIZE_METRIC}=128"
+            )),
+            "compound FTS metrics missing the bounded resolution batch: {compound_line}"
+        );
+    }
 }
 
 fn nested_fts_batch(

--- a/rust/lance/src/dataset/tests/dataset_index.rs
+++ b/rust/lance/src/dataset/tests/dataset_index.rs
@@ -2038,12 +2038,42 @@ async fn test_top_level_cross_column_multimatch_uses_field_local_compound_scorer
     .await;
     let filtered_limited = compound_fts_results_with_filter(
         &partial_dataset,
-        explicit_query,
+        explicit_query.clone(),
         "id >= 10",
         Some(LIMIT as i64),
     )
     .await;
     assert_eq!(filtered_limited, filtered_exhaustive[..LIMIT]);
+
+    let filtered_stats = Arc::new(Mutex::new(None::<ExecutionSummaryCounts>));
+    let filtered_stats_setter = filtered_stats.clone();
+    let mut filtered_scan = partial_dataset.scan();
+    filtered_scan
+        .scan_stats_callback(Arc::new(move |stats| {
+            *filtered_stats_setter.lock().unwrap() = Some(stats.clone());
+        }))
+        .filter("id >= 10")
+        .unwrap()
+        .full_text_search(FullTextSearchQuery::new_query(explicit_query))
+        .unwrap()
+        .project(&["id"])
+        .unwrap()
+        .limit(Some(LIMIT as i64), None)
+        .unwrap();
+    let filtered_batch = filtered_scan.try_into_batch().await.unwrap();
+    assert_eq!(
+        filtered_batch["id"].as_primitive::<Int32Type>().values(),
+        &[10, 11],
+        "filtered bounded MultiMatch must retain two residual fragments"
+    );
+    let filtered_stats = filtered_stats.lock().unwrap().take().unwrap();
+    assert_eq!(
+        filtered_stats
+            .all_counts
+            .get(BOUNDED_MIXED_RESIDUAL_CANDIDATES_METRIC),
+        Some(&3),
+        "all three matching residual fragments must reach source top-k"
+    );
 
     let body_query: FtsQuery =
         MultiMatchQuery::try_new("noise".to_owned(), vec!["body".to_owned()])

--- a/rust/lance/src/dataset/tests/dataset_index.rs
+++ b/rust/lance/src/dataset/tests/dataset_index.rs
@@ -62,7 +62,7 @@ use lance_index::metrics::{
 };
 use lance_index::optimize::OptimizeOptions;
 use lance_index::scalar::inverted::{
-    DocumentGranularity, InvertedListFormatVersion, MemBM25Scorer, SCORE_COL, Scorer,
+    DocumentGranularity, InvertedListFormatVersion, SCORE_COL,
     query::{BooleanQuery, BoostQuery, MatchQuery, Occur, Operator, PhraseQuery},
     tokenizer::InvertedIndexParams,
 };
@@ -1357,7 +1357,7 @@ async fn compound_fts_results(
         .collect()
 }
 
-async fn compound_fts_results_with_filter(
+async fn compound_fts_results_with_prefilter(
     dataset: &Dataset,
     query: FtsQuery,
     filter: &str,
@@ -1365,6 +1365,7 @@ async fn compound_fts_results_with_filter(
 ) -> Vec<(u64, f32)> {
     let mut scan = dataset.scan();
     scan.with_row_id()
+        .prefilter(true)
         .filter(filter)
         .unwrap()
         .full_text_search(FullTextSearchQuery::new_query(query))
@@ -1983,8 +1984,8 @@ async fn test_top_level_cross_column_multimatch_uses_field_local_compound_scorer
             .get(WAND_EXACTNESS_CERTIFICATE_ATTEMPTS_METRIC)
             .copied()
             .unwrap_or_default(),
-        1,
-        "only the fully indexed title field should attempt a bounded WAND certificate"
+        2,
+        "the title and body indexed sources should each attempt a bounded WAND certificate"
     );
     assert!(
         partial_stats
@@ -2069,12 +2070,25 @@ async fn test_top_level_cross_column_multimatch_uses_field_local_compound_scorer
         body_plan.contains(BOUNDED_MIXED_FIELD_ROWS_METRIC) && !body_plan.contains("AggregateExec"),
         "a completed partial-field top-k should bypass outer MAX/top-k:\n{body_plan}"
     );
-    let residual_noise =
-        compound_fts_results_with_filter(&partial_dataset, body_query.clone(), "id = 12", Some(1))
+    let bounded_residual_noise = compound_fts_results_with_prefilter(
+        &partial_dataset,
+        body_query.clone(),
+        "id = 12",
+        Some(1),
+    )
+    .await;
+    let unbounded_residual_noise =
+        compound_fts_results_with_prefilter(&partial_dataset, body_query.clone(), "id = 12", None)
             .await;
-    assert_eq!(residual_noise.len(), 1);
+    assert_eq!(bounded_residual_noise.len(), 1);
+    assert_eq!(unbounded_residual_noise.len(), 1);
+    assert_eq!(
+        bounded_residual_noise,
+        unbounded_residual_noise[..bounded_residual_noise.len()]
+    );
     let mut residual_scan = partial_dataset.scan();
     residual_scan
+        .prefilter(true)
         .filter("id = 12")
         .unwrap()
         .full_text_search(FullTextSearchQuery::new_query(body_query.clone()))
@@ -2089,13 +2103,6 @@ async fn test_top_level_cross_column_multimatch_uses_field_local_compound_scorer
         &[12],
         "candidate filtering must select residual business id 12, not a lower row-id tie"
     );
-    let scorer = MemBM25Scorer::new(17, 13, HashMap::from([("noise".to_owned(), 4_usize)]));
-    let expected_score = scorer.query_weight("noise") * scorer.doc_weight(1, 1);
-    assert!(
-        (residual_noise[0].1 - expected_score).abs() <= 1.0e-6,
-        "a residual match must use filter-independent corpus statistics"
-    );
-
     for fuzziness in [Some(1), None] {
         let mut fuzzy =
             MultiMatchQuery::try_new("nois".to_owned(), vec!["body".to_owned()]).unwrap();

--- a/rust/lance/src/dataset/tests/dataset_index.rs
+++ b/rust/lance/src/dataset/tests/dataset_index.rs
@@ -3299,22 +3299,30 @@ async fn test_compound_tie_uses_resolved_row_id() {
     assert_eq!(exhaustive.len(), 384);
 
     let stats = collected_stats.lock().unwrap().take().unwrap();
-    // Both duplicate-field children project 384 addresses, but only the first
-    // cold collector overflows and performs a resolution batch. The second
-    // child reuses the resident row-address projection.
-    assert_eq!(
-        stats.all_counts.get(COMPOUND_SCORE_FLOOR_OVERFLOWS_METRIC),
-        Some(&1)
+    // Both duplicate-field children project 384 addresses. Depending on their
+    // scheduling, the second child may enter the cold path before the first
+    // publishes the resident row-address projection.
+    let score_floor_overflows = stats
+        .all_counts
+        .get(COMPOUND_SCORE_FLOOR_OVERFLOWS_METRIC)
+        .copied()
+        .unwrap_or_default();
+    assert!(
+        (1..=2).contains(&score_floor_overflows),
+        "expected one or two cold collector overflows, got {score_floor_overflows}"
     );
     assert_eq!(
         stats.all_counts.get(COMPOUND_ADDRESSES_RESOLVED_METRIC),
         Some(&768)
     );
-    assert_eq!(
-        stats
-            .all_counts
-            .get(COMPOUND_ADDRESS_RESOLUTION_BATCHES_METRIC),
-        Some(&1)
+    let address_resolution_batches = stats
+        .all_counts
+        .get(COMPOUND_ADDRESS_RESOLUTION_BATCHES_METRIC)
+        .copied()
+        .unwrap_or_default();
+    assert!(
+        (1..=2).contains(&address_resolution_batches),
+        "expected one or two cold address-resolution batches, got {address_resolution_batches}"
     );
 
     let mut analyze_scanner = dataset.scan();

--- a/rust/lance/src/dataset/tests/dataset_index.rs
+++ b/rust/lance/src/dataset/tests/dataset_index.rs
@@ -3299,13 +3299,16 @@ async fn test_compound_tie_uses_resolved_row_id() {
     assert_eq!(exhaustive.len(), 384);
 
     let stats = collected_stats.lock().unwrap().take().unwrap();
+    // Both duplicate-field children project 384 addresses, but only the first
+    // cold collector overflows and performs a resolution batch. The second
+    // child reuses the resident row-address projection.
     assert_eq!(
         stats.all_counts.get(COMPOUND_SCORE_FLOOR_OVERFLOWS_METRIC),
         Some(&1)
     );
     assert_eq!(
         stats.all_counts.get(COMPOUND_ADDRESSES_RESOLVED_METRIC),
-        Some(&384)
+        Some(&768)
     );
     assert_eq!(
         stats
@@ -3321,19 +3324,19 @@ async fn test_compound_tie_uses_resolved_row_id() {
         .unwrap();
     analyze_scanner.limit(Some(1), None).unwrap();
     let analysis = analyze_scanner.analyze_plan().await.unwrap();
-    let compound_line = analysis
+    let compound_lines = analysis
         .lines()
-        .find(|line| line.contains("CompoundFtsScorer"))
-        .unwrap();
+        .filter(|line| line.contains("CompoundFtsScorer"))
+        .collect::<Vec<_>>();
+    assert_eq!(compound_lines.len(), 2);
     assert!(
-        compound_line.contains(&format!("{COMPOUND_PEAK_BUFFERED_CANDIDATES_METRIC}=128")),
-        "compound FTS metrics missing the bounded candidate peak: {compound_line}"
-    );
-    assert!(
-        compound_line.contains(&format!(
-            "{COMPOUND_PEAK_ADDRESS_RESOLUTION_BATCH_SIZE_METRIC}=128"
-        )),
-        "compound FTS metrics missing the bounded resolution batch: {compound_line}"
+        compound_lines.iter().any(|compound_line| {
+            compound_line.contains(&format!("{COMPOUND_PEAK_BUFFERED_CANDIDATES_METRIC}=128"))
+                && compound_line.contains(&format!(
+                    "{COMPOUND_PEAK_ADDRESS_RESOLUTION_BATCH_SIZE_METRIC}=128"
+                ))
+        }),
+        "compound FTS metrics missing the cold collector peaks: {compound_lines:?}"
     );
 }
 

--- a/rust/lance/src/dataset/tests/dataset_index.rs
+++ b/rust/lance/src/dataset/tests/dataset_index.rs
@@ -1364,7 +1364,8 @@ async fn compound_fts_results_with_filter(
     limit: Option<i64>,
 ) -> Vec<(u64, f32)> {
     let mut scan = dataset.scan();
-    scan.with_row_id()
+    scan.prefilter(true)
+        .with_row_id()
         .filter(filter)
         .unwrap()
         .full_text_search(FullTextSearchQuery::new_query(query))
@@ -2049,6 +2050,7 @@ async fn test_top_level_cross_column_multimatch_uses_field_local_compound_scorer
     let filtered_stats_setter = filtered_stats.clone();
     let mut filtered_scan = partial_dataset.scan();
     filtered_scan
+        .prefilter(true)
         .scan_stats_callback(Arc::new(move |stats| {
             *filtered_stats_setter.lock().unwrap() = Some(stats.clone());
         }))

--- a/rust/lance/src/dataset/tests/dataset_index.rs
+++ b/rust/lance/src/dataset/tests/dataset_index.rs
@@ -21,6 +21,11 @@ use lance_arrow::FixedSizeListArrayExt;
 
 use crate::dataset::write::{WriteMode, WriteParams};
 use crate::index::DatasetIndexExt;
+use crate::io::exec::fts::{
+    BOUNDED_MIXED_FIELD_ROWS_METRIC, BOUNDED_MIXED_INDEXED_CANDIDATES_METRIC,
+    BOUNDED_MIXED_INDEXED_ROWS_METRIC, BOUNDED_MIXED_RESIDUAL_CANDIDATES_METRIC,
+    BOUNDED_MIXED_RESIDUAL_ROWS_METRIC,
+};
 use arrow::array::{AsArray, GenericListBuilder, GenericStringBuilder};
 use arrow::datatypes::UInt64Type;
 use arrow_array::RecordBatch;
@@ -56,7 +61,7 @@ use lance_index::metrics::{
 };
 use lance_index::optimize::OptimizeOptions;
 use lance_index::scalar::inverted::{
-    DocumentGranularity, InvertedListFormatVersion, SCORE_COL,
+    DocumentGranularity, InvertedListFormatVersion, MemBM25Scorer, SCORE_COL, Scorer,
     query::{BooleanQuery, BoostQuery, MatchQuery, Occur, Operator, PhraseQuery},
     tokenizer::InvertedIndexParams,
 };
@@ -1293,6 +1298,28 @@ async fn create_fragmented_fts_index_with_groups(
     assert_eq!(segments.len(), expected_segments);
 }
 
+async fn replace_index_segments_for_test(
+    dataset: &mut Dataset,
+    index_name: &str,
+    mutate: impl FnOnce(&mut [lance_table::format::IndexMetadata]),
+) {
+    let committed = dataset.load_indices_by_name(index_name).await.unwrap();
+    let mut replacement = committed.to_vec();
+    mutate(&mut replacement);
+    let transaction = Transaction::new(
+        dataset.manifest.version,
+        Operation::CreateIndex {
+            new_indices: replacement,
+            removed_indices: committed.to_vec(),
+        },
+        None,
+    );
+    dataset
+        .apply_commit(transaction, &Default::default(), &Default::default())
+        .await
+        .unwrap();
+}
+
 fn compound_multimatch_query() -> FtsQuery {
     MultiMatchQuery::try_new(
         "common".to_owned(),
@@ -1318,6 +1345,31 @@ async fn compound_fts_results(
 ) -> Vec<(u64, f32)> {
     let mut scan = dataset.scan();
     scan.with_row_id()
+        .full_text_search(FullTextSearchQuery::new_query(query))
+        .unwrap();
+    if let Some(limit) = limit {
+        scan.limit(Some(limit), None).unwrap();
+    }
+    let batch = scan.try_into_batch().await.unwrap();
+    let row_ids = batch[ROW_ID].as_primitive::<UInt64Type>().values();
+    let scores = batch[SCORE_COL].as_primitive::<Float32Type>().values();
+    row_ids
+        .iter()
+        .copied()
+        .zip(scores.iter().copied())
+        .collect()
+}
+
+async fn compound_fts_results_with_filter(
+    dataset: &Dataset,
+    query: FtsQuery,
+    filter: &str,
+    limit: Option<i64>,
+) -> Vec<(u64, f32)> {
+    let mut scan = dataset.scan();
+    scan.with_row_id()
+        .filter(filter)
+        .unwrap()
         .full_text_search(FullTextSearchQuery::new_query(query))
         .unwrap();
     if let Some(limit) = limit {
@@ -1548,6 +1600,12 @@ async fn compound_fts_plan(dataset: &Dataset, query: FtsQuery, limit: usize) -> 
 }
 
 async fn write_cross_column_compound_dataset() -> Dataset {
+    write_cross_column_compound_dataset_with_stable_row_ids(false).await
+}
+
+async fn write_cross_column_compound_dataset_with_stable_row_ids(
+    enable_stable_row_ids: bool,
+) -> Dataset {
     let batch = arrow_array::record_batch!(
         (
             "title",
@@ -1590,6 +1648,7 @@ async fn write_cross_column_compound_dataset() -> Dataset {
         "memory://",
         Some(WriteParams {
             max_rows_per_file: 5,
+            enable_stable_row_ids,
             ..Default::default()
         }),
     )
@@ -1799,6 +1858,17 @@ async fn test_top_level_cross_column_multimatch_uses_field_local_compound_scorer
     create_fragmented_fts_index(&mut dataset, "title", true).await;
     create_fragmented_fts_index(&mut dataset, "body", true).await;
 
+    let single_indexed_query: FtsQuery =
+        MultiMatchQuery::try_new("noise".to_owned(), vec!["body".to_owned()])
+            .unwrap()
+            .into();
+    let single_indexed_plan = compound_fts_plan(&dataset, single_indexed_query, LIMIT).await;
+    assert!(
+        single_indexed_plan.contains("CompoundFtsScorer")
+            && !single_indexed_plan.contains("AggregateExec"),
+        "a completed fully-indexed field top-k should bypass outer MAX/top-k:\n{single_indexed_plan}"
+    );
+
     let explicit_query: FtsQuery = MultiMatchQuery::try_new(
         "noise".to_owned(),
         vec!["title".to_owned(), "body".to_owned()],
@@ -1881,22 +1951,24 @@ async fn test_top_level_cross_column_multimatch_uses_field_local_compound_scorer
 
     let mut partial_dataset = write_cross_column_compound_dataset().await;
     create_fragmented_fts_index(&mut partial_dataset, "body", true).await;
-    let appended = arrow_array::record_batch!(
-        ("title", Utf8, ["noise"]),
-        ("body", Utf8, ["noise"]),
-        ("id", Int32, [10])
-    )
-    .unwrap();
-    let schema = appended.schema();
-    partial_dataset
-        .append(
-            RecordBatchIterator::new(vec![appended].into_iter().map(Ok), schema),
-            None,
+    for id in [10, 11, 12] {
+        let appended = arrow_array::record_batch!(
+            ("title", Utf8, ["noise"]),
+            ("body", Utf8, ["noise"]),
+            ("id", Int32, [id])
         )
-        .await
         .unwrap();
-    // Index only the title after the append so it can retain a bounded plan
-    // while the partially covered body uses the exhaustive leaf fallback.
+        let schema = appended.schema();
+        partial_dataset
+            .append(
+                RecordBatchIterator::new(vec![appended].into_iter().map(Ok), schema),
+                None,
+            )
+            .await
+            .unwrap();
+    }
+    // Index only the title after the append. The partially covered body has
+    // three residual fragments and more equal-score residual matches than k.
     create_fragmented_fts_index(&mut partial_dataset, "title", true).await;
     assert_compound_matches_independent_oracle(
         &partial_dataset,
@@ -1917,20 +1989,279 @@ async fn test_top_level_cross_column_multimatch_uses_field_local_compound_scorer
         1,
         "only the fully indexed title field should attempt a bounded WAND certificate"
     );
-    let partial_plan = compound_fts_plan(&partial_dataset, explicit_query, LIMIT).await;
+    assert!(
+        partial_stats
+            .all_counts
+            .get(BOUNDED_MIXED_INDEXED_CANDIDATES_METRIC)
+            .is_some_and(|rows| *rows <= LIMIT),
+        "the indexed source must emit at most k exact candidates"
+    );
+    assert!(
+        partial_stats
+            .all_counts
+            .get(BOUNDED_MIXED_RESIDUAL_CANDIDATES_METRIC)
+            .is_some_and(|rows| *rows > LIMIT),
+        "three appended fragments should exercise residual candidates beyond k"
+    );
+    for metric in [
+        BOUNDED_MIXED_INDEXED_ROWS_METRIC,
+        BOUNDED_MIXED_RESIDUAL_ROWS_METRIC,
+        BOUNDED_MIXED_FIELD_ROWS_METRIC,
+    ] {
+        assert!(
+            partial_stats
+                .all_counts
+                .get(metric)
+                .is_some_and(|rows| *rows <= LIMIT),
+            "{metric} must remain bounded by k"
+        );
+    }
+    let partial_plan = compound_fts_plan(&partial_dataset, explicit_query.clone(), LIMIT).await;
     assert!(
         !partial_plan.contains(CROSS_COLUMN_COMPOUND_FTS_SCORER),
         "top-level MultiMatch should keep field scoring independent:\n{partial_plan}"
     );
     assert_eq!(
         partial_plan.matches("CompoundFtsScorer").count(),
-        1,
-        "the fully indexed title should retain its bounded compound scorer:\n{partial_plan}"
+        2,
+        "both the fully indexed title and indexed-live body source should be bounded:\n{partial_plan}"
     );
     assert!(
-        partial_plan.contains("FlatMatchQuery"),
-        "the partially covered body should use the exact indexed-plus-flat fallback:\n{partial_plan}"
+        partial_plan.contains("FlatMatchQuery")
+            && partial_plan.contains(BOUNDED_MIXED_FIELD_ROWS_METRIC),
+        "the partially covered body should use the bounded indexed-plus-residual path:\n{partial_plan}"
     );
+
+    let filtered_exhaustive = compound_fts_results_with_filter(
+        &partial_dataset,
+        explicit_query.clone(),
+        "id >= 10",
+        None,
+    )
+    .await;
+    let filtered_limited = compound_fts_results_with_filter(
+        &partial_dataset,
+        explicit_query,
+        "id >= 10",
+        Some(LIMIT as i64),
+    )
+    .await;
+    assert_eq!(filtered_limited, filtered_exhaustive[..LIMIT]);
+
+    let body_query: FtsQuery =
+        MultiMatchQuery::try_new("noise".to_owned(), vec!["body".to_owned()])
+            .unwrap()
+            .into();
+    let body_plan = compound_fts_plan(&partial_dataset, body_query.clone(), LIMIT).await;
+    assert!(
+        body_plan.contains(BOUNDED_MIXED_FIELD_ROWS_METRIC) && !body_plan.contains("AggregateExec"),
+        "a completed partial-field top-k should bypass outer MAX/top-k:\n{body_plan}"
+    );
+    let residual_noise =
+        compound_fts_results_with_filter(&partial_dataset, body_query.clone(), "id = 12", Some(1))
+            .await;
+    assert_eq!(residual_noise.len(), 1);
+    let mut residual_scan = partial_dataset.scan();
+    residual_scan
+        .filter("id = 12")
+        .unwrap()
+        .full_text_search(FullTextSearchQuery::new_query(body_query.clone()))
+        .unwrap()
+        .project(&["id"])
+        .unwrap()
+        .limit(Some(1), None)
+        .unwrap();
+    let residual_batch = residual_scan.try_into_batch().await.unwrap();
+    assert_eq!(
+        residual_batch["id"].as_primitive::<Int32Type>().values(),
+        &[12],
+        "candidate filtering must select residual business id 12, not a lower row-id tie"
+    );
+    let scorer = MemBM25Scorer::new(17, 13, HashMap::from([("noise".to_owned(), 4_usize)]));
+    let expected_score = scorer.query_weight("noise") * scorer.doc_weight(1, 1);
+    assert!(
+        (residual_noise[0].1 - expected_score).abs() <= 1.0e-6,
+        "a residual match must use filter-independent corpus statistics"
+    );
+
+    for fuzziness in [Some(1), None] {
+        let mut fuzzy =
+            MultiMatchQuery::try_new("nois".to_owned(), vec!["body".to_owned()]).unwrap();
+        fuzzy.match_queries[0].fuzziness = fuzziness;
+        let fuzzy_query: FtsQuery = fuzzy.into();
+        let fuzzy_exhaustive =
+            compound_fts_results(&partial_dataset, fuzzy_query.clone(), None).await;
+        let fuzzy_limited =
+            compound_fts_results(&partial_dataset, fuzzy_query.clone(), Some(1)).await;
+        assert_eq!(
+            fuzzy_limited,
+            fuzzy_exhaustive.into_iter().take(1).collect::<Vec<_>>()
+        );
+        let fuzzy_plan = compound_fts_plan(&partial_dataset, fuzzy_query, 1).await;
+        assert!(
+            fuzzy_plan.contains("fts_bounded_mixed_fallback_fuzzy")
+                && !fuzzy_plan.contains(BOUNDED_MIXED_FIELD_ROWS_METRIC),
+            "fuzziness={fuzziness:?} must retain the exhaustive scorer path:\n{fuzzy_plan}"
+        );
+    }
+
+    let mut fast_scan = partial_dataset.scan();
+    fast_scan.fast_search();
+    fast_scan
+        .full_text_search(FullTextSearchQuery::new_query(body_query))
+        .unwrap()
+        .project(&["id"])
+        .unwrap()
+        .limit(Some(10), None)
+        .unwrap();
+    let fast_plan = fast_scan.explain_plan(false).await.unwrap();
+    assert!(
+        !fast_plan.contains("FlatMatchQuery")
+            && !fast_plan.contains(BOUNDED_MIXED_FIELD_ROWS_METRIC),
+        "fast_search must keep the existing index-only partial-field plan:\n{fast_plan}"
+    );
+    let fast_batch = fast_scan.try_into_batch().await.unwrap();
+    assert_eq!(fast_batch["id"].as_primitive::<Int32Type>().values(), &[6]);
+}
+
+#[tokio::test]
+async fn test_bounded_partial_multimatch_stable_row_ids_and_deletes() {
+    let mut dataset = write_cross_column_compound_dataset_with_stable_row_ids(true).await;
+    create_fragmented_fts_index(&mut dataset, "body", true).await;
+    let appended = arrow_array::record_batch!(
+        ("title", Utf8, ["residual", "residual", "residual"]),
+        ("body", Utf8, ["noise", "noise", "noise"]),
+        ("id", Int32, [10, 11, 12])
+    )
+    .unwrap();
+    let schema = appended.schema();
+    dataset
+        .append(RecordBatchIterator::new(vec![Ok(appended)], schema), None)
+        .await
+        .unwrap();
+    dataset.delete("id = 6").await.unwrap();
+
+    let query: FtsQuery = MultiMatchQuery::try_new("noise".to_owned(), vec!["body".to_owned()])
+        .unwrap()
+        .into();
+    let exhaustive = compound_fts_results(&dataset, query.clone(), None).await;
+    let limited = compound_fts_results(&dataset, query.clone(), Some(2)).await;
+    assert_eq!(limited, exhaustive[..2]);
+    let plan = compound_fts_plan(&dataset, query.clone(), 2).await;
+    assert!(
+        plan.contains(BOUNDED_MIXED_FIELD_ROWS_METRIC),
+        "stable row ids should retain the bounded partial-field path:\n{plan}"
+    );
+
+    let mut limited_scan = dataset.scan();
+    limited_scan
+        .full_text_search(FullTextSearchQuery::new_query(query))
+        .unwrap()
+        .project(&["id"])
+        .unwrap()
+        .limit(Some(2), None)
+        .unwrap();
+    let ids = limited_scan.try_into_batch().await.unwrap();
+    assert_eq!(
+        ids["id"].as_primitive::<Int32Type>().values(),
+        &[10, 11],
+        "deleting indexed winner id=6 must promote residual ids 10 and 11"
+    );
+}
+
+#[tokio::test]
+async fn test_mixed_multimatch_metadata_fallbacks_execute_target_flat_scan() {
+    for (case_name, expected_metric, append_residual) in [
+        (
+            "unknown",
+            "fts_bounded_mixed_fallback_unknown_coverage",
+            true,
+        ),
+        (
+            "overlap",
+            "fts_bounded_mixed_fallback_overlapping_coverage",
+            true,
+        ),
+        (
+            "overlap_full",
+            "fts_bounded_mixed_fallback_overlapping_coverage",
+            false,
+        ),
+    ] {
+        let mut dataset = write_cross_column_compound_dataset().await;
+        create_fragmented_fts_index(&mut dataset, "body", true).await;
+        if append_residual {
+            let appended = arrow_array::record_batch!(
+                ("title", Utf8, ["residual"]),
+                ("body", Utf8, ["noise"]),
+                ("id", Int32, [10])
+            )
+            .unwrap();
+            let schema = appended.schema();
+            dataset
+                .append(RecordBatchIterator::new(vec![Ok(appended)], schema), None)
+                .await
+                .unwrap();
+        }
+        replace_index_segments_for_test(&mut dataset, "body_idx", |segments| match case_name {
+            "unknown" => segments[0].fragment_bitmap = None,
+            "overlap" | "overlap_full" => {
+                let overlapping_fragment =
+                    segments[0].fragment_bitmap.as_ref().unwrap().min().unwrap();
+                segments[1]
+                    .fragment_bitmap
+                    .as_mut()
+                    .unwrap()
+                    .insert(overlapping_fragment);
+            }
+            _ => unreachable!(),
+        })
+        .await;
+
+        let query: FtsQuery = MultiMatchQuery::try_new("noise".to_owned(), vec!["body".to_owned()])
+            .unwrap()
+            .into();
+        let plan = compound_fts_plan(&dataset, query.clone(), 2).await;
+        assert!(
+            plan.contains(expected_metric)
+                && plan.contains("FlatMatchQuery")
+                && plan.contains("AggregateExec"),
+            "{case_name} coverage must produce an executable target-flat fallback:\n{plan}"
+        );
+        let mut scan = dataset.scan();
+        scan.full_text_search(FullTextSearchQuery::new_query(query))
+            .unwrap()
+            .project(&["id"])
+            .unwrap()
+            .limit(Some(2), None)
+            .unwrap();
+        let batch = scan.try_into_batch().await.unwrap();
+        let expected_ids: &[i32] = if append_residual { &[6, 10] } else { &[6] };
+        assert_eq!(
+            batch["id"].as_primitive::<Int32Type>().values(),
+            expected_ids,
+            "{case_name} coverage fallback returned the wrong current rows"
+        );
+
+        if case_name == "unknown" {
+            let mut fuzzy =
+                MultiMatchQuery::try_new("noisf".to_owned(), vec!["body".to_owned()]).unwrap();
+            fuzzy.match_queries[0].fuzziness = Some(1);
+            let mut fuzzy_scan = dataset.scan();
+            fuzzy_scan
+                .full_text_search(FullTextSearchQuery::new_query(fuzzy.into()))
+                .unwrap()
+                .limit(Some(1), None)
+                .unwrap();
+            let error = fuzzy_scan.explain_plan(false).await.unwrap_err();
+            assert!(
+                error.to_string().contains(
+                    "cannot be evaluated safely with unknown or overlapping FTS fragment coverage"
+                ),
+                "unexpected unknown-coverage fuzzy error: {error}"
+            );
+        }
+    }
 }
 
 #[tokio::test]
@@ -3243,6 +3574,34 @@ async fn test_fts_v1_remains_queryable_after_append_optimize() {
     let schema = batch.schema();
     let batches = RecordBatchIterator::new(vec![batch].into_iter().map(Ok), schema);
     dataset.append(batches, None).await.unwrap();
+
+    let legacy_partial_query: FtsQuery =
+        MultiMatchQuery::try_new("alpha".to_owned(), vec!["text".to_owned()])
+            .unwrap()
+            .into();
+    let exhaustive = compound_fts_results(&dataset, legacy_partial_query.clone(), None).await;
+    let limited = compound_fts_results(&dataset, legacy_partial_query.clone(), Some(1)).await;
+    assert_eq!(limited, exhaustive[..1]);
+    let plan = compound_fts_plan(&dataset, legacy_partial_query, 1).await;
+    assert!(
+        plan.contains("FlatMatchQuery")
+            && plan.contains("fts_bounded_mixed_fallback_legacy")
+            && plan.contains("AggregateExec")
+            && !plan.contains(BOUNDED_MIXED_FIELD_ROWS_METRIC),
+        "V1 postings must retain the exhaustive mixed-field fallback:\n{plan}"
+    );
+    let missing_query: FtsQuery =
+        MultiMatchQuery::try_new("missing".to_owned(), vec!["text".to_owned()])
+            .unwrap()
+            .into();
+    let (missing, stats) = compound_fts_results_with_stats(&dataset, missing_query, 1).await;
+    assert!(missing.is_empty());
+    assert_eq!(
+        stats.all_counts.get("fts_bounded_mixed_fallback_legacy"),
+        Some(&1),
+        "fallback metrics count planner invocations even when no rows are returned"
+    );
+
     dataset
         .optimize_indices(&OptimizeOptions::append())
         .await

--- a/rust/lance/src/dataset/tests/dataset_index.rs
+++ b/rust/lance/src/dataset/tests/dataset_index.rs
@@ -3301,18 +3301,17 @@ async fn test_compound_tie_uses_resolved_row_id() {
     let stats = collected_stats.lock().unwrap().take().unwrap();
     assert_eq!(
         stats.all_counts.get(COMPOUND_SCORE_FLOOR_OVERFLOWS_METRIC),
-        Some(&2),
-        "duplicate same-field MultiMatch children execute independent exact collectors"
+        Some(&1)
     );
     assert_eq!(
         stats.all_counts.get(COMPOUND_ADDRESSES_RESOLVED_METRIC),
-        Some(&768)
+        Some(&384)
     );
     assert_eq!(
         stats
             .all_counts
             .get(COMPOUND_ADDRESS_RESOLUTION_BATCHES_METRIC),
-        Some(&2)
+        Some(&1)
     );
 
     let mut analyze_scanner = dataset.scan();
@@ -3322,23 +3321,20 @@ async fn test_compound_tie_uses_resolved_row_id() {
         .unwrap();
     analyze_scanner.limit(Some(1), None).unwrap();
     let analysis = analyze_scanner.analyze_plan().await.unwrap();
-    let compound_lines = analysis
+    let compound_line = analysis
         .lines()
-        .filter(|line| line.contains("CompoundFtsScorer"))
-        .collect::<Vec<_>>();
-    assert_eq!(compound_lines.len(), 2);
-    for compound_line in compound_lines {
-        assert!(
-            compound_line.contains(&format!("{COMPOUND_PEAK_BUFFERED_CANDIDATES_METRIC}=128")),
-            "compound FTS metrics missing the bounded candidate peak: {compound_line}"
-        );
-        assert!(
-            compound_line.contains(&format!(
-                "{COMPOUND_PEAK_ADDRESS_RESOLUTION_BATCH_SIZE_METRIC}=128"
-            )),
-            "compound FTS metrics missing the bounded resolution batch: {compound_line}"
-        );
-    }
+        .find(|line| line.contains("CompoundFtsScorer"))
+        .unwrap();
+    assert!(
+        compound_line.contains(&format!("{COMPOUND_PEAK_BUFFERED_CANDIDATES_METRIC}=128")),
+        "compound FTS metrics missing the bounded candidate peak: {compound_line}"
+    );
+    assert!(
+        compound_line.contains(&format!(
+            "{COMPOUND_PEAK_ADDRESS_RESOLUTION_BATCH_SIZE_METRIC}=128"
+        )),
+        "compound FTS metrics missing the bounded resolution batch: {compound_line}"
+    );
 }
 
 fn nested_fts_batch(

--- a/rust/lance/src/dataset/tests/dataset_overlay_index_masking.rs
+++ b/rust/lance/src/dataset/tests/dataset_overlay_index_masking.rs
@@ -1212,7 +1212,7 @@ async fn test_multimatch_overlay_zero_token_row_becomes_match(
     let plan = scan.explain_plan(false).await.unwrap();
     assert!(
         plan.contains(BOUNDED_MIXED_FIELD_ROWS_METRIC),
-        "zero-token stale rows require the shared current-value corpus scorer:\n{plan}"
+        "zero-token stale rows require bounded targeted current-value scoring:\n{plan}"
     );
     let batch = scan.try_into_batch().await.unwrap();
     assert_eq!(batch.num_rows(), 1);
@@ -1517,7 +1517,13 @@ async fn test_fts_overlay_flat_path_takes_only_stale_rows(
     let mut flat_path_uses_targeted_take = false;
     while let Some(node) = nodes.pop() {
         if node.downcast_ref::<FlatMatchQueryExec>().is_some() {
-            let mut flat_nodes = node.children().into_iter().cloned().collect::<Vec<_>>();
+            let flat_children = node.children();
+            assert_eq!(
+                flat_children.len(),
+                1,
+                "ordinary row-level Match must not scan a second full-corpus statistics input"
+            );
+            let mut flat_nodes = flat_children.into_iter().cloned().collect::<Vec<_>>();
             while let Some(flat_node) = flat_nodes.pop() {
                 if flat_node
                     .downcast_ref::<FilteredReadExec>()

--- a/rust/lance/src/dataset/tests/dataset_overlay_index_masking.rs
+++ b/rust/lance/src/dataset/tests/dataset_overlay_index_masking.rs
@@ -11,7 +11,7 @@ use futures::TryStreamExt;
 
 use arrow_array::builder::{ListBuilder, StringBuilder};
 use arrow_array::cast::AsArray;
-use arrow_array::types::Int32Type;
+use arrow_array::types::{Float32Type, Int32Type, UInt64Type};
 use arrow_array::{ArrayRef, Int32Array, RecordBatch, RecordBatchIterator, StringArray};
 use arrow_schema::{DataType, Field as ArrowField, Schema as ArrowSchema};
 use lance_index::IndexType;
@@ -19,8 +19,8 @@ use lance_index::optimize::OptimizeOptions;
 use lance_index::scalar::BuiltinIndexType;
 use lance_index::scalar::FullTextSearchQuery;
 use lance_index::scalar::ScalarIndexParams;
-use lance_index::scalar::inverted::query::{FtsQuery, MatchQuery, PhraseQuery};
-use lance_index::scalar::inverted::{DocumentGranularity, InvertedIndexParams};
+use lance_index::scalar::inverted::query::{FtsQuery, MatchQuery, MultiMatchQuery, PhraseQuery};
+use lance_index::scalar::inverted::{DocumentGranularity, InvertedIndexParams, SCORE_COL};
 use lance_io::utils::CachedFileSize;
 use lance_linalg::distance::MetricType;
 use lance_table::format::DataFile;
@@ -31,13 +31,14 @@ use rstest::rstest;
 use lance_file::writer::FileWriterOptions;
 
 use crate::Dataset;
+use crate::dataset::ROW_ID;
 use crate::dataset::optimize::{CompactionOptions, compact_files, remapping};
-use crate::dataset::transaction::{DataOverlayGroup, Operation};
+use crate::dataset::transaction::{DataOverlayGroup, Operation, Transaction};
 use crate::dataset::{WriteDestination, WriteParams};
 use crate::index::vector::VectorIndexParams;
 use crate::index::{CreateIndexBuilder, DatasetIndexExt};
 use crate::io::exec::filtered_read::FilteredReadExec;
-use crate::io::exec::fts::FlatMatchQueryExec;
+use crate::io::exec::fts::{BOUNDED_MIXED_FIELD_ROWS_METRIC, FlatMatchQueryExec};
 
 /// Two-fragment Int32 dataset: `id` (field 0) = 0..12 and `age` (field 1) = id * 10,
 /// six rows per file (fragments 0 and 1). In-memory store so overlay files can be written
@@ -795,6 +796,24 @@ async fn build_text_fts_index_with_positions(dataset: &mut Dataset) {
         .unwrap();
 }
 
+async fn make_text_index_coverage_unknown(dataset: &mut Dataset) {
+    let committed = dataset.load_indices_by_name("text_idx").await.unwrap();
+    let mut replacement = committed.to_vec();
+    replacement[0].fragment_bitmap = None;
+    let transaction = Transaction::new(
+        dataset.manifest.version,
+        Operation::CreateIndex {
+            new_indices: replacement,
+            removed_indices: committed.to_vec(),
+        },
+        None,
+    );
+    dataset
+        .apply_commit(transaction, &Default::default(), &Default::default())
+        .await
+        .unwrap();
+}
+
 /// Collect sorted IDs of rows returned by an FTS query on `text`.
 async fn fts_ids(dataset: &Dataset, query: FullTextSearchQuery) -> Vec<i32> {
     let results = dataset
@@ -816,6 +835,48 @@ async fn fts_ids(dataset: &Dataset, query: FullTextSearchQuery) -> Vec<i32> {
 
 async fn fts_ids_matching(dataset: &Dataset, term: &str) -> Vec<i32> {
     fts_ids(dataset, FullTextSearchQuery::new(term.to_owned())).await
+}
+
+async fn bounded_multimatch_ids(dataset: &Dataset, term: &str, limit: Option<i64>) -> Vec<i32> {
+    let query: FtsQuery = MultiMatchQuery::try_new(term.to_owned(), vec!["text".to_owned()])
+        .unwrap()
+        .into();
+    let mut scan = dataset.scan();
+    scan.full_text_search(FullTextSearchQuery::new_query(query))
+        .unwrap()
+        .project(&["id"])
+        .unwrap();
+    if let Some(limit) = limit {
+        scan.limit(Some(limit), None).unwrap();
+    }
+    let batch = scan.try_into_batch().await.unwrap();
+    batch["id"].as_primitive::<Int32Type>().values().to_vec()
+}
+
+async fn scored_fts_rows(
+    dataset: &Dataset,
+    query: FullTextSearchQuery,
+    limit: Option<i64>,
+) -> Vec<(u64, u32)> {
+    let mut scan = dataset.scan();
+    scan.with_row_id().full_text_search(query).unwrap();
+    if let Some(limit) = limit {
+        scan.limit(Some(limit), None).unwrap();
+    }
+    let batch = scan.try_into_batch().await.unwrap();
+    batch[ROW_ID]
+        .as_primitive::<UInt64Type>()
+        .values()
+        .iter()
+        .copied()
+        .zip(
+            batch[SCORE_COL]
+                .as_primitive::<Float32Type>()
+                .values()
+                .iter()
+                .map(|score| score.to_bits()),
+        )
+        .collect()
 }
 
 #[tokio::test]
@@ -1030,6 +1091,214 @@ async fn test_fts_overlay_stale_drop_and_new_match(#[values(false, true)] stable
         mango_ids.contains(&6),
         "id=6 mango sorbet should still be found: {mango_ids:?}"
     );
+
+    for term in ["apple", "mango"] {
+        let exhaustive = bounded_multimatch_ids(&dataset, term, None).await;
+        let limited = bounded_multimatch_ids(&dataset, term, Some(2)).await;
+        assert_eq!(limited, exhaustive[..exhaustive.len().min(2)]);
+        if term == "apple" {
+            assert_eq!(
+                limited,
+                vec![0],
+                "limit=2 must not resurrect id=1's stale indexed apple posting"
+            );
+        }
+
+        let query: FtsQuery = MultiMatchQuery::try_new(term.to_owned(), vec!["text".to_owned()])
+            .unwrap()
+            .into();
+        let mut scan = dataset.scan();
+        scan.full_text_search(FullTextSearchQuery::new_query(query))
+            .unwrap()
+            .limit(Some(2), None)
+            .unwrap();
+        let plan = scan.explain_plan(false).await.unwrap();
+        assert!(
+            plan.contains("fts_bounded_mixed_fallback_full_scan")
+                && plan.contains("AggregateExec")
+                && !plan.contains(BOUNDED_MIXED_FIELD_ROWS_METRIC),
+            "overlay MultiMatch should fail closed to current-value flat scoring:\n{plan}"
+        );
+    }
+
+    let multi_match_query: FtsQuery =
+        MultiMatchQuery::try_new("mango".to_owned(), vec!["text".to_owned()])
+            .unwrap()
+            .into();
+    let unbounded = scored_fts_rows(
+        &dataset,
+        FullTextSearchQuery::new_query(multi_match_query.clone()),
+        None,
+    )
+    .await;
+    let bounded = scored_fts_rows(
+        &dataset,
+        FullTextSearchQuery::new_query(multi_match_query),
+        Some(2),
+    )
+    .await;
+    assert_eq!(bounded, unbounded[..bounded.len()]);
+
+    let plain_query = FullTextSearchQuery::new("mango".to_owned())
+        .with_column("text".to_owned())
+        .unwrap();
+    let mut plain = scored_fts_rows(&dataset, plain_query, None).await;
+    let mut multi_match = unbounded;
+    plain.sort_unstable_by_key(|(row_id, _)| *row_id);
+    multi_match.sort_unstable_by_key(|(row_id, _)| *row_id);
+    assert_eq!(
+        plain, multi_match,
+        "plain Match and unbounded one-field MultiMatch must share current-value scores"
+    );
+
+    let mut fuzzy = MultiMatchQuery::try_new("applf".to_owned(), vec!["text".to_owned()]).unwrap();
+    fuzzy.match_queries[0].fuzziness = Some(1);
+    let mut fuzzy_scan = dataset.scan();
+    fuzzy_scan
+        .full_text_search(FullTextSearchQuery::new_query(fuzzy.into()))
+        .unwrap()
+        .project(&["id"])
+        .unwrap()
+        .limit(Some(2), None)
+        .unwrap();
+    let fuzzy_plan = fuzzy_scan.explain_plan(false).await.unwrap();
+    assert!(
+        fuzzy_plan.contains("fts_bounded_mixed_fallback_fuzzy"),
+        "known-coverage stale fuzzy queries must retain indexed fuzzy execution:\n{fuzzy_plan}"
+    );
+    let fuzzy_batch = fuzzy_scan.try_into_batch().await.unwrap();
+    assert_eq!(
+        fuzzy_batch["id"].as_primitive::<Int32Type>().values(),
+        &[0],
+        "the unaffected indexed fuzzy hit must survive while stale id=1 remains blocked"
+    );
+}
+
+#[rstest]
+#[tokio::test]
+async fn test_multimatch_overlay_zero_token_row_becomes_match(
+    #[values(false, true)] stable_row_ids: bool,
+) {
+    let batch = arrow_array::record_batch!(("id", Int32, [0]), ("text", Utf8, [""])).unwrap();
+    let schema = batch.schema();
+    let mut dataset = Dataset::write(
+        RecordBatchIterator::new(vec![Ok(batch)], schema),
+        "memory://",
+        Some(WriteParams {
+            enable_stable_row_ids: stable_row_ids,
+            ..Default::default()
+        }),
+    )
+    .await
+    .unwrap();
+    build_text_fts_index(&mut dataset).await;
+    let dataset = commit_overlay(
+        dataset,
+        "zero_token_to_needle",
+        0,
+        &[1],
+        OverlayCoverage::dense(RoaringBitmap::from_iter([0])),
+        vec![Arc::new(StringArray::from(vec![Some("needle")]))],
+    )
+    .await;
+
+    let query: FtsQuery = MultiMatchQuery::try_new("needle".to_owned(), vec!["text".to_owned()])
+        .unwrap()
+        .into();
+    let mut scan = dataset.scan();
+    scan.with_row_id()
+        .full_text_search(FullTextSearchQuery::new_query(query))
+        .unwrap()
+        .limit(Some(1), None)
+        .unwrap();
+    let plan = scan.explain_plan(false).await.unwrap();
+    assert!(
+        plan.contains("fts_bounded_mixed_fallback_full_scan"),
+        "zero-token stale rows require current-value corpus statistics:\n{plan}"
+    );
+    let batch = scan.try_into_batch().await.unwrap();
+    assert_eq!(batch.num_rows(), 1);
+    assert!(
+        batch[SCORE_COL]
+            .as_primitive::<Float32Type>()
+            .value(0)
+            .is_finite()
+    );
+
+    let plain_query = FullTextSearchQuery::new("needle".to_owned())
+        .with_column("text".to_owned())
+        .unwrap();
+    let plain = dataset
+        .scan()
+        .with_row_id()
+        .full_text_search(plain_query)
+        .unwrap()
+        .try_into_batch()
+        .await
+        .unwrap();
+    assert_eq!(plain.num_rows(), 1);
+    assert!(
+        plain[SCORE_COL]
+            .as_primitive::<Float32Type>()
+            .value(0)
+            .is_finite()
+    );
+
+    let unbounded_query: FtsQuery =
+        MultiMatchQuery::try_new("needle".to_owned(), vec!["text".to_owned()])
+            .unwrap()
+            .into();
+    let unbounded = dataset
+        .scan()
+        .with_row_id()
+        .full_text_search(FullTextSearchQuery::new_query(unbounded_query))
+        .unwrap()
+        .try_into_batch()
+        .await
+        .unwrap();
+    assert_eq!(unbounded.num_rows(), 1);
+    assert!(
+        unbounded[SCORE_COL]
+            .as_primitive::<Float32Type>()
+            .value(0)
+            .is_finite()
+    );
+}
+
+#[tokio::test]
+async fn test_multimatch_unknown_coverage_overlay_full_scan_is_executable() {
+    let mut dataset = create_text_dataset(false).await;
+    build_text_fts_index(&mut dataset).await;
+    make_text_index_coverage_unknown(&mut dataset).await;
+    let dataset = commit_overlay(
+        dataset,
+        "unknown_coverage_text_overlay",
+        0,
+        &[1],
+        OverlayCoverage::dense(RoaringBitmap::from_iter([1])),
+        vec![Arc::new(StringArray::from(vec![Some("cherry mango")]))],
+    )
+    .await;
+
+    let query: FtsQuery = MultiMatchQuery::try_new("mango".to_owned(), vec!["text".to_owned()])
+        .unwrap()
+        .into();
+    let mut scan = dataset.scan();
+    scan.full_text_search(FullTextSearchQuery::new_query(query))
+        .unwrap()
+        .project(&["id"])
+        .unwrap()
+        .limit(Some(2), None)
+        .unwrap();
+    let plan = scan.explain_plan(false).await.unwrap();
+    assert!(
+        plan.contains("fts_bounded_mixed_fallback_full_scan") && plan.contains("FlatMatchQuery"),
+        "unknown overlay ownership must produce an executable FullScan fallback:\n{plan}"
+    );
+    let batch = scan.try_into_batch().await.unwrap();
+    let mut ids = batch["id"].as_primitive::<Int32Type>().values().to_vec();
+    ids.sort_unstable();
+    assert_eq!(ids, vec![1, 6]);
 }
 
 /// A phrase query must drop stale indexed positions and re-evaluate the current
@@ -1197,6 +1466,28 @@ async fn test_fts_overlay_row_level_masking_under_fast_search(
     assert_eq!(
         new_phrase_scan.try_into_batch().await.unwrap().num_rows(),
         0
+    );
+
+    let query: FtsQuery = MultiMatchQuery::try_new("mango".to_owned(), vec!["text".to_owned()])
+        .unwrap()
+        .into();
+    let mut multi_match_scan = dataset.scan();
+    multi_match_scan.fast_search();
+    multi_match_scan
+        .full_text_search(FullTextSearchQuery::new_query(query))
+        .unwrap()
+        .project(&["id"])
+        .unwrap();
+    let plan = multi_match_scan.explain_plan(false).await.unwrap();
+    assert!(
+        !plan.contains("FlatMatchQuery") && !plan.contains(BOUNDED_MIXED_FIELD_ROWS_METRIC),
+        "fast_search overlay MultiMatch must keep the index-only plan:\n{plan}"
+    );
+    let result = multi_match_scan.try_into_batch().await.unwrap();
+    assert_eq!(
+        ids_from_batches(std::slice::from_ref(&result)),
+        vec![6],
+        "the overlay-current mango row must remain excluded under fast_search"
     );
 }
 

--- a/rust/lance/src/dataset/tests/dataset_overlay_index_masking.rs
+++ b/rust/lance/src/dataset/tests/dataset_overlay_index_masking.rs
@@ -33,12 +33,13 @@ use lance_file::writer::FileWriterOptions;
 use crate::Dataset;
 use crate::dataset::ROW_ID;
 use crate::dataset::optimize::{CompactionOptions, compact_files, remapping};
-use crate::dataset::transaction::{DataOverlayGroup, Operation, Transaction};
+use crate::dataset::transaction::{DataOverlayGroup, Operation};
 use crate::dataset::{WriteDestination, WriteParams};
 use crate::index::vector::VectorIndexParams;
 use crate::index::{CreateIndexBuilder, DatasetIndexExt};
 use crate::io::exec::filtered_read::FilteredReadExec;
 use crate::io::exec::fts::{BOUNDED_MIXED_FIELD_ROWS_METRIC, FlatMatchQueryExec};
+use crate::session::index_caches::IndexMetadataKey;
 
 /// Two-fragment Int32 dataset: `id` (field 0) = 0..12 and `age` (field 1) = id * 10,
 /// six rows per file (fragments 0 and 1). In-memory store so overlay files can be written
@@ -800,18 +801,14 @@ async fn make_text_index_coverage_unknown(dataset: &mut Dataset) {
     let committed = dataset.load_indices_by_name("text_idx").await.unwrap();
     let mut replacement = committed.to_vec();
     replacement[0].fragment_bitmap = None;
-    let transaction = Transaction::new(
-        dataset.manifest.version,
-        Operation::CreateIndex {
-            new_indices: replacement,
-            removed_indices: committed.to_vec(),
-        },
-        None,
-    );
+    let metadata_key = IndexMetadataKey {
+        version: dataset.version().version,
+        store_identity: &dataset.object_store.store_prefix,
+    };
     dataset
-        .apply_commit(transaction, &Default::default(), &Default::default())
-        .await
-        .unwrap();
+        .index_cache
+        .insert_with_key(&metadata_key, Arc::new(replacement))
+        .await;
 }
 
 /// Collect sorted IDs of rows returned by an FTS query on `text`.
@@ -1114,10 +1111,11 @@ async fn test_fts_overlay_stale_drop_and_new_match(#[values(false, true)] stable
             .unwrap();
         let plan = scan.explain_plan(false).await.unwrap();
         assert!(
-            plan.contains("fts_bounded_mixed_fallback_full_scan")
-                && plan.contains("AggregateExec")
-                && !plan.contains(BOUNDED_MIXED_FIELD_ROWS_METRIC),
-            "overlay MultiMatch should fail closed to current-value flat scoring:\n{plan}"
+            plan.contains(BOUNDED_MIXED_FIELD_ROWS_METRIC)
+                && plan.contains("CompoundFtsScorer")
+                && plan.contains("FlatMatchQuery")
+                && !plan.contains("AggregateExec"),
+            "known-coverage overlay MultiMatch should use bounded indexed-live plus targeted stale scoring:\n{plan}"
         );
     }
 
@@ -1213,8 +1211,8 @@ async fn test_multimatch_overlay_zero_token_row_becomes_match(
         .unwrap();
     let plan = scan.explain_plan(false).await.unwrap();
     assert!(
-        plan.contains("fts_bounded_mixed_fallback_full_scan"),
-        "zero-token stale rows require current-value corpus statistics:\n{plan}"
+        plan.contains(BOUNDED_MIXED_FIELD_ROWS_METRIC),
+        "zero-token stale rows require the shared current-value corpus scorer:\n{plan}"
     );
     let batch = scan.try_into_batch().await.unwrap();
     assert_eq!(batch.num_rows(), 1);
@@ -1269,8 +1267,7 @@ async fn test_multimatch_overlay_zero_token_row_becomes_match(
 async fn test_multimatch_unknown_coverage_overlay_full_scan_is_executable() {
     let mut dataset = create_text_dataset(false).await;
     build_text_fts_index(&mut dataset).await;
-    make_text_index_coverage_unknown(&mut dataset).await;
-    let dataset = commit_overlay(
+    let mut dataset = commit_overlay(
         dataset,
         "unknown_coverage_text_overlay",
         0,
@@ -1279,6 +1276,7 @@ async fn test_multimatch_unknown_coverage_overlay_full_scan_is_executable() {
         vec![Arc::new(StringArray::from(vec![Some("cherry mango")]))],
     )
     .await;
+    make_text_index_coverage_unknown(&mut dataset).await;
 
     let query: FtsQuery = MultiMatchQuery::try_new("mango".to_owned(), vec!["text".to_owned()])
         .unwrap()

--- a/rust/lance/src/io/exec/fts.rs
+++ b/rust/lance/src/io/exec/fts.rs
@@ -658,6 +658,8 @@ pub struct CompoundQueryExec {
     /// Corpus-wide scorer published by the residual branch of a mixed search.
     shared_scorer: Option<Arc<SharedFtsScorer>>,
     segment_selection: FtsSegmentSelection,
+    /// Rows whose indexed values were superseded by a newer data overlay.
+    overlay_block: Option<RowAddrMask>,
     /// Caller-supplied row-address mask, intersected into the prefilter so the
     /// compound scorer ranks only surviving rows (see
     /// [`MatchQueryExec::with_external_mask`]).
@@ -715,6 +717,7 @@ impl CompoundQueryExec {
             base_scorer: None,
             shared_scorer: None,
             segment_selection,
+            overlay_block: None,
             external_mask: None,
             properties: Arc::new(PlanProperties::new(
                 EquivalenceProperties::new(FTS_SCHEMA.clone()),
@@ -743,6 +746,12 @@ impl CompoundQueryExec {
 
     pub(crate) fn with_shared_scorer(mut self, scorer: Arc<SharedFtsScorer>) -> Self {
         self.shared_scorer = Some(scorer);
+        self
+    }
+
+    /// Exclude rows whose indexed text was superseded by a newer data overlay.
+    pub(crate) fn with_overlay_block(mut self, overlay_block: RowAddrMask) -> Self {
+        self.overlay_block = Some(overlay_block);
         self
     }
 
@@ -901,6 +910,7 @@ impl ExecutionPlan for CompoundQueryExec {
             base_scorer: self.base_scorer.clone(),
             shared_scorer: self.shared_scorer.clone(),
             segment_selection: self.segment_selection.clone(),
+            overlay_block: self.overlay_block.clone(),
             external_mask: self.external_mask.clone(),
             properties: self.properties.clone(),
             metrics: ExecutionPlanMetricsSet::new(),
@@ -921,6 +931,7 @@ impl ExecutionPlan for CompoundQueryExec {
         let preset_base_scorer = self.base_scorer.clone();
         let shared_scorer = self.shared_scorer.clone();
         let segment_selection = self.segment_selection.clone();
+        let overlay_block = self.overlay_block.clone();
         let external_mask = self.external_mask.clone();
         let metrics = Arc::new(FtsIndexMetrics::new(&self.metrics, partition));
 
@@ -958,7 +969,7 @@ impl ExecutionPlan for CompoundQueryExec {
                 &prefilter_source,
                 dataset,
                 &segments,
-                None,
+                overlay_block,
                 external_mask,
             )?;
             let deleted_fragments =
@@ -1715,10 +1726,7 @@ impl SharedFtsScorer {
     }
 
     fn advance_generation(generation: &mut u64) -> u64 {
-        *generation = match generation.checked_add(1) {
-            Some(next) => next,
-            None => 1,
-        };
+        *generation = generation.checked_add(1).unwrap_or(1);
         *generation
     }
 

--- a/rust/lance/src/io/exec/fts.rs
+++ b/rust/lance/src/io/exec/fts.rs
@@ -3,7 +3,7 @@
 
 use std::cmp::Ordering;
 use std::collections::{HashMap, HashSet};
-use std::sync::{Arc, OnceLock};
+use std::sync::{Arc, Mutex, MutexGuard, OnceLock};
 
 use arrow::array::{AsArray, BooleanBuilder, ListBuilder, UInt32Builder};
 use arrow::datatypes::{Float32Type, UInt64Type};
@@ -68,6 +68,7 @@ use lance_index::scalar::inverted::{
     DOC_INDEX_COL, DocumentGranularity, FTS_SCHEMA, FlatBm25SearchOptions, InvertedIndex,
     MemBM25Scorer, SCORE_COL, Scorer, build_global_bm25_scorer, compound_search,
     compound_search_with_base_scorer, cross_column_compound_search,
+    flat_bm25_search_stream_with_options_and_fixed_scorer,
     flat_bm25_search_stream_with_options_and_scorer, fts_schema,
 };
 use lance_index::{prefilter::PreFilter, scalar::inverted::query::BooleanQuery};
@@ -372,6 +373,117 @@ fn scored_documents_batch(schema: SchemaRef, documents: Vec<ScoredDoc>) -> Resul
     Ok(RecordBatch::try_new(schema, columns)?)
 }
 
+pub(crate) const BOUNDED_MIXED_INDEXED_CANDIDATES_METRIC: &str =
+    "fts_bounded_mixed_indexed_candidates";
+pub(crate) const BOUNDED_MIXED_INDEXED_ROWS_METRIC: &str = "fts_bounded_mixed_indexed_rows";
+pub(crate) const BOUNDED_MIXED_RESIDUAL_CANDIDATES_METRIC: &str =
+    "fts_bounded_mixed_residual_candidates";
+pub(crate) const BOUNDED_MIXED_RESIDUAL_ROWS_METRIC: &str = "fts_bounded_mixed_residual_rows";
+pub(crate) const BOUNDED_MIXED_FIELD_ROWS_METRIC: &str = "fts_bounded_mixed_field_rows";
+
+/// Pass-through instrumentation for the bounded mixed-field planner.
+#[derive(Debug)]
+pub(crate) struct BoundedMixedFtsMetricsExec {
+    input: Arc<dyn ExecutionPlan>,
+    metric_name: &'static str,
+    count_invocation: bool,
+    metrics: ExecutionPlanMetricsSet,
+}
+
+impl BoundedMixedFtsMetricsExec {
+    pub(crate) fn new(input: Arc<dyn ExecutionPlan>, metric_name: &'static str) -> Self {
+        Self {
+            input,
+            metric_name,
+            count_invocation: false,
+            metrics: ExecutionPlanMetricsSet::new(),
+        }
+    }
+
+    pub(crate) fn new_event(input: Arc<dyn ExecutionPlan>, metric_name: &'static str) -> Self {
+        Self {
+            input,
+            metric_name,
+            count_invocation: true,
+            metrics: ExecutionPlanMetricsSet::new(),
+        }
+    }
+}
+
+impl DisplayAs for BoundedMixedFtsMetricsExec {
+    fn fmt_as(&self, _t: DisplayFormatType, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "BoundedMixedFtsMetrics: metric={}", self.metric_name)
+    }
+}
+
+impl ExecutionPlan for BoundedMixedFtsMetricsExec {
+    fn name(&self) -> &str {
+        "BoundedMixedFtsMetricsExec"
+    }
+
+    fn children(&self) -> Vec<&Arc<dyn ExecutionPlan>> {
+        vec![&self.input]
+    }
+
+    fn required_input_distribution(&self) -> Vec<Distribution> {
+        vec![Distribution::SinglePartition]
+    }
+
+    fn with_new_children(
+        self: Arc<Self>,
+        mut children: Vec<Arc<dyn ExecutionPlan>>,
+    ) -> DataFusionResult<Arc<dyn ExecutionPlan>> {
+        if children.len() != 1 {
+            return Err(DataFusionError::Internal(format!(
+                "bounded mixed FTS metrics expected one child, got {}",
+                children.len()
+            )));
+        }
+        let input = children.pop().ok_or_else(|| {
+            DataFusionError::Internal("bounded mixed FTS metrics lost its child".to_string())
+        })?;
+        let exec = if self.count_invocation {
+            Self::new_event(input, self.metric_name)
+        } else {
+            Self::new(input, self.metric_name)
+        };
+        Ok(Arc::new(exec))
+    }
+
+    fn execute(
+        &self,
+        partition: usize,
+        context: Arc<datafusion::execution::TaskContext>,
+    ) -> DataFusionResult<SendableRecordBatchStream> {
+        let rows = self.metrics.new_count(self.metric_name, partition);
+        let count_invocation = self.count_invocation;
+        if count_invocation && partition == 0 {
+            rows.add(1);
+        }
+        let stream = self
+            .input
+            .execute(partition, context)?
+            .map_ok(move |batch| {
+                if !count_invocation {
+                    rows.add(batch.num_rows());
+                }
+                batch
+            });
+        Ok(Box::pin(RecordBatchStreamAdapter::new(
+            self.schema(),
+            stream,
+        )))
+    }
+
+    fn metrics(&self) -> Option<MetricsSet> {
+        Some(self.metrics.clone_inner())
+    }
+
+    fn properties(&self) -> &Arc<PlanProperties> {
+        self.input.properties()
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 struct DocumentKey {
     row_id: u64,
@@ -543,6 +655,8 @@ pub struct CompoundQueryExec {
     /// When set, leaf scorers use this instead of building one from the
     /// searched segments — see [`MatchQueryExec::with_base_scorer`].
     base_scorer: Option<Arc<MemBM25Scorer>>,
+    /// Corpus-wide scorer published by the residual branch of a mixed search.
+    shared_scorer: Option<Arc<SharedFtsScorer>>,
     segment_selection: FtsSegmentSelection,
     /// Caller-supplied row-address mask, intersected into the prefilter so the
     /// compound scorer ranks only surviving rows (see
@@ -599,6 +713,7 @@ impl CompoundQueryExec {
             params,
             prefilter_source,
             base_scorer: None,
+            shared_scorer: None,
             segment_selection,
             external_mask: None,
             properties: Arc::new(PlanProperties::new(
@@ -623,6 +738,11 @@ impl CompoundQueryExec {
     /// expansions. Execution returns an error when any required token is absent.
     pub fn with_base_scorer(mut self, scorer: Arc<MemBM25Scorer>) -> Self {
         self.base_scorer = Some(scorer);
+        self
+    }
+
+    pub(crate) fn with_shared_scorer(mut self, scorer: Arc<SharedFtsScorer>) -> Self {
+        self.shared_scorer = Some(scorer);
         self
     }
 
@@ -734,6 +854,14 @@ impl ExecutionPlan for CompoundQueryExec {
             .collect()
     }
 
+    fn reset_state(self: Arc<Self>) -> DataFusionResult<Arc<dyn ExecutionPlan>> {
+        if let Some(shared_scorer) = &self.shared_scorer {
+            shared_scorer.invalidate();
+        }
+        let children = self.children().into_iter().cloned().collect();
+        self.with_new_children(children)
+    }
+
     fn with_new_children(
         self: Arc<Self>,
         mut children: Vec<Arc<dyn ExecutionPlan>>,
@@ -771,6 +899,7 @@ impl ExecutionPlan for CompoundQueryExec {
             params: self.params.clone(),
             prefilter_source,
             base_scorer: self.base_scorer.clone(),
+            shared_scorer: self.shared_scorer.clone(),
             segment_selection: self.segment_selection.clone(),
             external_mask: self.external_mask.clone(),
             properties: self.properties.clone(),
@@ -789,7 +918,8 @@ impl ExecutionPlan for CompoundQueryExec {
         let tokenized_query = self.tokenized_query.clone();
         let params = self.params.clone();
         let prefilter_source = self.prefilter_source.clone();
-        let base_scorer = self.base_scorer.clone();
+        let preset_base_scorer = self.base_scorer.clone();
+        let shared_scorer = self.shared_scorer.clone();
         let segment_selection = self.segment_selection.clone();
         let external_mask = self.external_mask.clone();
         let metrics = Arc::new(FtsIndexMetrics::new(&self.metrics, partition));
@@ -854,6 +984,11 @@ impl ExecutionPlan for CompoundQueryExec {
                     .sum::<usize>()
                     .saturating_mul(count_fts_leaves(&query)),
             );
+            let base_scorer = match (preset_base_scorer, shared_scorer) {
+                (Some(scorer), _) => Some(scorer),
+                (None, Some(shared_scorer)) => Some(shared_scorer.wait().await?),
+                (None, None) => None,
+            };
             let certificate_limit = match (&query, params.limit) {
                 (FtsQuery::Match(match_query), Some(limit))
                     if limit > 0
@@ -1545,37 +1680,100 @@ fn tokenize_cross_column_compound_query(
     Ok(TokenizedCompoundQuery(leaves))
 }
 
-type SharedScorerResult = std::result::Result<Arc<MemBM25Scorer>, Arc<str>>;
+#[derive(Clone, Debug)]
+enum SharedScorerState {
+    Pending,
+    Ready(Arc<MemBM25Scorer>),
+    Failed(Arc<str>),
+    Cancelled,
+    Invalidated,
+}
 
 /// Coordinates BM25 corpus statistics between the indexed and flat branches
 /// of a mixed search. The flat branch extends the indexed statistics with the
 /// unindexed documents, then publishes the resulting corpus-wide scorer.
 #[derive(Debug)]
 pub(crate) struct SharedFtsScorer {
-    sender: tokio::sync::watch::Sender<Option<SharedScorerResult>>,
+    generation: Mutex<u64>,
+    sender: tokio::sync::watch::Sender<SharedScorerState>,
 }
 
 impl SharedFtsScorer {
     pub(crate) fn new() -> Self {
-        let (sender, _) = tokio::sync::watch::channel(None);
-        Self { sender }
+        let (sender, _) = tokio::sync::watch::channel(SharedScorerState::Pending);
+        Self {
+            generation: Mutex::new(0),
+            sender,
+        }
     }
 
-    fn publish(&self, scorer: MemBM25Scorer) {
-        self.sender.send_replace(Some(Ok(Arc::new(scorer))));
+    fn generation(&self) -> MutexGuard<'_, u64> {
+        match self.generation.lock() {
+            Ok(generation) => generation,
+            Err(poisoned) => poisoned.into_inner(),
+        }
     }
 
-    fn publish_error(&self, error: &DataFusionError) {
-        self.sender
-            .send_replace(Some(Err(Arc::from(error.to_string()))));
+    fn advance_generation(generation: &mut u64) -> u64 {
+        *generation = match generation.checked_add(1) {
+            Some(next) => next,
+            None => 1,
+        };
+        *generation
+    }
+
+    fn begin_generation(&self) -> u64 {
+        let mut current = self.generation();
+        let generation = Self::advance_generation(&mut current);
+        self.sender.send_replace(SharedScorerState::Pending);
+        generation
+    }
+
+    fn invalidate(&self) {
+        let mut current = self.generation();
+        Self::advance_generation(&mut current);
+        self.sender.send_replace(SharedScorerState::Invalidated);
+    }
+
+    fn publish(&self, generation: u64, scorer: MemBM25Scorer) {
+        let current = self.generation();
+        if *current == generation {
+            self.sender
+                .send_replace(SharedScorerState::Ready(Arc::new(scorer)));
+        }
+    }
+
+    fn publish_error(&self, generation: u64, error: &DataFusionError) {
+        let current = self.generation();
+        if *current == generation {
+            self.sender
+                .send_replace(SharedScorerState::Failed(Arc::from(error.to_string())));
+        }
+    }
+
+    fn cancel(&self, generation: u64) {
+        let current = self.generation();
+        if *current == generation {
+            self.sender.send_replace(SharedScorerState::Cancelled);
+        }
     }
 
     async fn wait(&self) -> DataFusionResult<Arc<MemBM25Scorer>> {
         let mut receiver = self.sender.subscribe();
         loop {
-            let result = receiver.borrow_and_update().clone();
-            if let Some(result) = result {
-                return result.map_err(|message| DataFusionError::Execution(message.to_string()));
+            let state = receiver.borrow_and_update().clone();
+            match state {
+                SharedScorerState::Ready(scorer) => return Ok(scorer),
+                SharedScorerState::Failed(message) => {
+                    return Err(DataFusionError::Execution(message.to_string()));
+                }
+                SharedScorerState::Cancelled => {
+                    return Err(DataFusionError::Execution(
+                        "mixed FTS corpus scorer producer was cancelled before publishing statistics"
+                            .to_string(),
+                    ));
+                }
+                SharedScorerState::Pending | SharedScorerState::Invalidated => {}
             }
             receiver.changed().await.map_err(|_| {
                 DataFusionError::Execution(
@@ -1589,24 +1787,27 @@ impl SharedFtsScorer {
 
 struct SharedFtsScorerProducer {
     scorer: Arc<SharedFtsScorer>,
+    generation: u64,
     completed: bool,
 }
 
 impl SharedFtsScorerProducer {
     fn new(scorer: Arc<SharedFtsScorer>) -> Self {
+        let generation = scorer.begin_generation();
         Self {
             scorer,
+            generation,
             completed: false,
         }
     }
 
     fn publish(mut self, scorer: MemBM25Scorer) {
-        self.scorer.publish(scorer);
+        self.scorer.publish(self.generation, scorer);
         self.completed = true;
     }
 
     fn publish_error(mut self, error: &DataFusionError) {
-        self.scorer.publish_error(error);
+        self.scorer.publish_error(self.generation, error);
         self.completed = true;
     }
 }
@@ -1614,9 +1815,7 @@ impl SharedFtsScorerProducer {
 impl Drop for SharedFtsScorerProducer {
     fn drop(&mut self) {
         if !self.completed {
-            self.scorer.sender.send_replace(Some(Err(Arc::from(
-                "mixed FTS corpus scorer producer was cancelled before publishing statistics",
-            ))));
+            self.scorer.cancel(self.generation);
         }
     }
 }
@@ -2250,6 +2449,14 @@ impl ExecutionPlan for MatchQueryExec {
             .iter()
             .map(|_| Distribution::SinglePartition)
             .collect()
+    }
+
+    fn reset_state(self: Arc<Self>) -> DataFusionResult<Arc<dyn ExecutionPlan>> {
+        if let Some(shared_scorer) = &self.shared_scorer {
+            shared_scorer.invalidate();
+        }
+        let children = self.children().into_iter().cloned().collect();
+        self.with_new_children(children)
     }
 
     fn with_new_children(
@@ -2904,6 +3111,8 @@ pub struct FlatMatchQueryExec {
     tokenized_query: Arc<OnceLock<TokenizedQuery>>,
     params: FtsSearchParams,
     unindexed_input: Arc<dyn ExecutionPlan>,
+    /// Unfiltered residual documents used only to extend corpus statistics.
+    corpus_stats_input: Option<Arc<dyn ExecutionPlan>>,
     /// Optional override for the BM25 scorer normally built locally inside
     /// `execute()`. See [`MatchQueryExec::with_base_scorer`].
     base_scorer: Option<Arc<MemBM25Scorer>>,
@@ -2987,6 +3196,7 @@ impl FlatMatchQueryExec {
             tokenized_query: Arc::new(OnceLock::new()),
             params,
             unindexed_input,
+            corpus_stats_input: None,
             base_scorer: None,
             shared_scorer: None,
             preset_segments: None,
@@ -3043,6 +3253,7 @@ impl FlatMatchQueryExec {
             tokenized_query: Arc::new(OnceLock::new()),
             params,
             unindexed_input,
+            corpus_stats_input: None,
             base_scorer: None,
             shared_scorer: None,
             preset_segments: Some(segments),
@@ -3062,6 +3273,11 @@ impl FlatMatchQueryExec {
 
     pub(crate) fn with_shared_scorer(mut self, scorer: Arc<SharedFtsScorer>) -> Self {
         self.shared_scorer = Some(scorer);
+        self
+    }
+
+    pub(crate) fn with_corpus_stats_input(mut self, input: Arc<dyn ExecutionPlan>) -> Self {
+        self.corpus_stats_input = Some(input);
         self
     }
 
@@ -3092,7 +3308,11 @@ impl ExecutionPlan for FlatMatchQueryExec {
     }
 
     fn children(&self) -> Vec<&Arc<dyn ExecutionPlan>> {
-        vec![&self.unindexed_input]
+        let mut children = vec![&self.unindexed_input];
+        if let Some(corpus_stats_input) = &self.corpus_stats_input {
+            children.push(corpus_stats_input);
+        }
+        children
     }
 
     fn required_input_distribution(&self) -> Vec<Distribution> {
@@ -3100,25 +3320,46 @@ impl ExecutionPlan for FlatMatchQueryExec {
         // output partition, so the input must be coalesced to one partition. Without
         // this, EnforceDistribution may round-robin the scan across `target_partitions`
         // and only partition 0 is consumed, silently dropping the other fragments.
-        vec![Distribution::SinglePartition]
+        self.children()
+            .iter()
+            .map(|_| Distribution::SinglePartition)
+            .collect()
+    }
+
+    fn reset_state(self: Arc<Self>) -> DataFusionResult<Arc<dyn ExecutionPlan>> {
+        if let Some(shared_scorer) = &self.shared_scorer {
+            shared_scorer.invalidate();
+        }
+        let children = self.children().into_iter().cloned().collect();
+        self.with_new_children(children)
     }
 
     fn with_new_children(
         self: Arc<Self>,
         mut children: Vec<Arc<dyn ExecutionPlan>>,
     ) -> DataFusionResult<Arc<dyn ExecutionPlan>> {
-        if children.len() != 1 {
-            return Err(DataFusionError::Internal(
-                "Unexpected number of children".to_string(),
-            ));
+        let expected_children = 1 + usize::from(self.corpus_stats_input.is_some());
+        if children.len() != expected_children {
+            return Err(DataFusionError::Internal(format!(
+                "FlatMatchQueryExec expected {expected_children} children, got {}",
+                children.len()
+            )));
         }
-        let unindexed_input = children.pop().unwrap();
+        let corpus_stats_input = if self.corpus_stats_input.is_some() {
+            children.pop()
+        } else {
+            None
+        };
+        let unindexed_input = children.pop().ok_or_else(|| {
+            DataFusionError::Internal("FlatMatchQueryExec lost its candidate input".to_string())
+        })?;
         Ok(Arc::new(Self {
             dataset: self.dataset.clone(),
             query: self.query.clone(),
             tokenized_query: self.tokenized_query.clone(),
             params: self.params.clone(),
             unindexed_input,
+            corpus_stats_input,
             base_scorer: self.base_scorer.clone(),
             shared_scorer: self.shared_scorer.clone(),
             preset_segments: self.preset_segments.clone(),
@@ -3148,6 +3389,7 @@ impl ExecutionPlan for FlatMatchQueryExec {
         let document_granularity = self.document_granularity;
         let document_column = self.document_column.clone();
         let phrase_slop = self.params.phrase_slop;
+        let corpus_stats_input = self.corpus_stats_input.clone();
 
         // CPU time accumulator passed into `flat_bm25_search_stream_with_metrics`
         // so it can attribute the spawn_cpu tokenize work and synchronous
@@ -3161,9 +3403,12 @@ impl ExecutionPlan for FlatMatchQueryExec {
             query.terms
         )))?;
         let unindexed_input = document_input(
-            self.unindexed_input.execute(partition, context)?,
+            self.unindexed_input.execute(partition, context.clone())?,
             &document_column,
         )?;
+        let corpus_stats_input = corpus_stats_input
+            .map(|input| document_input(input.execute(partition, context)?, &document_column))
+            .transpose()?;
 
         let stream = stream::once(async move {
             let shared_scorer_producer = shared_scorer_producer;
@@ -3172,7 +3417,7 @@ impl ExecutionPlan for FlatMatchQueryExec {
                     Some(segments) => Some(segments),
                     None => load_segments(&ds, &column, document_granularity).await?,
                 };
-                let (tokenizer, base_scorer) = match segments {
+                let (tokenizer, stats_tokenizer, base_scorer) = match segments {
                     Some(segments) => {
                         let _details = load_segment_details(&ds, &column, &segments).await?;
                         let indices =
@@ -3203,32 +3448,71 @@ impl ExecutionPlan for FlatMatchQueryExec {
                                 scorer
                             }
                         };
-                        (tokenizer, Some(base_scorer))
+                        (tokenizer, first_index.tokenizer(), Some(base_scorer))
                     }
                     None => {
                         let mut tokenizer = default_text_tokenizer();
                         let query_tokens = collect_query_tokens(&query.terms, &mut tokenizer);
                         record_tokenized_query(&tokenized_query, &query_tokens);
-                        (tokenizer, preset_base_scorer.map(|s| (*s).clone()))
+                        (
+                            tokenizer,
+                            default_text_tokenizer(),
+                            preset_base_scorer.map(|s| (*s).clone()),
+                        )
                     }
                 };
-
-                flat_bm25_search_stream_with_options_and_scorer(
-                    unindexed_input,
-                    document_column,
-                    query.terms,
-                    tokenizer,
-                    base_scorer,
-                    FlatBm25SearchOptions {
-                        target_batch_size,
-                        elapsed_compute: Some(elapsed_compute),
-                        operator: query.operator,
-                        boost: query.boost,
-                        document_granularity,
-                        phrase_slop,
-                    },
-                )
-                .await
+                if let Some(corpus_stats_input) = corpus_stats_input {
+                    let (_, scorer) = flat_bm25_search_stream_with_options_and_scorer(
+                        corpus_stats_input,
+                        document_column.clone(),
+                        query.terms.clone(),
+                        stats_tokenizer,
+                        base_scorer,
+                        FlatBm25SearchOptions {
+                            target_batch_size,
+                            elapsed_compute: Some(elapsed_compute.clone()),
+                            operator: query.operator,
+                            boost: query.boost,
+                            document_granularity,
+                            phrase_slop,
+                        },
+                    )
+                    .await?;
+                    let stream = flat_bm25_search_stream_with_options_and_fixed_scorer(
+                        unindexed_input,
+                        document_column,
+                        query.terms,
+                        tokenizer,
+                        scorer.clone(),
+                        FlatBm25SearchOptions {
+                            target_batch_size,
+                            elapsed_compute: Some(elapsed_compute),
+                            operator: query.operator,
+                            boost: query.boost,
+                            document_granularity,
+                            phrase_slop,
+                        },
+                    )
+                    .await?;
+                    Ok((stream, scorer))
+                } else {
+                    flat_bm25_search_stream_with_options_and_scorer(
+                        unindexed_input,
+                        document_column,
+                        query.terms,
+                        tokenizer,
+                        base_scorer,
+                        FlatBm25SearchOptions {
+                            target_batch_size,
+                            elapsed_compute: Some(elapsed_compute),
+                            operator: query.operator,
+                            boost: query.boost,
+                            document_granularity,
+                            phrase_slop,
+                        },
+                    )
+                    .await
+                }
             }
             .await;
 
@@ -3557,6 +3841,14 @@ impl ExecutionPlan for PhraseQueryExec {
             .iter()
             .map(|_| Distribution::SinglePartition)
             .collect()
+    }
+
+    fn reset_state(self: Arc<Self>) -> DataFusionResult<Arc<dyn ExecutionPlan>> {
+        if let Some(shared_scorer) = &self.shared_scorer {
+            shared_scorer.invalidate();
+        }
+        let children = self.children().into_iter().cloned().collect();
+        self.with_new_children(children)
     }
 
     fn with_new_children(
@@ -4260,7 +4552,8 @@ impl ExecutionPlan for BooleanQueryExec {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::{Arc, Mutex};
+    use std::collections::HashMap;
+    use std::sync::{Arc, Barrier, Mutex};
 
     use crate::index::DatasetIndexExt;
     use arrow_array::{
@@ -4284,7 +4577,7 @@ mod tests {
         PhraseQuery, collect_query_tokens, has_query_token,
     };
     use lance_index::scalar::inverted::{
-        DocumentGranularity, FTS_SCHEMA, InvertedIndex, Language, SCORE_COL,
+        DocumentGranularity, FTS_SCHEMA, InvertedIndex, Language, MemBM25Scorer, SCORE_COL,
         build_global_bm25_scorer,
     };
     use lance_index::scalar::{FullTextSearchQuery, InvertedIndexParams};
@@ -4304,12 +4597,61 @@ mod tests {
     use super::{
         BoolSlot, BoostQueryExec, CompoundQueryExec, CrossColumnCompoundQueryExec,
         FTS_SEGMENT_BIND_DURATION_METRIC, FlatMatchFilterExec, FlatMatchQueryExec, MatchQueryExec,
-        PhraseQueryExec, WandExactnessCertificate, build_boolean_query_children,
-        classify_wand_exactness_certificate, default_text_tokenizer, open_fts_segments,
+        PhraseQueryExec, SharedFtsScorer, SharedFtsScorerProducer, WandExactnessCertificate,
+        build_boolean_query_children, classify_wand_exactness_certificate, default_text_tokenizer,
+        open_fts_segments,
     };
     use crate::io::exec::utils::IndexMetrics;
     use datafusion::physical_plan::empty::EmptyExec;
     use datafusion::physical_plan::repartition::RepartitionExec;
+
+    #[tokio::test]
+    async fn shared_scorer_ignores_cancelled_stale_generation_after_reset() {
+        let scorer = Arc::new(SharedFtsScorer::new());
+        let stale_producer = SharedFtsScorerProducer::new(scorer.clone());
+        scorer.invalidate();
+        let current_producer = SharedFtsScorerProducer::new(scorer.clone());
+        drop(stale_producer);
+
+        current_producer.publish(MemBM25Scorer::new(
+            3,
+            2,
+            HashMap::from([("needle".to_string(), 1)]),
+        ));
+        let published = scorer.wait().await.unwrap();
+        assert_eq!(published.num_docs, 2);
+        assert_eq!(published.total_tokens, 3);
+    }
+
+    #[tokio::test]
+    async fn shared_scorer_serializes_publish_against_reset() {
+        let scorer = Arc::new(SharedFtsScorer::new());
+        let stale_producer = SharedFtsScorerProducer::new(scorer.clone());
+        let barrier = Arc::new(Barrier::new(2));
+        let publish_barrier = barrier.clone();
+        let publish = std::thread::spawn(move || {
+            publish_barrier.wait();
+            stale_producer.publish(MemBM25Scorer::new(
+                1,
+                1,
+                HashMap::from([("stale".to_string(), 1)]),
+            ));
+        });
+        barrier.wait();
+        scorer.invalidate();
+        publish.join().unwrap();
+
+        let current = SharedFtsScorerProducer::new(scorer.clone());
+        current.publish(MemBM25Scorer::new(
+            7,
+            3,
+            HashMap::from([("current".to_string(), 2)]),
+        ));
+        let published = scorer.wait().await.unwrap();
+        assert_eq!(published.num_docs, 3);
+        assert_eq!(published.total_tokens, 7);
+        assert_eq!(published.num_docs_containing_token("current"), 2);
+    }
     use datafusion::physical_plan::union::UnionExec;
     use datafusion_physical_plan::joins::HashJoinExec;
 

--- a/rust/lance/src/io/exec/fts.rs
+++ b/rust/lance/src/io/exec/fts.rs
@@ -655,8 +655,6 @@ pub struct CompoundQueryExec {
     /// When set, leaf scorers use this instead of building one from the
     /// searched segments — see [`MatchQueryExec::with_base_scorer`].
     base_scorer: Option<Arc<MemBM25Scorer>>,
-    /// Corpus-wide scorer published by the residual branch of a mixed search.
-    shared_scorer: Option<Arc<SharedFtsScorer>>,
     segment_selection: FtsSegmentSelection,
     /// Rows whose indexed values were superseded by a newer data overlay.
     overlay_block: Option<RowAddrMask>,
@@ -715,7 +713,6 @@ impl CompoundQueryExec {
             params,
             prefilter_source,
             base_scorer: None,
-            shared_scorer: None,
             segment_selection,
             overlay_block: None,
             external_mask: None,
@@ -741,11 +738,6 @@ impl CompoundQueryExec {
     /// expansions. Execution returns an error when any required token is absent.
     pub fn with_base_scorer(mut self, scorer: Arc<MemBM25Scorer>) -> Self {
         self.base_scorer = Some(scorer);
-        self
-    }
-
-    pub(crate) fn with_shared_scorer(mut self, scorer: Arc<SharedFtsScorer>) -> Self {
-        self.shared_scorer = Some(scorer);
         self
     }
 
@@ -863,14 +855,6 @@ impl ExecutionPlan for CompoundQueryExec {
             .collect()
     }
 
-    fn reset_state(self: Arc<Self>) -> DataFusionResult<Arc<dyn ExecutionPlan>> {
-        if let Some(shared_scorer) = &self.shared_scorer {
-            shared_scorer.invalidate();
-        }
-        let children = self.children().into_iter().cloned().collect();
-        self.with_new_children(children)
-    }
-
     fn with_new_children(
         self: Arc<Self>,
         mut children: Vec<Arc<dyn ExecutionPlan>>,
@@ -908,7 +892,6 @@ impl ExecutionPlan for CompoundQueryExec {
             params: self.params.clone(),
             prefilter_source,
             base_scorer: self.base_scorer.clone(),
-            shared_scorer: self.shared_scorer.clone(),
             segment_selection: self.segment_selection.clone(),
             overlay_block: self.overlay_block.clone(),
             external_mask: self.external_mask.clone(),
@@ -928,8 +911,7 @@ impl ExecutionPlan for CompoundQueryExec {
         let tokenized_query = self.tokenized_query.clone();
         let params = self.params.clone();
         let prefilter_source = self.prefilter_source.clone();
-        let preset_base_scorer = self.base_scorer.clone();
-        let shared_scorer = self.shared_scorer.clone();
+        let base_scorer = self.base_scorer.clone();
         let segment_selection = self.segment_selection.clone();
         let overlay_block = self.overlay_block.clone();
         let external_mask = self.external_mask.clone();
@@ -995,11 +977,6 @@ impl ExecutionPlan for CompoundQueryExec {
                     .sum::<usize>()
                     .saturating_mul(count_fts_leaves(&query)),
             );
-            let base_scorer = match (preset_base_scorer, shared_scorer) {
-                (Some(scorer), _) => Some(scorer),
-                (None, Some(shared_scorer)) => Some(shared_scorer.wait().await?),
-                (None, None) => None,
-            };
             let certificate_limit = match (&query, params.limit) {
                 (FtsQuery::Match(match_query), Some(limit))
                     if limit > 0


### PR DESCRIPTION
## Performance issue

Top-level `MultiMatch` plans every field independently. A fully indexed field uses bounded exact top-k execution, but one field with an unindexed fragment or stale overlay row currently runs its indexed and flat leaves with `limit=None`. Common terms can therefore send corpus-scale matches into the outer MAX aggregate for a small-k query.

Linear: https://linear.app/lancedb/issue/OSS-2102/bound-partial-index-and-overlay-multimatch-field-fallback

## How this improves it

- Prove known, non-overlapping fragment coverage before enabling the optimization.
- Split a partial field into disjoint indexed-live and residual sources.
- Preserve the existing source-local BM25 scoring contract used by unbounded and plain `Match` execution.
- Run exact `(score DESC, row_id ASC)` top-k independently for each source, then merge an exact field-local top-k before the outer DisMax/MAX.
- Exclude stale indexed values with the overlay mask and evaluate only targeted current stale rows on the flat source.
- Keep ordinary row-level `Match` on its existing posting-plus-targeted-flat plan; one stale row does not add a full-corpus statistics scan.
- Keep fully indexed fields on their existing compound/WAND path.
- Return a single field directly only when its child already proves exact field top-k.
- Fail closed for fuzzy shapes that cannot yet be evaluated correctly; the full auto-fuzzy/residual contract is tracked separately by [OSS-2103](https://linear.app/lancedb/issue/OSS-2103/honor-auto-fuzziness-and-fuzzy-residual-rows-in-mixed-fts-plans).

## Correctness boundaries

- Known partial or row-overlay, explicit-exact fields use bounded indexed-live plus residual execution.
- Per-source top-k is sufficient because the sources are disjoint and use the same deterministic `(score DESC, row_id ASC)` order as their unbounded forms.
- Unknown or overlapping exact coverage uses a current-value target-flat fallback.
- Fuzzy known-stale fields preserve the existing executable path; unknown fuzzy coverage returns a clear unsupported error instead of silently running exact-flat matching.
- Default post-filter semantics are unchanged; callers that require filtering before top-k use `prefilter(true)`.
- `fast_search` remains index-only.

## Coverage

Added production-path coverage for append-created partial indices, multi-partition residual inputs, prefilters, bounded-vs-unbounded score parity, stable row IDs, deletes, equal-score ties, row overlays, targeted stale takes, zero-token-to-match overlays, unknown/overlapping coverage, legacy/full-scan fallback, fuzzy fail-safe routing, fast search, single-field direct return, and fallback/row-bound metrics.

Independent static review found no remaining P1/P2 blocker. Final diff SHA-256 after the concurrency-aware metric follow-up: `bb3bfe6cbd8827d95518e8ac69eedb76c0b6e9c587f0236ddad2a74bbad1d03b`.

## Validation

- `cargo check -p lance --tests`
- `cargo fmt --all`
- `git diff --check`

Per request, test binaries and clippy were not run locally; CI will run them.

## Benchmark (final)

Environment: `c4-highmem-16` in `us-central1-c`, 8 workers, 64 GiB index cache, frozen 10M MMLB dataset plus one 100k-row unindexed fragment. The warm treatment used 25 frozen queries, 5 repetitions, four baseline and four target processes in two-block ABBA order with forward/reverse case order. Cold processes dropped the page cache before every run.

| Scenario / metric | Baseline | This PR | Benefit |
| --- | ---: | ---: | ---: |
| Partial warm k=10 throughput (higher is better) | 0.153970 q/s | 0.153301 q/s | 0.996x throughput |
| Partial warm k=100 throughput (higher is better) | 0.154013 q/s | 0.153427 q/s | 0.996x throughput |
| Partial cold k=10 query latency (lower is better) | 10,312.63 ms | 10,410.47 ms | 0.991x speedup |
| Partial cold k=100 query latency (lower is better) | 10,343.41 ms | 10,376.93 ms | 0.997x speedup |
| Fully indexed warm k=10 throughput (higher is better) | 1,528.02 q/s | 1,532.50 q/s | 1.003x throughput |
| Fully indexed warm k=100 throughput (higher is better) | 802.24 q/s | 799.18 q/s | 0.996x throughput |

Correctness and activation passed: baseline/target exhaustive oracles were 50/50 exact, all result and row digests were stable, and all 25 target canaries used the bounded mixed plan at k=10 and k=100.

The implementation did reduce its intended intermediate work. Across the canary cohort, k=10 indexed comparisons fell from 9,936,016 to 1,786,519 (5.56x fewer), and 99,330 residual matches were reduced to 440 downstream rows (225.75x fewer). However, both builds still scanned 4,800,000 residual rows and read 13,473,219,753 bytes. `FlatMatchQueryExec` tokenizes and scores the complete residual input before the new `SortExec(fetch=k)` runs, so raw residual processing remains the dominant cost.

This misses the Linear performance gate of at least 1.20x end-to-end latency improvement. Lucene NRT avoids this shape by flushing fresh documents into searchable leaves before opening a reader, then sharing a competitive threshold across leaf collectors and DisMax children: [IndexWriter NRT flush](https://github.com/apache/lucene/blob/6c73e1f4e92c505e616ab3a62d2281682d418356/lucene/core/src/java/org/apache/lucene/index/IndexWriter.java#L567-L597), [TopScoreDocCollectorManager](https://github.com/apache/lucene/blob/6c73e1f4e92c505e616ab3a62d2281682d418356/lucene/core/src/java/org/apache/lucene/search/TopScoreDocCollectorManager.java#L23-L25), and [DisjunctionMaxScorer](https://github.com/apache/lucene/blob/6c73e1f4e92c505e616ab3a62d2281682d418356/lucene/core/src/java/org/apache/lucene/search/DisjunctionMaxScorer.java#L112-L120).

The PR is closed because the optimization is correct but ineffective for the target workload. Artifacts remain under `/mnt/benchmark-ssd/mmlb-queue/02-oss2102/results`.
