### PR TITLE
feat(encoding): add CANDIDATE_BATCH_SIZES and plan_decoded_bytes trait defaults

### DIFF
--- a/rust/lance-encoding/src/decoder.rs
+++ b/rust/lance-encoding/src/decoder.rs
@@ -324,21 +324,6 @@ pub trait LogicalPageDecoder: std::fmt::Debug + Send {
     fn drain(&mut self, num_rows: u64) -> Result<NextDecodeTask>;
 
     fn data_type(&self) -> &DataType;
-
-    /// Returns a byte-count estimate for each of [`CANDIDATE_BATCH_SIZES`]
-    /// row counts, clamped to `rows_remaining`.
-    ///
-    /// The default implementation is schema-based. v2.0 decoders keep this
-    /// default; the exact path is only engaged for v2.1+ structural decoders.
-    fn plan_decoded_bytes(&self, rows_remaining: u64) -> Result<[u64; 8]> {
-        let bpr = estimate_bytes_per_row(self.data_type()) as u64;
-        let mut out = [0u64; 8];
-        for (i, &c) in CANDIDATE_BATCH_SIZES.iter().enumerate() {
-            let rows = (c as u64).min(rows_remaining);
-            out[i] = rows * bpr;
-        }
-        Ok(out)
-    }
 }
 
 // If users are getting batches over 10MiB large then it's time to reduce the batch size
