### PR TITLE
test(core): cover cache entry body framing, alignment, and truncation errors

### DIFF
--- a/rust/lance-core/src/cache/entry_io.rs
+++ b/rust/lance-core/src/cache/entry_io.rs
@@ -200,3 +200,193 @@ impl<'a> CacheEntryReader<'a> {
         self.data.slice(self.offset..)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use std::sync::Arc;
+
+    use arrow_array::{Int32Array, UInt64Array};
+    use arrow_schema::{DataType, Field, Schema};
+    use lance_arrow::ipc::IPC_SECTION_ALIGNMENT;
+
+    /// Write a body starting at entry offset `pos` and return the bytes.
+    ///
+    /// `pos` models the envelope the [`CacheCodec`](super::CacheCodec) wrapper
+    /// writes ahead of the body; it only affects section alignment.
+    fn write_body(pos: usize, f: impl FnOnce(&mut CacheEntryWriter<'_>)) -> Bytes {
+        let mut buf = Vec::new();
+        let mut writer = CacheEntryWriter::with_pos(&mut buf, pos);
+        f(&mut writer);
+        Bytes::from(buf)
+    }
+
+    fn int_batch(values: Vec<i32>) -> RecordBatch {
+        let schema = Schema::new(vec![Field::new("i", DataType::Int32, false)]);
+        RecordBatch::try_new(schema.into(), vec![Arc::new(Int32Array::from(values))]).unwrap()
+    }
+
+    #[test]
+    fn test_u8_roundtrip_and_truncation() {
+        let data = write_body(0, |w| {
+            w.write_u8(7).unwrap();
+            w.write_u8(255).unwrap();
+        });
+        assert_eq!(data.as_ref(), &[7, 255]);
+
+        let mut reader = CacheEntryReader::new(&data, 0, 1);
+        assert_eq!(reader.read_u8().unwrap(), 7);
+        assert_eq!(reader.read_u8().unwrap(), 255);
+
+        // A third read has nothing left and must say so rather than wrap around.
+        let message = reader.read_u8().unwrap_err().to_string();
+        assert!(message.contains("missing tag byte"), "{message}");
+    }
+
+    /// Headers are framed as `[len: u32 LE][bytes]`; `u64` stands in for a real
+    /// header proto here (prost encodes it as `google.protobuf.UInt64Value`).
+    #[test]
+    fn test_header_roundtrip_is_length_prefixed() {
+        let data = write_body(0, |w| w.write_header(&1234u64).unwrap());
+
+        let encoded_len = 1234u64.encoded_len();
+        assert_eq!(
+            u32::from_le_bytes(data[..4].try_into().unwrap()) as usize,
+            encoded_len
+        );
+        assert_eq!(data.len(), 4 + encoded_len);
+
+        let mut reader = CacheEntryReader::new(&data, 0, 1);
+        assert_eq!(reader.read_header::<u64>().unwrap(), 1234);
+        // The reader consumed exactly the prefix plus the payload.
+        assert!(reader.body().is_empty());
+    }
+
+    #[test]
+    fn test_read_header_rejects_truncated_length_prefix() {
+        let data = Bytes::from_static(&[0, 0]);
+        let message = CacheEntryReader::new(&data, 0, 1)
+            .read_header::<u64>()
+            .unwrap_err()
+            .to_string();
+        assert!(message.contains("truncated length prefix"), "{message}");
+    }
+
+    #[test]
+    fn test_read_header_rejects_truncated_body() {
+        // Prefix claims 16 payload bytes; only 3 follow.
+        let mut data = 16u32.to_le_bytes().to_vec();
+        data.extend_from_slice(&[1, 2, 3]);
+        let data = Bytes::from(data);
+
+        let message = CacheEntryReader::new(&data, 0, 1)
+            .read_header::<u64>()
+            .unwrap_err()
+            .to_string();
+        assert!(message.contains("truncated body"), "{message}");
+    }
+
+    /// A length prefix that is in range but whose payload is not valid protobuf
+    /// must surface as a decode error, not a panic inside prost.
+    #[test]
+    fn test_read_header_rejects_undecodable_payload() {
+        // Field 1 tagged as a varint, then a varint that never terminates.
+        let payload = [0x08u8, 0xFF, 0xFF, 0xFF];
+        let mut data = (payload.len() as u32).to_le_bytes().to_vec();
+        data.extend_from_slice(&payload);
+        let data = Bytes::from(data);
+
+        let message = CacheEntryReader::new(&data, 0, 1)
+            .read_header::<u64>()
+            .unwrap_err()
+            .to_string();
+        assert!(message.contains("decode failed"), "{message}");
+    }
+
+    #[test]
+    fn test_raw_roundtrip_leaves_the_rest_as_body() {
+        let data = write_body(0, |w| {
+            w.write_raw(&[1, 2, 3]).unwrap();
+            w.raw_writer().write_all(&[9, 9]).unwrap();
+        });
+        // 8-byte length prefix + 3 payload + 2 trailing.
+        assert_eq!(data.len(), 13);
+
+        let mut reader = CacheEntryReader::new(&data, 0, 1);
+        assert_eq!(reader.read_raw().unwrap().as_ref(), &[1, 2, 3]);
+        assert_eq!(reader.body().as_ref(), &[9, 9]);
+    }
+
+    #[test]
+    fn test_reader_exposes_the_entry_version() {
+        let data = Bytes::from_static(&[0]);
+        assert_eq!(CacheEntryReader::new(&data, 0, 7).version(), 7);
+    }
+
+    /// The reason `pos` is tracked at all: an IPC section must begin on a
+    /// 64-byte boundary *of the whole entry*, so the envelope bytes ahead of the
+    /// body count toward the padding. Writer and reader have to agree on that,
+    /// and only a non-multiple-of-64 prefix makes a disagreement visible.
+    #[test]
+    fn test_ipc_section_is_aligned_against_the_envelope() {
+        const ENVELOPE: usize = 13;
+        let batch = int_batch(vec![1, 2, 3]);
+
+        let mut buf = vec![0xAAu8; ENVELOPE];
+        let mut writer = CacheEntryWriter::with_pos(&mut buf, ENVELOPE);
+        writer.write_header(&1234u64).unwrap();
+        writer.write_ipc(&batch).unwrap();
+        let data = Bytes::from(buf);
+
+        let header_end = ENVELOPE + 4 + 1234u64.encoded_len();
+        let stream_start = header_end.next_multiple_of(IPC_SECTION_ALIGNMENT);
+        assert!(stream_start > header_end, "padding should be non-empty");
+        assert!(
+            data[header_end..stream_start].iter().all(|b| *b == 0),
+            "the gap must be zero padding"
+        );
+
+        let mut reader = CacheEntryReader::new(&data, ENVELOPE, 1);
+        assert_eq!(reader.read_header::<u64>().unwrap(), 1234);
+        assert_eq!(reader.read_ipc().unwrap(), batch);
+        assert!(reader.body().is_empty());
+    }
+
+    #[test]
+    fn test_ipc_batches_roundtrip() {
+        let batches = vec![int_batch(vec![1, 2]), int_batch(vec![3])];
+        let data = write_body(0, |w| w.write_ipc_batches(batches.clone()).unwrap());
+
+        let mut reader = CacheEntryReader::new(&data, 0, 1);
+        assert_eq!(reader.read_ipc_batches().unwrap(), batches);
+    }
+
+    /// The shape a real codec writes: a discriminant, a header, an arrow section
+    /// and a blob. Each reader step has to pick up exactly where the previous one
+    /// stopped, and the arrow section still has to land on its boundary even
+    /// though a `write_u8` moved the position by one.
+    #[test]
+    fn test_mixed_sections_stay_in_sync() {
+        let schema = Schema::new(vec![Field::new("u", DataType::UInt64, false)]);
+        let batch = RecordBatch::try_new(
+            schema.into(),
+            vec![Arc::new(UInt64Array::from(vec![u64::MAX, 0]))],
+        )
+        .unwrap();
+
+        let data = write_body(0, |w| {
+            w.write_u8(2).unwrap();
+            w.write_header(&99u64).unwrap();
+            w.write_ipc(&batch).unwrap();
+            w.write_raw(&[7, 7, 7]).unwrap();
+        });
+
+        let mut reader = CacheEntryReader::new(&data, 0, 1);
+        assert_eq!(reader.read_u8().unwrap(), 2);
+        assert_eq!(reader.read_header::<u64>().unwrap(), 99);
+        assert_eq!(reader.read_ipc().unwrap(), batch);
+        assert_eq!(reader.read_raw().unwrap().as_ref(), &[7, 7, 7]);
+        assert!(reader.body().is_empty());
+    }
+}


### PR DESCRIPTION
`cache/entry_io.rs` had no tests. `codec.rs` covers the envelope around it, but
its own tests only reach `write_raw`/`read_raw`, so `write_u8`, `write_header`,
both IPC paths and all four read guards had no assertions.

The one worth pinning is alignment. `with_pos` exists so an arrow section lands
on a 64-byte boundary of the whole entry, counting the envelope written ahead of
the body. Writer and reader have to agree on that, and only a
non-multiple-of-64 prefix makes a disagreement visible.

Adds 10 tests: a round-trip per section kind, a mixed body in the shape a real
codec writes, the alignment invariant, and the truncated and undecodable header
errors. `u64` stands in for a header proto — prost encodes it as
`google.protobuf.UInt64Value`, so no new dependency.

Verified non-vacuous: making `with_pos` ignore the envelope, dropping the
`write_u8` position bump, dropping the in-range filter on the length prefix, and
not advancing in `read_u8` each fail exactly one test.
