### PR TITLE
feat(java): expose global BM25 statistics for FTS queries

### DIFF
--- a/java/lance-jni/src/blocking_dataset.rs
+++ b/java/lance-jni/src/blocking_dataset.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright The Lance Authors
 
+use crate::blocking_scanner::build_full_text_search_query;
 use crate::error::{Error, Result};
 use crate::ffi::JNIEnvExt;
 use crate::index_progress::JavaIndexBuildProgress;
@@ -52,6 +53,7 @@ use lance_file::version::LanceFileVersion;
 use lance_index::IndexCriteria as RustIndexCriteria;
 use lance_index::optimize::OptimizeOptions;
 use lance_index::progress::{IndexBuildProgress, noop_progress};
+use lance_index::scalar::FullTextSearchQuery;
 use lance_index::{IndexParams, IndexType};
 use lance_io::object_store::ObjectStoreRegistry;
 use lance_io::object_store::{LanceNamespaceStorageOptionsProvider, StorageOptionsProvider};
@@ -3930,6 +3932,37 @@ fn inner_get_index_statistics<'local>(
     };
     let jstats = env.new_string(stats_json)?;
     Ok(jstats)
+}
+
+#[unsafe(no_mangle)]
+pub extern "system" fn Java_org_lance_Dataset_nativeGetFtsGlobalStatistics(
+    mut env: JNIEnv,
+    java_dataset: JObject,
+    query_obj: JObject,
+) -> jbyteArray {
+    match inner_get_fts_global_statistics(&mut env, java_dataset, query_obj) {
+        Ok(byte_array) => byte_array,
+        Err(error) => {
+            error.throw(&mut env);
+            std::ptr::null_mut()
+        }
+    }
+}
+
+fn inner_get_fts_global_statistics(
+    env: &mut JNIEnv,
+    java_dataset: JObject,
+    query_obj: JObject,
+) -> Result<jbyteArray> {
+    let query = build_full_text_search_query(env, query_obj)?;
+    let mut scanner = {
+        let dataset_guard =
+            unsafe { env.get_rust_field::<_, _, BlockingDataset>(java_dataset, NATIVE_DATASET) }?;
+        dataset_guard.inner.scan()
+    };
+    scanner.full_text_search(FullTextSearchQuery::new_query(query))?;
+    let statistics = block_on(scanner.fts_global_statistics())?;
+    Ok(**env.byte_array_from_slice(&statistics)?)
 }
 
 #[unsafe(no_mangle)]

--- a/java/src/main/java/org/lance/Dataset.java
+++ b/java/src/main/java/org/lance/Dataset.java
@@ -28,6 +28,8 @@ import org.lance.index.IndexType;
 import org.lance.index.OptimizeOptions;
 import org.lance.index.scalar.ZoneStats;
 import org.lance.ipc.DataStatistics;
+import org.lance.ipc.FtsGlobalStatistics;
+import org.lance.ipc.FullTextQuery;
 import org.lance.ipc.LanceScanner;
 import org.lance.ipc.ScanOptions;
 import org.lance.memwal.InitializeMemWalParams;
@@ -1675,6 +1677,33 @@ public class Dataset implements Closeable {
   }
 
   private native String nativeGetIndexStatistics(String indexName);
