### PR TITLE
fix(linalg): enforce the dist_table length contract in release

### DIFF
--- a/rust/lance-linalg/src/simd/dist_table.rs
+++ b/rust/lance-linalg/src/simd/dist_table.rs
@@ -14,19 +14,31 @@ pub const PERM0: [usize; 16] = [0, 8, 1, 9, 2, 10, 3, 11, 4, 12, 5, 13, 6, 14, 7
 pub const PERM0_INVERSE: [usize; 16] = [0, 2, 4, 6, 8, 10, 12, 14, 1, 3, 5, 7, 9, 11, 13, 15];
 pub const BATCH_SIZE: usize = 32;
 
-// This function is used to sum the distance table for 4-bit codes.
-// the distance table is a 2D array, that dist_table[i][j] is the distance between the i-th subvector and the code j,
-// the distance table is stored as a flat array for better cache locality and SIMD instruction usage.
-//
-// The codes are organized in the order of PERM0:
-// +----------+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+
-// | address  |  0 |  1 |  2 |  3 |  4 |  5 |  6 |  7 |  8 |  9 | 10 | 11 | 12 | 13 | 14 | 15 |
-// | (bytes)  |    |    |    |    |    |    |    |    |    |    |    |    |    |    |    |    |
-// +----------+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+
-// | bits 0..3|  0 |  8 |  1 |  9 |  2 | 10 |  3 | 11 |  4 | 12 |  5 | 13 |  6 | 14 |  7 | 15 |
-// | bits 4..7| 16 | 24 | 17 | 25 | 18 | 26 | 19 | 27 | 20 | 28 | 21 | 29 | 22 | 30 | 23 | 31 |
-// +----------+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+
-// so that we can use SIMD instruction (especially _mm256_shuffle_epi8) to do the summation.
+/// Sum a 4-bit distance table over `n` vectors of `code_len` bytes each.
+///
+/// The distance table is a 2D array, where `dist_table[i][j]` is the distance between
+/// the i-th subvector and the code `j`, stored as a flat array for cache locality and
+/// SIMD use.
+///
+/// The codes are organized in the order of PERM0, so that the summation can use
+/// `_mm256_shuffle_epi8` and its counterparts:
+///
+/// ```text
+/// +----------+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+
+/// | address  |  0 |  1 |  2 |  3 |  4 |  5 |  6 |  7 |  8 |  9 | 10 | 11 | 12 | 13 | 14 | 15 |
+/// | (bytes)  |    |    |    |    |    |    |    |    |    |    |    |    |    |    |    |    |
+/// +----------+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+
+/// | bits 0..3|  0 |  8 |  1 |  9 |  2 | 10 |  3 | 11 |  4 | 12 |  5 | 13 |  6 | 14 |  7 | 15 |
+/// | bits 4..7| 16 | 24 | 17 | 25 | 18 | 26 | 19 | 27 | 20 | 28 | 21 | 29 | 22 | 30 | 23 | 31 |
+/// +----------+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+
+/// ```
+///
+/// # Panics
+///
+/// Each length is checked on entry, in this order: `n` against [`BATCH_SIZE`],
+/// `dists.len()` against `n`, `codes.len()` against `n * code_len`, and
+/// `dist_table.len()` against `BATCH_SIZE * code_len`. A failing check panics with a
+/// message naming this function and both operands.
 #[inline]
 pub fn sum_4bit_dist_table(
     n: usize,
@@ -35,10 +47,25 @@ pub fn sum_4bit_dist_table(
     dist_table: &[u8],
     dists: &mut [u16],
 ) {
-    assert!(n.is_multiple_of(BATCH_SIZE));
-    assert!(dists.len() >= n);
-    assert!(codes.len() >= n * code_len);
-    assert!(dist_table.len() >= BATCH_SIZE * code_len);
+    assert!(
+        n.is_multiple_of(BATCH_SIZE),
+        "sum_4bit_dist_table needs a vector count that is a multiple of {BATCH_SIZE}, got {n}"
+    );
+    assert!(
+        dists.len() >= n,
+        "sum_4bit_dist_table needs one output slot per vector, got {n} vector(s) and {} slot(s)",
+        dists.len()
+    );
+    assert!(
+        codes.len() >= n * code_len,
+        "sum_4bit_dist_table needs {n} * {code_len} code bytes, got {}",
+        codes.len()
+    );
+    assert!(
+        dist_table.len() >= BATCH_SIZE * code_len,
+        "sum_4bit_dist_table needs {BATCH_SIZE} * {code_len} table bytes, got {}",
+        dist_table.len()
+    );
     // A `u16` slice is also a valid `MaybeUninit<u16>` slice. The dispatched
     // kernels overwrite every output slot.
     let dists = unsafe {
@@ -51,11 +78,18 @@ pub fn sum_4bit_dist_table(
 ///
 /// Every element in `dists[..n]` is initialized before this function returns.
 ///
+/// # Panics
+///
+/// Panics if `dist_table` holds fewer than `BATCH_SIZE * code_len` bytes, or if `codes`
+/// or `dists` is too short for the batch being indexed.
+///
 /// # Safety
 ///
 /// `n` must be a multiple of [`BATCH_SIZE`], `codes` must contain at least
-/// `n * code_len` bytes, `dist_table` must contain at least
-/// `BATCH_SIZE * code_len` bytes, and `dists` must contain at least `n` slots.
+/// `n * code_len` bytes, and `dists` must contain at least `n` slots. The dispatch
+/// reaches `codes` and `dists` through bounds-checked slices, so a length too short for
+/// the batch being indexed panics instead of being read or written out of bounds; `n` is
+/// not checked outside debug builds.
 #[inline]
 pub unsafe fn sum_4bit_dist_table_uninit(
     n: usize,
@@ -67,6 +101,15 @@ pub unsafe fn sum_4bit_dist_table_uninit(
     debug_assert!(n.is_multiple_of(BATCH_SIZE));
     debug_assert!(dists.len() >= n);
     debug_assert!(codes.len() >= n * code_len);
+    // The SIMD kernels read the table through a raw pointer over a range bounded by the
+    // one batch of codes they are handed, so this check has to run before the dispatch.
+    // Always-on rather than `debug_assert!`, because that range is where a short table
+    // would be read out of bounds.
+    assert!(
+        dist_table.len() >= BATCH_SIZE * code_len,
+        "sum_4bit_dist_table_uninit needs {BATCH_SIZE} * {code_len} table bytes, got {}",
+        dist_table.len()
+    );
 
     match *SIMD_SUPPORT {
         #[cfg(all(kernel_support = "avx512_dist_table", target_arch = "x86_64"))]
@@ -155,6 +198,17 @@ pub fn sum_4bit_dist_table_scalar(
     }
 }
 
+/// A `u16`-table sum with no SIMD dispatch: it forwards to
+/// [`sum_4bit_dist_table_u16_scalar`] on every architecture.
+///
+/// # Panics
+///
+/// `n`, `codes.len()` and `dists.len()` are `debug_assert!`-ed rather than checked, and
+/// `dist_table.len()` is not checked at all. With debug assertions off, a `codes` or
+/// `dists` too short for `n` panics from the slicing below and a short `dist_table`
+/// panics inside [`sum_4bit_dist_table_u16_scalar`]; an `n` that is not a multiple of
+/// [`BATCH_SIZE`] is not rejected, and the vectors past the last whole batch are left as
+/// the caller passed them in.
 #[inline]
 #[allow(unused)]
 pub fn sum_4bit_dist_table_u16(
@@ -175,6 +229,8 @@ pub fn sum_4bit_dist_table_u16(
     );
 }
 
+/// Transpose a `u16` distance table into the low and high byte planes that
+/// [`sum_4bit_hacc_dist_table`] reads, resizing `hacc_dist_table` to twice the input.
 #[inline]
 pub fn transfer_4bit_dist_table_u16(dist_table: &[u16], hacc_dist_table: &mut Vec<u8>) {
     debug_assert!(dist_table.len().is_multiple_of(32));
@@ -194,6 +250,18 @@ pub fn transfer_4bit_dist_table_u16(dist_table: &[u16], hacc_dist_table: &mut Ve
     }
 }
 
+/// High-accuracy counterpart of [`sum_4bit_dist_table`], accumulating into `u32`.
+///
+/// The table is the `u16` distance table transposed into low and high byte planes by
+/// [`transfer_4bit_dist_table_u16`], so it is sized by `code_len * 64` rather than
+/// `BATCH_SIZE * code_len`.
+///
+/// # Panics
+///
+/// Each length is checked on entry, in this order: `n` against [`BATCH_SIZE`],
+/// `dists.len()` against `n`, `codes.len()` against `n * code_len`, and
+/// `hacc_dist_table.len()` against `code_len * 64`. A failing check panics with a
+/// message naming this function and both operands.
 #[inline]
 pub fn sum_4bit_hacc_dist_table(
     n: usize,
@@ -202,10 +270,26 @@ pub fn sum_4bit_hacc_dist_table(
     hacc_dist_table: &[u8],
     dists: &mut [u32],
 ) {
-    assert!(n.is_multiple_of(BATCH_SIZE));
-    assert!(dists.len() >= n);
-    assert!(codes.len() >= n * code_len);
-    assert!(hacc_dist_table.len() >= code_len * 64);
+    assert!(
+        n.is_multiple_of(BATCH_SIZE),
+        "sum_4bit_hacc_dist_table needs a vector count that is a multiple of {BATCH_SIZE}, got {n}"
+    );
+    assert!(
+        dists.len() >= n,
+        "sum_4bit_hacc_dist_table needs one output slot per vector, \
+         got {n} vector(s) and {} slot(s)",
+        dists.len()
+    );
+    assert!(
+        codes.len() >= n * code_len,
+        "sum_4bit_hacc_dist_table needs {n} * {code_len} code bytes, got {}",
+        codes.len()
+    );
+    assert!(
+        hacc_dist_table.len() >= code_len * 64,
+        "sum_4bit_hacc_dist_table needs {code_len} * 64 table bytes, got {}",
+        hacc_dist_table.len()
+    );
     // A `u32` slice is also a valid `MaybeUninit<u32>` slice. The dispatched
     // kernels overwrite every output slot.
     let dists = unsafe {
@@ -218,11 +302,18 @@ pub fn sum_4bit_hacc_dist_table(
 ///
 /// Every element in `dists[..n]` is initialized before this function returns.
 ///
+/// # Panics
+///
+/// Panics if `hacc_dist_table` holds fewer than `code_len * 64` bytes, or if `codes` or
+/// `dists` is too short for the batch being indexed.
+///
 /// # Safety
 ///
 /// `n` must be a multiple of [`BATCH_SIZE`], `codes` must contain at least
-/// `n * code_len` bytes, `hacc_dist_table` must contain at least
-/// `code_len * 64` bytes, and `dists` must contain at least `n` slots.
+/// `n * code_len` bytes, and `dists` must contain at least `n` slots. Both arms reach
+/// `codes` and `dists` through bounds-checked slices, so a length too short for the
+/// batch being indexed panics instead of being read or written out of bounds; `n` is not
+/// checked outside debug builds.
 #[inline]
 pub unsafe fn sum_4bit_hacc_dist_table_uninit(
     n: usize,
@@ -234,7 +325,13 @@ pub unsafe fn sum_4bit_hacc_dist_table_uninit(
     debug_assert!(n.is_multiple_of(BATCH_SIZE));
     debug_assert!(dists.len() >= n);
     debug_assert!(codes.len() >= n * code_len);
-    debug_assert!(hacc_dist_table.len() >= code_len * 64);
+    // Always-on rather than `debug_assert!`, so a short table is rejected with a message
+    // naming this function and `code_len` in release builds too.
+    assert!(
+        hacc_dist_table.len() >= code_len * 64,
+        "sum_4bit_hacc_dist_table_uninit needs {code_len} * 64 table bytes, got {}",
+        hacc_dist_table.len()
+    );
 
     match *SIMD_SUPPORT {
         #[cfg(target_arch = "x86_64")]
@@ -393,6 +490,16 @@ fn sum_4bit_hacc_dist_table_avx2(
     }
 }
 
+/// Accumulate one 32-vector batch of high-accuracy 4-bit codes.
+///
+/// The stores that write `dists` are unconditional, so the output requirement below
+/// does not scale with the input: a batch of no codes still writes every slot.
+///
+/// # Safety
+///
+/// The host must support AVX2. `codes.len()` must be a multiple of
+/// [`BATCH_SIZE`], `hacc_dist_table` must contain at least `2 * codes.len()`
+/// bytes, and `dists` must contain at least [`BATCH_SIZE`] slots.
 #[cfg(target_arch = "x86_64")]
 #[target_feature(enable = "avx2")]
 #[inline]
@@ -478,6 +585,17 @@ unsafe fn sum_hacc_dist_table_32bytes_batch_avx2(
     _mm256_storeu_si256(dists.as_mut_ptr().add(24) as *mut __m256i, res3);
 }
 
+/// Accumulate one 32-vector batch of 4-bit codes against a `u8` distance table.
+///
+/// `codes` and `dist_table` are loaded at the same offsets, which is why the table
+/// requirement below is expressed in terms of `codes.len()`. The stores that write
+/// `dists` are unconditional, so the output requirement does not scale with the input.
+///
+/// # Safety
+///
+/// The host must support AVX2. `codes.len()` must be a multiple of [`BATCH_SIZE`],
+/// `dist_table` must contain at least `codes.len()` bytes, and `dists` must contain at
+/// least [`BATCH_SIZE`] slots.
 #[cfg(target_arch = "x86_64")]
 #[target_feature(enable = "avx2")]
 #[inline]
@@ -556,6 +674,17 @@ unsafe fn sum_dist_table_32bytes_batch_avx2(
     _mm256_storeu_si256(dists.as_mut_ptr().add(16) as *mut __m256i, dis1);
 }
 
+/// NEON counterpart of `sum_dist_table_32bytes_batch_avx2`, with the same memory
+/// obligations.
+///
+/// It carries no `#[target_feature]` gate, so it relies on `neon` being enabled by the
+/// target's default feature set. As in that kernel, the stores that write `dists` are
+/// unconditional.
+///
+/// # Safety
+///
+/// `codes.len()` must be a multiple of [`BATCH_SIZE`], `dist_table` must contain at
+/// least `codes.len()` bytes, and `dists` must contain at least [`BATCH_SIZE`] slots.
 #[cfg(target_arch = "aarch64")]
 #[inline]
 unsafe fn sum_dist_table_32bytes_batch_neon(
@@ -634,6 +763,20 @@ unsafe fn sum_dist_table_32bytes_batch_neon(
 // We implement the AVX512 version in C because AVX512 is not stable yet in Rust,
 // implement it in Rust once we upgrade rust to 1.89.0.
 unsafe extern "C" {
+    /// AVX-512 counterpart of the AVX2 batch kernel, compiled from `dist_table.c`.
+    ///
+    /// `code_length` bounds the reads of both `codes` and `dist_table`; the tail
+    /// iteration loads through `_mm512_maskz_loadu_epi8`, so a `code_length` that
+    /// does not fill the last 64-byte chunk zero-fills the rest of the chunk instead
+    /// of reading past either buffer. It does not bound the write: the kernel ends in
+    /// one unconditional `_mm512_storeu_si512(dists, ...)`, so it stores
+    /// [`BATCH_SIZE`] `u16` values whatever `code_length` is.
+    ///
+    /// # Safety
+    ///
+    /// The host must support AVX-512BW. `codes` and `dist_table` must each be valid
+    /// for reads of `code_length` bytes, and `dists` must be valid for writes of
+    /// [`BATCH_SIZE`] `u16` values.
     #[cfg(all(kernel_support = "avx512_dist_table", target_arch = "x86_64"))]
     pub fn sum_4bit_dist_table_32bytes_batch_avx512(
         codes: *const u8,
@@ -646,6 +789,145 @@ unsafe extern "C" {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    use rstest::rstest;
+
+    /// Each case violates exactly one of the four preconditions and satisfies the
+    /// other three, so the case name says which `assert!` is under test. The valid
+    /// baseline is `n = 64`, `code_len = 2`: 128 code bytes, a 64-byte table and 64
+    /// output slots. `n` is two batches rather than one so the two bounds print
+    /// different numbers, `64 * 2` for the codes and `32 * 2` for the table. The last
+    /// two cases match on the `code bytes` and `table bytes` wording, so they stay
+    /// distinct even where those numbers coincide. The assertion also requires the
+    /// entry function's name: `sum_4bit_dist_table_uninit` repeats the table relation
+    /// in the same wording, so matching a fragment alone would let a deleted `assert!`
+    /// here pass on the strength of that later check.
+    #[rstest]
+    #[case::n_not_a_multiple_of_batch_size(65, 2, 130, 64, 65, "a multiple of 32, got 65")]
+    #[case::fewer_slots_than_vectors(64, 2, 128, 64, 63, "got 64 vector(s) and 63 slot(s)")]
+    #[case::codes_shorter_than_n_times_code_len(64, 2, 127, 64, 64, "64 * 2 code bytes, got 127")]
+    #[case::table_shorter_than_one_batch(64, 2, 128, 63, 64, "32 * 2 table bytes, got 63")]
+    fn test_sum_4bit_dist_table_rejects_bad_lengths(
+        #[case] n: usize,
+        #[case] code_len: usize,
+        #[case] codes_len: usize,
+        #[case] dist_table_len: usize,
+        #[case] dists_len: usize,
+        #[case] expected: &str,
+    ) {
+        let codes = vec![0u8; codes_len];
+        let dist_table = vec![0u8; dist_table_len];
+        let mut dists = vec![0u16; dists_len];
+        let payload = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            sum_4bit_dist_table(n, code_len, &codes, &dist_table, &mut dists);
+        }))
+        .expect_err("a bad length must panic");
+        let message = panic_message(&*payload);
+        assert!(
+            message.contains("sum_4bit_dist_table needs") && message.contains(expected),
+            "expected {expected:?} from sum_4bit_dist_table, got {message:?}"
+        );
+    }
+
+    /// The high-accuracy twin of [`test_sum_4bit_dist_table_rejects_bad_lengths`],
+    /// with the same baseline. Its table is sized by `code_len * 64` rather than
+    /// `BATCH_SIZE * code_len`, so the baseline table is 128 bytes for `code_len = 2`.
+    #[rstest]
+    #[case::n_not_a_multiple_of_batch_size(65, 2, 130, 128, 65, "a multiple of 32, got 65")]
+    #[case::fewer_slots_than_vectors(64, 2, 128, 128, 63, "got 64 vector(s) and 63 slot(s)")]
+    #[case::codes_shorter_than_n_times_code_len(64, 2, 127, 128, 64, "64 * 2 code bytes, got 127")]
+    #[case::table_shorter_than_code_len_times_64(
+        64,
+        2,
+        128,
+        127,
+        64,
+        "2 * 64 table bytes, got 127"
+    )]
+    fn test_sum_4bit_hacc_dist_table_rejects_bad_lengths(
+        #[case] n: usize,
+        #[case] code_len: usize,
+        #[case] codes_len: usize,
+        #[case] hacc_dist_table_len: usize,
+        #[case] dists_len: usize,
+        #[case] expected: &str,
+    ) {
+        let codes = vec![0u8; codes_len];
+        let hacc_dist_table = vec![0u8; hacc_dist_table_len];
+        let mut dists = vec![0u32; dists_len];
+        let payload = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            sum_4bit_hacc_dist_table(n, code_len, &codes, &hacc_dist_table, &mut dists);
+        }))
+        .expect_err("a bad length must panic");
+        let message = panic_message(&*payload);
+        assert!(
+            message.contains("sum_4bit_hacc_dist_table needs") && message.contains(expected),
+            "expected {expected:?} from sum_4bit_hacc_dist_table, got {message:?}"
+        );
+    }
+
+    fn panic_message(payload: &(dyn std::any::Any + Send)) -> String {
+        payload
+            .downcast_ref::<String>()
+            .map(String::as_str)
+            .or_else(|| payload.downcast_ref::<&'static str>().copied())
+            .expect("panic payload should be a string")
+            .to_string()
+    }
+
+    /// The `pub unsafe` variant carries the same table check, with its own message,
+    /// because the `lance-index` callers reach it directly rather than through the safe
+    /// entry point above.
+    #[test]
+    fn test_sum_4bit_dist_table_uninit_rejects_short_table() {
+        let code_len = 2;
+        let codes = vec![0u8; BATCH_SIZE * code_len];
+        let dist_table = vec![0u8; BATCH_SIZE * code_len - 1];
+        let mut dists = vec![MaybeUninit::<u16>::uninit(); BATCH_SIZE];
+        let payload = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            // SAFETY: every remaining obligation holds, and the short table is
+            // rejected by the check above the dispatch, before any kernel runs.
+            unsafe {
+                sum_4bit_dist_table_uninit(BATCH_SIZE, code_len, &codes, &dist_table, &mut dists)
+            };
+        }))
+        .expect_err("a short distance table must panic");
+        let message = panic_message(&*payload);
+        assert!(
+            message.contains("sum_4bit_dist_table_uninit needs 32 * 2 table bytes, got 63"),
+            "expected the uninit entry's own table message, got {message:?}"
+        );
+    }
+
+    /// The high-accuracy twin carries its own always-on table check, so a short table is
+    /// rejected before the dispatch, with a message naming this function and its table
+    /// relation, whether or not debug assertions are on.
+    #[test]
+    fn test_sum_4bit_hacc_dist_table_uninit_rejects_short_table() {
+        let code_len = 2;
+        let codes = vec![0u8; BATCH_SIZE * code_len];
+        let hacc_dist_table = vec![0u8; code_len * 64 - 1];
+        let mut dists = vec![MaybeUninit::<u32>::uninit(); BATCH_SIZE];
+        let payload = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            // SAFETY: every obligation except the table length holds, and that one is
+            // rejected by the check above the dispatch, before any arm runs.
+            unsafe {
+                sum_4bit_hacc_dist_table_uninit(
+                    BATCH_SIZE,
+                    code_len,
+                    &codes,
+                    &hacc_dist_table,
+                    &mut dists,
+                )
+            };
+        }))
+        .expect_err("a short high-accuracy table must panic");
+        let message = panic_message(&*payload);
+        assert!(
+            message.contains("sum_4bit_hacc_dist_table_uninit needs 2 * 64 table bytes, got 127"),
+            "expected the uninit entry's own table message, got {message:?}"
+        );
+    }
 
     #[test]
     fn test_perm0_inverse_matches_perm0() {


### PR DESCRIPTION
## What was wrong

`sum_4bit_dist_table_uninit` is a `pub unsafe fn` whose `# Safety` section listed four obligations. Its body checked three of them. The missing one was `dist_table.len() >= BATCH_SIZE * code_len`, and it is the only one of the four that nothing else re-checks: the other three are re-established by the bounds-checked slices the function hands each kernel, while the table is forwarded whole and read through a raw pointer.

| arm | how it reads the table | highest byte touched |
|---|---|---|
| `sum_4bit_dist_table_32bytes_batch_avx512` (C) | `dist_table` pointer plus `code_length`, no output capacity | `BATCH_SIZE * code_len` |
| `sum_dist_table_32bytes_batch_avx2` | `dist_table.as_ptr().add(i)` and `.add(i + 32)` | `BATCH_SIZE * code_len` |
| `sum_dist_table_32bytes_batch_neon` | `dt_ptr.add(i)` and `.add(i + 16)` | `BATCH_SIZE * code_len` |
| scalar fallback | bounds-checked slicing | `BATCH_SIZE * code_len` |

So a table one byte short was an out-of-bounds read on three of the four arms, in every profile. Its twin `sum_4bit_hacc_dist_table_uninit` did carry a `debug_assert!` for the analogous obligation, so this was an asymmetry rather than a considered choice.

The two safe entry points already assert all four lengths, but nothing in the repository calls them: the three production call sites (`lance-index/src/vector/bq/storage.rs:990`, `:1058`, `:1171`) all use the `_uninit` variants, so those eight asserts never see in-tree traffic.

## Is it reachable today?

Not from a well-formed index, and the margin is zero. The obligation holds by exact equality: `dist_table.len() == code_dim * 4 == BATCH_SIZE * code_len`, which needs `code_dim % 8 == 0`. `RabitQuantizer::build` rejects a dim that is not a multiple of 8, and the three call sites size their tables from `quantize_dist_table_into`, `quantize_ex_fastscan_dist_table_into` and `transfer_4bit_dist_table_u16`, each of which lands exactly on the bound. Zero margin means any drift is immediately an overread of 4 to 28 bytes into a reused scratch `Vec`, which yields wrong distances rather than a crash.

Worth stating because it is the reason to prefer an always-on check: `try_from_batch` validates `codes.value_length()` against the metadata but does not re-validate that divisibility, so the length that reaches the raw-pointer read is derived from file contents.

## The fix

Both `_uninit` functions now open with one always-on `assert!` on their table length, carrying the function name and both operands. That is the whole functional change, six lines.

An earlier revision of this branch also resliced the table to `BATCH_SIZE * code_len` below the assert. That is gone: the assert enforces the identical bound and fires first, so the reslice could never reject anything, and describing the division of labour between the two turned out to be impossible to do accurately. One construct per function, one sentence to explain it.

## Why `assert!` here

`rust/AGENTS.md` reserves `assert!` for "conditions preventing data corruption" and asks for descriptive messages on both counts. Reading a stale buffer tail back as a distance is that, and the check runs once per query per partition scan rather than per row, so the cost is one comparison against a loop that does `BATCH_SIZE * code_len` shuffle-accumulate lookups.

One place where a maintainer could reasonably push back, so I will name it rather than wait for it. On the high-accuracy twin the promotion from `debug_assert!` to `assert!` is not strictly a safety fix: both of its arms reach the table through bounds-checked sub-slices, so a short table there was already a panic rather than a read past the end. By the letter of `rust/AGENTS.md:49` that makes it a non-safety invariant and `debug_assert!` would be the prescribed tool. I promoted it anyway, for two reasons: it makes the two functions identical in shape, and it is what lets a test pin the behaviour in the profile CI actually runs. Reverting it is a one-word change if you disagree.

## Behaviour change

For a short table this replaces an out-of-bounds read with a panic on three arms, and replaces a panic that named nothing with one that names the function and both lengths on the fourth. No in-repo caller can trip it, including the `simd_len == 0` path a partition under 32 rows takes, since the table is built before `simd_len` is computed and its size does not depend on it.

## Documentation

The file had no `# Safety` section anywhere, on either of its two `pub unsafe` entry points' kernels or on the `pub` `unsafe extern "C"` declaration. That declaration is reachable as `lance_linalg::simd::dist_table::sum_4bit_dist_table_32bytes_batch_avx512`, its signature carries `code_length` but no output capacity, and the C body ends in one unconditional `_mm512_storeu_si512`, so it always writes 32 `u16` whatever `code_length` is. All four now state their contracts. The three `pub` entry points that had no rustdoc at all gained a summary and a `# Panics` section, and `sum_4bit_dist_table`'s existing block comment became rustdoc so the PERM0 layout table renders.

## Tests

Ten cases, one per always-on check. Two four-case `#[rstest]` groups drive the safe entry points with exactly one precondition violated per case, and two single tests drive the `_uninit` entry points, which is the path production uses. Every case matches the panic message, including the entry function's name: `"sum_4bit_dist_table_uninit needs"` does not contain `"sum_4bit_dist_table needs"`, so deleting a check in the safe entry cannot pass on the strength of the one further down.

The baseline is `n = 64`, `code_len = 2` rather than one batch, so that the code bound and the table bound print different numbers and the last two cases in each group cannot be confused for one another.

## Out of scope, and worth a separate look

`sum_4bit_dist_table_u16` and `transfer_4bit_dist_table_u16` keep `debug_assert!`-only preconditions. That is deliberate: their violations are bounds-checked panics or silently truncated output, never a read past the end. The rule this change follows is "always-on where a violation is a raw-pointer read past the end", and only the two `_uninit` functions qualify.

Two things I found while working on this that belong upstream of this file rather than in it. `code_len == 0` passes all four entry asserts and then diverges by architecture: the SIMD arms write 32 zeros, the scalar fallback panics on a divide by zero. And `RabitQuantizer::new` plus the `try_from_batch` read path do not enforce the `dim % 8 == 0` that the table sizing depends on; the right place to reject that is RQ index creation.

## Test plan

- `cargo test -p lance-linalg --lib`: 189 passed on aarch64-apple-darwin in both dev and release, 248 on x86_64-apple-darwin in both. The counts match across profiles, so nothing here is debug-only
- `cargo clippy -p lance-linalg --all-targets -- -D warnings` on both targets, `cargo fmt --all -- --check`, `RUSTDOCFLAGS="-D warnings" cargo doc -p lance-linalg --no-deps --document-private-items`: clean
- `cargo check -p lance-index --lib` and the 222 `lance-index` BQ tests: pass
- Mutation testing: neutralising the condition of any one of the ten always-on checks fails exactly one case, measured one at a time with the file restored and its checksum verified between runs. A separate sweep of 21 subtler mutations found no survivors: `>=` weakened to `>` on all eight comparisons, the two table bounds swapped between the functions in both directions, `n` substituted for `dists.len()` as both condition and message argument, and an operand swap inside each of the four numeric messages

The AVX2 and AVX-512 arms were compiled for `x86_64-apple-darwin` but never executed: this machine is aarch64 and an x86_64 build under Rosetta reports neither feature. Their bounds are derived from the loads and stores rather than measured, with the NEON arm exercised as corroboration.
