### PR TITLE
fix(mem_wal): seal the memtable on max_memtable_rows

### DIFF
--- a/rust/lance/benches/mem_wal/fts/mem_wal_fts_read_bench.rs
+++ b/rust/lance/benches/mem_wal/fts/mem_wal_fts_read_bench.rs
@@ -673,14 +673,9 @@ async fn run_search(args: &Args) -> Result<serde_json::Value> {
 
     let shard_id = Uuid::new_v4();
     let row_bytes = 2048; // rough FineWeb text row size
-    // The memtable flush trigger is `estimated_size >= max_memtable_size ||
-    // batch_store_full`. FineWeb text rows vary in size, so a byte threshold
-    // is an unreliable way to flush exactly one generation per
-    // `max_memtable_rows`. Instead make the *batch-count* cap the trigger:
-    // set `max_memtable_batches` to one generation's worth of batches so the
-    // store fills (and flushes) precisely at each generation boundary,
-    // independent of text length. Keep `max_memtable_size` high so it never
-    // pre-empts the batch-count trigger.
+    // The memtable seals at `max_memtable_rows`, giving one generation per cap.
+    // `max_memtable_batches` is sized to that same boundary, and
+    // `max_memtable_size` kept high so the byte threshold never pre-empts it.
     let batches_per_gen = (args.max_memtable_rows / args.batch_rows).max(1);
     let config = ShardWriterConfig {
         shard_id,

--- a/rust/lance/src/dataset/mem_wal/write.rs
+++ b/rust/lance/src/dataset/mem_wal/write.rs
@@ -121,8 +121,9 @@ pub struct ShardWriterConfig {
 
     /// Maximum number of rows in a MemTable.
     ///
-    /// Used to pre-allocate the in-memory HNSW graph and vector storage
-    /// capacity. When the memtable reaches capacity, it will be flushed.
+    /// Sizes the in-memory index pre-allocation. The memtable seals before a
+    /// write that would carry it past this, and a single write larger than the
+    /// cap is rejected.
     /// Default: 100,000 rows
     pub max_memtable_rows: usize,
 
@@ -1354,6 +1355,7 @@ async fn replay_memtable_from_wal(
     wal_flusher: &WalFlusher,
     index_configs: &[MemIndexConfig],
     max_memtable_size: usize,
+    max_memtable_rows: usize,
     max_resident_bytes: usize,
 ) -> Result<ReplayResult> {
     // WAL positions are 1-based (see `FIRST_WAL_ENTRY_POSITION`), so a
@@ -1395,27 +1397,21 @@ async fn replay_memtable_from_wal(
                         .map(|b| ensure_tombstone_column(b, &storage_schema))
                         .collect::<Result<Vec<_>>>()?;
 
-                    // Seal + flush at the entry boundary on the *same* criteria the
-                    // live path uses (`maybe_trigger_memtable_flush`): the memtable
-                    // is at or over `max_memtable_size` bytes, or this whole entry
-                    // won't fit the batch store. The byte trigger is the one that
-                    // matters beyond avoiding overflow — it is what keeps a memtable
-                    // under `max_memtable_rows`, and therefore keeps the in-memory
-                    // HNSW index (sized to `max_memtable_rows`) from exhausting its
-                    // capacity when the final active memtable is indexed.
-                    //
-                    // Rotate at the entry boundary so no entry is split across two
+                    // Seal + flush on the same criteria the live path uses, measured
+                    // against this whole entry, so no entry is split across two
                     // memtables and each sealed one covers a clean range of complete
-                    // entries. Never rotate an empty memtable — if a single entry
-                    // has more batches than a memtable can hold, a fresh one would
-                    // overflow too, the same hard limit the live put path has, left
-                    // to the insert below to surface.
+                    // entries. An empty memtable is never rotated: a fresh one holds
+                    // an oversized entry no better, left to the insert below to
+                    // surface.
+                    let entry_rows: usize = batches.iter().map(|b| b.num_rows()).sum();
                     if !active.batch_store().is_empty()
                         && memtable_reached_flush_threshold(
                             &active,
                             max_memtable_size,
+                            max_memtable_rows,
                             max_resident_bytes,
                             batches.len(),
+                            entry_rows,
                         )
                     {
                         let store = active.batch_store();
@@ -1483,13 +1479,13 @@ async fn replay_memtable_from_wal(
 /// flushed.
 ///
 /// The single source of truth for the flush trigger, shared by the live put path
-/// (`maybe_trigger_memtable_flush`, checking post-insert with `incoming_batches =
-/// 1` — "is there room for the next batch") and by replay (checking pre-insert
-/// with the next WAL entry's batch count). Keeping one predicate is what stops the
-/// two from drifting — e.g. someone adding a third criterion to one and not the
-/// other, which is the exact class of bug this whole change set is about.
+/// (`maybe_trigger_memtable_flush`) and by replay so the two cannot drift.
 ///
-/// Three arms, each answering a different question:
+/// `incoming_batches` / `incoming_rows` are what is about to be inserted.
+/// Pre-insert callers pass the real counts; post-insert callers pass `(1, 1)`,
+/// asking whether there is room for one more batch.
+///
+/// Four arms, each answering a different question:
 ///
 /// - **Row window** against `max_memtable_size`. The knob an operator sizes: it
 ///   measures what a flush actually writes, so a generation stays a predictable
@@ -1504,16 +1500,23 @@ async fn replay_memtable_from_wal(
 ///   succeed. This is the drain path that makes the ceiling live rather than a
 ///   trap.
 /// - **Batch-store capacity**, room for `incoming_batches` more.
+/// - **Row count** against `max_memtable_rows`, room for `incoming_rows` more.
+///   A hard capacity rather than a target: the in-memory indexes are
+///   pre-allocated to exactly this many rows, so an overshoot fails the index
+///   apply. The live path checks this arm pre-insert as well.
 fn memtable_reached_flush_threshold(
     memtable: &MemTable,
     max_memtable_size: usize,
+    max_memtable_rows: usize,
     max_resident_bytes: usize,
     incoming_batches: usize,
+    incoming_rows: usize,
 ) -> bool {
     let store = memtable.batch_store();
     store.row_bytes() >= max_memtable_size
         || memtable_resident_bytes(memtable) >= max_resident_bytes
         || store.remaining_capacity() < incoming_batches
+        || store.total_rows().saturating_add(incoming_rows) > max_memtable_rows
 }
 
 /// What this memtable holds in memory: the heap its batches pin plus its
@@ -1842,19 +1845,32 @@ impl SharedWriterState {
 
     /// Check if memtable flush is needed and trigger if so.
     ///
+    /// `incoming_batches` / `incoming_rows`: see [`memtable_reached_flush_threshold`].
+    ///
     /// Takes `&mut WriterState` directly since caller already holds the lock.
-    fn maybe_trigger_memtable_flush(&self, state: &mut WriterState) -> Result<()> {
+    fn maybe_trigger_memtable_flush(
+        &self,
+        state: &mut WriterState,
+        incoming_batches: usize,
+        incoming_rows: usize,
+    ) -> Result<()> {
         if state.flush_requested {
             return Ok(());
         }
 
-        // Checked post-insert: flush if there is no longer room for even one more
-        // batch (or the byte threshold is crossed). Same predicate replay uses.
+        // An empty memtable has nothing to seal, and freezing one would spin: its
+        // indexes alone can sit above the ceiling.
+        if state.memtable.batch_count() == 0 {
+            return Ok(());
+        }
+
         let should_flush = memtable_reached_flush_threshold(
             &state.memtable,
             self.config.max_memtable_size,
+            self.config.max_memtable_rows,
             self.config.max_unflushed_memtable_bytes,
-            1,
+            incoming_batches,
+            incoming_rows,
         );
 
         if should_flush {
@@ -2320,6 +2336,7 @@ impl ShardWriter {
             &wal_flusher,
             index_configs,
             config.max_memtable_size,
+            config.max_memtable_rows,
             config.max_unflushed_memtable_bytes,
         )
         .await?;
@@ -2786,6 +2803,21 @@ impl ShardWriter {
         // poisoned writer can't drift further from the durable WAL.
         self.wal_flusher.check_poisoned()?;
 
+        // A write lands whole in one memtable, so one larger than the cap fits
+        // nowhere — a fresh memtable overflows the same way. Deletes arrive here
+        // as tombstone rows and are bounded the same way.
+        let incoming_rows: usize = batches.iter().map(|b| b.num_rows()).sum();
+        if incoming_rows > self.config.max_memtable_rows {
+            return Err(Error::invalid_input(format!(
+                "write of {incoming_rows} rows across {} batches exceeds \
+                 max_memtable_rows={}: a write is never split across memtables, and the \
+                 in-memory indexes are sized to that cap. Split the write, or raise \
+                 max_memtable_rows",
+                batches.len(),
+                self.config.max_memtable_rows,
+            )));
+        }
+
         // The seal check runs inside the lock immediately after an insert, but the
         // index apply that follows it runs *outside* — and replay hands back a
         // memtable whose indexes were built after its last check too. Either way
@@ -2799,12 +2831,7 @@ impl ShardWriter {
             >= self.config.max_unflushed_memtable_bytes
         {
             let mut state = state_lock.write().await;
-            // Nothing to seal in an empty memtable, and freezing one would spin:
-            // an injected controller skips the open-time reservation check, so a
-            // fresh memtable can sit above this ceiling on its indexes alone.
-            if state.memtable.batch_count() > 0 {
-                writer_state.maybe_trigger_memtable_flush(&mut state)?;
-            }
+            writer_state.maybe_trigger_memtable_flush(&mut state, 1, 1)?;
         }
 
         // Apply backpressure if needed (before acquiring main lock)
@@ -2817,6 +2844,10 @@ impl ShardWriter {
         // Acquire write lock for entire operation (atomic approach)
         let (batch_positions, durable_watcher, batch_store, indexes) = {
             let mut state = state_lock.write().await;
+
+            // 0. Seal first if this put would not fit: the row cap is a hard
+            //    index capacity, so an overshoot cannot be undone afterwards.
+            writer_state.maybe_trigger_memtable_flush(&mut state, batches.len(), incoming_rows)?;
 
             // 1. Insert all batches into memtable atomically
             let results = state.memtable.insert_batches_only(batches).await?;
@@ -2854,7 +2885,7 @@ impl ShardWriter {
             writer_state.maybe_trigger_wal_flush(&mut state);
 
             // 6. Check if memtable flush is needed (may freeze and rotate)
-            if let Err(e) = writer_state.maybe_trigger_memtable_flush(&mut state) {
+            if let Err(e) = writer_state.maybe_trigger_memtable_flush(&mut state, 1, 1) {
                 warn!("Failed to trigger memtable flush: {}", e);
             }
 
@@ -6376,8 +6407,8 @@ mod tests {
     /// other did not, so they disagreed by a fixed offset on every memtable.
     ///
     /// Only that arm is shared. `memtable_reached_flush_threshold` also seals on
-    /// resident bytes, which `should_flush` knows nothing about, so the ceiling
-    /// below is held out of range to compare like with like.
+    /// resident bytes and row count, which `should_flush` knows nothing about, so
+    /// both are held out of range below to compare like with like.
     #[tokio::test]
     async fn test_both_seal_predicates_share_one_byte_arm() {
         let schema = create_test_schema();
@@ -6396,8 +6427,8 @@ mod tests {
         // would be comparing something other than the row arm.
 
         // `incoming_batches` of 1 against a capacity of 64 keeps the batch-count
-        // arm out of it, and `usize::MAX` keeps the resident arm out, so only the
-        // row-window arms are being compared.
+        // arm out of it, and the two `usize::MAX` limits keep the row-count and
+        // resident arms out, so only the row-window arms are being compared.
         for (bytes, expected) in [(at, true), (at + 1, false)] {
             assert_eq!(
                 memtable.should_flush(bytes),
@@ -6405,7 +6436,7 @@ mod tests {
                 "should_flush at {bytes}"
             );
             assert_eq!(
-                memtable_reached_flush_threshold(&memtable, bytes, usize::MAX, 1),
+                memtable_reached_flush_threshold(&memtable, bytes, usize::MAX, usize::MAX, 1, 1),
                 expected,
                 "the two seal predicates disagree at {bytes}; a bloom-sized offset \
                  between them makes every memtable seal early on one path"
@@ -7450,6 +7481,94 @@ mod tests {
                 .unwrap();
         assert_eq!(total_rows(&writer_c, &base_uri, shard_id).await as i32, N);
         writer_c.close().await.unwrap();
+    }
+
+    /// The same rotation, driven by `max_memtable_rows` instead of the batch cap.
+    ///
+    /// Replay builds the final memtable's indexes itself, so a WAL holding more
+    /// rows than one memtable's capacity has to rotate for `open()` to succeed.
+    #[tokio::test]
+    async fn test_replay_rotates_when_wal_exceeds_the_row_cap() {
+        use lance_arrow::FixedSizeListArrayExt;
+
+        let (store, base_path, base_uri, _temp_dir) = create_local_store().await;
+        let dim = 8;
+        let schema = hnsw_schema(dim);
+        let shard_id = Uuid::new_v4();
+        let cap = 8;
+
+        let vector_batch = |start: i32, rows: usize| {
+            let vectors = FixedSizeListArray::try_new_from_values(
+                Float32Array::from(
+                    (0..rows * dim as usize)
+                        .map(|v| v as f32 * 0.01)
+                        .collect::<Vec<_>>(),
+                ),
+                dim,
+            )
+            .unwrap();
+            RecordBatch::try_new(
+                schema.clone(),
+                vec![
+                    Arc::new(Int32Array::from(
+                        (start..start + rows as i32).collect::<Vec<_>>(),
+                    )),
+                    Arc::new(vectors),
+                ],
+            )
+            .unwrap()
+        };
+
+        // Writer A's row cap is far above what it writes, so all 32 rows land in
+        // one memtable and dropping it without close leaves them all in the WAL.
+        let writer_a_config = ShardWriterConfig {
+            max_memtable_rows: 10_000,
+            ..memtable_config_with_pk(shard_id)
+        };
+        // Writer B caps a memtable at 8 rows — and sizes its HNSW graph to match.
+        let config = ShardWriterConfig {
+            max_memtable_rows: cap,
+            ..memtable_config_with_pk(shard_id)
+        };
+
+        {
+            let writer_a = ShardWriter::open(
+                store.clone(),
+                base_path.clone(),
+                base_uri.clone(),
+                writer_a_config,
+                schema.clone(),
+                hnsw_configs(),
+            )
+            .await
+            .unwrap();
+            for round in 0..8i32 {
+                writer_a
+                    .put(vec![vector_batch(round * 4, 4)])
+                    .await
+                    .unwrap();
+            }
+        }
+
+        // Replay has 32 rows to place into memtables capped at 8.
+        let writer_b =
+            ShardWriter::open(store, base_path, base_uri, config, schema, hnsw_configs())
+                .await
+                .expect("a WAL holding more rows than the cap must still reopen");
+
+        let manifest = writer_b.manifest().await.unwrap().unwrap();
+        assert!(
+            !manifest.sstables.is_empty(),
+            "replay must have sealed and flushed the memtables it filled"
+        );
+        let stats = writer_b.memtable_stats().await.unwrap();
+        assert!(
+            stats.row_count <= cap,
+            "replay left {} rows in a memtable capped at {cap}",
+            stats.row_count
+        );
+
+        writer_b.close().await.unwrap();
     }
 
     /// Replay-on-open recovers durable WAL entries that were never flushed
@@ -9080,13 +9199,187 @@ mod tests {
 
         // Row arm way out of range; only the resident arm can fire.
         assert!(
-            memtable_reached_flush_threshold(&memtable, usize::MAX, resident, 1),
+            memtable_reached_flush_threshold(&memtable, usize::MAX, usize::MAX, resident, 1, 1),
             "resident bytes at the ceiling must seal"
         );
         assert!(
-            !memtable_reached_flush_threshold(&memtable, usize::MAX, resident + 1, 1),
+            !memtable_reached_flush_threshold(
+                &memtable,
+                usize::MAX,
+                usize::MAX,
+                resident + 1,
+                1,
+                1
+            ),
             "and must not seal below it"
         );
+    }
+
+    /// The row arm answers for the rows about to arrive, not the rows already
+    /// inserted: the cap is a hard index capacity.
+    #[tokio::test]
+    async fn test_row_arm_seals_on_max_memtable_rows() {
+        let schema = create_test_schema();
+        let mut memtable =
+            MemTable::with_capacity(schema.clone(), 1, vec![], CacheConfig::default(), 64).unwrap();
+        memtable
+            .insert(create_test_batch(&schema, 0, 50))
+            .await
+            .unwrap();
+
+        // Byte and resident arms out of range; only the row arm can fire.
+        let row_arm = |cap, incoming| {
+            memtable_reached_flush_threshold(&memtable, usize::MAX, cap, usize::MAX, 1, incoming)
+        };
+        assert!(!row_arm(50, 0), "50 rows under a cap of 50 must not seal");
+        assert!(row_arm(50, 1), "no room for one more row must seal");
+        assert!(
+            !row_arm(60, 10),
+            "a put that exactly fills the cap must not seal"
+        );
+        assert!(
+            row_arm(60, 11),
+            "a put that would overflow the cap must seal"
+        );
+    }
+
+    /// A memtable stays within `max_memtable_rows` with the byte and batch arms
+    /// far out of reach, so only the row arm can seal it.
+    #[tokio::test]
+    async fn test_put_seals_on_max_memtable_rows() {
+        let (store, base_path, base_uri, _t) = create_local_store().await;
+        let schema = create_test_schema();
+        let cap = 64;
+        let config = ShardWriterConfig {
+            shard_id: Uuid::new_v4(),
+            durable_write: false,
+            max_memtable_rows: cap,
+            // Both far out of reach, so only the row arm can seal.
+            max_memtable_size: 64 * 1024 * 1024,
+            max_memtable_batches: 8_000,
+            ..Default::default()
+        };
+        let writer = ShardWriter::open(store, base_path, base_uri, config, schema.clone(), vec![])
+            .await
+            .unwrap();
+
+        for round in 0..10i32 {
+            writer
+                .put(vec![create_test_batch(&schema, round * 10, 10)])
+                .await
+                .unwrap();
+            let stats = writer.memtable_stats().await.unwrap();
+            assert!(
+                stats.row_count <= cap,
+                "the active memtable holds {} rows, past the cap of {cap}",
+                stats.row_count
+            );
+        }
+
+        assert!(
+            writer.memtable_stats().await.unwrap().generation > 1,
+            "100 rows under a cap of {cap} must have rotated at least once"
+        );
+
+        writer.close().await.unwrap();
+    }
+
+    /// A put is never split across memtables, so one larger than the cap is
+    /// rejected as invalid input rather than overflowing a fresh memtable.
+    #[tokio::test]
+    async fn test_put_rejects_more_rows_than_a_memtable_holds() {
+        let (store, base_path, base_uri, _t) = create_local_store().await;
+        let schema = create_test_schema();
+        let config = ShardWriterConfig {
+            shard_id: Uuid::new_v4(),
+            durable_write: false,
+            max_memtable_rows: 8,
+            ..Default::default()
+        };
+        let writer = ShardWriter::open(store, base_path, base_uri, config, schema.clone(), vec![])
+            .await
+            .unwrap();
+
+        // Split across two batches: the cap is on the put, not on one batch.
+        let err = writer
+            .put(vec![
+                create_test_batch(&schema, 0, 5),
+                create_test_batch(&schema, 5, 4),
+            ])
+            .await
+            .expect_err("a put of 9 rows under a cap of 8 must be rejected");
+        assert!(
+            matches!(err, Error::InvalidInput { .. }),
+            "an oversized put is caller error, not a writer fault: {err}"
+        );
+        assert!(
+            err.to_string().contains("max_memtable_rows=8"),
+            "the error must name the knob and its value, got: {err}"
+        );
+
+        // Exactly the cap still goes through, and the writer is unharmed.
+        writer
+            .put(vec![create_test_batch(&schema, 0, 8)])
+            .await
+            .unwrap();
+        writer.close().await.unwrap();
+    }
+
+    /// An HNSW graph is sized to `max_memtable_rows`, so a shard that writes past
+    /// the cap has to keep sealing for the graph to never see a row it cannot
+    /// hold.
+    #[tokio::test]
+    async fn test_hnsw_index_survives_a_shard_that_outgrows_the_row_cap() {
+        use lance_arrow::FixedSizeListArrayExt;
+
+        let (store, base_path, base_uri, _t) = create_local_store().await;
+        let dim = 8;
+        let schema = hnsw_schema(dim);
+        let cap = 64;
+        let config = ShardWriterConfig {
+            shard_id: Uuid::new_v4(),
+            durable_write: false,
+            max_memtable_rows: cap,
+            max_memtable_size: 64 * 1024 * 1024,
+            max_memtable_batches: 8_000,
+            ..Default::default()
+        };
+        let writer = ShardWriter::open(
+            store,
+            base_path,
+            base_uri,
+            config,
+            schema.clone(),
+            hnsw_configs(),
+        )
+        .await
+        .unwrap();
+
+        for round in 0..20i32 {
+            let ids: Vec<i32> = (0..10).map(|v| v + round * 10).collect();
+            let vectors = FixedSizeListArray::try_new_from_values(
+                Float32Array::from(
+                    (0..10 * dim as usize)
+                        .map(|v| v as f32 * 0.01)
+                        .collect::<Vec<_>>(),
+                ),
+                dim,
+            )
+            .unwrap();
+            let batch = RecordBatch::try_new(
+                schema.clone(),
+                vec![Arc::new(Int32Array::from(ids)), Arc::new(vectors)],
+            )
+            .unwrap();
+            writer
+                .put(vec![batch])
+                .await
+                .unwrap_or_else(|e| panic!("put {round} was refused: {e}"));
+        }
+
+        // The index apply runs outside the put, so a poisoned writer surfaces here
+        // even when every put returned Ok.
+        writer.close().await.unwrap();
     }
 
     /// The post-insert seal check runs inside the writer lock; the index apply


### PR DESCRIPTION
## The bug

`max_memtable_rows` is documented as a memtable seal trigger, and the in-memory indexes are pre-allocated to exactly that many rows. No arm of the seal predicate ever read it:

```rust
store.row_bytes() >= max_memtable_size
    || memtable_resident_bytes(memtable) >= max_resident_bytes
    || store.remaining_capacity() < incoming_batches
```

Bytes, resident bytes, batch count. A shard whose rows are smaller than `max_memtable_size / max_memtable_rows` therefore grows past the cap unchecked, and the row past an HNSW graph's capacity fails the index apply — which poisons the writer:

```
HNSW vector store capacity 64 exhausted: inserting rows [60..70);
the store is sized below the memtable's row capacity
```

Replay hits the same wall while rebuilding the tail memtable's indexes, so the shard cannot be reopened either.

On defaults (256MB / 100k rows) the byte arm only beats the row cap when rows average ≥ ~2.7KB. A 1024-dim f32 vector is safe; 512-dim or 128-dim is not.

## When

Never enforced — a pickaxe over all history finds no commit comparing a row count to `max_memtable_rows`. What changed is the consequence: #6701 replaced the memtable's IVF-PQ index (an unbounded per-partition overflow map, where overrunning the cap merely degraded search) with a fixed-capacity HNSW that hard-errors, and in the same commit rewrote the config doc from "used to pre-allocate index storage" to "When the memtable reaches capacity, it will be flushed". The promise and the fatal consequence landed together; the enforcement never did. #7888 later codified the byte arm as the cap's proxy — true only if `max_memtable_size / avg_row_bytes <= max_memtable_rows`, which nothing validates.

## The fix

A fourth arm on the shared predicate: `total_rows + incoming_rows > max_memtable_rows`.

Unlike the byte arms this is a **hard** capacity rather than a target, so the live path also checks it **pre-insert**. That half is load-bearing: by the time a post-insert check fires, the rows an index cannot hold are already in the memtable the index apply will run over. Post-insert callers pass `(1, 1)` — "room for one more batch holding at least one row" — preserving today's prompt seal. Replay measures the whole incoming entry.

A write larger than the cap has no landing place at all, since a write is never split across memtables and rotating only hands it to a fresh memtable that overflows the same way. `put`/`delete` now reject it as invalid input naming the knob, rather than letting it surface as an exhausted index. Replay is deliberately **not** gated by that check — a WAL written under a larger cap must still open.

## Tests

Five added, each verified to fail without the fix:

| Test | Without the fix |
| --- | --- |
| `test_row_arm_seals_on_max_memtable_rows` | predicate never fires on rows |
| `test_put_seals_on_max_memtable_rows` | memtable grows unbounded past the cap |
| `test_hnsw_index_survives_a_shard_that_outgrows_the_row_cap` | `put 6 was refused: HNSW vector store capacity 64 exhausted` |
| `test_replay_rotates_when_wal_exceeds_the_row_cap` | `open()` fails — permanently unopenable shard |
| `test_put_rejects_more_rows_than_a_memtable_holds` | oversized write poisons the writer instead of erroring |

The pre-insert placement is pinned specifically: with the arm added but the pre-insert call removed, the HNSW test still fails at put #6.

`cargo test -p lance --lib` — 3142 passed, 0 failed. Integration tests pass. `cargo clippy -p lance --tests --benches -- -D warnings` clean, `cargo fmt --all` applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NrtBDRTTnQfoxrErYydtgQ
