### PR TITLE
fix(index): stream bulk index file copies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4937,6 +4937,7 @@ dependencies = [
  "rstest",
  "serde",
  "serde_json",
+ "serial_test",
  "tempfile",
  "test-log",
  "tokio",

--- a/docs/src/guide/object_store.md
+++ b/docs/src/guide/object_store.md
@@ -55,6 +55,12 @@ Native copy can reduce client bandwidth and transfer cost, but it requires copy
 support from the object-store integration and is subject to the provider
 request's timeout and retry behavior.
 
+Deep clone bounds non-local file movement to four concurrent files by default.
+Set `LANCE_DEEP_CLONE_STREAM_CONCURRENCY` to a positive integer to override this
+operation-specific limit. The bound also applies when server-side copy is
+enabled because S3 and GCS copies above the provider's single-copy size limit
+fall back to streaming through Lance.
+
 ## Per-Base Configuration
 
 A dataset can register additional base paths that store part of its data, and each

--- a/docs/src/guide/object_store.md
+++ b/docs/src/guide/object_store.md
@@ -41,6 +41,19 @@ These options apply to all object stores.
 | `client_max_retries`         | Number of times for the object store client to retry the request. Default, `3`.                                                                                                                                                                                                                         |
 | `client_retry_timeout`       | Timeout for the object store client to retry the request in seconds. Default, `180`.                                                                                                                                                                                                                    |
 
+### Bulk copy strategy
+
+Lance streams bulk index-file movement and dataset deep-clone files through
+read and write APIs by default. This avoids requiring a provider-native copy
+operation and works across different object stores.
+
+Set `LANCE_IO_SERVER_SIDE_COPY_ENABLED` to a truthy value (`1`, `true`, `on`,
+`yes`, or `y`, case-insensitive) to opt same-store cloud copies into the
+provider-native server-side copy operation. Cross-store and local copies do not
+use this setting. Native copy can reduce client bandwidth and transfer cost, but
+it requires copy support from the object-store integration and is subject to the
+provider request's timeout and retry behavior.
+
 ## Per-Base Configuration
 
 A dataset can register additional base paths that store part of its data, and each

--- a/docs/src/guide/object_store.md
+++ b/docs/src/guide/object_store.md
@@ -48,11 +48,12 @@ read and write APIs by default. This avoids requiring a provider-native copy
 operation and works across different object stores.
 
 Set `LANCE_IO_SERVER_SIDE_COPY_ENABLED` to a truthy value (`1`, `true`, `on`,
-`yes`, or `y`, case-insensitive) to opt same-store cloud copies into the
-provider-native server-side copy operation. Cross-store and local copies do not
-use this setting. Native copy can reduce client bandwidth and transfer cost, but
-it requires copy support from the object-store integration and is subject to the
-provider request's timeout and retry behavior.
+`yes`, or `y`, case-insensitive) to opt cloud copies whose source and destination
+share the same object-store client into the provider-native server-side copy
+operation. Cross-client, cross-store, and local copies do not use this setting.
+Native copy can reduce client bandwidth and transfer cost, but it requires copy
+support from the object-store integration and is subject to the provider
+request's timeout and retry behavior.
 
 ## Per-Base Configuration
 

--- a/rust/lance-index/src/scalar/inverted/builder.rs
+++ b/rust/lance-index/src/scalar/inverted/builder.rs
@@ -2546,6 +2546,77 @@ mod tests {
         }
     }
 