+
+  /**
+   * Build global BM25 statistics for a full-text query across every committed segment of its
+   * logical FTS index.
+   *
+   * <p>The returned opaque protobuf is bound to this dataset version and the exact segment set. It
+   * does not include documents in unindexed fragments. Queries spanning more than one indexed
+   * column are not supported.
+   *
+   * <pre>{@code
+   * FtsGlobalStatistics statistics =
+   *     dataset.getFtsGlobalStatistics(FullTextQuery.match("hello", "text"));
+   * byte[] transportPayload = statistics.toBytes();
+   * }</pre>
+   *
+   * @param query full-text query whose token statistics should be collected
+   * @return opaque, protobuf-encoded global FTS statistics
+   */
+  public FtsGlobalStatistics getFtsGlobalStatistics(FullTextQuery query) {
+    Preconditions.checkNotNull(query, "query must not be null");
+    try (LockManager.ReadLock readLock = lockManager.acquireReadLock()) {
+      Preconditions.checkArgument(nativeDatasetHandle != 0, "Dataset is closed");
+      return FtsGlobalStatistics.fromBytes(nativeGetFtsGlobalStatistics(query));
+    }
+  }
+
+  private native byte[] nativeGetFtsGlobalStatistics(FullTextQuery query);
 
   /**
    * Describe indices on this dataset filtered by criteria.

--- a/java/src/main/java/org/lance/Dataset.java
+++ b/java/src/main/java/org/lance/Dataset.java
@@ -1683,8 +1683,9 @@ public class Dataset implements Closeable {
    * logical FTS index.
    *
    * <p>The returned opaque protobuf is bound to this dataset version and the exact segment set. It
-   * does not include documents in unindexed fragments. Queries spanning more than one indexed
-   * column are not supported.
+   * also preserves the prepared vocabulary and original token positions of every scoring query
+   * leaf, including fuzzy expansions. It does not include documents in unindexed fragments.
+   * Queries spanning more than one indexed column are not supported.
    *
    * <pre>{@code
    * FtsGlobalStatistics statistics =

--- a/java/src/main/java/org/lance/Dataset.java
+++ b/java/src/main/java/org/lance/Dataset.java
@@ -1684,8 +1684,10 @@ public class Dataset implements Closeable {
    *
    * <p>The returned opaque protobuf is bound to this dataset version and the exact segment set. It
    * also preserves the prepared vocabulary and original token positions of every scoring query
-   * leaf, including fuzzy expansions. It does not include documents in unindexed fragments.
-   * Queries spanning more than one indexed column are not supported.
+   * leaf, including fuzzy expansions. It does not include documents in unindexed fragments. Queries
+   * spanning more than one indexed column are not supported. The caller must attach the payload
+   * only to the same query used to produce it because V1 consumers cannot independently verify the
+   * source query identity.
    *
    * <pre>{@code
    * FtsGlobalStatistics statistics =

--- a/java/src/main/java/org/lance/ipc/FtsGlobalStatistics.java
+++ b/java/src/main/java/org/lance/ipc/FtsGlobalStatistics.java
@@ -20,8 +20,9 @@ import java.util.Objects;
  * Opaque protobuf-encoded global BM25 statistics for one full-text query.
  *
  * <p>The payload is bound to the dataset version, logical FTS index, exact committed segment set,
- * indexed column, document granularity, and query terms. It can be transported to another Lance
- * executor without exposing Rust scorer internals as a Java API.
+ * indexed column, document granularity, prepared query leaves, and their original token positions.
+ * It can be transported to another Lance executor without exposing Rust scorer internals as a Java
+ * API.
  */
 public final class FtsGlobalStatistics {
   private final byte[] protobuf;

--- a/java/src/main/java/org/lance/ipc/FtsGlobalStatistics.java
+++ b/java/src/main/java/org/lance/ipc/FtsGlobalStatistics.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.lance.ipc;
+
+import java.util.Arrays;
+import java.util.Objects;
+
+/**
+ * Opaque protobuf-encoded global BM25 statistics for one full-text query.
+ *
+ * <p>The payload is bound to the dataset version, logical FTS index, exact committed segment set,
+ * indexed column, document granularity, and query terms. It can be transported to another Lance
+ * executor without exposing Rust scorer internals as a Java API.
+ */
+public final class FtsGlobalStatistics {
+  private final byte[] protobuf;
+
+  private FtsGlobalStatistics(byte[] protobuf) {
+    Objects.requireNonNull(protobuf, "protobuf must not be null");
+    if (protobuf.length == 0) {
+      throw new IllegalArgumentException("protobuf must not be empty");
+    }
+    this.protobuf = Arrays.copyOf(protobuf, protobuf.length);
+  }
+
+  /** Reconstruct an opaque statistics handle received from another process. */
+  public static FtsGlobalStatistics fromBytes(byte[] protobuf) {
+    return new FtsGlobalStatistics(protobuf);
+  }
+
+  /** Return a defensive copy of the protobuf transport payload. */
+  public byte[] toBytes() {
+    return Arrays.copyOf(protobuf, protobuf.length);
+  }
+}

--- a/java/src/main/java/org/lance/ipc/FtsGlobalStatistics.java
+++ b/java/src/main/java/org/lance/ipc/FtsGlobalStatistics.java
@@ -22,7 +22,8 @@ import java.util.Objects;
  * <p>The payload is bound to the dataset version, logical FTS index, exact committed segment set,
  * indexed column, document granularity, prepared query leaves, and their original token positions.
  * It can be transported to another Lance executor without exposing Rust scorer internals as a Java
- * API.
+ * API. The caller must attach it only to the same query used to produce it because V1 consumers
+ * cannot independently verify the source query identity.
  */
 public final class FtsGlobalStatistics {
   private final byte[] protobuf;

--- a/java/src/test/java/org/lance/ipc/LanceScannerFullTextSearchTest.java
+++ b/java/src/test/java/org/lance/ipc/LanceScannerFullTextSearchTest.java
@@ -41,6 +41,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Collections;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -53,6 +54,15 @@ class LanceScannerFullTextSearchTest {
         "memory://fts_java_match",
         FullTextQuery.match("hello", "doc", DocumentGranularity.ROW),
         2L);
+  }
+
+  @Test
+  void testGetFtsGlobalStatistics() throws Exception {
+    runFtsQuery(
+        "memory://fts_java_global_statistics",
+        FullTextQuery.match("hello", "doc", DocumentGranularity.ROW),
+        2L,
+        true);
   }
 
   @Test
@@ -108,6 +118,12 @@ class LanceScannerFullTextSearchTest {
   }
 
   private void runFtsQuery(String uri, FullTextQuery query, long expectedTotal) throws Exception {
+    runFtsQuery(uri, query, expectedTotal, false);
+  }
+
+  private void runFtsQuery(
+      String uri, FullTextQuery query, long expectedTotal, boolean verifyGlobalStatistics)
+      throws Exception {
 
     Schema schema =
         new Schema(
@@ -168,6 +184,13 @@ class LanceScannerFullTextSearchTest {
                         Collections.singletonList("title"), IndexType.INVERTED, indexParams)
                     .withIndexName("title_idx")
                     .build());
+
+            if (verifyGlobalStatistics) {
+              FtsGlobalStatistics statistics = dataset.getFtsGlobalStatistics(query);
+              byte[] encoded = statistics.toBytes();
+              assertTrue(encoded.length > 0);
+              assertArrayEquals(encoded, FtsGlobalStatistics.fromBytes(encoded).toBytes());
+            }
 
             ScanOptions scanOptions = new ScanOptions.Builder().fullTextQuery(query).build();
 

--- a/protos/fts.proto
+++ b/protos/fts.proto
@@ -21,10 +21,20 @@ enum FtsDocumentGranularity {
 // Query-bound corpus statistics used to calculate comparable BM25 scores
 // across independently searched subsets of one logical FTS index.
 //
+// V1 represents exactly one BM25 corpus. Every scoring leaf must resolve to
+// index_name, column, document_granularity, and the corpus identified by
+// segment_uuids. A producer must reject a query containing a leaf from another
+// index, column, or document granularity.
+//
+// This is an opaque payload for a trusted planning flow. V1 does not carry the
+// source query or its preparation parameters, so a consumer cannot
+// independently prove query identity. The planner must attach the payload only
+// to the same query used to produce it.
+//
 // A consumer must reject an unsupported schema_version, a missing required
 // optional scalar, an invalid segment UUID, non-canonical ordering, duplicate
-// entries, or metadata that does not match the dataset snapshot and query it
-// will execute.
+// entries, or metadata that does not match the dataset snapshot and logical
+// FTS index it will execute.
 message FtsGlobalStatisticsProto {
   // V1 consumers must reject UNSPECIFIED and unknown values.
   FtsGlobalStatisticsSchemaVersion schema_version = 1;
@@ -50,8 +60,9 @@ message FtsGlobalStatisticsProto {
   repeated FtsTermStatisticsProto terms = 8;
   // Document unit shared by every segment in segment_uuids.
   FtsDocumentGranularity document_granularity = 9;
-  // Canonical prepared vocabulary for every scoring leaf in the query. Entries
-  // are ordered by leaf_ordinal.
+  // Canonical prepared vocabulary for every scoring leaf in the query. Every
+  // leaf belongs to the single corpus described above; cross-corpus queries
+  // cannot be encoded in V1. Entries are ordered by leaf_ordinal.
   repeated FtsPreparedQueryLeafProto query_leaves = 10;
 }
 

--- a/protos/fts.proto
+++ b/protos/fts.proto
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+syntax = "proto3";
+
+package lance.pb;
+
+// Semantic version of the global FTS statistics wire contract.
+enum FtsGlobalStatisticsSchemaVersion {
+  FTS_GLOBAL_STATISTICS_SCHEMA_VERSION_UNSPECIFIED = 0;
+  FTS_GLOBAL_STATISTICS_SCHEMA_VERSION_V1 = 1;
+}
+
+// Unit represented by one document in the FTS index.
+enum FtsDocumentGranularity {
+  FTS_DOCUMENT_GRANULARITY_UNSPECIFIED = 0;
+  FTS_DOCUMENT_GRANULARITY_ROW = 1;
+  FTS_DOCUMENT_GRANULARITY_LIST_ELEMENT = 2;
+}
+
+// Query-bound corpus statistics used to calculate comparable BM25 scores
+// across independently searched subsets of one logical FTS index.
+//
+// A consumer must reject an unsupported schema_version, a missing required
+// optional scalar, an invalid segment UUID, non-canonical ordering, duplicate
+// entries, or metadata that does not match the dataset snapshot and query it
+// will execute.
+message FtsGlobalStatisticsProto {
+  // V1 consumers must reject UNSPECIFIED and unknown values.
+  FtsGlobalStatisticsSchemaVersion schema_version = 1;
+  // Dataset snapshot from which the committed FTS segments were resolved.
+  // Version zero is invalid.
+  uint64 dataset_version = 2;
+  // Logical FTS index shared by every UUID in segment_uuids.
+  string index_name = 3;
+  // Canonical indexed field path used by the query.
+  string column = 4;
+  // Exact committed segment set whose corpus statistics were aggregated.
+  // Each entry is a 16-byte UUID in RFC 4122 network byte order. Entries are
+  // unique and sorted lexicographically by their raw bytes.
+  repeated bytes segment_uuids = 5;
+  // Sum of indexed document lengths across segment_uuids. Presence is required
+  // in V1; zero is valid for an empty-token corpus.
+  optional uint64 total_tokens = 6;
+  // Number of indexed documents across segment_uuids. Presence is required in
+  // V1; zero is valid for an empty corpus.
+  optional uint64 num_docs = 7;
+  // Unique term statistics referenced by query_leaves. Entries are sorted
+  // lexicographically by the UTF-8 bytes of term.
+  repeated FtsTermStatisticsProto terms = 8;
+  // Document unit shared by every segment in segment_uuids.
+  FtsDocumentGranularity document_granularity = 9;
+  // Canonical prepared vocabulary for every scoring leaf in the query. Entries
+  // are ordered by leaf_ordinal.
+  repeated FtsPreparedQueryLeafProto query_leaves = 10;
+}
+
+// Corpus statistics for one unique prepared query term.
+message FtsTermStatisticsProto {
+  string term = 1;
+  // Number of indexed documents containing term. Presence is required in V1;
+  // zero is valid when an exact query term is absent from the corpus.
+  optional uint64 document_frequency = 2;
+}
+
+// Canonical prepared vocabulary for one Match or Phrase leaf.
+message FtsPreparedQueryLeafProto {
+  // Zero-based leaf identity in this canonical depth-first traversal:
+  // Match/Phrase emits one leaf; Boost visits positive then negative;
+  // MultiMatch visits match queries in input order; Boolean visits should,
+  // must, then must_not, preserving input order within each group. Presence is
+  // required in V1.
+  optional uint32 leaf_ordinal = 1;
+  // Final tokens selected against the complete segment set. Entries are unique
+  // by (query_position, term_index), ordered first by query_position and then
+  // by term_index.
+  repeated FtsPreparedTokenProto tokens = 2;
+  // Whether at least one final token remains for every original query position.
+  // Presence is required in V1. Consumers use false to preserve empty results
+  // for AND and Phrase leaves after capped fuzzy expansion.
+  optional bool has_all_query_positions = 3;
+}
+
+// One final token and the original query position to which it belongs.
+message FtsPreparedTokenProto {
+  // Zero-based index into FtsGlobalStatisticsProto.terms. Presence is required
+  // in V1.
+  optional uint32 term_index = 1;
+  // Position produced when the query leaf was tokenized. Fuzzy alternatives
+  // for the same source token share this value. Presence is required in V1.
+  optional uint32 query_position = 2;
+}

--- a/rust/lance-index/src/scalar/inverted.rs
+++ b/rust/lance-index/src/scalar/inverted.rs
@@ -24,10 +24,10 @@ use arrow_schema::{DataType, Field};
 use async_trait::async_trait;
 pub use builder::InvertedIndexBuilder;
 pub use compound::{
-    build_global_bm25_scorer_for_query, compound_search, compound_search_prepared_match,
+    PreparedFtsGlobalStatistics, compound_search, compound_search_prepared_match,
     compound_search_prepared_match_with_score_floor, compound_search_with_base_scorer,
     compound_search_with_base_scorer_and_score_floor, exclusive_scaled_score_floor,
-    materialized_compound_top_k,
+    materialized_compound_top_k, prepare_fts_global_statistics,
 };
 #[doc(hidden)]
 pub use cross_column::cross_column_compound_search;
@@ -87,7 +87,8 @@ impl PreparedBm25Query {
         &self.scorer
     }
 
-    pub(crate) fn has_all_query_positions(&self) -> bool {
+    #[doc(hidden)]
+    pub fn has_all_query_positions(&self) -> bool {
         self.has_all_query_positions
     }
 }

--- a/rust/lance-index/src/scalar/inverted.rs
+++ b/rust/lance-index/src/scalar/inverted.rs
@@ -24,7 +24,7 @@ use arrow_schema::{DataType, Field};
 use async_trait::async_trait;
 pub use builder::InvertedIndexBuilder;
 pub use compound::{
-    compound_search, compound_search_prepared_match,
+    build_global_bm25_scorer_for_query, compound_search, compound_search_prepared_match,
     compound_search_prepared_match_with_score_floor, compound_search_with_base_scorer,
     compound_search_with_base_scorer_and_score_floor, exclusive_scaled_score_floor,
     materialized_compound_top_k,

--- a/rust/lance-index/src/scalar/inverted/compound.rs
+++ b/rust/lance-index/src/scalar/inverted/compound.rs
@@ -3773,6 +3773,91 @@ pub(super) fn collect_leaf_queries(query: &FtsQuery, leaves: &mut Vec<LeafQuery>
     Ok(())
 }
 
+/// Build one corpus-wide BM25 scorer containing every term required by a
+/// one-column FTS query.
+///
+/// Compound queries can contain multiple leaves with different fuzzy and
+/// phrase parameters. This helper applies each leaf's effective parameters,
+/// collects fuzzy expansions across every supplied segment, and returns one
+/// scorer whose term table is complete for later injection into any subset of
+/// those segments.
+///
+/// ```no_run
+/// # use std::sync::Arc;
+/// # use lance_core::Result;
+/// # use lance_index::scalar::inverted::{
+/// #     InvertedIndex, build_global_bm25_scorer_for_query,
+/// #     query::{FtsQuery, FtsSearchParams},
+/// # };
+/// # async fn example(
+/// #     indices: &[Arc<InvertedIndex>],
+/// #     query: &FtsQuery,
+/// #     params: &FtsSearchParams,
+/// # ) -> Result<()> {
+/// let scorer = build_global_bm25_scorer_for_query(indices, query, params, None).await?;
+/// assert!(scorer.num_docs() > 0);
+/// # Ok(())
+/// # }
+/// ```
+pub async fn build_global_bm25_scorer_for_query(
+    indices: &[Arc<InvertedIndex>],
+    query: &FtsQuery,
+    params: &FtsSearchParams,
+    metrics: Option<&dyn MetricsCollector>,
+) -> Result<MemBM25Scorer> {
+    let first_index = indices
+        .first()
+        .ok_or_else(|| Error::invalid_input("FTS index requires at least one segment"))?;
+    let mut leaf_queries = Vec::new();
+    collect_leaf_queries(query, &mut leaf_queries)?;
+    if leaf_queries.is_empty() {
+        return Err(Error::invalid_input(
+            "FTS query must contain at least one scoring leaf",
+        ));
+    }
+
+    let mut combined: Option<MemBM25Scorer> = None;
+    for leaf in leaf_queries {
+        let effective_params = leaf.effective_params(params);
+        let tokens = tokenize_leaf(first_index, &leaf, &effective_params);
+        let prepared =
+            prepare_bm25_query(indices, tokens, &effective_params, metrics, None).await?;
+        let leaf_scorer = prepared.scorer().as_ref().clone();
+        match &mut combined {
+            None => combined = Some(leaf_scorer),
+            Some(combined) => {
+                if combined.total_tokens != leaf_scorer.total_tokens
+                    || combined.num_docs != leaf_scorer.num_docs
+                {
+                    return Err(Error::internal(
+                        "FTS query leaves produced inconsistent corpus statistics",
+                    ));
+                }
+                for (term, document_frequency) in leaf_scorer.token_docs {
+                    match combined.token_docs.entry(term) {
+                        std::collections::hash_map::Entry::Vacant(entry) => {
+                            entry.insert(document_frequency);
+                        }
+                        std::collections::hash_map::Entry::Occupied(entry)
+                            if *entry.get() != document_frequency =>
+                        {
+                            return Err(Error::internal(format!(
+                                "FTS term '{}' produced inconsistent document frequencies {} and {}",
+                                entry.key(),
+                                entry.get(),
+                                document_frequency
+                            )));
+                        }
+                        std::collections::hash_map::Entry::Occupied(_) => {}
+                    }
+                }
+            }
+        }
+    }
+
+    combined.ok_or_else(|| Error::internal("FTS global scorer was not initialized"))
+}
+
 struct PreparedLeaf {
     query: Arc<PreparedBm25Query>,
     params: Arc<FtsSearchParams>,

--- a/rust/lance-index/src/scalar/inverted/compound.rs
+++ b/rust/lance-index/src/scalar/inverted/compound.rs
@@ -3773,20 +3773,46 @@ pub(super) fn collect_leaf_queries(query: &FtsQuery, leaves: &mut Vec<LeafQuery>
     Ok(())
 }
 
-/// Build one corpus-wide BM25 scorer containing every term required by a
+/// Prepared query leaves and their shared corpus-wide BM25 scorer.
+///
+/// Leaf order follows [`collect_leaf_queries`], so callers can preserve the
+/// identity and original token positions of every scoring leaf when moving
+/// statistics between distributed executors.
+#[doc(hidden)]
+#[derive(Debug, Clone)]
+pub struct PreparedFtsGlobalStatistics {
+    scorer: Arc<MemBM25Scorer>,
+    query_leaves: Vec<PreparedBm25Query>,
+}
+
+impl PreparedFtsGlobalStatistics {
+    /// BM25 statistics covering every term referenced by `query_leaves`.
+    #[doc(hidden)]
+    pub fn scorer(&self) -> &Arc<MemBM25Scorer> {
+        &self.scorer
+    }
+
+    /// Canonically ordered prepared Match and Phrase leaves.
+    #[doc(hidden)]
+    pub fn query_leaves(&self) -> &[PreparedBm25Query] {
+        &self.query_leaves
+    }
+}
+
+/// Prepare every scoring leaf and one corpus-wide BM25 scorer for a
 /// one-column FTS query.
 ///
 /// Compound queries can contain multiple leaves with different fuzzy and
 /// phrase parameters. This helper applies each leaf's effective parameters,
-/// collects fuzzy expansions across every supplied segment, and returns one
-/// scorer whose term table is complete for later injection into any subset of
-/// those segments.
+/// collects fuzzy expansions across every supplied segment, and retains each
+/// leaf's final vocabulary and original query positions alongside a scorer
+/// whose term table is complete for every leaf.
 ///
 /// ```no_run
 /// # use std::sync::Arc;
 /// # use lance_core::Result;
 /// # use lance_index::scalar::inverted::{
-/// #     InvertedIndex, build_global_bm25_scorer_for_query,
+/// #     InvertedIndex, prepare_fts_global_statistics,
 /// #     query::{FtsQuery, FtsSearchParams},
 /// # };
 /// # async fn example(
@@ -3794,17 +3820,18 @@ pub(super) fn collect_leaf_queries(query: &FtsQuery, leaves: &mut Vec<LeafQuery>
 /// #     query: &FtsQuery,
 /// #     params: &FtsSearchParams,
 /// # ) -> Result<()> {
-/// let scorer = build_global_bm25_scorer_for_query(indices, query, params, None).await?;
-/// assert!(scorer.num_docs() > 0);
+/// let statistics = prepare_fts_global_statistics(indices, query, params, None).await?;
+/// assert!(statistics.scorer().num_docs() > 0);
+/// assert!(!statistics.query_leaves().is_empty());
 /// # Ok(())
 /// # }
 /// ```
-pub async fn build_global_bm25_scorer_for_query(
+pub async fn prepare_fts_global_statistics(
     indices: &[Arc<InvertedIndex>],
     query: &FtsQuery,
     params: &FtsSearchParams,
     metrics: Option<&dyn MetricsCollector>,
-) -> Result<MemBM25Scorer> {
+) -> Result<PreparedFtsGlobalStatistics> {
     let first_index = indices
         .first()
         .ok_or_else(|| Error::invalid_input("FTS index requires at least one segment"))?;
@@ -3817,6 +3844,7 @@ pub async fn build_global_bm25_scorer_for_query(
     }
 
     let mut combined: Option<MemBM25Scorer> = None;
+    let mut query_leaves = Vec::with_capacity(leaf_queries.len());
     for leaf in leaf_queries {
         let effective_params = leaf.effective_params(params);
         let tokens = tokenize_leaf(first_index, &leaf, &effective_params);
@@ -3853,9 +3881,15 @@ pub async fn build_global_bm25_scorer_for_query(
                 }
             }
         }
+        query_leaves.push(prepared);
     }
 
-    combined.ok_or_else(|| Error::internal("FTS global scorer was not initialized"))
+    let scorer =
+        combined.ok_or_else(|| Error::internal("FTS global scorer was not initialized"))?;
+    Ok(PreparedFtsGlobalStatistics {
+        scorer: Arc::new(scorer),
+        query_leaves,
+    })
 }
 
 struct PreparedLeaf {

--- a/rust/lance/build.rs
+++ b/rust/lance/build.rs
@@ -18,7 +18,7 @@ fn main() -> Result<()> {
     prost_build.extern_path(".lance.datafusion", "::lance_datafusion::pb");
     prost_build.protoc_arg("--experimental_allow_proto3_optional");
     prost_build.enable_type_names();
-    prost_build.compile_protos(&["./protos/ann.proto"], &["./protos"])?;
+    prost_build.compile_protos(&["./protos/ann.proto", "./protos/fts.proto"], &["./protos"])?;
 
     Ok(())
 }

--- a/rust/lance/src/dataset/scanner.rs
+++ b/rust/lance/src/dataset/scanner.rs
@@ -77,8 +77,7 @@ use lance_index::scalar::inverted::query::{
 };
 use lance_index::scalar::inverted::{
     DOC_INDEX_COL, DOC_INDEX_FIELD, DocumentGranularity, INVERTED_INDEX_VERSION_V2,
-    INVERTED_INDEX_VERSION_V3, SCORE_COL, SCORE_FIELD, build_global_bm25_scorer_for_query,
-    fts_schema,
+    INVERTED_INDEX_VERSION_V3, SCORE_COL, SCORE_FIELD, fts_schema, prepare_fts_global_statistics,
 };
 use lance_index::scalar::registry::VALUE_COLUMN_NAME;
 use lance_index::vector::{ApproxMode, DEFAULT_QUERY_PARALLELISM, DIST_COL, Query};
@@ -1745,8 +1744,8 @@ impl Scanner {
         let indices =
             open_fts_segments(&self.dataset, &column, &segments, &NoOpMetricsCollector).await?;
         let params = query.params();
-        let scorer =
-            build_global_bm25_scorer_for_query(&indices, &query.query, &params, None).await?;
+        let prepared = prepare_fts_global_statistics(&indices, &query.query, &params, None).await?;
+        let scorer = prepared.scorer();
 
         let num_docs = u64::try_from(scorer.num_docs).map_err(|_| {
             Error::internal(format!(
@@ -1755,9 +1754,63 @@ impl Scanner {
             ))
         })?;
         let total_tokens = scorer.total_tokens;
-        let mut terms = scorer.token_docs.into_iter().collect::<Vec<_>>();
-        terms.sort_unstable_by(|left, right| left.0.cmp(&right.0));
-        let terms = terms
+        let mut term_statistics = scorer
+            .token_docs
+            .iter()
+            .map(|(term, document_frequency)| (term.clone(), *document_frequency))
+            .collect::<Vec<_>>();
+        term_statistics.sort_unstable_by(|left, right| left.0.cmp(&right.0));
+        let mut term_indices = HashMap::with_capacity(term_statistics.len());
+        for (term_index, (term, _)) in term_statistics.iter().enumerate() {
+            let term_index = u32::try_from(term_index).map_err(|_| {
+                Error::internal(format!(
+                    "FTS global term count {} exceeds u32::MAX",
+                    term_statistics.len()
+                ))
+            })?;
+            term_indices.insert(term.as_str(), term_index);
+        }
+        let query_leaves = prepared
+            .query_leaves()
+            .iter()
+            .enumerate()
+            .map(|(leaf_ordinal, prepared_leaf)| {
+                let leaf_ordinal = u32::try_from(leaf_ordinal).map_err(|_| {
+                    Error::internal(format!(
+                        "FTS prepared query leaf count {} exceeds u32::MAX",
+                        prepared.query_leaves().len()
+                    ))
+                })?;
+                let prepared_tokens = prepared_leaf.tokens();
+                let mut tokens = Vec::with_capacity(prepared_tokens.len());
+                for token_index in 0..prepared_tokens.len() {
+                    let term = prepared_tokens.get_token(token_index);
+                    let term_index = term_indices.get(term).copied().ok_or_else(|| {
+                        Error::internal(format!(
+                            "FTS prepared leaf {leaf_ordinal} references missing global term '{term}'"
+                        ))
+                    })?;
+                    tokens.push((prepared_tokens.position(token_index), term_index));
+                }
+                tokens.sort_unstable();
+                tokens.dedup();
+                let tokens = tokens
+                    .into_iter()
+                    .map(
+                        |(query_position, term_index)| crate::pb::FtsPreparedTokenProto {
+                            term_index: Some(term_index),
+                            query_position: Some(query_position),
+                        },
+                    )
+                    .collect();
+                Ok(crate::pb::FtsPreparedQueryLeafProto {
+                    leaf_ordinal: Some(leaf_ordinal),
+                    tokens,
+                    has_all_query_positions: Some(prepared_leaf.has_all_query_positions()),
+                })
+            })
+            .collect::<Result<Vec<_>>>()?;
+        let terms = term_statistics
             .into_iter()
             .map(|(term, document_frequency)| {
                 let document_frequency = u64::try_from(document_frequency).map_err(|_| {
@@ -1767,7 +1820,7 @@ impl Scanner {
                 })?;
                 Ok(crate::pb::FtsTermStatisticsProto {
                     term,
-                    document_frequency,
+                    document_frequency: Some(document_frequency),
                 })
             })
             .collect::<Result<Vec<_>>>()?;
@@ -1776,25 +1829,40 @@ impl Scanner {
             .ok_or_else(|| Error::internal("FTS index has no committed segments"))?
             .name
             .clone();
+        if let Some(segment) = segments.iter().find(|segment| segment.name != index_name) {
+            return Err(Error::internal(format!(
+                "FTS segment {} belongs to logical index '{}', expected '{}'",
+                segment.uuid, segment.name, index_name
+            )));
+        }
         let document_granularity = match document_granularity {
-            DocumentGranularity::Row => "row",
-            DocumentGranularity::ListElement => "list_element",
+            DocumentGranularity::Row => crate::pb::FtsDocumentGranularity::Row,
+            DocumentGranularity::ListElement => crate::pb::FtsDocumentGranularity::ListElement,
         };
         let mut segment_uuids = segments
-            .into_iter()
-            .map(|segment| segment.uuid.to_string())
+            .iter()
+            .map(|segment| segment.uuid.as_bytes().to_vec())
             .collect::<Vec<_>>();
         segment_uuids.sort_unstable();
+        if let Some(duplicate) = segment_uuids.windows(2).find(|uuids| uuids[0] == uuids[1]) {
+            return Err(Error::internal(format!(
+                "FTS logical index '{index_name}' contains duplicate segment UUID {}",
+                Uuid::from_slice(&duplicate[0]).map_err(|error| Error::internal(format!(
+                    "FTS segment UUID must contain 16 bytes: {error}"
+                )))?
+            )));
+        }
         Ok(crate::pb::FtsGlobalStatisticsProto {
-            format_version: crate::pb::FtsGlobalStatisticsFormatVersion::V1 as i32,
+            schema_version: crate::pb::FtsGlobalStatisticsSchemaVersion::V1 as i32,
             dataset_version: self.dataset.version_id(),
             index_name,
             column,
             segment_uuids,
-            total_tokens,
-            num_docs,
+            total_tokens: Some(total_tokens),
+            num_docs: Some(num_docs),
             terms,
-            document_granularity: document_granularity.to_string(),
+            document_granularity: document_granularity as i32,
+            query_leaves,
         }
         .encode_to_vec())
     }
@@ -16722,7 +16790,7 @@ full_filter=name LIKE Utf8(\"test%2\"), refine_filter=name LIKE Utf8(\"test%2\")
     }
 
     #[tokio::test]
-    async fn test_fts_global_statistics_cover_all_committed_segments() {
+    async fn test_fts_global_statistics_preserve_prepared_query() {
         let mut test_ds = TestVectorDataset::new(LanceFileVersion::Stable, false)
             .await
             .unwrap();
@@ -16740,33 +16808,118 @@ full_filter=name LIKE Utf8(\"test%2\"), refine_filter=name LIKE Utf8(\"test%2\")
         let statistics = crate::pb::FtsGlobalStatisticsProto::decode(encoded.as_slice()).unwrap();
 
         assert_eq!(
-            statistics.format_version,
-            crate::pb::FtsGlobalStatisticsFormatVersion::V1 as i32
+            statistics.schema_version,
+            crate::pb::FtsGlobalStatisticsSchemaVersion::V1 as i32
         );
         assert_eq!(statistics.dataset_version, test_ds.dataset.version_id());
         assert_eq!(statistics.index_name, "s_idx");
         assert_eq!(statistics.column, "s");
-        assert_eq!(statistics.document_granularity, "row");
+        assert_eq!(
+            statistics.document_granularity,
+            crate::pb::FtsDocumentGranularity::Row as i32
+        );
         assert_eq!(statistics.segment_uuids.len(), 2);
-        assert_eq!(statistics.num_docs, 400);
-        assert!(statistics.total_tokens > 0);
+        assert!(statistics.segment_uuids.iter().all(|uuid| uuid.len() == 16));
+        assert!(
+            statistics
+                .segment_uuids
+                .windows(2)
+                .all(|uuids| uuids[0] < uuids[1])
+        );
+        assert_eq!(statistics.num_docs, Some(400));
+        assert!(statistics.total_tokens.unwrap() > 0);
         let term_document_frequencies = statistics
             .terms
             .iter()
             .map(|term| (term.term.as_str(), term.document_frequency))
             .collect::<BTreeMap<_, _>>();
-        assert_eq!(term_document_frequencies.get("s"), Some(&400));
-        assert_eq!(term_document_frequencies.get("5"), Some(&1));
+        assert_eq!(term_document_frequencies.get("s"), Some(&Some(400)));
+        assert_eq!(term_document_frequencies.get("5"), Some(&Some(1)));
         assert!(
             statistics
                 .terms
                 .windows(2)
                 .all(|terms| terms[0].term < terms[1].term)
         );
+        assert_eq!(statistics.query_leaves.len(), 1);
+        let leaf = &statistics.query_leaves[0];
+        assert_eq!(leaf.leaf_ordinal, Some(0));
+        assert_eq!(leaf.has_all_query_positions, Some(true));
+        let leaf_tokens = leaf
+            .tokens
+            .iter()
+            .map(|token| {
+                (
+                    statistics.terms[token.term_index.unwrap() as usize]
+                        .term
+                        .as_str(),
+                    token.query_position.unwrap(),
+                )
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(leaf_tokens, [("s", 0), ("5", 1)]);
         assert_eq!(
             scanner.fts_global_statistics().await.unwrap(),
             encoded,
             "opaque statistics serialization must be deterministic"
+        );
+
+        let query: FtsQuery = BooleanQuery::new([
+            (
+                Occur::Should,
+                MatchQuery::new("s-5".to_string())
+                    .with_column(Some("s".to_string()))
+                    .into(),
+            ),
+            (
+                Occur::Must,
+                MatchQuery::new("s-205".to_string())
+                    .with_column(Some("s".to_string()))
+                    .with_fuzziness(Some(1))
+                    .with_max_expansions(50)
+                    .into(),
+            ),
+        ])
+        .into();
+        let mut compound_scanner = test_ds.dataset.scan();
+        compound_scanner
+            .full_text_search(FullTextSearchQuery::new_query(query))
+            .unwrap();
+        let compound_statistics = crate::pb::FtsGlobalStatisticsProto::decode(
+            compound_scanner
+                .fts_global_statistics()
+                .await
+                .unwrap()
+                .as_slice(),
+        )
+        .unwrap();
+        assert_eq!(compound_statistics.query_leaves.len(), 2);
+        assert_eq!(
+            compound_statistics
+                .query_leaves
+                .iter()
+                .map(|leaf| leaf.leaf_ordinal)
+                .collect::<Vec<_>>(),
+            [Some(0), Some(1)]
+        );
+        assert_eq!(
+            compound_statistics.query_leaves[0]
+                .tokens
+                .iter()
+                .map(|token| token.query_position.unwrap())
+                .collect::<BTreeSet<_>>(),
+            BTreeSet::from([0, 1])
+        );
+        let fuzzy_leaf = &compound_statistics.query_leaves[1];
+        assert_eq!(fuzzy_leaf.has_all_query_positions, Some(true));
+        assert!(fuzzy_leaf.tokens.len() > 2);
+        assert_eq!(
+            fuzzy_leaf
+                .tokens
+                .iter()
+                .map(|token| token.query_position.unwrap())
+                .collect::<BTreeSet<_>>(),
+            BTreeSet::from([0, 1])
         );
     }
 }

--- a/rust/lance/src/dataset/scanner.rs
+++ b/rust/lance/src/dataset/scanner.rs
@@ -77,7 +77,8 @@ use lance_index::scalar::inverted::query::{
 };
 use lance_index::scalar::inverted::{
     DOC_INDEX_COL, DOC_INDEX_FIELD, DocumentGranularity, INVERTED_INDEX_VERSION_V2,
-    INVERTED_INDEX_VERSION_V3, SCORE_COL, SCORE_FIELD, fts_schema,
+    INVERTED_INDEX_VERSION_V3, SCORE_COL, SCORE_FIELD, build_global_bm25_scorer_for_query,
+    fts_schema,
 };
 use lance_index::scalar::registry::VALUE_COLUMN_NAME;
 use lance_index::vector::{ApproxMode, DEFAULT_QUERY_PARALLELISM, DIST_COL, Query};
@@ -115,7 +116,7 @@ use crate::io::exec::filtered_read::{
 use crate::io::exec::fts::{
     BoostQueryExec, CompoundQueryExec, CrossColumnCompoundQueryExec, FlatMatchFilterExec,
     FlatMatchQueryExec, FtsDocumentExec, HybridCompoundQueryExec, MatchQueryExec, PhraseQueryExec,
-    SharedFtsScorer,
+    SharedFtsScorer, open_fts_segments,
 };
 use crate::io::exec::knn::MultivectorScoringExec;
 use crate::io::exec::scalar_index::{MaterializeIndexExec, ScalarIndexExec};
@@ -1681,6 +1682,115 @@ impl Scanner {
     pub fn full_text_search(&mut self, query: FullTextSearchQuery) -> Result<&mut Self> {
         self.full_text_query = Some(query);
         Ok(self)
+    }
+
+    /// Return opaque protobuf-encoded global BM25 statistics for this scanner's
+    /// full-text query.
+    ///
+    /// Statistics are aggregated across every committed physical segment of
+    /// the selected logical FTS index. The payload is bound to the current
+    /// dataset version, exact segment UUIDs, indexed column, document
+    /// granularity, and all query terms including fuzzy expansions. It does not
+    /// include documents in unindexed fragments.
+    ///
+    /// The query must resolve to exactly one indexed column. The returned bytes
+    /// are an opaque transport handle intended for Lance bindings and
+    /// distributed query planning.
+    ///
+    /// ```no_run
+    /// # use lance::{Dataset, Result};
+    /// # use lance_index::scalar::FullTextSearchQuery;
+    /// # async fn example(dataset: &Dataset) -> Result<()> {
+    /// let mut scanner = dataset.scan();
+    /// scanner.full_text_search(
+    ///     FullTextSearchQuery::new("hello".to_string()).with_column("text".to_string())?,
+    /// )?;
+    /// let statistics = scanner.fts_global_statistics().await?;
+    /// assert!(!statistics.is_empty());
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn fts_global_statistics(&self) -> Result<Vec<u8>> {
+        let query = self.full_text_query.as_ref().ok_or_else(|| {
+            Error::invalid_input("fts_global_statistics requires a full-text query")
+        })?;
+        let query = self.resolve_full_text_search_query(query).await?;
+        validate_fts_query_contract(&query.query)?;
+
+        let columns = query.columns();
+        if columns.len() != 1 {
+            return Err(Error::not_supported(format!(
+                "fts_global_statistics requires exactly one indexed column, got {}",
+                columns.len()
+            )));
+        }
+        let column = columns.into_iter().next().ok_or_else(|| {
+            Error::invalid_input("fts_global_statistics query does not reference a column")
+        })?;
+        let document_granularity = self.fts_document_granularity(&query.query)?;
+        let segments = load_segments(&self.dataset, &column, document_granularity)
+            .await?
+            .ok_or_else(|| {
+                Error::invalid_input(format!(
+                    "No Inverted index found for column {column} and document granularity {document_granularity:?}"
+                ))
+            })?;
+        load_segment_details(&self.dataset, &column, &segments).await?;
+        let indices =
+            open_fts_segments(&self.dataset, &column, &segments, &NoOpMetricsCollector).await?;
+        let params = query.params();
+        let scorer =
+            build_global_bm25_scorer_for_query(&indices, &query.query, &params, None).await?;
+
+        let num_docs = u64::try_from(scorer.num_docs).map_err(|_| {
+            Error::internal(format!(
+                "FTS document count {} exceeds u64::MAX",
+                scorer.num_docs
+            ))
+        })?;
+        let total_tokens = scorer.total_tokens;
+        let mut terms = scorer.token_docs.into_iter().collect::<Vec<_>>();
+        terms.sort_unstable_by(|left, right| left.0.cmp(&right.0));
+        let terms = terms
+            .into_iter()
+            .map(|(term, document_frequency)| {
+                let document_frequency = u64::try_from(document_frequency).map_err(|_| {
+                    Error::internal(format!(
+                        "FTS document frequency for term '{term}' exceeds u64::MAX"
+                    ))
+                })?;
+                Ok(crate::pb::FtsTermStatisticsProto {
+                    term,
+                    document_frequency,
+                })
+            })
+            .collect::<Result<Vec<_>>>()?;
+        let index_name = segments
+            .first()
+            .ok_or_else(|| Error::internal("FTS index has no committed segments"))?
+            .name
+            .clone();
+        let document_granularity = match document_granularity {
+            DocumentGranularity::Row => "row",
+            DocumentGranularity::ListElement => "list_element",
+        };
+        let mut segment_uuids = segments
+            .into_iter()
+            .map(|segment| segment.uuid.to_string())
+            .collect::<Vec<_>>();
+        segment_uuids.sort_unstable();
+        Ok(crate::pb::FtsGlobalStatisticsProto {
+            format_version: crate::pb::FtsGlobalStatisticsFormatVersion::V1 as i32,
+            dataset_version: self.dataset.version_id(),
+            index_name,
+            column,
+            segment_uuids,
+            total_tokens,
+            num_docs,
+            terms,
+            document_granularity: document_granularity.to_string(),
+        }
+        .encode_to_vec())
     }
 
     /// Set a filter using a Substrait ExtendedExpression message
@@ -7356,7 +7466,7 @@ pub mod test_dataset {
 #[cfg(test)]
 mod test {
 
-    use std::collections::BTreeSet;
+    use std::collections::{BTreeMap, BTreeSet};
     use std::time::{Duration, Instant};
     use std::vec;
 
@@ -16603,5 +16713,50 @@ full_filter=name LIKE Utf8(\"test%2\"), refine_filter=name LIKE Utf8(\"test%2\")
                 .as_primitive::<Int32Type>();
             assert_eq!(i_array.values(), &[expected_i]);
         }
+    }
+
+    #[tokio::test]
+    async fn test_fts_global_statistics_cover_all_committed_segments() {
+        let mut test_ds = TestVectorDataset::new(LanceFileVersion::Stable, false)
+            .await
+            .unwrap();
+        test_ds.make_segmented_fts_index().await.unwrap();
+
+        let mut scanner = test_ds.dataset.scan();
+        scanner
+            .full_text_search(FullTextSearchQuery::new("s-5".into()))
+            .unwrap();
+        let encoded = scanner.fts_global_statistics().await.unwrap();
+        let statistics = crate::pb::FtsGlobalStatisticsProto::decode(encoded.as_slice()).unwrap();
+
+        assert_eq!(
+            statistics.format_version,
+            crate::pb::FtsGlobalStatisticsFormatVersion::V1 as i32
+        );
+        assert_eq!(statistics.dataset_version, test_ds.dataset.version_id());
+        assert_eq!(statistics.index_name, "s_idx");
+        assert_eq!(statistics.column, "s");
+        assert_eq!(statistics.document_granularity, "row");
+        assert_eq!(statistics.segment_uuids.len(), 2);
+        assert_eq!(statistics.num_docs, 400);
+        assert!(statistics.total_tokens > 0);
+        let term_document_frequencies = statistics
+            .terms
+            .iter()
+            .map(|term| (term.term.as_str(), term.document_frequency))
+            .collect::<BTreeMap<_, _>>();
+        assert_eq!(term_document_frequencies.get("s"), Some(&400));
+        assert_eq!(term_document_frequencies.get("5"), Some(&1));
+        assert!(
+            statistics
+                .terms
+                .windows(2)
+                .all(|terms| terms[0].term < terms[1].term)
+        );
+        assert_eq!(
+            scanner.fts_global_statistics().await.unwrap(),
+            encoded,
+            "opaque statistics serialization must be deterministic"
+        );
     }
 }

--- a/rust/lance/src/dataset/scanner.rs
+++ b/rust/lance/src/dataset/scanner.rs
@@ -1694,7 +1694,9 @@ impl Scanner {
     ///
     /// The query must resolve to exactly one indexed column. The returned bytes
     /// are an opaque transport handle intended for Lance bindings and
-    /// distributed query planning.
+    /// distributed query planning. The caller must attach them only to the same
+    /// query used to produce them; V1 consumers cannot independently verify the
+    /// source query identity.
     ///
     /// ```no_run
     /// # use lance::{Dataset, Result};
@@ -8354,6 +8356,16 @@ mod test {
             ])))
             .limit(Some(10))
         };
+
+        let mut statistics_scan = dataset.scan();
+        statistics_scan.full_text_search(cross_column()).unwrap();
+        let error = statistics_scan.fts_global_statistics().await.unwrap_err();
+        assert!(matches!(&error, Error::NotSupported { .. }));
+        assert!(
+            error
+                .to_string()
+                .contains("requires exactly one indexed column")
+        );
 
         let mut scan = dataset.scan();
         scan.full_text_search(cross_column()).unwrap();

--- a/rust/lance/src/dataset/scanner.rs
+++ b/rust/lance/src/dataset/scanner.rs
@@ -1724,10 +1724,16 @@ impl Scanner {
                 columns.len()
             )));
         }
-        let column = columns.into_iter().next().ok_or_else(|| {
+        let requested_column = columns.into_iter().next().ok_or_else(|| {
             Error::invalid_input("fts_global_statistics query does not reference a column")
         })?;
         let document_granularity = self.fts_document_granularity(&query.query)?;
+        let column = resolve_fts_field(
+            self.dataset.schema(),
+            &requested_column,
+            document_granularity,
+        )?
+        .canonical_path;
         let segments = load_segments(&self.dataset, &column, document_granularity)
             .await?
             .ok_or_else(|| {
@@ -16724,7 +16730,11 @@ full_filter=name LIKE Utf8(\"test%2\"), refine_filter=name LIKE Utf8(\"test%2\")
 
         let mut scanner = test_ds.dataset.scan();
         scanner
-            .full_text_search(FullTextSearchQuery::new("s-5".into()))
+            .full_text_search(
+                FullTextSearchQuery::new("s-5".into())
+                    .with_column("S".into())
+                    .unwrap(),
+            )
             .unwrap();
         let encoded = scanner.fts_global_statistics().await.unwrap();
         let statistics = crate::pb::FtsGlobalStatisticsProto::decode(encoded.as_slice()).unwrap();

--- a/rust/lance/src/io/exec/fts.rs
+++ b/rust/lance/src/io/exec/fts.rs
@@ -261,7 +261,7 @@ async fn open_fts_segment(
     dataset: &Dataset,
     column: &str,
     segment: &IndexMetadata,
-    metrics: &IndexMetrics,
+    metrics: &dyn MetricsCollector,
 ) -> Result<Arc<InvertedIndex>> {
     let index = dataset
         .open_scalar_index(column, &segment.uuid, metrics)
@@ -282,11 +282,11 @@ async fn open_fts_segment(
 ///
 /// Exact multi-segment BM25 still needs every segment's local corpus statistics, so the
 /// current correctness-first path opens each committed segment before scoring.
-async fn open_fts_segments(
+pub(crate) async fn open_fts_segments(
     dataset: &Dataset,
     column: &str,
     segments: &[IndexMetadata],
-    metrics: &IndexMetrics,
+    metrics: &dyn MetricsCollector,
 ) -> Result<Vec<Arc<InvertedIndex>>> {
     try_join_all(
         segments


### PR DESCRIPTION

  - Collect query-bound BM25 statistics across all committed segments of a single logical FTS index.
  - Preserve the prepared vocabulary and original token positions for each scoring leaf, including fuzzy expansions.
  - Expose the statistics through the Java/JNI API as an opaque protobuf payload.
  - Reject queries whose scoring leaves span multiple FTS corpora.

  This is the implementation for #8937 and depends on #8938.

  It supports the distributed FTS use case described in apache/doris#67435.