### PR TITLE
perf(fts): keep compound scorer in fast search

### DIFF
--- a/rust/lance/src/dataset/scanner.rs
+++ b/rust/lance/src/dataset/scanner.rs
@@ -4242,10 +4242,16 @@ impl Scanner {
                     self.fts_overlay_plan(&column, document_granularity, target_fragments),
                 )
                 .await?;
-                if !self.retain_target_fragments(unindexed_fragments).is_empty() {
+                let unindexed_fragments = self.retain_target_fragments(unindexed_fragments);
+                if !unindexed_fragments.is_empty()
+                    && (!self.fast_search || unindexed_fragments.len() == target_fragments.len())
+                {
                     // Flat and posting-backed leaves do not share a document
                     // domain, so preserve the exact fallback for partial index
-                    // coverage.
+                    // coverage. Fast search deliberately excludes unindexed
+                    // fragments, so its indexed-only domain remains valid for
+                    // the compound scorer when at least one target fragment is
+                    // indexed.
                     return Ok(None);
                 }
                 let segments = match overlay_plan {

--- a/rust/lance/src/dataset/scanner.rs
+++ b/rust/lance/src/dataset/scanner.rs
@@ -4254,6 +4254,10 @@ impl Scanner {
                     // indexed.
                     return Ok(None);
                 }
+                let unindexed_fragment_ids = unindexed_fragments
+                    .iter()
+                    .map(|fragment| fragment.id as u32)
+                    .collect::<RoaringBitmap>();
                 let segments = match overlay_plan {
                     FtsOverlayPlan::Unchanged(Some(segments)) => segments,
                     FtsOverlayPlan::Unchanged(None) => {
@@ -4302,7 +4306,7 @@ impl Scanner {
                     }
                 }
 
-                Ok(Some((column, segments)))
+                Ok(Some((column, segments, unindexed_fragment_ids)))
             }
         }))
         .await?;
