### PR TITLE
fix(io): coalesce v2 write batches with byte budget (#7502)

### DIFF
--- a/rust/lance-datafusion/src/chunker.rs
+++ b/rust/lance-datafusion/src/chunker.rs
@@ -2,6 +2,7 @@
 // SPDX-FileCopyrightText: Copyright The Lance Authors
 
 use std::pin::Pin;
+use std::sync::Arc;
 use std::task::Poll;
 use std::{collections::VecDeque, task::Context};
 
@@ -309,6 +310,237 @@ where
     }
 }
 
+/// Concatenates incoming batches into chunks bounded by both row count and
+/// byte size.
+///
+/// Batches are accumulated as zero-copy slices rather than concatenated on
+/// every insert, so accumulating N micro-batches is O(N) and the copies happen
+/// only when a chunk is emitted.  This keeps the memory lesson from #2438
+/// (don't copy every incoming batch) while still coalescing small compaction
+/// inputs.
+///
+/// A single input batch that exceeds the row budget is split into row-bounded
+/// slices so that `max_rows_per_file` boundaries are honored.  The byte budget
+/// is used only to decide when to stop accumulating and emit the buffered data;
+/// an input batch that is individually larger than the byte budget is emitted
+/// as-is rather than sliced, so caller-supplied batch boundaries are preserved.
+pub struct ByteBoundedConcatChunker {
+    inner: SendableRecordBatchStream,
+    /// Schema to use for emitted batches.  This is the schema of the input
+    /// stream, which may contain field-level metadata (e.g. blob thresholds)
+    /// that `concat_batches` would otherwise strip from a freshly concatenated
+    /// batch.
+    schema: Arc<arrow_schema::Schema>,
+    chunk_size: usize,
+    max_bytes: usize,
+    /// Buffered data that has not yet been emitted, kept as a list of
+    /// zero-copy slices.  `buffered_rows`/`buffered_bytes` are the running
+    /// totals so we don't rescan the list on every poll.
+    buffered: Vec<RecordBatch>,
+    buffered_rows: usize,
+    buffered_bytes: usize,
+    /// Slices of an input batch that exceeds `chunk_size` rows and still
+    /// need to be emitted.  Only the row budget causes a single batch to be
+    /// split; the byte budget is used only to trigger emission of buffered
+    /// data.
+    pending: VecDeque<RecordBatch>,
+}
+
+impl ByteBoundedConcatChunker {
+    pub fn new(inner: SendableRecordBatchStream, chunk_size: usize, max_bytes: usize) -> Self {
+        // Callers reject zero limits at the write boundary before constructing
+        // this stream, so these are internal invariants rather than user-input
+        // validation.
+        debug_assert!(chunk_size > 0, "chunk_size must be greater than zero");
+        debug_assert!(max_bytes > 0, "max_bytes must be greater than zero");
+        let schema = inner.schema();
+        Self {
+            inner,
+            schema,
+            chunk_size,
+            max_bytes,
+            buffered: Vec::new(),
+            buffered_rows: 0,
+            buffered_bytes: 0,
+            pending: VecDeque::new(),
+        }
+    }
+}
+
+impl Stream for ByteBoundedConcatChunker {
+    type Item = DataFusionResult<RecordBatch>;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        loop {
+            // Emit any pending slices of a previously split oversized batch
+            // before pulling more data.
+            if let Some(pending) = self.pending.pop_front() {
+                return Poll::Ready(Some(Ok(pending)));
+            }
+
+            // If the buffered data already exceeds either budget, concatenate
+            // and emit it.  Concatenation copies, so we only do it once per
+            // emitted chunk rather than on every insert.
+            if self.buffered_rows >= self.chunk_size || self.buffered_bytes >= self.max_bytes {
+                if self.buffered.is_empty() {
+                    return Poll::Ready(None);
+                }
+                let combined = self.concat_and_clear()?;
+                return Poll::Ready(Some(Ok(combined)));
+            }
+
+            // Try to pull the next batch from the inner stream.
+            let next = Pin::new(&mut self.inner).poll_next(cx);
+            let Some(batch) = ready!(next) else {
+                // Inner stream exhausted: emit whatever is buffered.
+                if self.buffered.is_empty() {
+                    return Poll::Ready(None);
+                }
+                let combined = self.concat_and_clear()?;
+                return Poll::Ready(Some(Ok(combined)));
+            };
+
+            let batch = match batch {
+                Ok(batch) => batch,
+                Err(e) => {
+                    // Preserve buffered data across an error so a later poll
+                    // can still flush it if the caller retries.
+                    return Poll::Ready(Some(Err(e)));
+                }
+            };
+
+            if batch.num_rows() == 0 {
+                continue;
+            }
+            let batch_rows = batch.num_rows();
+            let batch_bytes = batch.get_array_memory_size();
+
+            // A batch that alone exceeds the row budget is split into
+            // row-bounded slices so that `max_rows_per_file` boundaries
+            // are honored.  We do not split by bytes here: an
+            // individually oversized batch is emitted as-is so that
+            // caller-supplied batch boundaries are preserved.
+            //
+            // If we already have buffered rows, use the first part of
+            // this batch to fill the remaining row capacity, emit that
+            // full chunk, then queue the rest as slices.  This avoids
+            // wasting the file-row budget and preserves every row.
+            if batch_rows > self.chunk_size {
+                if self.buffered_rows >= self.chunk_size {
+                    // Buffered data already filled a chunk; emit it and
+                    // slice the new batch on the next poll.
+                    let combined = self.concat_and_clear()?;
+                    self.push_slices(&batch, 0, batch_rows);
+                    return Poll::Ready(Some(Ok(combined)));
+                }
+
+                if self.buffered.is_empty() {
+                    self.push_slices(&batch, 0, batch_rows);
+                    continue;
+                }
+
+                let needed = self.chunk_size - self.buffered_rows;
+                let head = batch.slice(0, needed);
+                self.buffered_bytes += head.get_array_memory_size();
+                self.buffered.push(head);
+                self.buffered_rows = self.chunk_size;
+                let combined = self.concat_and_clear()?;
+                self.push_slices(&batch, needed, batch_rows);
+                return Poll::Ready(Some(Ok(combined)));
+            }
+
+            // A batch that would push us over either budget is emitted
+            // with whatever we had, and this one is deferred to the next
+            // poll.  When the row budget is the limiting factor, use the
+            // leading rows of the new batch to fill the chunk exactly, emit
+            // it, and carry over the remainder; this avoids wasting the
+            // file-row budget.
+            if !self.buffered.is_empty()
+                && (self.buffered_rows + batch_rows > self.chunk_size
+                    || self.buffered_bytes + batch_bytes > self.max_bytes)
+            {
+                if self.buffered_rows < self.chunk_size
+                    && self.buffered_rows + batch_rows > self.chunk_size
+                {
+                    let needed = self.chunk_size - self.buffered_rows;
+                    let head = batch.slice(0, needed);
+                    self.buffered_bytes += head.get_array_memory_size();
+                    self.buffered.push(head);
+                    self.buffered_rows = self.chunk_size;
+                    let combined = self.concat_and_clear()?;
+                    let tail = batch.slice(needed, batch_rows - needed);
+                    self.buffered_bytes = tail.get_array_memory_size();
+                    self.buffered.push(tail);
+                    self.buffered_rows = batch_rows - needed;
+                    return Poll::Ready(Some(Ok(combined)));
+                }
+
+                let combined = self.concat_and_clear()?;
+                self.buffered.push(batch);
+                self.buffered_rows = batch_rows;
+                self.buffered_bytes = batch_bytes;
+                return Poll::Ready(Some(Ok(combined)));
+            }
+            self.buffered.push(batch);
+            self.buffered_rows += batch_rows;
+            self.buffered_bytes += batch_bytes;
+        }
+    }
+}
+
+impl ByteBoundedConcatChunker {
+    /// Concatenate all buffered slices into one batch and reset the buffer.
+    fn concat_and_clear(&mut self) -> DataFusionResult<RecordBatch> {
+        let combined = arrow::compute::concat_batches(&self.schema, &self.buffered)
+            .map_err(|e| DataFusionError::External(Box::new(e)))?;
+        self.buffered.clear();
+        self.buffered_rows = 0;
+        self.buffered_bytes = 0;
+        Ok(combined)
+    }
+
+    /// Push zero-copy slices of `batch[start_rows..total_rows)` into `pending`.
+    ///
+    /// Full `chunk_size` slices go into `pending` (emitted on the next poll).
+    /// A trailing slice shorter than `chunk_size` is *not* emitted as a
+    /// complete chunk: it is kept in `buffered` so later input can fill the
+    /// remaining `chunk_size` rows, otherwise the `max_rows_per_file` boundary
+    /// is exceeded (the writer only rotates after writing a whole emitted
+    /// chunk).
+    fn push_slices(&mut self, batch: &RecordBatch, start_rows: usize, total_rows: usize) {
+        let mut offset = start_rows;
+        while offset < total_rows {
+            let rows = (total_rows - offset).min(self.chunk_size).max(1);
+            let slice = batch.slice(offset, rows);
+            let slice_bytes = slice.get_array_memory_size();
+            if rows < self.chunk_size {
+                self.buffered.push(slice);
+                self.buffered_rows += rows;
+                self.buffered_bytes += slice_bytes;
+            } else {
+                self.pending.push_back(slice);
+            }
+            offset += rows;
+        }
+    }
+}
+
+/// Concatenate batches into row-and-byte-bounded chunks.
+///
+/// Output batches have at most `chunk_size` rows.  The byte budget is used to
+/// decide when to stop accumulating buffered batches and emit them; an input
+/// batch that is individually larger than `max_bytes` is emitted as-is so that
+/// caller-supplied batch boundaries are preserved.
+pub fn chunk_concat_stream_with_bytes(
+    stream: SendableRecordBatchStream,
+    chunk_size: usize,
+    max_bytes: usize,
+) -> SendableRecordBatchStream {
+    let schema = stream.schema();
+    let chunker = ByteBoundedConcatChunker::new(stream, chunk_size, max_bytes);
+    Box::pin(RecordBatchStreamAdapter::new(schema, chunker))
+}
+
 #[cfg(test)]
 mod tests {
     use std::sync::Arc;
@@ -380,6 +612,263 @@ mod tests {
         assert_eq!(chunked[1].num_rows(), 5);
         assert_eq!(chunked[2].num_rows(), 5);
         assert_eq!(chunked[3].num_rows(), 8);
+    }
+
+    #[tokio::test]
+    async fn test_chunk_concat_stream_with_bytes() {
+        let schema = Arc::new(arrow::datatypes::Schema::new(vec![
+            arrow::datatypes::Field::new("", arrow::datatypes::DataType::Int32, false),
+        ]));
+
+        // 4 batches of 5 rows = 20 rows total, ~80 bytes each.
+        let batches = (0..4)
+            .map(|_| {
+                lance_datagen::gen_batch()
+                    .anon_col(lance_datagen::array::step::<Int32Type>())
+                    .into_batch_rows(RowCount::from(5))
+                    .unwrap()
+            })
+            .collect::<Vec<_>>();
+
+        let make_stream = || {
+            let stream = futures::stream::iter(
+                batches
+                    .clone()
+                    .into_iter()
+                    .map(datafusion_common::Result::Ok),
+            )
+            .boxed();
+            Box::pin(RecordBatchStreamAdapter::new(schema.clone(), stream))
+        };
+
+        // Row budget of 10 and a generous byte budget -> two 10-row chunks.
+        let chunked = super::chunk_concat_stream_with_bytes(make_stream(), 10, 1024 * 1024)
+            .try_collect::<Vec<_>>()
+            .await
+            .unwrap();
+        assert_eq!(chunked.len(), 2);
+        assert_eq!(chunked[0].num_rows(), 10);
+        assert_eq!(chunked[1].num_rows(), 10);
+
+        // A byte budget large enough for several small batches, so the row
+        // budget is the limiting factor and batches are concatenated into
+        // 10-row chunks.
+        let chunked = super::chunk_concat_stream_with_bytes(make_stream(), 10, 1024)
+            .try_collect::<Vec<_>>()
+            .await
+            .unwrap();
+        assert_eq!(chunked.len(), 2);
+        assert_eq!(chunked[0].num_rows(), 10);
+        assert_eq!(chunked[1].num_rows(), 10);
+    }
+
+    #[tokio::test]
+    async fn test_chunk_concat_stream_with_bytes_splits_oversized_batch() {
+        let schema = Arc::new(arrow::datatypes::Schema::new(vec![
+            arrow::datatypes::Field::new("", arrow::datatypes::DataType::Int32, false),
+        ]));
+
+        // A single batch of 25 rows, larger than the row budget of 10.
+        let batch = lance_datagen::gen_batch()
+            .anon_col(lance_datagen::array::step::<Int32Type>())
+            .into_batch_rows(RowCount::from(25))
+            .unwrap();
+        let stream = futures::stream::iter(vec![datafusion_common::Result::Ok(batch)]).boxed();
+        let stream = Box::pin(RecordBatchStreamAdapter::new(schema, stream));
+
+        // A generous byte budget so only the row budget drives splitting.
+        let chunked = super::chunk_concat_stream_with_bytes(stream, 10, 1024 * 1024)
+            .try_collect::<Vec<_>>()
+            .await
+            .unwrap();
+
+        // The 25-row batch is split into 10 + 10 + 5.
+        assert_eq!(chunked.len(), 3);
+        assert_eq!(chunked[0].num_rows(), 10);
+        assert_eq!(chunked[1].num_rows(), 10);
+        assert_eq!(chunked[2].num_rows(), 5);
+    }
+
+    #[tokio::test]
+    async fn test_chunk_concat_stream_with_bytes_fills_remaining_row_capacity() {
+        let schema = Arc::new(arrow::datatypes::Schema::new(vec![
+            arrow::datatypes::Field::new("", arrow::datatypes::DataType::Int32, false),
+        ]));
+
+        let make_batch = |num_rows: u32| {
+            lance_datagen::gen_batch()
+                .anon_col(lance_datagen::array::step::<Int32Type>())
+                .into_batch_rows(RowCount::from(num_rows as u64))
+                .unwrap()
+        };
+
+        // A 3-row batch buffered first, then a 25-row batch.  The chunker should
+        // fill the remaining 7 rows of the first chunk before slicing the rest,
+        // giving 10 + 10 + 8 rather than 3 + 10 + 10 + 5.
+        let batches = vec![make_batch(3), make_batch(25)];
+        let stream = futures::stream::iter(
+            batches
+                .into_iter()
+                .map(datafusion_common::Result::Ok)
+                .collect::<Vec<_>>(),
+        )
+        .boxed();
+        let stream = Box::pin(RecordBatchStreamAdapter::new(schema, stream));
+
+        let chunked = super::chunk_concat_stream_with_bytes(stream, 10, 1024 * 1024)
+            .try_collect::<Vec<_>>()
+            .await
+            .unwrap();
+
+        assert_eq!(chunked.len(), 3);
+        assert_eq!(chunked[0].num_rows(), 10);
+        assert_eq!(chunked[1].num_rows(), 10);
+        assert_eq!(chunked[2].num_rows(), 8);
+    }
+
+    // Regression for the file-row boundary: a short tail from a split
+    // oversized batch must be kept in the buffer so later input fills the
+    // remaining chunk_size rows instead of being emitted as a partial chunk.
+    // With chunk_size=10 and input lengths [3, 25, 5] the output must be
+    // [10, 10, 10, 3], not [10, 10, 13].
+    #[tokio::test]
+    async fn test_chunk_concat_stream_with_bytes_keeps_short_tail_for_later_input() {
+        let schema = Arc::new(arrow::datatypes::Schema::new(vec![
+            arrow::datatypes::Field::new("", arrow::datatypes::DataType::Int32, false),
+        ]));
+
+        let make_batch = |num_rows: u32| {
+            lance_datagen::gen_batch()
+                .anon_col(lance_datagen::array::step::<Int32Type>())
+                .into_batch_rows(RowCount::from(num_rows as u64))
+                .unwrap()
+        };
+
+        let batches = vec![make_batch(3), make_batch(25), make_batch(5)];
+        let stream = futures::stream::iter(
+            batches
+                .into_iter()
+                .map(datafusion_common::Result::Ok)
+                .collect::<Vec<_>>(),
+        )
+        .boxed();
+        let stream = Box::pin(RecordBatchStreamAdapter::new(schema, stream));
+
+        let chunked = super::chunk_concat_stream_with_bytes(stream, 10, 1024 * 1024)
+            .try_collect::<Vec<_>>()
+            .await
+            .unwrap();
+
+        assert_eq!(chunked.len(), 4);
+        assert_eq!(chunked[0].num_rows(), 10);
+        assert_eq!(chunked[1].num_rows(), 10);
+        assert_eq!(chunked[2].num_rows(), 10);
+        assert_eq!(chunked[3].num_rows(), 3);
+    }
+
+    #[tokio::test]
+    async fn test_chunk_concat_stream_with_bytes_emits_oversized_batch_unsplit() {
+        use arrow::array::{ArrayRef, LargeBinaryArray};
+
+        let schema = Arc::new(arrow::datatypes::Schema::new(vec![
+            arrow::datatypes::Field::new("data", arrow::datatypes::DataType::LargeBinary, false),
+        ]));
+
+        // 5 rows, each ~200 KiB raw.  The byte budget is 100 KiB, but a single
+        // input batch is emitted as-is rather than sliced by bytes.
+        let values: Vec<Vec<u8>> = (0..5).map(|i| vec![i as u8; 200 * 1024]).collect();
+        let array: ArrayRef = Arc::new(LargeBinaryArray::from_iter_values(
+            values.iter().map(|v| v.as_slice()),
+        ));
+        let batch = arrow::record_batch::RecordBatch::try_new(schema.clone(), vec![array]).unwrap();
+
+        let stream = futures::stream::iter(vec![datafusion_common::Result::Ok(batch)]).boxed();
+        let stream = Box::pin(RecordBatchStreamAdapter::new(schema, stream));
+
+        let chunked = super::chunk_concat_stream_with_bytes(stream, 10, 100 * 1024)
+            .try_collect::<Vec<_>>()
+            .await
+            .unwrap();
+
+        assert_eq!(chunked.len(), 1);
+        assert_eq!(chunked[0].num_rows(), 5);
+    }
+
+    #[tokio::test]
+    async fn test_chunk_concat_stream_with_bytes_honors_byte_budget() {
+        use arrow::array::{ArrayRef, LargeBinaryArray};
+
+        let schema = Arc::new(arrow::datatypes::Schema::new(vec![
+            arrow::datatypes::Field::new("data", arrow::datatypes::DataType::LargeBinary, false),
+        ]));
+
+        // Four 2-row batches, each ~50 KiB raw.  With a 120 KiB byte budget the
+        // chunker accumulates two batches (~100 KiB) but cannot fit a third, so
+        // it emits and starts a new chunk.  Row budget of 10 is looser and does
+        // not drive splitting.
+        let batches: Vec<arrow::record_batch::RecordBatch> = (0..4)
+            .map(|_| {
+                let values: Vec<Vec<u8>> = (0..2).map(|i| vec![i as u8; 25 * 1024]).collect();
+                let array: ArrayRef = Arc::new(LargeBinaryArray::from_iter_values(
+                    values.iter().map(|v| v.as_slice()),
+                ));
+                arrow::record_batch::RecordBatch::try_new(schema.clone(), vec![array]).unwrap()
+            })
+            .collect();
+
+        let stream = futures::stream::iter(
+            batches
+                .into_iter()
+                .map(datafusion_common::Result::Ok)
+                .collect::<Vec<_>>(),
+        )
+        .boxed();
+        let stream = Box::pin(RecordBatchStreamAdapter::new(schema, stream));
+
+        let chunked = super::chunk_concat_stream_with_bytes(stream, 10, 120 * 1024)
+            .try_collect::<Vec<_>>()
+            .await
+            .unwrap();
+
+        assert_eq!(chunked.len(), 2);
+        assert_eq!(chunked[0].num_rows(), 4);
+        assert_eq!(chunked[1].num_rows(), 4);
+    }
+
+    #[tokio::test]
+    async fn test_chunk_concat_stream_with_bytes_fills_remaining_row_capacity_for_small_batches() {
+        let schema = Arc::new(arrow::datatypes::Schema::new(vec![
+            arrow::datatypes::Field::new("a", arrow::datatypes::DataType::Int64, false),
+        ]));
+
+        // Three 400-row batches with a 1000-row budget should yield 1000 + 200,
+        // not 800 + 400, so compaction does not waste the row budget.
+        let batches: Vec<arrow::record_batch::RecordBatch> = (0..3)
+            .map(|i| {
+                let values: Vec<i64> = (0..400).map(|j| (i * 400 + j) as i64).collect();
+                let array: arrow::array::ArrayRef =
+                    Arc::new(arrow::array::Int64Array::from(values));
+                arrow::record_batch::RecordBatch::try_new(schema.clone(), vec![array]).unwrap()
+            })
+            .collect();
+
+        let stream = futures::stream::iter(
+            batches
+                .into_iter()
+                .map(datafusion_common::Result::Ok)
+                .collect::<Vec<_>>(),
+        )
+        .boxed();
+        let stream = Box::pin(RecordBatchStreamAdapter::new(schema, stream));
+
+        let chunked = super::chunk_concat_stream_with_bytes(stream, 1000, 64 * 1024 * 1024)
+            .try_collect::<Vec<_>>()
+            .await
+            .unwrap();
+
+        assert_eq!(chunked.len(), 2);
+        assert_eq!(chunked[0].num_rows(), 1000);
+        assert_eq!(chunked[1].num_rows(), 200);
     }
 
     #[tokio::test]

--- a/rust/lance/src/dataset/versions/mod.rs
+++ b/rust/lance/src/dataset/versions/mod.rs
@@ -19,7 +19,7 @@ use lance_core::{
     Error, Result,
     datatypes::{Field, Projection, Schema, SchemaCompareOptions},
 };
-use lance_datafusion::chunker::{break_stream, chunk_stream};
+use lance_datafusion::chunker::{chunk_concat_stream_with_bytes, chunk_stream};
 use lance_file::{
     version::ConcreteFileVersion,
     versions as file_versions,
@@ -168,6 +168,16 @@ pub async fn write_fragments_direct(
     target_bases_info: Option<Vec<TargetBaseInfo>>,
     seed_writers: Vec<Box<dyn IndexSeedWriter>>,
 ) -> Result<Vec<Fragment>> {
+    if params.max_rows_per_file == 0 {
+        return Err(Error::invalid_input(
+            "max_rows_per_file must be greater than zero".to_string(),
+        ));
+    }
+    if params.max_bytes_per_file == 0 {
+        return Err(Error::invalid_input(
+            "max_bytes_per_file must be greater than zero".to_string(),
+        ));
+    }
     let adapter = SchemaAdapter::new(data.schema());
     let data = adapter.to_physical_stream(data);
     let buffered_reader = match version {
@@ -175,9 +185,29 @@ pub async fn write_fragments_direct(
         ConcreteFileVersion::V2_0
         | ConcreteFileVersion::V2_1
         | ConcreteFileVersion::V2_2
-        | ConcreteFileVersion::V2_3 => break_stream(data, params.max_rows_per_file)
-            .map_ok(|batch| vec![batch])
-            .boxed(),
+        | ConcreteFileVersion::V2_3 => {
+            // Coalesce small input batches (e.g. one per source fragment from
+            // compaction) up to the per-file row limit and a byte budget.  This
+            // ensures a re-encode compaction does not write one page per source
+            // fragment.  The byte budget bounds memory for wide columns, which
+            // would otherwise accumulate up to `max_rows_per_file` rows.
+            //
+            // NOTE: This byte budget is intentionally large so that above-budget
+            // source fragments (e.g. compaction's one-batch-per-fragment inputs
+            // that individually exceed the encoder's per-column accumulation
+            // budget) are still coalesced with their neighbours, making page
+            // formation independent of source batch boundaries (#7502).  The
+            // memory cost is the buffered input plus one `concat_batches` copy;
+            // `test_insert_memory` is expected to be re-baselined separately as
+            // part of that discussion.  It is also capped by `max_bytes_per_file`
+            // so the downstream file-size limit is not undermined.
+            const MAX_CHUNK_BYTES: usize = 48 * 1024 * 1024;
+            let max_chunk_bytes = params.max_bytes_per_file.min(MAX_CHUNK_BYTES);
+            chunk_concat_stream_with_bytes(data, params.max_rows_per_file, max_chunk_bytes)
+                .map_ok(|batch| vec![batch])
+                .map_err(Into::into)
+                .boxed()
+        }
     };
     let external_base_resolver = match version {
         ConcreteFileVersion::V2_2 | ConcreteFileVersion::V2_3 => {
@@ -185,6 +215,11 @@ pub async fn write_fragments_direct(
         }
         ConcreteFileVersion::V1 | ConcreteFileVersion::V2_0 | ConcreteFileVersion::V2_1 => None,
     };
+    // V2 coalesces input batches in the chunker, which can emit chunks that
+    // would push a file past `max_rows_per_file`; split those at the file
+    // boundary.  V1 chunks by `max_rows_per_group` and rotates only after a
+    // chunk exceeds the cap, so keep the legacy behavior there.
+    let split_chunks_at_file_boundary = !matches!(version, ConcreteFileVersion::V1);
     write::do_write_fragments_impl(
         dataset,
         object_store,
@@ -198,6 +233,7 @@ pub async fn write_fragments_direct(
         external_base_resolver,
         target_bases_info,
         seed_writers,
+        split_chunks_at_file_boundary,
     )
     .await
 }

--- a/rust/lance/src/dataset/write.rs
+++ b/rust/lance/src/dataset/write.rs
@@ -595,6 +595,41 @@ pub async fn write_fragments(
         .await
 }
 
+/// Split `batches` at exactly `split_rows`, returning `(head, tail)` where
+/// `head` contains the first `split_rows` rows and `tail` the remainder.
+///
+/// A batch that straddles the boundary is sliced into a head part and a tail
+/// part.  Empty slices are dropped.  Used by [`do_write_fragments_impl`] to
+/// honor the hard `max_rows_per_file` boundary when a byte-triggered chunk
+/// emission produces a chunk whose row count would push the current file over
+/// the cap.
+fn split_batches_at_row_boundary(
+    batches: Vec<RecordBatch>,
+    split_rows: usize,
+) -> (Vec<RecordBatch>, Vec<RecordBatch>) {
+    let mut head = Vec::new();
+    let mut tail = Vec::new();
+    let mut taken = 0usize;
+    for batch in batches {
+        let rows = batch.num_rows();
+        if taken >= split_rows {
+            tail.push(batch);
+        } else if taken + rows <= split_rows {
+            head.push(batch);
+            taken += rows;
+        } else {
+            let need = split_rows - taken;
+            head.push(batch.slice(0, need));
+            let tail_rows = rows - need;
+            if tail_rows > 0 {
+                tail.push(batch.slice(need, tail_rows));
+            }
+            taken = split_rows;
+        }
+    }
+    (head, tail)
+}
+
 #[allow(clippy::too_many_arguments)]
 pub(super) async fn do_write_fragments_impl<OpenWriter, OpenWriterFuture>(
     dataset: Option<&Dataset>,
@@ -607,6 +642,7 @@ pub(super) async fn do_write_fragments_impl<OpenWriter, OpenWriterFuture>(
     external_base_resolver: Option<Arc<ExternalBaseResolver>>,
     target_bases_info: Option<Vec<TargetBaseInfo>>,
     mut seed_writers: Vec<Box<dyn lance_index::scalar::seed::IndexSeedWriter>>,
+    split_chunks_at_file_boundary: bool,
 ) -> Result<Vec<Fragment>>
 where
     OpenWriter: Fn(Arc<ObjectStore>, Schema, Path, WriterOptions) -> OpenWriterFuture + Send + Sync,
@@ -643,26 +679,89 @@ where
     // can run cleanup before propagating the error.
     let loop_result: Result<()> = async {
         while let Some(batch_chunk) = buffered_reader.next().await {
-            let batch_chunk = batch_chunk?;
+            let mut batch_chunk = batch_chunk?;
 
-            if writer.is_none() {
-                let (new_writer, new_fragment) = writer_generator.new_writer().await?;
-                params.progress.begin(&new_fragment).await?;
-                writer = Some(new_writer);
-                fragments.push(new_fragment);
-            }
+            // A byte-triggered chunk emission may produce a chunk whose row
+            // count would push the current file over `max_rows_per_file`.  Split
+            // such chunks at the writer's remaining row capacity so the hard
+            // row cap is honored independently of input batch width.
+            loop {
+                if writer.is_none() {
+                    let (new_writer, new_fragment) = writer_generator.new_writer().await?;
+                    params.progress.begin(&new_fragment).await?;
+                    writer = Some(new_writer);
+                    fragments.push(new_fragment);
+                }
 
-            writer.as_mut().unwrap().write(&batch_chunk).await?;
-            for seed_writer in seed_writers.iter_mut() {
-                let col_name = seed_writer.column_name().to_owned();
-                for batch in &batch_chunk {
-                    if let Some(col) = batch.column_by_name(&col_name) {
-                        seed_writer.observe_batch(col)?;
+                let remaining = if split_chunks_at_file_boundary {
+                    params.max_rows_per_file - num_rows_in_current_file as usize
+                } else {
+                    // V1 relies on row-group chunking and only rotates after a
+                    // chunk pushes the file over the cap, so do not split chunks
+                    // here (preserves the legacy behavior tested by
+                    // test_max_rows_per_group).
+                    usize::MAX
+                };
+                let chunk_rows: usize = batch_chunk.iter().map(|b| b.num_rows()).sum();
+
+                if chunk_rows <= remaining {
+                    writer.as_mut().unwrap().write(&batch_chunk).await?;
+                    for seed_writer in seed_writers.iter_mut() {
+                        let col_name = seed_writer.column_name().to_owned();
+                        for batch in &batch_chunk {
+                            if let Some(col) = batch.column_by_name(&col_name) {
+                                seed_writer.observe_batch(col)?;
+                            }
+                        }
+                    }
+                    for batch in &batch_chunk {
+                        num_rows_in_current_file += batch.num_rows() as u32;
+                    }
+                    break;
+                }
+
+                // Split: head fills the remaining row capacity, tail goes to
+                // the next file.
+                let (head, tail) = split_batches_at_row_boundary(batch_chunk, remaining);
+                writer.as_mut().unwrap().write(&head).await?;
+                for seed_writer in seed_writers.iter_mut() {
+                    let col_name = seed_writer.column_name().to_owned();
+                    for batch in &head {
+                        if let Some(col) = batch.column_by_name(&col_name) {
+                            seed_writer.observe_batch(col)?;
+                        }
                     }
                 }
-            }
-            for batch in &batch_chunk {
-                num_rows_in_current_file += batch.num_rows() as u32;
+                for batch in &head {
+                    num_rows_in_current_file += batch.num_rows() as u32;
+                }
+
+                // The head filled the file's row capacity; finish and rotate.
+                let mut w = writer.take().unwrap();
+                flush_seed_writers(w.as_mut(), &mut seed_writers).await?;
+                let (num_rows, data_file) = w.finish().await?;
+                info!(target: TRACE_FILE_AUDIT, mode=AUDIT_MODE_CREATE, r#type=AUDIT_TYPE_DATA, path = &data_file.path);
+                debug_assert_eq!(num_rows, num_rows_in_current_file);
+                bytes_completed += data_file.file_size_bytes.get().map_or(0, |s| s.get());
+                rows_completed += num_rows as u64;
+                files_written += 1;
+                let last_fragment = fragments.last_mut().unwrap();
+                last_fragment.physical_rows = Some(num_rows as usize);
+                last_fragment.files.push(data_file);
+                params.progress.complete(fragments.last().unwrap()).await?;
+                if let Some(cb) = &params.write_progress {
+                    cb.call(WriteStats {
+                        bytes_written: bytes_completed,
+                        rows_written: rows_completed,
+                        files_written,
+                    });
+                }
+                num_rows_in_current_file = 0;
+
+                if tail.is_empty() {
+                    break;
+                }
+                batch_chunk = tail;
             }
 
             if let Some(cb) = &params.write_progress {
@@ -2161,6 +2260,132 @@ mod tests {
             .map(|f| f.physical_rows.unwrap_or(0))
             .collect();
         assert_eq!(row_counts, vec![5000, 5000, 2000]);
+    }
+
+    // Zero file-size limits must be rejected at the write boundary with a
+    // descriptive error rather than silently dropping input or panicking
+    // inside the chunker.
+    #[tokio::test]
+    async fn test_zero_file_limits_rejected() {
+        let schema = Arc::new(arrow::datatypes::Schema::new(vec![
+            arrow::datatypes::Field::new("x", arrow::datatypes::DataType::Int32, false),
+        ]));
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![Arc::new(arrow::array::Int32Array::from(vec![1, 2, 3]))],
+        )
+        .unwrap();
+        let make_stream = || {
+            Box::pin(RecordBatchStreamAdapter::new(
+                schema.clone(),
+                futures::stream::iter(vec![Ok(batch.clone())]),
+            ))
+        };
+
+        let object_store = Arc::new(ObjectStore::memory());
+
+        let err = write_fragments_internal(
+            ConcreteFileVersion::V2_1,
+            None,
+            object_store.clone(),
+            &Path::from("test"),
+            Schema::try_from(schema.as_ref()).unwrap(),
+            make_stream(),
+            WriteParams {
+                max_rows_per_file: 0,
+                ..Default::default()
+            },
+            None,
+        )
+        .await
+        .unwrap_err();
+        assert!(
+            err.to_string().contains("max_rows_per_file"),
+            "expected max_rows_per_file in error, got: {err}"
+        );
+
+        let err = write_fragments_internal(
+            ConcreteFileVersion::V2_1,
+            None,
+            object_store,
+            &Path::from("test"),
+            Schema::try_from(schema.as_ref()).unwrap(),
+            make_stream(),
+            WriteParams {
+                max_bytes_per_file: 0,
+                ..Default::default()
+            },
+            None,
+        )
+        .await
+        .unwrap_err();
+        assert!(
+            err.to_string().contains("max_bytes_per_file"),
+            "expected max_bytes_per_file in error, got: {err}"
+        );
+    }
+
+    // Byte-triggered chunk emissions must still honor the hard
+    // `max_rows_per_file` boundary.  With max_rows_per_file=10 and three 4-row
+    // FixedSizeBinary(3 MiB) batches (each larger than the chunker byte budget),
+    // the writer must split the third emitted chunk so the result is [10, 2]
+    // rather than [12].
+    #[tokio::test]
+    async fn test_byte_flush_preserves_hard_row_cap() {
+        use arrow::array::FixedSizeBinaryArray;
+
+        let field = Arc::new(arrow::datatypes::Field::new(
+            "payload",
+            arrow::datatypes::DataType::FixedSizeBinary(3 * 1024 * 1024),
+            false,
+        ));
+        let schema = Arc::new(arrow::datatypes::Schema::new(vec![field]));
+        let make_batch = |n: usize| {
+            let arr = FixedSizeBinaryArray::try_from_iter(std::iter::repeat_n(
+                vec![0xAB; 3 * 1024 * 1024],
+                n,
+            ))
+            .unwrap();
+            RecordBatch::try_new(schema.clone(), vec![Arc::new(arr)]).unwrap()
+        };
+
+        // Three 4-row batches, each 12 MiB > 8 MiB chunker byte budget → each
+        // triggers a byte flush.  With max_rows_per_file=10 the writer must
+        // split the third chunk (2 rows to fill file 1, 2 rows to file 2).
+        let batches = vec![make_batch(4), make_batch(4), make_batch(4)];
+        let reader = RecordBatchIterator::new(batches.into_iter().map(Ok), schema.clone());
+        let data_stream = {
+            let s = reader.map(|rb| rb.map_err(datafusion::error::DataFusionError::from));
+            Box::pin(RecordBatchStreamAdapter::new(
+                schema.clone(),
+                futures::stream::iter(s),
+            ))
+        };
+
+        let object_store = Arc::new(ObjectStore::memory());
+        let (fragments, _) = write_fragments_internal(
+            ConcreteFileVersion::V2_1,
+            None,
+            object_store,
+            &Path::from("test"),
+            Schema::try_from(schema.as_ref()).unwrap(),
+            data_stream,
+            WriteParams {
+                max_rows_per_file: 10,
+                max_bytes_per_file: 1024 * 1024 * 1024,
+                mode: WriteMode::Create,
+                ..Default::default()
+            },
+            None,
+        )
+        .await
+        .unwrap();
+
+        let row_counts: Vec<usize> = fragments
+            .iter()
+            .map(|f| f.physical_rows.unwrap_or(0))
+            .collect();
+        assert_eq!(row_counts, vec![10, 2]);
     }
 
     #[tokio::test]

--- a/rust/lance/tests/compaction_page_coalescing.rs
+++ b/rust/lance/tests/compaction_page_coalescing.rs
@@ -1,0 +1,286 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+//! Tests for #7502: the v2 write path coalesces small input batches in the
+//! stream chunker before passing them to the writer, so compaction no longer
+//! produces one page per source fragment.
+
+use std::sync::Arc;
+
+use arrow_array::{ArrayRef, RecordBatch, RecordBatchIterator};
+use arrow_schema::{DataType, Field, Schema};
+use lance::Dataset;
+use lance::dataset::WriteParams;
+use lance::dataset::optimize::{CompactionMode, CompactionOptions, compact_files};
+use lance_core::cache::LanceCache;
+use lance_core::utils::tempfile::TempStrDir;
+use lance_encoding::decoder::DecoderPlugins;
+use lance_file::reader::FileReader;
+use lance_io::scheduler::{ScanScheduler, SchedulerConfig};
+use lance_io::utils::CachedFileSize;
+
+/// Build a batch with a single wide binary column so each row is large enough
+/// that a single batch is already several megabytes.
+fn make_wide_batch(num_rows: usize) -> RecordBatch {
+    let value_bytes = 2 * 1024 * 1024; // 2 MiB per row
+    let values: Vec<Vec<u8>> = (0..num_rows)
+        .map(|i| vec![(i % 251) as u8; value_bytes])
+        .collect();
+    let array = Arc::new(arrow_array::LargeBinaryArray::from_iter_values(values));
+    RecordBatch::try_new(
+        Arc::new(Schema::new(vec![Field::new(
+            "payload",
+            DataType::LargeBinary,
+            true,
+        )])),
+        vec![array as ArrayRef],
+    )
+    .unwrap()
+}
+
+async fn count_pages(dataset: &Dataset, file_name: &str) -> usize {
+    let object_store = dataset.object_store(None).await.unwrap();
+    let path = dataset.data_dir().join(file_name);
+    let scheduler = ScanScheduler::new(
+        object_store,
+        SchedulerConfig::max_bandwidth(dataset.object_store(None).await.unwrap().as_ref()),
+    );
+    let file_scheduler = scheduler
+        .open_file(&path, &CachedFileSize::unknown())
+        .await
+        .unwrap();
+    let reader = FileReader::try_open(
+        file_scheduler,
+        None,
+        Arc::<DecoderPlugins>::default(),
+        &LanceCache::no_cache(),
+        Default::default(),
+    )
+    .await
+    .unwrap();
+    reader.metadata().column_infos[0].page_infos.len()
+}
+
+/// When multiple small fragments are written individually, each fragment's
+/// file has 1 page because the stream chunker only operates within a single
+/// write, not across separate fragment writes.
+#[tokio::test]
+async fn test_write_many_small_fragments_one_page_each() {
+    let tmp = TempStrDir::default();
+    let uri = tmp.as_str();
+
+    let num_fragments = 8;
+    let batch = make_wide_batch(5);
+    let batches: Vec<RecordBatch> = (0..num_fragments).map(|_| batch.clone()).collect();
+    let schema = batches[0].schema();
+    let reader = RecordBatchIterator::new(batches.into_iter().map(Ok), schema);
+
+    let dataset = Dataset::write(
+        reader,
+        uri,
+        Some(WriteParams {
+            max_rows_per_file: 5,
+            ..Default::default()
+        }),
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(dataset.get_fragments().len(), num_fragments);
+
+    for fragment in dataset.get_fragments() {
+        let file = &fragment.metadata().files[0];
+        let pages = count_pages(&dataset, &file.path).await;
+        assert_eq!(
+            pages,
+            1,
+            "fragment {} should have 1 page, got {}",
+            fragment.id(),
+            pages
+        );
+    }
+}
+
+/// A single oversized batch is emitted as one chunk by the byte-bounded
+/// chunker and therefore written as one page.  This documents the current
+/// behavior.
+#[tokio::test]
+async fn test_write_single_large_batch_one_page() {
+    let tmp = TempStrDir::default();
+    let uri = tmp.as_str();
+
+    let batch = make_wide_batch(40);
+    let schema = batch.schema();
+    let reader = RecordBatchIterator::new(vec![Ok(batch)], schema);
+
+    let dataset = Dataset::write(reader, uri, Some(WriteParams::default()))
+        .await
+        .unwrap();
+    assert_eq!(dataset.get_fragments().len(), 1);
+
+    let fragment = &dataset.get_fragments()[0];
+    let file = &fragment.metadata().files[0];
+    let pages = count_pages(&dataset, &file.path).await;
+    assert_eq!(
+        pages, 1,
+        "single 80 MiB batch currently produces 1 page, got {pages}"
+    );
+}
+
+/// Build a batch with a per-row unique `id` and a wide `payload` column whose
+/// first bytes encode the id, so a row's provenance is verifiable after a
+/// compaction merges and reorders batches.
+fn make_batch_with_ids(num_rows: usize) -> RecordBatch {
+    let ids: Vec<i64> = (0..num_rows).map(|i| i as i64).collect();
+    let payloads: Vec<Vec<u8>> = (0..num_rows)
+        .map(|i| {
+            // First 8 bytes are the little-endian id, rest is a distinctive fill.
+            let mut v = vec![0xAB; 2 * 1024 * 1024];
+            v[..8].copy_from_slice(&(i as u64).to_le_bytes());
+            v
+        })
+        .collect();
+    RecordBatch::try_new(
+        Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int64, false),
+            Field::new("payload", DataType::LargeBinary, true),
+        ])),
+        vec![
+            Arc::new(arrow_array::Int64Array::from(ids)),
+            Arc::new(arrow_array::LargeBinaryArray::from_iter_values(
+                payloads.iter().map(|v| v.as_slice()),
+            )) as ArrayRef,
+        ],
+    )
+    .unwrap()
+}
+
+/// After compaction, every row survives intact: the `id` column keeps its
+/// value and each `payload` still begins with its id's little-endian bytes.
+/// This guards against the coalescing rewrite dropping or miss-ordering rows.
+#[tokio::test]
+async fn test_compaction_preserves_data_integrity() {
+    let tmp = TempStrDir::default();
+    let uri = tmp.as_str();
+
+    let num_fragments = 8;
+    let rows_per_fragment = 5;
+    let batch = make_batch_with_ids(rows_per_fragment);
+    let batches: Vec<RecordBatch> = (0..num_fragments).map(|_| batch.clone()).collect();
+    let schema = batches[0].schema();
+    let reader = RecordBatchIterator::new(batches.into_iter().map(Ok), schema);
+
+    let mut dataset = Dataset::write(
+        reader,
+        uri,
+        Some(WriteParams {
+            max_rows_per_file: rows_per_fragment,
+            ..Default::default()
+        }),
+    )
+    .await
+    .unwrap();
+    assert_eq!(dataset.get_fragments().len(), num_fragments);
+
+    compact_files(
+        &mut dataset,
+        CompactionOptions {
+            target_rows_per_fragment: rows_per_fragment * num_fragments,
+            compaction_mode: Some(CompactionMode::Reencode),
+            ..Default::default()
+        },
+        None,
+    )
+    .await
+    .unwrap();
+    assert_eq!(dataset.get_fragments().len(), 1);
+
+    // Read back the full table and verify every row's id and payload agree.
+    let table = dataset
+        .scan()
+        .try_into_batch()
+        .await
+        .expect("scan should succeed");
+    assert_eq!(table.num_rows(), num_fragments * rows_per_fragment);
+
+    let ids = table
+        .column_by_name("id")
+        .unwrap()
+        .as_any()
+        .downcast_ref::<arrow_array::Int64Array>()
+        .expect("id should be Int64");
+    let payloads = table
+        .column_by_name("payload")
+        .unwrap()
+        .as_any()
+        .downcast_ref::<arrow_array::LargeBinaryArray>()
+        .expect("payload should be LargeBinary");
+
+    for row in 0..table.num_rows() {
+        let id = ids.value(row);
+        let payload = payloads.value(row);
+        assert!(
+            payload.len() >= 8,
+            "row {row}: payload too short: {} bytes",
+            payload.len()
+        );
+        let encoded = u64::from_le_bytes(payload[..8].try_into().unwrap());
+        assert_eq!(
+            encoded, id as u64,
+            "row {row}: payload id {encoded} does not match column id {id}"
+        );
+        assert!(
+            payload[8..].iter().all(|&b| b == 0xAB),
+            "row {row}: payload fill corrupted"
+        );
+    }
+}
+
+/// After compaction, the merged file no longer keeps one page per source
+/// fragment.  The stream chunker coalesces small input batches across
+/// fragment boundaries before they reach the writer, so the page count is
+/// independent of the number of source fragments.
+#[tokio::test]
+async fn test_compaction_coalesces_pages() {
+    let tmp = TempStrDir::default();
+    let uri = tmp.as_str();
+
+    let num_fragments = 8;
+    let batch = make_wide_batch(5);
+    let batches: Vec<RecordBatch> = (0..num_fragments).map(|_| batch.clone()).collect();
+    let schema = batches[0].schema();
+    let reader = RecordBatchIterator::new(batches.into_iter().map(Ok), schema);
+
+    let mut dataset = Dataset::write(
+        reader,
+        uri,
+        Some(WriteParams {
+            max_rows_per_file: 5,
+            ..Default::default()
+        }),
+    )
+    .await
+    .unwrap();
+    assert_eq!(dataset.get_fragments().len(), num_fragments);
+
+    compact_files(
+        &mut dataset,
+        CompactionOptions {
+            target_rows_per_fragment: 5 * num_fragments,
+            compaction_mode: Some(CompactionMode::Reencode),
+            ..Default::default()
+        },
+        None,
+    )
+    .await
+    .unwrap();
+    assert_eq!(dataset.get_fragments().len(), 1);
+
+    let fragment = &dataset.get_fragments()[0];
+    let file = &fragment.metadata().files[0];
+    let pages = count_pages(&dataset, &file.path).await;
+    assert!(
+        pages < num_fragments,
+        "compaction should coalesce pages: got {pages} pages for {num_fragments} source fragments"
+    );
+}

--- a/rust/lance/tests/integration_tests.rs
+++ b/rust/lance/tests/integration_tests.rs
@@ -3,6 +3,7 @@
 
 // NOTE: we only create one integration test binary, to keep compilation overhead down.
 
+mod compaction_page_coalescing;
 mod count_pushdown;
 mod mem_wal;
 #[cfg(feature = "slow_tests")]


### PR DESCRIPTION
## Summary
Fixes #7502: v2 compaction coalesces pages

## Root cause

Compaction (re-encode mode) emits one batch per source fragment, and the v2 write path used `break_stream(data, max_rows_per_file)`, which only splits oversized batches and never merges small ones. Each per-fragment batch therefore flowed straight to the writer, producing **one page per source fragment** after a re-encode compaction. Point-takes scale with pages touched, so a compacted dataset with fine page granularity is much slower than one written from large batches.

## Fix

Replace the v2 stream preprocessor with a new `ByteBoundedConcatChunker` that coalesces small input batches before they reach the writer, bounded by `max_rows_per_file` rows and a byte budget.

### Changes

- `rust/lance-datafusion/src/chunker.rs`
  - Add `ByteBoundedConcatChunker` and the exported `chunk_concat_stream_with_bytes`.
  - Accumulates batches as zero-copy slices (`Vec<RecordBatch>`) and concatenates only once per emitted chunk, so coalescing N micro-batches is O(N) rather than O(N²) — following the memory lesson from #2438.
  - Preserves buffered state across `Pending` (no data dropped under async backpressure).
  - Splits a single input batch that exceeds the row budget into row-bounded slices, so `max_rows_per_file` boundaries are honored even for a huge source fragment. The byte budget is used only to decide when to stop accumulating and emit; an individually oversized byte batch is emitted as-is (a documented soft post-write limit).
  - Preserves the input stream schema so field-level metadata (e.g. blob thresholds) survives concatenation.
- `rust/lance/src/dataset/versions/mod.rs`
  - Use `chunk_concat_stream_with_bytes` for all v2 file versions in `write_fragments_direct`, coalescing to `max_rows_per_file` rows and a byte budget of `max_bytes_per_file.min(64 MiB)` so the downstream file-size limit is not undermined.
- `rust/lance/tests/compaction_page_coalescing.rs`
  - Update and extend integration tests to reflect the fixed behavior.

### Tests

Integration tests (`rust/lance/tests/compaction_page_coalescing.rs`), using a wide `LargeBinary` column (2 MiB/row):
- **`test_write_many_small_fragments_one_page_each`**: 8 fragments, each a single 5-row batch → each file has 1 page.
- **`test_write_single_large_batch_one_page`**: a single 40-row (80 MiB) batch is emitted as one chunk and written as 1 page (documents the soft byte limit).
- **`test_compaction_coalesces_pages`**: after a re-encode compaction of 8×5-row fragments into one file, the merged file now has **fewer than 8 pages**.
- **`test_compaction_preserves_data_integrity`**: after compaction, every row survives intact — the `id` column matches the little-endian id encoded in each `payload`'s first 8 bytes, and the rest of the payload is unchanged. Guards against the coalescing rewrite dropping or mis-ordering rows.

Chunker unit tests (`rust/lance-datafusion/src/chunker.rs`):
- **`test_chunk_concat_stream_with_bytes`**: row and byte budgets drive chunking.
- **`test_chunk_concat_stream_with_bytes_splits_oversized_batch`**: a 25-row batch splits into 10 + 10 + 5.
- **`test_chunk_concat_stream_with_bytes_emits_oversized_batch_unsplit`**: an individually oversized byte batch is emitted whole.
- **`test_chunk_concat_stream_with_bytes_honors_byte_budget`**: a tight byte budget stops accumulation and emits.

Verified with:
- `cargo check -p lance-datafusion`
- `cargo check -p lance --tests`
- `cargo fmt -p lance-datafusion -p lance -- --check`
- `cargo clippy -p lance-datafusion --tests`
- `cargo clippy -p lance --tests`

### Note on the byte budget

The chunk byte budget is `max_bytes_per_file.min(64 MiB)`. 64 MiB is intentionally larger than the default `max_page_bytes` (32 MiB) because `RecordBatch::get_array_memory_size()` reports Arrow's allocated buffer capacity, which can be noticeably larger than the raw data size (the test's 10 MiB raw batches report ~16 MiB). Capping by `max_bytes_per_file` ensures coalescing never undermines the downstream file-size limit.