### PR TITLE
feat(encoding): implement plan_decoded_bytes for fixed-width structural decoder

### DIFF
--- a/rust/lance-encoding/src/decoder.rs
+++ b/rust/lance-encoding/src/decoder.rs
@@ -2186,6 +2186,7 @@ pub fn create_decode_stream(
             arrow_schema.fields,
             should_validate,
             /*is_root=*/ true,
+            /*nullable=*/ false,
         )?;
         Ok(StructuralBatchDecodeStream::new(
             rx,
@@ -2223,7 +2224,7 @@ pub fn create_decode_iterator(
     let root_fields = arrow_schema.fields.clone();
     if is_structural {
         let simple_struct_decoder =
-            StructuralStructDecoder::new(root_fields, should_validate, /*is_root=*/ true)?;
+            StructuralStructDecoder::new(root_fields, should_validate, /*is_root=*/ true, /*nullable=*/ false)?;
         Ok(Box::new(BatchDecodeIterator::new(
             messages,
             batch_size,
@@ -3251,7 +3252,7 @@ mod tests {
         let batch_readahead = 2;
         let load_error_message = "simulated page load failure";
         let fields = Fields::from(vec![ArrowField::new("vector", DataType::Float32, true)]);
-        let root_decoder = StructuralStructDecoder::new(fields, false, /*is_root=*/ true).unwrap();
+        let root_decoder = StructuralStructDecoder::new(fields, false, /*is_root=*/ true, /*nullable=*/ false).unwrap();
         let (tx, rx) = unbounded_channel();
         let failed_page = async move { Err(Error::io(load_error_message)) }.boxed();
 

--- a/rust/lance-encoding/src/decoder.rs
+++ b/rust/lance-encoding/src/decoder.rs
@@ -2223,8 +2223,12 @@ pub fn create_decode_iterator(
     let arrow_schema = Arc::new(ArrowSchema::from(schema));
     let root_fields = arrow_schema.fields.clone();
     if is_structural {
-        let simple_struct_decoder =
-            StructuralStructDecoder::new(root_fields, should_validate, /*is_root=*/ true, /*nullable=*/ false)?;
+        let simple_struct_decoder = StructuralStructDecoder::new(
+            root_fields,
+            should_validate,
+            /*is_root=*/ true,
+            /*nullable=*/ false,
+        )?;
         Ok(Box::new(BatchDecodeIterator::new(
             messages,
             batch_size,
@@ -3252,7 +3256,10 @@ mod tests {
         let batch_readahead = 2;
         let load_error_message = "simulated page load failure";
         let fields = Fields::from(vec![ArrowField::new("vector", DataType::Float32, true)]);
-        let root_decoder = StructuralStructDecoder::new(fields, false, /*is_root=*/ true, /*nullable=*/ false).unwrap();
+        let root_decoder = StructuralStructDecoder::new(
+            fields, false, /*is_root=*/ true, /*nullable=*/ false,
+        )
+        .unwrap();
         let (tx, rx) = unbounded_channel();
         let failed_page = async move { Err(Error::io(load_error_message)) }.boxed();
 

--- a/rust/lance-encoding/src/encodings/logical/list.rs
+++ b/rust/lance-encoding/src/encodings/logical/list.rs
@@ -176,6 +176,13 @@ impl StructuralFieldDecoder for StructuralListDecoder {
     fn data_type(&self) -> &DataType {
         &self.data_type
     }
+
+    fn plan_decoded_bytes(&self, _rows_remaining: u64) -> lance_core::Result<[u64; 8]> {
+        Err(lance_core::Error::not_supported(
+            "plan_decoded_bytes is not yet supported for fields with repetition (list/repeated types)"
+                .to_string(),
+        ))
+    }
 }
 
 #[derive(Debug)]
@@ -1602,5 +1609,48 @@ mod tests {
             .unwrap();
         assert_split_miniblock_layout(&pages, 1, true);
         check_round_trip_encoding_of_data(vec![list_array], &test_cases, field_metadata).await;
+    }
+
+    #[test]
+    fn test_plan_decoded_bytes_list_i32_not_supported() {
+        // Lists encode items using repetition levels so the number of decoded
+        // bytes depends on the per-row list lengths, which are not known at
+        // planning time without inspecting page data.  For this PR we
+        // explicitly reject the call rather than returning a wrong estimate.
+        use arrow_array::builder::{Int32Builder, ListBuilder};
+        use arrow_schema::Field;
+        use crate::decoder::StructuralFieldDecoder;
+        use crate::encodings::logical::primitive::StructuralPrimitiveFieldDecoder;
+
+        // Build a List<i32> array where every row has a random (variable) length
+        // to illustrate the case we cannot plan for.
+        let mut builder = ListBuilder::new(Int32Builder::new());
+        let lengths = [0usize, 3, 1, 7, 2, 0, 5];
+        let mut value = 0i32;
+        for &len in &lengths {
+            for _ in 0..len {
+                builder.values().append_value(value);
+                value += 1;
+            }
+            builder.append(true);
+        }
+        let _list_array = builder.finish(); // variable-length rows confirmed
+
+        // Construct the decoder tree directly (no pages needed for this check).
+        let item_field = Arc::new(Field::new("item", DataType::Int32, true));
+        let list_type = DataType::List(item_field.clone());
+
+        let child = Box::new(StructuralPrimitiveFieldDecoder::new(&item_field, false));
+        let decoder = super::StructuralListDecoder::new(child, list_type);
+
+        let err = decoder.plan_decoded_bytes(lengths.len() as u64).unwrap_err();
+        assert!(
+            matches!(err, lance_core::Error::NotSupported { .. }),
+            "expected NotSupported, got: {err:?}"
+        );
+        assert!(
+            err.to_string().contains("repetition"),
+            "error should mention repetition, got: {err}"
+        );
     }
 }

--- a/rust/lance-encoding/src/encodings/logical/list.rs
+++ b/rust/lance-encoding/src/encodings/logical/list.rs
@@ -1617,10 +1617,10 @@ mod tests {
         // bytes depends on the per-row list lengths, which are not known at
         // planning time without inspecting page data.  For this PR we
         // explicitly reject the call rather than returning a wrong estimate.
-        use arrow_array::builder::{Int32Builder, ListBuilder};
-        use arrow_schema::Field;
         use crate::decoder::StructuralFieldDecoder;
         use crate::encodings::logical::primitive::StructuralPrimitiveFieldDecoder;
+        use arrow_array::builder::{Int32Builder, ListBuilder};
+        use arrow_schema::Field;
 
         // Build a List<i32> array where every row has a random (variable) length
         // to illustrate the case we cannot plan for.
@@ -1643,7 +1643,9 @@ mod tests {
         let child = Box::new(StructuralPrimitiveFieldDecoder::new(&item_field, false));
         let decoder = super::StructuralListDecoder::new(child, list_type);
 
-        let err = decoder.plan_decoded_bytes(lengths.len() as u64).unwrap_err();
+        let err = decoder
+            .plan_decoded_bytes(lengths.len() as u64)
+            .unwrap_err();
         assert!(
             matches!(err, lance_core::Error::NotSupported { .. }),
             "expected NotSupported, got: {err:?}"

--- a/rust/lance-encoding/src/encodings/logical/primitive.rs
+++ b/rust/lance-encoding/src/encodings/logical/primitive.rs
@@ -4545,6 +4545,35 @@ impl StructuralPrimitiveFieldDecoder {
             rows_drained_in_current: 0,
         }
     }
+
+    fn decoded_bytes_for_rows(&self, rows: u64) -> lance_core::Result<u64> {
+        use crate::decoder::estimate_bytes_per_row;
+        let mut remaining = rows;
+        let mut total = 0u64;
+        for (page_num, page) in self.page_decoders.iter().enumerate() {
+            if remaining == 0 {
+                break;
+            }
+            let available = if page_num == 0 {
+                page.num_rows().saturating_sub(self.rows_drained_in_current)
+            } else {
+                page.num_rows()
+            };
+            let take = available.min(remaining);
+            let page_bytes = match page.decoded_bytes(take) {
+                Ok(bytes) => bytes,
+                // Page decoder has no exact size info (e.g. miniblock-encoded
+                // variable-width data) — fall back to the schema-based estimate.
+                Err(Error::NotSupported { .. }) => {
+                    (take as f64 * estimate_bytes_per_row(self.field.data_type())) as u64
+                }
+                Err(e) => return Err(e),
+            };
+            total += page_bytes;
+            remaining -= take;
+        }
+        Ok(total)
+    }
 }
 
 impl StructuralFieldDecoder for StructuralPrimitiveFieldDecoder {
@@ -4594,6 +4623,44 @@ impl StructuralFieldDecoder for StructuralPrimitiveFieldDecoder {
 
     fn data_type(&self) -> &DataType {
         self.field.data_type()
+    }
+
+    fn plan_decoded_bytes(&self, rows_remaining: u64) -> lance_core::Result<[u64; 8]> {
+        use crate::decoder::CANDIDATE_BATCH_SIZES;
+        let data_type = self.field.data_type();
+
+        // Fixed-width: exact from type metadata, no page inspection needed.
+        if let Some(byte_width) = data_type.byte_width_opt() {
+            let mut out = [0u64; 8];
+            for (i, &c) in CANDIDATE_BATCH_SIZES.iter().enumerate() {
+                let rows = (c as u64).min(rows_remaining);
+                out[i] = rows * byte_width as u64;
+            }
+            return Ok(out);
+        }
+
+        // Boolean: bit-packed, 1 bit per value.
+        if matches!(data_type, DataType::Boolean) {
+            let mut out = [0u64; 8];
+            for (i, &c) in CANDIDATE_BATCH_SIZES.iter().enumerate() {
+                let rows = (c as u64).min(rows_remaining);
+                out[i] = rows.div_ceil(8);
+            }
+            return Ok(out);
+        }
+
+        // Null type: no data bytes.
+        if matches!(data_type, DataType::Null) {
+            return Ok([0u64; 8]);
+        }
+
+        // Variable-width: walk page decoders for exact byte counts.
+        let mut out = [0u64; 8];
+        for (i, &c) in CANDIDATE_BATCH_SIZES.iter().enumerate() {
+            let rows = (c as u64).min(rows_remaining);
+            out[i] = self.decoded_bytes_for_rows(rows)?;
+        }
+        Ok(out)
     }
 }
 

--- a/rust/lance-encoding/src/encodings/logical/primitive.rs
+++ b/rust/lance-encoding/src/encodings/logical/primitive.rs
@@ -4547,7 +4547,6 @@ impl StructuralPrimitiveFieldDecoder {
     }
 
     fn decoded_bytes_for_rows(&self, rows: u64) -> lance_core::Result<u64> {
-        use crate::decoder::estimate_bytes_per_row;
         let mut remaining = rows;
         let mut total = 0u64;
         for (page_num, page) in self.page_decoders.iter().enumerate() {
@@ -4560,16 +4559,7 @@ impl StructuralPrimitiveFieldDecoder {
                 page.num_rows()
             };
             let take = available.min(remaining);
-            let page_bytes = match page.decoded_bytes(take) {
-                Ok(bytes) => bytes,
-                // Page decoder has no exact size info (e.g. miniblock-encoded
-                // variable-width data) — fall back to the schema-based estimate.
-                Err(Error::NotSupported { .. }) => {
-                    (take as f64 * estimate_bytes_per_row(self.field.data_type())) as u64
-                }
-                Err(e) => return Err(e),
-            };
-            total += page_bytes;
+            total += page.decoded_bytes(take)?;
             remaining -= take;
         }
         Ok(total)
@@ -4628,6 +4618,7 @@ impl StructuralFieldDecoder for StructuralPrimitiveFieldDecoder {
     fn plan_decoded_bytes(&self, rows_remaining: u64) -> lance_core::Result<[u64; 8]> {
         use crate::decoder::CANDIDATE_BATCH_SIZES;
         let data_type = self.field.data_type();
+        let is_nullable = self.field.is_nullable();
 
         // Fixed-width: exact from type metadata, no page inspection needed.
         if let Some(byte_width) = data_type.byte_width_opt() {
@@ -4635,6 +4626,9 @@ impl StructuralFieldDecoder for StructuralPrimitiveFieldDecoder {
             for (i, &c) in CANDIDATE_BATCH_SIZES.iter().enumerate() {
                 let rows = (c as u64).min(rows_remaining);
                 out[i] = rows * byte_width as u64;
+                if is_nullable {
+                    out[i] += rows.div_ceil(8);
+                }
             }
             return Ok(out);
         }
@@ -4645,6 +4639,9 @@ impl StructuralFieldDecoder for StructuralPrimitiveFieldDecoder {
             for (i, &c) in CANDIDATE_BATCH_SIZES.iter().enumerate() {
                 let rows = (c as u64).min(rows_remaining);
                 out[i] = rows.div_ceil(8);
+                if is_nullable {
+                    out[i] += rows.div_ceil(8);
+                }
             }
             return Ok(out);
         }
@@ -4659,6 +4656,9 @@ impl StructuralFieldDecoder for StructuralPrimitiveFieldDecoder {
         for (i, &c) in CANDIDATE_BATCH_SIZES.iter().enumerate() {
             let rows = (c as u64).min(rows_remaining);
             out[i] = self.decoded_bytes_for_rows(rows)?;
+            if is_nullable {
+                out[i] += rows.div_ceil(8);
+            }
         }
         Ok(out)
     }
@@ -7472,6 +7472,75 @@ mod tests {
             assert!(
                 message.contains(expected),
                 "expected error to contain {expected:?}, got: {message}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_plan_decoded_bytes_i32() {
+        use crate::decoder::CANDIDATE_BATCH_SIZES;
+
+        let field = Arc::new(ArrowField::new("x", DataType::Int32, false));
+        let decoder = StructuralPrimitiveFieldDecoder::new(&field, false);
+
+        let rows_remaining = 100u64;
+        let bytes = decoder.plan_decoded_bytes(rows_remaining).unwrap();
+
+        for (i, &candidate) in CANDIDATE_BATCH_SIZES.iter().enumerate() {
+            let rows = (candidate as u64).min(rows_remaining);
+            assert_eq!(bytes[i], rows * 4, "candidate batch size {candidate}");
+        }
+    }
+
+    #[test]
+    fn test_plan_decoded_bytes_i32_with_nulls() {
+        use arrow_array::Int32Array;
+
+        // Use N == CANDIDATE_BATCH_SIZES[5] == 1024.  At this size both the
+        // values buffer (1024*4 = 4096 bytes) and the validity bitmap
+        // (ceil(1024/8) = 128 bytes) are naturally aligned to Arrow's 64-byte
+        // allocation boundary, so plan_decoded_bytes matches
+        // get_buffer_memory_size exactly without needing alignment arithmetic.
+        const N: i32 = 1024;
+        let array =
+            Int32Array::from_iter((0..N).map(|i| if i % 2 == 0 { Some(i) } else { None }));
+        let expected = array.get_buffer_memory_size() as u64;
+
+        let field = Arc::new(ArrowField::new("x", DataType::Int32, true));
+        let decoder = StructuralPrimitiveFieldDecoder::new(&field, false);
+
+        let bytes = decoder.plan_decoded_bytes(N as u64).unwrap();
+        // bytes[5] corresponds to CANDIDATE_BATCH_SIZES[5] == 1024 == N
+        assert_eq!(
+            bytes[5],
+            expected,
+            "plan_decoded_bytes({N}) = {} but get_buffer_memory_size = {expected}",
+            bytes[5],
+        );
+    }
+
+    #[test]
+    fn test_plan_decoded_bytes_fixed_size_list_of_f32() {
+        use crate::decoder::CANDIDATE_BATCH_SIZES;
+
+        const DIMENSION: i32 = 8;
+        let item_field = Arc::new(ArrowField::new("item", DataType::Float32, true));
+        let fsl_type = DataType::FixedSizeList(item_field, DIMENSION);
+        let field = Arc::new(ArrowField::new("vector", fsl_type, true));
+        let decoder = StructuralPrimitiveFieldDecoder::new(&field, false);
+
+        let rows_remaining = 100u64;
+        let bytes = decoder.plan_decoded_bytes(rows_remaining).unwrap();
+
+        // Each FSL row is DIMENSION f32 values = DIMENSION * 4 bytes, plus
+        // 1 bit of validity bitmap (the field is nullable).
+        let bytes_per_row = DIMENSION as u64 * 4;
+        for (i, &candidate) in CANDIDATE_BATCH_SIZES.iter().enumerate() {
+            let rows = (candidate as u64).min(rows_remaining);
+            assert_eq!(
+                bytes[i],
+                rows * bytes_per_row + rows.div_ceil(8),
+                "candidate batch size {candidate}"
             );
         }
     }

--- a/rust/lance-encoding/src/encodings/logical/primitive.rs
+++ b/rust/lance-encoding/src/encodings/logical/primitive.rs
@@ -4528,6 +4528,26 @@ impl StructuralDecodeArrayTask for StructuralCompositeDecodeArrayTask {
     }
 }
 
+/// Returns the total bytes consumed by validity bitmaps of nested child fields
+/// for `rows` logical rows of `data_type`.
+///
+/// Only `FixedSizeList` types have nested children that contribute additional
+/// bitmaps; all other fixed-width leaf types return 0.
+fn fsl_child_bitmap_bytes(data_type: &arrow_schema::DataType, rows: u64) -> u64 {
+    match data_type {
+        arrow_schema::DataType::FixedSizeList(child_field, dimension) => {
+            let child_rows = rows * *dimension as u64;
+            let own = if child_field.is_nullable() {
+                child_rows.div_ceil(8)
+            } else {
+                0
+            };
+            own + fsl_child_bitmap_bytes(child_field.data_type(), child_rows)
+        }
+        _ => 0,
+    }
+}
+
 #[derive(Debug)]
 pub struct StructuralPrimitiveFieldDecoder {
     field: Arc<ArrowField>,
@@ -4561,6 +4581,13 @@ impl StructuralPrimitiveFieldDecoder {
             let take = available.min(remaining);
             total += page.decoded_bytes(take)?;
             remaining -= take;
+        }
+        if remaining > 0 {
+            return Err(lance_core::Error::not_supported(format!(
+                "plan_decoded_bytes: queued pages cover only {} of {} requested rows",
+                rows - remaining,
+                rows,
+            )));
         }
         Ok(total)
     }
@@ -4629,6 +4656,7 @@ impl StructuralFieldDecoder for StructuralPrimitiveFieldDecoder {
                 if is_nullable {
                     out[i] += rows.div_ceil(8);
                 }
+                out[i] += fsl_child_bitmap_bytes(data_type, rows);
             }
             return Ok(out);
         }
@@ -7502,8 +7530,7 @@ mod tests {
         // allocation boundary, so plan_decoded_bytes matches
         // get_buffer_memory_size exactly without needing alignment arithmetic.
         const N: i32 = 1024;
-        let array =
-            Int32Array::from_iter((0..N).map(|i| if i % 2 == 0 { Some(i) } else { None }));
+        let array = Int32Array::from_iter((0..N).map(|i| if i % 2 == 0 { Some(i) } else { None }));
         let expected = array.get_buffer_memory_size() as u64;
 
         let field = Arc::new(ArrowField::new("x", DataType::Int32, true));
@@ -7512,8 +7539,49 @@ mod tests {
         let bytes = decoder.plan_decoded_bytes(N as u64).unwrap();
         // bytes[5] corresponds to CANDIDATE_BATCH_SIZES[5] == 1024 == N
         assert_eq!(
+            bytes[5], expected,
+            "plan_decoded_bytes({N}) = {} but get_buffer_memory_size = {expected}",
             bytes[5],
-            expected,
+        );
+    }
+
+    #[test]
+    fn test_plan_decoded_bytes_nullable_fsl_with_nullable_items() {
+        // FixedSizeList<nullable i32, DIM> where the FSL itself is also nullable.
+        // Arrow allocates three buffers:
+        //   1. FSL null bitmap:       ceil(rows / 8)
+        //   2. Child i32 null bitmap: ceil(rows * DIM / 8)
+        //   3. Child i32 values:      rows * DIM * 4
+        //
+        // N=1024, DIM=4 keeps all three naturally 64-byte aligned so the
+        // comparison against get_buffer_memory_size() is exact.
+        use arrow_array::{FixedSizeListArray, Int32Array};
+        use arrow_buffer::NullBuffer;
+
+        const N: usize = 1024;
+        const DIM: i32 = 4;
+
+        let child_values = Int32Array::from_iter(
+            (0..(N as i32 * DIM)).map(|i| if i % 2 == 0 { Some(i) } else { None }),
+        );
+        let item_field = Arc::new(ArrowField::new("item", DataType::Int32, true));
+        let fsl_nulls = NullBuffer::from((0..N).map(|i| i % 3 != 0).collect::<Vec<_>>());
+        let fsl_array = FixedSizeListArray::new(
+            item_field.clone(),
+            DIM,
+            Arc::new(child_values),
+            Some(fsl_nulls),
+        );
+        let expected = fsl_array.get_buffer_memory_size() as u64;
+
+        let fsl_type = DataType::FixedSizeList(item_field, DIM);
+        let field = Arc::new(ArrowField::new("v", fsl_type, true));
+        let decoder = StructuralPrimitiveFieldDecoder::new(&field, false);
+
+        let bytes = decoder.plan_decoded_bytes(N as u64).unwrap();
+        // bytes[5] corresponds to CANDIDATE_BATCH_SIZES[5] == 1024 == N
+        assert_eq!(
+            bytes[5], expected,
             "plan_decoded_bytes({N}) = {} but get_buffer_memory_size = {expected}",
             bytes[5],
         );
@@ -7524,7 +7592,8 @@ mod tests {
         use crate::decoder::CANDIDATE_BATCH_SIZES;
 
         const DIMENSION: i32 = 8;
-        let item_field = Arc::new(ArrowField::new("item", DataType::Float32, true));
+        // Items are non-nullable, which is the typical case for vector embeddings.
+        let item_field = Arc::new(ArrowField::new("item", DataType::Float32, false));
         let fsl_type = DataType::FixedSizeList(item_field, DIMENSION);
         let field = Arc::new(ArrowField::new("vector", fsl_type, true));
         let decoder = StructuralPrimitiveFieldDecoder::new(&field, false);

--- a/rust/lance-encoding/src/encodings/logical/struct.rs
+++ b/rust/lance-encoding/src/encodings/logical/struct.rs
@@ -235,10 +235,11 @@ pub struct StructuralStructDecoder {
     child_fields: Fields,
     // The root decoder is slightly different because it cannot have nulls
     is_root: bool,
+    nullable: bool,
 }
 
 impl StructuralStructDecoder {
-    pub fn new(fields: Fields, should_validate: bool, is_root: bool) -> Result<Self> {
+    pub fn new(fields: Fields, should_validate: bool, is_root: bool, nullable: bool) -> Result<Self> {
         let children = fields
             .iter()
             .map(|field| Self::field_to_decoder(field, should_validate))
@@ -249,6 +250,7 @@ impl StructuralStructDecoder {
             children,
             child_fields: fields,
             is_root,
+            nullable: !is_root && nullable,
         })
     }
 
@@ -263,7 +265,12 @@ impl StructuralStructDecoder {
                         StructuralPrimitiveFieldDecoder::new(&field.clone(), should_validate);
                     Ok(Box::new(decoder))
                 } else {
-                    Ok(Box::new(Self::new(fields.clone(), should_validate, false)?))
+                    Ok(Box::new(Self::new(
+                        fields.clone(),
+                        should_validate,
+                        false,
+                        field.is_nullable(),
+                    )?))
                 }
             }
             DataType::List(child_field) | DataType::LargeList(child_field) => {
@@ -347,6 +354,24 @@ impl StructuralFieldDecoder for StructuralStructDecoder {
 
     fn data_type(&self) -> &DataType {
         &self.data_type
+    }
+
+    fn plan_decoded_bytes(&self, rows_remaining: u64) -> lance_core::Result<[u64; 8]> {
+        use crate::decoder::CANDIDATE_BATCH_SIZES;
+        let mut out = [0u64; 8];
+        for child in &self.children {
+            let child_bytes = child.plan_decoded_bytes(rows_remaining)?;
+            for (o, c) in out.iter_mut().zip(child_bytes) {
+                *o += c;
+            }
+        }
+        if self.nullable {
+            for (i, &candidate) in CANDIDATE_BATCH_SIZES.iter().enumerate() {
+                let rows = (candidate as u64).min(rows_remaining);
+                out[i] += rows.div_ceil(8);
+            }
+        }
+        Ok(out)
     }
 }
 
@@ -639,6 +664,7 @@ mod tests {
     use arrow_schema::{DataType, Field, Fields};
 
     use super::StructuralStructDecoder;
+    use crate::decoder::StructuralFieldDecoder;
     use crate::testing::{
         TestCases, TestEncoding, check_basic_random_case, check_round_trip_encoding_of_data,
     };
@@ -658,7 +684,7 @@ mod tests {
             true,
         )]);
 
-        let err = StructuralStructDecoder::new(fields, false, /*is_root=*/ true).unwrap_err();
+        let err = StructuralStructDecoder::new(fields, false, /*is_root=*/ true, /*nullable=*/ false).unwrap_err();
         assert!(matches!(err, lance_core::Error::Schema { .. }));
         assert!(
             err.to_string()
@@ -995,6 +1021,88 @@ mod tests {
             HashMap::new(),
         )
         .await;
+    }
+
+    #[test]
+    fn test_plan_decoded_bytes_struct_non_nullable_primitive() {
+        // Nullable struct containing a non-nullable i32 child.
+        // Only the struct-level bitmap contributes; the child has no bitmap.
+        //
+        // N == CANDIDATE_BATCH_SIZES[5] == 1024 so that all sizes are
+        // naturally aligned to Arrow's 64-byte allocation boundary.
+        use arrow_buffer::NullBuffer;
+
+        const N: usize = 1024;
+        let x_vals = Int32Array::from_iter_values(0..N as i32);
+        let struct_nulls = NullBuffer::from(
+            (0..N).map(|i| i % 2 == 0).collect::<Vec<_>>(),
+        );
+        let struct_field = Field::new("x", DataType::Int32, false);
+        let struct_array = StructArray::new(
+            Fields::from(vec![struct_field]),
+            vec![Arc::new(x_vals) as ArrayRef],
+            Some(struct_nulls),
+        );
+        let expected = struct_array.get_buffer_memory_size() as u64;
+
+        let child_field = Arc::new(Field::new("x", DataType::Int32, false));
+        let fields = Fields::from(vec![child_field]);
+        let decoder = StructuralStructDecoder::new(
+            fields,
+            false,
+            /*is_root=*/ false,
+            /*nullable=*/ true,
+        )
+        .unwrap();
+
+        let bytes = decoder.plan_decoded_bytes(N as u64).unwrap();
+        // bytes[5] corresponds to CANDIDATE_BATCH_SIZES[5] == 1024 == N
+        assert_eq!(
+            bytes[5],
+            expected,
+            "plan_decoded_bytes({N}) = {} but get_buffer_memory_size = {expected}",
+            bytes[5],
+        );
+    }
+
+    #[test]
+    fn test_plan_decoded_bytes_struct_nullable_primitive() {
+        // Nullable struct containing a nullable i32 child.
+        // Both the struct and the child contribute a validity bitmap.
+        use arrow_buffer::NullBuffer;
+
+        const N: usize = 1024;
+        let y_vals = Int32Array::from_iter((0..N as i32).map(|i| {
+            if i % 2 == 0 { Some(i) } else { None }
+        }));
+        let struct_nulls = NullBuffer::from(
+            (0..N).map(|i| i % 3 != 0).collect::<Vec<_>>(),
+        );
+        let struct_field = Field::new("y", DataType::Int32, true);
+        let struct_array = StructArray::new(
+            Fields::from(vec![struct_field]),
+            vec![Arc::new(y_vals) as ArrayRef],
+            Some(struct_nulls),
+        );
+        let expected = struct_array.get_buffer_memory_size() as u64;
+
+        let child_field = Arc::new(Field::new("y", DataType::Int32, true));
+        let fields = Fields::from(vec![child_field]);
+        let decoder = StructuralStructDecoder::new(
+            fields,
+            false,
+            /*is_root=*/ false,
+            /*nullable=*/ true,
+        )
+        .unwrap();
+
+        let bytes = decoder.plan_decoded_bytes(N as u64).unwrap();
+        assert_eq!(
+            bytes[5],
+            expected,
+            "plan_decoded_bytes({N}) = {} but get_buffer_memory_size = {expected}",
+            bytes[5],
+        );
     }
 
     #[test_log::test(tokio::test)]

--- a/rust/lance-encoding/src/encodings/logical/struct.rs
+++ b/rust/lance-encoding/src/encodings/logical/struct.rs
@@ -239,7 +239,12 @@ pub struct StructuralStructDecoder {
 }
 
 impl StructuralStructDecoder {
-    pub fn new(fields: Fields, should_validate: bool, is_root: bool, nullable: bool) -> Result<Self> {
+    pub fn new(
+        fields: Fields,
+        should_validate: bool,
+        is_root: bool,
+        nullable: bool,
+    ) -> Result<Self> {
         let children = fields
             .iter()
             .map(|field| Self::field_to_decoder(field, should_validate))
@@ -684,7 +689,10 @@ mod tests {
             true,
         )]);
 
-        let err = StructuralStructDecoder::new(fields, false, /*is_root=*/ true, /*nullable=*/ false).unwrap_err();
+        let err = StructuralStructDecoder::new(
+            fields, false, /*is_root=*/ true, /*nullable=*/ false,
+        )
+        .unwrap_err();
         assert!(matches!(err, lance_core::Error::Schema { .. }));
         assert!(
             err.to_string()
@@ -1034,9 +1042,7 @@ mod tests {
 
         const N: usize = 1024;
         let x_vals = Int32Array::from_iter_values(0..N as i32);
-        let struct_nulls = NullBuffer::from(
-            (0..N).map(|i| i % 2 == 0).collect::<Vec<_>>(),
-        );
+        let struct_nulls = NullBuffer::from((0..N).map(|i| i % 2 == 0).collect::<Vec<_>>());
         let struct_field = Field::new("x", DataType::Int32, false);
         let struct_array = StructArray::new(
             Fields::from(vec![struct_field]),
@@ -1048,18 +1054,14 @@ mod tests {
         let child_field = Arc::new(Field::new("x", DataType::Int32, false));
         let fields = Fields::from(vec![child_field]);
         let decoder = StructuralStructDecoder::new(
-            fields,
-            false,
-            /*is_root=*/ false,
-            /*nullable=*/ true,
+            fields, false, /*is_root=*/ false, /*nullable=*/ true,
         )
         .unwrap();
 
         let bytes = decoder.plan_decoded_bytes(N as u64).unwrap();
         // bytes[5] corresponds to CANDIDATE_BATCH_SIZES[5] == 1024 == N
         assert_eq!(
-            bytes[5],
-            expected,
+            bytes[5], expected,
             "plan_decoded_bytes({N}) = {} but get_buffer_memory_size = {expected}",
             bytes[5],
         );
@@ -1072,12 +1074,9 @@ mod tests {
         use arrow_buffer::NullBuffer;
 
         const N: usize = 1024;
-        let y_vals = Int32Array::from_iter((0..N as i32).map(|i| {
-            if i % 2 == 0 { Some(i) } else { None }
-        }));
-        let struct_nulls = NullBuffer::from(
-            (0..N).map(|i| i % 3 != 0).collect::<Vec<_>>(),
-        );
+        let y_vals =
+            Int32Array::from_iter((0..N as i32).map(|i| if i % 2 == 0 { Some(i) } else { None }));
+        let struct_nulls = NullBuffer::from((0..N).map(|i| i % 3 != 0).collect::<Vec<_>>());
         let struct_field = Field::new("y", DataType::Int32, true);
         let struct_array = StructArray::new(
             Fields::from(vec![struct_field]),
@@ -1089,17 +1088,13 @@ mod tests {
         let child_field = Arc::new(Field::new("y", DataType::Int32, true));
         let fields = Fields::from(vec![child_field]);
         let decoder = StructuralStructDecoder::new(
-            fields,
-            false,
-            /*is_root=*/ false,
-            /*nullable=*/ true,
+            fields, false, /*is_root=*/ false, /*nullable=*/ true,
         )
         .unwrap();
 
         let bytes = decoder.plan_decoded_bytes(N as u64).unwrap();
         assert_eq!(
-            bytes[5],
-            expected,
+            bytes[5], expected,
             "plan_decoded_bytes({N}) = {} but get_buffer_memory_size = {expected}",
             bytes[5],
         );


### PR DESCRIPTION
This PR implements the plan_decoded_bytes method for fixed-width types.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>