### PR TITLE
feat(commit): let registered providers declare their commit handler

### DIFF
--- a/rust/lance-io/src/object_store.rs
+++ b/rust/lance-io/src/object_store.rs
@@ -224,6 +224,11 @@ pub struct ObjectStore {
     /// The backend's paginated listing API, when it has one. `None` means
     /// [`Self::read_dir_page`] has to list a directory in full to page through it.
     pub(crate) paginated_lister: Option<Arc<dyn PaginatedListStore>>,
+    /// The commit-handler capability declared by the provider that built this
+    /// store. It is captured at construction time so the default commit handler
+    /// is bound to the exact store, not re-derived from a registry that may
+    /// have changed.
+    commit_handler_type: CommitHandlerType,
 }
 
 // Hand-written because `PaginatedListStore` is not `Debug`.
@@ -244,6 +249,7 @@ impl std::fmt::Debug for ObjectStore {
             .field("io_tracker", &self.io_tracker)
             .field("store_prefix", &self.store_prefix)
             .field("paginated_lister", &self.paginated_lister.is_some())
+            .field("commit_handler_type", &self.commit_handler_type)
             .finish()
     }
 }
@@ -677,6 +683,9 @@ impl ObjectStore {
                 store_prefix,
                 // Type-erased on the way in, so there is no telling if it can paginate.
                 paginated_lister: None,
+                // A caller-supplied store has no provider to declare a
+                // capability, so fall back to the conflict-safe default.
+                commit_handler_type: CommitHandlerType::ConditionalPut,
             };
             let path = Path::parse(path.path())?;
             return Ok((Arc::new(store), path));
@@ -777,6 +786,13 @@ impl ObjectStore {
 
     pub fn scheme(&self) -> &str {
         &self.scheme
+    }
+
+    /// The commit-handler capability declared by the provider that built this
+    /// store. Commit-handler resolution uses this to pick the default handler,
+    /// so the choice stays bound to the store the provider actually produced.
+    pub fn commit_handler_type(&self) -> CommitHandlerType {
+        self.commit_handler_type
     }
 
     pub fn block_size(&self) -> usize {
@@ -1797,6 +1813,13 @@ impl ObjectStore {
             store_prefix,
             // Type-erased on the way in, so there is no telling if it can paginate.
             paginated_lister: None,
+            // Derive the capability from the registered provider for this
+            // scheme when one exists; otherwise fall back to the conflict-safe
+            // default.
+            commit_handler_type: DEFAULT_OBJECT_STORE_REGISTRY
+                .get_provider(scheme)
+                .map(|provider| provider.commit_handler())
+                .unwrap_or_default(),
         }
     }
 }

--- a/rust/lance-io/src/object_store.rs
+++ b/rust/lance-io/src/object_store.rs
@@ -141,7 +141,7 @@ fn stream_copy_error(
     }))
 }
 
