### PR TITLE
fix(fts): canonicalize fuzzy expansion across segments

### DIFF
--- a/rust/lance-index/src/scalar/inverted.rs
+++ b/rust/lance-index/src/scalar/inverted.rs
@@ -17,14 +17,15 @@ mod scorer;
 pub mod tokenizer;
 mod wand;
 
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::sync::Arc;
 
 use arrow_schema::{DataType, Field};
 use async_trait::async_trait;
 pub use builder::InvertedIndexBuilder;
 pub use compound::{
-    compound_search, compound_search_with_base_scorer,
+    compound_search, compound_search_prepared_match,
+    compound_search_prepared_match_with_score_floor, compound_search_with_base_scorer,
     compound_search_with_base_scorer_and_score_floor, exclusive_scaled_score_floor,
 };
 #[doc(hidden)]
@@ -36,93 +37,243 @@ pub use lance_tokenizer::Language;
 pub use scorer::{MemBM25Scorer, Scorer};
 pub use tokenizer::*;
 
-use crate::scalar::inverted::query::{FtsSearchParams, Tokens};
+use crate::scalar::inverted::query::{FtsSearchParams, Tokens, uses_fuzzy_expansion};
 
-/// Collect the unique terms needed to build a shared BM25 scorer.
+/// Canonical token vocabulary and BM25 statistics for one indexed query leaf.
 ///