@@ -4311,7 +4315,7 @@ impl Scanner {
         };
 
         if !cross_column {
-            let (_, segments) = segment_groups.into_iter().next().ok_or_else(|| {
+            let (_, segments, _) = segment_groups.into_iter().next().ok_or_else(|| {
                 Error::internal("compound scorer requires one column".to_string())
             })?;
             return Ok(Some(Arc::new(
@@ -4325,6 +4329,25 @@ impl Scanner {
                 .with_external_mask(self.external_row_mask.clone()),
             )));
         }
+
+        let mut coverage_groups = segment_groups.iter();
+        let Some((_, _, first_unindexed_fragments)) = coverage_groups.next() else {
+            return Ok(None);
+        };
+        if coverage_groups
+            .any(|(_, _, unindexed_fragments)| unindexed_fragments != first_unindexed_fragments)
+        {
+            // The cross-column scorer builds one shared prefilter. If column
+            // coverage differs, that prefilter's union can re-admit stale
+            // postings from a fragment invalidated only for another column.
+            // Keep the field-local fallback, which preserves each column's
+            // own index domain.
+            return Ok(None);
+        }
+        let segment_groups = segment_groups
+            .into_iter()
+            .map(|(column, segments, _)| (column, segments))
+            .collect();
 
         let exec = CrossColumnCompoundQueryExec::new_with_segments(
             self.dataset.clone(),

--- a/rust/lance/src/dataset/tests/dataset_index.rs
+++ b/rust/lance/src/dataset/tests/dataset_index.rs
@@ -2649,7 +2649,7 @@ async fn test_same_column_compound_fast_search_excludes_unindexed_rows() {
     let unindexed_fragment = dataset.get_fragments().last().unwrap().clone();
     let mut unindexed_only_scanner = dataset.scan();
     unindexed_only_scanner
-        .with_fragments(vec![unindexed_fragment])
+        .with_fragments(vec![unindexed_fragment.into()])
         .full_text_search(FullTextSearchQuery::new_query(query))
         .unwrap()
         .fast_search();

--- a/rust/lance/src/dataset/tests/dataset_index.rs
+++ b/rust/lance/src/dataset/tests/dataset_index.rs
@@ -1850,6 +1850,28 @@ async fn test_top_level_cross_column_multimatch_uses_field_local_compound_scorer
         partial_plan.contains("FlatMatchQuery"),
         "the partially covered body should use the exact indexed-plus-flat fallback:\n{partial_plan}"
     );
+
+    let mut fast_scanner = partial_dataset.scan();
+    fast_scanner
+        .with_row_id()
+        .full_text_search(FullTextSearchQuery::new_query(explicit_query))
+        .unwrap()
+        .fast_search();
+    fast_scanner.limit(Some(LIMIT as i64), None).unwrap();
+    let fast_plan = fast_scanner.explain_plan(false).await.unwrap();
+    assert!(
+        !fast_plan.contains(CROSS_COLUMN_COMPOUND_FTS_SCORER),
+        "top-level MultiMatch should keep field scoring independent:\n{fast_plan}"
+    );
+    assert_eq!(
+        fast_plan.matches("CompoundFtsScorer").count(),
+        2,
+        "fast search should use a field-local compound scorer for both fields:\n{fast_plan}"
+    );
+    assert!(
+        !fast_plan.contains("FlatMatchQuery"),
+        "fast search must skip the partially covered body's flat path:\n{fast_plan}"
+    );
 }
 
 #[rstest]
@@ -2523,7 +2545,7 @@ async fn test_cross_column_compound_incomplete_coverage_uses_exact_fallback() {
     let actual = compound_fts_results(&dataset, query.clone(), Some(1)).await;
     assert_scored_rows_close("incomplete_coverage", &actual, &expected);
 
-    let plan = compound_fts_plan(&dataset, query, 1).await;
+    let plan = compound_fts_plan(&dataset, query.clone(), 1).await;
     assert!(
         !plan.contains(CROSS_COLUMN_COMPOUND_FTS_SCORER),
         "incomplete column coverage must not use the cross-column scorer:\n{plan}"
@@ -2531,6 +2553,119 @@ async fn test_cross_column_compound_incomplete_coverage_uses_exact_fallback() {
     assert!(
         plan.contains("BooleanQuery"),
         "incomplete column coverage should retain the exact fallback:\n{plan}"
+    );
+
+    let mut fast_scanner = dataset.scan();
+    fast_scanner
+        .with_row_id()
+        .full_text_search(FullTextSearchQuery::new_query(query))
+        .unwrap()
+        .fast_search();
+    fast_scanner.limit(Some(1), None).unwrap();
+    let fast_plan = fast_scanner.explain_plan(false).await.unwrap();
+    assert!(
+        fast_plan.contains(CROSS_COLUMN_COMPOUND_FTS_SCORER),
+        "fast search should use indexed-only cross-column scoring:\n{fast_plan}"
+    );
+    assert_eq!(
+        fast_scanner.try_into_batch().await.unwrap().num_rows(),
+        0,
+        "the only hit is unindexed in body and must be excluded by fast search"
+    );
+}
+
+#[tokio::test]
+async fn test_same_column_compound_fast_search_excludes_unindexed_rows() {
+    let initial = arrow_array::record_batch!(
+        ("text", Utf8, ["fresh alpha", "old noise"]),
+        ("id", Int32, [0, 1])
+    )
+    .unwrap();
+    let schema = initial.schema();
+    let mut dataset = Dataset::write(
+        RecordBatchIterator::new(vec![initial].into_iter().map(Ok), schema),
+        "memory://",
+        None,
+    )
+    .await
+    .unwrap();
+    create_fragmented_fts_index(&mut dataset, "text", true).await;
+
+    let appended =
+        arrow_array::record_batch!(("text", Utf8, ["fresh alpha"]), ("id", Int32, [2])).unwrap();
+    let schema = appended.schema();
+    dataset
+        .append(
+            RecordBatchIterator::new(vec![appended].into_iter().map(Ok), schema),
+            None,
+        )
+        .await
+        .unwrap();
+
+    let query: FtsQuery = BooleanQuery::new([
+        (Occur::Must, compound_match_query("fresh", "text", 1.0)),
+        (Occur::Must, compound_match_query("alpha", "text", 1.0)),
+    ])
+    .into();
+
+    let mut exact_scanner = dataset.scan();
+    exact_scanner
+        .project(&["id"])
+        .unwrap()
+        .full_text_search(FullTextSearchQuery::new_query(query.clone()))
+        .unwrap();
+    exact_scanner.limit(Some(2), None).unwrap();
+    let exact = exact_scanner.try_into_batch().await.unwrap();
+    assert_eq!(
+        exact["id"].as_primitive::<Int32Type>().values(),
+        &[0, 2],
+        "exact search should include the appended hit"
+    );
+
+    let mut fast_scanner = dataset.scan();
+    fast_scanner
+        .project(&["id"])
+        .unwrap()
+        .full_text_search(FullTextSearchQuery::new_query(query.clone()))
+        .unwrap()
+        .fast_search();
+    fast_scanner.limit(Some(2), None).unwrap();
+    let fast_plan = fast_scanner.explain_plan(false).await.unwrap();
+    assert!(
+        fast_plan.contains("CompoundFtsScorer"),
+        "fast search should keep the same-column compound scorer:\n{fast_plan}"
+    );
+    assert!(
+        !fast_plan.contains("FlatMatchQuery"),
+        "fast search must not plan a flat scan for unindexed rows:\n{fast_plan}"
+    );
+    let fast = fast_scanner.try_into_batch().await.unwrap();
+    assert_eq!(
+        fast["id"].as_primitive::<Int32Type>().values(),
+        &[0],
+        "fast search should return only the indexed hit"
+    );
+
+    let unindexed_fragment = dataset.get_fragments().last().unwrap().clone();
+    let mut unindexed_only_scanner = dataset.scan();
+    unindexed_only_scanner
+        .with_fragments(vec![unindexed_fragment])
+        .full_text_search(FullTextSearchQuery::new_query(query))
+        .unwrap()
+        .fast_search();
+    unindexed_only_scanner.limit(Some(2), None).unwrap();
+    let unindexed_only_plan = unindexed_only_scanner.explain_plan(false).await.unwrap();
+    assert!(
+        !unindexed_only_plan.contains("CompoundFtsScorer"),
+        "an entirely unindexed target must not build a compound scorer:\n{unindexed_only_plan}"
+    );
+    assert_eq!(
+        unindexed_only_scanner
+            .try_into_batch()
+            .await
+            .unwrap()
+            .num_rows(),
+        0
     );
 }
 

--- a/rust/lance/src/dataset/tests/dataset_index.rs
+++ b/rust/lance/src/dataset/tests/dataset_index.rs
@@ -1836,7 +1836,7 @@ async fn test_top_level_cross_column_multimatch_uses_field_local_compound_scorer
         LIMIT,
     )
     .await;
-    let partial_plan = compound_fts_plan(&partial_dataset, explicit_query, LIMIT).await;
+    let partial_plan = compound_fts_plan(&partial_dataset, explicit_query.clone(), LIMIT).await;
     assert!(
         !partial_plan.contains(CROSS_COLUMN_COMPOUND_FTS_SCORER),
         "top-level MultiMatch should keep field scoring independent:\n{partial_plan}"
@@ -2564,8 +2564,12 @@ async fn test_cross_column_compound_incomplete_coverage_uses_exact_fallback() {
     fast_scanner.limit(Some(1), None).unwrap();
     let fast_plan = fast_scanner.explain_plan(false).await.unwrap();
     assert!(
-        fast_plan.contains(CROSS_COLUMN_COMPOUND_FTS_SCORER),
-        "fast search should use indexed-only cross-column scoring:\n{fast_plan}"
+        !fast_plan.contains(CROSS_COLUMN_COMPOUND_FTS_SCORER),
+        "different per-column coverage must retain field-local masking:\n{fast_plan}"
+    );
+    assert!(
+        fast_plan.contains("BooleanQuery"),
+        "different per-column coverage should retain the field-local fallback:\n{fast_plan}"
     );
     assert_eq!(
         fast_scanner.try_into_batch().await.unwrap().num_rows(),

--- a/rust/lance/src/dataset/tests/dataset_merge_update.rs
+++ b/rust/lance/src/dataset/tests/dataset_merge_update.rs
@@ -21,6 +21,7 @@ use lance_index::IndexType;
 use lance_index::optimize::OptimizeOptions;
 use lance_index::scalar::FullTextSearchQuery;
 use lance_index::scalar::ScalarIndexParams;
+use lance_index::scalar::inverted::query::{BooleanQuery, FtsQuery, MatchQuery, Occur};
 use lance_index::scalar::inverted::tokenizer::InvertedIndexParams;
 use mock_instant::thread_local::MockClock;
 
@@ -2763,6 +2764,140 @@ async fn test_fts_stale_entries_after_data_replacement() {
         .await
         .unwrap();
     assert_eq!(results.num_rows(), 1);
+}
+
+/// Cross-column compound fast search must not combine different column-local
+/// fragment domains after a partial data replacement.
+#[tokio::test]
+async fn test_cross_column_fast_search_blocks_column_local_stale_postings() {
+    let schema = Arc::new(ArrowSchema::new(vec![
+        ArrowField::new("id", DataType::Int32, false),
+        ArrowField::new("title", DataType::Utf8, false),
+        ArrowField::new("body", DataType::Utf8, false),
+    ]));
+    let batch = RecordBatch::try_new(
+        schema.clone(),
+        vec![
+            Arc::new(Int32Array::from(vec![0, 1])),
+            Arc::new(StringArray::from(vec!["noise", "target"])),
+            Arc::new(StringArray::from(vec!["noise", "stale"])),
+        ],
+    )
+    .unwrap();
+    let reader = RecordBatchIterator::new(vec![Ok(batch)], schema);
+    let mut dataset = Dataset::write(
+        reader,
+        "memory://cross_column_fast_search_replacement",
+        Some(WriteParams {
+            max_rows_per_file: 1,
+            ..Default::default()
+        }),
+    )
+    .await
+    .unwrap();
+
+    for column in ["title", "body"] {
+        dataset
+            .create_index(
+                &[column],
+                IndexType::Inverted,
+                None,
+                &InvertedIndexParams::default(),
+                true,
+            )
+            .await
+            .unwrap();
+    }
+
+    let body_schema = Arc::new(ArrowSchema::new(vec![ArrowField::new(
+        "body",
+        DataType::Utf8,
+        false,
+    )]));
+    let replacement = RecordBatch::try_new(
+        body_schema.clone(),
+        vec![Arc::new(StringArray::from(vec!["fresh"]))],
+    )
+    .unwrap();
+    let replacement_path = dataset.data_dir().join("body_replacement.lance");
+    let object_writer = dataset
+        .object_store
+        .create(&replacement_path)
+        .await
+        .unwrap();
+    let mut writer = lance_file::versions::v2_1::create_writer(
+        object_writer,
+        body_schema.as_ref().try_into().unwrap(),
+        Default::default(),
+    )
+    .unwrap();
+    writer.write_batch(&replacement).await.unwrap();
+    writer.finish().await.unwrap();
+
+    let (file_major_version, file_minor_version) =
+        LanceFileVersion::Stable.resolve().to_data_file_numbers();
+    let replacement_file = DataFile {
+        path: "body_replacement.lance".to_string(),
+        fields: Arc::from([2]),
+        column_indices: Arc::from([0]),
+        file_major_version,
+        file_minor_version,
+        file_size_bytes: CachedFileSize::unknown(),
+        base_id: None,
+    };
+    let read_version = dataset.version().version;
+    let dataset = Dataset::commit(
+        WriteDestination::Dataset(Arc::new(dataset)),
+        Operation::DataReplacement {
+            replacements: vec![DataReplacementGroup(1, replacement_file)],
+        },
+        Some(read_version),
+        None,
+        None,
+        Arc::new(Default::default()),
+        false,
+    )
+    .await
+    .unwrap();
+
+    let match_query = |term: &str, column: &str| {
+        MatchQuery::new(term.to_owned())
+            .with_column(Some(column.to_owned()))
+            .into()
+    };
+    let query: FtsQuery = BooleanQuery::new([
+        (Occur::Must, match_query("target", "title")),
+        (Occur::Must, match_query("stale", "body")),
+    ])
+    .into();
+
+    let mut exact_scanner = dataset.scan();
+    exact_scanner
+        .full_text_search(FullTextSearchQuery::new_query(query.clone()))
+        .unwrap();
+    exact_scanner.limit(Some(10), None).unwrap();
+    assert_eq!(
+        exact_scanner.try_into_batch().await.unwrap().num_rows(),
+        0,
+        "the current body value must not match the stale term"
+    );
+
+    let mut fast_scanner = dataset.scan();
+    fast_scanner
+        .full_text_search(FullTextSearchQuery::new_query(query))
+        .unwrap()
+        .fast_search();
+    fast_scanner.limit(Some(10), None).unwrap();
+    let fast_plan = fast_scanner.explain_plan(false).await.unwrap();
+    assert!(
+        !fast_plan.contains("CrossColumnCompoundFtsScorer"),
+        "different per-column coverage must retain field-local masking:\n{fast_plan}"
+    );
+    assert_eq!(
+        fast_scanner.try_into_batch().await.unwrap().num_rows(),
+        0,
+        "the title index must not re-admit the body's stale physical posting"
+    );
 }
 
 /// Same scenario as test_fts_index_incremental_reindex_after_in_place_update

--- a/rust/lance/src/dataset/tests/dataset_overlay_index_masking.rs
+++ b/rust/lance/src/dataset/tests/dataset_overlay_index_masking.rs
@@ -19,7 +19,9 @@ use lance_index::optimize::OptimizeOptions;
 use lance_index::scalar::BuiltinIndexType;
 use lance_index::scalar::FullTextSearchQuery;
 use lance_index::scalar::ScalarIndexParams;
-use lance_index::scalar::inverted::query::{FtsQuery, MatchQuery, MultiMatchQuery, PhraseQuery};
+use lance_index::scalar::inverted::query::{
+    BooleanQuery, FtsQuery, MatchQuery, MultiMatchQuery, Occur, PhraseQuery,
+};
 use lance_index::scalar::inverted::{DocumentGranularity, InvertedIndexParams};
 use lance_io::utils::CachedFileSize;
 use lance_linalg::distance::MetricType;
@@ -1267,6 +1269,34 @@ async fn test_fts_overlay_row_level_masking_under_fast_search(
     assert_eq!(
         new_phrase_scan.try_into_batch().await.unwrap().num_rows(),
         0
+    );
+
+    let match_query = |terms: &str| {
+        MatchQuery::new(terms.to_owned())
+            .with_column(Some("text".to_owned()))
+            .into()
+    };
+    let compound_query: FtsQuery = BooleanQuery::new([
+        (Occur::Must, match_query("apple")),
+        (Occur::Should, match_query("pie")),
+    ])
+    .into();
+    let mut compound_scan = dataset.scan();
+    compound_scan
+        .full_text_search(FullTextSearchQuery::new_query(compound_query))
+        .unwrap();
+    compound_scan.project(&["id"]).unwrap();
+    compound_scan.fast_search();
+    compound_scan.limit(Some(10), None).unwrap();
+    let compound_plan = compound_scan.explain_plan(false).await.unwrap();
+    assert!(
+        !compound_plan.contains("CompoundFtsScorer"),
+        "overlay-stale rows must keep compound fast search on the masked fallback:\n{compound_plan}"
+    );
+    let compound_result = compound_scan.try_into_batch().await.unwrap();
+    assert_eq!(
+        ids_from_batches(std::slice::from_ref(&compound_result)),
+        vec![0]
     );
 }
 


### PR DESCRIPTION
## Performance issue

A compound FTS query currently drops to the leaf-by-leaf fallback whenever any target fragment is not covered by the index. This is unnecessary for `fast_search`: by contract, fast search excludes unindexed fragments, so partial append-only coverage still has a valid indexed-only document domain.

## Change

Keep the same-column or cross-column compound scorer when all of the following hold:

- `fast_search` is enabled;
- at least one target fragment is indexed;
- the uncovered fragments are the append-only unindexed tail.

Row-level/full-scan overlays, unknown coverage, and an entirely unindexed target retain the existing fallback. Tests cover same-column Boolean, cross-column compound, top-level MultiMatch, all-unindexed targets, and stale overlays.

## Benchmark

Measured on `yang-agent-fts-compound-20260819-c` (`c4-highmem-16`, `us-central1-c`) using the existing 10M-row multilingual code-column fixture plus one 100k-row unindexed append fragment. Both builds used 8 query workers and a 64 GiB cache. Results are the mean of two per-arm p50 measurements in ABBA order; lower latency is better.

Baseline: `main` at `87378db57f061975b4e0908ab9b17625b6dd5bf7`. This PR: `a9c8e7e6c0436ef19f55fa5f37ac5414d32d8280`.

| Scenario / metric | Baseline | This PR | Benefit |
| --- | ---: | ---: | ---: |
| `boost_negative`, k=10, warm p50 | 167.935 ms | 3.870 ms | 43.40x speedup |
| `boost_negative`, k=100, warm p50 | 168.611 ms | 7.646 ms | 22.05x speedup |
| `must_should`, k=10, warm p50 | 115.958 ms | 3.517 ms | 32.97x speedup |
| `must_should`, k=100, warm p50 | 116.493 ms | 4.079 ms | 28.56x speedup |
| `phrase_should`, k=10, warm p50 | 148.265 ms | 7.515 ms | 19.73x speedup |
| `phrase_should`, k=100, warm p50 | 148.680 ms | 17.832 ms | 8.34x speedup |
| `should_sum`, k=10, warm p50 | 3.643 ms | 3.337 ms | 1.09x speedup |
| `should_sum`, k=100, warm p50 | 4.346 ms | 3.911 ms | 1.11x speedup |

Correctness preflight and timed output validation covered 1,000 exact ordered row-ID plus f32-score-bit digests. There were zero intra-build mismatches and zero cross-build mismatches.

## Validation

- `cargo fmt --all -- --check`
- `git diff --check HEAD^ HEAD`
- Rust tests and clippy: delegated to CI as requested
- Full GitHub CI is green; Lance Gatekeeper is waiting for review approval