+    #[derive(Debug)]
+    struct CopyFailingObjectStore {
+        inner: InMemory,
+        copy_count: Arc<AtomicUsize>,
+    }
+
+    impl Display for CopyFailingObjectStore {
+        fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+            write!(f, "CopyFailingObjectStore")
+        }
+    }
+
+    #[async_trait]
+    impl OSObjectStore for CopyFailingObjectStore {
+        async fn put_opts(
+            &self,
+            location: &Path,
+            bytes: PutPayload,
+            opts: PutOptions,
+        ) -> OSResult<PutResult> {
+            self.inner.put_opts(location, bytes, opts).await
+        }
+
+        async fn put_multipart_opts(
+            &self,
+            location: &Path,
+            opts: PutMultipartOptions,
+        ) -> OSResult<Box<dyn MultipartUpload>> {
+            self.inner.put_multipart_opts(location, opts).await
+        }
+
+        async fn get_opts(&self, location: &Path, options: GetOptions) -> OSResult<GetResult> {
+            self.inner.get_opts(location, options).await
+        }
+
+        async fn get_ranges(&self, location: &Path, ranges: &[Range<u64>]) -> OSResult<Vec<Bytes>> {
+            self.inner.get_ranges(location, ranges).await
+        }
+
+        fn delete_stream(
+            &self,
+            locations: BoxStream<'static, OSResult<Path>>,
+        ) -> BoxStream<'static, OSResult<Path>> {
+            self.inner.delete_stream(locations)
+        }
+
+        fn list(&self, prefix: Option<&Path>) -> BoxStream<'static, OSResult<ObjectMeta>> {
+            self.inner.list(prefix)
+        }
+
+        fn list_with_offset(
+            &self,
+            prefix: Option<&Path>,
+            offset: &Path,
+        ) -> BoxStream<'static, OSResult<ObjectMeta>> {
+            self.inner.list_with_offset(prefix, offset)
+        }
+
+        async fn list_with_delimiter(&self, prefix: Option<&Path>) -> OSResult<ListResult> {
+            self.inner.list_with_delimiter(prefix).await
+        }
+
+        async fn copy_opts(&self, _from: &Path, _to: &Path, _opts: CopyOptions) -> OSResult<()> {
+            self.copy_count.fetch_add(1, Ordering::SeqCst);
+            Err(object_store::Error::Generic {
+                store: "CopyFailingObjectStore",
+                source: "native copy disabled in test".into(),
+            })
+        }
+    }
+
     #[tokio::test]
     async fn test_list_metadata_files_propagates_list_error() -> Result<()> {
         let mut object_store = ObjectStore::memory();
@@ -3093,6 +3164,99 @@ mod tests {
                 );
             }
         }
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_fts_remap_streams_files_when_native_copy_fails() -> Result<()> {
+        let copy_count = Arc::new(AtomicUsize::new(0));
+        let mut object_store = ObjectStore::memory();
+        object_store.inner = Arc::new(CopyFailingObjectStore {
+            inner: InMemory::new(),
+            copy_count: copy_count.clone(),
+        });
+        let object_store = Arc::new(object_store);
+        let index_path = Path::from("index");
+        let base_store: Arc<dyn IndexStore> = Arc::new(LanceIndexStore::new(
+            object_store.clone(),
+            index_path.clone(),
+            Arc::new(LanceCache::no_cache()),
+        ));
+        let store = Arc::new(NoRenameStore::new(base_store.clone()));
+        let partitions = vec![5_u64, 1_u64];
+        let metadata_builder = InvertedIndexBuilder::from_existing_index(
+            InvertedIndexParams::default(),
+            None,
+            Vec::new(),
+            TokenSetFormat::default(),
+            None,
+            RoaringBitmap::new(),
+        );
+
+        for partition_id in &partitions {
+            write_partition_files(
+                base_store.as_ref(),
+                *partition_id,
+                PartitionWriteTarget::Staged,
+            )
+            .await?;
+            metadata_builder
+                .write_part_metadata(base_store.as_ref(), *partition_id)
+                .await?;
+        }
+
+        let probe_source = staged_partition_file_path(partitions[0], TOKENS_FILE);
+        let probe_source_size = base_store
+            .open_index_file(&probe_source)
+            .await?
+            .file_size_bytes()
+            .expect("written index file should report its size");
+        let copied = base_store
+            .copy_index_file_to(&probe_source, "probe.lance", base_store.as_ref())
+            .await?;
+        assert_eq!(copied.path, "probe.lance");
+        assert_eq!(copied.size_bytes, probe_source_size);
+        assert_eq!(
+            read_partition_file_marker(base_store.as_ref(), "probe.lance").await?,
+            partitions[0]
+        );
+
+        let renamed = base_store
+            .rename_index_file("probe.lance", "renamed-probe.lance")
+            .await?;
+        assert_eq!(renamed.path, "renamed-probe.lance");
+        assert_eq!(renamed.size_bytes, probe_source_size);
+        assert!(base_store.open_index_file("probe.lance").await.is_err());
+        assert_eq!(
+            read_partition_file_marker(base_store.as_ref(), "renamed-probe.lance").await?,
+            partitions[0]
+        );
+
+        let progress = Arc::new(RecordingProgress::default());
+        merge_index_files(object_store.as_ref(), &index_path, store, progress.clone()).await?;
+
+        let mut expected_partitions = partitions;
+        expected_partitions.sort_unstable();
+        for (new_id, old_id) in expected_partitions.iter().enumerate() {
+            assert_partition_file_markers(base_store.as_ref(), new_id as u64, *old_id).await?;
+        }
+        let remap_progress = progress
+            .recorded_events()
+            .into_iter()
+            .filter_map(|(kind, stage, completed)| {
+                (kind == "progress" && stage == "remap_partition_files").then_some(completed)
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(
+            remap_progress.last().copied(),
+            Some((expected_partitions.len() * PARTITION_FILE_SUFFIXES.len()) as u64)
+        );
+        assert_eq!(
+            copy_count.load(Ordering::SeqCst),
+            0,
+            "bulk index movement must not invoke native object-store copy"
+        );
 
         Ok(())
     }

--- a/rust/lance-index/src/scalar/lance_format.rs
+++ b/rust/lance-index/src/scalar/lance_format.rs
@@ -489,7 +489,7 @@ impl IndexStore for LanceIndexStore {
                 let dest_path = dest_store.index_file_path(new_name)?;
                 let result = self
                     .object_store
-                    .copy_via_stream(&path, &dest_store.object_store, &dest_path)
+                    .copy_bulk(&path, &dest_store.object_store, &dest_path)
                     .await?;
                 Ok(IndexFile {
                     path: new_name.to_string(),
@@ -517,7 +517,7 @@ impl IndexStore for LanceIndexStore {
         let new_path = self.index_file_path(new_name)?;
         let result = self
             .object_store
-            .copy_via_stream(&path, &self.object_store, &new_path)
+            .copy_bulk(&path, &self.object_store, &new_path)
             .await?;
         self.object_store.delete(&path).await?;
         Ok(IndexFile {

--- a/rust/lance-index/src/scalar/lance_format.rs
+++ b/rust/lance-index/src/scalar/lance_format.rs
@@ -484,21 +484,16 @@ impl IndexStore for LanceIndexStore {
     ) -> Result<IndexFile> {
         let path = self.index_file_path(name)?;
 
-        let other_store = dest_store.as_any().downcast_ref::<Self>();
-        match other_store {
-            Some(dest_store) if dest_store.object_store.scheme() == self.object_store.scheme() => {
-                // If both this store and the destination are lance stores we can use object_store's copy
-                // This does blindly assume that both stores are using the same underlying object_store
-                // but there is no easy way to verify this and it happens to always be true at the moment
+        match dest_store.as_any().downcast_ref::<Self>() {
+            Some(dest_store) => {
                 let dest_path = dest_store.index_file_path(new_name)?;
-                self.object_store.copy(&path, &dest_path).await?;
-                let size_bytes = match self.file_sizes.get(name) {
-                    Some(size_bytes) => *size_bytes,
-                    None => self.object_store.size(&path).await?,
-                };
+                let result = self
+                    .object_store
+                    .copy_via_stream(&path, &dest_store.object_store, &dest_path)
+                    .await?;
                 Ok(IndexFile {
                     path: new_name.to_string(),
-                    size_bytes,
+                    size_bytes: result.size as u64,
                 })
             }
             _ => {
@@ -520,15 +515,14 @@ impl IndexStore for LanceIndexStore {
     async fn rename_index_file(&self, name: &str, new_name: &str) -> Result<IndexFile> {
         let path = self.index_file_path(name)?;
         let new_path = self.index_file_path(new_name)?;
-        self.object_store.copy(&path, &new_path).await?;
+        let result = self
+            .object_store
+            .copy_via_stream(&path, &self.object_store, &new_path)
+            .await?;
         self.object_store.delete(&path).await?;
-        let size_bytes = match self.file_sizes.get(name) {
-            Some(size_bytes) => *size_bytes,
-            None => self.object_store.size(&new_path).await?,
-        };
         Ok(IndexFile {
             path: new_name.to_string(),
-            size_bytes,
+            size_bytes: result.size as u64,
         })
     }
 

--- a/rust/lance-io/Cargo.toml
+++ b/rust/lance-io/Cargo.toml
@@ -56,6 +56,7 @@ lance-testing.workspace = true
 test-log.workspace = true
 mockall.workspace = true
 rstest.workspace = true
+serial_test.workspace = true
 mock_instant.workspace = true
 tokio = { workspace = true, features = ["test-util"] }
 tracing-mock = { workspace = true }

--- a/rust/lance-io/src/object_store.rs
+++ b/rust/lance-io/src/object_store.rs
@@ -11,6 +11,7 @@ use std::str::FromStr;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
+use ::tracing::{Span, field::Empty, instrument};
 use async_trait::async_trait;
 use bytes::Bytes;
 use chrono::{DateTime, Utc};
@@ -1098,21 +1099,22 @@ impl ObjectStore {
     /// # Ok(())
     /// # }
     /// ```
-    #[tracing::instrument(
+    #[instrument(
         name = "multipart_stream_copy",
         level = "info",
         skip(self, destination_store),
         fields(
             source = %source_path,
             destination = %destination_path,
-            source_size = tracing::field::Empty,
+            source_size = Empty,
+            read_chunk_size = Empty,
             multipart_part_size = crate::object_writer::initial_upload_size(),
             multipart_concurrency = crate::object_writer::max_upload_parallelism(),
             part_count = 1_u64,
-            bytes_transferred = tracing::field::Empty,
-            destination_size = tracing::field::Empty,
-            validation = tracing::field::Empty,
-            elapsed_ms = tracing::field::Empty,
+            bytes_transferred = Empty,
+            destination_size = Empty,
+            validation = Empty,
+            elapsed_ms = Empty,
         ),
         err
     )]
@@ -1129,7 +1131,7 @@ impl ObjectStore {
         let source_size = reader.size().await.map_err(|source| {
             stream_copy_error("source metadata", source_path, destination_path, source)
         })?;
-        tracing::Span::current().record("source_size", source_size as u64);
+        Span::current().record("source_size", source_size as u64);
 
         let mut writer = destination_store
             .create(destination_path)
@@ -1142,19 +1144,30 @@ impl ObjectStore {
                     source,
                 )
             })?;
-        let mut stream = reader.get_stream().await.map_err(|source| {
-            stream_copy_error(
-                "source read initialization",
-                source_path,
-                destination_path,
-                source,
-            )
-        })?;
+        let read_chunk_size = usize::try_from(self.max_iop_size())
+            .unwrap_or(usize::MAX)
+            .max(1);
+        Span::current().record("read_chunk_size", read_chunk_size as u64);
         let mut bytes_transferred = 0usize;
-        while let Some(chunk) = stream.next().await {
-            let bytes = chunk.map_err(|source| {
+        while bytes_transferred < source_size {
+            let range_end = bytes_transferred
+                .checked_add(read_chunk_size)
+                .unwrap_or(source_size)
+                .min(source_size);
+            let range = bytes_transferred..range_end;
+            let expected_bytes = range.len();
+            let bytes = reader.get_range(range.clone()).await.map_err(|source| {
                 stream_copy_error("source read", source_path, destination_path, source)
             })?;
+            if bytes.len() != expected_bytes {
+                Span::current().record("validation", "failed");
+                return Err(Error::io(format!(
+                    "multipart_stream_copy source range size mismatch from {source_path} to \
+                     {destination_path}: range={range:?}, expected_bytes={expected_bytes}, \
+                     actual_bytes={}",
+                    bytes.len()
+                )));
+            }
             bytes_transferred = bytes_transferred.checked_add(bytes.len()).ok_or_else(|| {
                 Error::io(format!(
                     "multipart_stream_copy byte count overflow from {source_path} to \
@@ -1164,11 +1177,11 @@ impl ObjectStore {
             writer.write_all(&bytes).await.map_err(|source| {
                 stream_copy_error("destination write", source_path, destination_path, source)
             })?;
-            tracing::Span::current().record("bytes_transferred", bytes_transferred as u64);
+            Span::current().record("bytes_transferred", bytes_transferred as u64);
         }
 
         if bytes_transferred != source_size {
-            tracing::Span::current().record("validation", "failed");
+            Span::current().record("validation", "failed");
             return Err(Error::io(format!(
                 "multipart_stream_copy source size mismatch from {source_path} to \
                  {destination_path}: source_size={source_size}, \
@@ -1185,7 +1198,7 @@ impl ObjectStore {
             )
         })?;
         if write_result.size != source_size {
-            tracing::Span::current().record("validation", "failed");
+            Span::current().record("validation", "failed");
             return Err(Error::io(format!(
                 "multipart_stream_copy writer size mismatch from {source_path} to \
                  {destination_path}: source_size={source_size}, \
@@ -1206,9 +1219,9 @@ impl ObjectStore {
                         source,
                     )
                 })?;
-        tracing::Span::current().record("destination_size", destination_size);
+        Span::current().record("destination_size", destination_size);
         if destination_size != source_size as u64 {
-            tracing::Span::current().record("validation", "failed");
+            Span::current().record("validation", "failed");
             return Err(Error::io(format!(
                 "multipart_stream_copy destination size mismatch from {source_path} to \
                  {destination_path}: source_size={source_size}, \
@@ -1216,8 +1229,8 @@ impl ObjectStore {
             )));
         }
 
-        tracing::Span::current().record("validation", "passed");
-        tracing::Span::current().record("elapsed_ms", started_at.elapsed().as_millis() as u64);
+        Span::current().record("validation", "passed");
+        Span::current().record("elapsed_ms", started_at.elapsed().as_millis() as u64);
         Ok(write_result)
     }
 

--- a/rust/lance-io/src/object_store.rs
+++ b/rust/lance-io/src/object_store.rs
@@ -19,7 +19,7 @@ use futures::{FutureExt, Stream};
 use futures::{StreamExt, TryStreamExt, future, stream::BoxStream};
 use lance_core::deepsize::DeepSizeOf;
 use lance_core::error::LanceOptionExt;
-use lance_core::utils::parse::str_is_truthy;
+use lance_core::utils::parse::{parse_env_as_bool, str_is_truthy};
 use list_retry::ListRetryStream;
 use object_store::DynObjectStore;
 use object_store::ObjectStoreExt as OSObjectStoreExt;
@@ -79,6 +79,8 @@ use lance_core::{Error, Result};
 pub const DEFAULT_LOCAL_IO_PARALLELISM: usize = 8;
 // Cloud disks often need many many threads to saturate the network
 pub const DEFAULT_CLOUD_IO_PARALLELISM: usize = 64;
+
+const SERVER_SIDE_COPY_ENABLED_ENV: &str = "LANCE_IO_SERVER_SIDE_COPY_ENABLED";
 
 const DEFAULT_LOCAL_BLOCK_SIZE: usize = 4 * 1024; // 4KB block size
 #[cfg(any(
@@ -1075,6 +1077,91 @@ impl ObjectStore {
             Self::MAX_SINGLE_COPY_BYTES,
         )
         .await
+    }
+
+    /// Copy an object using the policy for bulk file movement.
+    ///
+    /// Streaming is the default because it works across object stores and does
+    /// not require provider-native copy support. Setting
+    /// `LANCE_IO_SERVER_SIDE_COPY_ENABLED` to a truthy value opts same-store
+    /// copies into [`Self::copy`]. Cross-store and local copies continue to use
+    /// [`Self::copy_via_stream`].
+    ///
+    /// ```no_run
+    /// # use lance_core::Result;
+    /// # use lance_io::object_store::ObjectStore;
+    /// # use object_store::path::Path;
+    /// # async fn copy(source: &ObjectStore, destination: &ObjectStore) -> Result<()> {
+    /// source
+    ///     .copy_bulk(
+    ///         &Path::from("staging/index.lance"),
+    ///         destination,
+    ///         &Path::from("index.lance"),
+    ///     )
+    ///     .await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn copy_bulk(
+        &self,
+        source_path: &Path,
+        destination_store: &Self,
+        destination_path: &Path,
+    ) -> Result<WriteResult> {
+        self.copy_bulk_with_server_side_copy(
+            source_path,
+            destination_store,
+            destination_path,
+            parse_env_as_bool(SERVER_SIDE_COPY_ENABLED_ENV, false),
+        )
+        .await
+    }
+
+    async fn copy_bulk_with_server_side_copy(
+        &self,
+        source_path: &Path,
+        destination_store: &Self,
+        destination_path: &Path,
+        server_side_copy_enabled: bool,
+    ) -> Result<WriteResult> {
+        if !server_side_copy_enabled || !self.can_server_side_copy_to(destination_store) {
+            return self
+                .copy_via_stream(source_path, destination_store, destination_path)
+                .await;
+        }
+
+        let source_size = self.size(source_path).await?;
+        let result_size = usize::try_from(source_size).map_err(|source| {
+            Error::io(format!(
+                "server-side copy source size conversion failed from {source_path} to \
+                 {destination_path}: source_size={source_size}, error={source}"
+            ))
+        })?;
+        self.copy(source_path, destination_path).await?;
+        let destination_size = destination_store.size(destination_path).await?;
+        if destination_size != source_size {
+            return Err(Error::io(format!(
+                "server-side copy destination size mismatch from {source_path} to \
+                 {destination_path}: source_size={source_size}, \
+                 destination_size={destination_size}"
+            )));
+        }
+
+        Ok(WriteResult {
+            size: result_size,
+            e_tag: None,
+        })
+    }
+
+    fn can_server_side_copy_to(&self, destination_store: &Self) -> bool {
+        if self.is_local() || destination_store.is_local() {
+            return false;
+        }
+
+        Arc::ptr_eq(&self.inner, &destination_store.inner)
+            || (self.is_cloud()
+                && destination_store.is_cloud()
+                && self.store_prefix == destination_store.store_prefix)
     }
 
     /// Copy an object by streaming its bytes through Lance's multipart-aware writer.
@@ -2498,6 +2585,7 @@ mod tests {
     struct MultipartObservations {
         part_count: AtomicUsize,
         abort_count: AtomicUsize,
+        native_copy_count: AtomicUsize,
     }
 
     #[derive(Debug)]
@@ -2610,11 +2698,11 @@ mod tests {
             self.inner.list_with_delimiter(prefix).await
         }
 
-        async fn copy_opts(&self, _from: &Path, _to: &Path, _opts: CopyOptions) -> OSResult<()> {
-            Err(object_store::Error::Generic {
-                store: "ObservedMultipartStore",
-                source: "native copy disabled in test".into(),
-            })
+        async fn copy_opts(&self, from: &Path, to: &Path, opts: CopyOptions) -> OSResult<()> {
+            self.observations
+                .native_copy_count
+                .fetch_add(1, Ordering::SeqCst);
+            self.inner.copy_opts(from, to, opts).await
         }
     }
 
@@ -2723,6 +2811,98 @@ mod tests {
         assert_eq!(result.size, contents.len());
         assert_eq!(
             store.read_one_all(&destination).await.unwrap().as_ref(),
+            contents
+        );
+    }
+
+    #[tokio::test]
+    async fn test_bulk_copy_streams_when_server_side_copy_is_disabled() {
+        let observations = Arc::new(MultipartObservations::default());
+        let mut store = ObjectStore::memory();
+        store.inner = Arc::new(ObservedMultipartStore {
+            inner: InMemory::new(),
+            observations: observations.clone(),
+            fail_parts: false,
+            destination_size_adjustment: 0,
+        });
+
+        let source = Path::from("source.bin");
+        let destination = Path::from("destination.bin");
+        let contents = b"stream by default";
+        store.put(&source, contents).await.unwrap();
+
+        let result = store
+            .copy_bulk_with_server_side_copy(&source, &store, &destination, false)
+            .await
+            .unwrap();
+
+        assert_eq!(result.size, contents.len());
+        assert_eq!(observations.native_copy_count.load(Ordering::SeqCst), 0);
+        assert_eq!(
+            store.read_one_all(&destination).await.unwrap().as_ref(),
+            contents
+        );
+    }
+
+    #[tokio::test]
+    async fn test_bulk_copy_uses_server_side_copy_when_enabled_for_same_store() {
+        let observations = Arc::new(MultipartObservations::default());
+        let mut store = ObjectStore::memory();
+        store.inner = Arc::new(ObservedMultipartStore {
+            inner: InMemory::new(),
+            observations: observations.clone(),
+            fail_parts: false,
+            destination_size_adjustment: 0,
+        });
+
+        let source = Path::from("source.bin");
+        let destination = Path::from("destination.bin");
+        let contents = b"use native copy when explicitly enabled";
+        store.put(&source, contents).await.unwrap();
+
+        let result = store
+            .copy_bulk_with_server_side_copy(&source, &store, &destination, true)
+            .await
+            .unwrap();
+
+        assert_eq!(result.size, contents.len());
+        assert_eq!(observations.native_copy_count.load(Ordering::SeqCst), 1);
+        assert_eq!(
+            store.read_one_all(&destination).await.unwrap().as_ref(),
+            contents
+        );
+    }
+
+    #[tokio::test]
+    async fn test_bulk_copy_streams_across_stores_when_server_side_copy_is_enabled() {
+        let source_store = ObjectStore::memory();
+        let observations = Arc::new(MultipartObservations::default());
+        let mut destination_store = ObjectStore::memory();
+        destination_store.inner = Arc::new(ObservedMultipartStore {
+            inner: InMemory::new(),
+            observations: observations.clone(),
+            fail_parts: false,
+            destination_size_adjustment: 0,
+        });
+
+        let source = Path::from("source.bin");
+        let destination = Path::from("destination.bin");
+        let contents = b"cross-store copies must stream";
+        source_store.put(&source, contents).await.unwrap();
+
+        let result = source_store
+            .copy_bulk_with_server_side_copy(&source, &destination_store, &destination, true)
+            .await
+            .unwrap();
+
+        assert_eq!(result.size, contents.len());
+        assert_eq!(observations.native_copy_count.load(Ordering::SeqCst), 0);
+        assert_eq!(
+            destination_store
+                .read_one_all(&destination)
+                .await
+                .unwrap()
+                .as_ref(),
             contents
         );
     }

--- a/rust/lance-io/src/object_store.rs
+++ b/rust/lance-io/src/object_store.rs
@@ -9,7 +9,7 @@ use std::ops::Range;
 use std::pin::Pin;
 use std::str::FromStr;
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use async_trait::async_trait;
 use bytes::Bytes;
@@ -99,6 +99,44 @@ pub static DEFAULT_MAX_IOP_SIZE: std::sync::LazyLock<u64> = std::sync::LazyLock:
 });
 
 pub const DEFAULT_DOWNLOAD_RETRY_COUNT: usize = 3;
+
+#[derive(Debug)]
+struct StreamCopyError {
+    stage: &'static str,
+    source_path: String,
+    destination_path: String,
+    source: Box<dyn std::error::Error + Send + Sync>,
+}
+
+impl std::fmt::Display for StreamCopyError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "multipart_stream_copy failed during {} from {} to {}: {}",
+            self.stage, self.source_path, self.destination_path, self.source
+        )
+    }
+}
+
+impl std::error::Error for StreamCopyError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        Some(self.source.as_ref())
+    }
+}
+
+fn stream_copy_error(
+    stage: &'static str,
+    source_path: &Path,
+    destination_path: &Path,
+    source: impl std::error::Error + Send + Sync + 'static,
+) -> Error {
+    Error::io_source(Box::new(StreamCopyError {
+        stage,
+        source_path: source_path.to_string(),
+        destination_path: destination_path.to_string(),
+        source: Box::new(source),
+    }))
+}
 
 pub use providers::{ObjectStoreProvider, ObjectStoreRegistry};
 pub use read_dir::ReadDirOptions;
@@ -1038,6 +1076,151 @@ impl ObjectStore {
         .await
     }
 
+    /// Copy an object by streaming its bytes through Lance's multipart-aware writer.
+    ///
+    /// Unlike [`Self::copy`], this never delegates to a provider-native server-side
+    /// copy. The source and destination may use different object stores. The copy
+    /// succeeds only after the byte count reported by the writer and a destination
+    /// metadata lookup both match the source size.
+    ///
+    /// ```no_run
+    /// # use lance_core::Result;
+    /// # use lance_io::object_store::ObjectStore;
+    /// # use object_store::path::Path;
+    /// # async fn copy(source: &ObjectStore, destination: &ObjectStore) -> Result<()> {
+    /// source
+    ///     .copy_via_stream(
+    ///         &Path::from("staging/index.lance"),
+    ///         destination,
+    ///         &Path::from("index.lance"),
+    ///     )
+    ///     .await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    #[tracing::instrument(
+        name = "multipart_stream_copy",
+        level = "info",
+        skip(self, destination_store),
+        fields(
+            source = %source_path,
+            destination = %destination_path,
+            source_size = tracing::field::Empty,
+            multipart_part_size = crate::object_writer::initial_upload_size(),
+            multipart_concurrency = crate::object_writer::max_upload_parallelism(),
+            part_count = 1_u64,
+            bytes_transferred = tracing::field::Empty,
+            destination_size = tracing::field::Empty,
+            validation = tracing::field::Empty,
+            elapsed_ms = tracing::field::Empty,
+        ),
+        err
+    )]
+    pub async fn copy_via_stream(
+        &self,
+        source_path: &Path,
+        destination_store: &Self,
+        destination_path: &Path,
+    ) -> Result<WriteResult> {
+        let started_at = Instant::now();
+        let reader = self.open(source_path).await.map_err(|source| {
+            stream_copy_error("source open", source_path, destination_path, source)
+        })?;
+        let source_size = reader.size().await.map_err(|source| {
+            stream_copy_error("source metadata", source_path, destination_path, source)
+        })?;
+        tracing::Span::current().record("source_size", source_size as u64);
+
+        let mut writer = destination_store
+            .create(destination_path)
+            .await
+            .map_err(|source| {
+                stream_copy_error(
+                    "destination writer creation",
+                    source_path,
+                    destination_path,
+                    source,
+                )
+            })?;
+        let mut stream = reader.get_stream().await.map_err(|source| {
+            stream_copy_error(
+                "source read initialization",
+                source_path,
+                destination_path,
+                source,
+            )
+        })?;
+        let mut bytes_transferred = 0usize;
+        while let Some(chunk) = stream.next().await {
+            let bytes = chunk.map_err(|source| {
+                stream_copy_error("source read", source_path, destination_path, source)
+            })?;
+            bytes_transferred = bytes_transferred.checked_add(bytes.len()).ok_or_else(|| {
+                Error::io(format!(
+                    "multipart_stream_copy byte count overflow from {source_path} to \
+                     {destination_path}"
+                ))
+            })?;
+            writer.write_all(&bytes).await.map_err(|source| {
+                stream_copy_error("destination write", source_path, destination_path, source)
+            })?;
+            tracing::Span::current().record("bytes_transferred", bytes_transferred as u64);
+        }
+
+        if bytes_transferred != source_size {
+            tracing::Span::current().record("validation", "failed");
+            return Err(Error::io(format!(
+                "multipart_stream_copy source size mismatch from {source_path} to \
+                 {destination_path}: source_size={source_size}, \
+                 bytes_transferred={bytes_transferred}"
+            )));
+        }
+
+        let write_result = Writer::shutdown(writer.as_mut()).await.map_err(|source| {
+            stream_copy_error(
+                "destination completion",
+                source_path,
+                destination_path,
+                source,
+            )
+        })?;
+        if write_result.size != source_size {
+            tracing::Span::current().record("validation", "failed");
+            return Err(Error::io(format!(
+                "multipart_stream_copy writer size mismatch from {source_path} to \
+                 {destination_path}: source_size={source_size}, \
+                 writer_size={}",
+                write_result.size
+            )));
+        }
+
+        let destination_size =
+            destination_store
+                .size(destination_path)
+                .await
+                .map_err(|source| {
+                    stream_copy_error(
+                        "destination validation",
+                        source_path,
+                        destination_path,
+                        source,
+                    )
+                })?;
+        tracing::Span::current().record("destination_size", destination_size);
+        if destination_size != source_size as u64 {
+            tracing::Span::current().record("validation", "failed");
+            return Err(Error::io(format!(
+                "multipart_stream_copy destination size mismatch from {source_path} to \
+                 {destination_path}: source_size={source_size}, \
+                 destination_size={destination_size}"
+            )));
+        }
+
+        tracing::Span::current().record("validation", "passed");
+        tracing::Span::current().record("elapsed_ms", started_at.elapsed().as_millis() as u64);
+        Ok(write_result)
+    }
+
     /// Copy `from` to `to`. When `multipart_copy_fallback` is set, a source
     /// larger than `max_single_copy` is streamed through a multipart write
     /// instead of a single-shot server-side copy. Both are parameters so tests
@@ -1474,7 +1657,7 @@ mod tests {
     use object_store::memory::InMemory;
     use object_store::{
         CopyOptions, GetOptions, GetResult, ListResult, MultipartUpload, PutMultipartOptions,
-        PutOptions, PutPayload, PutResult, Result as OSResult,
+        PutOptions, PutPayload, PutResult, Result as OSResult, UploadPart,
     };
     use rstest::rstest;
     use std::env::set_current_dir;
@@ -1482,7 +1665,7 @@ mod tests {
     use std::fs::{create_dir_all, write};
     use std::ops::Range;
     use std::path::Path as StdPath;
-    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 
     /// Write test content to file.
     fn write_to_file(path_str: &str, contents: &str) -> std::io::Result<()> {
@@ -2216,6 +2399,130 @@ mod tests {
         }
     }
 
+    #[derive(Debug, Default)]
+    struct MultipartObservations {
+        part_count: AtomicUsize,
+        abort_count: AtomicUsize,
+    }
+
+    #[derive(Debug)]
+    struct ObservedMultipartUpload {
+        inner: Box<dyn MultipartUpload>,
+        observations: Arc<MultipartObservations>,
+        fail_parts: bool,
+    }
+
+    #[async_trait]
+    impl MultipartUpload for ObservedMultipartUpload {
+        fn put_part(&mut self, data: PutPayload) -> UploadPart {
+            self.observations.part_count.fetch_add(1, Ordering::SeqCst);
+            if self.fail_parts {
+                return Box::pin(async {
+                    Err(object_store::Error::Generic {
+                        store: "ObservedMultipartStore",
+                        source: "injected multipart part failure".into(),
+                    })
+                });
+            }
+            self.inner.put_part(data)
+        }
+
+        async fn complete(&mut self) -> OSResult<PutResult> {
+            self.inner.complete().await
+        }
+
+        async fn abort(&mut self) -> OSResult<()> {
+            self.observations.abort_count.fetch_add(1, Ordering::SeqCst);
+            self.inner.abort().await
+        }
+    }
+
+    #[derive(Debug)]
+    struct ObservedMultipartStore {
+        inner: InMemory,
+        observations: Arc<MultipartObservations>,
+        fail_parts: bool,
+        destination_size_adjustment: u64,
+    }
+
+    impl Display for ObservedMultipartStore {
+        fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+            write!(f, "ObservedMultipartStore")
+        }
+    }
+
+    #[async_trait]
+    impl OSObjectStore for ObservedMultipartStore {
+        async fn put_opts(
+            &self,
+            location: &Path,
+            bytes: PutPayload,
+            opts: PutOptions,
+        ) -> OSResult<PutResult> {
+            self.inner.put_opts(location, bytes, opts).await
+        }
+
+        async fn put_multipart_opts(
+            &self,
+            location: &Path,
+            opts: PutMultipartOptions,
+        ) -> OSResult<Box<dyn MultipartUpload>> {
+            let inner = self.inner.put_multipart_opts(location, opts).await?;
+            Ok(Box::new(ObservedMultipartUpload {
+                inner,
+                observations: self.observations.clone(),
+                fail_parts: self.fail_parts,
+            }))
+        }
+
+        async fn get_opts(&self, location: &Path, options: GetOptions) -> OSResult<GetResult> {
+            let is_head = options.head;
+            let mut result = self.inner.get_opts(location, options).await?;
+            if is_head {
+                result.meta.size = result
+                    .meta
+                    .size
+                    .checked_add(self.destination_size_adjustment)
+                    .expect("test destination size should not overflow");
+            }
+            Ok(result)
+        }
+
+        async fn get_ranges(&self, location: &Path, ranges: &[Range<u64>]) -> OSResult<Vec<Bytes>> {
+            self.inner.get_ranges(location, ranges).await
+        }
+
+        fn delete_stream(
+            &self,
+            locations: BoxStream<'static, OSResult<Path>>,
+        ) -> BoxStream<'static, OSResult<Path>> {
+            self.inner.delete_stream(locations)
+        }
+
+        fn list(&self, prefix: Option<&Path>) -> BoxStream<'static, OSResult<ObjectMeta>> {
+            self.inner.list(prefix)
+        }
+
+        fn list_with_offset(
+            &self,
+            prefix: Option<&Path>,
+            offset: &Path,
+        ) -> BoxStream<'static, OSResult<ObjectMeta>> {
+            self.inner.list_with_offset(prefix, offset)
+        }
+
+        async fn list_with_delimiter(&self, prefix: Option<&Path>) -> OSResult<ListResult> {
+            self.inner.list_with_delimiter(prefix).await
+        }
+
+        async fn copy_opts(&self, _from: &Path, _to: &Path, _opts: CopyOptions) -> OSResult<()> {
+            Err(object_store::Error::Generic {
+                store: "ObservedMultipartStore",
+                source: "native copy disabled in test".into(),
+            })
+        }
+    }
+
     #[async_trait]
     impl OSObjectStore for CopyFailingStore {
         async fn put_opts(
@@ -2298,6 +2605,137 @@ mod tests {
                 .copy_impl(&from, &native, true, u64::MAX)
                 .await
                 .is_err()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_copy_via_stream_never_uses_native_copy() {
+        let mut store = ObjectStore::memory();
+        store.inner = Arc::new(CopyFailingStore {
+            inner: InMemory::new(),
+        });
+
+        let source = Path::from("source.bin");
+        let destination = Path::from("destination.bin");
+        let contents = b"stream raw bytes instead of issuing native copy";
+        store.put(&source, contents).await.unwrap();
+
+        let result = store
+            .copy_via_stream(&source, &store, &destination)
+            .await
+            .unwrap();
+
+        assert_eq!(result.size, contents.len());
+        assert_eq!(
+            store.read_one_all(&destination).await.unwrap().as_ref(),
+            contents
+        );
+    }
+
+    #[tokio::test]
+    async fn test_copy_via_stream_uses_multiple_parts() {
+        let source_store = ObjectStore::memory();
+        let observations = Arc::new(MultipartObservations::default());
+        let mut destination_store = ObjectStore::memory();
+        destination_store.inner = Arc::new(ObservedMultipartStore {
+            inner: InMemory::new(),
+            observations: observations.clone(),
+            fail_parts: false,
+            destination_size_adjustment: 0,
+        });
+
+        let source = Path::from("source.bin");
+        let destination = Path::from("destination.bin");
+        let contents = vec![42; crate::object_writer::initial_upload_size() * 2 + 1];
+        source_store.put(&source, &contents).await.unwrap();
+
+        let result = source_store
+            .copy_via_stream(&source, &destination_store, &destination)
+            .await
+            .unwrap();
+
+        assert_eq!(result.size, contents.len());
+        assert!(
+            observations.part_count.load(Ordering::SeqCst) >= 2,
+            "stream copy should split a large destination into multiple upload parts"
+        );
+        assert_eq!(
+            destination_store
+                .read_one_all(&destination)
+                .await
+                .unwrap()
+                .as_ref(),
+            contents.as_slice()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_copy_via_stream_aborts_failed_upload_and_retains_source() {
+        let source_store = ObjectStore::memory();
+        let observations = Arc::new(MultipartObservations::default());
+        let mut destination_store = ObjectStore::memory();
+        destination_store.inner = Arc::new(ObservedMultipartStore {
+            inner: InMemory::new(),
+            observations: observations.clone(),
+            fail_parts: true,
+            destination_size_adjustment: 0,
+        });
+
+        let source = Path::from("source.bin");
+        let destination = Path::from("destination.bin");
+        let contents = vec![7; crate::object_writer::initial_upload_size() * 2];
+        source_store.put(&source, &contents).await.unwrap();
+
+        let error = source_store
+            .copy_via_stream(&source, &destination_store, &destination)
+            .await
+            .unwrap_err();
+        assert!(
+            error.to_string().contains("destination write")
+                && error
+                    .to_string()
+                    .contains("injected multipart part failure"),
+            "expected upload-stage context and the underlying error, got: {error}"
+        );
+
+        for _ in 0..10 {
+            if observations.abort_count.load(Ordering::SeqCst) > 0 {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+        assert_eq!(observations.abort_count.load(Ordering::SeqCst), 1);
+        assert_eq!(
+            source_store.read_one_all(&source).await.unwrap().as_ref(),
+            contents.as_slice()
+        );
+        assert!(!destination_store.exists(&destination).await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn test_copy_via_stream_rejects_destination_size_mismatch() {
+        let source_store = ObjectStore::memory();
+        let mut destination_store = ObjectStore::memory();
+        destination_store.inner = Arc::new(ObservedMultipartStore {
+            inner: InMemory::new(),
+            observations: Arc::new(MultipartObservations::default()),
+            fail_parts: false,
+            destination_size_adjustment: 1,
+        });
+
+        let source = Path::from("source.bin");
+        let destination = Path::from("destination.bin");
+        let contents = b"validate the destination after completion";
+        source_store.put(&source, contents).await.unwrap();
+
+        let error = source_store
+            .copy_via_stream(&source, &destination_store, &destination)
+            .await
+            .unwrap_err();
+
+        assert!(
+            error.to_string().contains("destination size mismatch"),
+            "expected validation failure, got: {error}"
         );
     }
 

--- a/rust/lance-io/src/object_store.rs
+++ b/rust/lance-io/src/object_store.rs
@@ -2756,12 +2756,16 @@ mod tests {
             "expected upload-stage context and the underlying error, got: {error}"
         );
 
-        for _ in 0..10 {
-            if observations.abort_count.load(Ordering::SeqCst) > 0 {
-                break;
+        tokio::time::timeout(Duration::from_secs(1), async {
+            loop {
+                if observations.abort_count.load(Ordering::SeqCst) > 0 {
+                    break;
+                }
+                tokio::task::yield_now().await;
             }
-            tokio::task::yield_now().await;
-        }
+        })
+        .await
+        .expect("multipart abort should complete");
         assert_eq!(observations.abort_count.load(Ordering::SeqCst), 1);
         assert_eq!(
             source_store.read_one_all(&source).await.unwrap().as_ref(),

--- a/rust/lance-io/src/object_store.rs
+++ b/rust/lance-io/src/object_store.rs
@@ -1112,9 +1112,27 @@ impl ObjectStore {
             source_path,
             destination_store,
             destination_path,
-            parse_env_as_bool(SERVER_SIDE_COPY_ENABLED_ENV, false),
+            self.uses_server_side_copy(destination_store),
         )
         .await
+    }
+
+    /// Return whether bulk movement to `destination_store` currently selects
+    /// provider-native server-side copy.
+    ///
+    /// This is true only when `LANCE_IO_SERVER_SIDE_COPY_ENABLED` is truthy and
+    /// both stores identify the same cloud backend.
+    ///
+    /// ```no_run
+    /// # use lance_io::object_store::ObjectStore;
+    /// # fn policy(source: &ObjectStore, destination: &ObjectStore) {
+    /// let uses_server_side_copy = source.uses_server_side_copy(destination);
+    /// # let _ = uses_server_side_copy;
+    /// # }
+    /// ```
+    pub fn uses_server_side_copy(&self, destination_store: &Self) -> bool {
+        parse_env_as_bool(SERVER_SIDE_COPY_ENABLED_ENV, false)
+            && self.can_server_side_copy_to(destination_store)
     }
 
     async fn copy_bulk_with_server_side_copy(
@@ -1137,7 +1155,9 @@ impl ObjectStore {
                  {destination_path}: source_size={source_size}, error={source}"
             ))
         })?;
-        self.copy(source_path, destination_path).await?;
+        destination_store
+            .copy(source_path, destination_path)
+            .await?;
         let destination_size = destination_store.size(destination_path).await?;
         if destination_size != source_size {
             return Err(Error::io(format!(
@@ -1154,14 +1174,10 @@ impl ObjectStore {
     }
 
     fn can_server_side_copy_to(&self, destination_store: &Self) -> bool {
-        if self.is_local() || destination_store.is_local() {
-            return false;
-        }
-
-        Arc::ptr_eq(&self.inner, &destination_store.inner)
-            || (self.is_cloud()
-                && destination_store.is_cloud()
-                && self.store_prefix == destination_store.store_prefix)
+        self.is_cloud()
+            && destination_store.is_cloud()
+            && (Arc::ptr_eq(&self.inner, &destination_store.inner)
+                || self.store_prefix == destination_store.store_prefix)
     }
 
     /// Copy an object by streaming its bytes through Lance's multipart-aware writer.
@@ -2846,11 +2862,24 @@ mod tests {
 
     #[tokio::test]
     async fn test_bulk_copy_uses_server_side_copy_when_enabled_for_same_store() {
-        let observations = Arc::new(MultipartObservations::default());
-        let mut store = ObjectStore::memory();
-        store.inner = Arc::new(ObservedMultipartStore {
-            inner: InMemory::new(),
-            observations: observations.clone(),
+        let shared_inner = InMemory::new();
+        let source_observations = Arc::new(MultipartObservations::default());
+        let mut source_store = ObjectStore::memory();
+        source_store.scheme = "test-cloud".to_string();
+        source_store.store_prefix = "test-cloud$bucket".to_string();
+        source_store.inner = Arc::new(ObservedMultipartStore {
+            inner: shared_inner.clone(),
+            observations: source_observations.clone(),
+            fail_parts: false,
+            destination_size_adjustment: 0,
+        });
+        let destination_observations = Arc::new(MultipartObservations::default());
+        let mut destination_store = ObjectStore::memory();
+        destination_store.scheme = "test-cloud".to_string();
+        destination_store.store_prefix = "test-cloud$bucket".to_string();
+        destination_store.inner = Arc::new(ObservedMultipartStore {
+            inner: shared_inner,
+            observations: destination_observations.clone(),
             fail_parts: false,
             destination_size_adjustment: 0,
         });
@@ -2858,18 +2887,78 @@ mod tests {
         let source = Path::from("source.bin");
         let destination = Path::from("destination.bin");
         let contents = b"use native copy when explicitly enabled";
-        store.put(&source, contents).await.unwrap();
+        source_store.put(&source, contents).await.unwrap();
 
-        let result = store
-            .copy_bulk_with_server_side_copy(&source, &store, &destination, true)
+        let result = source_store
+            .copy_bulk_with_server_side_copy(&source, &destination_store, &destination, true)
             .await
             .unwrap();
 
         assert_eq!(result.size, contents.len());
-        assert_eq!(observations.native_copy_count.load(Ordering::SeqCst), 1);
         assert_eq!(
-            store.read_one_all(&destination).await.unwrap().as_ref(),
+            source_observations.native_copy_count.load(Ordering::SeqCst),
+            0
+        );
+        assert_eq!(
+            destination_observations
+                .native_copy_count
+                .load(Ordering::SeqCst),
+            1
+        );
+        assert_eq!(
+            destination_store
+                .read_one_all(&destination)
+                .await
+                .unwrap()
+                .as_ref(),
             contents
+        );
+    }
+
+    #[tokio::test]
+    async fn test_bulk_copy_rejects_server_side_destination_size_mismatch() {
+        let shared_inner = InMemory::new();
+        let mut source_store = ObjectStore::memory();
+        source_store.scheme = "test-cloud".to_string();
+        source_store.store_prefix = "test-cloud$bucket".to_string();
+        source_store.inner = Arc::new(ObservedMultipartStore {
+            inner: shared_inner.clone(),
+            observations: Arc::new(MultipartObservations::default()),
+            fail_parts: false,
+            destination_size_adjustment: 0,
+        });
+        let destination_observations = Arc::new(MultipartObservations::default());
+        let mut destination_store = ObjectStore::memory();
+        destination_store.scheme = "test-cloud".to_string();
+        destination_store.store_prefix = "test-cloud$bucket".to_string();
+        destination_store.inner = Arc::new(ObservedMultipartStore {
+            inner: shared_inner,
+            observations: destination_observations.clone(),
+            fail_parts: false,
+            destination_size_adjustment: 1,
+        });
+
+        let source = Path::from("source.bin");
+        let destination = Path::from("destination.bin");
+        source_store
+            .put(&source, b"validate native copy")
+            .await
+            .unwrap();
+
+        let error = source_store
+            .copy_bulk_with_server_side_copy(&source, &destination_store, &destination, true)
+            .await
+            .unwrap_err();
+
+        assert!(
+            error.to_string().contains("destination size mismatch"),
+            "expected validation failure, got: {error}"
+        );
+        assert_eq!(
+            destination_observations
+                .native_copy_count
+                .load(Ordering::SeqCst),
+            1
         );
     }
 

--- a/rust/lance-io/src/object_store.rs
+++ b/rust/lance-io/src/object_store.rs
@@ -1126,9 +1126,11 @@ impl ObjectStore {
     ) -> Result<WriteResult> {
         let started_at = Instant::now();
         if self.has_direct_local_paths() && destination_store.has_direct_local_paths() {
-            let source_size = self.size(source_path).await.map_err(|source| {
-                stream_copy_error("source metadata", source_path, destination_path, source)
-            })?;
+            let source_size = std::fs::metadata(super::local::to_local_path(source_path))
+                .map_err(|source| {
+                    stream_copy_error("source metadata", source_path, destination_path, source)
+                })?
+                .len();
             let source_size = usize::try_from(source_size).map_err(|source| {
                 stream_copy_error(
                     "source size conversion",

--- a/rust/lance-io/src/object_store.rs
+++ b/rust/lance-io/src/object_store.rs
@@ -1110,7 +1110,7 @@ impl ObjectStore {
             read_chunk_size = Empty,
             multipart_part_size = crate::object_writer::initial_upload_size(),
             multipart_concurrency = crate::object_writer::max_upload_parallelism(),
-            part_count = 1_u64,
+            part_count = Empty,
             bytes_transferred = Empty,
             destination_size = Empty,
             validation = Empty,
@@ -1132,6 +1132,50 @@ impl ObjectStore {
             stream_copy_error("source metadata", source_path, destination_path, source)
         })?;
         Span::current().record("source_size", source_size as u64);
+
+        if self.has_direct_local_paths() && destination_store.has_direct_local_paths() {
+            let metrics = self.io_tracker.begin_io("copy");
+            let result = super::local::copy_file(source_path, destination_path);
+            metrics.record(&result, source_size as u64);
+            result.map_err(|source| {
+                stream_copy_error(
+                    "local filesystem copy",
+                    source_path,
+                    destination_path,
+                    source,
+                )
+            })?;
+
+            let destination_size =
+                destination_store
+                    .size(destination_path)
+                    .await
+                    .map_err(|source| {
+                        stream_copy_error(
+                            "destination validation",
+                            source_path,
+                            destination_path,
+                            source,
+                        )
+                    })?;
+            Span::current().record("bytes_transferred", source_size as u64);
+            Span::current().record("destination_size", destination_size);
+            if destination_size != source_size as u64 {
+                Span::current().record("validation", "failed");
+                return Err(Error::io(format!(
+                    "multipart_stream_copy destination size mismatch from {source_path} to \
+                     {destination_path}: source_size={source_size}, \
+                     destination_size={destination_size}"
+                )));
+            }
+
+            Span::current().record("validation", "passed");
+            Span::current().record("elapsed_ms", started_at.elapsed().as_millis() as u64);
+            return Ok(WriteResult {
+                size: source_size,
+                e_tag: None,
+            });
+        }
 
         let mut writer = destination_store
             .create(destination_path)
@@ -1177,8 +1221,8 @@ impl ObjectStore {
             writer.write_all(&bytes).await.map_err(|source| {
                 stream_copy_error("destination write", source_path, destination_path, source)
             })?;
-            Span::current().record("bytes_transferred", bytes_transferred as u64);
         }
+        Span::current().record("bytes_transferred", bytes_transferred as u64);
 
         if bytes_transferred != source_size {
             Span::current().record("validation", "failed");
@@ -2647,7 +2691,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_copy_via_stream_uses_multiple_parts() {
-        let source_store = ObjectStore::memory();
+        let mut source_store = ObjectStore::memory();
+        source_store.max_iop_size = 1024 * 1024;
         let observations = Arc::new(MultipartObservations::default());
         let mut destination_store = ObjectStore::memory();
         destination_store.inner = Arc::new(ObservedMultipartStore {

--- a/rust/lance-io/src/object_store.rs
+++ b/rust/lance-io/src/object_store.rs
@@ -1102,7 +1102,7 @@ impl ObjectStore {
     #[instrument(
         name = "multipart_stream_copy",
         level = "info",
-        skip(self, destination_store),
+        skip(self, source_path, destination_store, destination_path),
         fields(
             source = %source_path,
             destination = %destination_path,
@@ -1125,16 +1125,21 @@ impl ObjectStore {
         destination_path: &Path,
     ) -> Result<WriteResult> {
         let started_at = Instant::now();
-        let reader = self.open(source_path).await.map_err(|source| {
-            stream_copy_error("source open", source_path, destination_path, source)
-        })?;
-        let source_size = reader.size().await.map_err(|source| {
-            stream_copy_error("source metadata", source_path, destination_path, source)
-        })?;
-        Span::current().record("source_size", source_size as u64);
-
         if self.has_direct_local_paths() && destination_store.has_direct_local_paths() {
-            let metrics = self.io_tracker.begin_io("copy");
+            let source_size = self.size(source_path).await.map_err(|source| {
+                stream_copy_error("source metadata", source_path, destination_path, source)
+            })?;
+            let source_size = usize::try_from(source_size).map_err(|source| {
+                stream_copy_error(
+                    "source size conversion",
+                    source_path,
+                    destination_path,
+                    source,
+                )
+            })?;
+            Span::current().record("source_size", source_size as u64);
+
+            let metrics = destination_store.io_tracker.begin_io("copy");
             let result = super::local::copy_file(source_path, destination_path);
             metrics.record(&result, source_size as u64);
             result.map_err(|source| {
@@ -1176,6 +1181,14 @@ impl ObjectStore {
                 e_tag: None,
             });
         }
+
+        let reader = self.open(source_path).await.map_err(|source| {
+            stream_copy_error("source open", source_path, destination_path, source)
+        })?;
+        let source_size = reader.size().await.map_err(|source| {
+            stream_copy_error("source metadata", source_path, destination_path, source)
+        })?;
+        Span::current().record("source_size", source_size as u64);
 
         let mut writer = destination_store
             .create(destination_path)
@@ -1250,15 +1263,6 @@ impl ObjectStore {
             }
         }
         Span::current().record("bytes_transferred", bytes_transferred as u64);
-
-        if bytes_transferred != source_size {
-            Span::current().record("validation", "failed");
-            return Err(Error::io(format!(
-                "multipart_stream_copy source size mismatch from {source_path} to \
-                 {destination_path}: source_size={source_size}, \
-                 bytes_transferred={bytes_transferred}"
-            )));
-        }
 
         let write_result = Writer::shutdown(writer.as_mut()).await.map_err(|source| {
             stream_copy_error(

--- a/rust/lance-io/src/object_store.rs
+++ b/rust/lance-io/src/object_store.rs
@@ -1193,34 +1193,61 @@ impl ObjectStore {
             .max(1);
         Span::current().record("read_chunk_size", read_chunk_size as u64);
         let mut bytes_transferred = 0usize;
-        while bytes_transferred < source_size {
-            let range_end = bytes_transferred
-                .checked_add(read_chunk_size)
-                .unwrap_or(source_size)
-                .min(source_size);
-            let range = bytes_transferred..range_end;
-            let expected_bytes = range.len();
-            let bytes = reader.get_range(range.clone()).await.map_err(|source| {
+        if source_size > 0 {
+            let first_range = 0..read_chunk_size.min(source_size);
+            let mut current_range = first_range.clone();
+            let mut current_bytes = reader.get_range(first_range).await.map_err(|source| {
                 stream_copy_error("source read", source_path, destination_path, source)
             })?;
-            if bytes.len() != expected_bytes {
-                Span::current().record("validation", "failed");
-                return Err(Error::io(format!(
-                    "multipart_stream_copy source range size mismatch from {source_path} to \
-                     {destination_path}: range={range:?}, expected_bytes={expected_bytes}, \
-                     actual_bytes={}",
-                    bytes.len()
-                )));
+
+            loop {
+                let expected_bytes = current_range.len();
+                if current_bytes.len() != expected_bytes {
+                    Span::current().record("validation", "failed");
+                    return Err(Error::io(format!(
+                        "multipart_stream_copy source range size mismatch from {source_path} to \
+                         {destination_path}: range={current_range:?}, \
+                         expected_bytes={expected_bytes}, actual_bytes={}",
+                        current_bytes.len()
+                    )));
+                }
+                bytes_transferred = bytes_transferred
+                    .checked_add(current_bytes.len())
+                    .ok_or_else(|| {
+                        Error::io(format!(
+                            "multipart_stream_copy byte count overflow from {source_path} to \
+                             {destination_path}"
+                        ))
+                    })?;
+
+                if bytes_transferred == source_size {
+                    writer.write_all(&current_bytes).await.map_err(|source| {
+                        stream_copy_error(
+                            "destination write",
+                            source_path,
+                            destination_path,
+                            source,
+                        )
+                    })?;
+                    break;
+                }
+
+                let range_end = bytes_transferred
+                    .checked_add(read_chunk_size)
+                    .unwrap_or(source_size)
+                    .min(source_size);
+                let next_range = bytes_transferred..range_end;
+                let next_read = reader.get_range(next_range.clone());
+                let (write_result, next_bytes) =
+                    tokio::join!(writer.write_all(&current_bytes), next_read);
+                write_result.map_err(|source| {
+                    stream_copy_error("destination write", source_path, destination_path, source)
+                })?;
+                current_bytes = next_bytes.map_err(|source| {
+                    stream_copy_error("source read", source_path, destination_path, source)
+                })?;
+                current_range = next_range;
             }
-            bytes_transferred = bytes_transferred.checked_add(bytes.len()).ok_or_else(|| {
-                Error::io(format!(
-                    "multipart_stream_copy byte count overflow from {source_path} to \
-                     {destination_path}"
-                ))
-            })?;
-            writer.write_all(&bytes).await.map_err(|source| {
-                stream_copy_error("destination write", source_path, destination_path, source)
-            })?;
         }
         Span::current().record("bytes_transferred", bytes_transferred as u64);
 

--- a/rust/lance-io/src/object_store.rs
+++ b/rust/lance-io/src/object_store.rs
@@ -1846,6 +1846,7 @@ mod tests {
         PutOptions, PutPayload, PutResult, Result as OSResult, UploadPart,
     };
     use rstest::rstest;
+    use serial_test::serial;
     use std::env::set_current_dir;
     use std::fmt::{Display, Formatter};
     use std::fs::{create_dir_all, write};
@@ -2846,6 +2847,32 @@ mod tests {
             store.read_one_all(&destination).await.unwrap().as_ref(),
             contents
         );
+    }
+
+    #[test]
+    #[serial(server_side_copy_env)]
+    fn test_server_side_copy_environment_policy() {
+        let previous_value = std::env::var_os(SERVER_SIDE_COPY_ENABLED_ENV);
+        let mut store = ObjectStore::memory();
+        store.scheme = "test-cloud".to_string();
+        let destination_store = store.clone();
+
+        // SAFETY: this serialized test is the only test that mutates this task-specific
+        // environment variable, and it restores the original value before returning.
+        unsafe { std::env::remove_var(SERVER_SIDE_COPY_ENABLED_ENV) };
+        assert!(!store.uses_server_side_copy(&destination_store));
+
+        // SAFETY: see the serialized-test guarantee above.
+        unsafe { std::env::set_var(SERVER_SIDE_COPY_ENABLED_ENV, "true") };
+        assert!(store.uses_server_side_copy(&destination_store));
+
+        // SAFETY: restore the process environment before the test returns.
+        unsafe {
+            match previous_value {
+                Some(value) => std::env::set_var(SERVER_SIDE_COPY_ENABLED_ENV, value),
+                None => std::env::remove_var(SERVER_SIDE_COPY_ENABLED_ENV),
+            }
+        }
     }
 
     #[tokio::test]

--- a/rust/lance-io/src/object_store.rs
+++ b/rust/lance-io/src/object_store.rs
@@ -1128,6 +1128,11 @@ impl ObjectStore {
         if self.has_direct_local_paths() && destination_store.has_direct_local_paths() {
             let source_size = std::fs::metadata(super::local::to_local_path(source_path))
                 .map_err(|source| {
+                    let source = if source.kind() == std::io::ErrorKind::NotFound {
+                        Error::not_found(source_path.to_string())
+                    } else {
+                        Error::from(source)
+                    };
                     stream_copy_error("source metadata", source_path, destination_path, source)
                 })?
                 .len();
@@ -2719,6 +2724,26 @@ mod tests {
         assert_eq!(
             store.read_one_all(&destination).await.unwrap().as_ref(),
             contents
+        );
+    }
+
+    #[tokio::test]
+    async fn test_copy_via_stream_preserves_local_not_found() {
+        let directory = TempStdDir::default();
+        let (store, base_path) = ObjectStore::from_uri(directory.to_str().unwrap())
+            .await
+            .unwrap();
+        let source = base_path.clone().join("missing.bin");
+        let destination = base_path.join("destination.bin");
+
+        let error = store
+            .copy_via_stream(&source, &store, &destination)
+            .await
+            .unwrap_err();
+
+        assert!(
+            error.is_not_found(),
+            "expected not-found error, got: {error}"
         );
     }
 

--- a/rust/lance-io/src/object_store.rs
+++ b/rust/lance-io/src/object_store.rs
@@ -1117,20 +1117,7 @@ impl ObjectStore {
         .await
     }
 
-    /// Return whether bulk movement to `destination_store` currently selects
-    /// provider-native server-side copy.
-    ///
-    /// This is true only when `LANCE_IO_SERVER_SIDE_COPY_ENABLED` is truthy and
-    /// both stores identify the same cloud backend.
-    ///
-    /// ```no_run
-    /// # use lance_io::object_store::ObjectStore;
-    /// # fn policy(source: &ObjectStore, destination: &ObjectStore) {
-    /// let uses_server_side_copy = source.uses_server_side_copy(destination);
-    /// # let _ = uses_server_side_copy;
-    /// # }
-    /// ```
-    pub fn uses_server_side_copy(&self, destination_store: &Self) -> bool {
+    fn uses_server_side_copy(&self, destination_store: &Self) -> bool {
         parse_env_as_bool(SERVER_SIDE_COPY_ENABLED_ENV, false)
             && self.can_server_side_copy_to(destination_store)
     }
@@ -1174,10 +1161,11 @@ impl ObjectStore {
     }
 
     fn can_server_side_copy_to(&self, destination_store: &Self) -> bool {
+        // Prefixes can collide across endpoints or wrappers, where native copy could
+        // read or write the wrong backend. Exact client identity is required.
         self.is_cloud()
             && destination_store.is_cloud()
-            && (Arc::ptr_eq(&self.inner, &destination_store.inner)
-                || self.store_prefix == destination_store.store_prefix)
+            && Arc::ptr_eq(&self.inner, &destination_store.inner)
     }
 
     /// Copy an object by streaming its bytes through Lance's multipart-aware writer.
@@ -2677,7 +2665,7 @@ mod tests {
         async fn get_opts(&self, location: &Path, options: GetOptions) -> OSResult<GetResult> {
             let is_head = options.head;
             let mut result = self.inner.get_opts(location, options).await?;
-            if is_head {
+            if is_head && location.filename() == Some("destination.bin") {
                 result.meta.size = result
                     .meta
                     .size
@@ -2862,6 +2850,41 @@ mod tests {
 
     #[tokio::test]
     async fn test_bulk_copy_uses_server_side_copy_when_enabled_for_same_store() {
+        let observations = Arc::new(MultipartObservations::default());
+        let mut source_store = ObjectStore::memory();
+        source_store.scheme = "test-cloud".to_string();
+        source_store.inner = Arc::new(ObservedMultipartStore {
+            inner: InMemory::new(),
+            observations: observations.clone(),
+            fail_parts: false,
+            destination_size_adjustment: 0,
+        });
+        let destination_store = source_store.clone();
+
+        let source = Path::from("source.bin");
+        let destination = Path::from("destination.bin");
+        let contents = b"use native copy when explicitly enabled";
+        source_store.put(&source, contents).await.unwrap();
+
+        let result = source_store
+            .copy_bulk_with_server_side_copy(&source, &destination_store, &destination, true)
+            .await
+            .unwrap();
+
+        assert_eq!(result.size, contents.len());
+        assert_eq!(observations.native_copy_count.load(Ordering::SeqCst), 1);
+        assert_eq!(
+            destination_store
+                .read_one_all(&destination)
+                .await
+                .unwrap()
+                .as_ref(),
+            contents
+        );
+    }
+
+    #[tokio::test]
+    async fn test_bulk_copy_streams_for_distinct_clients_with_same_prefix() {
         let shared_inner = InMemory::new();
         let source_observations = Arc::new(MultipartObservations::default());
         let mut source_store = ObjectStore::memory();
@@ -2903,7 +2926,7 @@ mod tests {
             destination_observations
                 .native_copy_count
                 .load(Ordering::SeqCst),
-            1
+            0
         );
         assert_eq!(
             destination_store
@@ -2917,26 +2940,16 @@ mod tests {
 
     #[tokio::test]
     async fn test_bulk_copy_rejects_server_side_destination_size_mismatch() {
-        let shared_inner = InMemory::new();
+        let observations = Arc::new(MultipartObservations::default());
         let mut source_store = ObjectStore::memory();
         source_store.scheme = "test-cloud".to_string();
-        source_store.store_prefix = "test-cloud$bucket".to_string();
         source_store.inner = Arc::new(ObservedMultipartStore {
-            inner: shared_inner.clone(),
-            observations: Arc::new(MultipartObservations::default()),
-            fail_parts: false,
-            destination_size_adjustment: 0,
-        });
-        let destination_observations = Arc::new(MultipartObservations::default());
-        let mut destination_store = ObjectStore::memory();
-        destination_store.scheme = "test-cloud".to_string();
-        destination_store.store_prefix = "test-cloud$bucket".to_string();
-        destination_store.inner = Arc::new(ObservedMultipartStore {
-            inner: shared_inner,
-            observations: destination_observations.clone(),
+            inner: InMemory::new(),
+            observations: observations.clone(),
             fail_parts: false,
             destination_size_adjustment: 1,
         });
+        let destination_store = source_store.clone();
 
         let source = Path::from("source.bin");
         let destination = Path::from("destination.bin");
@@ -2954,12 +2967,7 @@ mod tests {
             error.to_string().contains("destination size mismatch"),
             "expected validation failure, got: {error}"
         );
-        assert_eq!(
-            destination_observations
-                .native_copy_count
-                .load(Ordering::SeqCst),
-            1
-        );
+        assert_eq!(observations.native_copy_count.load(Ordering::SeqCst), 1);
     }
 
     #[tokio::test]

--- a/rust/lance-io/src/object_store.rs
+++ b/rust/lance-io/src/object_store.rs
@@ -2703,11 +2703,11 @@ mod tests {
             .copy_via_stream(&source, &destination_store, &destination)
             .await
             .unwrap_err();
+        let error_message = error.to_string();
         assert!(
-            error.to_string().contains("destination write")
-                && error
-                    .to_string()
-                    .contains("injected multipart part failure"),
+            (error_message.contains("destination write")
+                || error_message.contains("destination completion"))
+                && error_message.contains("injected multipart part failure"),
             "expected upload-stage context and the underlying error, got: {error}"
         );
 

--- a/rust/lance-io/src/object_writer.rs
+++ b/rust/lance-io/src/object_writer.rs
@@ -27,7 +27,7 @@ use tokio::runtime::Handle;
 /// Start at 5MB.
 const INITIAL_UPLOAD_STEP: usize = 1024 * 1024 * 5;
 
-fn max_upload_parallelism() -> usize {
+pub(crate) fn max_upload_parallelism() -> usize {
     static MAX_UPLOAD_PARALLELISM: OnceLock<usize> = OnceLock::new();
     *MAX_UPLOAD_PARALLELISM.get_or_init(|| {
         std::env::var("LANCE_UPLOAD_CONCURRENCY")
@@ -51,7 +51,7 @@ fn clamp_initial_upload_size(raw: usize) -> (usize, bool) {
     (clamped, clamped != raw)
 }
 
-fn initial_upload_size() -> usize {
+pub(crate) fn initial_upload_size() -> usize {
     static LANCE_INITIAL_UPLOAD_SIZE: OnceLock<usize> = OnceLock::new();
     *LANCE_INITIAL_UPLOAD_SIZE.get_or_init(|| {
         let Some(raw) = std::env::var("LANCE_INITIAL_UPLOAD_SIZE")
@@ -228,6 +228,7 @@ impl UploadState {
         let this = std::mem::replace(self, Self::Done(WriteResult::default()));
         *self = match this {
             Self::Started(store) => {
+                tracing::Span::current().record("part_count", 1_u64);
                 let started_at = Instant::now();
                 let fut = async move {
                     let size = buffer.len();
@@ -262,6 +263,7 @@ impl UploadState {
                 part_idx,
             } => {
                 debug_assert!(futures.is_empty());
+                tracing::Span::current().record("part_count", part_idx as u64);
                 let started_at = Instant::now();
                 let fut = async move {
                     let res = upload.complete().await.map_err(|source| {

--- a/rust/lance/src/dataset.rs
+++ b/rust/lance/src/dataset.rs
@@ -175,6 +175,7 @@ pub use write::{
 pub(crate) const INDICES_DIR: &str = "_indices";
 pub(crate) const DATA_DIR: &str = "data";
 pub(crate) const TRANSACTIONS_DIR: &str = "_transactions";
+const DEFAULT_MAX_STREAM_COPY_PARALLELISM: usize = 4;
 
 fn parse_deep_clone_stream_concurrency(value: &str) -> Result<usize> {
     value
@@ -185,6 +186,20 @@ fn parse_deep_clone_stream_concurrency(value: &str) -> Result<usize> {
                 "LANCE_DEEP_CLONE_STREAM_CONCURRENCY must be a positive integer, got {value:?}"
             ))
         })
+}
+
+fn deep_clone_copy_parallelism(
+    configured_io_parallelism: usize,
+    uses_streaming_copy: bool,
+    stream_copy_parallelism: Option<usize>,
+) -> usize {
+    if !uses_streaming_copy {
+        configured_io_parallelism
+    } else if let Some(value) = stream_copy_parallelism {
+        value
+    } else {
+        configured_io_parallelism.min(DEFAULT_MAX_STREAM_COPY_PARALLELISM)
+    }
 }
 
 // We default to 6GB for the index cache, since indices are often large but
@@ -3322,10 +3337,10 @@ impl Dataset {
             path
         };
 
-        const DEFAULT_MAX_STREAM_COPY_PARALLELISM: usize = 4;
         let configured_io_parallelism = src_ds.object_store.io_parallelism();
-        let uses_streaming_copy = !(src_ds.object_store.has_direct_local_paths()
-            && target_store.has_direct_local_paths());
+        let uses_streaming_copy = !src_ds.object_store.uses_server_side_copy(&target_store)
+            && !(src_ds.object_store.has_direct_local_paths()
+                && target_store.has_direct_local_paths());
         let stream_copy_parallelism = match std::env::var("LANCE_DEEP_CLONE_STREAM_CONCURRENCY") {
             Ok(value) => Some(parse_deep_clone_stream_concurrency(&value)?),
             Err(std::env::VarError::NotPresent) => None,
@@ -3338,13 +3353,11 @@ impl Dataset {
         };
         // Limit the number of concurrently buffered transfers by default while
         // preserving efficient local copies and the operation-specific override.
-        let io_parallelism = if !uses_streaming_copy {
-            configured_io_parallelism
-        } else if let Some(value) = stream_copy_parallelism {
-            value
-        } else {
-            configured_io_parallelism.min(DEFAULT_MAX_STREAM_COPY_PARALLELISM)
-        };
+        let io_parallelism = deep_clone_copy_parallelism(
+            configured_io_parallelism,
+            uses_streaming_copy,
+            stream_copy_parallelism,
+        );
         let copy_futures = src_paths
             .iter()
             .map(|(relative_path, base)| {

--- a/rust/lance/src/dataset.rs
+++ b/rust/lance/src/dataset.rs
@@ -3336,13 +3336,11 @@ impl Dataset {
             }
         };
         // Limit the number of concurrently buffered transfers by default while
-        // preserving efficient local copies and explicit operator settings.
+        // preserving efficient local copies and the operation-specific override.
         let io_parallelism = if !uses_streaming_copy {
             configured_io_parallelism
         } else if let Some(value) = stream_copy_parallelism {
             value
-        } else if std::env::var_os("LANCE_IO_THREADS").is_some() {
-            configured_io_parallelism
         } else {
             configured_io_parallelism.min(DEFAULT_MAX_STREAM_COPY_PARALLELISM)
         };

--- a/rust/lance/src/dataset.rs
+++ b/rust/lance/src/dataset.rs
@@ -3267,6 +3267,8 @@ impl Dataset {
     /// Note: external `base_paths` referenced by the source manifest are read through
     /// this dataset's object store; per-base distinct source credentials are not yet
     /// supported (see <https://github.com/lance-format/lance/issues/6093>).
+    /// Object-store streaming defaults to at most four concurrent file copies;
+    /// `LANCE_DEEP_CLONE_STREAM_CONCURRENCY` overrides that limit for this operation.
     pub async fn deep_clone(
         &mut self,
         target_path: &str,
@@ -3312,15 +3314,20 @@ impl Dataset {
         let configured_io_parallelism = src_ds.object_store.io_parallelism();
         let uses_streaming_copy = !(src_ds.object_store.has_direct_local_paths()
             && target_store.has_direct_local_paths());
-        // A streaming copy may hold one source range plus several upload parts.
-        // Bound the default aggregate footprint while preserving efficient local
-        // copies and an operator's explicit LANCE_IO_THREADS override.
-        let io_parallelism =
-            if uses_streaming_copy && std::env::var_os("LANCE_IO_THREADS").is_none() {
-                configured_io_parallelism.min(DEFAULT_MAX_STREAM_COPY_PARALLELISM)
-            } else {
-                configured_io_parallelism
-            };
+        // Limit the number of concurrently buffered transfers by default while
+        // preserving efficient local copies and explicit operator settings.
+        let io_parallelism = if !uses_streaming_copy {
+            configured_io_parallelism
+        } else if let Ok(value) = std::env::var("LANCE_DEEP_CLONE_STREAM_CONCURRENCY") {
+            value
+                .parse::<NonZero<usize>>()
+                .expect("LANCE_DEEP_CLONE_STREAM_CONCURRENCY must be a positive integer")
+                .get()
+        } else if std::env::var_os("LANCE_IO_THREADS").is_some() {
+            configured_io_parallelism
+        } else {
+            configured_io_parallelism.min(DEFAULT_MAX_STREAM_COPY_PARALLELISM)
+        };
         let copy_futures = src_paths
             .iter()
             .map(|(relative_path, base)| {

--- a/rust/lance/src/dataset.rs
+++ b/rust/lance/src/dataset.rs
@@ -3308,11 +3308,19 @@ impl Dataset {
             path
         };
 
-        const MAX_STREAM_COPY_PARALLELISM: usize = 4;
-        let io_parallelism = self
-            .object_store
-            .io_parallelism()
-            .min(MAX_STREAM_COPY_PARALLELISM);
+        const DEFAULT_MAX_STREAM_COPY_PARALLELISM: usize = 4;
+        let configured_io_parallelism = src_ds.object_store.io_parallelism();
+        let uses_streaming_copy = !(src_ds.object_store.has_direct_local_paths()
+            && target_store.has_direct_local_paths());
+        // A streaming copy may hold one source range plus several upload parts.
+        // Bound the default aggregate footprint while preserving efficient local
+        // copies and an operator's explicit LANCE_IO_THREADS override.
+        let io_parallelism =
+            if uses_streaming_copy && std::env::var_os("LANCE_IO_THREADS").is_none() {
+                configured_io_parallelism.min(DEFAULT_MAX_STREAM_COPY_PARALLELISM)
+            } else {
+                configured_io_parallelism
+            };
         let copy_futures = src_paths
             .iter()
             .map(|(relative_path, base)| {

--- a/rust/lance/src/dataset.rs
+++ b/rust/lance/src/dataset.rs
@@ -3338,9 +3338,10 @@ impl Dataset {
         };
 
         let configured_io_parallelism = src_ds.object_store.io_parallelism();
-        let uses_streaming_copy = !src_ds.object_store.uses_server_side_copy(&target_store)
-            && !(src_ds.object_store.has_direct_local_paths()
-                && target_store.has_direct_local_paths());
+        // Provider-native copy can fall back to streaming for large objects, so every
+        // non-direct-local transfer stays within the bounded file-copy window.
+        let uses_streaming_copy = !(src_ds.object_store.has_direct_local_paths()
+            && target_store.has_direct_local_paths());
         let stream_copy_parallelism = match std::env::var("LANCE_DEEP_CLONE_STREAM_CONCURRENCY") {
             Ok(value) => Some(parse_deep_clone_stream_concurrency(&value)?),
             Err(std::env::VarError::NotPresent) => None,

--- a/rust/lance/src/dataset.rs
+++ b/rust/lance/src/dataset.rs
@@ -3325,12 +3325,22 @@ impl Dataset {
         let configured_io_parallelism = src_ds.object_store.io_parallelism();
         let uses_streaming_copy = !(src_ds.object_store.has_direct_local_paths()
             && target_store.has_direct_local_paths());
+        let stream_copy_parallelism = match std::env::var("LANCE_DEEP_CLONE_STREAM_CONCURRENCY") {
+            Ok(value) => Some(parse_deep_clone_stream_concurrency(&value)?),
+            Err(std::env::VarError::NotPresent) => None,
+            Err(std::env::VarError::NotUnicode(value)) => {
+                return Err(Error::invalid_input(format!(
+                    "LANCE_DEEP_CLONE_STREAM_CONCURRENCY must be valid UTF-8 and a positive \
+                     integer, got {value:?}"
+                )));
+            }
+        };
         // Limit the number of concurrently buffered transfers by default while
         // preserving efficient local copies and explicit operator settings.
         let io_parallelism = if !uses_streaming_copy {
             configured_io_parallelism
-        } else if let Ok(value) = std::env::var("LANCE_DEEP_CLONE_STREAM_CONCURRENCY") {
-            parse_deep_clone_stream_concurrency(&value)?
+        } else if let Some(value) = stream_copy_parallelism {
+            value
         } else if std::env::var_os("LANCE_IO_THREADS").is_some() {
             configured_io_parallelism
         } else {

--- a/rust/lance/src/dataset.rs
+++ b/rust/lance/src/dataset.rs
@@ -35,7 +35,6 @@ use lance_io::object_store::{
     WrappingObjectStore,
 };
 use lance_io::scheduler::{ScanScheduler, SchedulerConfig};
-use lance_io::traits::{WriteExt, Writer};
 use lance_io::utils::{
     CachedFileSize, read_last_block, read_message, read_metadata_offset, read_struct,
 };
@@ -3308,17 +3307,6 @@ impl Dataset {
             path
         };
 
-        // When the source and target live in the same store we can keep the copy
-        // server-side. Otherwise (e.g. cloning across accounts) we stream each file
-        // from the source store to the target store.
-        let same_store = src_ds.object_store.store_prefix == target_store.store_prefix;
-
-        // TODO: Leverage object store bulk copy for efficient same-store deep_clone.
-        //
-        // All cloud storage providers support batch copy APIs that would provide significant
-        // performance improvements. We use single file copy before we have upstream support.
-        //
-        // Tracked by: https://github.com/lance-format/lance/issues/5435
         let io_parallelism = self.object_store.io_parallelism();
         let copy_futures = src_paths
             .iter()
@@ -3328,14 +3316,9 @@ impl Dataset {
                 let src_path = build_absolute_path(relative_path, base);
                 let target_path = build_absolute_path(relative_path, &target_base);
                 async move {
-                    if same_store {
-                        target_store.copy(&src_path, &target_path).await?;
-                    } else {
-                        let reader = source_store.open(&src_path).await?;
-                        let mut writer = target_store.create(&target_path).await?;
-                        writer.copy_from_reader(reader.as_ref()).await?;
-                        writer.shutdown().await?;
-                    }
+                    source_store
+                        .copy_via_stream(&src_path, &target_store, &target_path)
+                        .await?;
                     Result::Ok(())
                 }
             })

--- a/rust/lance/src/dataset.rs
+++ b/rust/lance/src/dataset.rs
@@ -176,6 +176,17 @@ pub(crate) const INDICES_DIR: &str = "_indices";
 pub(crate) const DATA_DIR: &str = "data";
 pub(crate) const TRANSACTIONS_DIR: &str = "_transactions";
 
+fn parse_deep_clone_stream_concurrency(value: &str) -> Result<usize> {
+    value
+        .parse::<NonZero<usize>>()
+        .map(NonZero::get)
+        .map_err(|_| {
+            Error::invalid_input(format!(
+                "LANCE_DEEP_CLONE_STREAM_CONCURRENCY must be a positive integer, got {value:?}"
+            ))
+        })
+}
+
 // We default to 6GB for the index cache, since indices are often large but
 // worth caching.
 pub const DEFAULT_INDEX_CACHE_SIZE: usize = 6 * 1024 * 1024 * 1024;
@@ -3319,10 +3330,7 @@ impl Dataset {
         let io_parallelism = if !uses_streaming_copy {
             configured_io_parallelism
         } else if let Ok(value) = std::env::var("LANCE_DEEP_CLONE_STREAM_CONCURRENCY") {
-            value
-                .parse::<NonZero<usize>>()
-                .expect("LANCE_DEEP_CLONE_STREAM_CONCURRENCY must be a positive integer")
-                .get()
+            parse_deep_clone_stream_concurrency(&value)?
         } else if std::env::var_os("LANCE_IO_THREADS").is_some() {
             configured_io_parallelism
         } else {

--- a/rust/lance/src/dataset.rs
+++ b/rust/lance/src/dataset.rs
@@ -3265,9 +3265,10 @@ impl Dataset {
     /// The source files are read through this dataset's own object store while the
     /// copies are written through the target object store built from `store_params`.
     /// This makes the clone work across accounts/stores (e.g. between two abfss
-    /// accounts). Object-store files are streamed through this process instead of
-    /// using provider-native copy operations; local files retain their filesystem
-    /// copy path.
+    /// accounts). Object-store files are streamed through this process by default;
+    /// `LANCE_IO_SERVER_SIDE_COPY_ENABLED` opts same-store copies into
+    /// provider-native copy operations. Cross-store copies continue to stream, and
+    /// local files retain their filesystem copy path.
     ///
     /// Parameters:
     /// - `target_path`: the URI string to clone the dataset into.
@@ -3353,7 +3354,7 @@ impl Dataset {
                 let target_path = build_absolute_path(relative_path, &target_base);
                 async move {
                     source_store
-                        .copy_via_stream(&src_path, &target_store, &target_path)
+                        .copy_bulk(&src_path, &target_store, &target_path)
                         .await?;
                     Result::Ok(())
                 }

--- a/rust/lance/src/dataset.rs
+++ b/rust/lance/src/dataset.rs
@@ -3249,13 +3249,14 @@ impl Dataset {
 
     /// Deep clone the target version into a new dataset at target_path.
     /// This copies all relevant dataset files (data files, deletion files, and
-    /// index files) into the target dataset without loading data into memory.
+    /// index files) into the target dataset with bounded memory use.
     ///
     /// The source files are read through this dataset's own object store while the
     /// copies are written through the target object store built from `store_params`.
     /// This makes the clone work across accounts/stores (e.g. between two abfss
-    /// accounts): when the source and target stores are the same the copy stays
-    /// server-side, otherwise the data is streamed through this process.
+    /// accounts). Object-store files are streamed through this process instead of
+    /// using provider-native copy operations; local files retain their filesystem
+    /// copy path.
     ///
     /// Parameters:
     /// - `target_path`: the URI string to clone the dataset into.
@@ -3307,7 +3308,11 @@ impl Dataset {
             path
         };
 
-        let io_parallelism = self.object_store.io_parallelism();
+        const MAX_STREAM_COPY_PARALLELISM: usize = 4;
+        let io_parallelism = self
+            .object_store
+            .io_parallelism()
+            .min(MAX_STREAM_COPY_PARALLELISM);
         let copy_futures = src_paths
             .iter()
             .map(|(relative_path, base)| {

--- a/rust/lance/src/dataset/tests/dataset_io.rs
+++ b/rust/lance/src/dataset/tests/dataset_io.rs
@@ -2010,9 +2010,8 @@ async fn test_deep_clone_cross_store(
     #[values(LanceFileVersion::Legacy, LanceFileVersion::Stable)]
     data_storage_version: LanceFileVersion,
 ) {
-    // Source lives in an in-memory store while the target is a local directory, so the
-    // The two stores have different `store_prefix`es, exercising source and destination
-    // stores with separate credentials and storage implementations.
+    // Source lives in an in-memory store while the target is a local directory. Their
+    // different `store_prefix`es exercise separate source and destination implementations.
     let session = Arc::new(Session::default());
     let test_dir = TempStdDir::default();
     let clone_dir = test_dir.join("clone_ds");

--- a/rust/lance/src/dataset/tests/dataset_io.rs
+++ b/rust/lance/src/dataset/tests/dataset_io.rs
@@ -87,7 +87,7 @@ fn test_parse_deep_clone_stream_concurrency_accepts_positive_value() {
 }
 
 #[rstest]
-#[case::server_side_copy(64, false, None, 64)]
+#[case::direct_local_copy(64, false, None, 64)]
 #[case::streaming_default_cap(64, true, None, 4)]
 #[case::streaming_configured_below_cap(2, true, None, 2)]
 #[case::streaming_override(64, true, Some(17), 17)]

--- a/rust/lance/src/dataset/tests/dataset_io.rs
+++ b/rust/lance/src/dataset/tests/dataset_io.rs
@@ -15,8 +15,8 @@ use crate::dataset::WriteMode::Overwrite;
 use crate::dataset::builder::DatasetBuilder;
 use crate::dataset::transaction::Operation;
 use crate::dataset::{
-    ManifestWriteConfig, parse_deep_clone_stream_concurrency, validate_dataset_root_for_drop,
-    write_manifest_file,
+    ManifestWriteConfig, deep_clone_copy_parallelism, parse_deep_clone_stream_concurrency,
+    validate_dataset_root_for_drop, write_manifest_file,
 };
 use crate::session::Session;
 use crate::session::caches::ManifestKey;
@@ -84,6 +84,23 @@ fn test_parse_deep_clone_stream_concurrency_rejects_invalid_values(#[case] value
 #[test]
 fn test_parse_deep_clone_stream_concurrency_accepts_positive_value() {
     assert_eq!(parse_deep_clone_stream_concurrency("17").unwrap(), 17);
+}
+
+#[rstest]
+#[case::server_side_copy(64, false, None, 64)]
+#[case::streaming_default_cap(64, true, None, 4)]
+#[case::streaming_configured_below_cap(2, true, None, 2)]
+#[case::streaming_override(64, true, Some(17), 17)]
+fn test_deep_clone_copy_parallelism(
+    #[case] configured: usize,
+    #[case] uses_streaming_copy: bool,
+    #[case] stream_override: Option<usize>,
+    #[case] expected: usize,
+) {
+    assert_eq!(
+        deep_clone_copy_parallelism(configured, uses_streaming_copy, stream_override),
+        expected
+    );
 }
 
 #[tokio::test]

--- a/rust/lance/src/dataset/tests/dataset_io.rs
+++ b/rust/lance/src/dataset/tests/dataset_io.rs
@@ -2001,8 +2001,8 @@ async fn test_deep_clone_recognizes_ambiguous_commit_as_own() {
 // Uses an in-memory source store to force a cross-store copy. The in-memory store has
 // known platform-specific quirks on Windows (it reads back empty there; see the note in
 // tests/resource_tests.rs), so this test is gated to non-Windows. The local write side is
-// covered on Windows by `test_deep_clone` (same-store), and the cross-store streaming path
-// against real cloud stores is platform-agnostic std/tokio I/O.
+// covered on Windows by `test_deep_clone`, and streaming copies against real cloud stores
+// use platform-agnostic std/tokio I/O.
 #[cfg(not(windows))]
 #[rstest]
 #[tokio::test]
@@ -2011,8 +2011,8 @@ async fn test_deep_clone_cross_store(
     data_storage_version: LanceFileVersion,
 ) {
     // Source lives in an in-memory store while the target is a local directory, so the
-    // two stores have different `store_prefix`es and `deep_clone` must stream files from
-    // the source store to the target store (the cross-account code path).
+    // The two stores have different `store_prefix`es, exercising source and destination
+    // stores with separate credentials and storage implementations.
     let session = Arc::new(Session::default());
     let test_dir = TempStdDir::default();
     let clone_dir = test_dir.join("clone_ds");

--- a/rust/lance/src/dataset/tests/dataset_io.rs
+++ b/rust/lance/src/dataset/tests/dataset_io.rs
@@ -78,7 +78,7 @@ fn test_parse_deep_clone_stream_concurrency_rejects_invalid_values(#[case] value
     let error = parse_deep_clone_stream_concurrency(value).unwrap_err();
     let message = error.to_string();
     assert!(message.contains("LANCE_DEEP_CLONE_STREAM_CONCURRENCY"));
-    assert!(message.contains(value));
+    assert!(message.contains(&format!("{value:?}")));
 }
 
 #[test]

--- a/rust/lance/src/dataset/tests/dataset_io.rs
+++ b/rust/lance/src/dataset/tests/dataset_io.rs
@@ -14,7 +14,10 @@ use crate::dataset::WriteDestination;
 use crate::dataset::WriteMode::Overwrite;
 use crate::dataset::builder::DatasetBuilder;
 use crate::dataset::transaction::Operation;
-use crate::dataset::{ManifestWriteConfig, validate_dataset_root_for_drop, write_manifest_file};
+use crate::dataset::{
+    ManifestWriteConfig, parse_deep_clone_stream_concurrency, validate_dataset_root_for_drop,
+    write_manifest_file,
+};
 use crate::session::Session;
 use crate::session::caches::ManifestKey;
 use crate::{Dataset, Error, Result};
@@ -64,6 +67,23 @@ fn file_object_store_uri(path: &std::path::Path) -> String {
     let path = path.to_str().unwrap().replace('\\', "/");
     let path_prefix = if path.starts_with('/') { "" } else { "/" };
     format!("file-object-store://{path_prefix}{path}")
+}
+
+#[rstest]
+#[case::empty("")]
+#[case::zero("0")]
+#[case::negative("-1")]
+#[case::not_a_number("many")]
+fn test_parse_deep_clone_stream_concurrency_rejects_invalid_values(#[case] value: &str) {
+    let error = parse_deep_clone_stream_concurrency(value).unwrap_err();
+    let message = error.to_string();
+    assert!(message.contains("LANCE_DEEP_CLONE_STREAM_CONCURRENCY"));
+    assert!(message.contains(value));
+}
+
+#[test]
+fn test_parse_deep_clone_stream_concurrency_accepts_positive_value() {
+    assert_eq!(parse_deep_clone_stream_concurrency("17").unwrap(), 17);
 }
 
 #[tokio::test]


### PR DESCRIPTION
Stream bulk index and deep-clone files through Lance's multipart-aware writer by default instead of requiring provider-native copy requests.

Set `LANCE_IO_SERVER_SIDE_COPY_ENABLED` to a truthy value to opt cloud movement that shares the exact object-store client back into native server-side copy. Cross-client and cross-store movement always streams, and the explicit streaming API remains unchanged.

Default streaming accepts client bandwidth and transfer cost in exchange for avoiding single-request copy timeouts and providing uniform bounded-transfer, retry, cleanup, and validation behavior. Server-side deep-clone copy efficiency remains tracked separately in #5435.

This also improves object-store compatibility by reducing the API surface Lance requires by default: integrations can support these bulk-movement paths with read/write primitives and do not need a dedicated file-copy operation.

Add transfer validation, structured copy context, multipart failure cleanup coverage, policy-selection tests, and an FTS remap regression test that rejects native copy.
