### PR TITLE
fix(python): don't seed IVF centroids with NaN vectors

### DIFF
--- a/python/python/lance/vector.py
+++ b/python/python/lance/vector.py
@@ -198,6 +198,33 @@ def train_pq_codebook_on_accelerator(
     return pq_codebook, kmeans_list
 
 
+def _sample_init_centroids(
+    ds: Iterable["torch.Tensor"], k: int, filter_nan: bool
+) -> "torch.Tensor":
+    """Take up to k vectors from ds to seed kmeans, skipping non-finite ones."""
+    # `column is not null` does not exclude NaN vectors, so they can still be
+    # sampled here.  Training drops them (distance returns id -1), but a NaN
+    # centroid never recovers and leaves every partition NaN.
+    sampled = []
+    num_sampled = 0
+    for batch in ds:
+        if filter_nan:
+            batch = batch[batch.isfinite().flatten(1).all(dim=1)]
+        if batch.shape[0] == 0:
+            continue
+        sampled.append(batch)
+        num_sampled += batch.shape[0]
+        if num_sampled >= k:
+            break
+
+    if num_sampled == 0:
+        raise ValueError(
+            "Cannot initialize centroids: the sampled vectors are all null or "
+            "non-finite"
+        )
+    return torch.cat(sampled)[:k]
+
+
 def train_ivf_centroids_on_accelerator(
     dataset: LanceDataset,
     column: str,
@@ -245,7 +272,7 @@ def train_ivf_centroids_on_accelerator(
         filter=filt,
     )
 
-    init_centroids = next(iter(ds))
+    init_centroids = _sample_init_centroids(ds, k, filter_nan)
     LOGGER.info("Done sampling: centroids shape: %s", init_centroids.shape)
 
     ds = TorchDataset(

--- a/python/python/tests/test_vector_index.py
+++ b/python/python/tests/test_vector_index.py
@@ -568,6 +568,42 @@ def test_torch_index_with_nans(tmp_path, index_file_version):
     validate_vector_index(dataset, "vector", sample_size=16)
 
 
+def test_torch_index_nan_init_centroid(tmp_path):
+    """A NaN vector must never seed a centroid.
+
+    `vector is not null` does not exclude NaN, so sampling could pick one; with
+    a single partition that left every residual NaN and the index build failed.
+    """
+    torch = pytest.importorskip("torch")
+    from lance.torch.data import LanceDataset as TorchDataset
+    from lance.vector import _sample_init_centroids
+
+    # Only the last 8 rows are finite, so any sample that keeps NaN rows seeds
+    # the centroid with one.
+    mat = np.full((32, 8), np.nan, dtype=np.float32)
+    mat[24:] = np.random.randn(8, 8).astype(np.float32)
+    dataset = lance.write_dataset(vec_to_table(data=mat), tmp_path)
+    assert dataset.to_table()["vector"].null_count == 0
+
+    ds = TorchDataset(dataset, batch_size=1, columns=["vector"], samples=32)
+    centroids = _sample_init_centroids(ds, 4, filter_nan=True)
+    assert centroids.shape[0] == 4
+    assert torch.isfinite(centroids).all()
+
+
+def test_torch_index_all_nan_rejected(tmp_path):
+    pytest.importorskip("torch")
+    from lance.torch.data import LanceDataset as TorchDataset
+    from lance.vector import _sample_init_centroids
+
+    mat = np.full((16, 8), np.nan, dtype=np.float32)
+    dataset = lance.write_dataset(vec_to_table(data=mat), tmp_path)
+
+    ds = TorchDataset(dataset, batch_size=1, columns=["vector"], samples=16)
+    with pytest.raises(ValueError, match="all null or non-finite"):
+        _sample_init_centroids(ds, 1, filter_nan=True)
+
+
 def test_index_with_no_centroid_movement(tmp_path):
     torch = pytest.importorskip("torch")
 


### PR DESCRIPTION
## Problem

Initial centroids are sampled under `"<column> is not null"`, which does not exclude NaN - `_filtered_efficient_sample` narrows the filter to `pc.drop_null`, and NaN vectors are not null. A sampled NaN centroid never recovers: with `num_partitions=1` every distance is NaN, `compute_partitions` masks out every row on `partitions.isfinite()`, and the empty residual dataset makes `train_pq_codebook_on_accelerator` raise `StopIteration`.

Training already handles NaN (distance returns id `-1`, `_fit_once` masks those rows); only initialization was unguarded.

## Change

`_sample_init_centroids` pulls batches until it has `k` finite vectors, skipping non-finite rows, and raises `ValueError` when nothing finite is found. Behaviour for finite data is unchanged — it still takes the first `k` sampled rows.

## Tests

- `test_torch_index_nan_init_centroid` — a dataset whose only finite vectors are the last 8 rows; asserts `null_count == 0` (so the SQL filter cannot help) and that the sampled centroids are finite.
- `test_torch_index_all_nan_rejected` — all-NaN input raises rather than producing a NaN centroid.

Both fail on `main` and pass with this change.

Also fixes the ~1% flake in `test_torch_index_with_nans`, e.g. https://github.com/lance-format/lance/actions/runs/32862948967.