-pub use providers::{ObjectStoreProvider, ObjectStoreRegistry};
+pub use providers::{CommitHandlerType, ObjectStoreProvider, ObjectStoreRegistry};
 pub use read_dir::ReadDirOptions;
 pub use storage_options::{
     BASE_SCOPED_OPTION_PREFIX, BaseScopedStorageOptionsProvider, EXPIRES_AT_MILLIS_KEY,

--- a/rust/lance-io/src/object_store/providers.rs
+++ b/rust/lance-io/src/object_store/providers.rs
@@ -244,6 +244,11 @@ impl ObjectStoreRegistry {
     ) -> Result<Arc<ObjectStore>> {
         let mut store = provider.new_store(base_path, params).await?;
 
+        // Capture the provider's declared commit-handler capability on the
+        // exact store it built, so commit-handler resolution is bound to this
+        // store rather than a later registry lookup.
+        store.commit_handler_type = provider.commit_handler();
+
         store.inner = store.inner.traced();
 
         // Label metrics by the store's unique prefix (e.g. `s3$bucket`,
@@ -723,5 +728,69 @@ mod tests {
         assert!(!Arc::ptr_eq(&first, &second));
         let stats = registry.stats();
         assert_eq!((stats.hits, stats.misses, stats.active_stores), (0, 0, 0));
+    }
+
+    /// A provider that builds a working in-memory store yet declares it can
+    /// only offer unsafe commits, used to prove the declared capability is
+    /// stamped onto the store the registry builds even for a known scheme.
+    #[derive(Debug)]
+    struct UnsafeMemoryProvider;
+
+    #[async_trait::async_trait]
+    impl ObjectStoreProvider for UnsafeMemoryProvider {
+        async fn new_store(
+            &self,
+            base_path: Url,
+            params: &ObjectStoreParams,
+        ) -> Result<ObjectStore> {
+            MemoryStoreProvider.new_store(base_path, params).await
+        }
+
+        fn commit_handler(&self) -> CommitHandlerType {
+            CommitHandlerType::Unsafe
+        }
+
+        fn calculate_object_store_prefix(
+            &self,
+            _url: &Url,
+            _storage_options: Option<&HashMap<String, String>>,
+        ) -> Result<String> {
+            Ok("memory".to_string())
+        }
+    }
+
+    #[tokio::test]
+    async fn test_provider_commit_handler_travels_with_store() {
+        let url = Url::parse("memory://bucket/ds").unwrap();
+
+        // A built-in provider declares the conflict-safe default, and the
+        // registry stamps that capability onto the store it builds.
+        let registry = ObjectStoreRegistry::default();
+        let store = registry
+            .new_store(url.clone(), &ObjectStoreParams::default())
+            .await
+            .unwrap();
+        assert_eq!(
+            store.commit_handler_type(),
+            CommitHandlerType::ConditionalPut
+        );
+
+        // Overriding a known scheme with a provider that declares Unsafe makes
+        // the store it builds carry Unsafe: the capability is bound to the
+        // exact store, not inferred from the scheme name.
+        let registry = ObjectStoreRegistry::default();
+        registry.insert("memory", Arc::new(UnsafeMemoryProvider));
+        let store = registry
+            .new_store(url.clone(), &ObjectStoreParams::default())
+            .await
+            .unwrap();
+        assert_eq!(store.commit_handler_type(), CommitHandlerType::Unsafe);
+
+        // A cached store keeps the capability it was built with.
+        let cached = registry
+            .get_store(url, &ObjectStoreParams::default())
+            .await
+            .unwrap();
+        assert_eq!(cached.commit_handler_type(), CommitHandlerType::Unsafe);
     }
 }

--- a/rust/lance-io/src/object_store/providers.rs
+++ b/rust/lance-io/src/object_store/providers.rs
@@ -38,9 +38,39 @@ pub mod tencent;
 #[cfg(feature = "tos")]
 pub mod tos;
 
+/// Which built-in commit handler a provider's stores should use.
+///
+/// Commit-handler selection is otherwise inferred from the URL scheme. A
+/// registered out-of-tree provider serves a scheme that the built-in resolver
+/// does not recognize, so this lets the provider declare the guarantee its
+/// store actually offers instead of falling back to a scheme-string guess.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum CommitHandlerType {
+    /// Atomic put-if-not-exists. Safe for concurrent writers: a second writer
+    /// racing on the same manifest version gets a conflict instead of silently
+    /// overwriting. This is the default; it fits any store whose backend
+    /// supports create-if-not-exists (most object stores).
+    #[default]
+    ConditionalPut,
+    /// Blind overwrite with no concurrency protection. A store that cannot
+    /// offer atomic create-if-not-exists should return this so callers get the
+    /// documented "concurrent writes may lose data" behavior rather than an
+    /// error at commit time.
+    Unsafe,
+}
+
 #[async_trait::async_trait]
 pub trait ObjectStoreProvider: std::fmt::Debug + Sync + Send {
     async fn new_store(&self, base_path: Url, params: &ObjectStoreParams) -> Result<ObjectStore>;
+
+    /// The commit handler this provider's stores should use.
+    ///
+    /// Defaults to the conflict-safe [`CommitHandlerType::ConditionalPut`].
+    /// Override it to return [`CommitHandlerType::Unsafe`] for a store that
+    /// cannot support atomic create-if-not-exists.
+    fn commit_handler(&self) -> CommitHandlerType {
+        CommitHandlerType::ConditionalPut
+    }
 
     /// Extract the path relative to the base of the store.
     ///

--- a/rust/lance-io/src/object_store/providers.rs
+++ b/rust/lance-io/src/object_store/providers.rs
@@ -793,4 +793,27 @@ mod tests {
             .unwrap();
         assert_eq!(cached.commit_handler_type(), CommitHandlerType::Unsafe);
     }
+
+    #[test]
+    fn test_builtin_providers_keep_conditional_put_capability() {
+        // Regression guard for existing providers: the declared capability now
+        // drives commit-handler selection, so every provider the default
+        // registry ships must keep declaring the conflict-safe put-if-not-exists
+        // handler it resolved to before this change. A built-in that silently
+        // switched to Unsafe would change the commit handler of every store on
+        // that scheme.
+        let registry = ObjectStoreRegistry::default();
+        let providers = registry
+            .providers
+            .read()
+            .expect("ObjectStoreRegistry lock poisoned");
+        assert!(!providers.is_empty());
+        for (scheme, provider) in providers.iter() {
+            assert_eq!(
+                provider.commit_handler(),
+                CommitHandlerType::ConditionalPut,
+                "built-in provider for `{scheme}` changed its declared commit handler",
+            );
+        }
+    }
 }

--- a/rust/lance-io/src/object_store/providers/aws.rs
+++ b/rust/lance-io/src/object_store/providers/aws.rs
@@ -266,6 +266,7 @@ impl ObjectStoreProvider for AwsStoreProvider {
             store_prefix: self
                 .calculate_object_store_prefix(&base_path, params.storage_options())?,
             paginated_lister,
+            commit_handler_type: crate::object_store::CommitHandlerType::ConditionalPut,
         })
     }
 }

--- a/rust/lance-io/src/object_store/providers/azure.rs
+++ b/rust/lance-io/src/object_store/providers/azure.rs
@@ -306,6 +306,7 @@ impl ObjectStoreProvider for AzureBlobStoreProvider {
             store_prefix: self
                 .calculate_object_store_prefix(&base_path, params.storage_options())?,
             paginated_lister,
+            commit_handler_type: crate::object_store::CommitHandlerType::ConditionalPut,
         })
     }
 

--- a/rust/lance-io/src/object_store/providers/gcp.rs
+++ b/rust/lance-io/src/object_store/providers/gcp.rs
@@ -350,6 +350,7 @@ impl ObjectStoreProvider for GcsStoreProvider {
             store_prefix: self
                 .calculate_object_store_prefix(&base_path, params.storage_options())?,
             paginated_lister,
+            commit_handler_type: crate::object_store::CommitHandlerType::ConditionalPut,
         })
     }
 }

--- a/rust/lance-io/src/object_store/providers/goosefs.rs
+++ b/rust/lance-io/src/object_store/providers/goosefs.rs
@@ -193,6 +193,7 @@ impl ObjectStoreProvider for GooseFsStoreProvider {
                 .calculate_object_store_prefix(&base_path, params.storage_options())?,
             // Listed in full: no paginated lister covers OpenDAL yet.
             paginated_lister: None,
+            commit_handler_type: crate::object_store::CommitHandlerType::ConditionalPut,
         })
     }
 