-/// The scorer only needs corpus-level document frequencies, so we keep a
-/// deduplicated term list here instead of constructing a full `Tokens`
-/// object with positions. When fuzziness is enabled, each segment may
-/// contribute additional terms (via `expand_fuzzy_tokens`); the union of
-/// those terms is what the global scorer must cover.
-fn scorer_terms(
+/// Keeping these values together prevents a search path from expanding one
+/// vocabulary while scoring another. Positions on `tokens` identify fuzzy
+/// alternatives belonging to the same original query position.
+#[doc(hidden)]
+#[derive(Clone)]
+pub struct PreparedBm25Query {
+    tokens: Arc<Tokens>,
+    scorer: Arc<MemBM25Scorer>,
+    has_all_query_positions: bool,
+}
+
+impl std::fmt::Debug for PreparedBm25Query {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("PreparedBm25Query")
+            .field("token_count", &self.tokens.len())
+            .field("has_all_query_positions", &self.has_all_query_positions)
+            .field("scorer", &self.scorer)
+            .finish()
+    }
+}
+
+impl PreparedBm25Query {
+    pub(crate) fn from_parts(
+        tokens: Arc<Tokens>,
+        scorer: Arc<MemBM25Scorer>,
+        has_all_query_positions: bool,
+    ) -> Self {
+        Self {
+            tokens,
+            scorer,
+            has_all_query_positions,
+        }
+    }
+
+    #[doc(hidden)]
+    pub fn tokens(&self) -> &Arc<Tokens> {
+        &self.tokens
+    }
+
+    #[doc(hidden)]
+    pub fn scorer(&self) -> &Arc<MemBM25Scorer> {
+        &self.scorer
+    }
+
+    pub(crate) fn has_all_query_positions(&self) -> bool {
+        self.has_all_query_positions
+    }
+}
+
+pub(crate) fn final_query_tokens(
     indices: &[Arc<InvertedIndex>],
     query_tokens: &Tokens,
     params: &FtsSearchParams,
-) -> Result<Vec<String>> {
-    let mut terms = Vec::new();
+) -> Result<Tokens> {
+    if !uses_fuzzy_expansion(params.fuzziness) {
+        return Ok(query_tokens.clone());
+    }
+
+    let initial_capacity = query_tokens.len().min(params.max_expansions);
+    let mut expanded_tokens = Vec::with_capacity(initial_capacity);
+    let mut expanded_positions = Vec::with_capacity(initial_capacity);
     let mut seen = HashSet::new();
-
-    if !matches!(params.fuzziness, Some(n) if n != 0) {
-        for token in query_tokens {
-            if seen.insert(token.to_string()) {
-                terms.push(token.to_string());
+    let mut source_terms_by_position = BTreeMap::<u32, Vec<&str>>::new();
+    for token_idx in 0..query_tokens.len() {
+        source_terms_by_position
+            .entry(query_tokens.position(token_idx))
+            .or_default()
+            .push(query_tokens.get_token(token_idx));
+    }
+    for (position, source_terms) in source_terms_by_position {
+        let remaining = params.max_expansions.saturating_sub(expanded_tokens.len());
+        if remaining == 0 {
+            break;
+        }
+        let mut candidates = BTreeSet::new();
+        let mut seen_source_terms = HashSet::new();
+        for source_term in source_terms {
+            if !seen_source_terms.insert(source_term) {
+                continue;
+            }
+            // One source token has one canonical automaton across every
+            // selected segment. Drop it after this source term so peak DFA
+            // memory is independent of the number of query terms.
+            let automaton = FuzzyAutomaton::new(source_term, query_tokens.token_type(), params)?;
+            for index in indices {
+                index.collect_fuzzy_candidates_with_automaton(
+                    &automaton,
+                    remaining,
+                    &mut candidates,
+                )?;
             }
         }
-        return Ok(terms);
-    }
-
-    for index in indices {
-        let expanded = index.expand_fuzzy_tokens(query_tokens, params)?;
-        for idx in 0..expanded.len() {
-            let token = expanded.get_token(idx);
-            if seen.insert(token.to_string()) {
-                terms.push(token.to_string());
+        for candidate in candidates {
+            if expanded_tokens.len() >= params.max_expansions {
+                break;
+            }
+            if seen.insert((candidate.clone(), position)) {
+                expanded_tokens.push(candidate);
+                expanded_positions.push(position);
             }
         }
     }
-    Ok(terms)
+    Ok(Tokens::with_positions(
+        expanded_tokens,
+        expanded_positions,
+        query_tokens.token_type().clone(),
+    ))
+}
+
+fn unique_terms(tokens: &Tokens) -> Vec<String> {
+    let mut terms = Vec::with_capacity(tokens.len());
+    let mut seen = HashSet::new();
+    for token in tokens {
+        if seen.insert(token.clone()) {
+            terms.push(token.clone());
+        }
+    }
+    terms
+}
+
+pub(crate) fn has_all_query_positions(query_tokens: &Tokens, final_tokens: &Tokens) -> bool {
+    let surviving_positions = (0..final_tokens.len())
+        .map(|index| final_tokens.position(index))
+        .collect::<HashSet<_>>();
+    (0..query_tokens.len()).all(|index| surviving_positions.contains(&query_tokens.position(index)))
+}
+
+/// Expand and score one indexed query leaf exactly once across all segments.
+///
+/// Expansion consumes one deterministic `max_expansions` budget in query
+/// position order, with terms ordered lexicographically across every physical
+/// segment and partition and deduplicated by `(term, position)`. The scorer's
+/// document frequencies are then merged for exactly those final terms.
+///
+/// `base_scorer` is an API-compatibility hook for distributed/mixed callers
+/// that already own corpus-wide statistics. It is validated against the final
+/// vocabulary before being paired with the tokens.
+#[doc(hidden)]
+pub async fn prepare_bm25_query(
+    indices: &[Arc<InvertedIndex>],
+    query_tokens: Tokens,
+    params: &FtsSearchParams,
+    metrics: Option<&dyn crate::scalar::MetricsCollector>,
+    base_scorer: Option<Arc<MemBM25Scorer>>,
+) -> Result<PreparedBm25Query> {
+    let first_index = indices.first().ok_or_else(|| {
+        lance_core::Error::invalid_input("FTS index requires at least one segment")
+    })?;
+    let (tokens, has_all_query_positions) = if uses_fuzzy_expansion(params.fuzziness) {
+        let tokens = Arc::new(final_query_tokens(indices, &query_tokens, params)?);
+        let has_all_query_positions = has_all_query_positions(&query_tokens, tokens.as_ref());
+        (tokens, has_all_query_positions)
+    } else {
+        (Arc::new(query_tokens), true)
+    };
+    let terms = unique_terms(tokens.as_ref());
+    let scorer = if let Some(scorer) = base_scorer {
+        if let Some(missing) = terms
+            .iter()
+            .find(|term| !scorer.token_docs.contains_key(term.as_str()))
+        {
+            return Err(lance_core::Error::invalid_input(format!(
+                "injected BM25 scorer is missing compound FTS token '{missing}'"
+            )));
+        }
+        scorer
+    } else {
+        let (mut total_tokens, mut num_docs, first_token_docs) =
+            first_index.bm25_stats_for_terms(&terms, metrics).await?;
+        let mut token_docs = HashMap::with_capacity(terms.len());
+        for (term, count) in terms.iter().cloned().zip(first_token_docs) {
+            token_docs.insert(term, count);
+        }
+
+        for index in indices.iter().skip(1) {
+            let (segment_total_tokens, segment_num_docs, segment_token_docs) =
+                index.bm25_stats_for_terms(&terms, metrics).await?;
+            total_tokens = total_tokens
+                .checked_add(segment_total_tokens)
+                .ok_or_else(|| lance_core::Error::index("FTS corpus token count overflows u64"))?;
+            num_docs = num_docs.checked_add(segment_num_docs).ok_or_else(|| {
+                lance_core::Error::index("FTS corpus document count overflows usize")
+            })?;
+            for (term, count) in terms.iter().zip(segment_token_docs) {
+                let total = token_docs.get_mut(term).ok_or_else(|| {
+                    lance_core::Error::internal(format!(
+                        "global scorer term '{term}' was not initialized"
+                    ))
+                })?;
+                *total = total.checked_add(count).ok_or_else(|| {
+                    lance_core::Error::index(format!(
+                        "FTS document frequency for term '{term}' overflows usize"
+                    ))
+                })?;
+            }
+        }
+        Arc::new(MemBM25Scorer::new(total_tokens, num_docs, token_docs))
+    };
+
+    Ok(PreparedBm25Query {
+        tokens,
+        scorer,
+        has_all_query_positions,
+    })
 }
 
 /// Build a shared [`MemBM25Scorer`] across a set of FTS index segments.
 ///
+/// Compatibility wrapper for callers that only need statistics. Indexed
+/// execution should retain the [`PreparedBm25Query`] returned by
+/// [`prepare_bm25_query`] so the same final vocabulary reaches search.
+///
 /// Aggregates each segment's `(total_tokens, num_docs, per_term_doc_freq)`
-/// statistics — obtained via [`InvertedIndex::bm25_stats_for_terms`] — into a
-/// single corpus-wide scorer, so that BM25 IDF scoring uses *global*
-/// statistics rather than per-segment statistics. Computes the union of
-/// fuzzy-expanded terms when `params.fuzziness` is set.
+/// statistics into a single corpus-wide scorer.
 ///
 /// `metrics`, when provided, is forwarded to the per-token metadata cache
 /// boundary on each segment so callers running under an `ExecutionPlan`
 /// (e.g. `MatchQueryExec`) see the reads triggered here in their per-query
 /// `index_cache_hits`/`index_cache_misses` counters.
 ///
-/// Public as the canonical producer paired with the `with_base_scorer`
-/// consumer on FTS exec types: callers holding `Arc<InvertedIndex>` segment
-/// handles locally can construct an injectable scorer without reimplementing
-/// per-segment stat aggregation, term deduplication, and fuzzy-expansion
-/// union. Keeps a single source of truth for BM25 IDF arithmetic across
-/// segments.
+/// For exact queries this remains the compatibility producer paired with the
+/// `with_base_scorer` consumer on FTS exec types. Fuzzy distributed execution
+/// must retain the full [`PreparedBm25Query`] from [`prepare_bm25_query`]; a
+/// scorer alone cannot preserve the canonical expansion vocabulary.
 pub async fn build_global_bm25_scorer(
     indices: &[Arc<InvertedIndex>],
     query_tokens: &Tokens,
     params: &FtsSearchParams,
     metrics: Option<&dyn crate::scalar::MetricsCollector>,
 ) -> Result<MemBM25Scorer> {
-    let terms = scorer_terms(indices, query_tokens, params)?;
-    let first_index = indices.first().ok_or_else(|| {
-        lance_core::Error::invalid_input("FTS index requires at least one segment")
-    })?;
-    let (mut total_tokens, mut num_docs, first_token_docs) =
-        first_index.bm25_stats_for_terms(&terms, metrics).await?;
-    let mut token_docs = HashMap::with_capacity(terms.len());
-    for (term, count) in terms.iter().cloned().zip(first_token_docs) {
-        token_docs.insert(term, count);
-    }
-
-    for index in indices.iter().skip(1) {
-        let (segment_total_tokens, segment_num_docs, segment_token_docs) =
-            index.bm25_stats_for_terms(&terms, metrics).await?;
-        total_tokens += segment_total_tokens;
-        num_docs += segment_num_docs;
-        for (term, count) in terms.iter().zip(segment_token_docs) {
-            *token_docs
-                .get_mut(term)
-                .expect("global scorer terms should already be initialized") += count;
-        }
-    }
-
-    Ok(MemBM25Scorer::new(total_tokens, num_docs, token_docs))
+    let prepared = prepare_bm25_query(indices, query_tokens.clone(), params, metrics, None).await?;
+    Ok(prepared.scorer.as_ref().clone())
 }
 
 use lance_core::Error;

--- a/rust/lance-index/src/scalar/inverted/compound.rs
+++ b/rust/lance-index/src/scalar/inverted/compound.rs
@@ -16,13 +16,14 @@ use lance_select::RowAddrMask;
 use lance_tokenizer::{SimpleTokenizer, TextAnalyzer};
 
 use super::{
-    InvertedIndex, build_global_bm25_scorer,
+    InvertedIndex, PreparedBm25Query,
     document_tokenizer::{DocType, JsonTokenizer, LanceTokenizer},
     documents::{
         CachedRowAddressOrder, DocId, DocLengths, DocVisibility, OrderedRowAddressProjection,
         PartitionDocuments, ResidentAddressProjection, RowAddressProjectionOrderError,
     },
     index::{DocSet, InvertedPartition},
+    prepare_bm25_query,
     query::{
         FtsQuery, FtsSearchParams, MatchQuery, Operator, PhraseQuery, Tokens, collect_query_tokens,
     },
@@ -3470,10 +3471,9 @@ pub(super) fn collect_leaf_queries(query: &FtsQuery, leaves: &mut Vec<LeafQuery>
 }
 
 struct PreparedLeaf {
-    tokens_by_segment: Vec<Arc<Tokens>>,
+    query: Arc<PreparedBm25Query>,
     params: Arc<FtsSearchParams>,
     operator: Operator,
-    scorer: Arc<MemBM25Scorer>,
 }
 
 pub(super) fn tokenize_leaf(
@@ -3481,9 +3481,12 @@ pub(super) fn tokenize_leaf(
     leaf: &LeafQuery,
     params: &FtsSearchParams,
 ) -> Tokens {
-    let is_fuzzy_match = matches!(leaf, LeafQuery::Match(_))
-        && matches!(params.fuzziness, Some(distance) if distance != 0);
-    let mut tokenizer = if is_fuzzy_match {
+    // Keep the legacy explicit-fuzzy rewrite independent of index analysis.
+    // AUTO fuzziness still expands later, but its source terms must first use
+    // the same normalization and filtering as the indexed vocabulary.
+    let is_explicit_fuzzy_match = matches!(leaf, LeafQuery::Match(_))
+        && matches!(params.fuzziness, Some(distance) if distance > 0);
+    let mut tokenizer = if is_explicit_fuzzy_match {
         let analyzer = TextAnalyzer::from(SimpleTokenizer::default());
         match index.tokenizer().doc_type() {
             DocType::Text => Box::new(TextTokenizer::new(analyzer)) as Box<dyn LanceTokenizer>,
@@ -3495,48 +3498,13 @@ pub(super) fn tokenize_leaf(
     collect_query_tokens(leaf.terms(), &mut tokenizer)
 }
 
-pub(super) fn expanded_leaf_tokens(
-    index: &InvertedIndex,
-    tokens: &Tokens,
-    params: &FtsSearchParams,
-    operator: Operator,
-) -> Result<Tokens> {
-    if !matches!(params.fuzziness, Some(distance) if distance != 0) {
-        return Ok(tokens.clone());
-    }
-    let expanded = index.expand_fuzzy_tokens(tokens, params)?;
-    if operator == Operator::And || params.phrase_slop.is_some() {
-        let surviving = (0..expanded.len())
-            .map(|index| expanded.position(index))
-            .collect::<HashSet<_>>();
-        if (0..tokens.len()).any(|index| !surviving.contains(&tokens.position(index))) {
-            return Ok(Tokens::with_positions(
-                Vec::new(),
-                Vec::new(),
-                tokens.token_type().clone(),
-            ));
-        }
-    }
-    Ok(expanded)
-}
-
-fn validate_injected_scorer_tokens(scorer: &MemBM25Scorer, tokens: &Tokens) -> Result<()> {
-    for token in tokens {
-        if !scorer.token_docs.contains_key(token) {
-            return Err(Error::invalid_input(format!(
-                "injected BM25 scorer is missing compound FTS token '{token}'"
-            )));
-        }
-    }
-    Ok(())
-}
-
 async fn prepare_compound_query(
     indices: &[Arc<InvertedIndex>],
     query: &FtsQuery,
     params: &FtsSearchParams,
     metrics: &dyn MetricsCollector,
     base_scorer: Option<Arc<MemBM25Scorer>>,
+    prepared_match: Option<Arc<PreparedBm25Query>>,
 ) -> Result<(CompoundScorerPlan, Vec<PreparedLeaf>)> {
     let first_index = indices
         .first()
@@ -3553,30 +3521,31 @@ async fn prepare_compound_query(
     }
 
     let mut leaves = Vec::with_capacity(leaf_queries.len());
+    if prepared_match.is_some() && leaf_queries.len() != 1 {
+        return Err(Error::internal(
+            "prepared Match replay requires exactly one compound FTS leaf",
+        ));
+    }
     for leaf in leaf_queries {
         let effective_params = leaf.effective_params(params);
         let tokens = tokenize_leaf(first_index, &leaf, &effective_params);
-        let scorer = match &base_scorer {
-            Some(scorer) => scorer.clone(),
+        let prepared = match &prepared_match {
+            Some(prepared) => prepared.clone(),
             None => Arc::new(
-                build_global_bm25_scorer(indices, &tokens, &effective_params, Some(metrics))
-                    .await?,
+                prepare_bm25_query(
+                    indices,
+                    tokens,
+                    &effective_params,
+                    Some(metrics),
+                    base_scorer.clone(),
+                )
+                .await?,
             ),
         };
-        let mut tokens_by_segment = Vec::with_capacity(indices.len());
-        for index in indices {
-            let expanded_tokens =
-                expanded_leaf_tokens(index, &tokens, &effective_params, leaf.operator())?;
-            if base_scorer.is_some() {
-                validate_injected_scorer_tokens(&scorer, &expanded_tokens)?;
-            }
-            tokens_by_segment.push(Arc::new(expanded_tokens));
-        }
         leaves.push(PreparedLeaf {
-            tokens_by_segment,
+            query: prepared,
             params: Arc::new(effective_params),
             operator: leaf.operator(),
-            scorer,
         });
     }
     Ok((plan, leaves))
@@ -3617,13 +3586,17 @@ async fn load_compound_partition(
 ) -> Result<Option<LoadedPartition>> {
     let leaf_loads = leaves.iter().map(|leaf| {
         let partition = partition.clone();
-        let tokens = leaf.tokens_by_segment[segment_ordinal].clone();
+        let tokens = leaf.query.tokens().clone();
         let params = leaf.params.clone();
-        let scorer = leaf.scorer.clone();
+        let scorer = leaf.query.scorer().clone();
         let metrics = metrics.clone();
         let operator = leaf.operator;
+        let has_all_query_positions = leaf.query.has_all_query_positions();
         async move {
-            let postings = if tokens.is_empty() {
+            let postings = if tokens.is_empty()
+                || ((operator == Operator::And || params.phrase_slop.is_some())
+                    && !has_all_query_positions)
+            {
                 Vec::new()
             } else {
                 partition
@@ -3956,7 +3929,7 @@ pub async fn compound_search(
     prefilter: Arc<dyn PreFilter>,
     metrics: Arc<dyn MetricsCollector>,
 ) -> Result<(Vec<u64>, Vec<f32>)> {
-    compound_search_impl(indices, query, params, prefilter, metrics, None, None).await
+    compound_search_impl(indices, query, params, prefilter, metrics, None, None, None).await
 }
 
 /// Search one-column compound FTS with caller-supplied corpus-wide BM25 statistics.
@@ -3979,6 +3952,7 @@ pub async fn compound_search_with_base_scorer(
         prefilter,
         metrics,
         Some(base_scorer),
+        None,
         None,
     )
     .await
@@ -4006,6 +3980,66 @@ pub async fn compound_search_with_base_scorer_and_score_floor(
         metrics,
         Some(base_scorer),
         Some(score_floor),
+        None,
+    )
+    .await
+}
+
+/// Replay one root Match query with the exact vocabulary/scorer pair used by
+/// an earlier bounded WAND probe.
+#[doc(hidden)]
+pub async fn compound_search_prepared_match(
+    indices: &[Arc<InvertedIndex>],
+    query: &FtsQuery,
+    params: &FtsSearchParams,
+    prefilter: Arc<dyn PreFilter>,
+    metrics: Arc<dyn MetricsCollector>,
+    prepared_match: Arc<PreparedBm25Query>,
+) -> Result<(Vec<u64>, Vec<f32>)> {
+    if !matches!(query, FtsQuery::Match(_)) {
+        return Err(Error::invalid_input(
+            "prepared Match replay requires a root Match query",
+        ));
+    }
+    compound_search_impl(
+        indices,
+        query,
+        params,
+        prefilter,
+        metrics,
+        None,
+        None,
+        Some(prepared_match),
+    )
+    .await
+}
+
+/// Replay one root Match query with a prepared vocabulary/scorer pair and an
+/// inclusive initial score floor.
+#[doc(hidden)]
+pub async fn compound_search_prepared_match_with_score_floor(
+    indices: &[Arc<InvertedIndex>],
+    query: &FtsQuery,
+    params: &FtsSearchParams,
+    prefilter: Arc<dyn PreFilter>,
+    metrics: Arc<dyn MetricsCollector>,
+    prepared_match: Arc<PreparedBm25Query>,
+    score_floor: f32,
+) -> Result<(Vec<u64>, Vec<f32>)> {
+    if !matches!(query, FtsQuery::Match(_)) {
+        return Err(Error::invalid_input(
+            "prepared Match replay requires a root Match query",
+        ));
+    }
+    compound_search_impl(
+        indices,
+        query,
+        params,
+        prefilter,
+        metrics,
+        None,
+        Some(score_floor),
+        Some(prepared_match),
     )
     .await
 }
@@ -4018,13 +4052,21 @@ async fn compound_search_impl(
     metrics: Arc<dyn MetricsCollector>,
     base_scorer: Option<Arc<MemBM25Scorer>>,
     initial_score_floor: Option<f32>,
+    prepared_match: Option<Arc<PreparedBm25Query>>,
 ) -> Result<(Vec<u64>, Vec<f32>)> {
     let limit = params.limit.unwrap_or(usize::MAX);
     if limit == 0 {
         return Ok((Vec::new(), Vec::new()));
     }
-    let (plan, leaves) =
-        prepare_compound_query(indices, query, params, metrics.as_ref(), base_scorer).await?;
+    let (plan, leaves) = prepare_compound_query(
+        indices,
+        query,
+        params,
+        metrics.as_ref(),
+        base_scorer,
+        prepared_match,
+    )
+    .await?;
     prefilter.wait_for_ready().await?;
     let mask = prefilter.mask();
     let competitive_score = Arc::new(CompetitiveScore::default());

--- a/rust/lance-index/src/scalar/inverted/compound.rs
+++ b/rust/lance-index/src/scalar/inverted/compound.rs
@@ -4044,6 +4044,10 @@ pub async fn compound_search_prepared_match_with_score_floor(
     .await
 }
 
+// These arguments keep the public entry points explicit while centralizing the
+// shared search loop; bundling them would only move the same independent inputs
+// into an internal forwarding struct.
+#[allow(clippy::too_many_arguments)]
 async fn compound_search_impl(
     indices: &[Arc<InvertedIndex>],
     query: &FtsQuery,

--- a/rust/lance-index/src/scalar/inverted/cross_column.rs
+++ b/rust/lance-index/src/scalar/inverted/cross_column.rs
@@ -22,19 +22,22 @@ use roaring::{RoaringBitmap, RoaringTreemap};
 use super::compound::{
     BoxScorer, ComposableScorer, CompoundLeafPlanInput, CompoundPlanAnalysis, CompoundScorerPlan,
     EmptyScorer, LeafQuery, MaterializedScorer, RowAddressMergeScorer, RowAddressSource,
-    ScoreBounds, ScoredRow, TopKCollector, collect_leaf_queries, expanded_leaf_tokens,
-    map_scorer_to_row_addresses, prepare_row_address_projection, tokenize_leaf,
+    ScoreBounds, ScoredRow, TopKCollector, collect_leaf_queries, map_scorer_to_row_addresses,
+    prepare_row_address_projection, tokenize_leaf,
 };
 use super::documents::{
     DocId, DocLengths, DocVisibility, PartitionDocuments, ResidentAddressProjection,
 };
 use super::index::{InvertedPartition, PostingLoadOptions};
-use super::query::{FtsQuery, FtsSearchParams, Operator, Tokens};
+use super::query::{FtsQuery, FtsSearchParams, Operator};
 use super::scorer::MemBM25Scorer;
 use super::wand::{
     FLAT_SEARCH_PERCENT_THRESHOLD, FlatDocuments, PostingIterator, WandCursor, WandDocuments,
 };
-use super::{DocInfo, DocumentGranularity, InvertedIndex};
+use super::{
+    DocInfo, DocumentGranularity, InvertedIndex, PreparedBm25Query, final_query_tokens,
+    has_all_query_positions,
+};
 use crate::metrics::MetricsCollector;
 use crate::prefilter::PreFilter;
 
@@ -53,10 +56,9 @@ const MAX_STAGED_GENERATOR_CANDIDATES: usize = 1_000_000;
 
 struct PreparedCrossColumnLeaf {
     column_ordinal: usize,
-    tokens_by_segment: Vec<Arc<Tokens>>,
+    query: Arc<PreparedBm25Query>,
     params: Arc<FtsSearchParams>,
     operator: Operator,
-    scorer: Arc<MemBM25Scorer>,
 }
 
 struct LoadedCrossColumnLeaf {
@@ -252,21 +254,21 @@ fn staged_candidate_budget(num_docs: usize, limit: usize) -> usize {
 fn leaf_plan_input(leaf: &PreparedCrossColumnLeaf) -> Result<CompoundLeafPlanInput> {
     let mut seen_terms = HashSet::<(u32, String)>::new();
     let mut costs_by_position = HashMap::<u32, usize>::new();
-    for tokens in &leaf.tokens_by_segment {
-        for token_index in 0..tokens.len() {
-            let position = tokens.position(token_index);
-            let token = tokens.get_token(token_index);
-            if seen_terms.insert((position, token.to_owned())) {
-                let frequency = leaf.scorer.num_docs_containing_token(token);
-                let position_cost = costs_by_position.entry(position).or_default();
-                *position_cost = position_cost.saturating_add(frequency);
-            }
+    let tokens = leaf.query.tokens();
+    for token_index in 0..tokens.len() {
+        let position = tokens.position(token_index);
+        let token = tokens.get_token(token_index);
+        if seen_terms.insert((position, token.to_owned())) {
+            let frequency = leaf.query.scorer().num_docs_containing_token(token);
+            let position_cost = costs_by_position.entry(position).or_default();
+            *position_cost = position_cost.saturating_add(frequency);
         }
     }
 
     let requires_every_position =
         leaf.operator == Operator::And || leaf.params.phrase_slop.is_some();
-    let possible = !costs_by_position.is_empty()
+    let possible = (!requires_every_position || leaf.query.has_all_query_positions())
+        && !costs_by_position.is_empty()
         && if requires_every_position {
             costs_by_position.values().all(|cost| *cost > 0)
         } else {
@@ -287,7 +289,7 @@ fn leaf_plan_input(leaf: &PreparedCrossColumnLeaf) -> Result<CompoundLeafPlanInp
             .copied()
             .fold(0, usize::saturating_add)
     }
-    .min(leaf.scorer.num_docs());
+    .min(leaf.query.scorer().num_docs());
     Ok(CompoundLeafPlanInput::new(
         true,
         cost,
@@ -319,7 +321,11 @@ fn staged_generator(
     let num_docs = analysis
         .generator_leaves
         .iter()
-        .map(|&leaf_ordinal| leaves.get(leaf_ordinal).map(|leaf| leaf.scorer.num_docs()))
+        .map(|&leaf_ordinal| {
+            leaves
+                .get(leaf_ordinal)
+                .map(|leaf| leaf.query.scorer().num_docs())
+        })
         .collect::<Option<Vec<_>>>()?
         .into_iter()
         .max()
@@ -541,52 +547,50 @@ async fn prepare_column_leaves(
     for (leaf_ordinal, leaf) in leaf_queries {
         let effective_params = leaf.effective_params(params);
         let tokens = tokenize_leaf(first_index, leaf, &effective_params);
-        let tokens_by_segment = indices
-            .iter()
-            .map(|index| {
-                expanded_leaf_tokens(index, &tokens, &effective_params, leaf.operator())
-                    .map(Arc::new)
-            })
-            .collect::<Result<Vec<_>>>()?;
-        for tokens in &tokens_by_segment {
-            for token in tokens.as_ref() {
-                if seen_terms.insert(token.clone()) {
-                    union_terms.push(token.clone());
-                }
+        let final_tokens = Arc::new(final_query_tokens(indices, &tokens, &effective_params)?);
+        for token in final_tokens.as_ref() {
+            if seen_terms.insert(token.clone()) {
+                union_terms.push(token.clone());
             }
         }
+        let has_all_positions = has_all_query_positions(&tokens, final_tokens.as_ref());
         leaf_metadata.push((
             *leaf_ordinal,
-            tokens_by_segment,
+            final_tokens,
+            has_all_positions,
             Arc::new(effective_params),
             leaf.operator(),
         ));
     }
 
-    // One union-term scorer per column means every leaf shares the same corpus
-    // totals and the index metadata for each segment is fetched only once.
+    // One union-term scorer per column preserves the existing metadata-I/O
+    // boundary while every leaf keeps its own canonical vocabulary budget.
     let scorer = build_column_scorer(indices, union_terms, metrics).await?;
-
     Ok(leaf_metadata
         .into_iter()
-        .map(|(leaf_ordinal, tokens_by_segment, params, operator)| {
-            (
-                leaf_ordinal,
-                PreparedCrossColumnLeaf {
-                    column_ordinal,
-                    tokens_by_segment,
-                    params,
-                    operator,
-                    scorer: scorer.clone(),
-                },
-            )
-        })
+        .map(
+            |(leaf_ordinal, tokens, has_all_positions, params, operator)| {
+                (
+                    leaf_ordinal,
+                    PreparedCrossColumnLeaf {
+                        column_ordinal,
+                        query: Arc::new(PreparedBm25Query::from_parts(
+                            tokens,
+                            scorer.clone(),
+                            has_all_positions,
+                        )),
+                        params,
+                        operator,
+                    },
+                )
+            },
+        )
         .collect())
 }
 
 fn viable_leaf_ordinals(
     column_ordinal: usize,
-    segment_ordinal: usize,
+    _segment_ordinal: usize,
     partition: &InvertedPartition,
     prepared_leaves: &[PreparedCrossColumnLeaf],
     leaf_ordinals: &[usize],
@@ -604,11 +608,7 @@ fn viable_leaf_ordinals(
                 leaf.column_ordinal
             )));
         }
-        let tokens = leaf.tokens_by_segment.get(segment_ordinal).ok_or_else(|| {
-            Error::internal(format!(
-                "cross-column FTS leaf {leaf_ordinal} has no tokens for segment {segment_ordinal}"
-            ))
-        })?;
+        let tokens = leaf.query.tokens();
         if partition.may_match_tokens(
             tokens.as_ref(),
             leaf.operator,
@@ -622,7 +622,7 @@ fn viable_leaf_ordinals(
 
 async fn load_source_leaves(
     partition: Arc<InvertedPartition>,
-    segment_ordinal: usize,
+    _segment_ordinal: usize,
     viable_leaf_ordinals: Vec<usize>,
     prepared_leaves: Arc<Vec<PreparedCrossColumnLeaf>>,
     metrics: Arc<dyn MetricsCollector>,
@@ -642,12 +642,11 @@ async fn load_source_leaves(
                     "cross-column FTS source references missing leaf {leaf_ordinal}"
                 ))
             })?;
-            let tokens = leaf.tokens_by_segment.get(segment_ordinal).ok_or_else(|| {
-                Error::internal(format!(
-                    "cross-column FTS leaf {leaf_ordinal} has no tokens for segment {segment_ordinal}"
-                ))
-            })?;
-            let postings = if tokens.is_empty() {
+            let tokens = leaf.query.tokens();
+            let postings = if tokens.is_empty()
+                || ((leaf.operator == Operator::And || leaf.params.phrase_slop.is_some())
+                    && !leaf.query.has_all_query_positions())
+            {
                 Vec::new()
             } else {
                 partition
@@ -655,7 +654,7 @@ async fn load_source_leaves(
                         tokens.as_ref(),
                         leaf.params.as_ref(),
                         leaf.operator,
-                        leaf.scorer.as_ref(),
+                        leaf.query.scorer().as_ref(),
                         metrics.as_ref(),
                         PostingLoadOptions::cache_aware_exact(true),
                     )
@@ -667,7 +666,7 @@ async fn load_source_leaves(
                 postings,
                 params: leaf.params.clone(),
                 operator: leaf.operator,
-                scorer: leaf.scorer.clone(),
+                scorer: leaf.query.scorer().clone(),
             })
         }
     }))
@@ -1678,7 +1677,7 @@ mod tests {
     use crate::prefilter::NoFilter;
     use crate::scalar::inverted::encoding::compress_posting_list;
     use crate::scalar::inverted::query::{
-        BooleanQuery, MatchQuery, MultiMatchQuery, Occur, PhraseQuery,
+        BooleanQuery, MatchQuery, MultiMatchQuery, Occur, PhraseQuery, Tokens,
     };
     use crate::scalar::inverted::tokenizer::document_tokenizer::DocType;
     use crate::scalar::inverted::{
@@ -1743,19 +1742,28 @@ mod tests {
         num_docs: usize,
         token_docs: impl IntoIterator<Item = (&'static str, usize)>,
     ) -> PreparedCrossColumnLeaf {
+        let mut segment_tokens = tokens_by_segment.into_iter();
+        let tokens = Arc::new(segment_tokens.next().unwrap());
+        for segment_tokens in segment_tokens {
+            assert_eq!(segment_tokens.len(), tokens.len());
+            for index in 0..segment_tokens.len() {
+                assert_eq!(segment_tokens.get_token(index), tokens.get_token(index));
+                assert_eq!(segment_tokens.position(index), tokens.position(index));
+            }
+        }
+        let scorer = Arc::new(MemBM25Scorer::new(
+            num_docs as u64,
+            num_docs,
+            token_docs
+                .into_iter()
+                .map(|(token, count)| (token.to_owned(), count))
+                .collect(),
+        ));
         PreparedCrossColumnLeaf {
             column_ordinal: 0,
-            tokens_by_segment: tokens_by_segment.into_iter().map(Arc::new).collect(),
+            query: Arc::new(PreparedBm25Query::from_parts(tokens, scorer, true)),
             params: Arc::new(FtsSearchParams::new().with_phrase_slop(phrase_slop)),
             operator,
-            scorer: Arc::new(MemBM25Scorer::new(
-                num_docs as u64,
-                num_docs,
-                token_docs
-                    .into_iter()
-                    .map(|(token, count)| (token.to_owned(), count))
-                    .collect(),
-            )),
         }
     }
 

--- a/rust/lance-index/src/scalar/inverted/index/partition.rs
+++ b/rust/lance-index/src/scalar/inverted/index/partition.rs
@@ -2,7 +2,469 @@
 // SPDX-FileCopyrightText: Copyright The Lance Authors
 
 use super::*;
+use crate::scalar::inverted::document_tokenizer::DocType;
 use smallvec::SmallVec;
+use std::collections::VecDeque;
+
+const UNICODE_LEVENSHTEIN_STATE_LIMIT: usize = 10_000;
+
+type ByteTransitions = Box<[Option<usize>; 256]>;
+
+struct UnicodeDfaState {
+    transitions: ByteTransitions,
+    is_match: bool,
+}
+
+/// A Unicode-scalar Levenshtein automaton for FST dictionaries.
+///
+/// `fst` 0.4's built-in automaton can lose exact transitions when multiple
+/// non-ASCII query scalars share a UTF-8 lead byte. This implementation fixes
+/// that overlap while retaining the same execution model: query construction
+/// interns bounded Levenshtein rows and compiles a byte DFA, then FST traversal
+/// performs one table lookup per byte without allocating.
+pub(in crate::scalar::inverted) struct UnicodeLevenshtein {
+    states: Vec<UnicodeDfaState>,
+    start_state: usize,
+    #[cfg(test)]
+    exact_override_counts: Vec<usize>,
+}
+
+#[derive(Debug)]
+struct UnicodeLevenshteinError {
+    state_limit: usize,
+}
+
+impl std::fmt::Display for UnicodeLevenshteinError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            formatter,
+            "Unicode Levenshtein automaton exceeds state limit of {}",
+            self.state_limit
+        )
+    }
+}
+
+#[derive(Default)]
+struct ExactUtf8Trie {
+    target: Option<usize>,
+    children: BTreeMap<u8, ExactUtf8Trie>,
+}
+
+impl ExactUtf8Trie {
+    fn insert(&mut self, bytes: &[u8], target: usize) {
+        let mut node = self;
+        for byte in bytes {
+            node = node.children.entry(*byte).or_default();
+        }
+        node.target = Some(target);
+    }
+}
+
+struct UnicodeLevenshteinBuilder {
+    query: Vec<char>,
+    exact_prefix: Vec<u8>,
+    max_distance: usize,
+    state_limit: usize,
+    states: Vec<UnicodeDfaState>,
+    rows: HashMap<Vec<usize>, usize>,
+    pending_rows: VecDeque<Vec<usize>>,
+    default_utf8_transitions: HashMap<usize, ByteTransitions>,
+    #[cfg(test)]
+    exact_override_counts: Vec<usize>,
+}
+
+impl UnicodeLevenshtein {
+    fn new(
+        fuzzy_suffix: &str,
+        exact_prefix: &str,
+        max_distance: u32,
+    ) -> std::result::Result<Self, UnicodeLevenshteinError> {
+        Self::new_with_limit(
+            fuzzy_suffix,
+            exact_prefix,
+            max_distance,
+            UNICODE_LEVENSHTEIN_STATE_LIMIT,
+        )
+    }
+
+    fn new_with_limit(
+        fuzzy_suffix: &str,
+        exact_prefix: &str,
+        max_distance: u32,
+        state_limit: usize,
+    ) -> std::result::Result<Self, UnicodeLevenshteinError> {
+        UnicodeLevenshteinBuilder {
+            query: fuzzy_suffix.chars().collect(),
+            exact_prefix: exact_prefix.as_bytes().to_vec(),
+            max_distance: max_distance as usize,
+            state_limit,
+            states: Vec::new(),
+            rows: HashMap::new(),
+            pending_rows: VecDeque::new(),
+            default_utf8_transitions: HashMap::new(),
+            #[cfg(test)]
+            exact_override_counts: Vec::new(),
+        }
+        .build()
+    }
+}
+
+impl Automaton for UnicodeLevenshtein {
+    type State = Option<usize>;
+
+    #[inline]
+    fn start(&self) -> Self::State {
+        Some(self.start_state)
+    }
+
+    #[inline]
+    fn is_match(&self, state: &Self::State) -> bool {
+        state.is_some_and(|state| self.states[state].is_match)
+    }
+
+    #[inline]
+    fn can_match(&self, state: &Self::State) -> bool {
+        state.is_some()
+    }
+
+    #[inline]
+    fn accept(&self, state: &Self::State, byte: u8) -> Self::State {
+        state.and_then(|state| self.states[state].transitions[byte as usize])
+    }
+}
+
+pub(in crate::scalar::inverted) struct AsciiFuzzyAutomaton {
+    levenshtein: fst::automaton::Levenshtein,
+    exact_prefix: Vec<u8>,
+}
+
+#[derive(Clone, Copy)]
+pub(in crate::scalar::inverted) struct AsciiFuzzyState {
+    levenshtein: Option<usize>,
+    exact_prefix_bytes_matched: Option<usize>,
+}
+
+impl Automaton for AsciiFuzzyAutomaton {
+    type State = AsciiFuzzyState;
+
+    #[inline]
+    fn start(&self) -> Self::State {
+        AsciiFuzzyState {
+            levenshtein: self.levenshtein.start(),
+            exact_prefix_bytes_matched: Some(0),
+        }
+    }
+
+    #[inline]
+    fn is_match(&self, state: &Self::State) -> bool {
+        self.levenshtein.is_match(&state.levenshtein)
+            && state.exact_prefix_bytes_matched == Some(self.exact_prefix.len())
+    }
+
+    #[inline]
+    fn can_match(&self, state: &Self::State) -> bool {
+        self.levenshtein.can_match(&state.levenshtein) && state.exact_prefix_bytes_matched.is_some()
+    }
+
+    #[inline]
+    fn accept(&self, state: &Self::State, byte: u8) -> Self::State {
+        let exact_prefix_bytes_matched = state.exact_prefix_bytes_matched.and_then(|position| {
+            if position == self.exact_prefix.len() {
+                Some(position)
+            } else if self.exact_prefix[position] == byte {
+                Some(position + 1)
+            } else {
+                None
+            }
+        });
+        AsciiFuzzyState {
+            levenshtein: self.levenshtein.accept(&state.levenshtein, byte),
+            exact_prefix_bytes_matched,
+        }
+    }
+}
+
+pub(in crate::scalar::inverted) enum FuzzyAutomaton {
+    Ascii(AsciiFuzzyAutomaton),
+    Unicode(UnicodeLevenshtein),
+}
+
+pub(in crate::scalar::inverted) enum FuzzyAutomatonState {
+    Ascii(AsciiFuzzyState),
+    Unicode(Option<usize>),
+}
+
+impl FuzzyAutomaton {
+    pub(in crate::scalar::inverted) fn new(
+        token: &str,
+        token_type: &DocType,
+        params: &FtsSearchParams,
+    ) -> Result<Self> {
+        let fuzzy = fuzzy_term_options(token, token_type, params.fuzziness, params.prefix_length);
+        if token.is_ascii() {
+            let levenshtein = fst::automaton::Levenshtein::new(token, fuzzy.edit_distance)
+                .map_err(|error| {
+                    Error::index(format!("failed to construct the fuzzy query: {error}"))
+                })?;
+            Ok(Self::Ascii(AsciiFuzzyAutomaton {
+                levenshtein,
+                exact_prefix: fuzzy.exact_prefix.as_bytes().to_vec(),
+            }))
+        } else {
+            let levenshtein = UnicodeLevenshtein::new(
+                fuzzy.fuzzy_suffix,
+                fuzzy.exact_prefix,
+                fuzzy.edit_distance,
+            )
+            .map_err(|error| {
+                Error::index(format!("failed to construct the fuzzy query: {error}"))
+            })?;
+            Ok(Self::Unicode(levenshtein))
+        }
+    }
+}
+
+impl Automaton for FuzzyAutomaton {
+    type State = FuzzyAutomatonState;
+
+    #[inline]
+    fn start(&self) -> Self::State {
+        match self {
+            Self::Ascii(automaton) => FuzzyAutomatonState::Ascii(automaton.start()),
+            Self::Unicode(automaton) => FuzzyAutomatonState::Unicode(automaton.start()),
+        }
+    }
+
+    #[inline]
+    fn is_match(&self, state: &Self::State) -> bool {
+        match (self, state) {
+            (Self::Ascii(automaton), FuzzyAutomatonState::Ascii(state)) => {
+                automaton.is_match(state)
+            }
+            (Self::Unicode(automaton), FuzzyAutomatonState::Unicode(state)) => {
+                automaton.is_match(state)
+            }
+            _ => false,
+        }
+    }
+
+    #[inline]
+    fn can_match(&self, state: &Self::State) -> bool {
+        match (self, state) {
+            (Self::Ascii(automaton), FuzzyAutomatonState::Ascii(state)) => {
+                automaton.can_match(state)
+            }
+            (Self::Unicode(automaton), FuzzyAutomatonState::Unicode(state)) => {
+                automaton.can_match(state)
+            }
+            _ => false,
+        }
+    }
+
+    #[inline]
+    fn accept(&self, state: &Self::State, byte: u8) -> Self::State {
+        match (self, state) {
+            (Self::Ascii(automaton), FuzzyAutomatonState::Ascii(state)) => {
+                FuzzyAutomatonState::Ascii(automaton.accept(state, byte))
+            }
+            (Self::Unicode(automaton), FuzzyAutomatonState::Unicode(state)) => {
+                FuzzyAutomatonState::Unicode(automaton.accept(state, byte))
+            }
+            (Self::Ascii(_), _) => FuzzyAutomatonState::Ascii(AsciiFuzzyState {
+                levenshtein: None,
+                exact_prefix_bytes_matched: None,
+            }),
+            (Self::Unicode(_), _) => FuzzyAutomatonState::Unicode(None),
+        }
+    }
+}
+
+impl UnicodeLevenshteinBuilder {
+    fn empty_transitions() -> ByteTransitions {
+        Box::new([None; 256])
+    }
+
+    fn add_state(
+        &mut self,
+        transitions: ByteTransitions,
+        is_match: bool,
+    ) -> std::result::Result<usize, UnicodeLevenshteinError> {
+        if self.states.len() >= self.state_limit {
+            return Err(UnicodeLevenshteinError {
+                state_limit: self.state_limit,
+            });
+        }
+        let state = self.states.len();
+        self.states.push(UnicodeDfaState {
+            transitions,
+            is_match,
+        });
+        Ok(state)
+    }
+
+    fn advance_row(&self, distances: &[usize], candidate: Option<char>) -> Vec<usize> {
+        let cutoff = self.max_distance.saturating_add(1);
+        let mut next = Vec::with_capacity(self.query.len() + 1);
+        next.push(distances[0].saturating_add(1).min(cutoff));
+        for (query_index, query) in self.query.iter().enumerate() {
+            let substitution_cost = usize::from(Some(*query) != candidate);
+            let insertion = distances[query_index + 1].saturating_add(1);
+            let deletion = next[query_index].saturating_add(1);
+            let substitution = distances[query_index].saturating_add(substitution_cost);
+            next.push(insertion.min(deletion).min(substitution).min(cutoff));
+        }
+        next
+    }
+
+    fn intern_row(
+        &mut self,
+        distances: Vec<usize>,
+    ) -> std::result::Result<Option<usize>, UnicodeLevenshteinError> {
+        if distances
+            .iter()
+            .all(|distance| *distance > self.max_distance)
+        {
+            return Ok(None);
+        }
+        if let Some(state) = self.rows.get(&distances) {
+            return Ok(Some(*state));
+        }
+        let is_match = distances
+            .last()
+            .is_some_and(|distance| *distance <= self.max_distance);
+        let state = self.add_state(Self::empty_transitions(), is_match)?;
+        self.rows.insert(distances.clone(), state);
+        self.pending_rows.push_back(distances);
+        Ok(Some(state))
+    }
+
+    fn state_with_range(
+        &mut self,
+        start: u8,
+        end: u8,
+        target: usize,
+    ) -> std::result::Result<usize, UnicodeLevenshteinError> {
+        let mut transitions = Self::empty_transitions();
+        transitions[start as usize..=end as usize].fill(Some(target));
+        self.add_state(transitions, false)
+    }
+
+    fn build_default_utf8_transitions(
+        &mut self,
+        target: usize,
+    ) -> std::result::Result<ByteTransitions, UnicodeLevenshteinError> {
+        if let Some(transitions) = self.default_utf8_transitions.get(&target) {
+            return Ok(transitions.clone());
+        }
+
+        let one_continuation = self.state_with_range(0x80, 0xbf, target)?;
+        let two_continuations = self.state_with_range(0x80, 0xbf, one_continuation)?;
+        let three_continuations = self.state_with_range(0x80, 0xbf, two_continuations)?;
+        let e0_second = self.state_with_range(0xa0, 0xbf, one_continuation)?;
+        let ed_second = self.state_with_range(0x80, 0x9f, one_continuation)?;
+        let f0_second = self.state_with_range(0x90, 0xbf, two_continuations)?;
+        let f4_second = self.state_with_range(0x80, 0x8f, two_continuations)?;
+
+        let mut transitions = Self::empty_transitions();
+        transitions[0x00..=0x7f].fill(Some(target));
+        transitions[0xc2..=0xdf].fill(Some(one_continuation));
+        transitions[0xe0] = Some(e0_second);
+        transitions[0xe1..=0xec].fill(Some(two_continuations));
+        transitions[0xed] = Some(ed_second);
+        transitions[0xee..=0xef].fill(Some(two_continuations));
+        transitions[0xf0] = Some(f0_second);
+        transitions[0xf1..=0xf3].fill(Some(three_continuations));
+        transitions[0xf4] = Some(f4_second);
+        self.default_utf8_transitions
+            .insert(target, transitions.clone());
+        Ok(transitions)
+    }
+
+    fn overlay_exact_trie(
+        &mut self,
+        transitions: &mut ByteTransitions,
+        trie: &ExactUtf8Trie,
+    ) -> std::result::Result<(), UnicodeLevenshteinError> {
+        for (byte, child) in &trie.children {
+            if let Some(target) = child.target {
+                debug_assert!(child.children.is_empty());
+                transitions[*byte as usize] = Some(target);
+                continue;
+            }
+
+            let mut child_transitions = transitions[*byte as usize]
+                .map(|state| self.states[state].transitions.clone())
+                .unwrap_or_else(Self::empty_transitions);
+            self.overlay_exact_trie(&mut child_transitions, child)?;
+            transitions[*byte as usize] = Some(self.add_state(child_transitions, false)?);
+        }
+        Ok(())
+    }
+
+    fn build_boundary_state(
+        &mut self,
+        distances: &[usize],
+    ) -> std::result::Result<(), UnicodeLevenshteinError> {
+        let boundary_state = self.rows[distances];
+        let mismatch = self.advance_row(distances, None);
+        let mismatch_state = self.intern_row(mismatch)?;
+        let mut transitions = match mismatch_state {
+            Some(target) => self.build_default_utf8_transitions(target)?,
+            None => Self::empty_transitions(),
+        };
+
+        let mut exact_trie = ExactUtf8Trie::default();
+        let mut exact_scalars = SmallVec::<[char; 8]>::new();
+        for (query_index, query_scalar) in self.query.iter().copied().enumerate() {
+            if distances[query_index] <= self.max_distance && !exact_scalars.contains(&query_scalar)
+            {
+                exact_scalars.push(query_scalar);
+            }
+        }
+        #[cfg(test)]
+        self.exact_override_counts.push(exact_scalars.len());
+        for query_scalar in exact_scalars {
+            let exact = self.advance_row(distances, Some(query_scalar));
+            if let Some(target) = self.intern_row(exact)? {
+                let mut encoded = [0; 4];
+                exact_trie.insert(query_scalar.encode_utf8(&mut encoded).as_bytes(), target);
+            }
+        }
+        self.overlay_exact_trie(&mut transitions, &exact_trie)?;
+        self.states[boundary_state].transitions = transitions;
+        Ok(())
+    }
+
+    fn build(mut self) -> std::result::Result<UnicodeLevenshtein, UnicodeLevenshteinError> {
+        let cutoff = self.max_distance.saturating_add(1);
+        let initial_distances = (0..=self.query.len())
+            .map(|distance| distance.min(cutoff))
+            .collect::<Vec<_>>();
+        let initial_is_match = initial_distances
+            .last()
+            .is_some_and(|distance| *distance <= self.max_distance);
+        let suffix_start = self.add_state(Self::empty_transitions(), initial_is_match)?;
+        self.rows.insert(initial_distances.clone(), suffix_start);
+        self.pending_rows.push_back(initial_distances);
+        while let Some(distances) = self.pending_rows.pop_front() {
+            self.build_boundary_state(&distances)?;
+        }
+
+        let mut start_state = suffix_start;
+        for byte in std::mem::take(&mut self.exact_prefix).into_iter().rev() {
+            let mut transitions = Self::empty_transitions();
+            transitions[byte as usize] = Some(start_state);
+            start_state = self.add_state(transitions, false)?;
+        }
+
+        Ok(UnicodeLevenshtein {
+            states: self.states,
+            start_state,
+            #[cfg(test)]
+            exact_override_counts: self.exact_override_counts,
+        })
+    }
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 struct PositionMatchSummary {
@@ -269,6 +731,7 @@ impl InvertedPartition {
         let mut new_tokens = Vec::with_capacity(min(tokens.len(), params.max_expansions));
         let mut new_positions = Vec::with_capacity(new_tokens.capacity());
         let mut seen = HashSet::new();
+        let mut seen_source_terms = HashSet::new();
         for token_idx in 0..tokens.len() {
             let remaining = params.max_expansions.saturating_sub(new_tokens.len());
             if remaining == 0 {
@@ -276,15 +739,12 @@ impl InvertedPartition {
             }
             let token = tokens.get_token(token_idx);
             let position = tokens.position(token_idx);
-            let base_prefix_len = tokens.token_type().prefix_len(token) as u32;
+            if !seen_source_terms.insert((position, token)) {
+                continue;
+            }
             let mut candidates = BTreeSet::new();
-            self.collect_fuzzy_candidates(
-                token,
-                base_prefix_len,
-                params,
-                remaining,
-                &mut candidates,
-            )?;
+            let automaton = FuzzyAutomaton::new(token, tokens.token_type(), params)?;
+            self.collect_fuzzy_candidates_with_automaton(&automaton, remaining, &mut candidates)?;
             for candidate in candidates {
                 if new_tokens.len() >= params.max_expansions {
                     break;
@@ -309,31 +769,15 @@ impl InvertedPartition {
     /// lossless for that selection because any term among the merged
     /// lexicographically-smallest `limit` is also among its own partition's
     /// smallest `limit`.
-    pub(super) fn collect_fuzzy_candidates(
+    pub(super) fn collect_fuzzy_candidates_with_automaton<A: Automaton>(
         &self,
-        token: &str,
-        base_prefix_len: u32,
-        params: &FtsSearchParams,
+        automaton: &A,
         limit: usize,
         candidates: &mut BTreeSet<String>,
     ) -> Result<()> {
-        let fuzziness = match params.fuzziness {
-            Some(fuzziness) => fuzziness,
-            None => MatchQuery::auto_fuzziness(token),
-        };
-        let lev = fst::automaton::Levenshtein::new(token, fuzziness)
-            .map_err(|e| Error::index(format!("failed to construct the fuzzy query: {}", e)))?;
-
         if let TokenMap::Fst(ref map) = self.tokens.tokens {
             let mut expanded = Vec::new();
-            match base_prefix_len + params.prefix_length {
-                0 => take_fst_keys(map.search(lev), &mut expanded, limit),
-                prefix_length => {
-                    let prefix = &token[..min(prefix_length as usize, token.len())];
-                    let prefix = fst::automaton::Str::new(prefix).starts_with();
-                    take_fst_keys(map.search(lev.intersection(prefix)), &mut expanded, limit)
-                }
-            }
+            take_fst_keys(map.search(automaton), &mut expanded, limit);
             candidates.extend(expanded);
             Ok(())
         } else {
@@ -687,10 +1131,9 @@ impl InvertedPartition {
         } = options;
         let is_phrase_query = params.phrase_slop.is_some();
         let is_and_query = operator == Operator::And;
-        // Fuzzy expansion already ran once at the index level (see
-        // `InvertedIndex::bm25_search`) under the global `max_expansions`
-        // budget. Positions identify alternatives that must share one posting
-        // iterator, including code identifier subwords and fuzzy expansions.
+        // The caller passes final tokens after any fuzzy expansion. Positions
+        // identify alternatives that must share one posting iterator,
+        // including code identifier subwords and fuzzy expansions.
         let mut token_ids = Vec::with_capacity(tokens.len());
         let mut position_matches = SmallVec::<[(u32, bool); 8]>::new();
         for index in 0..tokens.len() {
@@ -1067,6 +1510,129 @@ mod tests {
 
     fn position_summary(entries: &[(u32, bool)]) -> PositionMatchSummary {
         summarize_position_matches(entries.iter().copied().collect())
+    }
+
+    fn automaton_accepts<A: Automaton>(automaton: &A, candidate: &[u8]) -> bool {
+        let mut state = automaton.start();
+        for byte in candidate {
+            state = automaton.accept(&state, *byte);
+            if !automaton.can_match(&state) {
+                break;
+            }
+        }
+        automaton.is_match(&state)
+    }
+
+    #[rstest]
+    #[case::empty("", "", 0, "", true)]
+    #[case::empty_with_one_insertion("", "", 1, "é", true)]
+    #[case::unicode_deletion("بسرع", "", 1, "بسر", true)]
+    #[case::unicode_distance_two("猫咪", "", 2, "小猫咪呀", true)]
+    #[case::unicode_over_distance("猫咪", "", 1, "小猫咪呀", false)]
+    #[case::exact_unicode_prefix("clair", "é", 1, "éclait", true)]
+    #[case::wrong_unicode_prefix("clair", "é", 1, "àclait", false)]
+    fn unicode_levenshtein_table_matches_scalar_distance(
+        #[case] fuzzy_suffix: &str,
+        #[case] exact_prefix: &str,
+        #[case] max_distance: u32,
+        #[case] candidate: &str,
+        #[case] expected: bool,
+    ) {
+        let automaton = UnicodeLevenshtein::new(fuzzy_suffix, exact_prefix, max_distance).unwrap();
+
+        assert_eq!(
+            automaton_accepts(&automaton, candidate.as_bytes()),
+            expected
+        );
+    }
+
+    #[test]
+    fn unicode_levenshtein_rejects_invalid_utf8_and_dead_states() {
+        let automaton = UnicodeLevenshtein::new("بسرع", "", 1).unwrap();
+        let start = automaton.start();
+        assert!(automaton.can_match(&start));
+
+        let partial = automaton.accept(&start, 0xd8);
+        assert!(automaton.can_match(&partial));
+        assert!(!automaton.is_match(&partial));
+
+        let invalid = automaton.accept(&partial, b'a');
+        assert!(!automaton.can_match(&invalid));
+        assert!(!automaton.is_match(&invalid));
+
+        let empty = UnicodeLevenshtein::new("", "", 0).unwrap();
+        let dead = empty.accept(&empty.start(), b'a');
+        assert!(!empty.can_match(&dead));
+    }
+
+    #[test]
+    fn unicode_levenshtein_enforces_construction_state_limit() {
+        let error = match UnicodeLevenshtein::new_with_limit("بسرع", "", 1, 1) {
+            Ok(_) => panic!("a one-state limit must reject the Unicode fuzzy DFA"),
+            Err(error) => error,
+        };
+
+        assert_eq!(error.state_limit, 1);
+    }
+
+    #[test]
+    fn unicode_levenshtein_only_overrides_row_active_scalars() {
+        let query = "ابتثجحخدذرزسشصضطظعغفقكلمن";
+        let scalar_count = query.chars().count();
+        let automaton = UnicodeLevenshtein::new(query, "", 1).unwrap();
+        let row_count = automaton.exact_override_counts.len();
+        let override_count = automaton.exact_override_counts.iter().sum::<usize>();
+
+        assert!(row_count > 0);
+        assert!(
+            automaton
+                .exact_override_counts
+                .iter()
+                .all(|count| *count <= 3),
+            "distance=1 has at most a three-position active DP band"
+        );
+        assert!(
+            override_count <= row_count * 3 && override_count < row_count * scalar_count,
+            "row-active overrides must stay well below all-scalars-per-row construction"
+        );
+
+        let repeated = UnicodeLevenshtein::new("بببببببببببببببب", "", 1).unwrap();
+        assert!(
+            repeated
+                .exact_override_counts
+                .iter()
+                .all(|count| *count <= 1),
+            "the same active scalar must install only one exact override per row"
+        );
+    }
+
+    #[test]
+    fn ascii_fuzzy_automaton_keeps_exact_prefix_semantics() {
+        let params = FtsSearchParams::new()
+            .with_fuzziness(Some(1))
+            .with_prefix_length(1);
+        let automaton = FuzzyAutomaton::new("cafe", &DocType::Text, &params).unwrap();
+
+        assert!(automaton_accepts(&automaton, "café".as_bytes()));
+        assert!(!automaton_accepts(&automaton, "dafé".as_bytes()));
+    }
+
+    #[test]
+    fn unicode_levenshtein_handles_shared_utf8_lead_bytes() {
+        let mut builder = fst::MapBuilder::memory();
+        for (token_id, token) in ["assemblees", "café", "بسرعة"].into_iter().enumerate() {
+            builder.insert(token, token_id as u64).unwrap();
+        }
+        let map = builder.into_map();
+        let mut matches = Vec::new();
+
+        take_fst_keys(
+            map.search(UnicodeLevenshtein::new("بسرع", "", 1).unwrap()),
+            &mut matches,
+            10,
+        );
+
+        assert_eq!(matches, vec!["بسرعة"]);
     }
 
     #[test]

--- a/rust/lance-index/src/scalar/inverted/index/partition.rs
+++ b/rust/lance-index/src/scalar/inverted/index/partition.rs
@@ -47,7 +47,7 @@ impl std::fmt::Display for UnicodeLevenshteinError {
 #[derive(Default)]
 struct ExactUtf8Trie {
     target: Option<usize>,
-    children: BTreeMap<u8, ExactUtf8Trie>,
+    children: BTreeMap<u8, Self>,
 }
 
 impl ExactUtf8Trie {
@@ -1567,9 +1567,8 @@ mod tests {
 
     #[test]
     fn unicode_levenshtein_enforces_construction_state_limit() {
-        let error = match UnicodeLevenshtein::new_with_limit("بسرع", "", 1, 1) {
-            Ok(_) => panic!("a one-state limit must reject the Unicode fuzzy DFA"),
-            Err(error) => error,
+        let Err(error) = UnicodeLevenshtein::new_with_limit("بسرع", "", 1, 1) else {
+            panic!("a one-state limit must reject the Unicode fuzzy DFA");
         };
 
         assert_eq!(error.state_limit, 1);

--- a/rust/lance-index/src/scalar/inverted/index/search.rs
+++ b/rust/lance-index/src/scalar/inverted/index/search.rs
@@ -1,9 +1,39 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright The Lance Authors
 
+use super::partition::FuzzyAutomaton;
 use super::*;
 
 impl InvertedIndex {
+    /// Add this segment's lexicographically smallest fuzzy candidates for one
+    /// compiled query-token automaton to a caller-owned cross-segment merge
+    /// set.
+    ///
+    /// The set is trimmed after every partition merge, so it always contains
+    /// at most `limit` terms. Dropping the current largest term is lossless:
+    /// no later merge can make it one of the globally smallest `limit` terms.
+    pub(in crate::scalar::inverted) fn collect_fuzzy_candidates_with_automaton(
+        &self,
+        automaton: &FuzzyAutomaton,
+        limit: usize,
+        candidates: &mut BTreeSet<String>,
+    ) -> Result<()> {
+        // The caller owns one compiled automaton for this source token. Reuse
+        // it across every physical partition instead of rebuilding a DFA per
+        // dictionary.
+        while candidates.len() > limit {
+            candidates.pop_last();
+        }
+        for partition in &self.partitions {
+            partition.collect_fuzzy_candidates_with_automaton(automaton, limit, candidates)?;
+            while candidates.len() > limit {
+                candidates.pop_last();
+            }
+            debug_assert!(candidates.len() <= limit);
+        }
+        Ok(())
+    }
+
     /// Build a single-segment [`MemBM25Scorer`] whose per-term IDF table
     /// covers every token that the per-partition scoring loop will look
     /// up. For fuzzy queries that means the union of Levenshtein
@@ -16,7 +46,7 @@ impl InvertedIndex {
         params: &FtsSearchParams,
         metrics: Option<&dyn MetricsCollector>,
     ) -> Result<MemBM25Scorer> {
-        if matches!(params.fuzziness, Some(n) if n != 0) {
+        if uses_fuzzy_expansion(params.fuzziness) {
             let expanded = self.expand_fuzzy_tokens(query_tokens, params)?;
             self.bm25_scorer_for_final_tokens(&expanded, metrics).await
         } else {
@@ -133,34 +163,42 @@ impl InvertedIndex {
     /// Expand fuzzy query tokens against all partitions in this segment.
     ///
     /// `params.max_expansions` caps the whole query's expansion, not any
-    /// single partition's: for each query token the per-partition candidates
-    /// (each streamed in FST key order) merge into one lexicographically
-    /// ordered set, and the remaining budget takes a prefix of it. The
-    /// selected terms are a pure function of the segment's vocabulary, so
-    /// splitting the same corpus into more partitions cannot change which
-    /// terms a fuzzy query matches.
+    /// single partition's: source terms at the same query position and their
+    /// per-partition candidates merge into one lexicographically ordered set,
+    /// and the remaining budget takes a prefix of it. The selected terms are
+    /// a pure function of the segment's vocabulary, so changing source-token
+    /// order or splitting the same corpus into more partitions cannot change
+    /// which terms a fuzzy query matches.
     pub fn expand_fuzzy_tokens(&self, tokens: &Tokens, params: &FtsSearchParams) -> Result<Tokens> {
-        let mut expanded_tokens = Vec::new();
-        let mut expanded_positions = Vec::new();
+        let initial_capacity = tokens.len().min(params.max_expansions);
+        let mut expanded_tokens = Vec::with_capacity(initial_capacity);
+        let mut expanded_positions = Vec::with_capacity(initial_capacity);
         let mut seen = HashSet::new();
+        let mut source_terms_by_position = BTreeMap::<u32, Vec<&str>>::new();
         for token_idx in 0..tokens.len() {
+            source_terms_by_position
+                .entry(tokens.position(token_idx))
+                .or_default()
+                .push(tokens.get_token(token_idx));
+        }
+        for (position, source_terms) in source_terms_by_position {
             let remaining = params.max_expansions.saturating_sub(expanded_tokens.len());
             if remaining == 0 {
                 break;
             }
-            let token = tokens.get_token(token_idx);
-            let position = tokens.position(token_idx);
             // Each partition contributes at most its `remaining`
             // lexicographically smallest candidates, so the global
             // lex-smallest `remaining` selection below is unaffected by the
             // per-partition truncation.
             let mut candidates = BTreeSet::new();
-            let base_prefix_len = tokens.token_type().prefix_len(token) as u32;
-            for partition in &self.partitions {
-                partition.collect_fuzzy_candidates(
-                    token,
-                    base_prefix_len,
-                    params,
+            let mut seen_source_terms = HashSet::new();
+            for source_term in source_terms {
+                if !seen_source_terms.insert(source_term) {
+                    continue;
+                }
+                let automaton = FuzzyAutomaton::new(source_term, tokens.token_type(), params)?;
+                self.collect_fuzzy_candidates_with_automaton(
+                    &automaton,
                     remaining,
                     &mut candidates,
                 )?;
@@ -184,8 +222,10 @@ impl InvertedIndex {
 
     /// Search documents that match the query and return row ids sorted by BM25 score.
     ///
-    /// When `base_scorer` is provided, search uses those corpus-level BM25 statistics
-    /// instead of deriving them from this segment alone.
+    /// When `base_scorer` is provided for an exact query, search uses those
+    /// corpus-level BM25 statistics instead of deriving them from this segment
+    /// alone. Fuzzy queries must use [`Self::bm25_search_prepared`], because a
+    /// scorer alone does not identify the canonical capped vocabulary.
     #[instrument(level = "debug", skip_all)]
     pub async fn bm25_search(
         &self,
@@ -206,6 +246,10 @@ impl InvertedIndex {
     }
 
     /// Search logical FTS documents, retaining element coordinates when present.
+    ///
+    /// A scorer-only override is valid for exact queries. Fuzzy callers must
+    /// use [`Self::bm25_search_prepared_documents`] so the canonical vocabulary
+    /// and its statistics cannot diverge.
     #[instrument(level = "debug", skip_all)]
     pub async fn bm25_search_documents(
         &self,
@@ -279,11 +323,16 @@ impl InvertedIndex {
         base_scorer: Option<&MemBM25Scorer>,
         initial_score_floor: Option<f32>,
     ) -> Result<Vec<ScoredDoc>> {
+        if base_scorer.is_some() && uses_fuzzy_expansion(params.fuzziness) {
+            return Err(Error::invalid_input(
+                "fuzzy BM25 search cannot use an injected scorer without its prepared vocabulary; use bm25_search_prepared or bm25_search_prepared_documents",
+            ));
+        }
         // Fuzzy expansion runs once here, with the global `max_expansions`
         // budget, instead of once per partition: partitions receive the
         // final token list, so the matched terms cannot depend on how the
         // corpus happens to be partitioned.
-        let tokens = if matches!(params.fuzziness, Some(n) if n != 0) {
+        let tokens = if uses_fuzzy_expansion(params.fuzziness) {
             let expanded = Arc::new(self.expand_fuzzy_tokens(tokens.as_ref(), params.as_ref())?);
             if operator == Operator::And || params.phrase_slop.is_some() {
                 // AND/phrase semantics require every original token position
@@ -301,10 +350,6 @@ impl InvertedIndex {
             tokens
         };
 
-        // The wand only consults `scorer.doc_weight`, which is metadata-free.
-        // The outer aggregation below consults `scorer.query_weight`, which
-        // hits per-token `posting_len`; building a `MemBM25Scorer` with
-        // precomputed per-term IDFs avoids the v2 bulk metadata pull.
         let local_scorer;
         let scorer: &MemBM25Scorer = if let Some(base_scorer) = base_scorer {
             base_scorer
@@ -314,6 +359,131 @@ impl InvertedIndex {
                 .await?;
             &local_scorer
         };
+        self.bm25_search_final_documents(
+            tokens,
+            params,
+            operator,
+            prefilter,
+            metrics,
+            scorer,
+            initial_score_floor,
+        )
+        .await
+    }
+
+    /// Search with a vocabulary/scorer pair prepared once across every
+    /// physical segment. No fuzzy expansion or local scorer construction is
+    /// permitted below this boundary.
+    #[doc(hidden)]
+    pub async fn bm25_search_prepared(
+        &self,
+        prepared: Arc<crate::scalar::inverted::PreparedBm25Query>,
+        params: Arc<FtsSearchParams>,
+        operator: Operator,
+        prefilter: Arc<dyn PreFilter>,
+        metrics: Arc<dyn MetricsCollector>,
+    ) -> Result<(Vec<u64>, Vec<f32>)> {
+        let documents = self
+            .bm25_search_prepared_documents(prepared, params, operator, prefilter, metrics)
+            .await?;
+        Ok(documents
+            .into_iter()
+            .map(|document| (document.row_id, document.score.0))
+            .unzip())
+    }
+
+    /// Search logical FTS documents with a vocabulary/scorer pair prepared
+    /// once across every physical segment.
+    #[doc(hidden)]
+    pub async fn bm25_search_prepared_documents(
+        &self,
+        prepared: Arc<crate::scalar::inverted::PreparedBm25Query>,
+        params: Arc<FtsSearchParams>,
+        operator: Operator,
+        prefilter: Arc<dyn PreFilter>,
+        metrics: Arc<dyn MetricsCollector>,
+    ) -> Result<Vec<ScoredDoc>> {
+        self.bm25_search_prepared_documents_impl(
+            prepared, params, operator, prefilter, metrics, None,
+        )
+        .await
+    }
+
+    /// Search logical FTS documents with a prepared vocabulary/scorer pair and
+    /// an exclusive initial raw-score floor.
+    #[doc(hidden)]
+    #[allow(clippy::too_many_arguments)]
+    pub async fn bm25_search_prepared_documents_with_score_floor(
+        &self,
+        prepared: Arc<crate::scalar::inverted::PreparedBm25Query>,
+        params: Arc<FtsSearchParams>,
+        operator: Operator,
+        prefilter: Arc<dyn PreFilter>,
+        metrics: Arc<dyn MetricsCollector>,
+        initial_score_floor: f32,
+    ) -> Result<Vec<ScoredDoc>> {
+        if self.is_legacy() {
+            return Err(Error::invalid_input(
+                "an initial Match WAND score floor requires a modern FTS index",
+            ));
+        }
+        if !initial_score_floor.is_finite() {
+            return Err(Error::invalid_input(format!(
+                "initial Match WAND score floor must be finite, got {initial_score_floor}"
+            )));
+        }
+        self.bm25_search_prepared_documents_impl(
+            prepared,
+            params,
+            operator,
+            prefilter,
+            metrics,
+            Some(initial_score_floor),
+        )
+        .await
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    async fn bm25_search_prepared_documents_impl(
+        &self,
+        prepared: Arc<crate::scalar::inverted::PreparedBm25Query>,
+        params: Arc<FtsSearchParams>,
+        operator: Operator,
+        prefilter: Arc<dyn PreFilter>,
+        metrics: Arc<dyn MetricsCollector>,
+        initial_score_floor: Option<f32>,
+    ) -> Result<Vec<ScoredDoc>> {
+        if (operator == Operator::And || params.phrase_slop.is_some())
+            && !prepared.has_all_query_positions()
+        {
+            return Ok(Vec::new());
+        }
+        self.bm25_search_final_documents(
+            prepared.tokens().clone(),
+            params,
+            operator,
+            prefilter,
+            metrics,
+            prepared.scorer().as_ref(),
+            initial_score_floor,
+        )
+        .await
+    }
+
+    async fn bm25_search_final_documents(
+        &self,
+        tokens: Arc<Tokens>,
+        params: Arc<FtsSearchParams>,
+        operator: Operator,
+        prefilter: Arc<dyn PreFilter>,
+        metrics: Arc<dyn MetricsCollector>,
+        scorer: &MemBM25Scorer,
+        initial_score_floor: Option<f32>,
+    ) -> Result<Vec<ScoredDoc>> {
+        // The wand only consults `scorer.doc_weight`, which is metadata-free.
+        // The outer aggregation below consults `scorer.query_weight`; pairing
+        // final tokens with precomputed per-term IDFs avoids the v2 bulk
+        // metadata pull and keeps scoring aligned with the rewrite.
         let impact_scorer = Arc::new(scorer.clone());
 
         let limit = params.limit.unwrap_or(usize::MAX);

--- a/rust/lance-index/src/scalar/inverted/index/search.rs
+++ b/rust/lance-index/src/scalar/inverted/index/search.rs
@@ -470,6 +470,10 @@ impl InvertedIndex {
         .await
     }
 
+    // This is the boundary between query preparation and final document search;
+    // each argument is an independent prepared input consumed by both legacy and
+    // modern implementations.
+    #[allow(clippy::too_many_arguments)]
     async fn bm25_search_final_documents(
         &self,
         tokens: Arc<Tokens>,

--- a/rust/lance-index/src/scalar/inverted/index/tests/query.rs
+++ b/rust/lance-index/src/scalar/inverted/index/tests/query.rs
@@ -301,6 +301,448 @@ async fn write_variant_partition(
     builder.write(store.as_ref()).await.unwrap();
 }
 
+async fn write_pair_partition(
+    store: &Arc<LanceIndexStore>,
+    partition_id: u64,
+    documents: &[(&str, &str, u64)],
+) {
+    let mut builder = InnerBuilder::new(partition_id, false, TokenSetFormat::default());
+    let mut postings = BTreeMap::<String, PostingListBuilder>::new();
+    for (left, right, row_id) in documents {
+        let doc_id = builder.docs.append(*row_id, 2);
+        for token in [left, right] {
+            postings
+                .entry((*token).to_owned())
+                .or_insert_with(|| PostingListBuilder::new(false))
+                .add(doc_id, PositionRecorder::Count(1));
+        }
+    }
+    for (token, posting) in postings {
+        builder.tokens.add(token);
+        builder.posting_lists.push(posting);
+    }
+    builder.write(store.as_ref()).await.unwrap();
+}
+
+async fn load_test_index(
+    store: Arc<LanceIndexStore>,
+    partition_ids: Vec<u64>,
+) -> Arc<InvertedIndex> {
+    write_test_metadata(&store, partition_ids, InvertedIndexParams::default()).await;
+    InvertedIndex::load(store, None, &LanceCache::with_capacity(4096))
+        .await
+        .unwrap()
+}
+
+fn token_positions(tokens: &Tokens) -> Vec<(String, u32)> {
+    (0..tokens.len())
+        .map(|index| (tokens.get_token(index).to_owned(), tokens.position(index)))
+        .collect()
+}
+
+async fn prepared_results(
+    indices: &[Arc<InvertedIndex>],
+    prepared: Arc<crate::scalar::inverted::PreparedBm25Query>,
+    params: Arc<FtsSearchParams>,
+) -> Vec<(u64, u32)> {
+    let mut results = Vec::new();
+    for index in indices {
+        let documents = index
+            .bm25_search_prepared_documents(
+                prepared.clone(),
+                params.clone(),
+                Operator::And,
+                Arc::new(NoFilter),
+                Arc::new(NoOpMetricsCollector),
+            )
+            .await
+            .unwrap();
+        results.extend(
+            documents
+                .into_iter()
+                .map(|document| (document.row_id, document.score.0.to_bits())),
+        );
+    }
+    results.sort_unstable();
+    results
+}
+
+#[tokio::test]
+async fn test_canonical_fuzzy_rewrite_is_independent_of_segment_and_partition_shape() {
+    let documents = [
+        ("alpha", "beta", 100),
+        ("alpha", "betb", 101),
+        ("alphb", "beta", 102),
+        ("alphb", "betb", 103),
+        ("alphc", "beta", 104),
+        ("alphc", "betb", 105),
+        ("alphd", "beta", 106),
+        ("alphd", "betb", 107),
+    ];
+
+    let single_dir = TempObjDir::default();
+    let single_store = Arc::new(LanceIndexStore::new(
+        ObjectStore::local().into(),
+        single_dir.clone(),
+        Arc::new(LanceCache::no_cache()),
+    ));
+    write_pair_partition(&single_store, 0, &documents).await;
+    let single = vec![load_test_index(single_store, vec![0]).await];
+
+    let partitioned_dir = TempObjDir::default();
+    let partitioned_store = Arc::new(LanceIndexStore::new(
+        ObjectStore::local().into(),
+        partitioned_dir.clone(),
+        Arc::new(LanceCache::no_cache()),
+    ));
+    for (partition_id, document) in documents.iter().enumerate() {
+        write_pair_partition(
+            &partitioned_store,
+            partition_id as u64,
+            std::slice::from_ref(document),
+        )
+        .await;
+    }
+    let partitioned =
+        vec![load_test_index(partitioned_store, (0_u64..documents.len() as u64).collect()).await];
+
+    let mut segmented = Vec::with_capacity(documents.len());
+    let mut segmented_dirs = Vec::with_capacity(documents.len());
+    for document in &documents {
+        let segment_dir = TempObjDir::default();
+        let store = Arc::new(LanceIndexStore::new(
+            ObjectStore::local().into(),
+            segment_dir.clone(),
+            Arc::new(LanceCache::no_cache()),
+        ));
+        write_pair_partition(&store, 0, std::slice::from_ref(document)).await;
+        segmented.push(load_test_index(store, vec![0]).await);
+        segmented_dirs.push(segment_dir);
+    }
+
+    let params = Arc::new(
+        FtsSearchParams::new()
+            .with_limit(Some(10))
+            .with_fuzziness(Some(1))
+            .with_max_expansions(5),
+    );
+    let query_tokens = Tokens::new(vec!["alphx".to_owned(), "betx".to_owned()], DocType::Text);
+    let expected_tokens = vec![
+        ("alpha".to_owned(), 0),
+        ("alphb".to_owned(), 0),
+        ("alphc".to_owned(), 0),
+        ("alphd".to_owned(), 0),
+        ("beta".to_owned(), 1),
+    ];
+
+    let mut layouts = vec![single, partitioned, segmented.clone()];
+    let mut reversed_segments = segmented;
+    reversed_segments.reverse();
+    layouts.push(reversed_segments);
+
+    let mut all_results = Vec::new();
+    for indices in layouts {
+        let prepared = Arc::new(
+            crate::scalar::inverted::prepare_bm25_query(
+                &indices,
+                query_tokens.clone(),
+                params.as_ref(),
+                None,
+                None,
+            )
+            .await
+            .unwrap(),
+        );
+        assert_eq!(token_positions(prepared.tokens()), expected_tokens);
+        assert_eq!(prepared.scorer().total_tokens, 16);
+        assert_eq!(prepared.scorer().num_docs, 8);
+        assert_eq!(
+            prepared.scorer().token_docs,
+            HashMap::from([
+                ("alpha".to_owned(), 2),
+                ("alphb".to_owned(), 2),
+                ("alphc".to_owned(), 2),
+                ("alphd".to_owned(), 2),
+                ("beta".to_owned(), 4),
+            ])
+        );
+        all_results.push(prepared_results(&indices, prepared, params.clone()).await);
+    }
+
+    assert_eq!(
+        all_results[0]
+            .iter()
+            .map(|(row_id, _)| *row_id)
+            .collect::<Vec<_>>(),
+        vec![100, 102, 104, 106]
+    );
+    assert!(all_results.windows(2).all(|pair| pair[0] == pair[1]));
+}
+
+#[tokio::test]
+async fn test_fuzzy_injected_scorer_requires_prepared_vocabulary() {
+    let subset_dir = TempObjDir::default();
+    let subset_store = Arc::new(LanceIndexStore::new(
+        ObjectStore::local().into(),
+        subset_dir.clone(),
+        Arc::new(LanceCache::no_cache()),
+    ));
+    write_variant_partition(&subset_store, 0, &["lance"], &[100]).await;
+    let subset = load_test_index(subset_store, vec![0]).await;
+
+    let other_dir = TempObjDir::default();
+    let other_store = Arc::new(LanceIndexStore::new(
+        ObjectStore::local().into(),
+        other_dir.clone(),
+        Arc::new(LanceCache::no_cache()),
+    ));
+    write_variant_partition(&other_store, 0, &["lancd"], &[200]).await;
+    let other = load_test_index(other_store, vec![0]).await;
+
+    let params = Arc::new(
+        FtsSearchParams::new()
+            .with_limit(Some(10))
+            .with_fuzziness(Some(1))
+            .with_max_expansions(1),
+    );
+    let query_tokens = Tokens::new(vec!["lancx".to_owned()], DocType::Text);
+    let prepared = Arc::new(
+        crate::scalar::inverted::prepare_bm25_query(
+            &[subset.clone(), other],
+            query_tokens.clone(),
+            params.as_ref(),
+            None,
+            None,
+        )
+        .await
+        .unwrap(),
+    );
+    assert_eq!(
+        token_positions(prepared.tokens()),
+        vec![("lancd".to_owned(), 0)]
+    );
+
+    let error = subset
+        .bm25_search(
+            Arc::new(query_tokens),
+            params.clone(),
+            Operator::Or,
+            Arc::new(NoFilter),
+            Arc::new(NoOpMetricsCollector),
+            Some(prepared.scorer().as_ref()),
+        )
+        .await
+        .unwrap_err();
+    assert!(
+        error.to_string().contains(
+            "fuzzy BM25 search cannot use an injected scorer without its prepared vocabulary"
+        ),
+        "unexpected scorer-only fuzzy error: {error}"
+    );
+
+    let (row_ids, _) = subset
+        .bm25_search_prepared(
+            prepared,
+            params,
+            Operator::Or,
+            Arc::new(NoFilter),
+            Arc::new(NoOpMetricsCollector),
+        )
+        .await
+        .unwrap();
+    assert!(row_ids.is_empty());
+
+    let exact_tokens = Arc::new(Tokens::new(vec!["lance".to_owned()], DocType::Text));
+    let exact_params = Arc::new(FtsSearchParams::new().with_limit(Some(10)));
+    let exact_scorer = subset
+        .bm25_base_scorer(exact_tokens.as_ref(), exact_params.as_ref(), None)
+        .await
+        .unwrap();
+    let (row_ids, _) = subset
+        .bm25_search(
+            exact_tokens,
+            exact_params,
+            Operator::Or,
+            Arc::new(NoFilter),
+            Arc::new(NoOpMetricsCollector),
+            Some(&exact_scorer),
+        )
+        .await
+        .unwrap();
+    assert_eq!(row_ids, vec![100]);
+}
+
+#[tokio::test]
+async fn test_unicode_fuzzy_prefix_uses_character_boundaries() {
+    let tmpdir = TempObjDir::default();
+    let store = Arc::new(LanceIndexStore::new(
+        ObjectStore::local().into(),
+        tmpdir.clone(),
+        Arc::new(LanceCache::no_cache()),
+    ));
+    write_variant_partition(&store, 0, &["éclair"], &[100]).await;
+    let index = load_test_index(store, vec![0]).await;
+    let params = Arc::new(
+        FtsSearchParams::new()
+            .with_limit(Some(10))
+            .with_fuzziness(Some(1))
+            .with_prefix_length(1),
+    );
+
+    let (row_ids, _) = index
+        .bm25_search(
+            Arc::new(Tokens::new(vec!["éclait".to_owned()], DocType::Text)),
+            params.clone(),
+            Operator::Or,
+            Arc::new(NoFilter),
+            Arc::new(NoOpMetricsCollector),
+            None,
+        )
+        .await
+        .unwrap();
+    assert_eq!(row_ids, vec![100]);
+
+    let (row_ids, _) = index
+        .bm25_search(
+            Arc::new(Tokens::new(vec!["àclait".to_owned()], DocType::Text)),
+            params,
+            Operator::Or,
+            Arc::new(NoFilter),
+            Arc::new(NoOpMetricsCollector),
+            None,
+        )
+        .await
+        .unwrap();
+    assert!(row_ids.is_empty());
+}
+
+#[tokio::test]
+async fn test_fuzzy_expansion_uses_unicode_scalar_edit_distance() {
+    let tmpdir = TempObjDir::default();
+    let store = Arc::new(LanceIndexStore::new(
+        ObjectStore::local().into(),
+        tmpdir.clone(),
+        Arc::new(LanceCache::no_cache()),
+    ));
+    write_variant_partition(
+        &store,
+        0,
+        &["بسرعة", "café", "éclair", "êclair"],
+        &[100, 101, 102, 103],
+    )
+    .await;
+    let index = load_test_index(store, vec![0]).await;
+    let params = FtsSearchParams::new()
+        .with_fuzziness(Some(1))
+        .with_max_expansions(10);
+
+    for (query, expected) in [
+        // The inserted Arabic letter is two UTF-8 bytes but one scalar value.
+        ("بسرع", vec!["بسرعة"]),
+        // An ASCII query must still match a non-ASCII scalar substitution.
+        ("cafe", vec!["café"]),
+        // Replacing one accented scalar must cost one edit, not two bytes.
+        ("èclair", vec!["éclair", "êclair"]),
+    ] {
+        let tokens = Tokens::new(vec![query.to_owned()], DocType::Text);
+        let expanded = index.expand_fuzzy_tokens(&tokens, &params).unwrap();
+        assert_eq!(
+            token_positions(&expanded)
+                .into_iter()
+                .map(|(token, _)| token)
+                .collect::<Vec<_>>(),
+            expected,
+            "fuzzy expansion must count Unicode scalar edits for {query:?}"
+        );
+    }
+}
+
+#[tokio::test]
+async fn test_unicode_fuzzy_cap_order_is_independent_of_partition_shape() {
+    let single_dir = TempObjDir::default();
+    let single_store = Arc::new(LanceIndexStore::new(
+        ObjectStore::local().into(),
+        single_dir.clone(),
+        Arc::new(LanceCache::no_cache()),
+    ));
+    write_variant_partition(
+        &single_store,
+        0,
+        &["cafe", "cafè", "café", "cafê"],
+        &[100, 101, 102, 103],
+    )
+    .await;
+    let single = load_test_index(single_store, vec![0]).await;
+
+    let split_dir = TempObjDir::default();
+    let split_store = Arc::new(LanceIndexStore::new(
+        ObjectStore::local().into(),
+        split_dir.clone(),
+        Arc::new(LanceCache::no_cache()),
+    ));
+    write_variant_partition(&split_store, 0, &["cafè", "cafê"], &[101, 103]).await;
+    write_variant_partition(&split_store, 1, &["cafe", "café"], &[100, 102]).await;
+    let split = load_test_index(split_store, vec![0, 1]).await;
+
+    let params = FtsSearchParams::new()
+        .with_fuzziness(Some(1))
+        .with_max_expansions(3);
+    let query = Tokens::new(vec!["café".to_owned()], DocType::Text);
+    let expected = vec![
+        ("cafe".to_owned(), 0),
+        ("cafè".to_owned(), 0),
+        ("café".to_owned(), 0),
+    ];
+
+    for index in [single, split] {
+        let expanded = index.expand_fuzzy_tokens(&query, &params).unwrap();
+        assert_eq!(
+            token_positions(&expanded),
+            expected,
+            "the Unicode fuzzy cap must select the same lexicographic prefix across layouts"
+        );
+    }
+}
+
+#[tokio::test]
+async fn test_json_fuzzy_prefix_keeps_path_and_type_exact() {
+    let tmpdir = TempObjDir::default();
+    let store = Arc::new(LanceIndexStore::new(
+        ObjectStore::local().into(),
+        tmpdir.clone(),
+        Arc::new(LanceCache::no_cache()),
+    ));
+    write_variant_partition(
+        &store,
+        0,
+        &["other,str,éclair", "payload,str,éclair"],
+        &[101, 100],
+    )
+    .await;
+    let index = load_test_index(store, vec![0]).await;
+    let params = Arc::new(
+        FtsSearchParams::new()
+            .with_limit(Some(10))
+            .with_fuzziness(None)
+            .with_prefix_length(1),
+    );
+    let (row_ids, _) = index
+        .bm25_search(
+            Arc::new(Tokens::new(
+                vec!["payload,str,éclait".to_owned()],
+                DocType::Json,
+            )),
+            params,
+            Operator::Or,
+            Arc::new(NoFilter),
+            Arc::new(NoOpMetricsCollector),
+            None,
+        )
+        .await
+        .unwrap();
+    assert_eq!(row_ids, vec![100]);
+}
+
 #[tokio::test]
 async fn test_fuzzy_expansion_cap_is_global_across_partitions() {
     let tmpdir = TempObjDir::default();
@@ -333,6 +775,68 @@ async fn test_fuzzy_expansion_cap_is_global_across_partitions() {
         "max_expansions must cap the whole query across partitions, \
              in lexicographic order"
     );
+}
+
+#[tokio::test]
+async fn test_fuzzy_candidate_merge_stays_bounded_across_partitions() {
+    let tmpdir = TempObjDir::default();
+    let store = Arc::new(LanceIndexStore::new(
+        ObjectStore::local().into(),
+        tmpdir.clone(),
+        Arc::new(LanceCache::no_cache()),
+    ));
+
+    write_variant_partition(&store, 0, &["alphd", "alphe"], &[100, 101]).await;
+    write_variant_partition(&store, 1, &["alpha", "alphf"], &[102, 103]).await;
+    write_variant_partition(&store, 2, &["alphb", "alphc"], &[104, 105]).await;
+    let index = load_test_index(store, vec![0, 1, 2]).await;
+    let params = FtsSearchParams::new().with_fuzziness(Some(1));
+    let limit = 2;
+    let mut candidates = BTreeSet::new();
+    let automaton = FuzzyAutomaton::new("alphx", &DocType::Text, &params).unwrap();
+
+    index
+        .collect_fuzzy_candidates_with_automaton(&automaton, limit, &mut candidates)
+        .unwrap();
+
+    assert!(candidates.len() <= limit);
+    assert_eq!(
+        candidates,
+        BTreeSet::from(["alpha".to_owned(), "alphb".to_owned()])
+    );
+}
+
+#[tokio::test]
+async fn test_fuzzy_expansion_merges_same_position_alternatives_canonically() {
+    let tmpdir = TempObjDir::default();
+    let store = Arc::new(LanceIndexStore::new(
+        ObjectStore::local().into(),
+        tmpdir.clone(),
+        Arc::new(LanceCache::no_cache()),
+    ));
+
+    write_variant_partition(&store, 0, &["alpha", "betaa"], &[100, 101]).await;
+    let index = load_test_index(store, vec![0]).await;
+    let params = FtsSearchParams::new()
+        .with_fuzziness(Some(1))
+        .with_max_expansions(1);
+
+    let forward = Tokens::with_positions(
+        vec!["alphx".to_owned(), "betax".to_owned()],
+        vec![0, 0],
+        DocType::Text,
+    );
+    let reversed = Tokens::with_positions(
+        vec!["betax".to_owned(), "alphx".to_owned()],
+        vec![0, 0],
+        DocType::Text,
+    );
+
+    let forward = index.expand_fuzzy_tokens(&forward, &params).unwrap();
+    let reversed = index.expand_fuzzy_tokens(&reversed, &params).unwrap();
+    let expected = vec![("alpha".to_owned(), 0)];
+    assert_eq!(token_positions(&forward), expected);
+    assert_eq!(token_positions(&reversed), expected);
 }
 
 #[tokio::test]

--- a/rust/lance-index/src/scalar/inverted/query.rs
+++ b/rust/lance-index/src/scalar/inverted/query.rs
@@ -9,6 +9,49 @@ use serde::ser::SerializeMap;
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
 
+/// Return whether a Match query requires vocabulary expansion.
+///
+/// `None` selects automatic fuzziness, while `Some(0)` is the only exact
+/// Match mode. Keeping this predicate here prevents tokenization, scorer
+/// preparation, and posting search from assigning different meanings to the
+/// same wire value.
+pub fn uses_fuzzy_expansion(fuzziness: Option<u32>) -> bool {
+    fuzziness != Some(0)
+}
+
+/// Fully resolved fuzzy options for one token.
+pub(crate) struct FuzzyTermOptions<'a> {
+    pub(crate) edit_distance: u32,
+    pub(crate) exact_prefix: &'a str,
+    pub(crate) fuzzy_suffix: &'a str,
+}
+
+/// Resolve automatic edit distance and the exact prefix for one token.
+///
+/// JSON tokens have the form `path,type,value`. The path and type are always
+/// exact; automatic fuzziness and the caller's prefix length apply only to the
+/// value. Prefix lengths count Unicode scalar values, even though the returned
+/// prefix remains a byte slice for the FST automaton.
+pub(crate) fn fuzzy_term_options<'a>(
+    token: &'a str,
+    token_type: &DocType,
+    fuzziness: Option<u32>,
+    prefix_length: u32,
+) -> FuzzyTermOptions<'a> {
+    let value_start = token_type.prefix_len(token);
+    let value = &token[value_start..];
+    let edit_distance = fuzziness.unwrap_or_else(|| MatchQuery::auto_fuzziness(value));
+    let value_prefix_end = value
+        .char_indices()
+        .nth(prefix_length as usize)
+        .map_or(value.len(), |(offset, _)| offset);
+    FuzzyTermOptions {
+        edit_distance,
+        exact_prefix: &token[..value_start + value_prefix_end],
+        fuzzy_suffix: &value[value_prefix_end..],
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct FtsSearchParams {
     /// Controls result completeness for each recursively planned FTS node.
@@ -21,6 +64,8 @@ pub struct FtsSearchParams {
     pub limit: Option<usize>,
     pub wand_factor: f32,
     pub fuzziness: Option<u32>,
+    /// Final fuzzy vocabulary budget for one Match leaf across all selected
+    /// segments and partitions.
     pub max_expansions: usize,
     // None means not a phrase query
     // Some(n) means a phrase query with slop n
@@ -294,8 +339,11 @@ pub struct MatchQuery {
     // - 2 for terms with length > 5
     pub fuzziness: Option<u32>,
 
-    /// The maximum number of terms to expand for fuzzy matching.
-    /// Default to 50.
+    /// The maximum final vocabulary size for this Match leaf.
+    ///
+    /// One budget is shared across all query positions and every selected
+    /// physical segment and partition. Sibling Match leaves, including fields
+    /// of a MultiMatch query, have independent budgets. Defaults to 50.
     #[serde(default = "MatchQuery::default_max_expansions")]
     pub max_expansions: usize,
 
@@ -379,7 +427,7 @@ impl MatchQuery {
     }
 
     pub fn auto_fuzziness(token: &str) -> u32 {
-        match token.len() {
+        match token.chars().count() {
             0..=2 => 0,
             3..=5 => 1,
             _ => 2,
@@ -959,10 +1007,52 @@ pub fn fill_fts_query_column(
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+
+    #[test]
+    fn test_fuzzy_expansion_mode_and_unicode_auto_boundaries() {
+        assert!(!uses_fuzzy_expansion(Some(0)));
+        assert!(uses_fuzzy_expansion(Some(1)));
+        assert!(uses_fuzzy_expansion(None));
+
+        for (token, expected) in [
+            ("ab", 0),
+            ("abc", 1),
+            ("abcde", 1),
+            ("abcdef", 2),
+            ("你好", 0),
+            ("你好啊", 1),
+            ("你好啊世界", 1),
+            ("你好啊世界呀", 2),
+        ] {
+            assert_eq!(
+                MatchQuery::auto_fuzziness(token),
+                expected,
+                "unexpected automatic fuzziness for {token:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_json_fuzzy_options_keep_path_and_type_exact() {
+        let automatic = fuzzy_term_options("payload,str,éclair", &DocType::Json, None, 1);
+        assert_eq!(automatic.edit_distance, 2);
+        assert_eq!(automatic.exact_prefix, "payload,str,é");
+        assert_eq!(automatic.fuzzy_suffix, "clair");
+
+        let explicit = fuzzy_term_options("payload,str,éclair", &DocType::Json, Some(1), 0);
+        assert_eq!(explicit.edit_distance, 1);
+        assert_eq!(explicit.exact_prefix, "payload,str,");
+        assert_eq!(explicit.fuzzy_suffix, "éclair");
+
+        let text = fuzzy_term_options("éclair", &DocType::Text, None, 1);
+        assert_eq!(text.edit_distance, 2);
+        assert_eq!(text.exact_prefix, "é");
+        assert_eq!(text.fuzzy_suffix, "clair");
+    }
+
     #[test]
     fn test_boolean_query_introspection_includes_must_not() {
-        use super::*;
-
         let implicit = MatchQuery::new("exclude".to_string())
             .with_boost(3.0)
             .with_fuzziness(Some(1))

--- a/rust/lance/src/dataset/scanner.rs
+++ b/rust/lance/src/dataset/scanner.rs
@@ -360,6 +360,41 @@ fn normalize_fts_zero_boosts(query: &mut FtsQuery) {
     }
 }
 
+/// Keep AUTO fuzziness exact at the public dataset-planning boundary.
+///
+/// Low-level index preparation already understands `fuzziness=None`, but a
+/// partial dataset plan must prepare one vocabulary across indexed and current
+/// unindexed rows. AUTO activation is deferred until OSS-2105 lands that
+/// current-row preparation atomically. Until then, recursively rewrite AUTO to
+/// exact while preserving explicit positive fuzziness.
+fn apply_dataset_planner_auto_fuzziness_compatibility_gate(query: &mut FtsQuery) {
+    match query {
+        FtsQuery::Match(query) => {
+            query.fuzziness.get_or_insert(0);
+        }
+        FtsQuery::Phrase(_) => {}
+        FtsQuery::Boost(query) => {
+            apply_dataset_planner_auto_fuzziness_compatibility_gate(&mut query.positive);
+            apply_dataset_planner_auto_fuzziness_compatibility_gate(&mut query.negative);
+        }
+        FtsQuery::MultiMatch(query) => {
+            for match_query in &mut query.match_queries {
+                match_query.fuzziness.get_or_insert(0);
+            }
+        }
+        FtsQuery::Boolean(query) => {
+            for child in query
+                .should
+                .iter_mut()
+                .chain(&mut query.must)
+                .chain(&mut query.must_not)
+            {
+                apply_dataset_planner_auto_fuzziness_compatibility_gate(child);
+            }
+        }
+    }
+}
+
 /// Parse an environment variable as a specific type, logging a warning on parse failure.
 fn parse_env_var<T: std::str::FromStr>(env_var_name: &str, default_val: &str) -> Option<T>
 where
@@ -4113,6 +4148,7 @@ impl Scanner {
             resolved.query = fill_fts_query_column(&resolved.query, &indexed_columns, false)?;
             Self::set_missing_query_granularity(&mut resolved.query, DocumentGranularity::Row);
         }
+        apply_dataset_planner_auto_fuzziness_compatibility_gate(&mut resolved.query);
         resolved.query = self
             .resolve_fts_query_document_granularity(resolved.query)
             .await?;
@@ -7209,6 +7245,69 @@ mod test {
         assert_eq!(boost_bits(&query), vec![nz, nz, nz, nz, b2, b3, nz, b4]);
         normalize_fts_zero_boosts(&mut query);
         assert_eq!(boost_bits(&query), vec![pz, pz, pz, pz, b2, b3, pz, b4]);
+    }
+
+    #[test]
+    fn test_dataset_planner_defers_auto_fuzziness_recursively() {
+        fn collect_fuzziness(query: &FtsQuery, values: &mut Vec<Option<u32>>) {
+            match query {
+                FtsQuery::Match(query) => values.push(query.fuzziness),
+                FtsQuery::Phrase(_) => {}
+                FtsQuery::Boost(query) => {
+                    collect_fuzziness(&query.positive, values);
+                    collect_fuzziness(&query.negative, values);
+                }
+                FtsQuery::MultiMatch(query) => {
+                    values.extend(query.match_queries.iter().map(|query| query.fuzziness));
+                }
+                FtsQuery::Boolean(query) => {
+                    for child in query
+                        .should
+                        .iter()
+                        .chain(&query.must)
+                        .chain(&query.must_not)
+                    {
+                        collect_fuzziness(child, values);
+                    }
+                }
+            }
+        }
+
+        let auto_match = |terms: &str| {
+            MatchQuery::new(terms.to_owned())
+                .with_fuzziness(None)
+                .into()
+        };
+        let mut multi_match = MultiMatchQuery::try_new(
+            "multi".to_owned(),
+            vec!["title".to_owned(), "body".to_owned()],
+        )
+        .unwrap();
+        multi_match.match_queries[0].fuzziness = None;
+        multi_match.match_queries[1].fuzziness = Some(1);
+        let boost = BoostQuery::new(
+            auto_match("positive"),
+            MatchQuery::new("negative".to_owned())
+                .with_fuzziness(Some(0))
+                .into(),
+            None,
+        );
+        let mut query: FtsQuery = BooleanQuery::new([
+            (Occur::Should, auto_match("root")),
+            (Occur::Must, FtsQuery::MultiMatch(multi_match)),
+            (Occur::MustNot, boost.into()),
+        ])
+        .into();
+
+        apply_dataset_planner_auto_fuzziness_compatibility_gate(&mut query);
+
+        let mut fuzziness = Vec::new();
+        collect_fuzziness(&query, &mut fuzziness);
+        assert_eq!(
+            fuzziness,
+            [Some(0), Some(0), Some(1), Some(0), Some(0)],
+            "AUTO must become exact without changing explicit fuzzy or exact leaves"
+        );
     }
 
     #[test]

--- a/rust/lance/src/dataset/tests/dataset_index.rs
+++ b/rust/lance/src/dataset/tests/dataset_index.rs
@@ -1938,6 +1938,152 @@ async fn test_top_level_cross_column_multimatch_uses_field_local_compound_scorer
 }
 
 #[tokio::test]
+async fn test_multimatch_fields_have_independent_fuzzy_expansion_budgets() {
+    let batch = arrow_array::record_batch!(
+        ("title", Utf8, ["alpha", "nothing"]),
+        ("body", Utf8, ["nothing", "alphi"]),
+        ("id", Int32, [0, 1])
+    )
+    .unwrap();
+    let schema = batch.schema();
+    let mut dataset = Dataset::write(
+        RecordBatchIterator::new(vec![batch].into_iter().map(Ok), schema),
+        "memory://",
+        None,
+    )
+    .await
+    .unwrap();
+    create_fragmented_fts_index(&mut dataset, "title", true).await;
+    create_fragmented_fts_index(&mut dataset, "body", true).await;
+
+    let fuzzy_multimatch = || {
+        let mut query = MultiMatchQuery::try_new(
+            "alphx".to_owned(),
+            vec!["title".to_owned(), "body".to_owned()],
+        )
+        .unwrap();
+        for field in &mut query.match_queries {
+            field.fuzziness = Some(1);
+            field.max_expansions = 1;
+        }
+        query
+    };
+
+    let top_level: FtsQuery = fuzzy_multimatch().into();
+    let top_level_plan = compound_fts_plan(&dataset, top_level.clone(), 10).await;
+    assert!(top_level_plan.matches("CompoundFtsScorer").count() >= 2);
+    assert!(!top_level_plan.contains(CROSS_COLUMN_COMPOUND_FTS_SCORER));
+    let top_level_results = compound_fts_results(&dataset, top_level, Some(10)).await;
+    assert_eq!(top_level_results.len(), 2);
+
+    let nested: FtsQuery =
+        BooleanQuery::new([(Occur::Must, FtsQuery::MultiMatch(fuzzy_multimatch()))]).into();
+    let nested_plan = compound_fts_plan(&dataset, nested.clone(), 10).await;
+    assert!(nested_plan.contains(CROSS_COLUMN_COMPOUND_FTS_SCORER));
+    let nested_results = compound_fts_results(&dataset, nested, Some(10)).await;
+    assert_scored_rows_close(
+        "multimatch_independent_fuzzy_budgets",
+        &nested_results,
+        &top_level_results,
+    );
+}
+
+#[tokio::test]
+async fn test_dataset_planner_defers_auto_fuzziness_for_partial_indices() {
+    let indexed = arrow_array::record_batch!(
+        ("title", Utf8, ["alpha"]),
+        ("body", Utf8, ["alpha"]),
+        ("id", Int32, [0])
+    )
+    .unwrap();
+    let schema = indexed.schema();
+    let mut dataset = Dataset::write(
+        RecordBatchIterator::new(vec![indexed].into_iter().map(Ok), schema),
+        "memory://",
+        None,
+    )
+    .await
+    .unwrap();
+    create_fragmented_fts_index(&mut dataset, "title", true).await;
+    create_fragmented_fts_index(&mut dataset, "body", true).await;
+
+    let unindexed = arrow_array::record_batch!(
+        ("title", Utf8, ["alpha"]),
+        ("body", Utf8, ["alpha"]),
+        ("id", Int32, [1])
+    )
+    .unwrap();
+    let schema = unindexed.schema();
+    dataset
+        .append(
+            RecordBatchIterator::new(vec![unindexed].into_iter().map(Ok), schema),
+            None,
+        )
+        .await
+        .unwrap();
+
+    let auto_match = |terms: &str| -> FtsQuery {
+        MatchQuery::new(terms.to_owned())
+            .with_column(Some("title".to_owned()))
+            .with_fuzziness(None)
+            .into()
+    };
+    let auto_multimatch = |terms: &str| {
+        let mut query = MultiMatchQuery::try_new(
+            terms.to_owned(),
+            vec!["title".to_owned(), "body".to_owned()],
+        )
+        .unwrap();
+        for match_query in &mut query.match_queries {
+            match_query.fuzziness = None;
+        }
+        query
+    };
+
+    for (case_name, query, expected_ids) in [
+        ("match_exact", auto_match("ALPHA"), &[0, 1][..]),
+        ("match_typo", auto_match("alphx"), &[][..]),
+        (
+            "multimatch_exact",
+            FtsQuery::MultiMatch(auto_multimatch("ALPHA")),
+            &[0, 1][..],
+        ),
+        (
+            "multimatch_typo",
+            FtsQuery::MultiMatch(auto_multimatch("alphx")),
+            &[][..],
+        ),
+        (
+            "nested_multimatch_exact",
+            BooleanQuery::new([(Occur::Must, FtsQuery::MultiMatch(auto_multimatch("ALPHA")))])
+                .into(),
+            &[0, 1][..],
+        ),
+        (
+            "nested_multimatch_typo",
+            BooleanQuery::new([(Occur::Must, FtsQuery::MultiMatch(auto_multimatch("alphx")))])
+                .into(),
+            &[][..],
+        ),
+    ] {
+        let batch = dataset
+            .scan()
+            .project(&["id"])
+            .unwrap()
+            .full_text_search(FullTextSearchQuery::new_query(query).limit(Some(10)))
+            .unwrap()
+            .try_into_batch()
+            .await
+            .unwrap();
+        assert_eq!(
+            batch["id"].as_primitive::<Int32Type>().values(),
+            expected_ids,
+            "indexed and unindexed rows diverged for {case_name}"
+        );
+    }
+}
+
+#[tokio::test]
 async fn test_field_local_match_wand_exactness_certificates() {
     let mut dataset = write_cross_column_compound_dataset().await;
     create_fragmented_fts_index_with_order(&mut dataset, "title", true, true).await;
@@ -2124,6 +2270,61 @@ async fn test_field_local_match_wand_exactness_certificates() {
             .get(WAND_EXACTNESS_CERTIFICATE_CANDIDATES_METRIC),
         Some(&3)
     );
+
+    for (
+        case_name,
+        exact_term,
+        fuzzy_term,
+        limit,
+        expected_strict,
+        expected_exhaustive,
+        expected_fallbacks,
+    ) in [
+        ("strict", "alpha", "alphx", 1, 1, 1, 0),
+        ("exhaustive", "tiebody", "tiebodx", 3, 0, 2, 0),
+        ("ambiguous", "tie", "tix", 1, 0, 1, 1),
+    ] {
+        let exact =
+            compound_fts_results(&dataset, field_local_query(exact_term), Some(limit)).await;
+        let mut fuzzy = MultiMatchQuery::try_new(
+            fuzzy_term.to_owned(),
+            vec!["title".to_owned(), "body".to_owned()],
+        )
+        .unwrap();
+        for query in &mut fuzzy.match_queries {
+            query.fuzziness = Some(1);
+        }
+        let (actual, stats) = compound_fts_results_with_stats(&dataset, fuzzy.into(), limit).await;
+        assert_scored_rows_close(
+            &format!("fuzzy_wand_certificate_{case_name}"),
+            &actual,
+            &exact,
+        );
+        assert_eq!(
+            stats
+                .all_counts
+                .get(WAND_EXACTNESS_CERTIFICATE_ATTEMPTS_METRIC),
+            Some(&2),
+            "{case_name} fuzzy query must attempt one certificate per field"
+        );
+        for (metric, expected) in [
+            (WAND_EXACTNESS_CERTIFICATE_STRICT_METRIC, expected_strict),
+            (
+                WAND_EXACTNESS_CERTIFICATE_EXHAUSTIVE_METRIC,
+                expected_exhaustive,
+            ),
+            (
+                WAND_EXACTNESS_CERTIFICATE_FALLBACKS_METRIC,
+                expected_fallbacks,
+            ),
+        ] {
+            assert_eq!(
+                stats.all_counts.get(metric),
+                Some(&expected),
+                "{case_name} fuzzy query used the wrong certificate path for {metric}"
+            );
+        }
+    }
 
     let zero_boost_query: FtsQuery = MultiMatchQuery::try_new(
         "blocked".to_owned(),

--- a/rust/lance/src/dataset/tests/dataset_index.rs
+++ b/rust/lance/src/dataset/tests/dataset_index.rs
@@ -2282,7 +2282,7 @@ async fn test_field_local_match_wand_exactness_certificates() {
     ) in [
         ("strict", "alpha", "alphx", 1, 1, 1, 0),
         ("exhaustive", "tiebody", "tiebodx", 3, 0, 2, 0),
-        ("ambiguous", "tie", "tix", 1, 0, 1, 1),
+        ("ambiguous", "tie", "tix", 1, 0, 2, 0),
     ] {
         let exact =
             compound_fts_results(&dataset, field_local_query(exact_term), Some(limit)).await;

--- a/rust/lance/src/io/exec/fts.rs
+++ b/rust/lance/src/io/exec/fts.rs
@@ -4821,7 +4821,7 @@ mod tests {
     use lance_core::{ROW_ID, utils::address::RowAddress};
     use lance_datafusion::datagen::DatafusionDatagenExt;
     use lance_datafusion::exec::{ExecutionStatsCallback, ExecutionSummaryCounts};
-    use lance_datafusion::utils::{MetricsExt, PARTITIONS_SEARCHED_METRIC};
+    use lance_datafusion::utils::PARTITIONS_SEARCHED_METRIC;
     use lance_datagen::{BatchCount, ByteCount, RowCount};
     use lance_index::metrics::{MetricsCollector, NoOpMetricsCollector};
     use lance_index::scalar::inverted::builder::ScoredDoc;

--- a/rust/lance/src/io/exec/fts.rs
+++ b/rust/lance/src/io/exec/fts.rs
@@ -67,15 +67,15 @@ use lance_index::scalar::inverted::builder::document_input;
 use lance_index::scalar::inverted::document_tokenizer::{DocType, JsonTokenizer, LanceTokenizer};
 use lance_index::scalar::inverted::query::{
     BoostQuery, FtsQuery, FtsQueryNode, FtsSearchParams, MatchQuery, Operator, PhraseQuery, Tokens,
-    collect_query_tokens, has_query_token,
+    collect_query_tokens, has_query_token, uses_fuzzy_expansion,
 };
 use lance_index::scalar::inverted::tokenizer::document_tokenizer::TextTokenizer;
 use lance_index::scalar::inverted::{
     DOC_INDEX_COL, DocumentGranularity, FTS_SCHEMA, FlatBm25SearchOptions, InvertedIndex,
-    MemBM25Scorer, SCORE_COL, Scorer, build_global_bm25_scorer, compound_search,
-    compound_search_with_base_scorer, compound_search_with_base_scorer_and_score_floor,
-    cross_column_compound_search, exclusive_scaled_score_floor,
-    flat_bm25_search_stream_with_options_and_scorer, fts_schema,
+    MemBM25Scorer, PreparedBm25Query, SCORE_COL, Scorer, build_global_bm25_scorer, compound_search,
+    compound_search_prepared_match, compound_search_prepared_match_with_score_floor,
+    compound_search_with_base_scorer, cross_column_compound_search, exclusive_scaled_score_floor,
+    flat_bm25_search_stream_with_options_and_scorer, fts_schema, prepare_bm25_query,
 };
 use lance_index::{prefilter::PreFilter, scalar::inverted::query::BooleanQuery};
 use lance_tokenizer::{SimpleTokenizer, TextAnalyzer};
@@ -308,12 +308,75 @@ async fn open_fts_segments(
     .await
 }
 
+async fn search_prepared_segments(
+    indices: &[Arc<InvertedIndex>],
+    prepared: Arc<PreparedMatch>,
+    pre_filter: Arc<dyn PreFilter>,
+    metrics: Arc<FtsIndexMetrics>,
+    initial_score_floor: Option<f32>,
+) -> Result<Vec<ScoredDoc>> {
+    let limit = prepared.params.limit.unwrap_or(usize::MAX);
+    let mut candidates = std::collections::BinaryHeap::new();
+    let searches = indices
+        .iter()
+        .map(|index| {
+            let index = Arc::clone(index);
+            let prepared = prepared.clone();
+            let pre_filter = pre_filter.clone();
+            let metrics = metrics.clone();
+            async move {
+                if let Some(initial_score_floor) = initial_score_floor {
+                    index
+                        .bm25_search_prepared_documents_with_score_floor(
+                            prepared.query.clone(),
+                            prepared.params.clone(),
+                            prepared.operator,
+                            pre_filter,
+                            metrics,
+                            initial_score_floor,
+                        )
+                        .await
+                } else {
+                    index
+                        .bm25_search_prepared_documents(
+                            prepared.query.clone(),
+                            prepared.params.clone(),
+                            prepared.operator,
+                            pre_filter,
+                            metrics,
+                        )
+                        .await
+                }
+            }
+        })
+        .collect::<Vec<_>>();
+    let searches = stream::iter(searches).buffer_unordered(get_num_compute_intensive_cpus());
+    let mut searches = searches;
+
+    while let Some(documents) = searches.try_next().await? {
+        for document in documents {
+            if candidates.len() < limit {
+                candidates.push(std::cmp::Reverse(document));
+            } else if candidates.peek().unwrap().0.score < document.score {
+                candidates.pop();
+                candidates.push(std::cmp::Reverse(document));
+            }
+        }
+    }
+
+    Ok(candidates
+        .into_sorted_vec()
+        .into_iter()
+        .map(|std::cmp::Reverse(document)| document)
+        .collect())
+}
+
 #[allow(clippy::too_many_arguments)]
 async fn search_segments(
     indices: &[Arc<InvertedIndex>],
     tokens: Arc<Tokens>,
     params: Arc<FtsSearchParams>,
-    operator: lance_index::scalar::inverted::query::Operator,
+    operator: Operator,
     pre_filter: Arc<dyn PreFilter>,
     metrics: Arc<FtsIndexMetrics>,
     base_scorer: Arc<MemBM25Scorer>,
@@ -377,6 +440,33 @@ async fn search_segments(
         .into_iter()
         .map(|std::cmp::Reverse(document)| document)
         .collect())
+}
+
+#[derive(Clone)]
+struct PreparedMatch {
+    query: Arc<PreparedBm25Query>,
+    params: Arc<FtsSearchParams>,
+    operator: Operator,
+}
+
+impl PreparedMatch {
+    async fn new(
+        indices: &[Arc<InvertedIndex>],
+        tokens: Tokens,
+        params: FtsSearchParams,
+        operator: Operator,
+        metrics: &FtsIndexMetrics,
+        base_scorer: Option<Arc<MemBM25Scorer>>,
+    ) -> Result<Self> {
+        let query = Arc::new(
+            prepare_bm25_query(indices, tokens, &params, Some(metrics), base_scorer).await?,
+        );
+        Ok(Self {
+            query,
+            params: Arc::new(params),
+            operator,
+        })
+    }
 }
 
 fn scored_documents_batch(schema: SchemaRef, documents: Vec<ScoredDoc>) -> Result<RecordBatch> {
@@ -559,6 +649,27 @@ fn compound_leaf_columns(query: &FtsQuery) -> Result<Vec<&str>> {
     Ok(columns)
 }
 
+fn compound_query_uses_fuzzy_expansion(query: &FtsQuery) -> bool {
+    match query {
+        FtsQuery::Match(query) => uses_fuzzy_expansion(query.fuzziness),
+        FtsQuery::Phrase(_) => false,
+        FtsQuery::Boost(query) => {
+            compound_query_uses_fuzzy_expansion(&query.positive)
+                || compound_query_uses_fuzzy_expansion(&query.negative)
+        }
+        FtsQuery::MultiMatch(query) => query
+            .match_queries
+            .iter()
+            .any(|query| uses_fuzzy_expansion(query.fuzziness)),
+        FtsQuery::Boolean(query) => query
+            .should
+            .iter()
+            .chain(&query.must)
+            .chain(&query.must_not)
+            .any(compound_query_uses_fuzzy_expansion),
+    }
+}
+
 /// One DataFusion boundary around a posting-backed compound scorer tree.
 #[derive(Debug)]
 pub struct CompoundQueryExec {
@@ -570,6 +681,10 @@ pub struct CompoundQueryExec {
     /// When set, leaf scorers use this instead of building one from the
     /// searched segments — see [`MatchQueryExec::with_base_scorer`].
     base_scorer: Option<Arc<MemBM25Scorer>>,
+    /// Canonical vocabulary/scorer pair for a root Match query prepared over
+    /// the complete corpus before this exec was restricted to a segment
+    /// subset.
+    prepared_match: Option<Arc<PreparedBm25Query>>,
     segment_selection: FtsSegmentSelection,
     /// Caller-supplied row-address mask, intersected into the prefilter so the
     /// compound scorer ranks only surviving rows (see
@@ -626,6 +741,7 @@ impl CompoundQueryExec {
             params,
             prefilter_source,
             base_scorer: None,
+            prepared_match: None,
             segment_selection,
             external_mask: None,
             properties: Arc::new(PlanProperties::new(
@@ -650,6 +766,19 @@ impl CompoundQueryExec {
     /// expansions. Execution returns an error when any required token is absent.
     pub fn with_base_scorer(mut self, scorer: Arc<MemBM25Scorer>) -> Self {
         self.base_scorer = Some(scorer);
+        self.prepared_match = None;
+        self
+    }
+
+    /// Override root-Match preparation with one canonical vocabulary/scorer
+    /// pair built against the complete corpus.
+    ///
+    /// This is required for distributed fuzzy execution over a segment subset;
+    /// a scorer alone cannot preserve the globally capped rewrite.
+    #[doc(hidden)]
+    pub fn with_prepared_match(mut self, prepared: Arc<PreparedBm25Query>) -> Self {
+        self.prepared_match = Some(prepared);
+        self.base_scorer = None;
         self
     }
 
@@ -752,28 +881,28 @@ fn count_smaller_row_id_replacements(
         .count()
 }
 
-async fn exact_match_fallback(
+async fn exact_prepared_match_fallback(
     indices: &[Arc<InvertedIndex>],
     query: &FtsQuery,
     params: &FtsSearchParams,
     prefilter: Arc<dyn PreFilter>,
     metrics: Arc<FtsIndexMetrics>,
-    base_scorer: Arc<MemBM25Scorer>,
+    prepared_match: Arc<PreparedBm25Query>,
     score_floor: Option<f32>,
 ) -> Result<(Vec<u64>, Vec<f32>)> {
     if let Some(score_floor) = score_floor {
-        compound_search_with_base_scorer_and_score_floor(
+        compound_search_prepared_match_with_score_floor(
             indices,
             query,
             params,
             prefilter,
             metrics,
-            base_scorer,
+            prepared_match,
             score_floor,
         )
         .await
     } else {
-        compound_search_with_base_scorer(indices, query, params, prefilter, metrics, base_scorer)
+        compound_search_prepared_match(indices, query, params, prefilter, metrics, prepared_match)
             .await
     }
 }
@@ -851,6 +980,7 @@ impl ExecutionPlan for CompoundQueryExec {
             params: self.params.clone(),
             prefilter_source,
             base_scorer: self.base_scorer.clone(),
+            prepared_match: self.prepared_match.clone(),
             segment_selection: self.segment_selection.clone(),
             external_mask: self.external_mask.clone(),
             properties: self.properties.clone(),
@@ -869,7 +999,8 @@ impl ExecutionPlan for CompoundQueryExec {
         let tokenized_query = self.tokenized_query.clone();
         let params = self.params.clone();
         let prefilter_source = self.prefilter_source.clone();
-        let base_scorer = self.base_scorer.clone();
+        let preset_base_scorer = self.base_scorer.clone();
+        let preset_prepared_match = self.prepared_match.clone();
         let segment_selection = self.segment_selection.clone();
         let external_mask = self.external_mask.clone();
         let metrics = Arc::new(FtsIndexMetrics::new(&self.metrics, partition));
@@ -895,6 +1026,21 @@ impl ExecutionPlan for CompoundQueryExec {
                     &metrics.segment_bind_duration,
                 )
                 .await?;
+            if preset_prepared_match.is_some() && !matches!(&query, FtsQuery::Match(_)) {
+                return Err(DataFusionError::Execution(
+                    "CompoundQueryExec prepared vocabulary requires a root Match query".to_string(),
+                ));
+            }
+            let scorer_only_fuzzy = preset_prepared_match.is_none()
+                && compound_query_uses_fuzzy_expansion(&query)
+                && preset_base_scorer.is_some();
+            let scorer_override_covers_all = if scorer_only_fuzzy {
+                segment_selection
+                    .covers_all_committed(&dataset, column, DocumentGranularity::Row, &segments)
+                    .await?
+            } else {
+                true
+            };
             let _details = load_segment_details(&dataset, column, &segments).await?;
             let indices =
                 open_fts_segments(&dataset, column, &segments, &metrics.index_metrics).await?;
@@ -934,6 +1080,16 @@ impl ExecutionPlan for CompoundQueryExec {
                     .sum::<usize>()
                     .saturating_mul(count_fts_leaves(&query)),
             );
+            let base_scorer = match (preset_prepared_match.is_some(), preset_base_scorer) {
+                (true, _) => None,
+                (false, scorer) => scorer,
+            };
+            if base_scorer.is_some() && scorer_only_fuzzy && !scorer_override_covers_all {
+                return Err(DataFusionError::Execution(
+                    "fuzzy CompoundQueryExec cannot use a scorer-only override over a segment subset; prepare the canonical vocabulary with prepare_bm25_query and pass it with with_prepared_match"
+                    .to_string(),
+                ));
+            }
             let certificate_limit = match (&query, params.limit) {
                 (FtsQuery::Match(match_query), Some(limit))
                     if limit > 0
@@ -954,45 +1110,55 @@ impl ExecutionPlan for CompoundQueryExec {
             let (row_ids, scores) = if let Some((match_query, limit, wand_limit)) =
                 certificate_limit
             {
-                let first_index = indices.first().ok_or_else(|| {
-                    DataFusionError::Execution(format!(
-                        "FTS index for column {column} has no segments"
-                    ))
-                })?;
-                let mut tokenizer =
-                    tokenizer_for_match_query(first_index.as_ref(), match_query.fuzziness);
-                let tokens = Arc::new(collect_query_tokens(&match_query.terms, &mut tokenizer));
-                let base_wand_params =
-                    MatchQueryExec::effective_params(&match_query, params.clone())
-                        .with_phrase_slop(None)
-                        .with_limit(Some(wand_limit));
-                let scorer_start = std::time::Instant::now();
-                let base_scorer = Arc::new(
-                    build_global_bm25_scorer(
-                        &indices,
-                        tokens.as_ref(),
-                        &base_wand_params,
-                        Some(metrics.as_ref()),
-                    )
-                    .await?,
-                );
-                metrics.record_scorer_build(scorer_start.elapsed());
+                let wand_params = MatchQueryExec::effective_params(&match_query, params.clone())
+                    .with_phrase_slop(None)
+                    .with_limit(Some(wand_limit));
+                let prepared = if let Some(prepared_match) = preset_prepared_match.clone() {
+                    Arc::new(PreparedMatch {
+                        query: prepared_match,
+                        params: Arc::new(wand_params),
+                        operator: match_query.operator,
+                    })
+                } else {
+                    let first_index = indices.first().ok_or_else(|| {
+                        DataFusionError::Execution(format!(
+                            "FTS index for column {column} has no segments"
+                        ))
+                    })?;
+                    let mut tokenizer =
+                        tokenizer_for_match_query(first_index.as_ref(), match_query.fuzziness);
+                    let tokens = collect_query_tokens(&match_query.terms, &mut tokenizer);
+                    let scorer_start = std::time::Instant::now();
+                    let prepared = Arc::new(
+                        PreparedMatch::new(
+                            &indices,
+                            tokens,
+                            wand_params,
+                            match_query.operator,
+                            metrics.as_ref(),
+                            None,
+                        )
+                        .await?,
+                    );
+                    metrics.record_scorer_build(scorer_start.elapsed());
+                    prepared
+                };
 
                 // Zero-weight terms can match documents without contributing a
                 // positive score. A short score-only WAND result therefore does
                 // not prove exhaustion. Preserve exact membership semantics for
                 // those rare corpora without recording a certificate attempt.
-                if base_scorer.token_docs.keys().any(|token| {
-                    let weight = base_scorer.query_weight(token);
+                if prepared.query.scorer().token_docs.keys().any(|token| {
+                    let weight = prepared.query.scorer().query_weight(token);
                     !weight.is_finite() || weight <= 0.0
                 }) {
-                    compound_search_with_base_scorer(
+                    compound_search_prepared_match(
                         &indices,
                         &query,
                         &params,
                         prefilter,
                         metrics.clone(),
-                        base_scorer,
+                        prepared.query.clone(),
                     )
                     .await?
                 } else {
@@ -1000,14 +1166,11 @@ impl ExecutionPlan for CompoundQueryExec {
                     prefilter.wait_for_ready().await?;
                     let probe_start = std::time::Instant::now();
                     let probe_comparisons = metrics.index_metrics.comparisons();
-                    let mut documents = search_segments(
+                    let mut documents = search_prepared_segments(
                         &indices,
-                        tokens.clone(),
-                        Arc::new(base_wand_params.clone()),
-                        match_query.operator,
+                        prepared.clone(),
                         prefilter.clone(),
                         metrics.clone(),
-                        base_scorer.clone(),
                         None,
                     )
                     .await?;
@@ -1043,21 +1206,26 @@ impl ExecutionPlan for CompoundQueryExec {
                                 (score_floor, completion_limit)
                             {
                                 metrics.record_wand_tie_completion_attempts(1);
-                                let completion_params = Arc::new(
-                                    base_wand_params.clone().with_limit(Some(completion_limit)),
-                                );
+                                let completion_prepared = Arc::new(PreparedMatch {
+                                    query: prepared.query.clone(),
+                                    params: Arc::new(
+                                        prepared
+                                            .params
+                                            .as_ref()
+                                            .clone()
+                                            .with_limit(Some(completion_limit)),
+                                    ),
+                                    operator: prepared.operator,
+                                });
                                 let completion_start = std::time::Instant::now();
                                 let completion_comparisons = metrics.index_metrics.comparisons();
                                 let raw_score_floor =
                                     exclusive_scaled_score_floor(score_floor, match_query.boost);
-                                let mut completion = search_segments(
+                                let mut completion = search_prepared_segments(
                                     &indices,
-                                    tokens,
-                                    completion_params,
-                                    match_query.operator,
+                                    completion_prepared,
                                     prefilter.clone(),
                                     metrics.clone(),
-                                    base_scorer.clone(),
                                     raw_score_floor,
                                 )
                                 .await?;
@@ -1114,13 +1282,13 @@ impl ExecutionPlan for CompoundQueryExec {
                                         let fallback_start = std::time::Instant::now();
                                         let fallback_comparisons =
                                             metrics.index_metrics.comparisons();
-                                        let results = exact_match_fallback(
+                                        let results = exact_prepared_match_fallback(
                                             &indices,
                                             &query,
                                             &params,
                                             prefilter,
                                             metrics.clone(),
-                                            base_scorer,
+                                            prepared.query.clone(),
                                             seeded_floor,
                                         )
                                         .await?;
@@ -1145,13 +1313,13 @@ impl ExecutionPlan for CompoundQueryExec {
                                 }
                                 let fallback_start = std::time::Instant::now();
                                 let fallback_comparisons = metrics.index_metrics.comparisons();
-                                let results = exact_match_fallback(
+                                let results = exact_prepared_match_fallback(
                                     &indices,
                                     &query,
                                     &params,
                                     prefilter,
                                     metrics.clone(),
-                                    base_scorer,
+                                    prepared.query.clone(),
                                     score_floor,
                                 )
                                 .await?;
@@ -1170,8 +1338,19 @@ impl ExecutionPlan for CompoundQueryExec {
                     }
                 }
             } else {
-                match base_scorer {
-                    Some(base_scorer) => {
+                match (preset_prepared_match, base_scorer) {
+                    (Some(prepared_match), _) => {
+                        compound_search_prepared_match(
+                            &indices,
+                            &query,
+                            &params,
+                            prefilter,
+                            metrics.clone(),
+                            prepared_match,
+                        )
+                        .await?
+                    }
+                    (None, Some(base_scorer)) => {
                         compound_search_with_base_scorer(
                             &indices,
                             &query,
@@ -1182,7 +1361,7 @@ impl ExecutionPlan for CompoundQueryExec {
                         )
                         .await?
                     }
-                    None => {
+                    (None, None) => {
                         compound_search(&indices, &query, &params, prefilter, metrics.clone())
                             .await?
                     }
@@ -1603,7 +1782,10 @@ fn tokenizer_for_match_query(
     index: &InvertedIndex,
     fuzziness: Option<u32>,
 ) -> Box<dyn LanceTokenizer> {
-    if !matches!(fuzziness, Some(distance) if distance != 0) {
+    // Preserve the legacy explicit-fuzzy behavior, while AUTO fuzziness uses
+    // the index analyzer so its source terms share the indexed vocabulary's
+    // normalization and filtering.
+    if !matches!(fuzziness, Some(distance) if distance > 0) {
         return index.tokenizer();
     }
 
@@ -1850,6 +2032,34 @@ impl FtsSegmentSelection {
             Self::ExactResolved(segments) => Some(segments),
             Self::AllCommitted | Self::ExactUuids(_) => None,
         }
+    }
+
+    fn searches_all_committed(&self) -> bool {
+        matches!(self, Self::AllCommitted)
+    }
+
+    async fn covers_all_committed(
+        &self,
+        dataset: &Dataset,
+        column: &str,
+        document_granularity: DocumentGranularity,
+        resolved: &[IndexMetadata],
+    ) -> DataFusionResult<bool> {
+        if self.searches_all_committed() {
+            return Ok(true);
+        }
+        let Some(committed) = load_segments(dataset, column, document_granularity).await? else {
+            return Ok(false);
+        };
+        let selected = resolved
+            .iter()
+            .map(|segment| segment.uuid)
+            .collect::<HashSet<_>>();
+        let committed = committed
+            .iter()
+            .map(|segment| segment.uuid)
+            .collect::<HashSet<_>>();
+        Ok(selected == committed)
     }
 
     fn explicit_segment_uuids(&self) -> Option<Vec<Uuid>> {
@@ -2244,6 +2454,10 @@ pub struct MatchQueryExec {
     /// When set, `execute()` skips `build_global_bm25_scorer` and threads this
     /// scorer down to `InvertedIndex::bm25_search`.
     base_scorer: Option<Arc<MemBM25Scorer>>,
+    /// Canonical fuzzy vocabulary and corpus-wide scorer prepared against the
+    /// complete distributed corpus. Unlike `base_scorer`, this is safe to
+    /// forward to an exec that searches only a segment subset.
+    prepared_query: Option<Arc<PreparedBm25Query>>,
     /// Corpus-wide scorer published by the flat branch of a mixed search.
     shared_scorer: Option<Arc<SharedFtsScorer>>,
     segment_selection: FtsSegmentSelection,
@@ -2334,6 +2548,7 @@ impl MatchQueryExec {
             params,
             prefilter_source,
             base_scorer: None,
+            prepared_query: None,
             shared_scorer: None,
             segment_selection: FtsSegmentSelection::AllCommitted,
             overlay_block: None,
@@ -2397,6 +2612,7 @@ impl MatchQueryExec {
             params,
             prefilter_source,
             base_scorer: None,
+            prepared_query: None,
             shared_scorer: None,
             segment_selection: FtsSegmentSelection::ExactResolved(Arc::from(segments)),
             overlay_block: None,
@@ -2440,6 +2656,7 @@ impl MatchQueryExec {
             params,
             prefilter_source,
             base_scorer: None,
+            prepared_query: None,
             shared_scorer: None,
             segment_selection: FtsSegmentSelection::exact_uuids(segment_uuids),
             overlay_block: None,
@@ -2462,9 +2679,25 @@ impl MatchQueryExec {
     /// routes per-segment work to multiple hosts and aggregates stats
     /// out-of-band, so each per-host leaf scores against the full corpus
     /// rather than its local segment subset. See [`build_global_bm25_scorer`]
-    /// for constructing one.
+    /// for constructing one. For a fuzzy query over an explicit segment
+    /// subset, use [`Self::with_prepared_query`] so the globally selected
+    /// vocabulary travels with the scorer.
     pub fn with_base_scorer(mut self, scorer: Arc<MemBM25Scorer>) -> Self {
         self.base_scorer = Some(scorer);
+        self.prepared_query = None;
+        self
+    }
+
+    /// Override local query preparation with one canonical vocabulary/scorer
+    /// pair built against the complete corpus.
+    ///
+    /// Distributed fuzzy callers must use this instead of
+    /// [`Self::with_base_scorer`], because worker-local expansion can select a
+    /// different capped vocabulary from the one used to build the scorer.
+    #[doc(hidden)]
+    pub fn with_prepared_query(mut self, query: Arc<PreparedBm25Query>) -> Self {
+        self.prepared_query = Some(query);
+        self.base_scorer = None;
         self
     }
 
@@ -2562,6 +2795,7 @@ impl ExecutionPlan for MatchQueryExec {
                     params: self.params.clone(),
                     prefilter_source: PreFilterSource::None,
                     base_scorer: self.base_scorer.clone(),
+                    prepared_query: self.prepared_query.clone(),
                     shared_scorer: self.shared_scorer.clone(),
                     segment_selection: self.segment_selection.clone(),
                     overlay_block: self.overlay_block.clone(),
@@ -2595,6 +2829,7 @@ impl ExecutionPlan for MatchQueryExec {
                     params: self.params.clone(),
                     prefilter_source,
                     base_scorer: self.base_scorer.clone(),
+                    prepared_query: self.prepared_query.clone(),
                     shared_scorer: self.shared_scorer.clone(),
                     segment_selection: self.segment_selection.clone(),
                     overlay_block: self.overlay_block.clone(),
@@ -2627,6 +2862,7 @@ impl ExecutionPlan for MatchQueryExec {
         let prefilter_source = self.prefilter_source.clone();
         let external_mask = self.external_mask.clone();
         let preset_base_scorer = self.base_scorer.clone();
+        let preset_prepared_query = self.prepared_query.clone();
         let shared_scorer = self.shared_scorer.clone();
         let segment_selection = self.segment_selection.clone();
         let overlay_block = self.overlay_block.clone();
@@ -2647,6 +2883,16 @@ impl ExecutionPlan for MatchQueryExec {
                     &metrics.segment_bind_duration,
                 )
                 .await?;
+            let scorer_only_fuzzy = preset_prepared_query.is_none()
+                && uses_fuzzy_expansion(params.fuzziness)
+                && (preset_base_scorer.is_some() || shared_scorer.is_some());
+            let scorer_override_covers_all = if scorer_only_fuzzy {
+                segment_selection
+                    .covers_all_committed(&ds, &column, document_granularity, &segments)
+                    .await?
+            } else {
+                true
+            };
             let indices =
                 open_fts_segments(&ds, &column, &segments, &metrics.index_metrics).await?;
 
@@ -2681,40 +2927,47 @@ impl ExecutionPlan for MatchQueryExec {
             let mut tokenizer = tokenizer_for_match_query(first_index, query.fuzziness);
             let tokens = collect_query_tokens(&query.terms, &mut tokenizer);
             record_tokenized_query(&tokenized_query, &tokens);
-            let base_scorer = match (preset_base_scorer, shared_scorer) {
-                (Some(scorer), _) => scorer,
-                (None, Some(shared_scorer)) => shared_scorer.wait().await?,
-                (None, None) => {
-                    let scorer_start = std::time::Instant::now();
-                    let scorer = Arc::new(
-                        build_global_bm25_scorer(
-                            &indices,
-                            &tokens,
-                            &params,
-                            Some(metrics.as_ref()),
-                        )
-                        .boxed()
-                        .await?,
-                    );
-                    metrics.record_scorer_build(scorer_start.elapsed());
-                    scorer
+            let prepared = if let Some(prepared_query) = preset_prepared_query {
+                Arc::new(PreparedMatch {
+                    query: prepared_query,
+                    params: Arc::new(params),
+                    operator: query.operator,
+                })
+            } else {
+                let base_scorer = match (preset_base_scorer, shared_scorer) {
+                    (Some(scorer), _) => Some(scorer),
+                    (None, Some(shared_scorer)) => Some(shared_scorer.wait().await?),
+                    (None, None) => None,
+                };
+                if base_scorer.is_some() && scorer_only_fuzzy && !scorer_override_covers_all {
+                    return Err(DataFusionError::Execution(
+                        "fuzzy MatchQuery cannot use a scorer-only override; prepare the canonical vocabulary with prepare_bm25_query and pass it with with_prepared_query"
+                            .to_string(),
+                    ));
                 }
+                let builds_local_scorer = base_scorer.is_none();
+                let scorer_start = std::time::Instant::now();
+                let prepared = Arc::new(
+                    PreparedMatch::new(
+                        &indices,
+                        tokens,
+                        params,
+                        query.operator,
+                        metrics.as_ref(),
+                        base_scorer,
+                    )
+                    .await?,
+                );
+                if builds_local_scorer {
+                    metrics.record_scorer_build(scorer_start.elapsed());
+                }
+                prepared
             };
 
             pre_filter.wait_for_ready().await?;
-            let tokens = Arc::new(tokens);
-            let params = Arc::new(params);
-            let mut documents = search_segments(
-                &indices,
-                tokens,
-                params,
-                query.operator,
-                pre_filter,
-                metrics.clone(),
-                base_scorer,
-                None,
-            )
-            .await?;
+            let mut documents =
+                search_prepared_segments(&indices, prepared, pre_filter, metrics.clone(), None)
+                    .await?;
             documents.iter_mut().for_each(|document| {
                 document.score.0 *= query.boost;
             });
@@ -2998,7 +3251,7 @@ impl FlatMatchFilterExec {
                 "column not set for MatchQuery {}",
                 query.terms
             )))?;
-        if query.fuzziness != Some(0) {
+        if uses_fuzzy_expansion(query.fuzziness) {
             return Err(DataFusionError::NotImplemented(format!(
                 "Fuzzy MatchQuery is not supported when FTS is used as a post-filter: column={}, fuzziness={:?}",
                 column, query.fuzziness
@@ -4568,7 +4821,7 @@ mod tests {
     use lance_core::{ROW_ID, utils::address::RowAddress};
     use lance_datafusion::datagen::DatafusionDatagenExt;
     use lance_datafusion::exec::{ExecutionStatsCallback, ExecutionSummaryCounts};
-    use lance_datafusion::utils::PARTITIONS_SEARCHED_METRIC;
+    use lance_datafusion::utils::{MetricsExt, PARTITIONS_SEARCHED_METRIC};
     use lance_datagen::{BatchCount, ByteCount, RowCount};
     use lance_index::metrics::{MetricsCollector, NoOpMetricsCollector};
     use lance_index::scalar::inverted::builder::ScoredDoc;
@@ -4578,7 +4831,7 @@ mod tests {
     };
     use lance_index::scalar::inverted::{
         DocumentGranularity, FTS_SCHEMA, InvertedIndex, Language, SCORE_COL,
-        build_global_bm25_scorer,
+        build_global_bm25_scorer, prepare_bm25_query,
     };
     use lance_index::scalar::{FullTextSearchQuery, InvertedIndexParams};
     use lance_index::{IndexCriteria, IndexType};
@@ -4597,9 +4850,12 @@ mod tests {
     use super::{
         BoolSlot, BoostQueryExec, CompoundQueryExec, CrossColumnCompoundQueryExec,
         FTS_SEGMENT_BIND_DURATION_METRIC, FlatMatchFilterExec, FlatMatchQueryExec, MatchQueryExec,
-        PhraseQueryExec, WAND_TIE_COMPLETION_BUDGET, WandExactnessCertificate,
+        PhraseQueryExec, WAND_EXACTNESS_CERTIFICATE_FALLBACKS_METRIC,
+        WAND_TIE_COMPLETION_ATTEMPTS_METRIC, WAND_TIE_COMPLETION_BUDGET,
+        WAND_TIE_COMPLETION_SUCCESSES_METRIC, WandExactnessCertificate,
         build_boolean_query_children, classify_wand_exactness_certificate,
         count_smaller_row_id_replacements, default_text_tokenizer, open_fts_segments,
+        tokenizer_for_match_query,
     };
     use crate::io::exec::utils::IndexMetrics;
     use datafusion::physical_plan::empty::EmptyExec;
@@ -5839,8 +6095,8 @@ mod tests {
                 (
                     "text",
                     Arc::new(StringArray::from(vec![
-                        Some("alpha beta"),
-                        Some("gamma lance"),
+                        Some("lancd alpha"),
+                        Some("lancd lance"),
                     ])) as ArrayRef,
                 ),
             ])
@@ -5864,7 +6120,7 @@ mod tests {
             .with_position(false)
             .lower_case(true)
             .stem(false)
-            .remove_stop_words(false)
+            .remove_stop_words(true)
             .ascii_folding(false)
             .max_token_length(None);
         let fragment_ids = ds
@@ -5941,6 +6197,46 @@ mod tests {
             "expected >= 2 segments to exercise global IDF, got {}",
             indices.len()
         );
+
+        let mut auto_tokenizer = tokenizer_for_match_query(&indices[0], None);
+        let auto_tokens = collect_query_tokens("THE LANCE", &mut auto_tokenizer);
+        assert_eq!(auto_tokens.len(), 1);
+        assert_eq!(auto_tokens.get_token(0), "lance");
+        let mut explicit_fuzzy_tokenizer = tokenizer_for_match_query(&indices[0], Some(1));
+        let explicit_fuzzy_tokens =
+            collect_query_tokens("THE LANCE", &mut explicit_fuzzy_tokenizer);
+        assert_eq!(explicit_fuzzy_tokens.len(), 2);
+        assert_eq!(explicit_fuzzy_tokens.get_token(0), "THE");
+        assert_eq!(explicit_fuzzy_tokens.get_token(1), "LANCE");
+
+        let auto_query = |terms: &str| {
+            MatchQuery::new(terms.to_owned())
+                .with_column(Some("text".to_owned()))
+                .with_fuzziness(None)
+                .with_document_granularity(DocumentGranularity::Row)
+        };
+        let lowercase_auto_exec = MatchQueryExec::new(
+            dataset.clone(),
+            auto_query("lance"),
+            search_params.clone(),
+            PreFilterSource::None,
+        )
+        .unwrap();
+        let lowercase_auto_results = execute_results(&lowercase_auto_exec).await.unwrap();
+        assert!(!lowercase_auto_results.is_empty());
+        let normalized_auto_exec = MatchQueryExec::new(
+            dataset.clone(),
+            auto_query("THE LANCE"),
+            search_params.clone(),
+            PreFilterSource::None,
+        )
+        .unwrap();
+        assert_eq!(
+            execute_results(&normalized_auto_exec).await.unwrap(),
+            lowercase_auto_results,
+            "AUTO fuzzy Match must preserve index lowercase and stop-word analysis"
+        );
+
         let mut tokenizer = indices[0].tokenizer();
         let tokens = collect_query_tokens(&query.terms, &mut tokenizer);
         let global_scorer = Arc::new(
@@ -5954,7 +6250,7 @@ mod tests {
             query.clone(),
             search_params.clone(),
             PreFilterSource::None,
-            preset_segments,
+            preset_segments.clone(),
         )
         .unwrap()
         .with_base_scorer(global_scorer);
@@ -5998,6 +6294,164 @@ mod tests {
                 "FTS score column should be Float32"
             );
         }
+
+        // A distributed fuzzy subset must receive the canonical vocabulary
+        // together with its scorer. A scorer-only override cannot reproduce a
+        // globally capped rewrite from worker-local segment vocabularies.
+        let fuzzy_query = MatchQuery::new("lancx".to_string())
+            .with_column(Some("text".to_string()))
+            .with_fuzziness(Some(1))
+            .with_max_expansions(1)
+            .with_document_granularity(DocumentGranularity::Row);
+        let fuzzy_params = search_params
+            .clone()
+            .with_fuzziness(Some(1))
+            .with_max_expansions(1);
+        let mut tokenizer = tokenizer_for_match_query(&indices[0], fuzzy_query.fuzziness);
+        let fuzzy_tokens = collect_query_tokens(&fuzzy_query.terms, &mut tokenizer);
+        let prepared = Arc::new(
+            prepare_bm25_query(&indices, fuzzy_tokens, &fuzzy_params, None, None)
+                .await
+                .unwrap(),
+        );
+        assert_eq!(prepared.tokens().len(), 1);
+        assert_eq!(prepared.tokens().get_token(0), "lancd");
+
+        let prepared_full_exec = MatchQueryExec::new_with_segments(
+            dataset.clone(),
+            fuzzy_query.clone(),
+            search_params.clone(),
+            PreFilterSource::None,
+            preset_segments.clone(),
+        )
+        .unwrap()
+        .with_prepared_query(prepared.clone());
+        let prepared_full_results = execute_row_ids(&prepared_full_exec).await.unwrap();
+        assert_eq!(prepared_full_results.len(), 2);
+
+        let all_committed_scorer_exec = MatchQueryExec::new(
+            dataset.clone(),
+            fuzzy_query.clone(),
+            search_params.clone(),
+            PreFilterSource::None,
+        )
+        .unwrap()
+        .with_base_scorer(prepared.scorer().clone());
+        assert_eq!(
+            execute_row_ids(&all_committed_scorer_exec).await.unwrap(),
+            prepared_full_results
+        );
+
+        let explicit_full_scorer_exec = MatchQueryExec::new_with_segments(
+            dataset.clone(),
+            fuzzy_query.clone(),
+            search_params.clone(),
+            PreFilterSource::None,
+            preset_segments.clone(),
+        )
+        .unwrap()
+        .with_base_scorer(prepared.scorer().clone());
+        assert_eq!(
+            execute_row_ids(&explicit_full_scorer_exec).await.unwrap(),
+            prepared_full_results
+        );
+
+        let subset_exec = MatchQueryExec::new_with_segments(
+            dataset.clone(),
+            fuzzy_query.clone(),
+            search_params.clone(),
+            PreFilterSource::None,
+            vec![preset_segments[0].clone()],
+        )
+        .unwrap()
+        .with_prepared_query(prepared.clone());
+        assert!(execute_row_ids(&subset_exec).await.unwrap().is_empty());
+
+        let scorer_only_exec = MatchQueryExec::new_with_segments(
+            dataset.clone(),
+            fuzzy_query.clone(),
+            search_params.clone(),
+            PreFilterSource::None,
+            vec![preset_segments[0].clone()],
+        )
+        .unwrap()
+        .with_base_scorer(prepared.scorer().clone());
+        assert_execution_error(
+            execute_row_ids(&scorer_only_exec).await.unwrap_err(),
+            "fuzzy MatchQuery cannot use a scorer-only override",
+        );
+
+        let compound_query = FtsQuery::Match(fuzzy_query.clone());
+        let compound_subset = CompoundQueryExec::new_with_segments(
+            dataset.clone(),
+            compound_query.clone(),
+            search_params.clone(),
+            PreFilterSource::None,
+            vec![preset_segments[0].clone()],
+        )
+        .with_prepared_match(prepared.clone());
+        assert!(execute_row_ids(&compound_subset).await.unwrap().is_empty());
+
+        let compound_scorer_only_subset = CompoundQueryExec::new_with_segments(
+            dataset.clone(),
+            compound_query.clone(),
+            search_params.clone(),
+            PreFilterSource::None,
+            vec![preset_segments[0].clone()],
+        )
+        .with_base_scorer(prepared.scorer().clone());
+        assert_execution_error(
+            execute_row_ids(&compound_scorer_only_subset)
+                .await
+                .unwrap_err(),
+            "fuzzy CompoundQueryExec cannot use a scorer-only override over a segment subset",
+        );
+
+        let compound_full_scorer = CompoundQueryExec::new_with_segments(
+            dataset.clone(),
+            compound_query.clone(),
+            search_params.clone(),
+            PreFilterSource::None,
+            preset_segments.clone(),
+        )
+        .with_base_scorer(prepared.scorer().clone());
+        assert_eq!(
+            execute_row_ids(&compound_full_scorer).await.unwrap(),
+            prepared_full_results
+        );
+
+        // With limit=1 the two globally selected `lancd` documents tie. The
+        // WAND probe is ambiguous, so bounded tie completion must retain the
+        // same prepared vocabulary instead of rewriting against this exec's
+        // segments.
+        let compound_wand_replay = CompoundQueryExec::new_with_segments(
+            dataset,
+            compound_query,
+            search_params.with_limit(Some(1)),
+            PreFilterSource::None,
+            preset_segments,
+        )
+        .with_prepared_match(prepared);
+        assert_eq!(
+            execute_row_ids(&compound_wand_replay).await.unwrap().len(),
+            1
+        );
+        assert_eq!(
+            metric_value(
+                &compound_wand_replay,
+                WAND_EXACTNESS_CERTIFICATE_FALLBACKS_METRIC,
+            ),
+            0,
+            "the bounded prepared-vocabulary tie completion should avoid exact replay"
+        );
+        assert_eq!(
+            metric_value(&compound_wand_replay, WAND_TIE_COMPLETION_ATTEMPTS_METRIC,),
+            1
+        );
+        assert_eq!(
+            metric_value(&compound_wand_replay, WAND_TIE_COMPLETION_SUCCESSES_METRIC,),
+            1
+        );
 
         // Locally-bound helper: collect (row_id, score) pairs sorted by score desc.
         fn concat_score_batches(batches: &[RecordBatch]) -> Vec<(u64, f32)> {


### PR DESCRIPTION
## What is the bug?

`MatchQuery.fuzziness=None` is documented as automatic fuzziness, but indexed execution treated it as exact matching. Explicit fuzzy queries also spent `max_expansions` independently in each FTS segment, so vocabulary, scores, and results could change when the same corpus was split into a different segment layout.

The frozen 10M corpus exposed a second correctness gap in the underlying `fst` 0.4 Unicode DFA: query scalars that share a UTF-8 lead byte (for example Arabic `بسرع`) can overwrite one another's exact transitions, so a one-scalar edit can miss an indexed term such as `بسرعة`.

Linear: https://linear.app/lancedb/issue/OSS-2104/canonicalize-auto-fuzzy-expansion-across-fts-segments

## How does this PR fix it?

- Define exact versus fuzzy behavior once: `Some(0)` is exact, `None` supports automatic edit distance, and explicit positive distances remain fuzzy.
- Compute automatic distance and prefix boundaries in Unicode scalar values rather than UTF-8 bytes.
- Keep JSON path/type and the user prefix exact; apply edit distance only to the remaining value suffix.
- Compile a Unicode-scalar Levenshtein byte DFA for non-ASCII queries. DP rows are interned at construction time, valid UTF-8 transitions are compiled once, and exact scalar paths use a copy-on-write trie so shared lead bytes cannot overwrite sibling transitions. Each DP row installs only row-active exact scalars.
- Keep ASCII queries on the existing `fst::Levenshtein` hot path. Both paths stream FST keys in lexical order and stop at the requested candidate limit.
- Build one immutable automaton per distinct source token and reuse it across every selected segment and physical partition.
- Enforce one 10,000-state complexity guard across boundary, UTF-8 helper, exact override, and prefix states. Runtime DFA transitions are allocation-free table lookups.
- Collect fuzzy candidates across every selected segment and partition, then spend one deterministic whole-query `max_expansions` budget by query position.
- Trim cross-partition candidate merges to `O(max_expansions)` memory.
- Bind canonical tokens and corpus BM25 statistics in `PreparedBm25Query`, reused by Match, compound/WAND replay, and cross-column paths.
- Fail closed when a fuzzy scorer-only override is used on an unsafe segment subset.
- Keep public dataset `None` behavior exact in this parent until #8760 activates indexed and current-row AUTO semantics atomically.

Public query/wire APIs and on-disk index formats are unchanged.

## Coverage

Coverage includes:

- ASCII and Unicode automatic-fuzziness boundaries;
- Arabic insertion, ASCII-to-accent substitution, accented scalar substitution, deletion, and distance 2;
- exact Unicode/JSON prefixes, invalid and incomplete UTF-8, dead-state pruning, and the state limit;
- lexical cap order and partition/segment-layout invariance;
- same-position alternatives and whole-query expansion caps;
- distributed prepared-query subsets and scorer-only fail-close;
- WAND strict/exhaustive/ambiguous replay using the same prepared vocabulary;
- exact `Some(0)` controls.

The 10M oracle also exposed an unrelated pre-existing direct-leaf Match tie bug: bounded score-only heaps can choose different equal-score row IDs across runs. It is tracked separately as [OSS-2116](https://linear.app/lancedb/issue/OSS-2116/bug-make-bounded-direct-match-fts-ties-deterministic-by-row-id); this PR's compound benchmark keeps strict `(score DESC, row_id ASC)` correctness.

Current diff SHA-256 against the pinned parent `dafa4642658d996b3e31dde91e02f72db7860d7e`: `9583176273aa1d29d84720ba63471af69adba11dfd2e100a670744cc41dcff12`.

## Validation

- `cargo fmt --all`
- `git diff --check`
- `release-with-debug` Python native module built successfully on the benchmark VM.
- Targeted 10M activation passed for Arabic, Latin, ASCII-to-accent, direct Match, and single-MUST compound Match.
- Single-MUST compound exact oracle: baseline `0 / 100` mismatches; target `0 / 100`; cross-build comparison passed.

Per request, no local test, check, clippy, or test binary was run for the latest follow-up; CI is responsible for those checks.

## Benchmark

Completed on `yang-agent-fts-compound-20260819-c` (`c4-highmem-16`, 16 vCPUs) using the frozen 10M MMLB dataset and typo manifest. Baseline was `dafa4642658d996b3e31dde91e02f72db7860d7e`; target was `2e1684f0c15f4d9fbf4c8f5fe7d63d68d86f8835`. Native module SHA-256 values were `46e65866…66810` and `672d37b3…01263`.

Correctness gates passed:

- exact compound `Some(0)`: baseline `0 / 100` mismatches, target `0 / 100`, cross-build comparison passed;
- independent physical FST/Arrow dictionary oracle: no missing candidates;
- target fuzzy oracle: two fresh processes, `0` mismatches, cross-process comparison passed;
- exact result digests and target signatures were stable across the timed runs.

Warm exact confirmation used 250 queries × 100 repetitions, 8 workers, a 64 GiB index cache, four trials per build, and two-block ABBA order. Higher throughput and lower latency are better.

| Scenario / metric | Baseline | This PR | Benefit |
| --- | ---: | ---: | ---: |
| full-content exact, k=10, throughput | 2605.149 q/s | 2615.700 q/s | 1.0040x |
| full-content exact, k=10, p50 latency | 2.806 ms | 2.806 ms | 1.0003x |
| full-content exact, k=100, throughput | 2238.395 q/s | 2285.559 q/s | 1.0211x |
| full-content exact, k=100, p50 latency | 2.515 ms | 2.542 ms | 0.9892x |
| summary exact, k=10, throughput | 2696.461 q/s | 2698.689 q/s | 1.0008x |
| summary exact, k=10, p50 latency | 2.716 ms | 2.729 ms | 0.9953x |
| summary exact, k=100, throughput | 2556.329 q/s | 2559.313 q/s | 1.0012x |
| summary exact, k=100, p50 latency | 2.659 ms | 2.677 ms | 0.9934x |

The original 5-repetition warm block reported a 2.37% summary-k10 throughput loss because one target case lasted 0.488 s instead of about 0.455 s. The 20× longer exact-only confirmation above passed the unchanged 2% gate and measured `1.0008x` throughput for that case.

Explicit-fuzzy baseline and target semantics differ, so these warm values are raw costs rather than speedup claims. The primary warm run used 250 queries × 5 repetitions and the same ABBA/worker/cache settings.

| Scenario / p50 latency | Baseline | This PR | Benefit |
| --- | ---: | ---: | ---: |
| full-content fuzzy single, k=10 | 45.392 ms | 32.736 ms | not comparable |
| full-content fuzzy AND, k=10 | 67.617 ms | 46.923 ms | not comparable |
| summary fuzzy single, k=10 | 7.620 ms | 6.200 ms | not comparable |
| summary fuzzy AND, k=10 | 10.546 ms | 7.821 ms | not comparable |

Cold trials dropped the OS page cache before every process and used one cap-binding Arabic query, four trials per build. Exact k=10 was `304.641 → 302.261 ms` (`1.0079x`); exact k=100 was `303.240 → 312.341 ms` (`0.9709x`). The single-query cold k=100 difference was not reproduced by the longer warm confirmation. Fuzzy cold values are not comparable: the baseline incorrectly returned no Arabic fuzzy matches, while this PR performed the correct dictionary/posting work (for example full-content single k=10 was `34.758 → 391.799 ms`).

Result fingerprint: 636 files, 20,849,427 bytes, tree SHA-256 `6e56359787ba9eff857854874c56310e22b83f4145d42acd46b86ddc536c5d48`.