@@ -2972,14 +2957,10 @@ pub trait StructuralFieldDecoder: std::fmt::Debug + Send {
     /// The default implementation uses a schema-based estimate via
     /// [`estimate_bytes_per_row`]. Concrete implementations override this
     /// with exact computation.
-    fn plan_decoded_bytes(&self, rows_remaining: u64) -> Result<[u64; 8]> {
-        let bpr = estimate_bytes_per_row(self.data_type()) as u64;
-        let mut out = [0u64; 8];
-        for (i, &c) in CANDIDATE_BATCH_SIZES.iter().enumerate() {
-            let rows = (c as u64).min(rows_remaining);
-            out[i] = rows * bpr;
-        }
-        Ok(out)
+    fn plan_decoded_bytes(&self, _rows_remaining: u64) -> Result<[u64; 8]> {
+        Err(Error::not_supported(
+            "decoded_bytes is not implemented for this field decoder".to_string(),
+        ))
     }
 }
 

--- a/rust/lance-encoding/src/decoder.rs
+++ b/rust/lance-encoding/src/decoder.rs
@@ -259,6 +259,10 @@ use crate::format::pb21;
 use crate::repdef::{CompositeRepDefUnraveler, RepDefUnraveler};
 use crate::{BufferScheduler, EncodingsIo};
 
+/// Candidate batch sizes evaluated during byte-budget planning.
+/// Powers of 4, covering 1–16Ki rows in 8 probes.
+pub const CANDIDATE_BATCH_SIZES: [u32; 8] = [1, 4, 16, 64, 256, 1024, 4096, 16384];
+
 pub trait SchedulingJob: std::fmt::Debug {
     fn schedule_next(
         &mut self,
@@ -320,6 +324,21 @@ pub trait LogicalPageDecoder: std::fmt::Debug + Send {
     fn drain(&mut self, num_rows: u64) -> Result<NextDecodeTask>;
 
     fn data_type(&self) -> &DataType;
+
+    /// Returns a byte-count estimate for each of [`CANDIDATE_BATCH_SIZES`]
+    /// row counts, clamped to `rows_remaining`.
+    ///
+    /// The default implementation is schema-based. v2.0 decoders keep this
+    /// default; the exact path is only engaged for v2.1+ structural decoders.
+    fn plan_decoded_bytes(&self, rows_remaining: u64) -> Result<[u64; 8]> {
+        let bpr = estimate_bytes_per_row(self.data_type()) as u64;
+        let mut out = [0u64; 8];
+        for (i, &c) in CANDIDATE_BATCH_SIZES.iter().enumerate() {
+            let rows = (c as u64).min(rows_remaining);
+            out[i] = rows * bpr;
+        }
+        Ok(out)
+    }
 }
 
 // If users are getting batches over 10MiB large then it's time to reduce the batch size
@@ -1814,7 +1833,12 @@ impl<T: RootDecoderType> RecordBatchReader for BatchDecodeIterator<T> {
 /// This estimate ignores validity bitmaps at the moment.  We can't infer
 /// their presence simply from the data_type and their impact is probably
 /// fairly negligible.
-fn estimate_bytes_per_row(data_type: &DataType) -> f64 {
+/// Returns a schema-based estimate of the decoded bytes per row for `data_type`.
+///
+/// Fixed-width types are exact. Variable-width types (strings, lists, etc.) use
+/// heuristic constants. This estimate is used both in batch-size planning and as
+/// a fallback for V1 files that lack structural decoders.
+pub fn estimate_bytes_per_row(data_type: &DataType) -> f64 {
     if let Some(w) = data_type.byte_width_opt() {
         return w as f64;
     }
@@ -2883,6 +2907,17 @@ pub trait DecodePageTask: Send + std::fmt::Debug {
 pub trait StructuralPageDecoder: std::fmt::Debug + Send {
     fn drain(&mut self, num_rows: u64) -> Result<Box<dyn DecodePageTask>>;
     fn num_rows(&self) -> u64;
+    /// Returns the exact decoded byte count for the next `num_rows` rows
+    /// from this decoder's current position, without consuming any rows.
+    ///
+    /// Only implemented for variable-width page decoders. Fixed-width
+    /// decoded sizes are computed directly from the field's data type in
+    /// [`StructuralFieldDecoder::plan_decoded_bytes`].
+    fn decoded_bytes(&self, _num_rows: u64) -> Result<u64> {
+        Err(Error::not_supported(
+            "decoded_bytes is not implemented for this page decoder".to_string(),
+        ))
+    }
 }
 
 #[derive(Debug)]
@@ -2931,6 +2966,21 @@ pub trait StructuralFieldDecoder: std::fmt::Debug + Send {
     fn drain(&mut self, num_rows: u64) -> Result<Box<dyn StructuralDecodeArrayTask>>;
     /// The data type of the decoded data
     fn data_type(&self) -> &DataType;
+    /// Returns the exact decoded byte count for each of [`CANDIDATE_BATCH_SIZES`]
+    /// row counts, clamped to `rows_remaining`.
+    ///
+    /// The default implementation uses a schema-based estimate via
+    /// [`estimate_bytes_per_row`]. Concrete implementations override this
+    /// with exact computation.
+    fn plan_decoded_bytes(&self, rows_remaining: u64) -> Result<[u64; 8]> {
+        let bpr = estimate_bytes_per_row(self.data_type()) as u64;
+        let mut out = [0u64; 8];
+        for (i, &c) in CANDIDATE_BATCH_SIZES.iter().enumerate() {
+            let rows = (c as u64).min(rows_remaining);
+            out[i] = rows * bpr;
+        }
+        Ok(out)
+    }
 }
 
 #[derive(Debug, Default)]

--- a/rust/lance-encoding/src/decoder.rs
+++ b/rust/lance-encoding/src/decoder.rs
@@ -2894,10 +2894,6 @@ pub trait StructuralPageDecoder: std::fmt::Debug + Send {
     fn num_rows(&self) -> u64;
     /// Returns the exact decoded byte count for the next `num_rows` rows
     /// from this decoder's current position, without consuming any rows.
-    ///
-    /// Only implemented for variable-width page decoders. Fixed-width
-    /// decoded sizes are computed directly from the field's data type in
-    /// [`StructuralFieldDecoder::plan_decoded_bytes`].
     fn decoded_bytes(&self, _num_rows: u64) -> Result<u64> {
         Err(Error::not_supported(
             "decoded_bytes is not implemented for this page decoder".to_string(),
@@ -2954,9 +2950,12 @@ pub trait StructuralFieldDecoder: std::fmt::Debug + Send {
     /// Returns the exact decoded byte count for each of [`CANDIDATE_BATCH_SIZES`]
     /// row counts, clamped to `rows_remaining`.
     ///
-    /// The default implementation uses a schema-based estimate via
-    /// [`estimate_bytes_per_row`]. Concrete implementations override this
-    /// with exact computation.
+    /// Implementations should do their best to estimate the exact size required for
+    /// the uncompressed data.  In cases where this is not possible they should return
+    /// a worst-case estimate.
+    ///
+    /// The default implementation simply returns a "not supported" error though this
+    /// will hopefully be removed once implementation is complete.
     fn plan_decoded_bytes(&self, _rows_remaining: u64) -> Result<[u64; 8]> {
         Err(Error::not_supported(
             "decoded_bytes is not implemented for this field decoder".to_string(),


### PR DESCRIPTION
This is the first PR of the stack to add exact byte budget scans.  This is done by
splitting each decode task into two different tasks.  First, we look at the available (but
not yet decoded) bytes and calculate how many rows we should peel off to reach our target.

This will require cooperation from the compression methods.  For example, if the data is
LZ4 compressed we need to look at the uncompressed size marker at the start of the LZ4
frame to determine this.  In a few cases we can't actually know in advance how large the
decompressed size will be.  In these cases we should come up with a way to have a worst
case estimate so that we never exceed the budget.

This PR simply adds the trait to do this planning step and provides a default implementation.

This PR also introduces the concept of **candidate batch sizes**.  One of the trickiest parts of the feature is that we need to scan multiple columns of data, across multiple files.  If we divide our budget evenly across columns then we would get a different number of rows that fit for each column.  For example, if our budget is 1MiB and we have a 4KiB embedding column and nine 8-byte id columns then we would read batches of 25 rows (1MiB / 10 columns = 102.4 KiB/col = 25.6 embedding rows)

This could open up the complicated game of trying to unevenly weight the budget across columns.  Instead, we pick 8 candidate batch sizes in advance (based on powers of 4), and we always evaluate those 8 sizes.  The candidate sizes are 1, 4, 16, 64, 256, 1024, 4096, and 16384.  Using our example above we would get batches of size 64 instead of 25, better utilizing our available space without introducing complicated weighting mechanics.

This has the additional benefit of ensuring that all output batch sizes are powers of 2 (though different batches may have different sizes).  If a downstream step requires evenly sized batches (e.g. model training) then we can typically minimize the number of data copies required to achieve that.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>