### PR TITLE
feat(commit): default unrecognized schemes to put-if-not-exists commit handler

### DIFF
--- a/rust/lance-table/src/io/commit.rs
+++ b/rust/lance-table/src/io/commit.rs
@@ -1190,7 +1190,15 @@ pub async fn commit_handler_from_url(
                 .await?,
             }))
         }
-        _ => Ok(Arc::new(UnsafeCommitHandler)),
+        // Default for unrecognized schemes: prefer the conflict-safe
+        // put-if-not-exists handler over `UnsafeCommitHandler`. Most object
+        // stores (including out-of-tree providers registered at runtime) back
+        // onto storage that supports atomic create-if-not-exists, so this makes
+        // concurrent commits fail loudly with a conflict instead of silently
+        // clobbering each other's manifests. A store that genuinely lacks
+        // conditional-put support can still opt back into `UnsafeCommitHandler`
+        // explicitly (e.g. via a caller-supplied commit handler).
+        _ => Ok(Arc::new(ConditionalPutCommitHandler)),
     }
 }
 
@@ -2088,11 +2096,13 @@ mod tests {
     #[case::oss("oss://bucket-a/ds")]
     #[case::tos("tos://bucket-a/ds")]
     #[case::goosefs("goosefs://bucket-a/ds")]
+    #[case::custom_scheme("my-custom-scheme://bucket-a/ds")]
     async fn test_commit_handler_from_url_conditional_put_schemes(#[case] url: &str) {
         // Every scheme whose store supports atomic put-if-not-exists must
         // route to ConditionalPutCommitHandler — otherwise concurrent writers
         // fall through to UnsafeCommitHandler and silently clobber each
-        // other's manifests.
+        // other's manifests. Unrecognized schemes (e.g. runtime-registered
+        // out-of-tree providers) default to the same conflict-safe handler.
         let handler = commit_handler_from_url(url, &None).await.unwrap();
         assert_eq!(
             format!("{:?}", handler),


### PR DESCRIPTION
## Summary

`commit_handler_from_url` resolves the commit handler from the URL scheme string. Recognized schemes (`s3`, `gs`, `az`, `memory`, `file`, ...) get `ConditionalPutCommitHandler`, but **every other scheme fell through to `UnsafeCommitHandler`**, which blind-writes the manifest with no create-if-not-exists guard. Concurrent writers to such a scheme can all target the same next version, overwrite each other, and report success while silently losing updates.

This changes the default for unrecognized schemes to **`ConditionalPutCommitHandler`** (put-if-not-exists).

## Why

- Most object stores (including out-of-tree providers registered at runtime through the `ObjectStore` registry added in #8522) back onto storage that supports atomic create-if-not-exists.
- With this default, concurrent commits to an unrecognized scheme **fail loudly with a conflict** instead of silently clobbering each other.
- A store that genuinely lacks conditional-put support can still opt back into `UnsafeCommitHandler` via a caller-supplied commit handler.

## Test

Extended `test_commit_handler_from_url_conditional_put_schemes` with a `custom_scheme` case asserting an unrecognized scheme now routes to `ConditionalPutCommitHandler`.

## Context

Follow-up to #8522 per the review discussion. This is the first of two follow-ups; a subsequent change will let a provider **declare** its commit handler (e.g. `put-if-not-exists` vs `unsafe`) so selection is driven by the provider rather than a hardcoded scheme list.
