### PR TITLE
feat: commit preconditions judged on the manifest a commit lands on

### DIFF
--- a/rust/lance-table/src/io/commit.rs
+++ b/rust/lance-table/src/io/commit.rs
@@ -22,6 +22,7 @@
 //! terms of a lock. The trait [CommitLock] can be implemented as a simpler
 //! alternative to [CommitHandler].
 
+use std::collections::HashMap;
 use std::io;
 use std::pin::Pin;
 use std::sync::Arc;
@@ -1747,10 +1748,43 @@ pub struct PredecessorIdentity {
     pub identity: String,
 }
 
+/// A condition on the latest manifest, judged on every commit attempt;
+/// publication is then conditioned on that manifest still being the
+/// predecessor (`CommitHandler::commit_after`). Sees the manifest only.
+pub trait CommitPrecondition: Debug + Send + Sync {
+    /// `Err(Error::PrerequisiteFailed)` when `latest` does not satisfy it.
+    fn check(&self, latest: &Manifest) -> Result<()>;
+}
+
+/// The latest manifest must carry every `(key, value)` in its schema metadata.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct RequiredSchemaMetadata(pub HashMap<String, String>);
+
+impl CommitPrecondition for RequiredSchemaMetadata {
+    fn check(&self, latest: &Manifest) -> Result<()> {
+        for (key, expected) in &self.0 {
+            let actual = latest.schema.metadata.get(key);
+            if actual != Some(expected) {
+                return Err(lance_core::error::PrerequisiteFailedSnafu {
+                    message: format!(
+                        "commit requires schema metadata {key:?} = {expected:?} on version {}, \
+                         found {actual:?}",
+                        latest.version
+                    ),
+                }
+                .build());
+            }
+        }
+        Ok(())
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct CommitConfig {
     pub num_retries: u32,
     pub skip_auto_cleanup: bool,
+    /// Conditions on the latest manifest, all re-checked on every attempt.
+    pub preconditions: Vec<Arc<dyn CommitPrecondition>>,
     // TODO: add isolation_level
 }
 
@@ -1759,6 +1793,7 @@ impl Default for CommitConfig {
         Self {
             num_retries: 20,
             skip_auto_cleanup: false,
+            preconditions: Vec::new(),
         }
     }
 }

--- a/rust/lance/src/dataset.rs
+++ b/rust/lance/src/dataset.rs
@@ -793,6 +793,7 @@ impl Dataset {
             let metadata_key = crate::session::index_caches::IndexMetadataKey {
                 version: manifest_location.version,
                 store_identity: &object_store.store_prefix,
+                identity: manifest_location.identity.as_deref(),
             };
             ds_index_cache
                 .insert_with_key(&metadata_key, Arc::new(indices))
@@ -814,6 +815,7 @@ impl Dataset {
             let metadata_cache = session.metadata_cache.for_dataset(uri);
             let metadata_key = TransactionKey {
                 version: manifest_location.version,
+                identity: manifest_location.identity.as_deref(),
             };
             metadata_cache
                 .insert_with_key(&metadata_key, Arc::new(transaction))
@@ -842,6 +844,8 @@ impl Dataset {
         let manifest_key = ManifestKey {
             version: manifest_location.version,
             e_tag: manifest_location.e_tag.as_deref(),
+
+            identity: manifest_location.identity.as_deref(),
         };
         if let Some(cached) = metadata_cache.get_with_key(&manifest_key).await {
             return Ok(cached);
@@ -1207,6 +1211,8 @@ impl Dataset {
         let manifest_key = ManifestKey {
             version: location.version,
             e_tag: location.e_tag.as_deref(),
+
+            identity: location.identity.as_deref(),
         };
         let cached_manifest = self.metadata_cache.get_with_key(&manifest_key).await;
         if let Some(cached_manifest) = cached_manifest {
@@ -1241,6 +1247,7 @@ impl Dataset {
     pub async fn read_transaction(&self) -> Result<Option<Transaction>> {
         let transaction_key = TransactionKey {
             version: self.manifest.version,
+            identity: self.manifest_location.identity.as_deref(),
         };
         if let Some(transaction) = self.metadata_cache.get_with_key(&transaction_key).await {
             return Ok(Some((*transaction).clone()));
@@ -3547,8 +3554,10 @@ pub(crate) fn load_new_transactions(dataset: &Dataset) -> NewTransactionResult<'
     let transactions = manifests
         .map_ok(move |(manifest, location)| async move {
             let manifest_copy = manifest.clone();
+            let identity = location.identity.clone();
             let tx_key = TransactionKey {
                 version: manifest.version,
+                identity: identity.as_deref(),
             };
             let transaction =
                 if let Some(cached) = dataset.metadata_cache.get_with_key(&tx_key).await {
@@ -4093,9 +4102,10 @@ impl ManifestWriteConfig {
     }
 }
 
-/// Commit a manifest file and create a copy at the latest manifest path.
+/// [`write_manifest_file`], published only if `predecessor` still holds;
+/// see `CommitHandler::commit_after`.
 #[allow(clippy::too_many_arguments)]
-pub(crate) async fn write_manifest_file(
+pub(crate) async fn write_manifest_file_after(
     object_store: &ObjectStore,
     commit_handler: &dyn CommitHandler,
     base_path: &Path,
@@ -4104,7 +4114,40 @@ pub(crate) async fn write_manifest_file(
     config: &ManifestWriteConfig,
     naming_scheme: ManifestNamingScheme,
     transaction: Option<lance_table::format::Transaction>,
+    predecessor: Option<&lance_table::io::commit::PredecessorIdentity>,
 ) -> std::result::Result<ManifestLocation, CommitError> {
+    let Some(predecessor) = predecessor else {
+        return write_manifest_file(
+            object_store,
+            commit_handler,
+            base_path,
+            manifest,
+            indices,
+            config,
+            naming_scheme,
+            transaction,
+        )
+        .await;
+    };
+    prepare_manifest_for_write(manifest, config)?;
+    commit_handler
+        .commit_after(
+            manifest,
+            indices,
+            base_path,
+            object_store,
+            write_manifest_file_to_path,
+            naming_scheme,
+            transaction,
+            predecessor,
+        )
+        .await
+}
+
+fn prepare_manifest_for_write(
+    manifest: &mut Manifest,
+    config: &ManifestWriteConfig,
+) -> std::result::Result<(), CommitError> {
     if config.auto_set_feature_flags {
         // build_manifest may have already set FLAG_STABLE_ROW_IDS on the manifest.
         // Preserve it here so this second apply_feature_flags call does not clear it
@@ -4120,6 +4163,22 @@ pub(crate) async fn write_manifest_file(
     manifest.set_timestamp(timestamp_to_nanos(config.timestamp));
 
     manifest.update_max_fragment_id();
+    Ok(())
+}
+
+/// Commit a manifest file and create a copy at the latest manifest path.
+#[allow(clippy::too_many_arguments)]
+pub(crate) async fn write_manifest_file(
+    object_store: &ObjectStore,
+    commit_handler: &dyn CommitHandler,
+    base_path: &Path,
+    manifest: &mut Manifest,
+    indices: Option<Vec<IndexMetadata>>,
+    config: &ManifestWriteConfig,
+    naming_scheme: ManifestNamingScheme,
+    transaction: Option<lance_table::format::Transaction>,
+) -> std::result::Result<ManifestLocation, CommitError> {
+    prepare_manifest_for_write(manifest, config)?;
 
     commit_handler
         .commit(

--- a/rust/lance/src/dataset/index.rs
+++ b/rust/lance/src/dataset/index.rs
@@ -494,6 +494,7 @@ mod tests {
         let metadata_key = crate::session::index_caches::IndexMetadataKey {
             version: dataset.version().version,
             store_identity: &dataset.object_store.store_prefix,
+            identity: dataset.manifest_location.identity.as_deref(),
         };
         dataset
             .index_cache

--- a/rust/lance/src/dataset/tests/dataset_io.rs
+++ b/rust/lance/src/dataset/tests/dataset_io.rs
@@ -1124,6 +1124,8 @@ async fn test_checkout_removed_version_not_served_from_cache() {
             .get_with_key(&ManifestKey {
                 version,
                 e_tag: location.e_tag.as_deref(),
+
+                identity: location.identity.as_deref(),
             })
             .await
             .is_some(),
@@ -1150,6 +1152,8 @@ async fn test_checkout_removed_version_not_served_from_cache() {
             &ManifestKey {
                 version,
                 e_tag: None,
+
+                identity: None,
             },
             Arc::new(dataset.manifest().clone()),
         )

--- a/rust/lance/src/dataset/write/commit.rs
+++ b/rust/lance/src/dataset/write/commit.rs
@@ -10,7 +10,10 @@ use lance_io::object_store::{ObjectStore, ObjectStoreParams};
 use lance_select::RowAddrTreeMap;
 use lance_table::{
     format::{DataStorageFormat, is_detached_version},
-    io::commit::{CommitConfig, CommitHandler, ManifestNamingScheme},
+    io::commit::{
+        CommitConfig, CommitHandler, CommitPrecondition, ManifestNamingScheme,
+        RequiredSchemaMetadata,
+    },
 };
 
 use crate::io::commit::DEFAULT_COMMIT_RETRY_TIMEOUT;
@@ -213,6 +216,28 @@ impl<'a> CommitBuilder<'a> {
         self
     }
 
+    /// Judge `precondition` on every attempt; see [`CommitPrecondition`].
+    /// Handlers that cannot condition publication on the predecessor,
+    /// detached commits and dataset creation refuse it.
+    pub fn with_precondition(mut self, precondition: Arc<dyn CommitPrecondition>) -> Self {
+        self.commit_config.preconditions.push(precondition);
+        self
+    }
+
+    /// [`Self::with_precondition`] with [`RequiredSchemaMetadata`]: the latest
+    /// manifest must carry `value` under schema-metadata `key`, so a dataset
+    /// recreated at the same path is refused with [`Error::PrerequisiteFailed`].
+    pub fn with_required_schema_metadata(
+        self,
+        key: impl Into<String>,
+        value: impl Into<String>,
+    ) -> Self {
+        self.with_precondition(Arc::new(RequiredSchemaMetadata(HashMap::from([(
+            key.into(),
+            value.into(),
+        )]))))
+    }
+
     pub fn with_skip_auto_cleanup(mut self, skip_auto_cleanup: bool) -> Self {
         self.commit_config.skip_auto_cleanup = skip_auto_cleanup;
         self
@@ -335,6 +360,7 @@ impl<'a> CommitBuilder<'a> {
             }
         };
 
+        let staged_against_handle = matches!(self.dest, WriteDestination::Dataset(_));
         let dest = match &self.dest {
             WriteDestination::Dataset(dataset) => WriteDestination::Dataset(dataset.clone()),
             WriteDestination::Uri(uri) => {
@@ -432,6 +458,20 @@ impl<'a> CommitBuilder<'a> {
             ..Default::default()
         };
 
+        if !self.commit_config.preconditions.is_empty() {
+            if self.detached {
+                return Err(Error::invalid_input(
+                    "commit preconditions cannot be enforced on a detached commit",
+                ));
+            }
+            // A URI resolves to whatever occupies it now, not the incarnation
+            // the transaction was staged against.
+            if !staged_against_handle {
+                return Err(Error::invalid_input(
+                    "commit preconditions need the dataset handle the transaction was staged against, not a URI",
+                ));
+            }
+        }
         let (manifest, manifest_location) = if let Some(dataset) = dest.dataset() {
             if self.detached {
                 if matches!(manifest_naming_scheme, ManifestNamingScheme::V1) {
@@ -612,7 +652,13 @@ mod tests {
 
     use crate::utils::test::ThrottledStoreWrapper;
 
-    use crate::dataset::{InsertBuilder, WriteParams};
+    use crate::dataset::{InsertBuilder, WriteMode, WriteParams};
+    use lance_core::utils::tempfile::TempStrDir;
+    use lance_table::io::commit::PredecessorIdentity;
+    use lance_table::io::commit::external_manifest::{
+        ExternalManifestCommitHandler, ExternalManifestStore, Reservation, finalize_staged,
+    };
+    use object_store::path::Path;
 
     use super::*;
 
@@ -1224,5 +1270,582 @@ mod tests {
             "read_iops = {}; a full listing was likely used",
             io_stats.read_iops
         );
+    }
+
+    /// `(path, size, identity)` per version; identities are minted per
+    /// record and never reused, so a recreation at the same version differs.
+    type StoredRows = HashMap<(String, u64), (String, u64, String)>;
+
+    #[derive(Debug, Default)]
+    struct IdentifiedStore {
+        rows: std::sync::Mutex<StoredRows>,
+        next_identity: std::sync::atomic::AtomicU64,
+        hold_next_reservation: std::sync::atomic::AtomicBool,
+        reservation_held: tokio::sync::Notify,
+        release_reservation: tokio::sync::Notify,
+        fail_next_finalize: std::sync::atomic::AtomicBool,
+    }
+
+    impl IdentifiedStore {
+        fn mint(&self) -> String {
+            format!(
+                "identity-{}",
+                self.next_identity
+                    .fetch_add(1, std::sync::atomic::Ordering::SeqCst)
+            )
+        }
+
+        fn handler(self: &Arc<Self>) -> Arc<dyn CommitHandler> {
+            Arc::new(ExternalManifestCommitHandler {
+                external_manifest_store: self.clone(),
+            })
+        }
+
+        fn versions(&self) -> Vec<u64> {
+            let mut versions: Vec<u64> = self.rows.lock().unwrap().keys().map(|k| k.1).collect();
+            versions.sort();
+            versions
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl ExternalManifestStore for IdentifiedStore {
+        async fn get(&self, base_uri: &str, version: u64) -> Result<String> {
+            self.rows
+                .lock()
+                .unwrap()
+                .get(&(base_uri.to_string(), version))
+                .map(|row| row.0.clone())
+                .ok_or_else(|| Error::not_found(format!("{base_uri}@{version}")))
+        }
+
+        async fn get_latest_version(&self, base_uri: &str) -> Result<Option<(u64, String)>> {
+            Ok(self
+                .rows
+                .lock()
+                .unwrap()
+                .iter()
+                .filter(|(key, _)| key.0 == base_uri)
+                .max_by_key(|(key, _)| key.1)
+                .map(|(key, row)| (key.1, row.0.clone())))
+        }
+
+        async fn put_if_not_exists(
+            &self,
+            base_uri: &str,
+            version: u64,
+            path: &str,
+            size: u64,
+            _e_tag: Option<String>,
+        ) -> Result<()> {
+            let identity = self.mint();
+            let mut rows = self.rows.lock().unwrap();
+            let key = (base_uri.to_string(), version);
+            if rows.contains_key(&key) {
+                return Err(Error::commit_conflict_source(
+                    version,
+                    "manifest already exists".into(),
+                ));
+            }
+            rows.insert(key, (path.to_string(), size, identity));
+            Ok(())
+        }
+
+        async fn put_if_exists(
+            &self,
+            base_uri: &str,
+            version: u64,
+            path: &str,
+            size: u64,
+            _e_tag: Option<String>,
+        ) -> Result<()> {
+            let mut rows = self.rows.lock().unwrap();
+            let row = rows
+                .get_mut(&(base_uri.to_string(), version))
+                .ok_or_else(|| Error::not_found(format!("{base_uri}@{version}")))?;
+            row.0 = path.to_string();
+            row.1 = size;
+            Ok(())
+        }
+
+        async fn delete(&self, base_uri: &str) -> Result<()> {
+            self.rows.lock().unwrap().retain(|key, _| key.0 != base_uri);
+            Ok(())
+        }
+
+        async fn get_manifest_location(
+            &self,
+            base_uri: &str,
+            version: u64,
+        ) -> Result<ManifestLocation> {
+            let row = self
+                .rows
+                .lock()
+                .unwrap()
+                .get(&(base_uri.to_string(), version))
+                .cloned()
+                .ok_or_else(|| Error::not_found(format!("{base_uri}@{version}")))?;
+            Ok(ManifestLocation {
+                version,
+                path: Path::parse(&row.0).unwrap(),
+                size: Some(row.1),
+                naming_scheme: ManifestNamingScheme::V2,
+                e_tag: None,
+                identity: Some(row.2),
+            })
+        }
+
+        async fn get_latest_manifest_location(
+            &self,
+            base_uri: &str,
+        ) -> Result<Option<ManifestLocation>> {
+            match self.get_latest_version(base_uri).await? {
+                Some((version, _)) => self
+                    .get_manifest_location(base_uri, version)
+                    .await
+                    .map(Some),
+                None => Ok(None),
+            }
+        }
+
+        async fn list_versions(
+            &self,
+            base_uri: &str,
+            since: Option<u64>,
+        ) -> Result<Option<Vec<ManifestLocation>>> {
+            let versions: Vec<u64> = self
+                .rows
+                .lock()
+                .unwrap()
+                .keys()
+                .filter(|(base, _)| base == base_uri)
+                .map(|(_, version)| *version)
+                .collect();
+            let mut locations = Vec::new();
+            for version in versions {
+                if since.is_none_or(|since| version > since) {
+                    locations.push(self.get_manifest_location(base_uri, version).await?);
+                }
+            }
+            Ok(Some(locations))
+        }
+
+        async fn put(
+            &self,
+            base_path: &Path,
+            version: u64,
+            staging_path: &Path,
+            size: u64,
+            _e_tag: Option<String>,
+            object_store: &dyn object_store::ObjectStore,
+            naming_scheme: ManifestNamingScheme,
+        ) -> Result<ManifestLocation> {
+            self.put_if_not_exists(
+                base_path.as_ref(),
+                version,
+                staging_path.as_ref(),
+                size,
+                None,
+            )
+            .await?;
+            let mut location = finalize_staged(
+                self,
+                base_path,
+                version,
+                staging_path,
+                size,
+                object_store,
+                naming_scheme,
+            )
+            .await?;
+            location.identity = self.get_identity(base_path.as_ref(), version).await?;
+            Ok(location)
+        }
+
+        async fn finalize(
+            &self,
+            base_path: &Path,
+            version: u64,
+            staging_path: &Path,
+            size: u64,
+            object_store: &dyn object_store::ObjectStore,
+            naming_scheme: ManifestNamingScheme,
+        ) -> Result<ManifestLocation> {
+            if self
+                .fail_next_finalize
+                .swap(false, std::sync::atomic::Ordering::SeqCst)
+            {
+                return Err(Error::io("simulated copy failure after reservation"));
+            }
+            finalize_staged(
+                self,
+                base_path,
+                version,
+                staging_path,
+                size,
+                object_store,
+                naming_scheme,
+            )
+            .await
+        }
+
+        fn supports_predecessor_condition(&self) -> bool {
+            true
+        }
+
+        async fn get_identity(&self, base_uri: &str, version: u64) -> Result<Option<String>> {
+            Ok(self
+                .rows
+                .lock()
+                .unwrap()
+                .get(&(base_uri.to_string(), version))
+                .map(|row| row.2.clone()))
+        }
+
+        async fn put_if_predecessor(
+            &self,
+            base_uri: &str,
+            version: u64,
+            path: &str,
+            size: u64,
+            predecessor: &PredecessorIdentity,
+        ) -> Result<Reservation> {
+            if self
+                .hold_next_reservation
+                .swap(false, std::sync::atomic::Ordering::SeqCst)
+            {
+                self.reservation_held.notify_one();
+                self.release_reservation.notified().await;
+            }
+            let identity = self.mint();
+            let mut rows = self.rows.lock().unwrap();
+            let held = rows
+                .get(&(base_uri.to_string(), predecessor.version))
+                .is_some_and(|row| row.2 == predecessor.identity);
+            if !held {
+                return Ok(Reservation::PredecessorChanged);
+            }
+            let key = (base_uri.to_string(), version);
+            if rows.contains_key(&key) {
+                return Ok(Reservation::Taken);
+            }
+            rows.insert(key, (path.to_string(), size, identity.clone()));
+            Ok(Reservation::Reserved { identity })
+        }
+    }
+
+    fn gen_batch(generation: &str) -> RecordBatch {
+        let schema = Arc::new(ArrowSchema::new_with_metadata(
+            vec![ArrowField::new("i", DataType::Int32, false)],
+            HashMap::from([("gen".to_string(), generation.to_string())]),
+        ));
+        RecordBatch::try_new(
+            schema,
+            vec![Arc::new(Int32Array::from_iter_values(0..3_i32))],
+        )
+        .unwrap()
+    }
+
+    async fn create_with(uri: &str, generation: &str, handler: Arc<dyn CommitHandler>) -> Dataset {
+        InsertBuilder::new(uri)
+            .with_params(&WriteParams {
+                commit_handler: Some(handler),
+                ..Default::default()
+            })
+            .execute(vec![gen_batch(generation)])
+            .await
+            .unwrap()
+    }
+
+    async fn staged_append(dataset: &Dataset) -> Transaction {
+        InsertBuilder::new(WriteDestination::Dataset(Arc::new(dataset.clone())))
+            .with_params(&WriteParams {
+                mode: WriteMode::Append,
+                ..Default::default()
+            })
+            .execute_uncommitted(vec![gen_batch("a")])
+            .await
+            .unwrap()
+    }
+
+    /// Drop the dataset at `uri` from storage and from the store, then
+    /// create a new one there with a different generation.
+    async fn recreate(uri: &str, store: &Arc<IdentifiedStore>, generation: &str) -> Dataset {
+        std::fs::remove_dir_all(uri).unwrap();
+        store.delete(uri.trim_start_matches('/')).await.unwrap();
+        create_with(uri, generation, store.handler()).await
+    }
+
+    #[tokio::test]
+    async fn test_required_schema_metadata_is_refused_where_publication_cannot_be_conditioned() {
+        let dataset = InsertBuilder::new("memory://required-unsupported")
+            .execute(vec![gen_batch("a")])
+            .await
+            .unwrap();
+        let txn = staged_append(&dataset).await;
+        let err = CommitBuilder::new(WriteDestination::Dataset(Arc::new(dataset)))
+            .with_required_schema_metadata("gen", "a")
+            .execute(txn)
+            .await
+            .unwrap_err();
+        assert!(matches!(err, Error::NotSupported { .. }), "{err}");
+    }
+
+    /// Matching metadata lands; metadata changed before the commit fails it
+    /// even though the stale handle still shows the old value.
+    #[tokio::test]
+    async fn test_required_schema_metadata_is_judged_on_the_latest_manifest() {
+        let store = Arc::new(IdentifiedStore::default());
+        let uri = TempStrDir::default();
+        let dataset = create_with(uri.as_str(), "a", store.handler()).await;
+        let txn = staged_append(&dataset).await;
+        let committed = CommitBuilder::new(WriteDestination::Dataset(Arc::new(dataset)))
+            .with_required_schema_metadata("gen", "a")
+            .execute(txn)
+            .await
+            .unwrap();
+        assert_eq!(committed.version().version, 2);
+
+        let stale = committed.clone();
+        let txn = staged_append(&stale).await;
+        let mut moved = committed;
+        moved
+            .update_schema_metadata([("gen".to_string(), Some("b".to_string()))])
+            .await
+            .unwrap();
+        let err = CommitBuilder::new(WriteDestination::Dataset(Arc::new(stale)))
+            .with_required_schema_metadata("gen", "a")
+            .execute(txn)
+            .await
+            .unwrap_err();
+        assert!(matches!(err, Error::PrerequisiteFailed { .. }), "{err}");
+        assert_eq!(store.versions(), vec![1, 2, 3]);
+    }
+
+    /// A dataset recreated at the same path restarts its versions, so the
+    /// stale handle's conflict scan sees nothing newer; the requirement is
+    /// judged on the store's latest record and refuses the writer.
+    #[tokio::test]
+    async fn test_required_schema_metadata_refuses_a_same_version_recreation() {
+        let store = Arc::new(IdentifiedStore::default());
+        let uri = TempStrDir::default();
+        let stale = create_with(uri.as_str(), "a", store.handler()).await;
+        let mut recreated = recreate(uri.as_str(), &store, "b").await;
+        assert_eq!(recreated.version().version, stale.version().version);
+
+        let txn = staged_append(&stale).await;
+        let err = CommitBuilder::new(WriteDestination::Dataset(Arc::new(stale)))
+            .with_required_schema_metadata("gen", "a")
+            .execute(txn)
+            .await
+            .unwrap_err();
+        assert!(matches!(err, Error::PrerequisiteFailed { .. }), "{err}");
+        recreated.checkout_latest().await.unwrap();
+        assert_eq!(recreated.version().version, 1);
+        assert_eq!(store.versions(), vec![1]);
+    }
+
+    /// A recreation landing after the judgement but before the reservation
+    /// is refused by the reservation itself: nothing is published and the
+    /// recreated dataset is untouched.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_a_recreation_between_judgement_and_reservation_is_refused() {
+        let store = Arc::new(IdentifiedStore::default());
+        let uri = TempStrDir::default();
+        let stale = create_with(uri.as_str(), "a", store.handler()).await;
+        let txn = staged_append(&stale).await;
+
+        store
+            .hold_next_reservation
+            .store(true, std::sync::atomic::Ordering::SeqCst);
+        let committing = tokio::spawn(async move {
+            CommitBuilder::new(WriteDestination::Dataset(Arc::new(stale)))
+                .with_required_schema_metadata("gen", "a")
+                .execute(txn)
+                .await
+        });
+        tokio::time::timeout(Duration::from_secs(30), store.reservation_held.notified())
+            .await
+            .expect("the commit never reached its reservation");
+
+        let mut recreated = recreate(uri.as_str(), &store, "b").await;
+        store.release_reservation.notify_one();
+
+        let err = committing.await.unwrap().unwrap_err();
+        assert!(matches!(err, Error::PrerequisiteFailed { .. }), "{err}");
+        recreated.checkout_latest().await.unwrap();
+        assert_eq!(recreated.version().version, 1);
+        assert_eq!(store.versions(), vec![1]);
+        assert_eq!(
+            recreated.schema().metadata.get("gen").map(String::as_str),
+            Some("b")
+        );
+    }
+
+    /// Any precondition is judged on the latest manifest, not the handle's.
+    #[tokio::test]
+    async fn test_a_custom_precondition_is_judged_on_the_latest_manifest() {
+        #[derive(Debug)]
+        struct AtMostVersion(u64);
+        impl CommitPrecondition for AtMostVersion {
+            fn check(&self, latest: &Manifest) -> Result<()> {
+                if latest.version <= self.0 {
+                    return Ok(());
+                }
+                Err(lance_core::error::PrerequisiteFailedSnafu {
+                    message: format!("version {} > {}", latest.version, self.0),
+                }
+                .build())
+            }
+        }
+        let store = Arc::new(IdentifiedStore::default());
+        let uri = TempStrDir::default();
+        let dataset = create_with(uri.as_str(), "a", store.handler()).await;
+        let stale = dataset.clone();
+        let txn = staged_append(&stale).await;
+        InsertBuilder::new(WriteDestination::Dataset(Arc::new(dataset)))
+            .with_params(&WriteParams {
+                mode: WriteMode::Append,
+                ..Default::default()
+            })
+            .execute(vec![gen_batch("a")])
+            .await
+            .unwrap();
+        let err = CommitBuilder::new(WriteDestination::Dataset(Arc::new(stale)))
+            .with_precondition(Arc::new(AtMostVersion(1)))
+            .execute(txn)
+            .await
+            .unwrap_err();
+        assert!(matches!(err, Error::PrerequisiteFailed { .. }), "{err}");
+        assert_eq!(store.versions(), vec![1, 2]);
+    }
+
+    /// Two creations of an empty table write identical manifests, so only
+    /// the store's identity can tell the stale handle from the new table.
+    #[tokio::test]
+    async fn test_an_identical_empty_recreation_is_refused() {
+        let store = Arc::new(IdentifiedStore::default());
+        let uri = TempStrDir::default();
+        let create_empty = || async {
+            InsertBuilder::new(uri.as_str())
+                .with_params(&WriteParams {
+                    commit_handler: Some(store.handler()),
+                    ..Default::default()
+                })
+                .execute(vec![gen_batch("a").slice(0, 0)])
+                .await
+                .unwrap()
+        };
+        let stale = create_empty().await;
+        let txn = staged_append(&stale).await;
+        std::fs::remove_dir_all(uri.as_str()).unwrap();
+        store
+            .delete(uri.as_str().trim_start_matches('/'))
+            .await
+            .unwrap();
+        let mut recreated = create_empty().await;
+        assert_eq!(recreated.manifest().fragments, stale.manifest().fragments);
+
+        let err = CommitBuilder::new(WriteDestination::Dataset(Arc::new(stale)))
+            .with_required_schema_metadata("gen", "a")
+            .execute(txn)
+            .await
+            .unwrap_err();
+        assert!(matches!(err, Error::PrerequisiteFailed { .. }), "{err}");
+        recreated.checkout_latest().await.unwrap();
+        assert_eq!(recreated.version().version, 1);
+        assert_eq!(store.versions(), vec![1]);
+    }
+
+    /// A recreation that carries the same metadata still fails: the
+    /// candidate would be built from the deleted incarnation's manifest.
+    #[tokio::test]
+    async fn test_a_recreation_with_matching_metadata_is_refused() {
+        let store = Arc::new(IdentifiedStore::default());
+        let uri = TempStrDir::default();
+        let stale = create_with(uri.as_str(), "a", store.handler()).await;
+        let txn = staged_append(&stale).await;
+        let mut recreated = recreate(uri.as_str(), &store, "a").await;
+        let err = CommitBuilder::new(WriteDestination::Dataset(Arc::new(stale)))
+            .with_required_schema_metadata("gen", "a")
+            .execute(txn)
+            .await
+            .unwrap_err();
+        assert!(matches!(err, Error::PrerequisiteFailed { .. }), "{err}");
+        recreated.checkout_latest().await.unwrap();
+        assert_eq!(recreated.version().version, 1);
+        assert_eq!(store.versions(), vec![1]);
+    }
+
+    /// The version is ours once reserved; a finalization error afterwards is
+    /// resolved by outcome verification, not reported as a failed commit.
+    #[tokio::test]
+    async fn test_a_finalization_error_after_reservation_is_not_a_failure() {
+        let store = Arc::new(IdentifiedStore::default());
+        let uri = TempStrDir::default();
+        let dataset = create_with(uri.as_str(), "a", store.handler()).await;
+        let txn = staged_append(&dataset).await;
+        store
+            .fail_next_finalize
+            .store(true, std::sync::atomic::Ordering::SeqCst);
+        let committed = CommitBuilder::new(WriteDestination::Dataset(Arc::new(dataset)))
+            .with_required_schema_metadata("gen", "a")
+            .execute(txn)
+            .await
+            .unwrap();
+        assert_eq!(committed.version().version, 2);
+        assert_eq!(store.versions(), vec![1, 2]);
+    }
+
+    /// A URI destination reloads whatever occupies the URI, so a transaction
+    /// staged against a dropped dataset would land in its replacement.
+    #[tokio::test]
+    async fn test_preconditions_are_refused_for_uri_destinations() {
+        let store = Arc::new(IdentifiedStore::default());
+        let uri = TempStrDir::default();
+        let stale = create_with(uri.as_str(), "a", store.handler()).await;
+        let txn = staged_append(&stale).await;
+        let mut recreated = recreate(uri.as_str(), &store, "a").await;
+        let err = CommitBuilder::new(uri.as_str())
+            .with_commit_handler(store.handler())
+            .with_required_schema_metadata("gen", "a")
+            .execute(txn)
+            .await
+            .unwrap_err();
+        assert!(matches!(err, Error::InvalidInput { .. }), "{err}");
+        recreated.checkout_latest().await.unwrap();
+        assert_eq!(recreated.version().version, 1);
+        assert_eq!(store.versions(), vec![1]);
+    }
+
+    #[tokio::test]
+    async fn test_required_schema_metadata_is_refused_for_new_datasets() {
+        let uri = TempStrDir::default();
+        let txn = InsertBuilder::new(uri.as_str())
+            .execute_uncommitted(vec![gen_batch("a")])
+            .await
+            .unwrap();
+        let err = CommitBuilder::new(uri.as_str())
+            .with_required_schema_metadata("gen", "a")
+            .execute(txn)
+            .await
+            .unwrap_err();
+        assert!(matches!(err, Error::InvalidInput { .. }), "{err}");
+    }
+
+    #[tokio::test]
+    async fn test_required_schema_metadata_is_refused_on_detached_commits() {
+        let dataset = InsertBuilder::new("memory://required-detached")
+            .execute(vec![gen_batch("a")])
+            .await
+            .unwrap();
+        let txn = staged_append(&dataset).await;
+        let err = CommitBuilder::new(WriteDestination::Dataset(Arc::new(dataset)))
+            .with_detached(true)
+            .with_required_schema_metadata("gen", "a")
+            .execute(txn)
+            .await
+            .unwrap_err();
+        assert!(matches!(err, Error::InvalidInput { .. }), "{err}");
     }
 }

--- a/rust/lance/src/index.rs
+++ b/rust/lance/src/index.rs
@@ -1803,6 +1803,7 @@ impl DatasetIndexExt for Dataset {
         let metadata_key = IndexMetadataKey {
             version: self.version().version,
             store_identity: &self.object_store.store_prefix,
+            identity: self.manifest_location.identity.as_deref(),
         };
         let mut indices = self
             .index_cache
@@ -5644,6 +5645,7 @@ mod tests {
         let metadata_key = crate::session::index_caches::IndexMetadataKey {
             version: dataset.version().version,
             store_identity: &dataset.object_store.store_prefix,
+            identity: dataset.manifest_location.identity.as_deref(),
         };
         dataset
             .index_cache
@@ -6053,6 +6055,7 @@ mod tests {
         let metadata_key = crate::session::index_caches::IndexMetadataKey {
             version: dataset.version().version,
             store_identity: &dataset.object_store.store_prefix,
+            identity: dataset.manifest_location.identity.as_deref(),
         };
         dataset
             .index_cache

--- a/rust/lance/src/io/commit.rs
+++ b/rust/lance/src/io/commit.rs
@@ -39,7 +39,8 @@ use lance_table::format::{
     is_detached_version, list_index_files_with_sizes, pb,
 };
 use lance_table::io::commit::{
-    CommitConfig, CommitError, CommitHandler, ManifestLocation, ManifestNamingScheme,
+    CommitConfig, CommitError, CommitHandler, CommitPrecondition, ManifestLocation,
+    ManifestNamingScheme, PredecessorIdentity,
 };
 use lance_table::io::manifest::read_manifest;
 use rand::{Rng, rng};
@@ -51,7 +52,7 @@ use crate::dataset::fragment::FileFragment;
 use crate::dataset::transaction::{Operation, Transaction};
 use crate::dataset::{
     ManifestWriteConfig, NewTransactionResult, TRANSACTIONS_DIR, load_new_transactions,
-    write_manifest_file,
+    write_manifest_file, write_manifest_file_after,
 };
 use crate::index::DatasetIndexExt;
 use crate::index::DatasetIndexInternalExt;
@@ -292,6 +293,68 @@ async fn read_manifest_transaction(
     } else {
         Ok(None)
     }
+}
+
+/// Judge `preconditions` on the latest manifest and return the predecessor
+/// identity publication is conditioned on. The manifest at `handle`'s version
+/// must still carry the handle's identity: content cannot prove the base is live.
+async fn judge_preconditions(
+    object_store: &ObjectStore,
+    commit_handler: &dyn CommitHandler,
+    base_path: &Path,
+    handle: &ManifestLocation,
+    preconditions: &[Arc<dyn CommitPrecondition>],
+) -> Result<Option<PredecessorIdentity>> {
+    if preconditions.is_empty() {
+        return Ok(None);
+    }
+    let failed = |message: String| lance_core::error::PrerequisiteFailedSnafu { message }.build();
+    let Some(handle_identity) = handle.identity.as_deref() else {
+        return Err(failed(format!(
+            "the handle for version {} carries no identity to condition the commit on; reload it",
+            handle.version
+        )));
+    };
+    let Some(latest) = commit_handler
+        .resolve_latest_identity(base_path, object_store)
+        .await?
+    else {
+        return Err(failed(
+            "the latest manifest carries no identity to condition the commit on".to_string(),
+        ));
+    };
+    let recreated = || {
+        failed(format!(
+            "the dataset at '{base_path}' was recreated since version {} was loaded",
+            handle.version
+        ))
+    };
+    if latest.version < handle.version {
+        return Err(recreated());
+    }
+    let current = if latest.version == handle.version {
+        Some(latest.clone())
+    } else {
+        commit_handler
+            .resolve_identity(base_path, object_store, handle.version)
+            .await?
+    };
+    match current {
+        Some(current) if current.identity == handle_identity => {}
+        _ => return Err(recreated()),
+    }
+    let Some((manifest, _)) =
+        try_read_manifest_at(object_store, commit_handler, base_path, latest.version).await?
+    else {
+        return Err(failed(format!(
+            "manifest {} is no longer readable",
+            latest.version
+        )));
+    };
+    for precondition in preconditions {
+        precondition.check(&manifest)?;
+    }
+    Ok(Some(latest))
 }
 
 /// Read the manifest at `version`, distinguishing "no such version"
@@ -587,6 +650,7 @@ async fn record_new_dataset_commit(
 ) {
     let tx_key = crate::session::caches::TransactionKey {
         version: manifest.version,
+        identity: location.identity.as_deref(),
     };
     metadata_cache
         .insert_with_key(&tx_key, Arc::new(transaction.clone()))
@@ -595,6 +659,8 @@ async fn record_new_dataset_commit(
     let manifest_key = crate::session::caches::ManifestKey {
         version: location.version,
         e_tag: location.e_tag.as_deref(),
+
+        identity: location.identity.as_deref(),
     };
     metadata_cache
         .insert_with_key(&manifest_key, Arc::new(manifest.clone()))
@@ -1264,6 +1330,7 @@ async fn record_successful_commit(
 ) {
     let tx_key = crate::session::caches::TransactionKey {
         version: manifest.version,
+        identity: location.identity.as_deref(),
     };
     dataset
         .metadata_cache
@@ -1273,6 +1340,8 @@ async fn record_successful_commit(
     let manifest_key = crate::session::caches::ManifestKey {
         version: location.version,
         e_tag: location.e_tag.as_deref(),
+
+        identity: location.identity.as_deref(),
     };
     dataset
         .metadata_cache
@@ -1282,6 +1351,7 @@ async fn record_successful_commit(
         let key = IndexMetadataKey {
             version: manifest.version,
             store_identity: &dataset.object_store.store_prefix,
+            identity: location.identity.as_deref(),
         };
         dataset
             .index_cache
@@ -1316,6 +1386,12 @@ pub(crate) async fn commit_transaction(
 ) -> Result<(Manifest, ManifestLocation)> {
     // Note: object_store has been configured with WriteParams, but dataset.object_store.as_ref()
     // has not necessarily. So for anything involving writing, use `object_store`.
+    if !commit_config.preconditions.is_empty() && !commit_handler.supports_predecessor_condition() {
+        return Err(Error::not_supported(
+            "commit preconditions need a commit handler that can condition publication on \
+             the predecessor manifest, which this store's cannot",
+        ));
+    }
     let read_version = transaction.read_version;
     let mut target_version = read_version + 1;
     let original_dataset = dataset.clone();
@@ -1388,6 +1464,15 @@ pub(crate) async fn commit_transaction(
             transaction = rebase.finish(&dataset).await?;
         }
 
+        let predecessor = judge_preconditions(
+            object_store,
+            commit_handler,
+            &dataset.base,
+            &original_dataset.manifest_location,
+            &commit_config.preconditions,
+        )
+        .await?;
+
         // Recomputed every attempt: the rebase above may have rewritten the
         // transaction.
         let pb_transaction = pb::Transaction::from(&transaction);
@@ -1456,7 +1541,7 @@ pub(crate) async fn commit_transaction(
         )?;
 
         // Try to commit the manifest
-        let result = write_manifest_file(
+        let result = write_manifest_file_after(
             object_store,
             commit_handler,
             &dataset.base,
@@ -1469,6 +1554,7 @@ pub(crate) async fn commit_transaction(
             write_config,
             manifest_naming_scheme,
             inline_transaction.then(|| pb_transaction.into()),
+            predecessor.as_ref(),
         )
         .await;
 
@@ -1560,6 +1646,12 @@ pub(crate) async fn commit_transaction(
                 } else {
                     break;
                 }
+            }
+            // A refused reservation applied nothing; the outcome is known.
+            Err(CommitError::OtherError(err @ Error::PrerequisiteFailed { .. })) => {
+                cleanup_transaction_file(object_store, &dataset.base, &current_transaction_file)
+                    .await;
+                return Err(err);
             }
             Err(CommitError::OtherError(err)) => {
                 match verify_commit_outcome(

--- a/rust/lance/src/session/caches.rs
+++ b/rust/lance/src/session/caches.rs
@@ -66,16 +66,24 @@ impl Deref for DSMetadataCache {
 pub struct ManifestKey<'a> {
     pub version: u64,
     pub e_tag: Option<&'a str>,
+    /// `ManifestLocation::identity`: a recreated dataset reuses versions,
+    /// and without an e_tag the version alone would hit the old manifest.
+    pub identity: Option<&'a str>,
 }
 
 impl CacheKey for ManifestKey<'_> {
     type ValueType = Manifest;
     fn key(&self) -> Cow<'_, str> {
+        let mut key = format!("manifest/{}", self.version);
         if let Some(e_tag) = self.e_tag {
-            Cow::Owned(format!("manifest/{}/{}", self.version, e_tag))
-        } else {
-            Cow::Owned(format!("manifest/{}", self.version))
+            key.push('/');
+            key.push_str(e_tag);
         }
+        if let Some(identity) = self.identity {
+            key.push_str("/id/");
+            key.push_str(identity);
+        }
+        Cow::Owned(key)
     }
     fn type_name() -> &'static str {
         "Manifest"
@@ -93,18 +101,29 @@ impl CacheKey for ManifestKey<'_> {
         } else {
             builder.write_none();
         }
+        if let Some(identity) = self.identity {
+            builder.write_some();
+            builder.write_str(identity);
+        } else {
+            builder.write_none();
+        }
     }
 }
 
 #[derive(Debug)]
-pub struct TransactionKey {
+pub struct TransactionKey<'a> {
     pub version: u64,
+    /// See [`ManifestKey::identity`].
+    pub identity: Option<&'a str>,
 }
 
-impl CacheKey for TransactionKey {
+impl CacheKey for TransactionKey<'_> {
     type ValueType = Transaction;
     fn key(&self) -> Cow<'_, str> {
-        Cow::Owned(format!("txn/{}", self.version))
+        match self.identity {
+            Some(identity) => Cow::Owned(format!("txn/{}/id/{}", self.version, identity)),
+            None => Cow::Owned(format!("txn/{}", self.version)),
+        }
     }
     fn type_name() -> &'static str {
         "Transaction"
@@ -116,6 +135,12 @@ impl CacheKey for TransactionKey {
 
     fn write_key(&self, builder: &mut KeyBuilder) {
         builder.write_u64(self.version);
+        if let Some(identity) = self.identity {
+            builder.write_some();
+            builder.write_str(identity);
+        } else {
+            builder.write_none();
+        }
     }
 }
 
@@ -290,6 +315,44 @@ mod tests {
     use lance_table::rowids::write_row_ids;
 
     use super::*;
+    use crate::session::index_caches::IndexMetadataKey;
+
+    /// A recreated dataset reuses version numbers, so every version-scoped
+    /// key separates on identity.
+    #[test]
+    fn version_scoped_keys_separate_on_identity() {
+        let a = ManifestKey {
+            version: 2,
+            e_tag: None,
+            identity: Some("a"),
+        };
+        let b = ManifestKey {
+            version: 2,
+            e_tag: None,
+            identity: Some("b"),
+        };
+        assert_ne!(a.key(), b.key());
+        let a = TransactionKey {
+            version: 2,
+            identity: Some("a"),
+        };
+        let b = TransactionKey {
+            version: 2,
+            identity: Some("b"),
+        };
+        assert_ne!(a.key(), b.key());
+        let a = IndexMetadataKey {
+            version: 2,
+            store_identity: "s",
+            identity: Some("a"),
+        };
+        let b = IndexMetadataKey {
+            version: 2,
+            store_identity: "s",
+            identity: Some("b"),
+        };
+        assert_ne!(a.key(), b.key());
+    }
 
     #[tokio::test]
     async fn deletion_file_key_separates_storage_bases() {

--- a/rust/lance/src/session/index_caches.rs
+++ b/rust/lance/src/session/index_caches.rs
@@ -120,18 +120,25 @@ impl CacheKey for FragReuseIndexKey<'_> {
 pub struct IndexMetadataKey<'a> {
     pub version: u64,
     pub store_identity: &'a str,
+    /// See `ManifestKey::identity`.
+    pub identity: Option<&'a str>,
 }
 
 impl CacheKey for IndexMetadataKey<'_> {
     type ValueType = Vec<IndexMetadata>;
 
     fn key(&self) -> Cow<'_, str> {
-        Cow::Owned(format!(
+        let mut key = format!(
             "{}:{}/{}",
             self.store_identity.len(),
             self.store_identity,
             self.version
-        ))
+        );
+        if let Some(identity) = self.identity {
+            key.push_str("/id/");
+            key.push_str(identity);
+        }
+        Cow::Owned(key)
     }
 
     fn type_name() -> &'static str {
@@ -145,6 +152,12 @@ impl CacheKey for IndexMetadataKey<'_> {
     fn write_key(&self, builder: &mut KeyBuilder) {
         builder.write_str(self.store_identity);
         builder.write_u64(self.version);
+        if let Some(identity) = self.identity {
+            builder.write_some();
+            builder.write_str(identity);
+        } else {
+            builder.write_none();
+        }
     }
 
     fn codec() -> Option<lance_core::cache::CacheCodec> {
@@ -200,10 +213,12 @@ mod tests {
         let first = IndexMetadataKey {
             version: 7,
             store_identity: "s3$first-options",
+            identity: None,
         };
         let second = IndexMetadataKey {
             version: 7,
             store_identity: "s3$second-options",
+            identity: None,
         };
 
         assert_ne!(first.key(), second.key());


### PR DESCRIPTION
`CommitBuilder::with_precondition` takes a `CommitPrecondition`, judged on
the latest manifest on every attempt; publication is then conditioned on
that manifest still being the predecessor through
`CommitHandler::commit_after`. The handle's version must also still carry
the identity it was loaded with, so a candidate is never built from a
deleted incarnation. Refusal is `PrerequisiteFailed`; handlers that cannot
decide it atomically, detached commits, dataset creation and URI
destinations (which resolve to whatever occupies the URI now) refuse the
option outright.

`RequiredSchemaMetadata` is the first precondition, with
`with_required_schema_metadata(key, value)` as shorthand. The session
manifest, transaction and index-metadata caches key on identity too, since
a recreated dataset reuses version numbers.
