### PR TITLE
feat(python): restore index retraining

### DIFF
--- a/python/python/lance/dataset.py
+++ b/python/python/lance/dataset.py
@@ -7446,10 +7446,10 @@ class DatasetOptimizer:
         an expensive unindexed search on the new data.  As the amount of new
         unindexed data grows this can have an impact on search latency.
         This function will add the new data to existing indexes, restoring the
-        performance.  This function does not retrain the index, it only assigns
-        the new data to existing partitions.  This means an update is much quicker
-        than retraining the entire index but may have less accuracy (especially
-        if the new data exhibits new patterns, concepts, or trends)
+        performance. By default, this function does not retrain the index, it only
+        assigns the new data to existing partitions. This means an update is much
+        quicker than retraining the entire index but may have less accuracy
+        (especially if the new data exhibits new patterns, concepts, or trends)
 
         Parameters
         ----------
@@ -7459,7 +7459,7 @@ class DatasetOptimizer:
         index_names: List[str], default None
             The names of the indices to optimize.
             If None, all indices will be optimized.
-        retrain: bool, default False, deprecated
+        retrain: bool, default False
             Whether to retrain the whole index.
             If true, the index will be retrained based on the current data,
             `num_indices_to_merge` will be ignored,
@@ -7467,7 +7467,7 @@ class DatasetOptimizer:
 
             This is useful when the data distribution has changed significantly,
             and we want to retrain the index to improve the search quality.
-            This would be faster than re-create the index from scratch.
+            This rebuilds the index from the source data and may be expensive.
         """
         self._dataset._ds.optimize_indices(**kwargs)
 

--- a/python/python/tests/test_vector_index.py
+++ b/python/python/tests/test_vector_index.py
@@ -2148,29 +2148,48 @@ def test_no_stale_duplicate_after_partial_column_update(tmp_path):
     assert res["id"].is_unique, f"duplicate ids in result: {res['id'].tolist()}"
 
 
-@pytest.mark.skip(reason="retrain is deprecated")
-def test_retrain_indices(indexed_dataset):
-    data = create_table()
-    indexed_dataset = lance.write_dataset(data, indexed_dataset.uri, mode="append")
+@pytest.mark.parametrize("retrain", [None, False, True])
+def test_retrain_indices(tmp_path, retrain):
+    rng = np.random.default_rng(42)
+    ndim = 16
+    initial_vectors = rng.standard_normal((64, ndim), dtype=np.float32)
+    appended_vectors = rng.standard_normal((64, ndim), dtype=np.float32) + 100
+    old_centroid = np.full((1, ndim), -1000, dtype=np.float32)
+
+    indexed_dataset = lance.write_dataset(vec_to_table(initial_vectors), tmp_path)
+    indexed_dataset = indexed_dataset.create_index(
+        "vector",
+        index_type="IVF_FLAT",
+        num_partitions=1,
+        ivf_centroids=old_centroid,
+        index_file_version=IndexFileVersion.V3,
+    )
+    indexed_dataset = lance.write_dataset(
+        vec_to_table(appended_vectors), indexed_dataset.uri, mode="append"
+    )
+
     stats = indexed_dataset.stats.index_stats("vector_idx")
     assert stats["num_indices"] == 1
 
     indexed_dataset.optimize.optimize_indices(num_indices_to_merge=0)
     stats = indexed_dataset.stats.index_stats("vector_idx")
     assert stats["num_indices"] == 2
+    assert all(
+        index["centroids"] == old_centroid.tolist() for index in stats["indices"]
+    )
 
+    kwargs = {} if retrain is None else {"retrain": retrain}
+    indexed_dataset.optimize.optimize_indices(**kwargs)
     stats = indexed_dataset.stats.index_stats("vector_idx")
-    centroids = stats["indices"][0]["centroids"]
-    delta_centroids = stats["indices"][1]["centroids"]
-    assert centroids == delta_centroids
-
-    indexed_dataset.optimize.optimize_indices(retrain=True)
-    new_centroids = indexed_dataset.stats.index_stats("vector_idx")["indices"][0][
-        "centroids"
-    ]
-    stats = indexed_dataset.stats.index_stats("vector_idx")
-    assert stats["num_indices"] == 1
-    assert centroids != new_centroids
+    centroids = [index["centroids"] for index in stats["indices"]]
+    if retrain:
+        expected_centroid = np.concatenate([initial_vectors, appended_vectors]).mean(
+            axis=0
+        )
+        assert stats["num_indices"] == 1
+        assert np.allclose(centroids[0][0], expected_centroid)
+    else:
+        assert all(centroid == old_centroid.tolist() for centroid in centroids)
 
 
 def test_no_include_deleted_rows(indexed_dataset):

--- a/python/src/dataset.rs
+++ b/python/src/dataset.rs
@@ -2475,6 +2475,9 @@ impl Dataset {
             if let Some(num_indices_to_merge) = kwargs.get_item("num_indices_to_merge")? {
                 options.num_indices_to_merge = num_indices_to_merge.extract()?;
             }
+            if let Some(retrain) = kwargs.get_item("retrain")? {
+                options.retrain = retrain.extract()?;
+            }
             if let Some(index_names) = kwargs.get_item("index_names")? {
                 options.index_names = Some(
                     index_names


### PR DESCRIPTION
## Summary

- forward optimize_indices(retrain=...) through the PyO3 binding
- restore the Python documentation for explicit retraining
- re-enable the existing retrain test with deterministic model assertions

## Background

Retraining was deprecated in #4726, which removed the Python binding path and skipped its test. #8047 later restored explicit retraining as a full source rebuild that unifies vector index segment models, but the PyLance binding, documentation, and test were not restored with it.

## Testing

- uv run --python 3.12 pytest python/tests/test_vector_index.py::test_retrain_indices -vv
- uv run --python 3.12 make lint
- cargo fmt --all
- cargo clippy --all --tests --benches -- -D warnings