--- a/rust/lance-io/src/object_store/providers/huggingface.rs
+++ b/rust/lance-io/src/object_store/providers/huggingface.rs
@@ -219,6 +219,7 @@ impl ObjectStoreProvider for HuggingfaceStoreProvider {
                 .calculate_object_store_prefix(&base_path, params.storage_options())?,
             // Listed in full: no paginated lister covers OpenDAL yet.
             paginated_lister: None,
+            commit_handler_type: crate::object_store::CommitHandlerType::ConditionalPut,
         })
     }
 

--- a/rust/lance-io/src/object_store/providers/local.rs
+++ b/rust/lance-io/src/object_store/providers/local.rs
@@ -141,6 +141,7 @@ impl ObjectStoreProvider for FileStoreProvider {
             // Listed in full: reading a directory is one local walk whatever the page size,
             // so there is no request for a page to be pushed into.
             paginated_lister: None,
+            commit_handler_type: crate::object_store::CommitHandlerType::ConditionalPut,
         })
     }
 
@@ -204,6 +205,7 @@ mod tests {
             io_tracker: Default::default(),
             store_prefix: "file$rooted-test".to_owned(),
             paginated_lister: None,
+            commit_handler_type: crate::object_store::CommitHandlerType::ConditionalPut,
         }
     }
 

--- a/rust/lance-io/src/object_store/providers/memory.rs
+++ b/rust/lance-io/src/object_store/providers/memory.rs
@@ -37,6 +37,7 @@ impl ObjectStoreProvider for MemoryStoreProvider {
             // Listed in full: the store is already in memory, so a page costs no less than
             // the directory does.
             paginated_lister: None,
+            commit_handler_type: crate::object_store::CommitHandlerType::ConditionalPut,
         })
     }
 

--- a/rust/lance-io/src/object_store/providers/oss.rs
+++ b/rust/lance-io/src/object_store/providers/oss.rs
@@ -147,6 +147,7 @@ impl ObjectStoreProvider for OssStoreProvider {
             store_prefix: self.calculate_object_store_prefix(&url, params.storage_options())?,
             // Listed in full: no paginated lister covers OpenDAL yet.
             paginated_lister: None,
+            commit_handler_type: crate::object_store::CommitHandlerType::ConditionalPut,
         })
     }
 }

--- a/rust/lance-io/src/object_store/providers/tencent.rs
+++ b/rust/lance-io/src/object_store/providers/tencent.rs
@@ -103,6 +103,7 @@ impl ObjectStoreProvider for TencentStoreProvider {
             store_prefix: self.calculate_object_store_prefix(&url, params.storage_options())?,
             // Listed in full: no paginated lister covers OpenDAL yet.
             paginated_lister: None,
+            commit_handler_type: crate::object_store::CommitHandlerType::ConditionalPut,
         })
     }
 }

--- a/rust/lance-io/src/object_store/providers/tos.rs
+++ b/rust/lance-io/src/object_store/providers/tos.rs
@@ -153,6 +153,7 @@ impl ObjectStoreProvider for TosStoreProvider {
             store_prefix: self.calculate_object_store_prefix(&url, params.storage_options())?,
             // Listed in full: no paginated lister covers OpenDAL yet.
             paginated_lister: None,
+            commit_handler_type: crate::object_store::CommitHandlerType::ConditionalPut,
         })
     }
 }

--- a/rust/lance-namespace-impls/src/dir/manifest.rs
+++ b/rust/lance-namespace-impls/src/dir/manifest.rs
@@ -1819,8 +1819,13 @@ impl ManifestNamespace {
     }
 
     /// Resolve the commit handler for the `__manifest` dataset's storage backend.
