### PR TITLE
perf(fts): remove benchmark metrics from query hot paths

### DIFF
--- a/rust/lance-index-core/src/metrics.rs
+++ b/rust/lance-index-core/src/metrics.rs
@@ -3,63 +3,12 @@
 
 use std::sync::atomic::{AtomicUsize, Ordering};
 
-pub const AND_CANDIDATES_SEEN_METRIC: &str = "and_candidates_seen";
-pub const AND_CANDIDATES_PRUNED_BEFORE_RETURN_METRIC: &str = "and_candidates_pruned_before_return";
-pub const AND_FULL_SCORES_METRIC: &str = "and_full_scores";
-pub const FREQS_COLLECTED_METRIC: &str = "freqs_collected";
-pub const COMPOUND_ADDRESSES_RESOLVED_METRIC: &str = "compound_addresses_resolved";
-pub const COMPOUND_ADDRESS_RESOLUTION_BATCHES_METRIC: &str = "compound_address_resolution_batches";
-pub const COMPOUND_PEAK_ADDRESS_RESOLUTION_BATCH_SIZE_METRIC: &str =
-    "compound_peak_address_resolution_batch_size";
-pub const COMPOUND_SCORE_FLOOR_OVERFLOWS_METRIC: &str = "compound_score_floor_overflows";
-pub const COMPOUND_PEAK_BUFFERED_CANDIDATES_METRIC: &str = "compound_peak_buffered_candidates";
-pub const COMPOUND_SHOULD_SKIPPED_WINDOWS_METRIC: &str = "compound_should_skipped_windows";
-pub const COMPOUND_SHOULD_BOUND_RECOMPUTATIONS_METRIC: &str =
-    "compound_should_bound_recomputations";
-pub const COMPOUND_SHOULD_ESSENTIAL_EVALUATIONS_METRIC: &str =
-    "compound_should_essential_evaluations";
-pub const COMPOUND_SHOULD_NON_ESSENTIAL_EVALUATIONS_METRIC: &str =
-    "compound_should_non_essential_evaluations";
-pub const COMPOUND_PHRASE_EXACT_APPROXIMATIONS_METRIC: &str =
-    "compound_phrase_exact_approximations";
-pub const COMPOUND_PHRASE_SLOPPY_APPROXIMATIONS_METRIC: &str =
-    "compound_phrase_sloppy_approximations";
-pub const COMPOUND_PHRASE_EXACT_CONFIRMATIONS_METRIC: &str = "compound_phrase_exact_confirmations";
-pub const COMPOUND_PHRASE_SLOPPY_CONFIRMATIONS_METRIC: &str =
-    "compound_phrase_sloppy_confirmations";
-pub const COMPOUND_PHRASE_EXACT_CONFIRMATIONS_AVOIDED_METRIC: &str =
-    "compound_phrase_exact_confirmations_avoided";
-pub const COMPOUND_PHRASE_SLOPPY_CONFIRMATIONS_AVOIDED_METRIC: &str =
-    "compound_phrase_sloppy_confirmations_avoided";
-pub const CROSS_COLUMN_STAGED_ATTEMPTS_METRIC: &str = "cross_column_staged_attempts";
-pub const CROSS_COLUMN_STAGED_SUCCESSES_METRIC: &str = "cross_column_staged_successes";
-pub const CROSS_COLUMN_STAGED_FALLBACKS_METRIC: &str = "cross_column_staged_fallbacks";
-pub const CROSS_COLUMN_STAGED_CANDIDATES_METRIC: &str = "cross_column_staged_candidates";
-pub const WAND_EXACTNESS_CERTIFICATE_ATTEMPTS_METRIC: &str = "wand_exactness_certificate_attempts";
-pub const WAND_EXACTNESS_CERTIFICATE_STRICT_METRIC: &str = "wand_exactness_certificate_strict";
-pub const WAND_EXACTNESS_CERTIFICATE_EXHAUSTIVE_METRIC: &str =
-    "wand_exactness_certificate_exhaustive";
-pub const WAND_EXACTNESS_CERTIFICATE_FALLBACKS_METRIC: &str =
-    "wand_exactness_certificate_fallbacks";
-pub const WAND_EXACTNESS_CERTIFICATE_CANDIDATES_METRIC: &str =
-    "wand_exactness_certificate_candidates";
-pub const WAND_EXACTNESS_PROBE_MS_METRIC: &str = "wand_exactness_probe_ms";
-pub const WAND_EXACTNESS_PROBE_COMPARISONS_METRIC: &str = "wand_exactness_probe_comparisons";
-pub const WAND_TIE_COMPLETION_ATTEMPTS_METRIC: &str = "wand_tie_completion_attempts";
-pub const WAND_TIE_COMPLETION_SUCCESSES_METRIC: &str = "wand_tie_completion_successes";
-pub const WAND_TIE_COMPLETION_OVERFLOWS_METRIC: &str = "wand_tie_completion_overflows";
-pub const WAND_TIE_COMPLETION_CANDIDATES_METRIC: &str = "wand_tie_completion_candidates";
-pub const WAND_TIE_COMPLETION_ROW_ID_REPLACEMENTS_METRIC: &str =
-    "wand_tie_completion_row_id_replacements";
-pub const WAND_TIE_COMPLETION_MS_METRIC: &str = "wand_tie_completion_ms";
-pub const WAND_TIE_COMPLETION_COMPARISONS_METRIC: &str = "wand_tie_completion_comparisons";
-pub const WAND_SEEDED_FALLBACKS_METRIC: &str = "wand_seeded_fallbacks";
-pub const WAND_SEEDED_FALLBACK_MS_METRIC: &str = "wand_seeded_fallback_ms";
-pub const WAND_SEEDED_FALLBACK_COMPARISONS_METRIC: &str = "wand_seeded_fallback_comparisons";
-pub const NO_IMPACT_GLOBAL_SCORER_FALLBACKS_METRIC: &str = "no_impact_global_scorer_fallbacks";
 /// A trait used by the index to report metrics
 ///
-/// Callers can implement this trait to collect metrics
+/// Callers can implement this trait to collect metrics. Production collectors
+/// must stay coarse-grained: do not record per-document, posting, candidate, or
+/// window events here. Benchmark-only instrumentation belongs in test- or
+/// benchmark-local hooks.
 pub trait MetricsCollector: Send + Sync {
     /// Record partition loads
     ///
@@ -119,110 +68,6 @@ pub trait MetricsCollector: Send + Sync {
     fn record_index_cache_miss(&self) {
         self.record_index_cache_misses(1);
     }
-
-    /// Record AND candidates returned from WAND alignment to the scoring loop.
-    ///
-    /// This excludes candidates pruned before `next()` returns. Use this with
-    /// `record_and_candidates_pruned_before_return` to recover total aligned
-    /// AND candidates.
-    fn record_and_candidates_seen(&self, _num_candidates: usize) {}
-
-    /// Record AND candidates pruned during WAND alignment before `next()` returns.
-    fn record_and_candidates_pruned_before_return(&self, _num_candidates: usize) {}
-
-    fn record_and_full_scores(&self, _num_scores: usize) {}
-
-    fn record_freqs_collected(&self, _num_collections: usize) {}
-
-    /// Record compound FTS document addresses resolved for final row-ID ties.
-    fn record_compound_addresses_resolved(&self, _num_addresses: usize) {}
-
-    /// Record bounded compound FTS address-resolution batches.
-    fn record_compound_address_resolution_batches(&self, _num_batches: usize) {}
-
-    /// Record the largest compound FTS address-resolution batch.
-    fn record_compound_peak_address_resolution_batch_size(&self, _num_addresses: usize) {}
-
-    /// Record unresolved score floors that required a resolved-key retry.
-    fn record_compound_score_floor_overflows(&self, _num_overflows: usize) {}
-
-    /// Record a candidate-buffer high-water mark for compound FTS.
-    fn record_compound_peak_buffered_candidates(&self, _num_candidates: usize) {}
-
-    /// Record pure-SHOULD compound FTS windows skipped using score bounds.
-    fn record_compound_should_skipped_windows(&self, _num_windows: usize) {}
-
-    /// Record score-bound recomputations for pure-SHOULD compound FTS windows.
-    fn record_compound_should_bound_recomputations(&self, _num_recomputations: usize) {}
-
-    /// Record essential-clause evaluations for pure-SHOULD compound FTS.
-    fn record_compound_should_essential_evaluations(&self, _num_evaluations: usize) {}
-
-    /// Record non-essential-clause evaluations for pure-SHOULD compound FTS.
-    fn record_compound_should_non_essential_evaluations(&self, _num_evaluations: usize) {}
-
-    /// Record exact-phrase documents produced by the posting approximation.
-    fn record_compound_phrase_exact_approximations(&self, _num_approximations: usize) {}
-
-    /// Record sloppy-phrase documents produced by the posting approximation.
-    fn record_compound_phrase_sloppy_approximations(&self, _num_approximations: usize) {}
-
-    /// Record exact-phrase position confirmations.
-    fn record_compound_phrase_exact_confirmations(&self, _num_confirmations: usize) {}
-
-    /// Record sloppy-phrase position confirmations.
-    fn record_compound_phrase_sloppy_confirmations(&self, _num_confirmations: usize) {}
-
-    /// Record exact-phrase position confirmations avoided by a score bound.
-    fn record_compound_phrase_exact_confirmations_avoided(&self, _num_confirmations: usize) {}
-
-    /// Record sloppy-phrase position confirmations avoided by a score bound.
-    fn record_compound_phrase_sloppy_confirmations_avoided(&self, _num_confirmations: usize) {}
-
-    /// Record cross-column queries that attempted candidate-driven staging.
-    fn record_cross_column_staged_attempts(&self, _num_attempts: usize) {}
-
-    /// Record staged executions that produced a complete candidate set.
-    fn record_cross_column_staged_successes(&self, _num_successes: usize) {}
-
-    /// Record staged executions abandoned in favor of exact eager execution.
-    fn record_cross_column_staged_fallbacks(&self, _num_fallbacks: usize) {}
-
-    /// Record unique row-address candidates produced by successful staging.
-    fn record_cross_column_staged_candidates(&self, _num_candidates: usize) {}
-
-    /// Record root Match WAND executions that attempted a k+1 exactness certificate.
-    fn record_wand_exactness_certificate_attempts(&self, _num_attempts: usize) {}
-
-    /// Record certificates proven by a strict score gap after the kth result.
-    fn record_wand_exactness_certificate_strict(&self, _num_certificates: usize) {}
-
-    /// Record certificates proven because WAND exhausted all matching documents.
-    fn record_wand_exactness_certificate_exhaustive(&self, _num_certificates: usize) {}
-
-    /// Record ambiguous certificates that fell back to the exact compound scorer.
-    fn record_wand_exactness_certificate_fallbacks(&self, _num_fallbacks: usize) {}
-
-    /// Record WAND candidates returned to the certificate classifier.
-    fn record_wand_exactness_certificate_candidates(&self, _num_candidates: usize) {}
-
-    /// Record bounded WAND attempts to complete an ambiguous kth-score tie.
-    fn record_wand_tie_completion_attempts(&self, _num_attempts: usize) {}
-
-    /// Record kth-score ties completed without exact replay.
-    fn record_wand_tie_completion_successes(&self, _num_successes: usize) {}
-
-    /// Record kth-score ties that exceeded the bounded completion budget.
-    fn record_wand_tie_completion_overflows(&self, _num_overflows: usize) {}
-
-    /// Record candidates returned by bounded kth-score tie completion.
-    fn record_wand_tie_completion_candidates(&self, _num_candidates: usize) {}
-
-    /// Record exact replays seeded with an inclusive kth-score floor.
-    fn record_wand_seeded_fallbacks(&self, _num_fallbacks: usize) {}
-
-    /// Record partitions whose no-impact postings use scorer-derived bounds.
-    fn record_no_impact_global_scorer_fallbacks(&self, _num_fallbacks: usize) {}
 
     /// Returns an optional sink for recording exact I/O statistics (bytes read,
     /// IOPS, and requests) performed on behalf of this collector.

--- a/rust/lance-index/src/scalar/inverted/compound.rs
+++ b/rust/lance-index/src/scalar/inverted/compound.rs
@@ -284,9 +284,6 @@ pub(super) trait ComposableScorer: Send {
         false
     }
 
-    /// Report pending two-phase confirmations skipped by a doc-local bound.
-    fn record_confirmation_avoided(&mut self) {}
-
     fn matches(&mut self) -> Result<bool> {
         Ok(true)
     }
@@ -692,11 +689,7 @@ impl CompoundScorerPlan {
         }
     }
 
-    pub(super) fn build<'a>(
-        &self,
-        leaves: &mut [Option<BoxScorer<'a>>],
-        metrics: &'a dyn MetricsCollector,
-    ) -> Result<BoxScorer<'a>> {
+    pub(super) fn build<'a>(&self, leaves: &mut [Option<BoxScorer<'a>>]) -> Result<BoxScorer<'a>> {
         match self {
             Self::Leaf { index, boost } => {
                 let leaf = leaves
@@ -714,14 +707,14 @@ impl CompoundScorerPlan {
                 negative,
                 negative_boost,
             } => Ok(Box::new(BoostScorer::try_new(
-                positive.build(leaves, metrics)?,
-                negative.build(leaves, metrics)?,
+                positive.build(leaves)?,
+                negative.build(leaves)?,
                 *negative_boost,
             )?)),
             Self::MultiMatch(children) => Ok(Box::new(DisjunctionScorer::try_new(
                 children
                     .iter()
-                    .map(|child| child.build(leaves, metrics))
+                    .map(|child| child.build(leaves))
                     .collect::<Result<Vec<_>>>()?,
                 DisjunctionScore::Max,
             )?)),
@@ -729,19 +722,18 @@ impl CompoundScorerPlan {
                 should,
                 must,
                 must_not,
-            } => Ok(Box::new(BooleanScorer::try_new_with_metrics(
+            } => Ok(Box::new(BooleanScorer::try_new(
                 should
                     .iter()
-                    .map(|child| child.build(leaves, metrics))
+                    .map(|child| child.build(leaves))
                     .collect::<Result<Vec<_>>>()?,
                 must.iter()
-                    .map(|child| child.build(leaves, metrics))
+                    .map(|child| child.build(leaves))
                     .collect::<Result<Vec<_>>>()?,
                 must_not
                     .iter()
-                    .map(|child| child.build(leaves, metrics))
+                    .map(|child| child.build(leaves))
                     .collect::<Result<Vec<_>>>()?,
-                Some(metrics),
             )?)),
         }
     }
@@ -797,10 +789,6 @@ impl<D: WandDocuments + Sync> ComposableScorer for WandCursor<'_, D> {
 
     fn supports_doc_local_confirmation_pruning(&self) -> bool {
         self.match_cost().is_some()
-    }
-
-    fn record_confirmation_avoided(&mut self) {
-        WandCursor::record_confirmation_avoided(self)
     }
 
     fn matches(&mut self) -> Result<bool> {
@@ -1282,10 +1270,6 @@ impl ComposableScorer for RowAddressScorer<'_> {
 
     fn supports_doc_local_confirmation_pruning(&self) -> bool {
         self.source.supports_doc_local_confirmation_pruning()
-    }
-
-    fn record_confirmation_avoided(&mut self) {
-        self.source.record_confirmation_avoided()
     }
 
     fn matches(&mut self) -> Result<bool> {
@@ -1841,12 +1825,6 @@ impl ComposableScorer for RowAddressMergeScorer<'_> {
             .any(|source| source.supports_doc_local_confirmation_pruning())
     }
 
-    fn record_confirmation_avoided(&mut self) {
-        if let Ok(source) = self.current_source_mut() {
-            source.record_confirmation_avoided();
-        }
-    }
-
     fn matches(&mut self) -> Result<bool> {
         self.current_source_mut()?.matches()
     }
@@ -1964,7 +1942,6 @@ pub(super) struct TopKCollector<K = u64> {
     heap: BinaryHeap<HeapRow<K>>,
     competitive_score: Arc<CompetitiveScore>,
     tie_handling: TieHandling,
-    peak_buffered: usize,
 }
 
 impl<K: Copy + Ord> TopKCollector<K> {
@@ -2002,7 +1979,6 @@ impl<K: Copy + Ord> TopKCollector<K> {
             heap: BinaryHeap::with_capacity(limit.min(DEFAULT_BLOCK_SIZE)),
             competitive_score,
             tie_handling,
-            peak_buffered: 0,
         }
     }
 
@@ -2053,7 +2029,6 @@ impl<K: Copy + Ord> TopKCollector<K> {
                 }
             }
         }
-        self.peak_buffered = self.peak_buffered.max(self.heap.len());
         self.raise_competitive_score();
         CollectionStatus::Complete
     }
@@ -2130,7 +2105,6 @@ impl<K: Copy + Ord> TopKCollector<K> {
                     .current_score_upper_bound()?
                     .is_some_and(|upper| upper < min_score)
             {
-                scorer.record_confirmation_avoided();
                 doc = scorer.next()?;
                 continue;
             }
@@ -2346,10 +2320,6 @@ impl ComposableScorer for ScaleScorer<'_> {
 
     fn supports_doc_local_confirmation_pruning(&self) -> bool {
         self.child.supports_doc_local_confirmation_pruning()
-    }
-
-    fn record_confirmation_avoided(&mut self) {
-        self.child.record_confirmation_avoided()
     }
 
     fn matches(&mut self) -> Result<bool> {
@@ -2595,17 +2565,6 @@ impl ComposableScorer for DisjunctionScorer<'_> {
         self.children
             .iter()
             .any(|child| child.supports_doc_local_confirmation_pruning())
-    }
-
-    fn record_confirmation_avoided(&mut self) {
-        let Some(current) = self.current else {
-            return;
-        };
-        for child in &mut self.children {
-            if child.doc() == Some(current) {
-                child.record_confirmation_avoided();
-            }
-        }
     }
 
     fn matches(&mut self) -> Result<bool> {
@@ -2881,17 +2840,6 @@ impl ComposableScorer for RequiredConjunctionScorer<'_> {
             .any(|child| child.supports_doc_local_confirmation_pruning())
     }
 
-    fn record_confirmation_avoided(&mut self) {
-        let Some(current) = self.current else {
-            return;
-        };
-        for child in &mut self.children {
-            if child.doc() == Some(current) {
-                child.record_confirmation_avoided();
-            }
-        }
-    }
-
     fn matches(&mut self) -> Result<bool> {
         self.ensure_confirmed()
     }
@@ -3031,10 +2979,6 @@ impl ComposableScorer for BoostScorer<'_> {
 
     fn supports_doc_local_confirmation_pruning(&self) -> bool {
         self.positive.supports_doc_local_confirmation_pruning()
-    }
-
-    fn record_confirmation_avoided(&mut self) {
-        self.positive.record_confirmation_avoided()
     }
 
     fn matches(&mut self) -> Result<bool> {
@@ -3407,16 +3351,6 @@ impl ComposableScorer for ReqOptScorer<'_> {
             || self.optional.supports_doc_local_confirmation_pruning()
     }
 
-    fn record_confirmation_avoided(&mut self) {
-        let Some(current) = self.current else {
-            return;
-        };
-        self.required.record_confirmation_avoided();
-        if self.optional.doc() == Some(current) {
-            self.optional.record_confirmation_avoided();
-        }
-    }
-
     fn matches(&mut self) -> Result<bool> {
         self.ensure_confirmed()
     }
@@ -3447,20 +3381,10 @@ pub(super) struct BooleanScorer<'a> {
 }
 
 impl<'a> BooleanScorer<'a> {
-    #[cfg(test)]
     pub(super) fn try_new(
         should: Vec<BoxScorer<'a>>,
         must: Vec<BoxScorer<'a>>,
         must_not: Vec<BoxScorer<'a>>,
-    ) -> Result<Self> {
-        Self::try_new_with_metrics(should, must, must_not, None)
-    }
-
-    fn try_new_with_metrics(
-        should: Vec<BoxScorer<'a>>,
-        must: Vec<BoxScorer<'a>>,
-        must_not: Vec<BoxScorer<'a>>,
-        metrics: Option<&'a dyn MetricsCollector>,
     ) -> Result<Self> {
         let (driver, optional) = if must.is_empty() {
             if should.is_empty() {
@@ -3469,7 +3393,7 @@ impl<'a> BooleanScorer<'a> {
                 ));
             }
             let driver = if let Some(global_bounds) = ShouldMaxScoreScorer::global_bounds(&should) {
-                Box::new(ShouldMaxScoreScorer::new(should, global_bounds, metrics)) as BoxScorer<'a>
+                Box::new(ShouldMaxScoreScorer::new(should, global_bounds)) as BoxScorer<'a>
             } else {
                 Box::new(DisjunctionScorer::try_new(should, DisjunctionScore::Sum)?)
                     as BoxScorer<'a>
@@ -3720,23 +3644,6 @@ impl ComposableScorer for BooleanScorer<'_> {
 
     fn supports_doc_local_confirmation_pruning(&self) -> bool {
         self.defer_confirmation
-    }
-
-    fn record_confirmation_avoided(&mut self) {
-        let Some(current) = self.current else {
-            return;
-        };
-        self.driver.record_confirmation_avoided();
-        if let Some(optional) = &mut self.optional
-            && optional.doc() == Some(current)
-        {
-            optional.record_confirmation_avoided();
-        }
-        if let Some(prohibited) = &mut self.prohibited
-            && prohibited.doc() == Some(current)
-        {
-            prohibited.record_confirmation_avoided();
-        }
     }
 
     fn matches(&mut self) -> Result<bool> {
@@ -4080,7 +3987,7 @@ where
             Some(scorer)
         })
         .collect::<Vec<_>>();
-    let mut scorer = plan.build(&mut leaf_scorers, metrics)?;
+    let mut scorer = plan.build(&mut leaf_scorers)?;
     if leaf_scorers.iter().any(Option::is_some) {
         return Err(Error::internal(
             "compound FTS scorer did not consume every prepared leaf",
@@ -4126,7 +4033,6 @@ fn collect_loaded_partitions(
             } => {
                 let documents = ModernWandDocuments::filtered(lengths.as_ref(), &visibility);
                 if let Some(projection) = projection {
-                    let mut addresses_resolved = 0;
                     let status = collect_partition_with_documents(
                         &documents,
                         leaves,
@@ -4145,12 +4051,10 @@ fn collect_loaded_partitions(
                                     doc_id.get()
                                 ))
                             })?;
-                            addresses_resolved += 1;
                             Ok(row_id)
                         },
                     )?;
                     debug_assert_eq!(status, CollectionStatus::Complete);
-                    metrics.record_compound_addresses_resolved(addresses_resolved);
                 } else {
                     let max_buffered = collector
                         .limit
@@ -4174,7 +4078,6 @@ fn collect_loaded_partitions(
                             })?))
                         },
                     )?;
