### PR TITLE
fix(python): spell misnamed without a hyphen so the typos gate passes

### DIFF
--- a/python/src/object_store.rs
+++ b/python/src/object_store.rs
@@ -151,7 +151,7 @@ impl PyObjectStoreProvider {
     fn from_capsule(capsule: &Bound<'_, PyCapsule>) -> PyResult<Self> {
         // `pointer_checked(Some(name))` asks CPython for the pointer *and*
         // requires the capsule to carry exactly this name and a non-null
-        // pointer, so a foreign or mis-named capsule is rejected here rather
+        // pointer, so a foreign or misnamed capsule is rejected here rather
         // than dereferenced. (Passing `None` asks for a *nameless* capsule and
         // would reject every correctly-named one.)
         let ptr = capsule


### PR DESCRIPTION
`Spell Check with Typos` currently fails on every new pull request. The word
`mis-named` in `python/src/object_store.rs` landed with #8522, and typos v1.26.0
reads the `mis` token as a misspelling of `miss`:

```
error: `mis` should be `miss`, `mist`
  --> ./python/src/object_store.rs:154:37
```

The workflow only triggers on `pull_request`, so nothing re-checked main after
the merge and the failure now reproduces on unrelated branches.

Spells it `misnamed`, which keeps the sentence intact. Allow-listing `mis`
instead would suppress genuine `mis`/`miss` hits everywhere.

Verified with the same binary the workflow pins, typos-cli 1.26.0: `typos .`
exits 2 with the error above on main and exits 0 with no output on this branch.