-    async fn manifest_commit_handler(&self) -> Result<Arc<dyn CommitHandler>> {
-        commit_handler_from_url(&self.root, &None, self.object_store.commit_handler_type())
+    /// The capability is read from the exact store the commit is written through,
+    /// which for stores like `memory://` can differ from `self.object_store`.
+    async fn manifest_commit_handler(
+        &self,
+        object_store: &ObjectStore,
+    ) -> Result<Arc<dyn CommitHandler>> {
+        commit_handler_from_url(&self.root, &None, object_store.commit_handler_type())
             .await
             .map_err(|e| {
                 lance_core::Error::from(NamespaceError::Internal {
@@ -1950,7 +1955,6 @@ impl ManifestNamespace {
         let max_retries = self.manifest_rewrite_commit_retries();
         let mut retries = 0;
         let build_indices = self.inline_optimization_enabled;
-        let commit_handler = self.manifest_commit_handler().await?;
 
         loop {
             let dataset_guard = self.manifest_dataset.get_refreshed().await?;
@@ -1963,6 +1967,9 @@ impl ManifestNamespace {
             // Staged files, indices, the commit, and cleanup must all use the dataset's
             // own object store (see `commit_manifest_overwrite`).
             let object_store = dataset.object_store(None).await?;
+            // Resolve the handler from that same committing store so an override
+            // registered for this scheme is honored (see manifest_commit_handler).
+            let commit_handler = self.manifest_commit_handler(&object_store).await?;
 
             let source = Self::manifest_projected_stream(&dataset).await?;
             let resolution = make_mutation().conflict_resolution();

--- a/rust/lance-namespace-impls/src/dir/manifest.rs
+++ b/rust/lance-namespace-impls/src/dir/manifest.rs
@@ -1820,7 +1820,7 @@ impl ManifestNamespace {
 
     /// Resolve the commit handler for the `__manifest` dataset's storage backend.
     async fn manifest_commit_handler(&self) -> Result<Arc<dyn CommitHandler>> {
-        commit_handler_from_url(&self.root, &None, None)
+        commit_handler_from_url(&self.root, &None, self.object_store.commit_handler_type())
             .await
             .map_err(|e| {
                 lance_core::Error::from(NamespaceError::Internal {

--- a/rust/lance-namespace-impls/src/dir/manifest.rs
+++ b/rust/lance-namespace-impls/src/dir/manifest.rs
@@ -1820,7 +1820,7 @@ impl ManifestNamespace {
 
     /// Resolve the commit handler for the `__manifest` dataset's storage backend.
     async fn manifest_commit_handler(&self) -> Result<Arc<dyn CommitHandler>> {
-        commit_handler_from_url(&self.root, &None)
+        commit_handler_from_url(&self.root, &None, None)
             .await
             .map_err(|e| {
                 lance_core::Error::from(NamespaceError::Internal {

--- a/rust/lance-table/src/io/commit.rs
+++ b/rust/lance-table/src/io/commit.rs
@@ -1190,7 +1190,15 @@ pub async fn commit_handler_from_url(
                 .await?,
             }))
         }
-        _ => Ok(Arc::new(UnsafeCommitHandler)),
+        // Default for unrecognized schemes: prefer the conflict-safe
+        // put-if-not-exists handler over `UnsafeCommitHandler`. Most object
+        // stores (including out-of-tree providers registered at runtime) back
+        // onto storage that supports atomic create-if-not-exists, so this makes
+        // concurrent commits fail loudly with a conflict instead of silently
+        // clobbering each other's manifests. A store that genuinely lacks
+        // conditional-put support can still opt back into `UnsafeCommitHandler`
+        // explicitly (e.g. via a caller-supplied commit handler).
+        _ => Ok(Arc::new(ConditionalPutCommitHandler)),
     }
 }
 
@@ -2088,11 +2096,13 @@ mod tests {
     #[case::oss("oss://bucket-a/ds")]
     #[case::tos("tos://bucket-a/ds")]
     #[case::goosefs("goosefs://bucket-a/ds")]
+    #[case::custom_scheme("my-custom-scheme://bucket-a/ds")]
     async fn test_commit_handler_from_url_conditional_put_schemes(#[case] url: &str) {
         // Every scheme whose store supports atomic put-if-not-exists must
         // route to ConditionalPutCommitHandler — otherwise concurrent writers
         // fall through to UnsafeCommitHandler and silently clobber each
-        // other's manifests.
+        // other's manifests. Unrecognized schemes (e.g. runtime-registered
+        // out-of-tree providers) default to the same conflict-safe handler.
         let handler = commit_handler_from_url(url, &None).await.unwrap();
         assert_eq!(
             format!("{:?}", handler),

--- a/rust/lance-table/src/io/commit.rs
+++ b/rust/lance-table/src/io/commit.rs
@@ -50,9 +50,7 @@ pub mod dynamodb;
 pub mod external_manifest;
 
 use lance_core::{Error, Result};
-use lance_io::object_store::{
-    CommitHandlerType, ObjectStore, ObjectStoreExt, ObjectStoreParams, ObjectStoreRegistry,
-};
+use lance_io::object_store::{CommitHandlerType, ObjectStore, ObjectStoreExt, ObjectStoreParams};
 use lance_io::traits::{WriteExt, Writer};
 
 use crate::format::{IndexMetadata, Manifest, Transaction, is_detached_version};
@@ -1106,9 +1104,11 @@ pub async fn commit_handler_from_url(
     url_or_path: &str,
     // This looks unused if dynamodb feature disabled
     #[allow(unused_variables)] options: &Option<ObjectStoreParams>,
-    // Registry consulted for schemes the built-in resolver does not recognize,
-    // so a registered provider can declare its own commit handler.
-    registry: Option<&ObjectStoreRegistry>,
+    // Commit-handler capability captured from the constructed object store.
+    // The store carries the capability its provider declared, so the default
+    // handler is bound to that exact store rather than re-queried from a
+    // registry whose providers may have changed since the store was built.
+    capability: CommitHandlerType,
 ) -> Result<Arc<dyn CommitHandler>> {
     let local_handler: Arc<dyn CommitHandler> = if cfg!(windows) {
         Arc::new(RenameCommitHandler)
@@ -1129,9 +1129,6 @@ pub async fn commit_handler_from_url(
 
     match url.scheme() {
         "file" | "file-object-store" => Ok(local_handler),
-        "s3" | "gs" | "az" | "abfss" | "memory" | "oss" | "tos" | "shared-memory" | "goosefs" => {
-            Ok(Arc::new(ConditionalPutCommitHandler))
-        }
         "cos" => Ok(Arc::new(TencentCosCommitHandler)),
         #[cfg(not(feature = "dynamodb"))]
         "s3+ddb" => Err(Error::invalid_input_source(
@@ -1195,22 +1192,16 @@ pub async fn commit_handler_from_url(
                 .await?,
             }))
         }
-        // Unrecognized scheme. If a provider is registered for it, let the
-        // provider declare its commit handler; otherwise default to the
-        // conflict-safe put-if-not-exists handler rather than the unsafe
-        // blind-overwrite handler. A store that genuinely lacks atomic
-        // create-if-not-exists can register a provider that returns
-        // `CommitHandlerType::Unsafe`.
-        scheme => {
-            let declared = registry
-                .and_then(|r| r.get_provider(scheme))
-                .map(|p| p.commit_handler())
-                .unwrap_or_default();
-            match declared {
-                CommitHandlerType::ConditionalPut => Ok(Arc::new(ConditionalPutCommitHandler)),
-                CommitHandlerType::Unsafe => Ok(Arc::new(UnsafeCommitHandler)),
-            }
-        }
+        // Every other scheme derives its default handler from the capability
+        // captured on the constructed object store. Built-in providers declare
+        // `ConditionalPut`; a registered provider, even one overriding a known
+        // scheme such as `memory`, can declare `Unsafe`, and that declaration
+        // travels with the store it built. Explicit caller-supplied handlers
+        // are honored before this function is called and never reach here.
+        _ => match capability {
+            CommitHandlerType::ConditionalPut => Ok(Arc::new(ConditionalPutCommitHandler)),
+            CommitHandlerType::Unsafe => Ok(Arc::new(UnsafeCommitHandler)),
+        },
     }
 }
 
@@ -2115,7 +2106,9 @@ mod tests {
         // fall through to UnsafeCommitHandler and silently clobber each
         // other's manifests. Unrecognized schemes (e.g. runtime-registered
         // out-of-tree providers) default to the same conflict-safe handler.
-        let handler = commit_handler_from_url(url, &None, None).await.unwrap();
+        let handler = commit_handler_from_url(url, &None, CommitHandlerType::ConditionalPut)
+            .await
+            .unwrap();
         assert_eq!(
             format!("{:?}", handler),
             "ConditionalPutCommitHandler",
@@ -2123,44 +2116,39 @@ mod tests {
         );
     }
 
-    /// A provider that declares it can only offer unsafe commits, used to check
-    /// that a registered provider's `commit_handler()` overrides the default.
-    #[derive(Debug)]
-    struct UnsafeDeclaringProvider;
-
-    #[async_trait::async_trait]
-    impl lance_io::object_store::ObjectStoreProvider for UnsafeDeclaringProvider {
-        async fn new_store(
-            &self,
-            _base_path: url::Url,
-            _params: &lance_io::object_store::ObjectStoreParams,
-        ) -> Result<lance_io::object_store::ObjectStore> {
-            unimplemented!("test provider is only used for commit_handler()")
-        }
-
-        fn commit_handler(&self) -> CommitHandlerType {
-            CommitHandlerType::Unsafe
-        }
-    }
-
     #[tokio::test]
-    async fn test_registered_provider_declares_commit_handler() {
-        let registry = ObjectStoreRegistry::default();
-        registry.insert("custom-unsafe", Arc::new(UnsafeDeclaringProvider));
-
-        // A registered provider that declares Unsafe routes to UnsafeCommitHandler,
-        // overriding the conflict-safe default for unrecognized schemes.
-        let handler = commit_handler_from_url("custom-unsafe://bucket/ds", &None, Some(&registry))
-            .await
-            .unwrap();
+    async fn test_commit_handler_from_url_honors_store_capability() {
+        // A general object-store scheme takes its default handler from the
+        // capability captured on the constructed store: an Unsafe-declaring
+        // provider's store routes to UnsafeCommitHandler, a ConditionalPut one
+        // to ConditionalPutCommitHandler.
+        let handler =
+            commit_handler_from_url("memory://bucket/ds", &None, CommitHandlerType::Unsafe)
+                .await
+                .unwrap();
         assert_eq!(format!("{:?}", handler), "UnsafeCommitHandler");
 
-        // A scheme with no registered provider still defaults to the conflict-safe
-        // handler even when a registry is supplied.
-        let handler = commit_handler_from_url("other-scheme://bucket/ds", &None, Some(&registry))
+        let handler = commit_handler_from_url(
+            "memory://bucket/ds",
+            &None,
+            CommitHandlerType::ConditionalPut,
+        )
+        .await
+        .unwrap();
+        assert_eq!(format!("{:?}", handler), "ConditionalPutCommitHandler");
+
+        // A scheme with dedicated handling ignores the store capability: file
+        // keeps its local handler and cos keeps the Tencent handler even when
+        // the capability says Unsafe.
+        let handler = commit_handler_from_url("file:///tmp/ds", &None, CommitHandlerType::Unsafe)
             .await
             .unwrap();
-        assert_eq!(format!("{:?}", handler), "ConditionalPutCommitHandler");
+        assert_ne!(format!("{:?}", handler), "UnsafeCommitHandler");
+
+        let handler = commit_handler_from_url("cos://bucket/ds", &None, CommitHandlerType::Unsafe)
+            .await
+            .unwrap();
+        assert_eq!(format!("{:?}", handler), "TencentCosCommitHandler");
     }
 
     /// A [CommitLock] whose lease records whether it was released, so we can
@@ -2271,9 +2259,10 @@ mod tests {
 
     #[tokio::test]
     async fn test_cos_commit_requires_custom_handler() {
-        let handler = commit_handler_from_url("cos://bucket-a/ds", &None, None)
-            .await
-            .unwrap();
+        let handler =
+            commit_handler_from_url("cos://bucket-a/ds", &None, CommitHandlerType::Unsafe)
+                .await
+                .unwrap();
         assert_eq!(format!("{:?}", handler), "TencentCosCommitHandler");
 
         let mut manifest = test_manifest();

--- a/rust/lance-table/src/io/commit.rs
+++ b/rust/lance-table/src/io/commit.rs
@@ -50,7 +50,9 @@ pub mod dynamodb;
 pub mod external_manifest;
 
 use lance_core::{Error, Result};
-use lance_io::object_store::{ObjectStore, ObjectStoreExt, ObjectStoreParams};
+use lance_io::object_store::{
+    CommitHandlerType, ObjectStore, ObjectStoreExt, ObjectStoreParams, ObjectStoreRegistry,
+};
 use lance_io::traits::{WriteExt, Writer};
 
 use crate::format::{IndexMetadata, Manifest, Transaction, is_detached_version};
@@ -1104,6 +1106,9 @@ pub async fn commit_handler_from_url(
     url_or_path: &str,
     // This looks unused if dynamodb feature disabled
     #[allow(unused_variables)] options: &Option<ObjectStoreParams>,
+    // Registry consulted for schemes the built-in resolver does not recognize,
+    // so a registered provider can declare its own commit handler.
+    registry: Option<&ObjectStoreRegistry>,
 ) -> Result<Arc<dyn CommitHandler>> {
     let local_handler: Arc<dyn CommitHandler> = if cfg!(windows) {
         Arc::new(RenameCommitHandler)
@@ -1190,15 +1195,22 @@ pub async fn commit_handler_from_url(
                 .await?,
             }))
         }
-        // Default for unrecognized schemes: prefer the conflict-safe
-        // put-if-not-exists handler over `UnsafeCommitHandler`. Most object
-        // stores (including out-of-tree providers registered at runtime) back
-        // onto storage that supports atomic create-if-not-exists, so this makes
-        // concurrent commits fail loudly with a conflict instead of silently
-        // clobbering each other's manifests. A store that genuinely lacks
-        // conditional-put support can still opt back into `UnsafeCommitHandler`
-        // explicitly (e.g. via a caller-supplied commit handler).
-        _ => Ok(Arc::new(ConditionalPutCommitHandler)),
+        // Unrecognized scheme. If a provider is registered for it, let the
+        // provider declare its commit handler; otherwise default to the
+        // conflict-safe put-if-not-exists handler rather than the unsafe
+        // blind-overwrite handler. A store that genuinely lacks atomic
+        // create-if-not-exists can register a provider that returns
+        // `CommitHandlerType::Unsafe`.
+        scheme => {
+            let declared = registry
+                .and_then(|r| r.get_provider(scheme))
+                .map(|p| p.commit_handler())
+                .unwrap_or_default();
+            match declared {
+                CommitHandlerType::ConditionalPut => Ok(Arc::new(ConditionalPutCommitHandler)),
+                CommitHandlerType::Unsafe => Ok(Arc::new(UnsafeCommitHandler)),
+            }
+        }
     }
 }
 
@@ -2103,12 +2115,52 @@ mod tests {
         // fall through to UnsafeCommitHandler and silently clobber each
         // other's manifests. Unrecognized schemes (e.g. runtime-registered
         // out-of-tree providers) default to the same conflict-safe handler.
-        let handler = commit_handler_from_url(url, &None).await.unwrap();
+        let handler = commit_handler_from_url(url, &None, None).await.unwrap();
         assert_eq!(
             format!("{:?}", handler),
             "ConditionalPutCommitHandler",
             "{url} should route to ConditionalPutCommitHandler",
         );
+    }
+
+    /// A provider that declares it can only offer unsafe commits, used to check
+    /// that a registered provider's `commit_handler()` overrides the default.
+    #[derive(Debug)]
+    struct UnsafeDeclaringProvider;
+
+    #[async_trait::async_trait]
+    impl lance_io::object_store::ObjectStoreProvider for UnsafeDeclaringProvider {
+        async fn new_store(
+            &self,
+            _base_path: url::Url,
+            _params: &lance_io::object_store::ObjectStoreParams,
+        ) -> Result<lance_io::object_store::ObjectStore> {
+            unimplemented!("test provider is only used for commit_handler()")
+        }
+
+        fn commit_handler(&self) -> CommitHandlerType {
+            CommitHandlerType::Unsafe
+        }
+    }
+
+    #[tokio::test]
+    async fn test_registered_provider_declares_commit_handler() {
+        let registry = ObjectStoreRegistry::default();
+        registry.insert("custom-unsafe", Arc::new(UnsafeDeclaringProvider));
+
+        // A registered provider that declares Unsafe routes to UnsafeCommitHandler,
+        // overriding the conflict-safe default for unrecognized schemes.
+        let handler = commit_handler_from_url("custom-unsafe://bucket/ds", &None, Some(&registry))
+            .await
+            .unwrap();
+        assert_eq!(format!("{:?}", handler), "UnsafeCommitHandler");
+
+        // A scheme with no registered provider still defaults to the conflict-safe
+        // handler even when a registry is supplied.
+        let handler = commit_handler_from_url("other-scheme://bucket/ds", &None, Some(&registry))
+            .await
+            .unwrap();
+        assert_eq!(format!("{:?}", handler), "ConditionalPutCommitHandler");
     }
 
     /// A [CommitLock] whose lease records whether it was released, so we can
@@ -2219,7 +2271,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_cos_commit_requires_custom_handler() {
-        let handler = commit_handler_from_url("cos://bucket-a/ds", &None)
+        let handler = commit_handler_from_url("cos://bucket-a/ds", &None, None)
             .await
             .unwrap();
         assert_eq!(format!("{:?}", handler), "TencentCosCommitHandler");

--- a/rust/lance-table/src/io/commit.rs
+++ b/rust/lance-table/src/io/commit.rs
@@ -2151,6 +2151,29 @@ mod tests {
         assert_eq!(format!("{:?}", handler), "TencentCosCommitHandler");
     }
 
+    #[tokio::test]
+    async fn test_builtin_provider_resolves_unchanged_end_to_end() {
+        // Regression guard across the full chain for a built-in scheme: the
+        // capability the memory provider declares, captured on the store the
+        // default registry builds, must still resolve to the handler that
+        // scheme used before the capability was made provider-driven.
+        use lance_io::object_store::ObjectStoreRegistry;
+
+        let registry = ObjectStoreRegistry::default();
+        let store = registry
+            .new_store(
+                Url::parse("memory://bucket/ds").unwrap(),
+                &ObjectStoreParams::default(),
+            )
+            .await
+            .unwrap();
+        let handler =
+            commit_handler_from_url("memory://bucket/ds", &None, store.commit_handler_type())
+                .await
+                .unwrap();
+        assert_eq!(format!("{:?}", handler), "ConditionalPutCommitHandler");
+    }
+
     /// A [CommitLock] whose lease records whether it was released, so we can
     /// assert the lock does not leak when the commit future is cancelled.
     #[derive(Debug)]

--- a/rust/lance/src/dataset/builder.rs
+++ b/rust/lance/src/dataset/builder.rs
@@ -594,7 +594,12 @@ impl DatasetBuilder {
                     )),
                 })
             } else {
-                commit_handler_from_url(&self.table_uri, &Some(self.options.clone()), None).await?
+                commit_handler_from_url(
+                    &self.table_uri,
+                    &Some(self.options.clone()),
+                    object_store.commit_handler_type(),
+                )
+                .await?
             };
 
         Ok((object_store, base_path, commit_handler))

--- a/rust/lance/src/dataset/builder.rs
+++ b/rust/lance/src/dataset/builder.rs
@@ -594,7 +594,7 @@ impl DatasetBuilder {
                     )),
                 })
             } else {
-                commit_handler_from_url(&self.table_uri, &Some(self.options.clone())).await?
+                commit_handler_from_url(&self.table_uri, &Some(self.options.clone()), None).await?
             };
 
         Ok((object_store, base_path, commit_handler))

--- a/rust/lance/src/dataset/write.rs
+++ b/rust/lance/src/dataset/write.rs
@@ -1840,6 +1840,7 @@ async fn resolve_commit_handler(
     uri: &str,
     commit_handler: Option<Arc<dyn CommitHandler>>,
     store_options: &Option<ObjectStoreParams>,
+    registry: Option<&ObjectStoreRegistry>,
 ) -> Result<Arc<dyn CommitHandler>> {
     match commit_handler {
         None => {
@@ -1853,7 +1854,7 @@ async fn resolve_commit_handler(
                     "when creating a dataset with a custom object store the commit_handler must also be specified",
                 ));
             }
-            commit_handler_from_url(uri, store_options).await
+            commit_handler_from_url(uri, store_options, registry).await
         }
         Some(commit_handler) => {
             if uri.starts_with("s3+ddb") {

--- a/rust/lance/src/dataset/write.rs
+++ b/rust/lance/src/dataset/write.rs
@@ -23,7 +23,7 @@ use lance_file::versions::v1::writer::{
 };
 use lance_file::writer::{self as current_writer};
 use lance_io::object_store::{
-    ObjectStore, ObjectStoreParams, ObjectStoreRegistry, parse_base_scoped_key,
+    CommitHandlerType, ObjectStore, ObjectStoreParams, ObjectStoreRegistry, parse_base_scoped_key,
 };
 use lance_io::traits::Writer;
 use lance_table::format::{BasePath, DataFile, Fragment, IndexMetadata};
@@ -1840,7 +1840,7 @@ async fn resolve_commit_handler(
     uri: &str,
     commit_handler: Option<Arc<dyn CommitHandler>>,
     store_options: &Option<ObjectStoreParams>,
-    registry: Option<&ObjectStoreRegistry>,
+    capability: CommitHandlerType,
 ) -> Result<Arc<dyn CommitHandler>> {
     match commit_handler {
         None => {
@@ -1854,7 +1854,7 @@ async fn resolve_commit_handler(
                     "when creating a dataset with a custom object store the commit_handler must also be specified",
                 ));
             }
-            commit_handler_from_url(uri, store_options, registry).await
+            commit_handler_from_url(uri, store_options, capability).await
         }
         Some(commit_handler) => {
             if uri.starts_with("s3+ddb") {

--- a/rust/lance/src/dataset/write/commit.rs
+++ b/rust/lance/src/dataset/write/commit.rs
@@ -315,8 +315,13 @@ impl<'a> CommitBuilder<'a> {
                 {
                     commit_handler.clone()
                 } else {
-                    resolve_commit_handler(uri, self.commit_handler.clone(), &self.store_params)
-                        .await?
+                    resolve_commit_handler(
+                        uri,
+                        self.commit_handler.clone(),
+                        &self.store_params,
+                        Some(session.store_registry().as_ref()),
+                    )
+                    .await?
                 };
                 let (object_store, base_path) = if let Some(passed_store) = self.object_store {
                     (

--- a/rust/lance/src/dataset/write/commit.rs
+++ b/rust/lance/src/dataset/write/commit.rs
@@ -310,19 +310,7 @@ impl<'a> CommitBuilder<'a> {
                     .unwrap_or_else(|| dataset.commit_handler.clone()),
             ),
             WriteDestination::Uri(uri) => {
-                let commit_handler = if let (Some(_), Some(commit_handler)) =
-                    (&self.object_store, &self.commit_handler)
-                {
-                    commit_handler.clone()
-                } else {
-                    resolve_commit_handler(
-                        uri,
-                        self.commit_handler.clone(),
-                        &self.store_params,
-                        Some(session.store_registry().as_ref()),
-                    )
-                    .await?
-                };
+                let store_was_passed = self.object_store.is_some();
                 let (object_store, base_path) = if let Some(passed_store) = self.object_store {
                     (
                         passed_store,
@@ -333,6 +321,20 @@ impl<'a> CommitBuilder<'a> {
                         session.store_registry(),
                         uri,
                         &self.store_params.clone().unwrap_or_default(),
+                    )
+                    .await?
+                };
+                // Resolve the handler from the capability the constructed
+                // store carries, so the choice is bound to that store. An
+                // explicitly supplied handler alongside a custom store wins.
+                let commit_handler = if store_was_passed && self.commit_handler.is_some() {
+                    self.commit_handler.clone().expect("checked is_some")
+                } else {
+                    resolve_commit_handler(
+                        uri,
+                        self.commit_handler.clone(),
+                        &self.store_params,
+                        object_store.commit_handler_type(),
                     )
                     .await?
                 };

--- a/rust/lance/src/dataset/write/insert.rs
+++ b/rust/lance/src/dataset/write/insert.rs
@@ -376,7 +376,7 @@ impl<'a> InsertBuilder<'a> {
                     .map(|s| s.store_registry())
                     .unwrap_or_else(|| Arc::new(Default::default()));
                 let (object_store, base_path) = ObjectStore::from_uri_and_params(
-                    registry,
+                    registry.clone(),
                     uri,
                     &params.store_params.clone().unwrap_or_default(),
                 )
@@ -385,6 +385,7 @@ impl<'a> InsertBuilder<'a> {
                     uri,
                     params.commit_handler.clone(),
                     &params.store_params,
+                    Some(&registry),
                 )
                 .await?;
                 (object_store, base_path, commit_handler)
@@ -522,7 +523,7 @@ mod test {
             ))
             .await
             .unwrap();
-        dataset.commit_handler = commit_handler_from_url("cos://bucket/dataset", &None)
+        dataset.commit_handler = commit_handler_from_url("cos://bucket/dataset", &None, None)
             .await
             .unwrap();
 

--- a/rust/lance/src/dataset/write/insert.rs
+++ b/rust/lance/src/dataset/write/insert.rs
@@ -385,7 +385,7 @@ impl<'a> InsertBuilder<'a> {
                     uri,
                     params.commit_handler.clone(),
                     &params.store_params,
-                    Some(&registry),
+                    object_store.commit_handler_type(),
                 )
                 .await?;
                 (object_store, base_path, commit_handler)
@@ -523,9 +523,13 @@ mod test {
             ))
             .await
             .unwrap();
-        dataset.commit_handler = commit_handler_from_url("cos://bucket/dataset", &None, None)
-            .await
-            .unwrap();
+        dataset.commit_handler = commit_handler_from_url(
+            "cos://bucket/dataset",
+            &None,
+            lance_io::object_store::CommitHandlerType::ConditionalPut,
+        )
+        .await
+        .unwrap();
 
         let append_batch =
             RecordBatch::try_new(schema.clone(), vec![Arc::new(Int32Array::from(vec![2]))])

--- a/rust/lance/src/io/commit.rs
+++ b/rust/lance/src/io/commit.rs
@@ -2358,7 +2358,7 @@ mod tests {
         let uri = tmp.as_str();
         let schema = simple_schema();
         let batch = simple_batch(&schema, vec![1, 2, 3]);
-        let commit_handler = commit_handler_from_url("cos://bucket/dataset", &None)
+        let commit_handler = commit_handler_from_url("cos://bucket/dataset", &None, None)
             .await
             .unwrap();
         let params = WriteParams {

--- a/rust/lance/src/io/commit.rs
+++ b/rust/lance/src/io/commit.rs
@@ -2358,9 +2358,13 @@ mod tests {
         let uri = tmp.as_str();
         let schema = simple_schema();
         let batch = simple_batch(&schema, vec![1, 2, 3]);
-        let commit_handler = commit_handler_from_url("cos://bucket/dataset", &None, None)
-            .await
-            .unwrap();
+        let commit_handler = commit_handler_from_url(
+            "cos://bucket/dataset",
+            &None,
+            lance_io::object_store::CommitHandlerType::ConditionalPut,
+        )
+        .await
+        .unwrap();
         let params = WriteParams {
             commit_handler: Some(commit_handler),
             ..Default::default()


### PR DESCRIPTION
## Summary

Follow-up to #8522, stacked on #8773. Lets a registered `ObjectStoreProvider` **declare** which commit handler its store should use, instead of the handler being inferred purely from the URL scheme string.

## Changes

- **`CommitHandlerType { ConditionalPut, Unsafe }`** (new, in `lance-io`) — a small enum a provider returns to declare the concurrency guarantee its store actually offers. `ConditionalPut` is the `Default`.
- **`ObjectStoreProvider::commit_handler()`** (new trait method, default `ConditionalPut`) — a provider whose store cannot offer atomic create-if-not-exists overrides this to return `Unsafe`.
- **`commit_handler_from_url`** now takes an optional `&ObjectStoreRegistry`. For a scheme the built-in resolver does not recognize, it consults the registered provider's `commit_handler()` rather than guessing; with no registered provider it keeps the conflict-safe put-if-not-exists default.
- The write path threads the session's registry through `resolve_commit_handler`.

## Why

#8773 made the default for unrecognized schemes conflict-safe. This adds the escape hatch Weston asked for: a provider that genuinely can't do put-if-not-exists can opt into `UnsafeCommitHandler` explicitly, so selection is driven by the provider's real capability rather than a hardcoded scheme list. Per the review discussion, providers return a small fixed set (`ConditionalPut` / `Unsafe`); users are not expected to supply arbitrary commit handlers.

## Test

`test_registered_provider_declares_commit_handler`: a provider declaring `Unsafe` routes to `UnsafeCommitHandler`, and an unregistered custom scheme still defaults to `ConditionalPutCommitHandler`.

Verified locally: `cargo test -p lance-table`, `cargo clippy -p lance-io -p lance-table -p lance -p lance-namespace-impls -- -D warnings` clean.
