### PR TITLE
fix(fs): fix dataset files permission on local filesystem

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -209,7 +209,7 @@ serial_test = "3"
 snafu = "0.9"
 syn = { version = "2.0.37", features = ["full"] }
 lindera = { version = "3.0.7" }
-tempfile = "3"
+tempfile = "3.10"
 test-log = { version = "0.2.15" }
 tokio = { version = "1.23", features = [
     "rt-multi-thread",

--- a/rust/lance-io/src/object_store.rs
+++ b/rust/lance-io/src/object_store.rs
@@ -6,6 +6,8 @@
 use std::borrow::Cow;
 use std::collections::{HashMap, HashSet};
 use std::ops::Range;
+#[cfg(unix)]
+use std::os::unix::fs::PermissionsExt;
 use std::pin::Pin;
 use std::str::FromStr;
 use std::sync::Arc;
@@ -979,10 +981,19 @@ impl ObjectStore {
                     .parent()
                     .expect("file path must have parent")
                     .to_owned();
-                let named_temp =
-                    tokio::task::spawn_blocking(move || tempfile::NamedTempFile::new_in(parent))
-                        .await
-                        .map_err(|e| Error::io(format!("spawn_blocking failed: {}", e)))??;
+                let named_temp = tokio::task::spawn_blocking(move || {
+                    #[cfg(unix)]
+                    {
+                        // NamedTempFile defaults to 0o600. Use ordinary file creation permissions so the published file honors the caller's umask.
+                        tempfile::Builder::new()
+                            .permissions(std::fs::Permissions::from_mode(0o666))
+                            .tempfile_in(parent)
+                    }
+                    #[cfg(not(unix))]
+                    tempfile::NamedTempFile::new_in(parent)
+                })
+                .await
+                .map_err(|e| Error::io(format!("spawn_blocking failed: {}", e)))??;
                 let (std_file, temp_path) = named_temp.into_parts();
                 let file = tokio::fs::File::from_std(std_file);
                 Ok(Box::new(LocalWriter::new(
@@ -2444,6 +2455,29 @@ mod tests {
         let reader = ObjectStore::open_local(&file_path).await.unwrap();
         let buf = reader.get_range(0..5).await.unwrap();
         assert_eq!(buf.as_ref(), b"LOCAL");
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_direct_local_writer_uses_standard_file_permissions() {
+        let directory = TempStdDir::default();
+        let reference_path = directory.join("reference");
+        std::fs::File::create(&reference_path).unwrap();
+        let expected_mode = std::fs::metadata(reference_path)
+            .unwrap()
+            .permissions()
+            .mode()
+            & 0o777;
+
+        let output_path = directory.join("output");
+        let object_path = Path::from_absolute_path(&output_path).unwrap();
+        let store = ObjectStore::local();
+        let mut writer = store.create(&object_path).await.unwrap();
+        writer.write_all(b"LOCAL").await.unwrap();
+        Writer::shutdown(writer.as_mut()).await.unwrap();
+
+        let actual_mode = std::fs::metadata(output_path).unwrap().permissions().mode() & 0o777;
+        assert_eq!(actual_mode, expected_mode);
     }
 
     #[tokio::test]


### PR DESCRIPTION
Closes https://github.com/lance-format/lance/issues/8838

This PR fixes a bug that, within the same lance dataset on local filesystem, not all the files are created with the same permission. Example in my production usage
```sh
-rw------- (600)  root:root (0:0)  /mnt/nfs/crusoe/omni/text/voicesft-gk100k_distill-intake-k1024_20260825.lance/data/000000000011011010010110ed72104c008e0b8875d9a59132.lance
-rw------- (600)  root:root (0:0)  /mnt/nfs/crusoe/omni/text/voicesft-gk100k_distill-intake-k1024_20260825.lance/_indices/29f023dc-50a4-4586-83ea-9433a61716e0/page_data.lance
-rw-r--r-- (644)  root:root (0:0)  /mnt/nfs/crusoe/omni/text/voicesft-gk100k_distill-intake-k1024_20260825.lance/_versions/18446744073709551549.manifest
-rw-r--r-- (644)  root:root (0:0)  /mnt/nfs/crusoe/omni/text/voicesft-gk100k_distill-intake-k1024_20260825.lance/_transactions/0-b17a5e2e-c91f-4429-9766-1c0c2765f2b0.txn
```
As you can tell, data file and index files are created with `group` and `other` permission rejected, which caused us trouble when using NFS.

In this PR, I propose to use the default permission [0o666](https://doc.rust-lang.org/std/os/unix/fs/trait.OpenOptionsExt.html#tymethod.mode) for all files created.