-                    metrics.record_compound_peak_buffered_candidates(local_collector.peak_buffered);
                     let boundary = match status {
                         CollectionStatus::Complete => {
                             PartitionCollectionBoundary::Deferred(DeferredCompoundRows {
@@ -4183,7 +4086,6 @@ fn collect_loaded_partitions(
                             })
                         }
                         CollectionStatus::ScoreFloorOverflow => {
-                            metrics.record_compound_score_floor_overflows(1);
                             PartitionCollectionBoundary::Overflow(OverflowedCompoundPartition {
                                 segment_ordinal,
                                 partition_ordinal,
@@ -4192,7 +4094,6 @@ fn collect_loaded_partitions(
                             })
                         }
                     };
-                    metrics.record_compound_peak_buffered_candidates(collector.peak_buffered);
                     return Ok(CollectedPartitions {
                         collector,
                         remaining: partitions.collect(),
@@ -4202,7 +4103,6 @@ fn collect_loaded_partitions(
             }
         }
     }
-    metrics.record_compound_peak_buffered_candidates(collector.peak_buffered);
     Ok(CollectedPartitions {
         collector,
         remaining: Vec::new(),
@@ -4213,7 +4113,6 @@ fn collect_loaded_partitions(
 async fn merge_resolved_compound_rows(
     collector: &mut TopKCollector<u64>,
     deferred: DeferredCompoundRows,
-    metrics: &dyn MetricsCollector,
 ) -> Result<()> {
     for rows in deferred.rows.chunks(SCORE_FLOOR_RESOLUTION_BATCH_SIZE) {
         let doc_ids = rows.iter().map(|row| row.row_id).collect::<Vec<_>>();
@@ -4225,9 +4124,6 @@ async fn merge_resolved_compound_rows(
                 rows.len()
             )));
         }
-        metrics.record_compound_address_resolution_batches(1);
-        metrics.record_compound_peak_address_resolution_batch_size(rows.len());
-        metrics.record_compound_addresses_resolved(addresses.len());
         for (row, row_id) in rows.iter().zip(addresses) {
             let status = collector.insert(ScoredRow {
                 row_id,
@@ -4236,7 +4132,6 @@ async fn merge_resolved_compound_rows(
             debug_assert_eq!(status, CollectionStatus::Complete);
         }
     }
-    metrics.record_compound_peak_buffered_candidates(collector.peak_buffered);
     Ok(())
 }
 
@@ -4483,8 +4378,7 @@ async fn compound_search_impl(
             partitions = collected.remaining;
             match collected.boundary {
                 Some(PartitionCollectionBoundary::Deferred(deferred)) => {
-                    merge_resolved_compound_rows(&mut collector, deferred, metrics.as_ref())
-                        .await?;
+                    merge_resolved_compound_rows(&mut collector, deferred).await?;
                 }
                 Some(PartitionCollectionBoundary::Overflow(overflow)) => {
                     let retry = reload_compound_partition_with_projection(
@@ -4570,101 +4464,9 @@ mod tests {
         }
     }
 
-    fn should_maxscore<'a>(
-        children: Vec<BoxScorer<'a>>,
-        metrics: Option<&'a dyn MetricsCollector>,
-    ) -> ShouldMaxScoreScorer<'a> {
+    fn should_maxscore<'a>(children: Vec<BoxScorer<'a>>) -> ShouldMaxScoreScorer<'a> {
         let global_bounds = ShouldMaxScoreScorer::global_bounds(&children).unwrap();
-        ShouldMaxScoreScorer::new(children, global_bounds, metrics)
-    }
-
-    #[derive(Default)]
-    struct ShouldMetrics {
-        reports: AtomicUsize,
-        skipped_windows: AtomicUsize,
-        bound_recomputations: AtomicUsize,
-        essential_evaluations: AtomicUsize,
-        non_essential_evaluations: AtomicUsize,
-    }
-
-    #[derive(Default)]
-    struct PhraseMetrics {
-        exact_approximations: AtomicUsize,
-        sloppy_approximations: AtomicUsize,
-        exact_confirmations: AtomicUsize,
-        sloppy_confirmations: AtomicUsize,
-        exact_confirmations_avoided: AtomicUsize,
-        sloppy_confirmations_avoided: AtomicUsize,
-    }
-
-    impl MetricsCollector for PhraseMetrics {
-        fn record_parts_loaded(&self, _num_parts: usize) {}
-
-        fn record_index_loads(&self, _num_loads: usize) {}
-
-        fn record_comparisons(&self, _num_comparisons: usize) {}
-
-        fn record_compound_phrase_exact_approximations(&self, num_approximations: usize) {
-            self.exact_approximations
-                .fetch_add(num_approximations, AtomicOrdering::Relaxed);
-        }
-
-        fn record_compound_phrase_sloppy_approximations(&self, num_approximations: usize) {
-            self.sloppy_approximations
-                .fetch_add(num_approximations, AtomicOrdering::Relaxed);
-        }
-
-        fn record_compound_phrase_exact_confirmations(&self, num_confirmations: usize) {
-            self.exact_confirmations
-                .fetch_add(num_confirmations, AtomicOrdering::Relaxed);
-        }
-
-        fn record_compound_phrase_sloppy_confirmations(&self, num_confirmations: usize) {
-            self.sloppy_confirmations
-                .fetch_add(num_confirmations, AtomicOrdering::Relaxed);
-        }
-
-        fn record_compound_phrase_exact_confirmations_avoided(&self, num_confirmations: usize) {
-            self.exact_confirmations_avoided
-                .fetch_add(num_confirmations, AtomicOrdering::Relaxed);
-        }
-
-        fn record_compound_phrase_sloppy_confirmations_avoided(&self, num_confirmations: usize) {
-            self.sloppy_confirmations_avoided
-                .fetch_add(num_confirmations, AtomicOrdering::Relaxed);
-        }
-    }
-
-    impl MetricsCollector for ShouldMetrics {
-        fn record_parts_loaded(&self, _num_parts: usize) {}
-
-        fn record_index_loads(&self, _num_loads: usize) {}
-
-        fn record_comparisons(&self, _num_comparisons: usize) {}
-
-        fn record_compound_should_skipped_windows(&self, num_windows: usize) {
-            self.reports.fetch_add(1, AtomicOrdering::Relaxed);
-            self.skipped_windows
-                .fetch_add(num_windows, AtomicOrdering::Relaxed);
-        }
-
-        fn record_compound_should_bound_recomputations(&self, num_recomputations: usize) {
-            self.reports.fetch_add(1, AtomicOrdering::Relaxed);
-            self.bound_recomputations
-                .fetch_add(num_recomputations, AtomicOrdering::Relaxed);
-        }
-
-        fn record_compound_should_essential_evaluations(&self, num_evaluations: usize) {
-            self.reports.fetch_add(1, AtomicOrdering::Relaxed);
-            self.essential_evaluations
-                .fetch_add(num_evaluations, AtomicOrdering::Relaxed);
-        }
-
-        fn record_compound_should_non_essential_evaluations(&self, num_evaluations: usize) {
-            self.reports.fetch_add(1, AtomicOrdering::Relaxed);
-            self.non_essential_evaluations
-                .fetch_add(num_evaluations, AtomicOrdering::Relaxed);
-        }
+        ShouldMaxScoreScorer::new(children, global_bounds)
     }
 
     #[test]
@@ -4905,7 +4707,6 @@ mod tests {
         has_doc_upper: bool,
         approximations: Arc<AtomicUsize>,
         confirmations: Arc<AtomicUsize>,
-        confirmations_avoided: Arc<AtomicUsize>,
     }
 
     impl ComposableScorer for TwoPhaseScorer {
@@ -4965,11 +4766,6 @@ mod tests {
             true
         }
 
-        fn record_confirmation_avoided(&mut self) {
-            self.confirmations_avoided
-                .fetch_add(1, AtomicOrdering::Relaxed);
-        }
-
         fn matches(&mut self) -> Result<bool> {
             self.confirmations.fetch_add(1, AtomicOrdering::Relaxed);
             Ok(self
@@ -4995,24 +4791,8 @@ mod tests {
         Arc<AtomicUsize>,
         Arc<AtomicUsize>,
     ) {
-        let (scorer, approximations, confirmations, _) =
-            two_phase_with_avoided(values, accepted, match_cost);
-        (scorer, approximations, confirmations)
-    }
-
-    fn two_phase_with_avoided(
-        values: &[(u64, f32)],
-        accepted: Vec<u64>,
-        match_cost: Option<f32>,
-    ) -> (
-        Box<dyn ComposableScorer>,
-        Arc<AtomicUsize>,
-        Arc<AtomicUsize>,
-        Arc<AtomicUsize>,
-    ) {
         let approximations = Arc::new(AtomicUsize::new(0));
         let confirmations = Arc::new(AtomicUsize::new(0));
-        let confirmations_avoided = Arc::new(AtomicUsize::new(0));
         let scorer = TwoPhaseScorer {
             inner: MaterializedScorer::try_new(rows(values)).unwrap(),
             accepted,
@@ -5020,14 +4800,8 @@ mod tests {
             has_doc_upper: true,
             approximations: approximations.clone(),
             confirmations: confirmations.clone(),
-            confirmations_avoided: confirmations_avoided.clone(),
         };
-        (
-            Box::new(scorer),
-            approximations,
-            confirmations,
-            confirmations_avoided,
-        )
+        (Box::new(scorer), approximations, confirmations)
     }
 
     fn two_phase_without_doc_upper(
@@ -5037,11 +4811,9 @@ mod tests {
         Box<dyn ComposableScorer>,
         Arc<AtomicUsize>,
         Arc<AtomicUsize>,
-        Arc<AtomicUsize>,
     ) {
         let approximations = Arc::new(AtomicUsize::new(0));
         let confirmations = Arc::new(AtomicUsize::new(0));
-        let confirmations_avoided = Arc::new(AtomicUsize::new(0));
         let scorer = TwoPhaseScorer {
             inner: MaterializedScorer::try_new(rows(values)).unwrap(),
             accepted,
@@ -5049,14 +4821,8 @@ mod tests {
             has_doc_upper: false,
             approximations: approximations.clone(),
             confirmations: confirmations.clone(),
-            confirmations_avoided: confirmations_avoided.clone(),
         };
-        (
-            Box::new(scorer),
-            approximations,
-            confirmations,
-            confirmations_avoided,
-        )
+        (Box::new(scorer), approximations, confirmations)
     }
 
     #[derive(Default)]
@@ -5133,10 +4899,6 @@ mod tests {
 
         fn supports_doc_local_confirmation_pruning(&self) -> bool {
             self.inner.supports_doc_local_confirmation_pruning()
-        }
-
-        fn record_confirmation_avoided(&mut self) {
-            self.inner.record_confirmation_avoided()
         }
 
         fn matches(&mut self) -> Result<bool> {
@@ -5931,7 +5693,7 @@ mod tests {
 
         for slop in [0, 2] {
             let params = FtsSearchParams::default().with_phrase_slop(Some(slop));
-            let metrics = PhraseMetrics::default();
+            let metrics = NoOpMetricsCollector;
             let phrase = zero_weight_wand(&documents, scorer.clone(), &params, &metrics);
             // The high-scoring sibling keeps the shared block competitive, while
             // doc 0 still has a combined doc-local upper below the score floor.
@@ -5949,42 +5711,12 @@ mod tests {
                     .unwrap(),
                 rows(&[(1, 2.0)])
             );
-
-            if slop == 0 {
-                assert_eq!(
-                    metrics.exact_approximations.load(AtomicOrdering::Relaxed),
-                    1
-                );
-                assert_eq!(metrics.exact_confirmations.load(AtomicOrdering::Relaxed), 0);
-                assert_eq!(
-                    metrics
-                        .exact_confirmations_avoided
-                        .load(AtomicOrdering::Relaxed),
-                    1
-                );
-            } else {
-                assert_eq!(
-                    metrics.sloppy_approximations.load(AtomicOrdering::Relaxed),
-                    1
-                );
-                assert_eq!(
-                    metrics.sloppy_confirmations.load(AtomicOrdering::Relaxed),
-                    0
-                );
-                assert_eq!(
-                    metrics
-                        .sloppy_confirmations_avoided
-                        .load(AtomicOrdering::Relaxed),
-                    1
-                );
-            }
         }
     }
 
     #[test]
     fn phrase_positive_boost_uses_positive_upper_before_confirmation() {
-        let (phrase, _, confirmations, confirmations_avoided) =
-            two_phase_with_avoided(&[(0, 2.0), (1, 10.0)], vec![1], Some(1.0));
+        let (phrase, _, confirmations) = two_phase(&[(0, 2.0), (1, 10.0)], vec![1], Some(1.0));
         let mut scorer = BoostScorer::try_new(phrase, materialized(&[(1, 1.0)]), 0.5).unwrap();
         let competitive_score = Arc::new(CompetitiveScore::default());
         competitive_score.raise(9.5);
@@ -5996,13 +5728,12 @@ mod tests {
             rows(&[(1, 9.5)])
         );
         assert_eq!(confirmations.load(AtomicOrdering::Relaxed), 1);
-        assert_eq!(confirmations_avoided.load(AtomicOrdering::Relaxed), 1);
     }
 
     #[test]
     fn phrase_must_not_never_contributes_to_score_upper_bound() {
-        let (prohibited, approximations, confirmations, confirmations_avoided) =
-            two_phase_with_avoided(&[(0, 100.0)], Vec::new(), Some(1.0));
+        let (prohibited, approximations, confirmations) =
+            two_phase(&[(0, 100.0)], Vec::new(), Some(1.0));
         let mut scorer = BooleanScorer::try_new(
             Vec::new(),
             vec![materialized(&[(0, 1.0), (1, 10.0)])],
@@ -6022,13 +5753,11 @@ mod tests {
         // phrase is never advanced, so it cannot inflate that upper bound.
         assert_eq!(approximations.load(AtomicOrdering::Relaxed), 0);
         assert_eq!(confirmations.load(AtomicOrdering::Relaxed), 0);
-        assert_eq!(confirmations_avoided.load(AtomicOrdering::Relaxed), 0);
     }
 
     #[test]
     fn signed_and_unknown_doc_bounds_use_exact_confirmation_fallback() {
-        let (signed_phrase, _, signed_confirmations, signed_avoided) =
-            two_phase_with_avoided(&[(0, 2.0)], vec![0], Some(1.0));
+        let (signed_phrase, _, signed_confirmations) = two_phase(&[(0, 2.0)], vec![0], Some(1.0));
         let signed_optional =
             Box::new(BoostScorer::try_new(signed_phrase, materialized(&[(0, 2.0)]), 2.0).unwrap());
         let mut signed = BooleanScorer::try_new(
@@ -6047,9 +5776,7 @@ mod tests {
                 .is_empty()
         );
         assert_eq!(signed_confirmations.load(AtomicOrdering::Relaxed), 1);
-        assert_eq!(signed_avoided.load(AtomicOrdering::Relaxed), 0);
-
-        let (unknown_phrase, approximations, confirmations, confirmations_avoided) =
+        let (unknown_phrase, approximations, confirmations) =
             two_phase_without_doc_upper(&[(0, 1.0), (1, 100.0)], vec![1]);
         let mut unknown = BooleanScorer::try_new(
             vec![unknown_phrase, materialized(&[(0, 0.0), (1, 0.0)])],
@@ -6068,15 +5795,14 @@ mod tests {
         );
         assert_eq!(approximations.load(AtomicOrdering::Relaxed), 2);
         assert_eq!(confirmations.load(AtomicOrdering::Relaxed), 2);
-        assert_eq!(confirmations_avoided.load(AtomicOrdering::Relaxed), 0);
     }
 
     #[test]
     fn row_address_merge_forwards_phrase_doc_bound_and_avoidance() {
         // Cross-column eager execution maps each leaf into row-address space
         // and merges disjoint sources through this same wrapper stack.
-        let (phrase, approximations, confirmations, confirmations_avoided) =
-            two_phase_with_avoided(&[(0, 2.0), (1, 10.0)], vec![1], Some(1.0));
+        let (phrase, approximations, confirmations) =
+            two_phase(&[(0, 2.0), (1, 10.0)], vec![1], Some(1.0));
         let mapped_phrase = Box::new(RowAddressScorer::new(
             phrase,
             ordered_row_address_projection_for_test(vec![100, 200]),
@@ -6097,7 +5823,6 @@ mod tests {
         );
         assert_eq!(approximations.load(AtomicOrdering::Relaxed), 2);
         assert_eq!(confirmations.load(AtomicOrdering::Relaxed), 1);
-        assert_eq!(confirmations_avoided.load(AtomicOrdering::Relaxed), 1);
     }
 
     #[test]
@@ -6110,8 +5835,7 @@ mod tests {
                 .upper(),
             floor
         );
-        let (phrase, _, confirmations, confirmations_avoided) =
-            two_phase_with_avoided(&[(7, exact_score)], vec![7], Some(1.0));
+        let (phrase, _, confirmations) = two_phase(&[(7, exact_score)], vec![7], Some(1.0));
         let mut phrase = DisjunctionScorer::try_new(vec![phrase], DisjunctionScore::Sum).unwrap();
         let competitive_score = Arc::new(CompetitiveScore::default());
         competitive_score.raise(floor);
@@ -6123,13 +5847,11 @@ mod tests {
                 .is_empty()
         );
         assert_eq!(confirmations.load(AtomicOrdering::Relaxed), 1);
-        assert_eq!(confirmations_avoided.load(AtomicOrdering::Relaxed), 0);
     }
 
     #[test]
     fn surviving_nested_phrase_is_confirmed_exactly_once() {
-        let (phrase, _, confirmations, confirmations_avoided) =
-            two_phase_with_avoided(&[(3, 5.0)], vec![3], Some(1.0));
+        let (phrase, _, confirmations) = two_phase(&[(3, 5.0)], vec![3], Some(1.0));
         let nested = Box::new(
             DisjunctionScorer::try_new(
                 vec![phrase, materialized(&[(3, 0.0)])],
@@ -6144,7 +5866,6 @@ mod tests {
             rows(&[(3, 5.0)])
         );
         assert_eq!(confirmations.load(AtomicOrdering::Relaxed), 1);
-        assert_eq!(confirmations_avoided.load(AtomicOrdering::Relaxed), 0);
     }
 
     #[test]
@@ -6576,10 +6297,10 @@ mod tests {
             ("must_should", must_should, 11.0),
             ("nested", nested, 11.0),
         ] {
-            let (exact, _, exact_confirmations, exact_avoided) =
-                two_phase_with_avoided(&exact_approximations, vec![1, 3], Some(1.0));
-            let (sloppy, _, sloppy_confirmations, sloppy_avoided) =
-                two_phase_with_avoided(&sloppy_approximations, vec![1, 2, 3], Some(2.0));
+            let (exact, _, exact_confirmations) =
+                two_phase(&exact_approximations, vec![1, 3], Some(1.0));
+            let (sloppy, _, sloppy_confirmations) =
+                two_phase(&sloppy_approximations, vec![1, 2, 3], Some(2.0));
             let mut leaves = vec![
                 Some(exact),
                 Some(sloppy),
@@ -6597,7 +6318,7 @@ mod tests {
                     (4, 1.0),
                 ])),
             ];
-            let mut scorer = plan.build(&mut leaves, &NoOpMetricsCollector).unwrap();
+            let mut scorer = plan.build(&mut leaves).unwrap();
             let competitive_score = Arc::new(CompetitiveScore::default());
             competitive_score.raise(floor);
             let actual = TopKCollector::with_competitive_score(2, competitive_score)
@@ -6607,12 +6328,6 @@ mod tests {
 
             assert_eq!(actual, expected, "shape={shape}");
             assert_eq!(actual, rows(&[(1, floor), (3, floor)]), "shape={shape}");
-            assert!(
-                exact_avoided.load(AtomicOrdering::Relaxed)
-                    + sloppy_avoided.load(AtomicOrdering::Relaxed)
-                    > 0,
-                "shape={shape} should avoid at least one position confirmation"
-            );
             assert!(
                 exact_confirmations.load(AtomicOrdering::Relaxed) > 0
                     && sloppy_confirmations.load(AtomicOrdering::Relaxed) > 0,
@@ -6982,7 +6697,6 @@ mod tests {
             for (shape, plan) in &plans {
                 for limit in [1, 3, 7] {
                     let expected = exhaustive_compound_top_k(plan, &leaves, limit);
-                    let metrics = ShouldMetrics::default();
                     let mut mapped_leaves = leaves
                         .iter()
                         .map(|leaf| {
@@ -6993,7 +6707,7 @@ mod tests {
                             ))
                         })
                         .collect::<Vec<_>>();
-                    let mut scorer = plan.build(&mut mapped_leaves, &metrics).unwrap();
+                    let mut scorer = plan.build(&mut mapped_leaves).unwrap();
                     assert!(mapped_leaves.iter().all(Option::is_none));
                     let actual = TopKCollector::new(limit).collect(scorer.as_mut()).unwrap();
                     assert_eq!(actual, expected, "seed={seed} shape={shape} limit={limit}");
@@ -7009,10 +6723,9 @@ mod tests {
         let eager_results = TopKCollector::new(1).collect(&mut eager).unwrap();
         let eager_comparisons = scorer_advances(&eager_work);
 
-        let metrics = ShouldMetrics::default();
         let (children, optimized_work) = pure_should_canary_children();
         let optimized_results = {
-            let mut optimized = should_maxscore(children, Some(&metrics));
+            let mut optimized = should_maxscore(children);
             TopKCollector::new(1).collect(&mut optimized).unwrap()
         };
         let optimized_comparisons = scorer_advances(&optimized_work);
@@ -7024,16 +6737,6 @@ mod tests {
             optimized_comparisons * 5 <= eager_comparisons * 4,
             "pure-SHOULD MAXSCORE should reduce posting candidate probes by at least 20%: \
              optimized={optimized_comparisons} eager={eager_comparisons}"
-        );
-        assert_eq!(metrics.reports.load(AtomicOrdering::Relaxed), 4);
-        assert!(metrics.skipped_windows.load(AtomicOrdering::Relaxed) > 0);
-        assert!(metrics.bound_recomputations.load(AtomicOrdering::Relaxed) > 0);
-        assert!(metrics.essential_evaluations.load(AtomicOrdering::Relaxed) > 0);
-        assert!(
-            metrics
-                .non_essential_evaluations
-                .load(AtomicOrdering::Relaxed)
-                > 0
         );
     }
 
@@ -7059,10 +6762,8 @@ mod tests {
             for limit in [1, 7, 31, 512] {
                 let expected = exhaustive_should_top_k(&children, limit);
 
-                let mut optimized = should_maxscore(
-                    children.iter().map(|values| materialized(values)).collect(),
-                    None,
-                );
+                let mut optimized =
+                    should_maxscore(children.iter().map(|values| materialized(values)).collect());
                 let actual = TopKCollector::new(limit).collect(&mut optimized).unwrap();
                 assert_eq!(actual, expected, "seed={seed} limit={limit}");
             }
@@ -7072,19 +6773,15 @@ mod tests {
     #[test]
     fn pure_should_maxscore_confirms_two_phase_children_before_scoring() {
         let (phrase, _, confirmations) = two_phase(&[(1, 100.0)], Vec::new(), Some(10.0));
-        let metrics = ShouldMetrics::default();
         let competitive_score = Arc::new(CompetitiveScore::default());
         competitive_score.raise(10.0);
         let results = {
-            let mut scorer = should_maxscore(
-                vec![
-                    materialized(&[(0, 10.0)]),
-                    phrase,
-                    materialized(&[(1, 6.0)]),
-                    materialized(&[(1, 5.0)]),
-                ],
-                Some(&metrics),
-            );
+            let mut scorer = should_maxscore(vec![
+                materialized(&[(0, 10.0)]),
+                phrase,
+                materialized(&[(1, 6.0)]),
+                materialized(&[(1, 5.0)]),
+            ]);
             TopKCollector::with_competitive_score(1, competitive_score)
                 .collect(&mut scorer)
                 .unwrap()
@@ -7092,25 +6789,16 @@ mod tests {
 
         assert_eq!(results, rows(&[(1, 11.0)]));
         assert_eq!(confirmations.load(AtomicOrdering::Relaxed), 1);
-        assert!(
-            metrics
-                .non_essential_evaluations
-                .load(AtomicOrdering::Relaxed)
-                > 0
-        );
     }
 
     #[test]
     fn pure_should_maxscore_preserves_query_score_order_and_terminal_doc() {
-        let mut scorer = should_maxscore(
-            vec![
-                materialized(&[(u64::MAX, 16_777_216.0)]),
-                materialized(&[(u64::MAX, 1.0)]),
-                materialized(&[(u64::MAX, 1.0)]),
-                materialized(&[]),
-            ],
-            None,
-        );
+        let mut scorer = should_maxscore(vec![
+            materialized(&[(u64::MAX, 16_777_216.0)]),
+            materialized(&[(u64::MAX, 1.0)]),
+            materialized(&[(u64::MAX, 1.0)]),
+            materialized(&[]),
+        ]);
 
         assert_eq!(
             TopKCollector::new(1).collect(&mut scorer).unwrap(),
@@ -7137,7 +6825,6 @@ mod tests {
                 .into_iter()
                 .map(|score| materialized(&[(7, score)]))
                 .collect(),
-            None,
         );
         let competitive_score = Arc::new(CompetitiveScore::default());
         competitive_score.raise(exact_score);
@@ -7170,9 +6857,8 @@ mod tests {
             )
             .unwrap(),
         );
-        let metrics = ShouldMetrics::default();
         let results = {
-            let mut scorer = BooleanScorer::try_new_with_metrics(
+            let mut scorer = BooleanScorer::try_new(
                 vec![
                     nested_dismax,
                     nested_boolean,
@@ -7180,21 +6866,18 @@ mod tests {
                 ],
                 Vec::new(),
                 Vec::new(),
-                Some(&metrics),
             )
             .unwrap();
             TopKCollector::new(1).collect(&mut scorer).unwrap()
         };
 
         assert_eq!(results, rows(&[(2, 6.5)]));
-        assert_eq!(metrics.reports.load(AtomicOrdering::Relaxed), 4);
     }
 
     #[test]
     fn pure_should_maxscore_applies_must_not_before_raising_the_floor() {
-        let metrics = ShouldMetrics::default();
         let results = {
-            let mut scorer = BooleanScorer::try_new_with_metrics(
+            let mut scorer = BooleanScorer::try_new(
                 vec![
                     materialized(&[(0, 10.0), (1, 5.0)]),
                     materialized(&[(0, 1.0), (1, 1.0)]),
@@ -7202,19 +6885,16 @@ mod tests {
                 ],
                 Vec::new(),
                 vec![materialized(&[(0, 1.0)])],
-                Some(&metrics),
             )
             .unwrap();
             TopKCollector::new(1).collect(&mut scorer).unwrap()
         };
 
         assert_eq!(results, rows(&[(2, 8.0)]));
-        assert_eq!(metrics.reports.load(AtomicOrdering::Relaxed), 4);
     }
 
     #[test]
     fn pure_should_uses_exact_fallback_for_unsupported_shapes() {
-        let signed_metrics = ShouldMetrics::default();
         let signed_results = {
             let signed = Box::new(
                 BoostScorer::try_new(
@@ -7224,7 +6904,7 @@ mod tests {
                 )
                 .unwrap(),
             );
-            let mut scorer = BooleanScorer::try_new_with_metrics(
+            let mut scorer = BooleanScorer::try_new(
                 vec![
                     signed,
                     materialized(&[(0, 1.0), (1, 1.0)]),
@@ -7232,20 +6912,17 @@ mod tests {
                 ],
                 Vec::new(),
                 Vec::new(),
-                Some(&signed_metrics),
             )
             .unwrap();
             TopKCollector::new(2).collect(&mut scorer).unwrap()
         };
         assert_eq!(signed_results, rows(&[(0, 4.0), (1, 3.0)]));
-        assert_eq!(signed_metrics.reports.load(AtomicOrdering::Relaxed), 0);
 
-        let unbounded_metrics = ShouldMetrics::default();
         let unbounded_results = {
             let unbounded = Box::new(UnboundedScorer {
                 inner: MaterializedScorer::try_new(rows(&[(0, 1.0), (2, 3.0)])).unwrap(),
             });
-            let mut scorer = BooleanScorer::try_new_with_metrics(
+            let mut scorer = BooleanScorer::try_new(
                 vec![
                     unbounded,
                     materialized(&[(0, 2.0), (1, 2.0)]),
@@ -7253,21 +6930,17 @@ mod tests {
                 ],
                 Vec::new(),
                 Vec::new(),
-                Some(&unbounded_metrics),
             )
             .unwrap();
             TopKCollector::new(3).collect(&mut scorer).unwrap()
         };
         assert_eq!(unbounded_results, rows(&[(1, 6.0), (0, 3.0), (2, 3.0)]));
-        assert_eq!(unbounded_metrics.reports.load(AtomicOrdering::Relaxed), 0);
 
-        let low_count_metrics = ShouldMetrics::default();
         {
-            let mut scorer = BooleanScorer::try_new_with_metrics(
+            let mut scorer = BooleanScorer::try_new(
                 vec![materialized(&[(0, 1.0)]), materialized(&[(1, 2.0)])],
                 Vec::new(),
                 Vec::new(),
-                Some(&low_count_metrics),
             )
             .unwrap();
             assert_eq!(
@@ -7275,12 +6948,10 @@ mod tests {
                 rows(&[(1, 2.0), (0, 1.0)])
             );
         }
-        assert_eq!(low_count_metrics.reports.load(AtomicOrdering::Relaxed), 0);
 
-        let overflow_metrics = ShouldMetrics::default();
         let large_score = f32::MAX / 2.0;
         {
-            let mut scorer = BooleanScorer::try_new_with_metrics(
+            let mut scorer = BooleanScorer::try_new(
                 vec![
                     materialized(&[(0, large_score)]),
                     materialized(&[(1, large_score)]),
@@ -7288,7 +6959,6 @@ mod tests {
                 ],
                 Vec::new(),
                 Vec::new(),
-                Some(&overflow_metrics),
             )
             .unwrap();
             assert_eq!(
@@ -7296,6 +6966,5 @@ mod tests {
                 rows(&[(0, large_score), (1, large_score), (2, large_score)])
             );
         }
-        assert_eq!(overflow_metrics.reports.load(AtomicOrdering::Relaxed), 0);
     }
 }

--- a/rust/lance-index/src/scalar/inverted/compound/should_maxscore.rs
+++ b/rust/lance-index/src/scalar/inverted/compound/should_maxscore.rs
@@ -22,14 +22,6 @@ struct ReportedBounds {
     bounds: ScoreBounds,
 }
 
-#[derive(Default)]
-struct MaxScoreWork {
-    skipped_windows: usize,
-    bound_recomputations: usize,
-    essential_evaluations: usize,
-    non_essential_evaluations: usize,
-}
-
 /// Exact windowed MAXSCORE scorer for same-column Boolean SHOULD sums.
 ///
 /// List-wide maxima split clauses into a non-essential prefix whose total
@@ -53,8 +45,6 @@ pub(super) struct ShouldMaxScoreScorer<'a> {
     essential: Vec<bool>,
     bound_order: Vec<usize>,
     child_scores: Vec<Option<f32>>,
-    metrics: Option<&'a dyn MetricsCollector>,
-    work: MaxScoreWork,
 }
 
 impl<'a> ShouldMaxScoreScorer<'a> {
@@ -78,11 +68,7 @@ impl<'a> ShouldMaxScoreScorer<'a> {
             .then_some(bounds)
     }
 
-    pub(super) fn new(
-        children: Vec<BoxScorer<'a>>,
-        global_upper_bounds: Vec<f32>,
-        metrics: Option<&'a dyn MetricsCollector>,
-    ) -> Self {
+    pub(super) fn new(children: Vec<BoxScorer<'a>>, global_upper_bounds: Vec<f32>) -> Self {
         debug_assert_eq!(children.len(), global_upper_bounds.len());
         let num_children = children.len();
         let global_score_upper_bound = Self::sum_uppers(global_upper_bounds.iter());
@@ -109,8 +95,6 @@ impl<'a> ShouldMaxScoreScorer<'a> {
             essential: vec![true; num_children],
             bound_order,
             child_scores: vec![None; num_children],
-            metrics,
-            work: MaxScoreWork::default(),
         }
     }
 
@@ -228,9 +212,6 @@ impl<'a> ShouldMaxScoreScorer<'a> {
 
         self.select_essential_children();
         if !self.essential.iter().any(|is_essential| *is_essential) {
-            if self.children.iter().any(|child| child.doc().is_some()) {
-                self.work.skipped_windows = self.work.skipped_windows.saturating_add(1);
-            }
             self.exhaust();
             return Ok(());
         }
@@ -259,9 +240,6 @@ impl<'a> ShouldMaxScoreScorer<'a> {
             }
         }
         if !has_active_child {
-            if self.children.iter().any(|child| child.doc().is_some()) {
-                self.work.skipped_windows = self.work.skipped_windows.saturating_add(1);
-            }
             self.exhaust();
             return Ok(());
         }
@@ -274,7 +252,6 @@ impl<'a> ShouldMaxScoreScorer<'a> {
         for (index, child) in self.children.iter_mut().enumerate() {
             if self.essential[index] && child.doc().is_some_and(|doc| doc <= up_to) {
                 let bounds = child.score_bounds(up_to)?;
-                self.work.bound_recomputations = self.work.bound_recomputations.saturating_add(1);
                 if Self::usable_bounds(bounds) {
                     self.child_upper_bounds[index] =
                         bounds.upper.max(0.0).min(self.global_upper_bounds[index]);
@@ -318,7 +295,6 @@ impl<'a> ShouldMaxScoreScorer<'a> {
                 .ok_or_else(|| Error::internal("FTS SHOULD scorer did not prepare a window"))?;
 
             if window.combined_upper < self.min_competitive_score {
-                self.work.skipped_windows = self.work.skipped_windows.saturating_add(1);
                 if window.up_to == u64::MAX {
                     return Ok(self.exhaust());
                 }
@@ -344,14 +320,6 @@ impl<'a> ShouldMaxScoreScorer<'a> {
             }
 
             if window.up_to == u64::MAX {
-                if self
-                    .children
-                    .iter()
-                    .zip(&self.essential)
-                    .any(|(child, is_essential)| !*is_essential && child.doc().is_some())
-                {
-                    self.work.skipped_windows = self.work.skipped_windows.saturating_add(1);
-                }
                 return Ok(self.exhaust());
             }
             target = window.up_to + 1;
@@ -387,7 +355,6 @@ impl<'a> ShouldMaxScoreScorer<'a> {
             if !self.essential[index] || self.children[index].doc() != Some(current) {
                 continue;
             }
-            self.work.essential_evaluations = self.work.essential_evaluations.saturating_add(1);
             if self.children[index].matches()? {
                 self.child_scores[index] = Some(self.children[index].score()?);
             }
@@ -398,8 +365,6 @@ impl<'a> ShouldMaxScoreScorer<'a> {
                 if self.essential[index] || self.child_upper_bounds[index] == 0.0 {
                     continue;
                 }
-                self.work.non_essential_evaluations =
-                    self.work.non_essential_evaluations.saturating_add(1);
                 if self.children[index].doc().is_some_and(|doc| doc < current) {
                     self.children[index].advance(current)?;
                 }
@@ -614,17 +579,6 @@ impl ComposableScorer for ShouldMaxScoreScorer<'_> {
             .any(|child| child.supports_doc_local_confirmation_pruning())
     }
 
-    fn record_confirmation_avoided(&mut self) {
-        let Some(current) = self.current else {
-            return;
-        };
-        for child in &mut self.children {
-            if child.doc() == Some(current) {
-                child.record_confirmation_avoided();
-            }
-        }
-    }
-
     fn matches(&mut self) -> Result<bool> {
         self.ensure_confirmed()
     }
@@ -638,18 +592,5 @@ impl ComposableScorer for ShouldMaxScoreScorer<'_> {
 
     fn scores_non_negative(&self) -> bool {
         true
-    }
-}
-
-impl Drop for ShouldMaxScoreScorer<'_> {
-    fn drop(&mut self) {
-        let Some(metrics) = self.metrics else {
-            return;
-        };
-        metrics.record_compound_should_skipped_windows(self.work.skipped_windows);
-        metrics.record_compound_should_bound_recomputations(self.work.bound_recomputations);
-        metrics.record_compound_should_essential_evaluations(self.work.essential_evaluations);
-        metrics
-            .record_compound_should_non_essential_evaluations(self.work.non_essential_evaluations);
     }
 }

--- a/rust/lance-index/src/scalar/inverted/cross_column.rs
+++ b/rust/lance-index/src/scalar/inverted/cross_column.rs
@@ -1310,7 +1310,7 @@ fn score_cross_column_sources(
         debug_assert!(slot.is_none());
         *slot = Some(Box::new(MaterializedScorer::try_new(rows)?));
     }
-    let mut scorer = plan.build(&mut leaf_scorers, metrics.as_ref())?;
+    let mut scorer = plan.build(&mut leaf_scorers)?;
     if leaf_scorers.iter().any(Option::is_some) {
         return Err(Error::internal(
             "cross-column compound FTS scorer did not consume every prepared leaf",
@@ -1501,7 +1501,6 @@ pub async fn cross_column_compound_search(
     let staged_candidates = if let Some((generator_leaf_ordinals, candidate_budget)) =
         staged_generator
     {
-        metrics.record_cross_column_staged_attempts(1);
         let generator_leaf_set = generator_leaf_ordinals
             .iter()
             .copied()
@@ -1557,7 +1556,7 @@ pub async fn cross_column_compound_search(
             )
         })
         .await?;
-        let staged = if let Some(local_candidates) = local_candidates {
+        if let Some(local_candidates) = local_candidates {
             let resolved = stream::iter(
                 local_candidates
                     .into_iter()
@@ -1578,17 +1577,6 @@ pub async fn cross_column_compound_search(
             .await?
         } else {
             None
-        };
-        match staged {
-            Some(candidates) => {
-                metrics.record_cross_column_staged_successes(1);
-                metrics.record_cross_column_staged_candidates(candidates.addresses.len());
-                Some(candidates)
-            }
-            None => {
-                metrics.record_cross_column_staged_fallbacks(1);
-                None
-            }
         }
     } else {
         None

--- a/rust/lance-index/src/scalar/inverted/index/partition.rs
+++ b/rust/lance-index/src/scalar/inverted/index/partition.rs
@@ -1273,6 +1273,7 @@ impl InvertedPartition {
                 grouped_expansions: Vec::new(),
                 impact_safe,
                 exact_scoring_required,
+                #[cfg(test)]
                 no_impact_fallback,
             });
         }
@@ -1390,6 +1391,7 @@ impl InvertedPartition {
             grouped_expansions,
             impact_safe: false,
             exact_scoring_required: true,
+            #[cfg(test)]
             no_impact_fallback,
         })
     }

--- a/rust/lance-index/src/scalar/inverted/index/search.rs
+++ b/rust/lance-index/src/scalar/inverted/index/search.rs
@@ -567,7 +567,7 @@ impl InvertedIndex {
                                 grouped_expansions,
                                 impact_safe,
                                 exact_scoring_required,
-                                no_impact_fallback,
+                                ..
                             } = part
                                 .load_posting_lists(
                                     tokens.as_ref(),
@@ -580,9 +580,6 @@ impl InvertedIndex {
                                 .await?;
                             if postings.is_empty() {
                                 return Result::Ok(None);
-                            }
-                            if no_impact_fallback {
-                                metrics.record_no_impact_global_scorer_fallbacks(1);
                             }
                             let max_position = postings
                                 .iter()
@@ -827,7 +824,7 @@ impl InvertedIndex {
                                 grouped_expansions,
                                 impact_safe,
                                 exact_scoring_required,
-                                no_impact_fallback,
+                                ..
                             } = part
                                 .load_posting_lists(
                                     tokens.as_ref(),
@@ -840,9 +837,6 @@ impl InvertedIndex {
                                 .await?;
                             if postings.is_empty() {
                                 return Result::Ok(None);
-                            }
-                            if no_impact_fallback {
-                                metrics.record_no_impact_global_scorer_fallbacks(1);
                             }
                             let documents = part.docs.modern().cloned().ok_or_else(|| {
                                 Error::internal("modern index contains legacy partition documents")

--- a/rust/lance-index/src/scalar/inverted/index/search_candidates.rs
+++ b/rust/lance-index/src/scalar/inverted/index/search_candidates.rs
@@ -201,6 +201,7 @@ pub(in super::super) struct LoadedPostings {
     pub(super) grouped_expansions: Vec<GroupedExpansionTerms>,
     pub(super) impact_safe: bool,
     pub(super) exact_scoring_required: bool,
+    #[cfg(test)]
     pub(super) no_impact_fallback: bool,
 }
 
@@ -232,6 +233,7 @@ impl LoadedPostings {
             grouped_expansions: Vec::new(),
             impact_safe: false,
             exact_scoring_required: false,
+            #[cfg(test)]
             no_impact_fallback: false,
         }
     }

--- a/rust/lance-index/src/scalar/inverted/index/tests/scoring.rs
+++ b/rust/lance-index/src/scalar/inverted/index/tests/scoring.rs
@@ -4,24 +4,6 @@
 use super::super::partition::validate_no_impact_scorer_upper_bound;
 use super::*;
 
-#[derive(Default)]
-struct NoImpactFallbackMetrics {
-    global_scorer_fallbacks: AtomicU64,
-}
-
-impl MetricsCollector for NoImpactFallbackMetrics {
-    fn record_parts_loaded(&self, _num_parts: usize) {}
-
-    fn record_index_loads(&self, _num_indexes: usize) {}
-
-    fn record_comparisons(&self, _num_comparisons: usize) {}
-
-    fn record_no_impact_global_scorer_fallbacks(&self, num_fallbacks: usize) {
-        self.global_scorer_fallbacks
-            .fetch_add(num_fallbacks as u64, Ordering::Relaxed);
-    }
-}
-
 #[tokio::test]
 async fn test_bm25_search_uses_global_idf() {
     let tmpdir = TempObjDir::default();
@@ -359,7 +341,7 @@ async fn test_no_impact_segments_preserve_global_bm25_top_k() {
     ));
     let params = Arc::new(FtsSearchParams::new().with_limit(Some(2)));
     let mut candidates = Vec::new();
-    let metrics = Arc::new(NoImpactFallbackMetrics::default());
+    let metrics = Arc::new(NoOpMetricsCollector);
     // Reverse segment visitation so neither the result nor its row-id tie break
     // can accidentally depend on the physical search order.
     for index in [second_index, first_index] {
@@ -399,7 +381,6 @@ async fn test_no_impact_segments_preserve_global_bm25_top_k() {
     let exact_winner_score = scorer.query_weight("alpha") * scorer.doc_weight(1, 1);
     assert!((exact_winner_score - 4.633_705).abs() < 1e-5);
     assert!((exact_winner_score - candidates[0].1).abs() < 1e-5);
-    assert_eq!(metrics.global_scorer_fallbacks.load(Ordering::Relaxed), 2);
 }
 
 #[test]
@@ -1039,7 +1020,7 @@ async fn test_mixed_impact_and_legacy_partitions_use_global_final_scores() {
 
     let tokens = Arc::new(Tokens::new(vec!["alpha".to_string()], DocType::Text));
     let params = Arc::new(FtsSearchParams::new().with_limit(Some(1)));
-    let metrics = Arc::new(NoImpactFallbackMetrics::default());
+    let metrics = Arc::new(NoOpMetricsCollector);
     let (row_ids, scores) = index
         .bm25_search(
             tokens.clone(),
@@ -1054,7 +1035,6 @@ async fn test_mixed_impact_and_legacy_partitions_use_global_final_scores() {
 
     assert_eq!(row_ids, vec![200]);
     assert_eq!(row_ids.len(), scores.len());
-    assert_eq!(metrics.global_scorer_fallbacks.load(Ordering::Relaxed), 1);
 
     let scorer = index
         .bm25_base_scorer(tokens.as_ref(), params.as_ref(), None)
@@ -1085,7 +1065,7 @@ async fn test_two_no_impact_partitions_share_global_scorer_and_threshold() {
 
     let tokens = Arc::new(Tokens::new(vec!["alpha".to_string()], DocType::Text));
     let params = Arc::new(FtsSearchParams::new().with_limit(Some(1)));
-    let metrics = Arc::new(NoImpactFallbackMetrics::default());
+    let metrics = Arc::new(NoOpMetricsCollector);
     let (row_ids, scores) = index
         .bm25_search(
             tokens.clone(),
@@ -1100,7 +1080,6 @@ async fn test_two_no_impact_partitions_share_global_scorer_and_threshold() {
 
     assert_eq!(row_ids, vec![200]);
     assert_eq!(scores.len(), 1);
-    assert_eq!(metrics.global_scorer_fallbacks.load(Ordering::Relaxed), 2);
     let scorer = index
         .bm25_base_scorer(tokens.as_ref(), params.as_ref(), None)
         .await

--- a/rust/lance-index/src/scalar/inverted/wand.rs
+++ b/rust/lance-index/src/scalar/inverted/wand.rs
@@ -530,6 +530,7 @@ struct BlockMaxWindow {
 
 struct BlockMaxScore {
     score: f32,
+    #[cfg(test)]
     blocks_scanned: usize,
 }
 
@@ -561,6 +562,7 @@ impl BlockMaxWindow {
             self.reset(start_block_idx);
             return BlockMaxScore {
                 score: 0.0,
+                #[cfg(test)]
                 blocks_scanned: 0,
             };
         }
@@ -577,6 +579,7 @@ impl BlockMaxWindow {
             self.reset(start_block_idx);
             return BlockMaxScore {
                 score: 0.0,
+                #[cfg(test)]
                 blocks_scanned: 0,
             };
         }
@@ -588,11 +591,13 @@ impl BlockMaxWindow {
             self.reset(start_block_idx);
             return BlockMaxScore {
                 score: scorer_upper_bound(query_weight, scorer),
+                #[cfg(test)]
                 blocks_scanned: 0,
             };
         }
 
         self.next_block_idx = self.next_block_idx.max(start_block_idx);
+        #[cfg(test)]
         let mut blocks_scanned = 0;
         while self.next_block_idx < list.blocks.len()
             && list.block_least_doc_id(self.next_block_idx) as u64 <= up_to
@@ -611,7 +616,10 @@ impl BlockMaxWindow {
             }
             self.max_scores.push_back((self.next_block_idx, score));
             self.next_block_idx += 1;
-            blocks_scanned += 1;
+            #[cfg(test)]
+            {
+                blocks_scanned += 1;
+            }
         }
 
         let score = self
@@ -621,6 +629,7 @@ impl BlockMaxWindow {
             .unwrap_or(0.0);
         BlockMaxScore {
             score,
+            #[cfg(test)]
             blocks_scanned,
         }
     }
@@ -1337,6 +1346,7 @@ impl PostingIterator {
                 if self.has_grouped_terms() && list.block_size == MAX_POSTING_BLOCK_SIZE {
                     return BlockMaxScore {
                         score: self.approximate_upper_bound,
+                        #[cfg(test)]
                         blocks_scanned: 0,
                     };
                 }
@@ -1345,6 +1355,7 @@ impl PostingIterator {
                     if up_to <= u64::from(level0_up_to) {
                         return BlockMaxScore {
                             score: level0_score,
+                            #[cfg(test)]
                             blocks_scanned: 0,
                         };
                     }
@@ -1352,6 +1363,7 @@ impl PostingIterator {
                 if self.use_scorer_upper_bound {
                     return BlockMaxScore {
                         score: scorer_upper_bound(self.query_weight, scorer),
+                        #[cfg(test)]
                         blocks_scanned: 0,
                     };
                 }
@@ -1370,6 +1382,7 @@ impl PostingIterator {
                 } else {
                     self.approximate_upper_bound
                 },
+                #[cfg(test)]
                 blocks_scanned: 0,
             },
         }
@@ -2018,6 +2031,7 @@ impl PartialEq for TailPosting {
     }
 }
 
+#[cfg(test)]
 #[derive(Default)]
 struct AndWindowStats {
     windows_wide: usize,
@@ -2025,14 +2039,6 @@ struct AndWindowStats {
     windows_skipped: usize,
     range_blocks_scanned: usize,
     candidates_returned: usize,
-}
-
-#[derive(Default)]
-struct AndSearchStats {
-    pruned_before_return_start: usize,
-    candidates_seen: usize,
-    full_scores: usize,
-    freqs_collected: usize,
 }
 
 impl Eq for TailPosting {}
@@ -2084,8 +2090,8 @@ pub struct Wand<'a, S: Scorer, D: WandDocuments> {
     // Last conjunction doc returned to the caller. The next conjunction search
     // resumes strictly after this doc, like Lucene's `nextDoc()/advance()`.
     and_last_doc: Option<u64>,
+    #[cfg(test)]
     and_window_stats: AndWindowStats,
-    and_candidates_pruned_before_return: usize,
     // Test-only override for comparing bulk and classic conjunctions without
     // mutating the process-wide environment.
     bulk_and_mode_override: Option<BulkAndMode>,
@@ -2161,8 +2167,8 @@ impl<'a, S: Scorer, D: WandDocuments> Wand<'a, S, D> {
             up_to: None,
             and_max_score: f32::INFINITY,
             and_last_doc: None,
+            #[cfg(test)]
             and_window_stats: AndWindowStats::default(),
-            and_candidates_pruned_before_return: 0,
             bulk_and_mode_override: None,
             #[cfg(test)]
             bulk_and_searches: 0,
@@ -2294,19 +2300,12 @@ impl<'a, S: Scorer, D: WandDocuments> Wand<'a, S, D> {
 
         let mut candidates = TopKCollector::new(limit, std::cmp::min(limit, BLOCK_SIZE * 10));
         let mut num_comparisons = 0;
-        let mut and_search_stats = (self.operator == Operator::And).then_some(AndSearchStats {
-            pruned_before_return_start: self.and_candidates_pruned_before_return,
-            ..Default::default()
-        });
         loop {
             self.raise_to_shared_floor(params.wand_factor);
             let Some((doc, _)) = self.next()? else {
                 break;
             };
             num_comparisons += 1;
-            if let Some(and_stats) = and_search_stats.as_mut() {
-                and_stats.candidates_seen += 1;
-            }
 
             let posting_doc_id = doc.doc_id();
             let Some(document_key) = self.documents.document_key(&doc) else {
@@ -2334,9 +2333,6 @@ impl<'a, S: Scorer, D: WandDocuments> Wand<'a, S, D> {
                 {
                     continue;
                 }
-                if let Some(and_stats) = and_search_stats.as_mut() {
-                    and_stats.full_scores += 1;
-                }
                 self.score_in_query_order(doc_length)
             };
 
@@ -2345,38 +2341,15 @@ impl<'a, S: Scorer, D: WandDocuments> Wand<'a, S, D> {
                 doc_length,
                 posting_doc_id,
                 self.iter_term_freqs(),
-            )? {
-                if let Some(and_stats) = and_search_stats.as_mut() {
-                    and_stats.freqs_collected += 1;
-                }
-                if let Some(kth) = candidates.kth_score_if_full() {
-                    self.update_threshold(kth, params.wand_factor);
-                }
+            )? && let Some(kth) = candidates.kth_score_if_full()
+            {
+                self.update_threshold(kth, params.wand_factor);
             }
             if self.operator == Operator::Or {
                 self.push_back_leads(doc.doc_id() + 1);
             }
         }
-        if self.operator == Operator::And {
-            tracing::debug!(
-                and_windows_wide = self.and_window_stats.windows_wide,
-                and_windows_narrow = self.and_window_stats.windows_narrow,
-                and_windows_skipped = self.and_window_stats.windows_skipped,
-                and_range_blocks_scanned = self.and_window_stats.range_blocks_scanned,
-                and_candidates_returned = self.and_window_stats.candidates_returned,
-                "fts conjunction block-max window stats"
-            );
-        }
         metrics.record_comparisons(num_comparisons);
-        if let Some(and_stats) = and_search_stats {
-            let and_candidates_pruned_before_return = self
-                .and_candidates_pruned_before_return
-                .saturating_sub(and_stats.pruned_before_return_start);
-            metrics.record_and_candidates_seen(and_stats.candidates_seen);
-            metrics.record_and_candidates_pruned_before_return(and_candidates_pruned_before_return);
-            metrics.record_and_full_scores(and_stats.full_scores);
-            metrics.record_freqs_collected(and_stats.freqs_collected);
-        }
 
         candidates.into_candidates(|key| self.documents.candidate_from_key(key))
     }
@@ -3127,8 +3100,11 @@ impl<'a, S: Scorer, D: WandDocuments> Wand<'a, S, D> {
     fn next(&mut self) -> Result<Option<(DocInfo, f32)>> {
         if self.operator == Operator::And {
             let candidate = self.next_and_candidate();
-            if candidate.is_some() {
-                self.and_window_stats.candidates_returned += 1;
+            #[cfg(test)]
+            {
+                if candidate.is_some() {
+                    self.and_window_stats.candidates_returned += 1;
+                }
             }
             return Ok(candidate.map(|doc| (doc, 0.0)));
         }
@@ -3264,7 +3240,6 @@ impl<'a, S: Scorer, D: WandDocuments> Wand<'a, S, D> {
             let lead_doc = self.lead.first().and_then(|posting| posting.doc())?;
             let doc_length = self.documents.doc_length(&lead_doc);
             if self.and_candidate_cannot_beat_threshold(doc_length) {
-                self.and_candidates_pruned_before_return += 1;
                 let next_target = self.and_advance_target(doc.saturating_add(1));
                 if next_target == TERMINATED_DOC_ID {
                     return None;
@@ -3485,10 +3460,6 @@ impl<'a, S: Scorer, D: WandDocuments> Wand<'a, S, D> {
 
         let mut candidates = TopKCollector::new(limit, std::cmp::min(limit, BLOCK_SIZE * 10));
         let mut num_comparisons: usize = 0;
-        let mut stats = AndSearchStats {
-            pruned_before_return_start: self.and_candidates_pruned_before_return,
-            ..Default::default()
-        };
         let mut wins: Vec<WindowList> = Vec::with_capacity(num_lists);
         // Per-window candidate batch. The merge kernel only records matches;
         // scoring then runs in two passes so the doc-length gather issues
@@ -3732,12 +3703,13 @@ impl<'a, S: Scorer, D: WandDocuments> Wand<'a, S, D> {
                             score_sum_upper_bound_factor(num_lists),
                             CompetitiveFloorMode::Exclusive,
                         ) {
-                            self.and_candidates_pruned_before_return += 1;
                             continue;
                         }
                     }
-                    stats.candidates_seen += 1;
-                    self.and_window_stats.candidates_returned += 1;
+                    #[cfg(test)]
+                    {
+                        self.and_window_stats.candidates_returned += 1;
+                    }
                     num_comparisons += 1;
 
                     let Some(document_key) = self.documents.document_key_for_doc_id(doc) else {
@@ -3767,8 +3739,6 @@ impl<'a, S: Scorer, D: WandDocuments> Wand<'a, S, D> {
                             continue;
                         }
                     }
-                    stats.full_scores += 1;
-
                     let mut score = 0.0_f32;
                     for &clause_index in &score_order {
                         let win = &wins[clause_index];
@@ -3794,11 +3764,9 @@ impl<'a, S: Scorer, D: WandDocuments> Wand<'a, S, D> {
                                 })
                             },
                         ),
-                    )? {
-                        stats.freqs_collected += 1;
-                        if let Some(kth) = candidates.kth_score_if_full() {
-                            self.update_threshold(kth, params.wand_factor);
-                        }
+                    )? && let Some(kth) = candidates.kth_score_if_full()
+                    {
+                        self.update_threshold(kth, params.wand_factor);
                     }
                 }
             }
@@ -3809,22 +3777,7 @@ impl<'a, S: Scorer, D: WandDocuments> Wand<'a, S, D> {
             target = win_end + 1;
         }
 
-        tracing::debug!(
-            and_windows_wide = self.and_window_stats.windows_wide,
-            and_windows_narrow = self.and_window_stats.windows_narrow,
-            and_windows_skipped = self.and_window_stats.windows_skipped,
-            and_range_blocks_scanned = self.and_window_stats.range_blocks_scanned,
-            and_candidates_returned = self.and_window_stats.candidates_returned,
-            "fts conjunction block-max window stats (bulk)"
-        );
         metrics.record_comparisons(num_comparisons);
-        let pruned_before_return = self
-            .and_candidates_pruned_before_return
-            .saturating_sub(stats.pruned_before_return_start);
-        metrics.record_and_candidates_seen(stats.candidates_seen);
-        metrics.record_and_candidates_pruned_before_return(pruned_before_return);
-        metrics.record_and_full_scores(stats.full_scores);
-        metrics.record_freqs_collected(stats.freqs_collected);
 
         candidates.into_candidates(|key| self.documents.candidate_from_key(key))
     }
@@ -3861,7 +3814,10 @@ impl<'a, S: Scorer, D: WandDocuments> Wand<'a, S, D> {
         if narrow_max_score >= self.threshold {
             self.up_to = Some(narrow_up_to);
             self.and_max_score = narrow_max_score;
-            self.and_window_stats.windows_narrow += 1;
+            #[cfg(test)]
+            {
+                self.and_window_stats.windows_narrow += 1;
+            }
             return;
         }
 
@@ -3876,26 +3832,39 @@ impl<'a, S: Scorer, D: WandDocuments> Wand<'a, S, D> {
 
         if can_try_wide {
             let mut wide_bounds = SmallVec::<[f32; 8]>::new();
+            #[cfg(test)]
             let mut range_blocks_scanned = 0;
             for posting in &mut self.lead {
                 let block_max = posting.block_max_score_up_to_with_stats(lead_up_to, &self.scorer);
                 wide_bounds.push(block_max.score);
-                range_blocks_scanned += block_max.blocks_scanned;
+                #[cfg(test)]
+                {
+                    range_blocks_scanned += block_max.blocks_scanned;
+                }
             }
             let wide_max_score = conservative_score_sum(wide_bounds.into_iter());
-            self.and_window_stats.range_blocks_scanned += range_blocks_scanned;
+            #[cfg(test)]
+            {
+                self.and_window_stats.range_blocks_scanned += range_blocks_scanned;
+            }
 
             if wide_max_score < self.threshold {
                 self.up_to = Some(lead_up_to);
                 self.and_max_score = wide_max_score;
-                self.and_window_stats.windows_wide += 1;
+                #[cfg(test)]
+                {
+                    self.and_window_stats.windows_wide += 1;
+                }
                 return;
             }
         }
 
         self.up_to = Some(narrow_up_to);
         self.and_max_score = narrow_max_score;
-        self.and_window_stats.windows_narrow += 1;
+        #[cfg(test)]
+        {
+            self.and_window_stats.windows_narrow += 1;
+        }
     }
 
     fn and_advance_target(&mut self, mut target: u64) -> u64 {
@@ -3910,7 +3879,10 @@ impl<'a, S: Scorer, D: WandDocuments> Wand<'a, S, D> {
             if self.and_max_score >= self.threshold {
                 return target;
             }
-            self.and_window_stats.windows_skipped += 1;
+            #[cfg(test)]
+            {
+                self.and_window_stats.windows_skipped += 1;
+            }
             if up_to == TERMINATED_DOC_ID {
                 return TERMINATED_DOC_ID;
             }
@@ -4769,11 +4741,6 @@ impl<'a, D: WandDocuments> WandCursor<'a, D> {
             self.current_document_key = Some(document_key);
             self.current_score = score;
             self.confirmation = self.phrase_slop.is_none().then_some(true);
-            match self.phrase_slop {
-                Some(0) => self.metrics.record_compound_phrase_exact_approximations(1),
-                Some(_) => self.metrics.record_compound_phrase_sloppy_approximations(1),
-                None => {}
-            }
             self.shallow = None;
             return Ok(Some(doc_id));
         }
@@ -4824,29 +4791,9 @@ impl<'a, D: WandDocuments> WandCursor<'a, D> {
         let phrase_slop = self.phrase_slop.ok_or_else(|| {
             Error::internal("posting FTS scorer requires phrase slop for position confirmation")
         })?;
-        if phrase_slop == 0 {
-            self.metrics.record_compound_phrase_exact_confirmations(1);
-        } else {
-            self.metrics.record_compound_phrase_sloppy_confirmations(1);
-        }
         let confirmed = self.wand.check_positions(phrase_slop as i32)?;
         self.confirmation = Some(confirmed);
         Ok(confirmed)
-    }
-
-    pub(super) fn record_confirmation_avoided(&self) {
-        if self.confirmation.is_some() {
-            return;
-        }
-        match self.phrase_slop {
-            Some(0) => self
-                .metrics
-                .record_compound_phrase_exact_confirmations_avoided(1),
-            Some(_) => self
-                .metrics
-                .record_compound_phrase_sloppy_confirmations_avoided(1),
-            None => {}
-        }
     }
 
     pub(super) fn match_cost(&self) -> Option<f32> {
@@ -5060,7 +5007,7 @@ mod tests {
     use super::*;
     use crate::scalar::inverted::scorer::{IndexBM25Scorer, MemBM25Scorer};
     use crate::{
-        metrics::{MetricsCollector, NoOpMetricsCollector},
+        metrics::{LocalMetricsCollector, NoOpMetricsCollector},
         scalar::inverted::{
             CompressedPostingList, PlainPostingList, PostingListBuilder, SharedPositionStream,
             builder::PositionRecorder,
@@ -5690,80 +5637,6 @@ mod tests {
         }
     }
 
-    #[derive(Default)]
-    struct CountAndSearchStats {
-        comparisons: AtomicUsize,
-        candidates_seen: AtomicUsize,
-        candidates_pruned_before_return: AtomicUsize,
-        full_scores: AtomicUsize,
-        freqs_collected: AtomicUsize,
-    }
-
-    impl MetricsCollector for CountAndSearchStats {
-        fn record_parts_loaded(&self, _: usize) {}
-
-        fn record_index_loads(&self, _: usize) {}
-
-        fn record_comparisons(&self, n: usize) {
-            self.comparisons.fetch_add(n, Ordering::Relaxed);
-        }
-
-        fn record_and_candidates_seen(&self, n: usize) {
-            self.candidates_seen.fetch_add(n, Ordering::Relaxed);
-        }
-
-        fn record_and_candidates_pruned_before_return(&self, n: usize) {
-            self.candidates_pruned_before_return
-                .fetch_add(n, Ordering::Relaxed);
-        }
-
-        fn record_and_full_scores(&self, n: usize) {
-            self.full_scores.fetch_add(n, Ordering::Relaxed);
-        }
-
-        fn record_freqs_collected(&self, n: usize) {
-            self.freqs_collected.fetch_add(n, Ordering::Relaxed);
-        }
-    }
-
-    struct PanicOnAndMetrics {
-        comparisons: AtomicUsize,
-    }
-
-    impl PanicOnAndMetrics {
-        fn new() -> Self {
-            Self {
-                comparisons: AtomicUsize::new(0),
-            }
-        }
-    }
-
-    impl MetricsCollector for PanicOnAndMetrics {
-        fn record_parts_loaded(&self, _: usize) {}
-
-        fn record_index_loads(&self, _: usize) {}
-
-        fn record_comparisons(&self, n: usize) {
-            self.comparisons.fetch_add(n, Ordering::Relaxed);
-        }
-
-        fn record_and_candidates_seen(&self, _: usize) {
-            panic!("OR search should not record AND candidate metrics");
-        }
-
-        fn record_and_candidates_pruned_before_return(&self, _: usize) {
-            panic!("OR search should not record AND prune metrics");
-        }
-
-        fn record_and_full_scores(&self, _: usize) {
-            panic!("OR search should not record AND scoring metrics");
-        }
-
-        fn record_freqs_collected(&self, _: usize) {
-            panic!("OR search should not record AND frequency metrics");
-        }
-    }
-
     fn generate_posting_list(
         doc_ids: Vec<u32>,
         max_score: f32,
@@ -6264,7 +6137,7 @@ mod tests {
     }
 
     #[rstest]
-    fn test_or_search_does_not_record_and_metrics(#[values(false, true)] is_compressed: bool) {
+    fn test_or_search_records_comparisons(#[values(false, true)] is_compressed: bool) {
         let mut docs = DocSet::default();
         for row_id in 0..6 {
             docs.append(row_id, 1);
@@ -6290,7 +6163,7 @@ mod tests {
         ];
 
         let mut wand = Wand::new(Operator::Or, postings.into_iter(), &docs, UnitScorer);
-        let metrics = PanicOnAndMetrics::new();
+        let metrics = LocalMetricsCollector::default();
         let candidates = wand.search(&FtsSearchParams::default(), &metrics).unwrap();
 
         assert_eq!(sorted_candidate_row_ids(candidates), vec![0, 1, 2, 4, 5]);
@@ -7117,7 +6990,7 @@ mod tests {
     }
 
     #[test]
-    fn test_and_candidate_prune_records_scoring_counters() {
+    fn test_and_candidate_prune_keeps_top_candidate() {
         let total_docs = 2 * BLOCK_SIZE as u32 + 1;
         let mut docs = DocSet::default();
         for doc_id in 0..total_docs {
@@ -7152,7 +7025,7 @@ mod tests {
             &docs,
             InverseDocLengthScorer,
         );
-        let metrics = CountAndSearchStats::default();
+        let metrics = LocalMetricsCollector::default();
         let result = wand
             .search(&FtsSearchParams::new().with_limit(Some(1)), &metrics)
             .unwrap();
@@ -7163,16 +7036,7 @@ mod tests {
             .collect::<Vec<_>>();
         assert_eq!(addrs, vec![0]);
 
-        let candidates_seen = metrics.candidates_seen.load(Ordering::Relaxed);
-        let candidates_pruned_before_return = metrics
-            .candidates_pruned_before_return
-            .load(Ordering::Relaxed);
-        let full_scores = metrics.full_scores.load(Ordering::Relaxed);
         assert_eq!(metrics.comparisons.load(Ordering::Relaxed), 1);
-        assert_eq!(candidates_seen, 1);
-        assert!(candidates_pruned_before_return > 0);
-        assert_eq!(full_scores, 1);
-        assert_eq!(metrics.freqs_collected.load(Ordering::Relaxed), 1);
     }
 
     #[test]

--- a/rust/lance/src/dataset/tests/dataset_index.rs
+++ b/rust/lance/src/dataset/tests/dataset_index.rs
@@ -43,21 +43,6 @@ use lance_datafusion::utils::PARTITIONS_SEARCHED_METRIC;
 use lance_datagen::{BatchCount, Dimension, RowCount, array, gen_batch};
 use lance_file::reader::{FileReader, FileReaderOptions};
 use lance_file::version::{ConcreteFileVersion, LanceFileVersion};
-use lance_index::metrics::{
-    COMPOUND_ADDRESS_RESOLUTION_BATCHES_METRIC, COMPOUND_ADDRESSES_RESOLVED_METRIC,
-    COMPOUND_PEAK_ADDRESS_RESOLUTION_BATCH_SIZE_METRIC, COMPOUND_PEAK_BUFFERED_CANDIDATES_METRIC,
-    COMPOUND_SCORE_FLOOR_OVERFLOWS_METRIC, COMPOUND_SHOULD_BOUND_RECOMPUTATIONS_METRIC,
-    COMPOUND_SHOULD_ESSENTIAL_EVALUATIONS_METRIC, COMPOUND_SHOULD_NON_ESSENTIAL_EVALUATIONS_METRIC,
-    COMPOUND_SHOULD_SKIPPED_WINDOWS_METRIC, CROSS_COLUMN_STAGED_ATTEMPTS_METRIC,
-    CROSS_COLUMN_STAGED_CANDIDATES_METRIC, CROSS_COLUMN_STAGED_FALLBACKS_METRIC,
-    CROSS_COLUMN_STAGED_SUCCESSES_METRIC, WAND_EXACTNESS_CERTIFICATE_ATTEMPTS_METRIC,
-    WAND_EXACTNESS_CERTIFICATE_CANDIDATES_METRIC, WAND_EXACTNESS_CERTIFICATE_EXHAUSTIVE_METRIC,
-    WAND_EXACTNESS_CERTIFICATE_FALLBACKS_METRIC, WAND_EXACTNESS_CERTIFICATE_STRICT_METRIC,
-    WAND_SEEDED_FALLBACK_COMPARISONS_METRIC, WAND_SEEDED_FALLBACKS_METRIC,
-    WAND_TIE_COMPLETION_ATTEMPTS_METRIC, WAND_TIE_COMPLETION_CANDIDATES_METRIC,
-    WAND_TIE_COMPLETION_COMPARISONS_METRIC, WAND_TIE_COMPLETION_OVERFLOWS_METRIC,
-    WAND_TIE_COMPLETION_SUCCESSES_METRIC,
-};
 use lance_index::optimize::OptimizeOptions;
 use lance_index::scalar::inverted::{
     DocumentGranularity, InvertedListFormatVersion, SCORE_COL,
@@ -1337,34 +1322,6 @@ async fn compound_fts_results(
         .collect()
 }
 
-async fn compound_fts_results_with_stats(
-    dataset: &Dataset,
-    query: FtsQuery,
-    limit: i64,
-) -> (Vec<(u64, f32)>, ExecutionSummaryCounts) {
-    let collected_stats = Arc::new(Mutex::new(None::<ExecutionSummaryCounts>));
-    let stats_setter = collected_stats.clone();
-    let mut scan = dataset.scan();
-    scan.scan_stats_callback(Arc::new(move |stats| {
-        *stats_setter.lock().unwrap() = Some(stats.clone());
-    }))
-    .with_row_id()
-    .full_text_search(FullTextSearchQuery::new_query(query))
-    .unwrap()
-    .limit(Some(limit), None)
-    .unwrap();
-    let batch = scan.try_into_batch().await.unwrap();
-    let row_ids = batch[ROW_ID].as_primitive::<UInt64Type>().values();
-    let scores = batch[SCORE_COL].as_primitive::<Float32Type>().values();
-    let results = row_ids
-        .iter()
-        .copied()
-        .zip(scores.iter().copied())
-        .collect();
-    let stats = collected_stats.lock().unwrap().take().unwrap();
-    (results, stats)
-}
-
 fn compound_fts_result_bits(batch: &RecordBatch) -> Vec<(u64, u32)> {
     let row_ids = batch[ROW_ID].as_primitive::<UInt64Type>().values();
     let scores = batch[SCORE_COL].as_primitive::<Float32Type>().values();
@@ -1717,13 +1674,8 @@ async fn test_cross_column_compound_scorer_matches_independent_leaf_oracle() {
         );
     }
 
-    let collected_stats = Arc::new(Mutex::new(None::<ExecutionSummaryCounts>));
-    let stats_setter = collected_stats.clone();
     let mut scanner = dataset.scan();
     scanner
-        .scan_stats_callback(Arc::new(move |stats| {
-            *stats_setter.lock().unwrap() = Some(stats.clone());
-        }))
         .with_row_id()
         .full_text_search(FullTextSearchQuery::new_query(
             staged_required_optional.clone(),
@@ -1731,26 +1683,6 @@ async fn test_cross_column_compound_scorer_matches_independent_leaf_oracle() {
         .unwrap();
     scanner.limit(Some(3), None).unwrap();
     let staged_results = compound_fts_result_bits(&scanner.try_into_batch().await.unwrap());
-    let stats = collected_stats.lock().unwrap().take().unwrap();
-    assert_eq!(
-        stats.all_counts.get(CROSS_COLUMN_STAGED_ATTEMPTS_METRIC),
-        Some(&1)
-    );
-    assert_eq!(
-        stats.all_counts.get(CROSS_COLUMN_STAGED_SUCCESSES_METRIC),
-        Some(&1)
-    );
-    assert_eq!(
-        stats.all_counts.get(CROSS_COLUMN_STAGED_FALLBACKS_METRIC),
-        Some(&0)
-    );
-    assert!(
-        stats
-            .all_counts
-            .get(CROSS_COLUMN_STAGED_CANDIDATES_METRIC)
-            .is_some_and(|candidates| *candidates > 0),
-        "required+optional execution should materialize staged candidates"
-    );
 
     dataset
         .prewarm_index_with_options(
@@ -1767,28 +1699,13 @@ async fn test_cross_column_compound_scorer_matches_independent_leaf_oracle() {
         .await
         .unwrap();
 
-    let collected_stats = Arc::new(Mutex::new(None::<ExecutionSummaryCounts>));
-    let stats_setter = collected_stats.clone();
     let mut scanner = dataset.scan();
     scanner
-        .scan_stats_callback(Arc::new(move |stats| {
-            *stats_setter.lock().unwrap() = Some(stats.clone());
-        }))
         .with_row_id()
         .full_text_search(FullTextSearchQuery::new_query(staged_required_optional))
         .unwrap();
     scanner.limit(Some(3), None).unwrap();
     let resident_results = compound_fts_result_bits(&scanner.try_into_batch().await.unwrap());
-    let stats = collected_stats.lock().unwrap().take().unwrap();
-    assert_eq!(
-        stats.all_counts.get(CROSS_COLUMN_STAGED_ATTEMPTS_METRIC),
-        Some(&0),
-        "prewarmed cross-column queries should use the resident bounded coordinator"
-    );
-    assert_eq!(
-        stats.all_counts.get(CROSS_COLUMN_STAGED_SUCCESSES_METRIC),
-        Some(&0)
-    );
     assert_eq!(
         resident_results, staged_results,
         "resident and staged cross-column scans must return identical ordered row ids and score bits"
@@ -1919,19 +1836,7 @@ async fn test_top_level_cross_column_multimatch_uses_field_local_compound_scorer
         LIMIT,
     )
     .await;
-    let (_, partial_stats) =
-        compound_fts_results_with_stats(&partial_dataset, explicit_query.clone(), LIMIT as i64)
-            .await;
-    assert_eq!(
-        partial_stats
-            .all_counts
-            .get(WAND_EXACTNESS_CERTIFICATE_ATTEMPTS_METRIC)
-            .copied()
-            .unwrap_or_default(),
-        1,
-        "only the fully indexed title field should attempt a bounded WAND certificate"
-    );
-    let partial_plan = compound_fts_plan(&partial_dataset, explicit_query.clone(), LIMIT).await;
+    let partial_plan = compound_fts_plan(&partial_dataset, explicit_query, LIMIT).await;
     assert!(
         !partial_plan.contains(CROSS_COLUMN_COMPOUND_FTS_SCORER),
         "top-level MultiMatch should keep field scoring independent:\n{partial_plan}"
@@ -2278,78 +2183,18 @@ async fn test_field_local_match_wand_exactness_certificates() {
     let strict_oracle =
         sorted_compound_fts_oracle(independent_compound_fts_oracle(&dataset, &strict_query).await);
     assert!(strict_oracle[0].1.total_cmp(&strict_oracle[1].1).is_gt());
-    let (strict, stats) = compound_fts_results_with_stats(&dataset, strict_query, 1).await;
+    let strict = compound_fts_results(&dataset, strict_query, Some(1)).await;
     assert_scored_rows_close("wand_certificate_strict", &strict, &strict_oracle[..1]);
-    assert_eq!(
-        stats
-            .all_counts
-            .get(WAND_EXACTNESS_CERTIFICATE_ATTEMPTS_METRIC),
-        Some(&1)
-    );
-    assert_eq!(
-        stats
-            .all_counts
-            .get(WAND_EXACTNESS_CERTIFICATE_STRICT_METRIC),
-        Some(&1)
-    );
-    assert_eq!(
-        stats
-            .all_counts
-            .get(WAND_EXACTNESS_CERTIFICATE_EXHAUSTIVE_METRIC),
-        Some(&0)
-    );
-    assert_eq!(
-        stats
-            .all_counts
-            .get(WAND_EXACTNESS_CERTIFICATE_FALLBACKS_METRIC),
-        Some(&0)
-    );
-    assert_eq!(
-        stats
-            .all_counts
-            .get(WAND_EXACTNESS_CERTIFICATE_CANDIDATES_METRIC),
-        Some(&2)
-    );
 
     let exhaustive_query = field_local_query("tiebody");
     let exhaustive_oracle = sorted_compound_fts_oracle(
         independent_compound_fts_oracle(&dataset, &exhaustive_query).await,
     );
-    let (exhaustive, stats) = compound_fts_results_with_stats(&dataset, exhaustive_query, 3).await;
+    let exhaustive = compound_fts_results(&dataset, exhaustive_query, Some(3)).await;
     assert_scored_rows_close(
         "wand_certificate_exhaustive",
         &exhaustive,
         &exhaustive_oracle,
-    );
-    assert_eq!(
-        stats
-            .all_counts
-            .get(WAND_EXACTNESS_CERTIFICATE_ATTEMPTS_METRIC),
-        Some(&1)
-    );
-    assert_eq!(
-        stats
-            .all_counts
-            .get(WAND_EXACTNESS_CERTIFICATE_STRICT_METRIC),
-        Some(&0)
-    );
-    assert_eq!(
-        stats
-            .all_counts
-            .get(WAND_EXACTNESS_CERTIFICATE_EXHAUSTIVE_METRIC),
-        Some(&1)
-    );
-    assert_eq!(
-        stats
-            .all_counts
-            .get(WAND_EXACTNESS_CERTIFICATE_FALLBACKS_METRIC),
-        Some(&0)
-    );
-    assert_eq!(
-        stats
-            .all_counts
-            .get(WAND_EXACTNESS_CERTIFICATE_CANDIDATES_METRIC),
-        Some(&2)
     );
 
     let tied_query = field_local_query("tie");
@@ -2358,104 +2203,19 @@ async fn test_field_local_match_wand_exactness_certificates() {
     assert_eq!(tied_oracle.len(), 2);
     assert_eq!(tied_oracle[0].1, tied_oracle[1].1);
     assert!(tied_oracle[0].0 < tied_oracle[1].0);
-    let (tied, stats) = compound_fts_results_with_stats(&dataset, tied_query, 1).await;
+    let tied = compound_fts_results(&dataset, tied_query, Some(1)).await;
     assert_scored_rows_close("wand_certificate_tie_completion", &tied, &tied_oracle[..1]);
-    assert_eq!(
-        stats
-            .all_counts
-            .get(WAND_EXACTNESS_CERTIFICATE_ATTEMPTS_METRIC),
-        Some(&1)
-    );
-    assert_eq!(
-        stats
-            .all_counts
-            .get(WAND_EXACTNESS_CERTIFICATE_STRICT_METRIC),
-        Some(&0)
-    );
-    assert_eq!(
-        stats
-            .all_counts
-            .get(WAND_EXACTNESS_CERTIFICATE_EXHAUSTIVE_METRIC),
-        Some(&1)
-    );
-    assert_eq!(
-        stats
-            .all_counts
-            .get(WAND_EXACTNESS_CERTIFICATE_FALLBACKS_METRIC),
-        Some(&0)
-    );
-    assert_eq!(
-        stats
-            .all_counts
-            .get(WAND_EXACTNESS_CERTIFICATE_CANDIDATES_METRIC),
-        Some(&2)
-    );
-    assert_eq!(
-        stats.all_counts.get(WAND_TIE_COMPLETION_ATTEMPTS_METRIC),
-        Some(&1)
-    );
-    assert_eq!(
-        stats.all_counts.get(WAND_TIE_COMPLETION_SUCCESSES_METRIC),
-        Some(&1)
-    );
-    assert_eq!(
-        stats.all_counts.get(WAND_TIE_COMPLETION_OVERFLOWS_METRIC),
-        Some(&0)
-    );
-    assert_eq!(
-        stats.all_counts.get(WAND_TIE_COMPLETION_CANDIDATES_METRIC),
-        Some(&2)
-    );
-    assert_eq!(stats.all_counts.get(WAND_SEEDED_FALLBACKS_METRIC), Some(&0));
 
     let mixed_query = field_local_query("noise");
     let mixed_oracle =
         sorted_compound_fts_oracle(independent_compound_fts_oracle(&dataset, &mixed_query).await);
-    let (mixed, stats) = compound_fts_results_with_stats(&dataset, mixed_query, 1).await;
+    let mixed = compound_fts_results(&dataset, mixed_query, Some(1)).await;
     assert_scored_rows_close("wand_certificate_mixed_fields", &mixed, &mixed_oracle[..1]);
-    assert_eq!(
-        stats
-            .all_counts
-            .get(WAND_EXACTNESS_CERTIFICATE_ATTEMPTS_METRIC),
-        Some(&2)
-    );
-    assert_eq!(
-        stats
-            .all_counts
-            .get(WAND_EXACTNESS_CERTIFICATE_EXHAUSTIVE_METRIC),
-        Some(&2)
-    );
-    assert_eq!(
-        stats
-            .all_counts
-            .get(WAND_EXACTNESS_CERTIFICATE_STRICT_METRIC),
-        Some(&0)
-    );
-    assert_eq!(
-        stats
-            .all_counts
-            .get(WAND_EXACTNESS_CERTIFICATE_FALLBACKS_METRIC),
-        Some(&0)
-    );
-    assert_eq!(
-        stats
-            .all_counts
-            .get(WAND_EXACTNESS_CERTIFICATE_CANDIDATES_METRIC),
-        Some(&3)
-    );
 
-    for (
-        case_name,
-        exact_term,
-        fuzzy_term,
-        limit,
-        expected_strict,
-        expected_exhaustive,
-        expected_fallbacks,
-    ) in [
-        ("strict", "alpha", "alphx", 1, 1, 1, 0),
-        ("exhaustive", "tiebody", "tiebodx", 3, 0, 2, 0),
-        ("ambiguous", "tie", "tix", 1, 0, 2, 0),
+    for (case_name, exact_term, fuzzy_term, limit) in [
+        ("strict", "alpha", "alphx", 1),
+        ("exhaustive", "tiebody", "tiebodx", 3),
+        ("ambiguous", "tie", "tix", 1),
     ] {
         let exact =
             compound_fts_results(&dataset, field_local_query(exact_term), Some(limit)).await;
@@ -2467,54 +2227,13 @@ async fn test_field_local_match_wand_exactness_certificates() {
         for query in &mut fuzzy.match_queries {
             query.fuzziness = Some(1);
         }
-        let (actual, stats) = compound_fts_results_with_stats(&dataset, fuzzy.into(), limit).await;
+        let actual = compound_fts_results(&dataset, fuzzy.into(), Some(limit)).await;
         assert_scored_rows_close(
             &format!("fuzzy_wand_certificate_{case_name}"),
             &actual,
             &exact,
         );
-        assert_eq!(
-            stats
-                .all_counts
-                .get(WAND_EXACTNESS_CERTIFICATE_ATTEMPTS_METRIC),
-            Some(&2),
-            "{case_name} fuzzy query must attempt one certificate per field"
-        );
-        for (metric, expected) in [
-            (WAND_EXACTNESS_CERTIFICATE_STRICT_METRIC, expected_strict),
-            (
-                WAND_EXACTNESS_CERTIFICATE_EXHAUSTIVE_METRIC,
-                expected_exhaustive,
-            ),
-            (
-                WAND_EXACTNESS_CERTIFICATE_FALLBACKS_METRIC,
-                expected_fallbacks,
-            ),
-        ] {
-            assert_eq!(
-                stats.all_counts.get(metric),
-                Some(&expected),
-                "{case_name} fuzzy query used the wrong certificate path for {metric}"
-            );
-        }
     }
-
-    let zero_boost_query: FtsQuery = MultiMatchQuery::try_new(
-        "blocked".to_owned(),
-        vec!["title".to_owned(), "body".to_owned()],
-    )
-    .unwrap()
-    .try_with_boosts(vec![0.0, 0.0])
-    .unwrap()
-    .into();
-    let (_, stats) = compound_fts_results_with_stats(&dataset, zero_boost_query, 1).await;
-    assert_eq!(
-        stats
-            .all_counts
-            .get(WAND_EXACTNESS_CERTIFICATE_ATTEMPTS_METRIC),
-        Some(&0),
-        "zero-boost fields must use the exact path without attempting a certificate"
-    );
 }
 
 async fn write_wand_tie_dataset(num_ties: usize) -> Dataset {
@@ -2563,26 +2282,13 @@ async fn test_wand_tie_completion_recovers_reversed_segment_row_id() {
     assert_eq!(oracle.len(), 6);
     assert_eq!(oracle[0].0, 0);
 
-    let (actual, stats) = compound_fts_results_with_stats(&dataset, query, 1).await;
+    let actual = compound_fts_results(&dataset, query, Some(1)).await;
 
     assert_scored_rows_close(
         "wand_tie_completion_reversed_segments",
         &actual,
         &oracle[..1],
     );
-    assert_eq!(
-        stats.all_counts.get(WAND_TIE_COMPLETION_ATTEMPTS_METRIC),
-        Some(&1)
-    );
-    assert_eq!(
-        stats.all_counts.get(WAND_TIE_COMPLETION_SUCCESSES_METRIC),
-        Some(&1)
-    );
-    assert_eq!(
-        stats.all_counts.get(WAND_TIE_COMPLETION_CANDIDATES_METRIC),
-        Some(&6)
-    );
-    assert_eq!(stats.all_counts.get(WAND_SEEDED_FALLBACKS_METRIC), Some(&0));
 }
 
 #[tokio::test]
@@ -2596,41 +2302,9 @@ async fn test_wand_tie_overflow_uses_seeded_fuzzy_boosted_fallback() {
     assert_eq!(oracle.len(), NUM_TIES);
     assert_eq!(oracle[0].0, 0);
 
-    let (actual, stats) = compound_fts_results_with_stats(&dataset, query, 1).await;
+    let actual = compound_fts_results(&dataset, query, Some(1)).await;
 
     assert_scored_rows_close("wand_tie_seeded_fuzzy_boost", &actual, &oracle[..1]);
-    assert_eq!(
-        stats.all_counts.get(WAND_TIE_COMPLETION_ATTEMPTS_METRIC),
-        Some(&1)
-    );
-    assert_eq!(
-        stats.all_counts.get(WAND_TIE_COMPLETION_OVERFLOWS_METRIC),
-        Some(&1)
-    );
-    assert_eq!(
-        stats.all_counts.get(WAND_TIE_COMPLETION_CANDIDATES_METRIC),
-        Some(&130),
-        "k=1 reserves 128 tie slots plus one lower-score guard slot"
-    );
-    assert_eq!(
-        stats
-            .all_counts
-            .get(WAND_EXACTNESS_CERTIFICATE_FALLBACKS_METRIC),
-        Some(&1)
-    );
-    assert_eq!(stats.all_counts.get(WAND_SEEDED_FALLBACKS_METRIC), Some(&1));
-    assert!(
-        stats
-            .all_counts
-            .get(WAND_TIE_COMPLETION_COMPARISONS_METRIC)
-            .is_some_and(|comparisons| *comparisons > 0)
-    );
-    assert!(
-        stats
-            .all_counts
-            .get(WAND_SEEDED_FALLBACK_COMPARISONS_METRIC)
-            .is_some_and(|comparisons| *comparisons > 0)
-    );
 }
 
 #[tokio::test]
@@ -3076,37 +2750,13 @@ async fn test_nested_multimatch_limit_propagation() {
     );
     assert_compound_matches_independent_oracle(&dataset, "nested_multimatch_must", &must_query, 2)
         .await;
-    let collected_stats = Arc::new(Mutex::new(None::<ExecutionSummaryCounts>));
-    let stats_setter = collected_stats.clone();
     let mut staged_scanner = dataset.scan();
     staged_scanner
-        .scan_stats_callback(Arc::new(move |stats| {
-            *stats_setter.lock().unwrap() = Some(stats.clone());
-        }))
         .with_row_id()
         .full_text_search(FullTextSearchQuery::new_query(must_query.clone()))
         .unwrap();
     staged_scanner.limit(Some(2), None).unwrap();
     staged_scanner.try_into_batch().await.unwrap();
-    let staged_stats = collected_stats.lock().unwrap().take().unwrap();
-    assert_eq!(
-        staged_stats
-            .all_counts
-            .get(CROSS_COLUMN_STAGED_ATTEMPTS_METRIC),
-        Some(&1)
-    );
-    assert_eq!(
-        staged_stats
-            .all_counts
-            .get(CROSS_COLUMN_STAGED_SUCCESSES_METRIC),
-        Some(&1)
-    );
-    assert_eq!(
-        staged_stats
-            .all_counts
-            .get(CROSS_COLUMN_STAGED_FALLBACKS_METRIC),
-        Some(&0)
-    );
 
     let should_query: FtsQuery = BooleanQuery::new([
         (Occur::Should, compound_multimatch_query()),
@@ -3333,25 +2983,6 @@ async fn test_pure_should_maxscore_is_exact_across_fragments() {
     scanner.limit(Some(2), None).unwrap();
     scanner.try_into_batch().await.unwrap();
     let stats = collected_stats.lock().unwrap().take().unwrap();
-    for metric in [
-        COMPOUND_SHOULD_SKIPPED_WINDOWS_METRIC,
-        COMPOUND_SHOULD_BOUND_RECOMPUTATIONS_METRIC,
-        COMPOUND_SHOULD_ESSENTIAL_EVALUATIONS_METRIC,
-        COMPOUND_SHOULD_NON_ESSENTIAL_EVALUATIONS_METRIC,
-    ] {
-        assert!(
-            stats.all_counts.contains_key(metric),
-            "pure-SHOULD execution stats should expose {metric}"
-        );
-    }
-    assert!(
-        stats.all_counts[COMPOUND_SHOULD_BOUND_RECOMPUTATIONS_METRIC] > 0,
-        "pure-SHOULD execution should recompute clause bounds"
-    );
-    assert!(
-        stats.all_counts[COMPOUND_SHOULD_ESSENTIAL_EVALUATIONS_METRIC] > 0,
-        "pure-SHOULD execution should evaluate essential clauses"
-    );
     assert_eq!(
         stats.all_counts.get(PARTITIONS_SEARCHED_METRIC),
         Some(&(4 * 5)),
@@ -3441,13 +3072,8 @@ async fn test_compound_tie_uses_resolved_row_id() {
     )
     .unwrap()
     .into();
-    let collected_stats = Arc::new(Mutex::new(None::<ExecutionSummaryCounts>));
-    let stats_setter = collected_stats.clone();
     let mut scanner = dataset.scan();
     scanner
-        .scan_stats_callback(Arc::new(move |stats| {
-            *stats_setter.lock().unwrap() = Some(stats.clone());
-        }))
         .with_row_id()
         .full_text_search(FullTextSearchQuery::new_query(query.clone()))
         .unwrap();
@@ -3458,44 +3084,6 @@ async fn test_compound_tie_uses_resolved_row_id() {
     let exhaustive = compound_fts_results(&dataset, query.clone(), None).await;
     assert_eq!(limited_row_id, exhaustive[0].0);
     assert_eq!(exhaustive.len(), 384);
-
-    let stats = collected_stats.lock().unwrap().take().unwrap();
-    assert_eq!(
-        stats.all_counts.get(COMPOUND_SCORE_FLOOR_OVERFLOWS_METRIC),
-        Some(&1)
-    );
-    assert_eq!(
-        stats.all_counts.get(COMPOUND_ADDRESSES_RESOLVED_METRIC),
-        Some(&384)
-    );
-    assert_eq!(
-        stats
-            .all_counts
-            .get(COMPOUND_ADDRESS_RESOLUTION_BATCHES_METRIC),
-        Some(&1)
-    );
-
-    let mut analyze_scanner = dataset.scan();
-    analyze_scanner
-        .with_row_id()
-        .full_text_search(FullTextSearchQuery::new_query(query))
-        .unwrap();
-    analyze_scanner.limit(Some(1), None).unwrap();
-    let analysis = analyze_scanner.analyze_plan().await.unwrap();
-    let compound_line = analysis
-        .lines()
-        .find(|line| line.contains("CompoundFtsScorer"))
-        .unwrap();
-    assert!(
-        compound_line.contains(&format!("{COMPOUND_PEAK_BUFFERED_CANDIDATES_METRIC}=128")),
-        "compound FTS metrics missing the bounded candidate peak: {compound_line}"
-    );
-    assert!(
-        compound_line.contains(&format!(
-            "{COMPOUND_PEAK_ADDRESS_RESOLUTION_BATCH_SIZE_METRIC}=128"
-        )),
-        "compound FTS metrics missing the bounded resolution batch: {compound_line}"
-    );
 }
 
 fn nested_fts_batch(

--- a/rust/lance/src/io/exec/fts.rs
+++ b/rust/lance/src/io/exec/fts.rs
@@ -43,30 +43,7 @@ use crate::index::scalar::inverted::{
     transform_fts_document_stream,
 };
 use crate::{Dataset, index::DatasetIndexInternalExt};
-use lance_index::metrics::{
-    AND_CANDIDATES_PRUNED_BEFORE_RETURN_METRIC, AND_CANDIDATES_SEEN_METRIC, AND_FULL_SCORES_METRIC,
-    COMPOUND_ADDRESS_RESOLUTION_BATCHES_METRIC, COMPOUND_ADDRESSES_RESOLVED_METRIC,
-    COMPOUND_PEAK_ADDRESS_RESOLUTION_BATCH_SIZE_METRIC, COMPOUND_PEAK_BUFFERED_CANDIDATES_METRIC,
-    COMPOUND_PHRASE_EXACT_APPROXIMATIONS_METRIC,
-    COMPOUND_PHRASE_EXACT_CONFIRMATIONS_AVOIDED_METRIC, COMPOUND_PHRASE_EXACT_CONFIRMATIONS_METRIC,
-    COMPOUND_PHRASE_SLOPPY_APPROXIMATIONS_METRIC,
-    COMPOUND_PHRASE_SLOPPY_CONFIRMATIONS_AVOIDED_METRIC,
-    COMPOUND_PHRASE_SLOPPY_CONFIRMATIONS_METRIC, COMPOUND_SCORE_FLOOR_OVERFLOWS_METRIC,
-    COMPOUND_SHOULD_BOUND_RECOMPUTATIONS_METRIC, COMPOUND_SHOULD_ESSENTIAL_EVALUATIONS_METRIC,
-    COMPOUND_SHOULD_NON_ESSENTIAL_EVALUATIONS_METRIC, COMPOUND_SHOULD_SKIPPED_WINDOWS_METRIC,
-    CROSS_COLUMN_STAGED_ATTEMPTS_METRIC, CROSS_COLUMN_STAGED_CANDIDATES_METRIC,
-    CROSS_COLUMN_STAGED_FALLBACKS_METRIC, CROSS_COLUMN_STAGED_SUCCESSES_METRIC,
-    FREQS_COLLECTED_METRIC, MetricsCollector, NO_IMPACT_GLOBAL_SCORER_FALLBACKS_METRIC,
-    WAND_EXACTNESS_CERTIFICATE_ATTEMPTS_METRIC, WAND_EXACTNESS_CERTIFICATE_CANDIDATES_METRIC,
-    WAND_EXACTNESS_CERTIFICATE_EXHAUSTIVE_METRIC, WAND_EXACTNESS_CERTIFICATE_FALLBACKS_METRIC,
-    WAND_EXACTNESS_CERTIFICATE_STRICT_METRIC, WAND_EXACTNESS_PROBE_COMPARISONS_METRIC,
-    WAND_EXACTNESS_PROBE_MS_METRIC, WAND_SEEDED_FALLBACK_COMPARISONS_METRIC,
-    WAND_SEEDED_FALLBACK_MS_METRIC, WAND_SEEDED_FALLBACKS_METRIC,
-    WAND_TIE_COMPLETION_ATTEMPTS_METRIC, WAND_TIE_COMPLETION_CANDIDATES_METRIC,
-    WAND_TIE_COMPLETION_COMPARISONS_METRIC, WAND_TIE_COMPLETION_MS_METRIC,
-    WAND_TIE_COMPLETION_OVERFLOWS_METRIC, WAND_TIE_COMPLETION_ROW_ID_REPLACEMENTS_METRIC,
-    WAND_TIE_COMPLETION_SUCCESSES_METRIC,
-};
+use lance_index::metrics::MetricsCollector;
 use lance_index::scalar::inverted::builder::ScoredDoc;
 use lance_index::scalar::inverted::builder::document_input;
 use lance_index::scalar::inverted::document_tokenizer::{DocType, JsonTokenizer, LanceTokenizer};
@@ -873,19 +850,6 @@ fn finish_wand_documents(mut documents: Vec<ScoredDoc>, limit: usize) -> (Vec<u6
         .unzip()
 }
 
-fn count_smaller_row_id_replacements(
-    initial: &[ScoredDoc],
-    completion: &[ScoredDoc],
-    limit: usize,
-) -> usize {
-    initial
-        .iter()
-        .zip(completion)
-        .take(limit)
-        .filter(|(initial, completed)| completed.row_id < initial.row_id)
-        .count()
-}
-
 async fn exact_prepared_match_fallback(
     indices: &[Arc<InvertedIndex>],
     query: &FtsQuery,
@@ -1154,10 +1118,7 @@ impl ExecutionPlan for CompoundQueryExec {
                     )
                     .await?
                 } else {
-                    metrics.record_wand_exactness_certificate_attempts(1);
                     prefilter.wait_for_ready().await?;
-                    let probe_start = std::time::Instant::now();
-                    let probe_comparisons = metrics.index_metrics.comparisons();
                     let mut documents = search_prepared_segments(
                         &indices,
                         prepared.clone(),
@@ -1166,26 +1127,14 @@ impl ExecutionPlan for CompoundQueryExec {
                         None,
                     )
                     .await?;
-                    metrics.record_wand_exactness_probe(probe_start.elapsed());
-                    metrics.record_wand_exactness_probe_comparisons(
-                        metrics
-                            .index_metrics
-                            .comparisons()
-                            .saturating_sub(probe_comparisons),
-                    );
                     documents.iter_mut().for_each(|document| {
                         document.score.0 *= match_query.boost;
                     });
-                    metrics.record_wand_exactness_certificate_candidates(documents.len());
                     match classify_wand_exactness_certificate(&mut documents, limit, wand_limit) {
                         WandExactnessCertificate::Exhaustive => {
-                            metrics.record_wand_exactness_certificate_exhaustive(1);
                             finish_wand_documents(documents, limit)
                         }
-                        WandExactnessCertificate::Strict => {
-                            metrics.record_wand_exactness_certificate_strict(1);
-                            finish_wand_documents(documents, limit)
-                        }
+                        WandExactnessCertificate::Strict => finish_wand_documents(documents, limit),
                         WandExactnessCertificate::Ambiguous => {
                             let score_floor = documents
                                 .get(limit - 1)
@@ -1197,7 +1146,6 @@ impl ExecutionPlan for CompoundQueryExec {
                             if let (Some(score_floor), Some(completion_limit)) =
                                 (score_floor, completion_limit)
                             {
-                                metrics.record_wand_tie_completion_attempts(1);
                                 let completion_prepared = Arc::new(PreparedMatch {
                                     query: prepared.query.clone(),
                                     params: Arc::new(
@@ -1209,8 +1157,6 @@ impl ExecutionPlan for CompoundQueryExec {
                                     ),
                                     operator: prepared.operator,
                                 });
-                                let completion_start = std::time::Instant::now();
-                                let completion_comparisons = metrics.index_metrics.comparisons();
                                 let raw_score_floor =
                                     exclusive_scaled_score_floor(score_floor, match_query.boost);
                                 let mut completion = search_prepared_segments(
@@ -1221,44 +1167,18 @@ impl ExecutionPlan for CompoundQueryExec {
                                     raw_score_floor,
                                 )
                                 .await?;
-                                metrics.record_wand_tie_completion(completion_start.elapsed());
-                                metrics.record_wand_tie_completion_comparisons(
-                                    metrics
-                                        .index_metrics
-                                        .comparisons()
-                                        .saturating_sub(completion_comparisons),
-                                );
                                 completion.iter_mut().for_each(|document| {
                                     document.score.0 *= match_query.boost;
                                 });
-                                metrics.record_wand_tie_completion_candidates(completion.len());
                                 match classify_wand_exactness_certificate(
                                     &mut completion,
                                     limit,
                                     completion_limit,
                                 ) {
                                     WandExactnessCertificate::Exhaustive => {
-                                        metrics.record_wand_tie_completion_successes(1);
-                                        metrics.record_wand_tie_completion_row_id_replacements(
-                                            count_smaller_row_id_replacements(
-                                                &documents,
-                                                &completion,
-                                                limit,
-                                            ),
-                                        );
-                                        metrics.record_wand_exactness_certificate_exhaustive(1);
                                         finish_wand_documents(completion, limit)
                                     }
                                     WandExactnessCertificate::Strict => {
-                                        metrics.record_wand_tie_completion_successes(1);
-                                        metrics.record_wand_tie_completion_row_id_replacements(
-                                            count_smaller_row_id_replacements(
-                                                &documents,
-                                                &completion,
-                                                limit,
-                                            ),
-                                        );
-                                        metrics.record_wand_exactness_certificate_strict(1);
                                         finish_wand_documents(completion, limit)
                                     }
                                     WandExactnessCertificate::Ambiguous => {
@@ -1266,15 +1186,7 @@ impl ExecutionPlan for CompoundQueryExec {
                                             .iter()
                                             .all(|document| document.score.0.is_finite())
                                             .then_some(score_floor);
-                                        metrics.record_wand_exactness_certificate_fallbacks(1);
-                                        if seeded_floor.is_some() {
-                                            metrics.record_wand_tie_completion_overflows(1);
-                                            metrics.record_wand_seeded_fallbacks(1);
-                                        }
-                                        let fallback_start = std::time::Instant::now();
-                                        let fallback_comparisons =
-                                            metrics.index_metrics.comparisons();
-                                        let results = exact_prepared_match_fallback(
+                                        exact_prepared_match_fallback(
                                             &indices,
                                             &query,
                                             &params,
@@ -1283,29 +1195,11 @@ impl ExecutionPlan for CompoundQueryExec {
                                             prepared.query.clone(),
                                             seeded_floor,
                                         )
-                                        .await?;
-                                        if seeded_floor.is_some() {
-                                            metrics.record_wand_seeded_fallback(
-                                                fallback_start.elapsed(),
-                                            );
-                                            metrics.record_wand_seeded_fallback_comparisons(
-                                                metrics
-                                                    .index_metrics
-                                                    .comparisons()
-                                                    .saturating_sub(fallback_comparisons),
-                                            );
-                                        }
-                                        results
+                                        .await?
                                     }
                                 }
                             } else {
-                                metrics.record_wand_exactness_certificate_fallbacks(1);
-                                if score_floor.is_some() {
-                                    metrics.record_wand_seeded_fallbacks(1);
-                                }
-                                let fallback_start = std::time::Instant::now();
-                                let fallback_comparisons = metrics.index_metrics.comparisons();
-                                let results = exact_prepared_match_fallback(
+                                exact_prepared_match_fallback(
                                     &indices,
                                     &query,
                                     &params,
@@ -1314,17 +1208,7 @@ impl ExecutionPlan for CompoundQueryExec {
                                     prepared.query.clone(),
                                     score_floor,
                                 )
-                                .await?;
-                                if score_floor.is_some() {
-                                    metrics.record_wand_seeded_fallback(fallback_start.elapsed());
-                                    metrics.record_wand_seeded_fallback_comparisons(
-                                        metrics
-                                            .index_metrics
-                                            .comparisons()
-                                            .saturating_sub(fallback_comparisons),
-                                    );
-                                }
-                                results
+                                .await?
                             }
                         }
                     }
@@ -2129,47 +2013,6 @@ impl FtsSegmentSelection {
 pub struct FtsIndexMetrics {
     index_metrics: IndexMetrics,
     partitions_searched: Count,
-    and_candidates_seen: Count,
-    and_candidates_pruned_before_return: Count,
-    and_full_scores: Count,
-    freqs_collected: Count,
-    compound_addresses_resolved: Count,
-    compound_address_resolution_batches: Count,
-    compound_peak_address_resolution_batch_size: Gauge,
-    compound_score_floor_overflows: Count,
-    compound_peak_buffered_candidates: Gauge,
-    compound_should_skipped_windows: Count,
-    compound_should_bound_recomputations: Count,
-    compound_should_essential_evaluations: Count,
-    compound_should_non_essential_evaluations: Count,
-    compound_phrase_exact_approximations: Count,
-    compound_phrase_sloppy_approximations: Count,
-    compound_phrase_exact_confirmations: Count,
-    compound_phrase_sloppy_confirmations: Count,
-    compound_phrase_exact_confirmations_avoided: Count,
-    compound_phrase_sloppy_confirmations_avoided: Count,
-    cross_column_staged_attempts: Count,
-    cross_column_staged_successes: Count,
-    cross_column_staged_fallbacks: Count,
-    cross_column_staged_candidates: Count,
-    wand_exactness_certificate_attempts: Count,
-    wand_exactness_certificate_strict: Count,
-    wand_exactness_certificate_exhaustive: Count,
-    wand_exactness_certificate_fallbacks: Count,
-    wand_exactness_certificate_candidates: Count,
-    wand_exactness_probe_ms: Gauge,
-    wand_exactness_probe_comparisons: Count,
-    wand_tie_completion_attempts: Count,
-    wand_tie_completion_successes: Count,
-    wand_tie_completion_overflows: Count,
-    wand_tie_completion_candidates: Count,
-    wand_tie_completion_row_id_replacements: Count,
-    wand_tie_completion_ms: Gauge,
-    wand_tie_completion_comparisons: Count,
-    wand_seeded_fallbacks: Count,
-    wand_seeded_fallback_ms: Gauge,
-    wand_seeded_fallback_comparisons: Count,
-    no_impact_global_scorer_fallbacks: Count,
     /// Wall time (ms) of the exec-local `build_global_bm25_scorer`
     /// fallback; zero when a preset base scorer was injected.
     scorer_build_ms: Gauge,
@@ -2182,87 +2025,6 @@ impl FtsIndexMetrics {
         Self {
             index_metrics: IndexMetrics::new(metrics, partition),
             partitions_searched: metrics.new_count(PARTITIONS_SEARCHED_METRIC, partition),
-            and_candidates_seen: metrics.new_count(AND_CANDIDATES_SEEN_METRIC, partition),
-            and_candidates_pruned_before_return: metrics
-                .new_count(AND_CANDIDATES_PRUNED_BEFORE_RETURN_METRIC, partition),
-            and_full_scores: metrics.new_count(AND_FULL_SCORES_METRIC, partition),
-            freqs_collected: metrics.new_count(FREQS_COLLECTED_METRIC, partition),
-            compound_addresses_resolved: metrics
-                .new_count(COMPOUND_ADDRESSES_RESOLVED_METRIC, partition),
-            compound_address_resolution_batches: metrics
-                .new_count(COMPOUND_ADDRESS_RESOLUTION_BATCHES_METRIC, partition),
-            compound_peak_address_resolution_batch_size: metrics.new_gauge(
-                COMPOUND_PEAK_ADDRESS_RESOLUTION_BATCH_SIZE_METRIC,
-                partition,
-            ),
-            compound_score_floor_overflows: metrics
-                .new_count(COMPOUND_SCORE_FLOOR_OVERFLOWS_METRIC, partition),
-            compound_peak_buffered_candidates: metrics
-                .new_gauge(COMPOUND_PEAK_BUFFERED_CANDIDATES_METRIC, partition),
-            compound_should_skipped_windows: metrics
-                .new_count(COMPOUND_SHOULD_SKIPPED_WINDOWS_METRIC, partition),
-            compound_should_bound_recomputations: metrics
-                .new_count(COMPOUND_SHOULD_BOUND_RECOMPUTATIONS_METRIC, partition),
-            compound_should_essential_evaluations: metrics
-                .new_count(COMPOUND_SHOULD_ESSENTIAL_EVALUATIONS_METRIC, partition),
-            compound_should_non_essential_evaluations: metrics
-                .new_count(COMPOUND_SHOULD_NON_ESSENTIAL_EVALUATIONS_METRIC, partition),
-            compound_phrase_exact_approximations: metrics
-                .new_count(COMPOUND_PHRASE_EXACT_APPROXIMATIONS_METRIC, partition),
-            compound_phrase_sloppy_approximations: metrics
-                .new_count(COMPOUND_PHRASE_SLOPPY_APPROXIMATIONS_METRIC, partition),
-            compound_phrase_exact_confirmations: metrics
-                .new_count(COMPOUND_PHRASE_EXACT_CONFIRMATIONS_METRIC, partition),
-            compound_phrase_sloppy_confirmations: metrics
-                .new_count(COMPOUND_PHRASE_SLOPPY_CONFIRMATIONS_METRIC, partition),
-            compound_phrase_exact_confirmations_avoided: metrics.new_count(
-                COMPOUND_PHRASE_EXACT_CONFIRMATIONS_AVOIDED_METRIC,
-                partition,
-            ),
-            compound_phrase_sloppy_confirmations_avoided: metrics.new_count(
-                COMPOUND_PHRASE_SLOPPY_CONFIRMATIONS_AVOIDED_METRIC,
-                partition,
-            ),
-            cross_column_staged_attempts: metrics
-                .new_count(CROSS_COLUMN_STAGED_ATTEMPTS_METRIC, partition),
-            cross_column_staged_successes: metrics
-                .new_count(CROSS_COLUMN_STAGED_SUCCESSES_METRIC, partition),
-            cross_column_staged_fallbacks: metrics
-                .new_count(CROSS_COLUMN_STAGED_FALLBACKS_METRIC, partition),
-            cross_column_staged_candidates: metrics
-                .new_count(CROSS_COLUMN_STAGED_CANDIDATES_METRIC, partition),
-            wand_exactness_certificate_attempts: metrics
-                .new_count(WAND_EXACTNESS_CERTIFICATE_ATTEMPTS_METRIC, partition),
-            wand_exactness_certificate_strict: metrics
-                .new_count(WAND_EXACTNESS_CERTIFICATE_STRICT_METRIC, partition),
-            wand_exactness_certificate_exhaustive: metrics
-                .new_count(WAND_EXACTNESS_CERTIFICATE_EXHAUSTIVE_METRIC, partition),
-            wand_exactness_certificate_fallbacks: metrics
-                .new_count(WAND_EXACTNESS_CERTIFICATE_FALLBACKS_METRIC, partition),
-            wand_exactness_certificate_candidates: metrics
-                .new_count(WAND_EXACTNESS_CERTIFICATE_CANDIDATES_METRIC, partition),
-            wand_exactness_probe_ms: metrics.new_gauge(WAND_EXACTNESS_PROBE_MS_METRIC, partition),
-            wand_exactness_probe_comparisons: metrics
-                .new_count(WAND_EXACTNESS_PROBE_COMPARISONS_METRIC, partition),
-            wand_tie_completion_attempts: metrics
-                .new_count(WAND_TIE_COMPLETION_ATTEMPTS_METRIC, partition),
-            wand_tie_completion_successes: metrics
-                .new_count(WAND_TIE_COMPLETION_SUCCESSES_METRIC, partition),
-            wand_tie_completion_overflows: metrics
-                .new_count(WAND_TIE_COMPLETION_OVERFLOWS_METRIC, partition),
-            wand_tie_completion_candidates: metrics
-                .new_count(WAND_TIE_COMPLETION_CANDIDATES_METRIC, partition),
-            wand_tie_completion_row_id_replacements: metrics
-                .new_count(WAND_TIE_COMPLETION_ROW_ID_REPLACEMENTS_METRIC, partition),
-            wand_tie_completion_ms: metrics.new_gauge(WAND_TIE_COMPLETION_MS_METRIC, partition),
-            wand_tie_completion_comparisons: metrics
-                .new_count(WAND_TIE_COMPLETION_COMPARISONS_METRIC, partition),
-            wand_seeded_fallbacks: metrics.new_count(WAND_SEEDED_FALLBACKS_METRIC, partition),
-            wand_seeded_fallback_ms: metrics.new_gauge(WAND_SEEDED_FALLBACK_MS_METRIC, partition),
-            wand_seeded_fallback_comparisons: metrics
-                .new_count(WAND_SEEDED_FALLBACK_COMPARISONS_METRIC, partition),
-            no_impact_global_scorer_fallbacks: metrics
-                .new_count(NO_IMPACT_GLOBAL_SCORER_FALLBACKS_METRIC, partition),
             scorer_build_ms: metrics.new_gauge("scorer_build_ms", partition),
             segment_bind_duration: metrics.new_time(FTS_SEGMENT_BIND_DURATION_METRIC, partition),
             baseline_metrics: BaselineMetrics::new(metrics, partition),
@@ -2275,38 +2037,6 @@ impl FtsIndexMetrics {
 
     pub fn record_scorer_build(&self, elapsed: std::time::Duration) {
         self.scorer_build_ms.set(elapsed.as_millis() as usize);
-    }
-
-    fn record_wand_exactness_probe(&self, elapsed: std::time::Duration) {
-        self.wand_exactness_probe_ms
-            .set(elapsed.as_millis() as usize);
-    }
-
-    fn record_wand_exactness_probe_comparisons(&self, comparisons: usize) {
-        self.wand_exactness_probe_comparisons.add(comparisons);
-    }
-
-    fn record_wand_tie_completion(&self, elapsed: std::time::Duration) {
-        self.wand_tie_completion_ms
-            .set(elapsed.as_millis() as usize);
-    }
-
-    fn record_wand_tie_completion_comparisons(&self, comparisons: usize) {
-        self.wand_tie_completion_comparisons.add(comparisons);
-    }
-
-    fn record_wand_tie_completion_row_id_replacements(&self, replacements: usize) {
-        self.wand_tie_completion_row_id_replacements
-            .add(replacements);
-    }
-
-    fn record_wand_seeded_fallback(&self, elapsed: std::time::Duration) {
-        self.wand_seeded_fallback_ms
-            .set(elapsed.as_millis() as usize);
-    }
-
-    fn record_wand_seeded_fallback_comparisons(&self, comparisons: usize) {
-        self.wand_seeded_fallback_comparisons.add(comparisons);
     }
 }
 
@@ -2329,155 +2059,6 @@ impl MetricsCollector for FtsIndexMetrics {
 
     fn record_index_cache_misses(&self, num_misses: usize) {
         self.index_metrics.record_index_cache_misses(num_misses);
-    }
-
-    fn record_and_candidates_seen(&self, num_candidates: usize) {
-        self.and_candidates_seen.add(num_candidates);
-    }
-
-    fn record_and_candidates_pruned_before_return(&self, num_candidates: usize) {
-        self.and_candidates_pruned_before_return.add(num_candidates);
-    }
-
-    fn record_and_full_scores(&self, num_scores: usize) {
-        self.and_full_scores.add(num_scores);
-    }
-
-    fn record_freqs_collected(&self, num_collections: usize) {
-        self.freqs_collected.add(num_collections);
-    }
-
-    fn record_compound_addresses_resolved(&self, num_addresses: usize) {
-        self.compound_addresses_resolved.add(num_addresses);
-    }
-
-    fn record_compound_address_resolution_batches(&self, num_batches: usize) {
-        self.compound_address_resolution_batches.add(num_batches);
-    }
-
-    fn record_compound_peak_address_resolution_batch_size(&self, num_addresses: usize) {
-        self.compound_peak_address_resolution_batch_size
-            .set_max(num_addresses);
-    }
-
-    fn record_compound_score_floor_overflows(&self, num_overflows: usize) {
-        self.compound_score_floor_overflows.add(num_overflows);
-    }
-
-    fn record_compound_peak_buffered_candidates(&self, num_candidates: usize) {
-        self.compound_peak_buffered_candidates
-            .set_max(num_candidates);
-    }
-
-    fn record_compound_should_skipped_windows(&self, num_windows: usize) {
-        self.compound_should_skipped_windows.add(num_windows);
-    }
-
-    fn record_compound_should_bound_recomputations(&self, num_recomputations: usize) {
-        self.compound_should_bound_recomputations
-            .add(num_recomputations);
-    }
-
-    fn record_compound_should_essential_evaluations(&self, num_evaluations: usize) {
-        self.compound_should_essential_evaluations
-            .add(num_evaluations);
-    }
-
-    fn record_compound_should_non_essential_evaluations(&self, num_evaluations: usize) {
-        self.compound_should_non_essential_evaluations
-            .add(num_evaluations);
-    }
-
-    fn record_compound_phrase_exact_approximations(&self, num_approximations: usize) {
-        self.compound_phrase_exact_approximations
-            .add(num_approximations);
-    }
-
-    fn record_compound_phrase_sloppy_approximations(&self, num_approximations: usize) {
-        self.compound_phrase_sloppy_approximations
-            .add(num_approximations);
-    }
-
-    fn record_compound_phrase_exact_confirmations(&self, num_confirmations: usize) {
-        self.compound_phrase_exact_confirmations
-            .add(num_confirmations);
-    }
-
-    fn record_compound_phrase_sloppy_confirmations(&self, num_confirmations: usize) {
-        self.compound_phrase_sloppy_confirmations
-            .add(num_confirmations);
-    }
-
-    fn record_compound_phrase_exact_confirmations_avoided(&self, num_confirmations: usize) {
-        self.compound_phrase_exact_confirmations_avoided
-            .add(num_confirmations);
-    }
-
-    fn record_compound_phrase_sloppy_confirmations_avoided(&self, num_confirmations: usize) {
-        self.compound_phrase_sloppy_confirmations_avoided
-            .add(num_confirmations);
-    }
-
-    fn record_cross_column_staged_attempts(&self, num_attempts: usize) {
-        self.cross_column_staged_attempts.add(num_attempts);
-    }
-
-    fn record_cross_column_staged_successes(&self, num_successes: usize) {
-        self.cross_column_staged_successes.add(num_successes);
-    }
-
-    fn record_cross_column_staged_fallbacks(&self, num_fallbacks: usize) {
-        self.cross_column_staged_fallbacks.add(num_fallbacks);
-    }
-
-    fn record_cross_column_staged_candidates(&self, num_candidates: usize) {
-        self.cross_column_staged_candidates.add(num_candidates);
-    }
-
-    fn record_wand_exactness_certificate_attempts(&self, num_attempts: usize) {
-        self.wand_exactness_certificate_attempts.add(num_attempts);
-    }
-
-    fn record_wand_exactness_certificate_strict(&self, num_certificates: usize) {
-        self.wand_exactness_certificate_strict.add(num_certificates);
-    }
-
-    fn record_wand_exactness_certificate_exhaustive(&self, num_certificates: usize) {
-        self.wand_exactness_certificate_exhaustive
-            .add(num_certificates);
-    }
-
-    fn record_wand_exactness_certificate_fallbacks(&self, num_fallbacks: usize) {
-        self.wand_exactness_certificate_fallbacks.add(num_fallbacks);
-    }
-
-    fn record_wand_exactness_certificate_candidates(&self, num_candidates: usize) {
-        self.wand_exactness_certificate_candidates
-            .add(num_candidates);
-    }
-
-    fn record_wand_tie_completion_attempts(&self, num_attempts: usize) {
-        self.wand_tie_completion_attempts.add(num_attempts);
-    }
-
-    fn record_wand_tie_completion_successes(&self, num_successes: usize) {
-        self.wand_tie_completion_successes.add(num_successes);
-    }
-
-    fn record_wand_tie_completion_overflows(&self, num_overflows: usize) {
-        self.wand_tie_completion_overflows.add(num_overflows);
-    }
-
-    fn record_wand_tie_completion_candidates(&self, num_candidates: usize) {
-        self.wand_tie_completion_candidates.add(num_candidates);
-    }
-
-    fn record_wand_seeded_fallbacks(&self, num_fallbacks: usize) {
-        self.wand_seeded_fallbacks.add(num_fallbacks);
-    }
-
-    fn record_no_impact_global_scorer_fallbacks(&self, num_fallbacks: usize) {
-        self.no_impact_global_scorer_fallbacks.add(num_fallbacks);
     }
 }
 
@@ -4839,7 +4420,7 @@ mod tests {
     use lance_datafusion::exec::{ExecutionStatsCallback, ExecutionSummaryCounts};
     use lance_datafusion::utils::PARTITIONS_SEARCHED_METRIC;
     use lance_datagen::{BatchCount, ByteCount, RowCount};
-    use lance_index::metrics::{MetricsCollector, NoOpMetricsCollector};
+    use lance_index::metrics::NoOpMetricsCollector;
     use lance_index::scalar::inverted::builder::ScoredDoc;
     use lance_index::scalar::inverted::query::{
         BooleanQuery, BoostQuery, FtsQuery, FtsSearchParams, MatchQuery, Occur, Operator,
@@ -4866,12 +4447,9 @@ mod tests {
     use super::{
         BoolSlot, BoostQueryExec, CompoundQueryExec, CrossColumnCompoundQueryExec,
         FTS_SEGMENT_BIND_DURATION_METRIC, FlatMatchFilterExec, FlatMatchQueryExec, MatchQueryExec,
-        PhraseQueryExec, WAND_EXACTNESS_CERTIFICATE_FALLBACKS_METRIC,
-        WAND_TIE_COMPLETION_ATTEMPTS_METRIC, WAND_TIE_COMPLETION_BUDGET,
-        WAND_TIE_COMPLETION_SUCCESSES_METRIC, WandExactnessCertificate,
-        build_boolean_query_children, classify_wand_exactness_certificate,
-        count_smaller_row_id_replacements, default_text_tokenizer, open_fts_segments,
-        tokenizer_for_match_query,
+        PhraseQueryExec, WAND_TIE_COMPLETION_BUDGET, WandExactnessCertificate,
+        build_boolean_query_children, classify_wand_exactness_certificate, default_text_tokenizer,
+        open_fts_segments, tokenizer_for_match_query,
     };
     use crate::io::exec::utils::IndexMetrics;
     use datafusion::physical_plan::empty::EmptyExec;
@@ -4895,64 +4473,6 @@ mod tests {
         fn consume(self) -> ExecutionSummaryCounts {
             self.collected_stats.lock().unwrap().take().unwrap()
         }
-    }
-
-    #[test]
-    fn test_compound_should_metrics_are_counted_independently() {
-        let metrics_set = ExecutionPlanMetricsSet::new();
-        let metrics = super::FtsIndexMetrics::new(&metrics_set, 0);
-
-        metrics.record_compound_should_skipped_windows(2);
-        metrics.record_compound_should_bound_recomputations(3);
-        metrics.record_compound_should_essential_evaluations(5);
-        metrics.record_compound_should_non_essential_evaluations(7);
-
-        assert_eq!(metrics.compound_should_skipped_windows.value(), 2);
-        assert_eq!(metrics.compound_should_bound_recomputations.value(), 3);
-        assert_eq!(metrics.compound_should_essential_evaluations.value(), 5);
-        assert_eq!(metrics.compound_should_non_essential_evaluations.value(), 7);
-    }
-
-    #[test]
-    fn test_compound_phrase_metrics_separate_exact_and_sloppy_work() {
-        let metrics_set = ExecutionPlanMetricsSet::new();
-        let metrics = super::FtsIndexMetrics::new(&metrics_set, 0);
-
-        metrics.record_compound_phrase_exact_approximations(2);
-        metrics.record_compound_phrase_sloppy_approximations(3);
-        metrics.record_compound_phrase_exact_confirmations(5);
-        metrics.record_compound_phrase_sloppy_confirmations(7);
-        metrics.record_compound_phrase_exact_confirmations_avoided(11);
-        metrics.record_compound_phrase_sloppy_confirmations_avoided(13);
-
-        assert_eq!(metrics.compound_phrase_exact_approximations.value(), 2);
-        assert_eq!(metrics.compound_phrase_sloppy_approximations.value(), 3);
-        assert_eq!(metrics.compound_phrase_exact_confirmations.value(), 5);
-        assert_eq!(metrics.compound_phrase_sloppy_confirmations.value(), 7);
-        assert_eq!(
-            metrics.compound_phrase_exact_confirmations_avoided.value(),
-            11
-        );
-        assert_eq!(
-            metrics.compound_phrase_sloppy_confirmations_avoided.value(),
-            13
-        );
-    }
-
-    #[test]
-    fn test_cross_column_staged_metrics_are_counted_independently() {
-        let metrics_set = ExecutionPlanMetricsSet::new();
-        let metrics = super::FtsIndexMetrics::new(&metrics_set, 0);
-
-        metrics.record_cross_column_staged_attempts(2);
-        metrics.record_cross_column_staged_successes(1);
-        metrics.record_cross_column_staged_fallbacks(1);
-        metrics.record_cross_column_staged_candidates(17);
-
-        assert_eq!(metrics.cross_column_staged_attempts.value(), 2);
-        assert_eq!(metrics.cross_column_staged_successes.value(), 1);
-        assert_eq!(metrics.cross_column_staged_fallbacks.value(), 1);
-        assert_eq!(metrics.cross_column_staged_candidates.value(), 17);
     }
 
     #[test]
@@ -5045,68 +4565,6 @@ mod tests {
             WandExactnessCertificate::Ambiguous,
             "a full probe with no lower-score guard must replay exactly"
         );
-
-        let initial = vec![ScoredDoc::new(50, 3.0), ScoredDoc::new(99, 2.0)];
-        let completed = vec![ScoredDoc::new(50, 3.0), ScoredDoc::new(1, 2.0)];
-        assert_eq!(
-            count_smaller_row_id_replacements(&initial, &completed, 2),
-            1
-        );
-        assert_eq!(
-            count_smaller_row_id_replacements(&completed, &initial, 2),
-            0
-        );
-    }
-
-    #[test]
-    fn test_wand_exactness_certificate_metrics_are_counted_independently() {
-        let metrics_set = ExecutionPlanMetricsSet::new();
-        let metrics = super::FtsIndexMetrics::new(&metrics_set, 0);
-
-        metrics.record_wand_exactness_certificate_attempts(2);
-        metrics.record_wand_exactness_certificate_strict(3);
-        metrics.record_wand_exactness_certificate_exhaustive(5);
-        metrics.record_wand_exactness_certificate_fallbacks(7);
-        metrics.record_wand_exactness_certificate_candidates(11);
-        metrics.record_wand_tie_completion_attempts(13);
-        metrics.record_wand_tie_completion_successes(17);
-        metrics.record_wand_tie_completion_overflows(19);
-        metrics.record_wand_tie_completion_candidates(23);
-        metrics.record_wand_seeded_fallbacks(29);
-        metrics.record_wand_exactness_probe(std::time::Duration::from_millis(31));
-        metrics.record_wand_tie_completion(std::time::Duration::from_millis(37));
-        metrics.record_wand_seeded_fallback(std::time::Duration::from_millis(41));
-        metrics.record_wand_exactness_probe_comparisons(43);
-        metrics.record_wand_tie_completion_comparisons(47);
-        metrics.record_wand_seeded_fallback_comparisons(53);
-        metrics.record_wand_tie_completion_row_id_replacements(59);
-
-        assert_eq!(metrics.wand_exactness_certificate_attempts.value(), 2);
-        assert_eq!(metrics.wand_exactness_certificate_strict.value(), 3);
-        assert_eq!(metrics.wand_exactness_certificate_exhaustive.value(), 5);
-        assert_eq!(metrics.wand_exactness_certificate_fallbacks.value(), 7);
-        assert_eq!(metrics.wand_exactness_certificate_candidates.value(), 11);
-        assert_eq!(metrics.wand_tie_completion_attempts.value(), 13);
-        assert_eq!(metrics.wand_tie_completion_successes.value(), 17);
-        assert_eq!(metrics.wand_tie_completion_overflows.value(), 19);
-        assert_eq!(metrics.wand_tie_completion_candidates.value(), 23);
-        assert_eq!(metrics.wand_seeded_fallbacks.value(), 29);
-        assert_eq!(metrics.wand_exactness_probe_ms.value(), 31);
-        assert_eq!(metrics.wand_tie_completion_ms.value(), 37);
-        assert_eq!(metrics.wand_seeded_fallback_ms.value(), 41);
-        assert_eq!(metrics.wand_exactness_probe_comparisons.value(), 43);
-        assert_eq!(metrics.wand_tie_completion_comparisons.value(), 47);
-        assert_eq!(metrics.wand_seeded_fallback_comparisons.value(), 53);
-        assert_eq!(metrics.wand_tie_completion_row_id_replacements.value(), 59);
-    }
-
-    #[test]
-    fn test_no_impact_fallback_metrics_are_counted_independently() {
-        let metrics_set = ExecutionPlanMetricsSet::new();
-        let metrics = super::FtsIndexMetrics::new(&metrics_set, 0);
-
-        metrics.record_no_impact_global_scorer_fallbacks(3);
-        assert_eq!(metrics.no_impact_global_scorer_fallbacks.value(), 3);
     }
 
     async fn create_segment_selection_fixture() -> (Arc<Dataset>, Vec<IndexMetadata>, Vec<u32>) {
@@ -6487,23 +5945,6 @@ mod tests {
             execute_row_ids(&compound_wand_replay).await.unwrap().len(),
             1
         );
-        assert_eq!(
-            metric_value(
-                &compound_wand_replay,
-                WAND_EXACTNESS_CERTIFICATE_FALLBACKS_METRIC,
-            ),
-            0,
-            "the bounded prepared-vocabulary tie completion should avoid exact replay"
-        );
-        assert_eq!(
-            metric_value(&compound_wand_replay, WAND_TIE_COMPLETION_ATTEMPTS_METRIC,),
-            1
-        );
-        assert_eq!(
-            metric_value(&compound_wand_replay, WAND_TIE_COMPLETION_SUCCESSES_METRIC,),
-            1
-        );
-
         // Locally-bound helper: collect (row_id, score) pairs sorted by score desc.
         fn concat_score_batches(batches: &[RecordBatch]) -> Vec<(u64, f32)> {
             let mut out: Vec<(u64, f32)> = Vec::new();

--- a/rust/lance/src/io/exec/utils.rs
+++ b/rust/lance/src/io/exec/utils.rs
@@ -914,11 +914,6 @@ impl IndexMetrics {
     pub fn flush_io(&self) {
         self.io_metrics.record_stats(self.io_stats.snapshot());
     }
-
-    /// Return the cumulative comparison count for phase-level deltas.
-    pub fn comparisons(&self) -> usize {
-        self.index_comparisons.value()
-    }
 }
 
 impl MetricsCollector for IndexMetrics {


### PR DESCRIPTION
## Performance issue

Recent compound FTS optimizations exposed 41 validation metrics through the production DataFusion operator. This registered 58 metrics per FTS execution partition in total and kept benchmark bookkeeping in document, candidate, and window loops.

## How this improves performance

- Remove optimization-validation metrics from the production `MetricsCollector` surface and `FtsIndexMetrics` registration.
- Remove per-document phrase counters, per-candidate AND counters, per-window SHOULD counters, candidate-buffer high-water tracking, and phase-only WAND/cross-column bookkeeping.
- Keep only coarse production observability: generic index load/cache/I/O/comparison metrics, partitions searched, scorer build time, segment bind time, and DataFusion baseline metrics.
- Keep useful algorithm activation counters local to unit tests with `#[cfg(test)]` where practical.
- Document that benchmark-only instrumentation must stay in test or benchmark hooks.

The FTS-specific registrations fall from 44 to 3. Including unchanged generic index and DataFusion baseline metrics, the total per FTS execution partition falls from 58 to 17.

## Benchmark

Both runs compared baseline `0ac7d22fb35793fbf34b63e52061c1f91ea5722b` with this PR at `57d50914b0596a18ee2cce3180cf69048a625e64` on `yang-agent-fts-compound-20260819-c`, a GCP `c4-highmem-16` VM in `us-central1-c`, using the `release-with-debug` profile. Lower latency and higher QPS are better.

Protocol: five stratified queries, `must_should`, `should_sum`, `boost_negative`, and `phrase_should`, `k=10,100`, eight threads, one warmup plus three measured repetitions per trial, prewarmed index, and ABBA order (`baseline`, PR, PR, `baseline`) with forward/reverse case order. The manifest query IDs were normalized to contiguous IDs without changing query text, order, or source rows; its SHA256 is `2efbbf779e213918c33d7517d069994a05a0b30cf9a9af4d22f9d0c9657d7dd1`.

### Fully indexed 10M rows: compound fast path

All 24 preflight cases used `CompoundFtsScorer` in both builds. Full plan text and ordered row/score digests were identical. All 120 timed ordered row+f32 digest cases matched exactly, with zero intra-build or cross-build drift.

| Scenario / metric | Baseline | This PR | Benefit |
| --- | ---: | ---: | ---: |
| `boost_negative`, k=10, QPS | 549.823 q/s | 628.008 q/s | 1.1422x throughput |
| `boost_negative`, k=100, QPS | 329.995 q/s | 377.150 q/s | 1.1429x throughput |
| `must_should`, k=10, QPS | 904.788 q/s | 1,200.318 q/s | 1.3266x throughput |
| `must_should`, k=100, QPS | 915.663 q/s | 1,058.655 q/s | 1.1562x throughput |
| `phrase_should`, k=10, QPS | 559.690 q/s | 579.838 q/s | 1.0360x throughput |
| `phrase_should`, k=100, QPS | 144.353 q/s | 167.964 q/s | 1.1636x throughput |
| `should_sum`, k=10, QPS | 365.469 q/s | 482.858 q/s | 1.3212x throughput |
| `should_sum`, k=100, QPS | 387.701 q/s | 410.368 q/s | 1.0585x throughput |

Across these cases, p50 latency improved by 1.0527x to 1.2187x.

Result root: `/mnt/benchmark-ssd/mmlb-queue/08-compound-partial-layers/results/metrics-cleanup-57d50914b-full-index-abba2` (`results-fingerprint.json` tree SHA256 `a98748f9e4e3e942312cfb40943d7969d0836c8be69814c3b2c4dc683ca81cfd`).

### 10M indexed + 100k unindexed rows: current fast-search fallback

Current `main` plans this partially indexed workload into the leaf `BooleanQuery`/`BoostQuery` fallback rather than `CompoundFtsScorer`. All 24 preflight plans were byte-for-byte identical between builds, and all 120 timed ordered row+f32 digest cases matched exactly. The QPS ratios straddle 1.0x (0.9689x to 1.0261x), so this longer fallback workload shows no clear performance change.

| Scenario / metric | Baseline | This PR | Benefit |
| --- | ---: | ---: | ---: |
| `boost_negative`, k=10, QPS | 27.251 q/s | 27.762 q/s | 1.0188x throughput |
| `boost_negative`, k=100, QPS | 27.673 q/s | 28.287 q/s | 1.0222x throughput |
| `must_should`, k=10, QPS | 40.457 q/s | 39.199 q/s | 0.9689x throughput |
| `must_should`, k=100, QPS | 40.415 q/s | 40.158 q/s | 0.9937x throughput |
| `phrase_should`, k=10, QPS | 30.502 q/s | 30.390 q/s | 0.9963x throughput |
| `phrase_should`, k=100, QPS | 30.235 q/s | 30.506 q/s | 1.0090x throughput |
| `should_sum`, k=10, QPS | 97.810 q/s | 100.368 q/s | 1.0261x throughput |
| `should_sum`, k=100, QPS | 97.829 q/s | 98.694 q/s | 1.0088x throughput |

Result root: `/mnt/benchmark-ssd/mmlb-queue/08-compound-partial-layers/results/metrics-cleanup-57d50914b-abba2` (`results-fingerprint.json` tree SHA256 `84d789a5ef3e7e4589cb78573ca06af562dae028d896f8a1308d11f226663f61`).

## Validation

- `cargo fmt --all`
- `git diff --check`
- Full tests and clippy run in CI, per the current workflow.
