### PR TITLE
fix(ci): stabilize test_scan_slice against page-cache state

### DIFF
--- a/python/python/ci_benchmarks/benchmarks/test_scan.py
+++ b/python/python/ci_benchmarks/benchmarks/test_scan.py
@@ -30,4 +30,9 @@ def test_scan_slice(benchmark, dataset):
         ds = lance.dataset(dataset_uri)
         ds.to_table(offset=num_rows - 100, limit=50)
 
-    benchmark.pedantic(bench, rounds=1, iterations=1)
+    # A single unwarmed round measures whatever page-cache state the preceding
+    # benchmarks left behind (test_full_scan alone cycles the dataset plus a
+    # full in-memory table through RAM), not the scan itself.  Warm up once and
+    # take several rounds so the recorded value tracks the code path
+    # deterministically (see issue #8289).
+    benchmark.pedantic(bench, rounds=5, iterations=1, warmup_rounds=1)


### PR DESCRIPTION
## Problem

`test_scan_slice[tpch]` measures a single unwarmed round (`rounds=1, iterations=1`), so its recorded value tracks whatever OS page-cache state the preceding benchmarks left behind — not the scan itself. The same slice reads ~2 ms warm and >100 ms cold on unchanged code.

The apparent ~20x regression in #8289 began exactly when the merge_insert (#8052) and data-overlay (#7544) suites were added ahead of `test_scan` in the session (both merged 2026-07-31, hours after the last "good" measured commit). The reader commits the issue names were tested directly and are not at fault:

- pylance 10.1.0-beta.2 (pre-window) vs 11.0.0-beta.1 (post-window) vs current main, same TPC-H dataset: identical wall time, identical `elapsed_compute`, identical IO (27 IOPS / 14,378 bytes for the full open+scan)
- Datasets written by pre- and post-window versions are byte-identical (879,168,372 data bytes; 2,771 column-metadata bytes) and read identically in all writer×reader combinations
- Reproduced at CI scale (SF-10, 59,986,052 rows): identical, ~2 ms on both sides of the window

Even within `test_scan.py` alone, the slice shot recorded right after `test_full_scan`'s multi-GB materialization reads ~3x slower than steady state, on every version equally. #8290's cached-search step at the same date is likely the same mechanism.

## Fix

Warm up once and record five rounds so the published statistics track the code path deterministically. Adds ~5 extra 2-4 ms reads per run, next to the 10 s `test_full_scan` beside it.

## Validation

Run against TPC-H SF-10 locally: before — one polluted 6.8 ms shot; after — five stable warm rounds (min 3.59 ms, median 4.16 ms). `ruff check` and `ruff format` pass.

Fixes #8289
