### PR TITLE
fix(encoding): fail cleanly on corrupt full-zip variable pages

### DIFF
--- a/rust/lance-encoding/src/encodings/logical/primitive.rs
+++ b/rust/lance-encoding/src/encodings/logical/primitive.rs
@@ -3555,7 +3555,7 @@ impl VariableFullZipDecoder {
     /// The bytes come from the file, so both the prefix and the length it claims are
     /// bounds checked and report a corrupt file rather than reading past the end of
     /// the buffer. Reading the prefix and advancing past it happen here together, so
-    /// a page can only be walked with the width it was written with.
+    /// the prefix cannot be read at one width and skipped at another.
     fn split_next_value(data: &[u8], bits_per_length: u8) -> Result<(&[u8], &[u8])> {
         let width = bits_per_length as usize / 8;
         if data.len() < width {
@@ -3606,7 +3606,8 @@ impl VariableFullZipDecoder {
         // This undercounts if there are lists but, at this point, we don't really know how many items we have
         let mut rep = Vec::with_capacity(num_rows as usize);
         let mut def = Vec::with_capacity(num_rows as usize);
-        let bytes_cw = self.details.ctrl_word_parser.bytes_per_word() * num_rows as usize;
+        let bytes_per_word = self.details.ctrl_word_parser.bytes_per_word();
+        let bytes_cw = bytes_per_word * num_rows as usize;
 
         // This undercounts if there are lists
         // It can also overcount if there are invisible items
@@ -3636,13 +3637,12 @@ impl VariableFullZipDecoder {
             while !databuf.is_empty() {
                 // The remaining byte count comes from the file, so a page truncated
                 // mid-item can leave less than one control word here.
-                let bytes_per_word = self.details.ctrl_word_parser.bytes_per_word();
                 if databuf.len() < bytes_per_word {
                     return Err(Error::corrupt_file_named(
                         "variable_full_zip",
                         format!(
                             "truncated control word: {} byte(s) remain in the page buffer but \
-                             each item needs {bytes_per_word}",
+                             each control word needs {bytes_per_word}",
                             databuf.len()
                         ),
                     ));
@@ -7089,6 +7089,7 @@ mod tests {
     };
     use arrow_buffer::ScalarBuffer;
     use arrow_schema::{DataType, Field as ArrowField};
+    use lance_core::Error;
     use std::collections::HashMap;
     use std::{collections::VecDeque, sync::Arc};
 
@@ -10297,7 +10298,7 @@ mod tests {
     /// is the true maximum only at one bit. Callers that need `parse_desc` to classify
     /// items correctly at wider levels have to pass the real maxima instead; today's
     /// callers either use one bit or fail before `parse_desc` runs.
-    fn truncated_tail_details(
+    fn full_zip_variable_details(
         bits_rep: u8,
         bits_def: u8,
     ) -> std::sync::Arc<super::FullZipDecodeDetails> {
@@ -10340,7 +10341,7 @@ mod tests {
         let mut data = VecDeque::new();
         data.push_back(crate::buffer::LanceBuffer::from(buf));
         super::VariableFullZipDecoder::new(
-            truncated_tail_details(bits_rep, bits_def),
+            full_zip_variable_details(bits_rep, bits_def),
             data,
             num_rows,
             in_bits_per_length,
@@ -10365,8 +10366,6 @@ mod tests {
     /// release build read up to 8 bytes out of a 4 byte allocation.
     #[test]
     fn variable_full_zip_truncated_length_prefix_is_corrupt_file() {
-        use lance_core::Error;
-
         for (bits, buf_len) in [(32u8, 3usize), (64u8, 4usize)] {
             let err = decode_variable_full_zip(vec![0xAA; buf_len], 1, bits, bits)
                 .expect_err("a truncated length prefix must not decode");
@@ -10390,8 +10389,6 @@ mod tests {
     /// in production: `range end index 2903552 out of range for slice of length 38469`.
     #[test]
     fn variable_full_zip_value_length_past_page_end_is_corrupt_file() {
-        use lance_core::Error;
-
         // The prefix claims 64 bytes of value data but only 4 follow it.
         let mut page = 64_u32.to_le_bytes().to_vec();
         page.extend_from_slice(b"abcd");
@@ -10438,8 +10435,6 @@ mod tests {
     /// aborts the process before either length check above can run.
     #[test]
     fn variable_full_zip_truncated_control_word_is_corrupt_file() {
-        use lance_core::Error;
-
         // rep and def wide enough together to need a two byte control word, and a
         // single byte that cannot hold it.
         let err = decode_variable_full_zip_with_levels(vec![0xAAu8], 1, 32, 32, 4, 5)
@@ -10464,8 +10459,6 @@ mod tests {
         #[case] out_bits_per_offset: u8,
         #[case] keyword: &str,
     ) {
-        use lance_core::Error;
-
         let err =
             decode_variable_full_zip(vec![0xAA; 8], 1, in_bits_per_length, out_bits_per_offset)
                 .expect_err("an unsupported width must not decode");
@@ -10480,13 +10473,12 @@ mod tests {
     }
 
     /// A page claiming more rows than it carries bytes for must not underflow the
-    /// capacity estimate. This page's tail is also short, so the walk rejects it too —
-    /// a page that ends exactly on an item boundary while carrying fewer rows than
-    /// claimed is still accepted, which is tracked separately.
+    /// capacity estimate. This page's tail is also short, so the walk rejects it too.
+    /// A page that ends exactly on an item boundary while carrying fewer rows than
+    /// claimed still gets past the walk and then panics in `drain`, which indexes its
+    /// row-start vectors with that row count; see #8768.
     #[test]
     fn variable_full_zip_row_count_past_data_does_not_underflow() {
-        use lance_core::Error;
-
         // 10 rows x 1 control word byte is already more than the 4 bytes on hand, so
         // the capacity estimate underflows without saturating subtraction.
         let err = decode_variable_full_zip_with_levels(vec![0xAA; 4], 10, 32, 32, 1, 1)

--- a/rust/lance-encoding/src/encodings/logical/primitive.rs
+++ b/rust/lance-encoding/src/encodings/logical/primitive.rs
@@ -3420,8 +3420,21 @@ impl VariableFullZipDecoder {
             _ => unreachable!(),
         };
 
-        assert_eq!(in_bits_per_length % 8, 0);
-        assert!(out_bits_per_offset == 32 || out_bits_per_offset == 64);
+        if !matches!(in_bits_per_length, 8 | 16 | 32 | 64) {
+            return Err(Error::corrupt_file_named(
+                "variable_full_zip",
+                format!(
+                    "unsupported length prefix width {in_bits_per_length} bits, \
+                     expected 8, 16, 32 or 64"
+                ),
+            ));
+        }
+        if !matches!(out_bits_per_offset, 32 | 64) {
+            return Err(Error::corrupt_file_named(
+                "variable_full_zip",
+                format!("unsupported offset width {out_bits_per_offset} bits, expected 32 or 64"),
+            ));
+        }
 
         let mut decoder = Self {
             details,
@@ -3536,14 +3549,15 @@ impl VariableFullZipDecoder {
         }
     }
 
-    /// Reads a single length prefix from the front of `data`.
+    /// Splits the next length-prefixed value off the front of `data`, returning
+    /// `(value, rest)`.
     ///
-    /// The bytes come from the file. A page whose item walk ends with a partial
-    /// trailing item leaves fewer than `bits_per_offset / 8` bytes here, so this
-    /// is bounds checked and reports a corrupt file rather than reading past the
-    /// end of the buffer.
-    fn parse_length(data: &[u8], bits_per_offset: u8) -> Result<u64> {
-        let width = bits_per_offset as usize / 8;
+    /// The bytes come from the file, so both the prefix and the length it claims are
+    /// bounds checked and report a corrupt file rather than reading past the end of
+    /// the buffer. Reading the prefix and advancing past it happen here together, so
+    /// a page can only be walked with the width it was written with.
+    fn split_next_value(data: &[u8], bits_per_length: u8) -> Result<(&[u8], &[u8])> {
+        let width = bits_per_length as usize / 8;
         if data.len() < width {
             return Err(Error::corrupt_file_named(
                 "variable_full_zip",
@@ -3551,18 +3565,35 @@ impl VariableFullZipDecoder {
                     "truncated length prefix: {} byte(s) remain in the page buffer but a \
                      {}-bit length prefix requires {}",
                     data.len(),
-                    bits_per_offset,
+                    bits_per_length,
                     width
                 ),
             ));
         }
-        Ok(match bits_per_offset {
+        let length = match bits_per_length {
             8 => data[0] as u64,
             16 => u16::from_le_bytes(data[..2].try_into().unwrap()) as u64,
             32 => u32::from_le_bytes(data[..4].try_into().unwrap()) as u64,
             64 => u64::from_le_bytes(data[..8].try_into().unwrap()),
-            _ => unreachable!(),
-        })
+            _ => {
+                return Err(Error::corrupt_file_named(
+                    "variable_full_zip",
+                    format!("unsupported length prefix width: {bits_per_length} bits"),
+                ));
+            }
+        };
+        let rest = &data[width..];
+        if length > rest.len() as u64 {
+            return Err(Error::corrupt_file_named(
+                "variable_full_zip",
+                format!(
+                    "value length {} exceeds the {} byte(s) remaining in the page buffer",
+                    length,
+                    rest.len()
+                ),
+            ));
+        }
+        Ok(rest.split_at(length as usize))
     }
 
     fn unzip(
@@ -3589,14 +3620,33 @@ impl VariableFullZipDecoder {
         let bytes_data = data.iter().map(|d| d.len()).sum::<usize>();
         // This overcounts since bytes_lengths and bytes_cw are undercounts
         // It can also undercount if there are invisible items (hence the saturating_sub)
-        let mut unzipped_data =
-            Vec::with_capacity((bytes_data - bytes_cw).saturating_sub(bytes_lengths));
+        // Both subtractions saturate because bytes_cw is derived from the page's row
+        // count while bytes_data is the actual buffer size, and a corrupt page can
+        // claim more rows than it carries bytes for.
+        let mut unzipped_data = Vec::with_capacity(
+            bytes_data
+                .saturating_sub(bytes_cw)
+                .saturating_sub(bytes_lengths),
+        );
 
         let mut current_offset = 0_u64;
         let mut visible_item_count = 0_u64;
         for databuf in data.into_iter() {
             let mut databuf = databuf.as_ref();
             while !databuf.is_empty() {
+                // The remaining byte count comes from the file, so a page truncated
+                // mid-item can leave less than one control word here.
+                let bytes_per_word = self.details.ctrl_word_parser.bytes_per_word();
+                if databuf.len() < bytes_per_word {
+                    return Err(Error::corrupt_file_named(
+                        "variable_full_zip",
+                        format!(
+                            "truncated control word: {} byte(s) remain in the page buffer but \
+                             each item needs {bytes_per_word}",
+                            databuf.len()
+                        ),
+                    ));
+                }
                 let data_start = unzipped_data.len();
                 let offset_start = offsets_data.len();
                 // We might have only-rep or only-def, neither, or both.  They move at the same
@@ -3611,7 +3661,7 @@ impl VariableFullZipDecoder {
                 self.details
                     .ctrl_word_parser
                     .parse(databuf, &mut rep, &mut def);
-                databuf = &databuf[self.details.ctrl_word_parser.bytes_per_word()..];
+                databuf = &databuf[bytes_per_word..];
 
                 if ctrl_desc.is_new_row {
                     self.repdef_starts.push(repdef_start);
@@ -3622,17 +3672,16 @@ impl VariableFullZipDecoder {
                 if ctrl_desc.is_visible {
                     visible_item_count += 1;
                     if ctrl_desc.is_valid_item {
-                        let length = Self::parse_length(databuf, in_bits_per_length)?;
+                        let (value, rest) = Self::split_next_value(databuf, in_bits_per_length)?;
                         match out_bits_per_offset {
                             32 => offsets_data
                                 .extend_from_slice(&(current_offset as u32).to_le_bytes()),
                             64 => offsets_data.extend_from_slice(&current_offset.to_le_bytes()),
                             _ => unreachable!(),
                         };
-                        databuf = &databuf[bytes_per_offset..];
-                        unzipped_data.extend_from_slice(&databuf[..length as usize]);
-                        databuf = &databuf[length as usize..];
-                        current_offset += length;
+                        unzipped_data.extend_from_slice(value);
+                        current_offset += value.len() as u64;
+                        databuf = rest;
                     } else {
                         // Null items still get an offset
                         match out_bits_per_offset {
@@ -7011,6 +7060,7 @@ mod tests {
     use crate::buffer::LanceBuffer;
     use crate::compression::{
         BlockCompressor, DefaultDecompressionStrategy, MiniBlockDecompressor,
+        VariablePerValueDecompressor,
     };
     use crate::constants::{
         COMPRESSION_LEVEL_META_KEY, COMPRESSION_META_KEY, DICT_VALUES_COMPRESSION_LEVEL_META_KEY,
@@ -7024,12 +7074,13 @@ mod tests {
         ChunkDrainInstructions, LoadedChunk, PrimitiveStructuralEncoder,
         StructuralPrimitiveFieldDecoder,
     };
+    use crate::encodings::physical::binary::VariableDecoder;
     use crate::encodings::physical::rle::{RleDecompressor, RleEncoder, RleRuns, RunLengthWidth};
     use crate::encodings::physical::value::{ValueDecompressor, ValueEncoder};
     use crate::format::ProtobufUtils21;
     use crate::format::pb21;
     use crate::format::pb21::compressive_encoding::Compression;
-    use crate::repdef::build_control_word_iterator;
+    use crate::repdef::{ControlWordParser, DefinitionInterpretation, build_control_word_iterator};
     use crate::testing::TestEncoding;
     use crate::testing::{TestCases, check_round_trip_encoding_of_data};
     use arrow_array::{
@@ -10239,44 +10290,69 @@ mod tests {
         check_round_trip_encoding_of_data(vec![list_array], &test_cases, HashMap::new()).await;
     }
 
-    fn truncated_tail_details() -> std::sync::Arc<super::FullZipDecodeDetails> {
-        use crate::compression::VariablePerValueDecompressor;
-        use crate::encodings::physical::binary::VariableDecoder;
-        use crate::repdef::{ControlWordParser, DefinitionInterpretation};
-        use std::sync::Arc;
+    /// Details for a full-zip variable-width page with `bits_rep` / `bits_def` wide
+    /// control words. Both zero means no control word at all.
+    ///
+    /// `max_rep` / `max_visible_def` are derived as "1 if the level is present", which
+    /// is the true maximum only at one bit. Callers that need `parse_desc` to classify
+    /// items correctly at wider levels have to pass the real maxima instead; today's
+    /// callers either use one bit or fail before `parse_desc` runs.
+    fn truncated_tail_details(
+        bits_rep: u8,
+        bits_def: u8,
+    ) -> std::sync::Arc<super::FullZipDecodeDetails> {
         Arc::new(super::FullZipDecodeDetails {
             value_decompressor: super::PerValueDecompressor::Variable(Arc::new(
                 VariableDecoder::default(),
             )
                 as Arc<dyn VariablePerValueDecompressor>),
             def_meaning: vec![DefinitionInterpretation::NullableItem].into(),
-            ctrl_word_parser: ControlWordParser::new(0, 0),
-            max_rep: 0,
-            max_visible_def: 0,
+            ctrl_word_parser: ControlWordParser::new(bits_rep, bits_def),
+            max_rep: u16::from(bits_rep > 0),
+            max_visible_def: u16::from(bits_def > 0),
         })
     }
 
     fn decode_variable_full_zip(
         buf: Vec<u8>,
-        bits_per_offset: u8,
+        num_rows: u64,
+        in_bits_per_length: u8,
+        out_bits_per_offset: u8,
     ) -> lance_core::Result<super::VariableFullZipDecoder> {
-        use std::collections::VecDeque;
+        decode_variable_full_zip_with_levels(
+            buf,
+            num_rows,
+            in_bits_per_length,
+            out_bits_per_offset,
+            0,
+            0,
+        )
+    }
+
+    fn decode_variable_full_zip_with_levels(
+        buf: Vec<u8>,
+        num_rows: u64,
+        in_bits_per_length: u8,
+        out_bits_per_offset: u8,
+        bits_rep: u8,
+        bits_def: u8,
+    ) -> lance_core::Result<super::VariableFullZipDecoder> {
         let mut data = VecDeque::new();
         data.push_back(crate::buffer::LanceBuffer::from(buf));
         super::VariableFullZipDecoder::new(
-            truncated_tail_details(),
+            truncated_tail_details(bits_rep, bits_def),
             data,
-            1,
-            bits_per_offset,
-            bits_per_offset,
+            num_rows,
+            in_bits_per_length,
+            out_bits_per_offset,
         )
     }
 
     /// A well-formed length prefix decodes without incident, for both widths.
     #[test]
     fn variable_full_zip_wellformed_length_prefix() {
-        assert!(decode_variable_full_zip(0u32.to_le_bytes().to_vec(), 32).is_ok());
-        assert!(decode_variable_full_zip(0u64.to_le_bytes().to_vec(), 64).is_ok());
+        assert!(decode_variable_full_zip(0u32.to_le_bytes().to_vec(), 1, 32, 32).is_ok());
+        assert!(decode_variable_full_zip(0u64.to_le_bytes().to_vec(), 1, 64, 64).is_ok());
     }
 
     /// A page whose item walk ends with a partial length prefix must surface a
@@ -10292,7 +10368,7 @@ mod tests {
         use lance_core::Error;
 
         for (bits, buf_len) in [(32u8, 3usize), (64u8, 4usize)] {
-            let err = decode_variable_full_zip(vec![0xAA; buf_len], bits)
+            let err = decode_variable_full_zip(vec![0xAA; buf_len], 1, bits, bits)
                 .expect_err("a truncated length prefix must not decode");
             assert!(
                 matches!(err, Error::CorruptFile { .. }),
@@ -10307,5 +10383,121 @@ mod tests {
                 "error should say what is wrong, got: {msg}"
             );
         }
+    }
+
+    /// A length prefix whose value runs past the end of the page must surface a
+    /// corrupt-file error rather than slicing out of bounds. This is the panic seen
+    /// in production: `range end index 2903552 out of range for slice of length 38469`.
+    #[test]
+    fn variable_full_zip_value_length_past_page_end_is_corrupt_file() {
+        use lance_core::Error;
+
+        // The prefix claims 64 bytes of value data but only 4 follow it.
+        let mut page = 64_u32.to_le_bytes().to_vec();
+        page.extend_from_slice(b"abcd");
+
+        let err = decode_variable_full_zip(page, 1, 32, 32)
+            .expect_err("a value length past the end of the page must not decode");
+        assert!(
+            matches!(err, Error::CorruptFile { .. }),
+            "expected CorruptFile, got: {err:?}"
+        );
+        let msg = err.to_string();
+        assert!(
+            msg.contains("value length 64"),
+            "error should name the claimed length, got: {msg}"
+        );
+    }
+
+    /// `unzip` takes the on-disk length-prefix width and the in-memory offset width as
+    /// two parameters, and must advance the read cursor by the former.
+    ///
+    /// No writer emits a page with the two widths apart today: `create_decoder` passes
+    /// one value for both, and `serialize_full_zip_variable` writes the prefix at the
+    /// same width it uses for offsets. This pins the parameters as independent against
+    /// the `// TODO: byte pack the item lengths with varint encoding` in the writer,
+    /// which is the change that would drive them apart.
+    #[test]
+    fn variable_full_zip_advances_cursor_by_length_width() {
+        let mut page = 3_u16.to_le_bytes().to_vec();
+        page.extend_from_slice(b"abc");
+        page.extend_from_slice(&2_u16.to_le_bytes());
+        page.extend_from_slice(b"de");
+
+        let decoder = decode_variable_full_zip(page, 2, 16, 32).unwrap();
+
+        assert_eq!(decoder.data.as_ref(), b"abcde");
+        assert_eq!(
+            decoder.offsets.borrow_to_typed_slice::<u32>().as_ref(),
+            &[0, 3, 5]
+        );
+    }
+
+    /// A page truncated in the middle of a control word must surface a corrupt-file
+    /// error. Without the check the control word parser indexes the short slice and
+    /// aborts the process before either length check above can run.
+    #[test]
+    fn variable_full_zip_truncated_control_word_is_corrupt_file() {
+        use lance_core::Error;
+
+        // rep and def wide enough together to need a two byte control word, and a
+        // single byte that cannot hold it.
+        let err = decode_variable_full_zip_with_levels(vec![0xAAu8], 1, 32, 32, 4, 5)
+            .expect_err("a page ending mid control word must not decode");
+        assert!(
+            matches!(err, Error::CorruptFile { .. }),
+            "expected CorruptFile, got: {err:?}"
+        );
+        assert!(
+            err.to_string().contains("truncated control word"),
+            "error should say what is wrong, got: {err}"
+        );
+    }
+
+    /// The widths come out of the page metadata, so a width the decoder cannot decode
+    /// must be an error rather than a failed assertion.
+    #[rstest]
+    #[case::length_prefix_24(24, 32, "length prefix width 24")]
+    #[case::offset_width_0(32, 0, "offset width 0")]
+    fn variable_full_zip_rejects_unsupported_widths(
+        #[case] in_bits_per_length: u8,
+        #[case] out_bits_per_offset: u8,
+        #[case] keyword: &str,
+    ) {
+        use lance_core::Error;
+
+        let err =
+            decode_variable_full_zip(vec![0xAA; 8], 1, in_bits_per_length, out_bits_per_offset)
+                .expect_err("an unsupported width must not decode");
+        assert!(
+            matches!(err, Error::CorruptFile { .. }),
+            "expected CorruptFile, got: {err:?}"
+        );
+        assert!(
+            err.to_string().contains(keyword),
+            "error should name the width, got: {err}"
+        );
+    }
+
+    /// A page claiming more rows than it carries bytes for must not underflow the
+    /// capacity estimate. This page's tail is also short, so the walk rejects it too —
+    /// a page that ends exactly on an item boundary while carrying fewer rows than
+    /// claimed is still accepted, which is tracked separately.
+    #[test]
+    fn variable_full_zip_row_count_past_data_does_not_underflow() {
+        use lance_core::Error;
+
+        // 10 rows x 1 control word byte is already more than the 4 bytes on hand, so
+        // the capacity estimate underflows without saturating subtraction.
+        let err = decode_variable_full_zip_with_levels(vec![0xAA; 4], 10, 32, 32, 1, 1)
+            .expect_err("a row count past the page's data must not decode");
+        assert!(
+            matches!(err, Error::CorruptFile { .. }),
+            "expected CorruptFile, got: {err:?}"
+        );
+        assert!(
+            err.to_string().contains("truncated length prefix"),
+            "the walk should reject the page, got: {err}"
+        );
     }
 }

--- a/rust/lance-encoding/src/encodings/logical/primitive.rs
+++ b/rust/lance-encoding/src/encodings/logical/primitive.rs
@@ -10385,8 +10385,8 @@ mod tests {
     }
 
     /// A length prefix whose value runs past the end of the page must surface a
-    /// corrupt-file error rather than slicing out of bounds. This is the panic seen
-    /// in production: `range end index 2903552 out of range for slice of length 38469`.
+    /// corrupt-file error rather than slicing out of bounds, which panicked on the
+    /// decode task and reached the caller as an opaque aborted-task error.
     #[test]
     fn variable_full_zip_value_length_past_page_end_is_corrupt_file() {
         // The prefix claims 64 bytes of value data but only 4 follow it.

--- a/rust/lance-encoding/src/encodings/physical/binary.rs
+++ b/rust/lance-encoding/src/encodings/physical/binary.rs
@@ -839,7 +839,19 @@ mod tests {
         structural_encoding: &str,
         #[values(DataType::Utf8, DataType::Binary)] data_type: DataType,
     ) {
-        let string_array = StringArray::from(vec![Some("abc"), None, Some("pqr"), None, Some("m")]);
+        // Empty values at index 3 and at the end: the first is inside the take pass
+        // below rather than only the full scan, the second leaves the page's last item
+        // zero-length, which is the one shape where a length prefix of 0 has no bytes
+        // following it. No other forced-full-zip test carries an empty value.
+        let string_array = StringArray::from(vec![
+            Some("abc"),
+            None,
+            Some("pqr"),
+            Some(""),
+            None,
+            Some("m"),
+            Some(""),
+        ]);
         let string_array = arrow_cast::cast(&string_array, &data_type).unwrap();
 
         let mut field_metadata = HashMap::new();
@@ -852,7 +864,7 @@ mod tests {
             .with_range(0..2)
             .with_range(0..3)
             .with_range(1..3)
-            .with_indices(vec![0, 1, 3, 4]);
+            .with_indices(vec![0, 1, 3, 4, 6]);
         check_round_trip_encoding_of_data(
             vec![Arc::new(string_array)],
             &test_cases,


### PR DESCRIPTION
## What

`VariableFullZipDecoder::unzip` walks a variable-width full-zip page using lengths and widths read straight out of the file, with no bounds checks, so a corrupt or misaligned page aborts the process instead of failing the read. The slice panic it raises runs on a decode task, so the caller sees only an opaque aborted-task error rather than anything naming the page.

## Root cause

Four separate aborts on the same walk:

1. **The value length slices the page unchecked.** `&databuf[..length as usize]` where `length` came from the page bytes. Any corrupt or misread prefix ends the process.
2. **The read cursor advanced by the wrong width.** After parsing a prefix of `in_bits_per_length` bits, the cursor moved by `bytes_per_offset`, derived from `out_bits_per_offset`. These are two independent parameters of `unzip`; they are equal today only because `create_decoder` passes one value for both. The computed `bytes_per_length` was used for nothing but a capacity estimate. Splitting the read from the advance is what let the two drift apart in the first place.
3. **The loop checked that bytes remained, not that a whole control word did.** With a two or four byte control word, a page truncated mid word made `ControlWordParser::parse_desc` index past the end of the slice, one step earlier in the walk than either length check.
4. **`new` asserted values that come from the file.** The two widths arrive from the page protobuf, so `assert_eq!(in_bits_per_length % 8, 0)` turns a corrupt page into an abort, and the assertion admits widths the decoder cannot decode: 24 passes `% 8 == 0` and then reaches `unreachable!()`. The capacity estimate also subtracted a metadata-derived byte count from the actual buffer size without saturating, which underflows before any of the checks above can run.

## Fix

`parse_length` becomes `split_next_value(data, bits_per_length) -> Result<(&[u8], &[u8])>`: it reads the prefix, bounds-checks the length it claims against the bytes that follow, and returns the value together with the rest of the buffer. The width now appears once, so advancing by the wrong one is no longer expressible rather than merely fixed. Validation also moves ahead of the offset push.

The other three return `Error::CorruptFile` naming the offending value: a control-word length check at the top of the loop, a width check in `new` restricted to what the decoder actually decodes (`{8, 16, 32, 64}` for the prefix, `{32, 64}` for the offsets), and a saturating capacity estimate.

## Scope

This covers the item walk. Two aborts on the same decoder are left for page-metadata validation, tracked in #8768: the `num_rows`-derived preallocation in `new` still dies on an absurd row count before any of these checks run, and `drain` still indexes its row-start vectors with a row count the page bytes may not support.

## Test plan

Seven tests around `VariableFullZipDecoder`, all in the existing `mod tests` next to the pre-existing truncated-prefix test, sharing its helper:

- a value length past the end of the page, the case that panicked in the slice
- a page truncated mid control word
- unsupported prefix and offset widths, as an `rstest` over both
- a row count larger than the page's data, for the capacity underflow
- cursor advance with the prefix width and the offset width set apart, which pins the two `unzip` parameters as independent

Each was checked against the mutation it is meant to catch: reverting any one of the five production changes turns the corresponding test red, and each test asserts the error variant as well as the message.

`test_simple_binary` also gains two empty values, because no forced-full-zip round trip carried one: it had none itself, `test_empty_strings` uses default metadata so its short strings take the miniblock path, and the other full-zip string tests generate fixed-width random data. One sits at index 3, which the take pass reads, and one at the end, which leaves the page's last item zero-length with no bytes after its prefix. Writing the length check as `>=` instead of `>` turns that test red.

`cargo test -p lance-encoding` (584 passing, includes the full-zip round-trip and fuzz coverage), `cargo test -p lance-file` (157), `cargo fmt --all`, and `cargo clippy --all --tests --benches -- -D warnings` are clean.


