### PR TITLE
fix(label_list): bound index build memory with a sorted stream

### DIFF
--- a/rust/lance-index/src/scalar/bitmap.rs
+++ b/rust/lance-index/src/scalar/bitmap.rs
@@ -4,6 +4,7 @@
 use lance_core::utils::row_addr_remap::RowAddrRemap;
 use std::{
     any::Any,
+    borrow::Cow,
     cmp::Reverse,
     collections::{BTreeMap, BinaryHeap, HashMap},
     fmt::Debug,
@@ -62,7 +63,19 @@ const BITMAP_PART_LOOKUP_SUFFIX: &str = "_bitmap_page_lookup.lance";
 const EXPLICIT_SHARD_ID_TAG: u64 = 0;
 const IMPLICIT_FRAGMENT_ID_TAG: u64 = 1;
 
-const MAX_BITMAP_ARRAY_LENGTH: usize = i32::MAX as usize - 1024 * 1024; // leave headroom
+/// Maximum bytes a [`BitmapBatchWriter`] buffers before flushing a record
+/// batch.
+///
+/// Charged for the keys as well as the serialized bitmaps, so it limits this
+/// writer's buffered state independently of how many keys the index has. A
+/// flush temporarily makes another copy to build the Arrow arrays, and a single
+/// entry can exceed the threshold because it is checked after serialization.
+/// Memory held by the caller, input pipeline, caches, or merge state is outside
+/// this writer limit.
+///
+/// It also keeps both output columns far below the `i32` offset ceiling of
+/// Arrow's `Binary`/`Utf8` layouts.
+const MAX_BUFFERED_BYTES: usize = 32 * 1024 * 1024;
 
 const MAX_ROWS_PER_CHUNK: usize = 2 * 1024;
 // Smaller than MAX_ROWS_PER_CHUNK to bound the per-cursor in-memory batch
@@ -524,26 +537,6 @@ impl BitmapIndex {
     pub(crate) fn value_type(&self) -> &DataType {
         &self.value_type
     }
-
-    /// Loads the current bitmap index into an in-memory value-to-row-id map.
-    pub(crate) async fn load_bitmap_index_state(
-        &self,
-    ) -> Result<HashMap<ScalarValue, RowAddrTreeMap>> {
-        let mut state = HashMap::new();
-
-        for key in self.index_map.keys() {
-            let bitmap = self.load_bitmap(key, None).await?;
-            state.insert(key.0.clone(), (*bitmap).clone());
-        }
-
-        if !self.null_map.is_empty() {
-            let existing_null = new_null_array(&self.value_type, 1);
-            let existing_null = ScalarValue::try_from_array(existing_null.as_ref(), 0)?;
-            state.insert(existing_null, (*self.null_map).clone());
-        }
-
-        Ok(state)
-    }
 }
 
 impl DeepSizeOf for BitmapIndex {
@@ -843,11 +836,10 @@ impl ScalarIndex for BitmapIndex {
         mapping: &RowAddrRemap,
         dest_store: &dyn IndexStore,
     ) -> Result<CreatedIndex> {
-        let state = self.load_bitmap_index_state().await?;
-        let remapped_state = BitmapIndexPlugin::remap_bitmap_state(state, mapping);
-        let file =
-            BitmapIndexPlugin::write_bitmap_index(remapped_state, dest_store, &self.value_type)
-                .await?;
+        let mut writer =
+            new_bitmap_batch_writer(dest_store, BITMAP_LOOKUP_NAME, &self.value_type).await?;
+        remap_index_map(self, mapping, &mut writer).await?;
+        let file = writer.finish().await?;
 
         Ok(CreatedIndex {
             index_details: prost_types::Any::from_msg(&pbold::BitmapIndexDetails::default())
@@ -891,13 +883,25 @@ impl ScalarIndex for BitmapIndex {
 }
 
 /// Buffers serialized (key, bitmap) pairs and flushes them as record batches
-/// to the index file, respecting the MAX_BITMAP_ARRAY_LENGTH limit.
-struct BitmapBatchWriter {
+/// to the index file once they reach [`MAX_BUFFERED_BYTES`].
+pub(crate) struct BitmapBatchWriter {
     file: Box<dyn super::IndexWriter>,
     keys: Vec<ScalarValue>,
     serialized: Vec<Vec<u8>>,
     bytes: usize,
     num_bitmaps: usize,
+    /// Flush threshold override. Exists only so tests can drive the multi-batch
+    /// path without writing 32 MiB; release builds read the constant directly
+    /// via [`Self::max_buffered_bytes`].
+    #[cfg(test)]
+    max_buffered_bytes: usize,
+    /// Record batches handed to `file` so far, so tests can assert the writer
+    /// actually flushed rather than buffering everything.
+    #[cfg(test)]
+    batches_written: usize,
+    /// Global-buffer keys and the buffer index each was written to. Recorded
+    /// as file metadata at finish so readers can find them.
+    buffer_indices: HashMap<String, String>,
 }
 
 impl BitmapBatchWriter {
@@ -908,17 +912,59 @@ impl BitmapBatchWriter {
             serialized: Vec::new(),
             bytes: 0,
             num_bitmaps: 0,
+            #[cfg(test)]
+            max_buffered_bytes: MAX_BUFFERED_BYTES,
+            #[cfg(test)]
+            batches_written: 0,
+            buffer_indices: HashMap::new(),
         }
     }
 
+    #[cfg(test)]
+    fn with_max_buffered_bytes(mut self, bytes: usize) -> Self {
+        self.max_buffered_bytes = bytes;
+        self
+    }
+
+    fn max_buffered_bytes(&self) -> usize {
+        #[cfg(test)]
+        {
+            self.max_buffered_bytes
+        }
+        #[cfg(not(test))]
+        {
+            MAX_BUFFERED_BYTES
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn batches_written(&self) -> usize {
+        self.batches_written
+    }
+
+    /// Attach a global buffer to the file, recording its index under `key` so
+    /// that a reader can find it from the file metadata.
+    ///
+    /// Callable at any point: the underlying writer records the current offset
+    /// and writes the buffer immediately, so its position relative to the data
+    /// pages does not matter.
+    pub(crate) async fn add_global_buffer(&mut self, key: String, data: Bytes) -> Result<()> {
+        let buffer_idx = self.file.add_global_buffer(data).await?;
+        self.buffer_indices.insert(key, buffer_idx.to_string());
+        Ok(())
+    }
+
     /// Serialize and buffer a single (key, bitmap) pair, flushing the current
-    /// batch to disk if adding it would exceed MAX_BITMAP_ARRAY_LENGTH.
-    async fn emit(&mut self, key: ScalarValue, bitmap: &RowAddrTreeMap) -> Result<()> {
+    /// batch to disk if adding it would exceed [`MAX_BUFFERED_BYTES`].
+    pub(crate) async fn emit(&mut self, key: ScalarValue, bitmap: &RowAddrTreeMap) -> Result<()> {
         let mut buf = Vec::new();
         bitmap.serialize_into(&mut buf).unwrap();
-        let size = buf.len();
+        // `key.size()` already covers the `Vec<ScalarValue>` slot it moves into,
+        // but the parallel `Vec<Vec<u8>>` slot is pure per-entry overhead the
+        // budget would otherwise ignore -- ~22% low for small postings.
+        let size = buf.len() + key.size() + std::mem::size_of::<Vec<u8>>();
 
-        if self.bytes + size > MAX_BITMAP_ARRAY_LENGTH {
+        if self.bytes + size > self.max_buffered_bytes() {
             self.flush().await?;
         }
 
@@ -945,17 +991,22 @@ impl BitmapBatchWriter {
         let batch = BitmapIndexPlugin::get_batch_from_arrays(keys_array, bitmaps_array)?;
         self.file.write_record_batch(batch).await?;
         self.bytes = 0;
+        #[cfg(test)]
+        {
+            self.batches_written += 1;
+        }
         Ok(())
     }
 
-    /// Flush any remaining data, write index statistics, and finalize the file.
-    async fn finish(mut self) -> Result<IndexFile> {
+    /// Flush any remaining data, write index statistics and any global-buffer
+    /// indices, and finalize the file.
+    pub(crate) async fn finish(mut self) -> Result<IndexFile> {
         self.flush().await?;
         let stats_json = serde_json::to_string(&BitmapStatistics {
             num_bitmaps: self.num_bitmaps,
         })
         .map_err(|e| Error::internal(format!("failed to serialize bitmap statistics: {e}")))?;
-        let mut metadata = HashMap::new();
+        let mut metadata = std::mem::take(&mut self.buffer_indices);
         metadata.insert(INDEX_STATS_METADATA_KEY.to_string(), stats_json);
         self.file.finish_with_metadata(metadata).await
     }
@@ -1019,7 +1070,7 @@ fn deserialize_bitmap(bitmap_bytes: &[u8], file_name: &str) -> Result<RowAddrTre
     })
 }
 
-async fn new_bitmap_batch_writer(
+pub(crate) async fn new_bitmap_batch_writer(
     index_store: &dyn IndexStore,
     file_name: &str,
     value_type: &DataType,
@@ -1247,14 +1298,22 @@ pub struct BitmapIndexPlugin;
 /// Drop the rows an old posting should no longer expose -- rows whose fragment
 /// was removed, or (under stable row ids) rows rewritten by an update -- keeping
 /// only those `filter` still considers valid. A no-op when `filter` is `None`.
-fn retain_valid(
-    mut bitmap: RowAddrTreeMap,
+fn retain_valid<'a>(
+    bitmap: Cow<'a, RowAddrTreeMap>,
     filter: Option<&super::OldIndexDataFilter>,
-) -> RowAddrTreeMap {
-    if let Some(filter) = filter {
-        filter.retain_old_rows(&mut bitmap);
+) -> Cow<'a, RowAddrTreeMap> {
+    match filter {
+        Some(filter) => {
+            let mut bitmap = bitmap.into_owned();
+            filter.retain_old_rows(&mut bitmap);
+            Cow::Owned(bitmap)
+        }
+        // Passes the input through uncopied. Worth a `Cow` rather than an owned
+        // parameter because the update path walks one old posting per key and
+        // never has a filter, so an owned parameter deep-copied every posting in
+        // the index just to hand it straight back to `emit`.
+        None => bitmap,
     }
-    bitmap
 }
 
 impl BitmapIndexPlugin {
@@ -1270,118 +1329,6 @@ impl BitmapIndexPlugin {
         let columns = vec![keys, binary_bitmaps];
 
         Ok(RecordBatch::try_new(schema, columns)?)
-    }
-
-    async fn write_bitmap_index(
-        state: HashMap<ScalarValue, RowAddrTreeMap>,
-        index_store: &dyn IndexStore,
-        value_type: &DataType,
-    ) -> Result<IndexFile> {
-        Self::write_bitmap_index_with_extras(
-            state,
-            index_store,
-            value_type,
-            HashMap::new(),
-            Vec::new(),
-        )
-        .await
-    }
-
-    /// Writes a bitmap index and attaches extra metadata and global buffers.
-    pub(crate) async fn write_bitmap_index_with_extras(
-        state: HashMap<ScalarValue, RowAddrTreeMap>,
-        index_store: &dyn IndexStore,
-        value_type: &DataType,
-        mut metadata: HashMap<String, String>,
-        global_buffers: Vec<(String, Bytes)>,
-    ) -> Result<IndexFile> {
-        let num_bitmaps = state.len();
-        let schema = Arc::new(Schema::new(vec![
-            Field::new("keys", value_type.clone(), true),
-            Field::new("bitmaps", DataType::Binary, true),
-        ]));
-
-        let mut bitmap_index_file = index_store
-            .new_index_file(BITMAP_LOOKUP_NAME, schema)
-            .await?;
-
-        for (metadata_key, data) in global_buffers {
-            let buffer_idx = bitmap_index_file.add_global_buffer(data).await?;
-            metadata.insert(metadata_key, buffer_idx.to_string());
-        }
-
-        let mut cur_keys = Vec::new();
-        let mut cur_bitmaps = Vec::new();
-        let mut cur_bytes = 0;
-
-        for (key, bitmap) in state.into_iter() {
-            let mut bytes = Vec::new();
-            bitmap.serialize_into(&mut bytes).unwrap();
-            let bitmap_size = bytes.len();
-
-            if cur_bytes + bitmap_size > MAX_BITMAP_ARRAY_LENGTH {
-                let keys_array = ScalarValue::iter_to_array(cur_keys.clone()).unwrap();
-                let mut binary_builder = BinaryBuilder::new();
-                for b in &cur_bitmaps {
-                    binary_builder.append_value(b);
-                }
-                let bitmaps_array = Arc::new(binary_builder.finish()) as Arc<dyn Array>;
-
-                let record_batch = Self::get_batch_from_arrays(keys_array, bitmaps_array)?;
-                bitmap_index_file.write_record_batch(record_batch).await?;
-
-                cur_keys.clear();
-                cur_bitmaps.clear();
-                cur_bytes = 0;
-            }
-
-            cur_keys.push(key);
-            cur_bitmaps.push(bytes);
-            cur_bytes += bitmap_size;
-        }
-
-        // Flush any remaining
-        if !cur_keys.is_empty() {
-            let keys_array = ScalarValue::iter_to_array(cur_keys).unwrap();
-            let mut binary_builder = BinaryBuilder::new();
-            for b in &cur_bitmaps {
-                binary_builder.append_value(b);
-            }
-            let bitmaps_array = Arc::new(binary_builder.finish()) as Arc<dyn Array>;
-
-            let record_batch = Self::get_batch_from_arrays(keys_array, bitmaps_array)?;
-            bitmap_index_file.write_record_batch(record_batch).await?;
-        }
-
-        // Finish file with metadata that allows lightweight statistics reads
-        let stats_json = serde_json::to_string(&BitmapStatistics { num_bitmaps })
-            .map_err(|e| Error::internal(format!("failed to serialize bitmap statistics: {e}")))?;
-        metadata.insert(INDEX_STATS_METADATA_KEY.to_string(), stats_json);
-
-        bitmap_index_file.finish_with_metadata(metadata).await
-    }
-
-    /// Builds bitmap index state from a `(value, row_id)` stream without writing it.
-    pub(crate) async fn build_bitmap_index_state(
-        mut data_source: SendableRecordBatchStream,
-        mut state: HashMap<ScalarValue, RowAddrTreeMap>,
-    ) -> Result<(HashMap<ScalarValue, RowAddrTreeMap>, DataType)> {
-        let value_type = data_source.schema().field(0).data_type().clone();
-        while let Some(batch) = data_source.try_next().await? {
-            let values = batch.column_by_name(VALUE_COLUMN_NAME).expect_ok()?;
-            let row_ids = batch.column_by_name(ROW_ID).expect_ok()?;
-            debug_assert_eq!(row_ids.data_type(), &DataType::UInt64);
-
-            let row_id_column = row_ids.as_any().downcast_ref::<UInt64Array>().unwrap();
-
-            for i in 0..values.len() {
-                let row_id = row_id_column.value(i);
-                let key = ScalarValue::try_from_array(values.as_ref(), i)?;
-                state.entry(key.clone()).or_default().insert(row_id);
-            }
-        }
-
-        Ok((state, value_type))
     }
 
     pub async fn train_bitmap_index(
@@ -1410,133 +1357,37 @@ impl BitmapIndexPlugin {
     }
 
     /// Builds and writes a bitmap index in a streaming fashion from value-sorted
-    /// input. Only one value's bitmap is in memory at a time, reducing peak memory
-    /// from O(unique_values * avg_bitmap) to O(largest_single_bitmap).
+    /// input. Only one new value's aggregate bitmap is held at a time instead of
+    /// an aggregate map containing every value. The input pipeline, an existing
+    /// index and its cache, and the output writer retain separate memory.
     ///
     /// If `old_index` is provided, its existing bitmaps are merged with the new
     /// data via a sorted merge-join (the old index_map is a BTreeMap, already
     /// sorted by value).
     async fn streaming_build_and_write(
-        mut data_source: SendableRecordBatchStream,
+        data_source: SendableRecordBatchStream,
         old_index: Option<&BitmapIndex>,
         index_store: &dyn IndexStore,
         output_file_name: &str,
         old_data_filter: Option<&super::OldIndexDataFilter>,
     ) -> Result<IndexFile> {
         let value_type = data_source.schema().field(0).data_type().clone();
-
         let mut writer =
             new_bitmap_batch_writer(index_store, output_file_name, &value_type).await?;
-
-        // Collect old index keys (already in memory as BTreeMap keys — this is
-        // just a Vec of references, not a copy of the bitmaps themselves).
-        let old_keys: Vec<OrderableScalarValue> = old_index
-            .map(|idx| idx.index_map.keys().cloned().collect())
-            .unwrap_or_default();
-        let mut old_pos: usize = 0;
-
-        // Current value being accumulated from the new data stream.
-        let mut current_key: Option<ScalarValue> = None;
-        let mut current_bitmap = RowAddrTreeMap::default();
-        // Track whether we emitted a null bitmap (old index stores nulls
-        // separately in null_map, not in index_map).
-        let mut emitted_null = false;
-
-        while let Some(batch) = data_source.try_next().await? {
-            let values = batch.column_by_name(VALUE_COLUMN_NAME).expect_ok()?;
-            let row_ids = batch.column_by_name(ROW_ID).expect_ok()?;
-            debug_assert_eq!(row_ids.data_type(), &DataType::UInt64);
-            let row_id_column = row_ids.as_any().downcast_ref::<UInt64Array>().unwrap();
-
-            for i in 0..values.len() {
-                let row_id = row_id_column.value(i);
-                let key = ScalarValue::try_from_array(values.as_ref(), i)?;
-
-                match &current_key {
-                    Some(cur) if *cur == key => {
-                        current_bitmap.insert(row_id);
-                    }
-                    _ => {
-                        // Value changed — flush the previous run.
-                        if let Some(prev_key) = current_key.take() {
-                            let mut prev_bitmap = std::mem::take(&mut current_bitmap);
-                            Self::finish_run(
-                                prev_key,
-                                &mut prev_bitmap,
-                                old_index,
-                                &old_keys,
-                                &mut old_pos,
-                                &mut emitted_null,
-                                &mut writer,
-                                old_data_filter,
-                            )
-                            .await?;
-                        }
-                        current_key = Some(key);
-                        current_bitmap = RowAddrTreeMap::default();
-                        current_bitmap.insert(row_id);
-                    }
-                }
-            }
-        }
-
-        // Flush the last accumulated run from new data.
-        if let Some(last_key) = current_key.take() {
-            let mut last_bitmap = std::mem::take(&mut current_bitmap);
-            Self::finish_run(
-                last_key,
-                &mut last_bitmap,
-                old_index,
-                &old_keys,
-                &mut old_pos,
-                &mut emitted_null,
-                &mut writer,
-                old_data_filter,
-            )
-            .await?;
-        }
-
-        // Emit any remaining old-only entries.
-        if let Some(idx) = old_index {
-            while old_pos < old_keys.len() {
-                let old_bitmap = retain_valid(
-                    idx.load_bitmap(&old_keys[old_pos], None)
-                        .await?
-                        .as_ref()
-                        .clone(),
-                    old_data_filter,
-                );
-                writer
-                    .emit(old_keys[old_pos].0.clone(), &old_bitmap)
-                    .await?;
-                old_pos += 1;
-            }
-        }
-
-        // Emit old null bitmap if we didn't already merge it with new nulls.
-        if !emitted_null
-            && let Some(idx) = old_index
-            && !idx.null_map.is_empty()
-        {
-            let null_key = new_null_array(&value_type, 1);
-            let null_key = ScalarValue::try_from_array(null_key.as_ref(), 0)?;
-            let null_bitmap = retain_valid((*idx.null_map).clone(), old_data_filter);
-            writer.emit(null_key, &null_bitmap).await?;
-        }
-
+        build_index_map(data_source, old_index, old_data_filter, &mut writer).await?;
         writer.finish().await
     }
 
     /// Flush a completed value-run from the new data stream, emitting any
     /// old-only entries that sort before it and merging the old bitmap if the
     /// key exists in both old and new.
-    #[allow(clippy::too_many_arguments)]
     async fn finish_run(
         key: ScalarValue,
         bitmap: &mut RowAddrTreeMap,
         old_index: Option<&BitmapIndex>,
-        old_keys: &[OrderableScalarValue],
-        old_pos: &mut usize,
+        old_keys: &mut std::iter::Peekable<
+            std::collections::btree_map::Keys<'_, OrderableScalarValue, usize>,
+        >,
         emitted_null: &mut bool,
         writer: &mut BitmapBatchWriter,
         old_data_filter: Option<&super::OldIndexDataFilter>,
@@ -1546,7 +1397,7 @@ impl BitmapIndexPlugin {
             if let Some(idx) = old_index
                 && !idx.null_map.is_empty()
             {
-                *bitmap |= &retain_valid((*idx.null_map).clone(), old_data_filter);
+                *bitmap |= &*retain_valid(Cow::Borrowed(idx.null_map.as_ref()), old_data_filter);
             }
             *emitted_null = true;
             writer.emit(key, bitmap).await?;
@@ -1554,30 +1405,16 @@ impl BitmapIndexPlugin {
             let orderable = OrderableScalarValue(key.clone());
 
             // Emit old-only entries that sort before this key.
-            while *old_pos < old_keys.len() && old_keys[*old_pos] < orderable {
-                let old_bitmap = retain_valid(
-                    idx.load_bitmap(&old_keys[*old_pos], None)
-                        .await?
-                        .as_ref()
-                        .clone(),
-                    old_data_filter,
-                );
-                writer
-                    .emit(old_keys[*old_pos].0.clone(), &old_bitmap)
-                    .await?;
-                *old_pos += 1;
+            while let Some(old_key) = old_keys.next_if(|old| **old < orderable) {
+                let loaded = idx.load_bitmap(old_key, None).await?;
+                let old_bitmap = retain_valid(Cow::Borrowed(loaded.as_ref()), old_data_filter);
+                writer.emit(old_key.0.clone(), &old_bitmap).await?;
             }
 
             // If the old index also has this key, merge its bitmap.
-            if *old_pos < old_keys.len() && old_keys[*old_pos] == orderable {
-                *bitmap |= &retain_valid(
-                    idx.load_bitmap(&old_keys[*old_pos], None)
-                        .await?
-                        .as_ref()
-                        .clone(),
-                    old_data_filter,
-                );
-                *old_pos += 1;
+            if let Some(old_key) = old_keys.next_if(|old| **old == orderable) {
+                let loaded = idx.load_bitmap(old_key, None).await?;
+                *bitmap |= &*retain_valid(Cow::Borrowed(loaded.as_ref()), old_data_filter);
             }
 
             writer.emit(key, bitmap).await?;
@@ -1585,24 +1422,6 @@ impl BitmapIndexPlugin {
             writer.emit(key, bitmap).await?;
         }
         Ok(())
-    }
-
-    /// Remaps every bitmap in a materialized bitmap-index state using row-id mappings.
-    pub(crate) fn remap_bitmap_state(
-        state: HashMap<ScalarValue, RowAddrTreeMap>,
-        mapping: &RowAddrRemap,
-    ) -> HashMap<ScalarValue, RowAddrTreeMap> {
-        state
-            .into_iter()
-            .map(|(key, bitmap)| {
-                let remapped_bitmap =
-                    RowAddrTreeMap::from_iter(bitmap.row_addrs().unwrap().filter_map(|addr| {
-                        let addr_as_u64 = u64::from(addr);
-                        mapping.get(addr_as_u64).unwrap_or(Some(addr_as_u64))
-                    }));
-                (key, remapped_bitmap)
-            })
-            .collect()
     }
 
     /// Merge per-shard bitmap lookup files into a single bitmap index file.
@@ -1699,6 +1518,340 @@ pub async fn merge_index_files(
     Ok(())
 }
 
+/// Build a bitmap index map from value-sorted `(value, row_id)` input, emitting
+/// one key at a time into `writer`.
+///
+/// Takes the writer rather than creating the file so that a caller needing its
+/// own global buffers in the same file can reuse this. `LabelListIndex` does
+/// exactly that for its `list_nulls` set.
+///
+/// Input must be sorted by value with nulls first. This function's transient
+/// aggregation state is one key's bitmap at a time. When `old_index` is given,
+/// its entries are merge-joined in, loading each old bitmap on demand; its
+/// already-loaded `index_map` remains resident separately, outside that state.
+pub(crate) async fn build_index_map(
+    mut data_source: SendableRecordBatchStream,
+    old_index: Option<&BitmapIndex>,
+    old_data_filter: Option<&super::OldIndexDataFilter>,
+    writer: &mut BitmapBatchWriter,
+) -> Result<()> {
+    let value_type = data_source.schema().field(0).data_type().clone();
+
+    // Borrowed from the source's `index_map` rather than collected into a Vec.
+    // That map already holds every key, so collecting made a second full copy:
+    // a 64-byte `ScalarValue` per key plus its label text, which at 10M labels
+    // is most of a gigabyte for nothing.
+    let empty = BTreeMap::new();
+    let mut old_keys = old_index
+        .map(|idx| idx.index_map.as_ref())
+        .unwrap_or(&empty)
+        .keys()
+        .peekable();
+
+    // Current value being accumulated from the new data stream.
+    let mut current_key: Option<ScalarValue> = None;
+    let mut current_bitmap = RowAddrTreeMap::default();
+    // Track whether we emitted a null bitmap (old index stores nulls
+    // separately in null_map, not in index_map).
+    let mut emitted_null = false;
+
+    while let Some(batch) = data_source.try_next().await? {
+        let values = batch.column_by_name(VALUE_COLUMN_NAME).expect_ok()?;
+        let row_ids = batch.column_by_name(ROW_ID).expect_ok()?;
+        debug_assert_eq!(row_ids.data_type(), &DataType::UInt64);
+        let row_id_column = row_ids.as_any().downcast_ref::<UInt64Array>().unwrap();
+
+        for i in 0..values.len() {
+            let row_id = row_id_column.value(i);
+            let key = ScalarValue::try_from_array(values.as_ref(), i)?;
+
+            match &current_key {
+                Some(cur) if *cur == key => {
+                    current_bitmap.insert(row_id);
+                }
+                _ => {
+                    // Value changed — flush the previous run.
+                    if let Some(prev_key) = current_key.take() {
+                        // This function assumes value-sorted, nulls-first input
+                        // and does not check it in release builds. Violated
+                        // input emits one key twice -- the old-key cursor
+                        // advances past it on an earlier, larger run, so it
+                        // leaves as an old-only row and returns later carrying
+                        // only new rows. Neither row is complete, and
+                        // `BitmapIndex::load` inserts both into `index_map`,
+                        // so the later one shadows the earlier and its rows
+                        // are lost.
+                        debug_assert!(
+                            OrderableScalarValue(key.clone())
+                                > OrderableScalarValue(prev_key.clone()),
+                            "build_index_map input must be sorted ascending by value \
+                             with nulls first; got key {:?} after {:?}",
+                            key,
+                            prev_key
+                        );
+                        let mut prev_bitmap = std::mem::take(&mut current_bitmap);
+                        BitmapIndexPlugin::finish_run(
+                            prev_key,
+                            &mut prev_bitmap,
+                            old_index,
+                            &mut old_keys,
+                            &mut emitted_null,
+                            writer,
+                            old_data_filter,
+                        )
+                        .await?;
+                    }
+                    current_key = Some(key);
+                    current_bitmap = RowAddrTreeMap::default();
+                    current_bitmap.insert(row_id);
+                }
+            }
+        }
+    }
+
+    // Flush the last accumulated run from new data.
+    if let Some(last_key) = current_key.take() {
+        let mut last_bitmap = std::mem::take(&mut current_bitmap);
+        BitmapIndexPlugin::finish_run(
+            last_key,
+            &mut last_bitmap,
+            old_index,
+            &mut old_keys,
+            &mut emitted_null,
+            writer,
+            old_data_filter,
+        )
+        .await?;
+    }
+
+    // Emit any remaining old-only entries.
+    if let Some(idx) = old_index {
+        for old_key in old_keys {
+            let loaded = idx.load_bitmap(old_key, None).await?;
+            let old_bitmap = retain_valid(Cow::Borrowed(loaded.as_ref()), old_data_filter);
+            writer.emit(old_key.0.clone(), &old_bitmap).await?;
+        }
+    }
+
+    // Emit old null bitmap if we didn't already merge it with new nulls.
+    if !emitted_null
+        && let Some(idx) = old_index
+        && !idx.null_map.is_empty()
+    {
+        let null_key = new_null_array(&value_type, 1);
+        let null_key = ScalarValue::try_from_array(null_key.as_ref(), 0)?;
+        let null_bitmap = retain_valid(Cow::Borrowed(idx.null_map.as_ref()), old_data_filter);
+        writer.emit(null_key, &null_bitmap).await?;
+    }
+
+    Ok(())
+}
+
+/// Apply `mapping` to every row address in `index` without materializing every
+/// bitmap payload at once, writing the result through `writer`.
+///
+/// This helper's transient aggregation state is one bitmap at a time. The
+/// loaded `index_map`, index cache, mapping, and output writer remain resident
+/// separately. Nulls live outside `index_map`, in `null_map`, so they are
+/// remapped separately and emitted first -- a null sorts below every value.
+///
+/// Emits every key unconditionally, even one whose remapped bitmap comes out
+/// empty -- deliberately unlike [`merge_index_maps`], which drops a key its
+/// filter empties. Both are query-equivalent, since an absent key and a
+/// present-but-empty one both match no rows; this function preserves the key
+/// to match the old materialized-map remap path, which always produced one
+/// row per source key.
+pub(crate) async fn remap_index_map(
+    index: &BitmapIndex,
+    mapping: &RowAddrRemap,
+    writer: &mut BitmapBatchWriter,
+) -> Result<()> {
+    if !index.null_map.is_empty() {
+        let null_key = new_null_array(index.value_type(), 1);
+        let null_key = ScalarValue::try_from_array(null_key.as_ref(), 0)?;
+        writer
+            .emit(null_key, &remap_row_addrs(&index.null_map, mapping)?)
+            .await?;
+    }
+
+    for key in index.index_map.keys() {
+        let bitmap = index.load_bitmap(key, None).await?;
+        writer
+            .emit(key.0.clone(), &remap_row_addrs(&bitmap, mapping)?)
+            .await?;
+    }
+
+    Ok(())
+}
+
+pub(crate) fn remap_row_addrs(
+    bitmap: &RowAddrTreeMap,
+    mapping: &RowAddrRemap,
+) -> Result<RowAddrTreeMap> {
+    // `row_addrs` yields `None` when any fragment is a whole-fragment selection,
+    // which `RowAddrTreeMap::deserialize_from` produces for a zero-length
+    // per-fragment bitmap. Such a posting cannot be remapped address by address
+    // -- the individual addresses are not known -- so this is an error rather
+    // than something to paper over, and an error rather than the panic this
+    // inherited, since it crosses an FFI boundary.
+    let addrs = bitmap.row_addrs().ok_or_else(|| {
+        Error::invalid_input(
+            "Cannot remap a bitmap posting holding a whole-fragment selection; \
+             its individual row addresses are not enumerable"
+                .to_string(),
+        )
+    })?;
+    Ok(RowAddrTreeMap::from_iter(addrs.filter_map(|addr| {
+        let addr_as_u64 = u64::from(addr);
+        mapping.get(addr_as_u64).unwrap_or(Some(addr_as_u64))
+    })))
+}
+
+/// Total source entries a merge of `sources` will consume.
+///
+/// The exact denominator for the merge's progress: known before the merge
+/// starts, at no I/O cost since every `index_map` is already loaded, and reached
+/// exactly, because the merge drains each source's keys and advances every one
+/// of them once. Counting entries rather than emitted keys is what makes it
+/// exact -- a key held by three sources costs three loads and yields one output
+/// row, and a key whose rows are all retired by `old_data_filter` yields none.
+///
+/// Nulls are excluded, matching how the merge treats them everywhere else: they
+/// live in `null_map`, outside `index_map`, and are unioned in one step.
+pub(crate) fn merge_source_entry_count(sources: &[Arc<BitmapIndex>]) -> u64 {
+    sources.iter().map(|s| s.index_map.len() as u64).sum()
+}
+
+/// Merge loaded bitmap indexes into `writer` without materializing all source
+/// bitmap payloads at once.
+///
+/// Drives each source through its `index_map` -- a sorted `BTreeMap` rebuilt at
+/// load time -- rather than through the rows of its file. LabelList index files
+/// written before spill-based builds landed are unsorted on disk, so file order
+/// cannot be trusted for them; `index_map` order can, for old and new files
+/// alike, which is what makes this work without an index version bump.
+///
+/// Null keys live outside `index_map`, in each source's `null_map`, so they are
+/// unioned separately and emitted first -- a null sorts below every value.
+///
+/// The merge's transient aggregation state is the merged bitmap for the current
+/// key plus one loaded bitmap per participating source. Each source `index_map`,
+/// any bitmaps retained by the index cache, and the output writer remain outside
+/// that state.
+///
+/// `progress` reports source entries consumed, against the total from
+/// [`merge_source_entry_count`]. Not segments: the merge is key-driven and
+/// touches every source on every key, so no source is ever "done" to report.
+/// Not emitted keys either: those have no denominator that can be known up front
+/// or reached exactly. Entries have both, and are the unit the merge's cost is
+/// actually in, since it loads one bitmap per entry.
+///
+/// A key whose merged bitmap comes out empty (every one of its rows retired by
+/// `old_data_filter`) is dropped rather than emitted -- deliberately unlike
+/// [`remap_index_map`], which preserves such a key. Both are query-equivalent,
+/// since an absent key and a present-but-empty one both match no rows.
+pub(crate) async fn merge_index_maps(
+    sources: &[Arc<BitmapIndex>],
+    old_data_filter: Option<&super::OldIndexDataFilter>,
+    writer: &mut BitmapBatchWriter,
+    progress: Option<(&dyn IndexBuildProgress, &str)>,
+) -> Result<()> {
+    let Some(first) = sources.first() else {
+        return Err(Error::invalid_input(
+            "Bitmap index merge requires at least one source index".to_string(),
+        ));
+    };
+    let value_type = first.value_type().clone();
+
+    let mut merged_nulls = RowAddrTreeMap::default();
+    for source in sources {
+        merged_nulls |= source.null_map.as_ref();
+    }
+    let merged_nulls = retain_valid(Cow::Owned(merged_nulls), old_data_filter);
+    if !merged_nulls.is_empty() {
+        let null_key = new_null_array(&value_type, 1);
+        let null_key = ScalarValue::try_from_array(null_key.as_ref(), 0)?;
+        writer.emit(null_key, &merged_nulls).await?;
+    }
+
+    let mut consumed = 0u64;
+    // Cap reporting at roughly a hundred times across the merge. `stage_progress`
+    // is `#[async_trait]`, so every call boxes a future, and a real reporter does
+    // more: the Python one allocates and sends, the Java one makes a JNI upcall.
+    // One per key is millions of those on a high-cardinality column. Scaling the
+    // interval to the total rather than fixing it means a merge of fewer than a
+    // hundred keys still reports every key, which costs nothing at that size.
+    let report_every = (merge_source_entry_count(sources) / 100).max(1);
+    let mut last_reported = 0u64;
+
+    let mut key_iters: Vec<_> = sources
+        .iter()
+        .map(|source| source.index_map.keys())
+        .collect();
+
+    // Every source is sorted, so the smallest key any of them is currently
+    // positioned on is the next key overall. A min-heap holding one entry per
+    // live source finds it in `log(sources)`. What this replaced was not a
+    // cheaper comparison strategy but full materialization: the previous
+    // `merge_bitmap_indices` built a `HashMap<ScalarValue, RowAddrTreeMap>`
+    // holding every key of every source at once. The win here is bounded
+    // memory, not fewer comparisons. It is the same merge `merge_shards` runs
+    // over file-backed cursors.
+    //
+    // Entries borrow their key from the source's `index_map` rather than cloning
+    // it. Seeding the heap touches every source key, so cloning here would cost
+    // more than the scan it replaces whenever there are only a few sources.
+    let mut heap: BinaryHeap<Reverse<(&OrderableScalarValue, usize)>> =
+        BinaryHeap::with_capacity(key_iters.len());
+    for (source_idx, keys) in key_iters.iter_mut().enumerate() {
+        if let Some(key) = keys.next() {
+            heap.push(Reverse((key, source_idx)));
+        }
+    }
+
+    while let Some(Reverse((next_key, _))) = heap.peek().copied() {
+        let mut merged = RowAddrTreeMap::default();
+
+        // Drain the sources positioned on this key -- only those, where the
+        // previous scan visited every source on every key. A source's next key is
+        // strictly greater, so re-pushing it cannot re-enter this loop.
+        while let Some(Reverse((key, source_idx))) = heap.peek().copied() {
+            if key != next_key {
+                break;
+            }
+            heap.pop();
+            consumed += 1;
+            merged |= sources[source_idx].load_bitmap(key, None).await?.as_ref();
+            if let Some(next) = key_iters[source_idx].next() {
+                heap.push(Reverse((next, source_idx)));
+            }
+        }
+
+        let merged = retain_valid(Cow::Owned(merged), old_data_filter);
+        if !merged.is_empty() {
+            writer.emit(next_key.0.clone(), &merged).await?;
+        }
+
+        // Reported outside the guard above: a key the filter emptied still
+        // consumed its source entries, and skipping it would stall the count.
+        if consumed - last_reported >= report_every
+            && let Some((progress, stage)) = progress
+        {
+            last_reported = consumed;
+            progress.stage_progress(stage, consumed).await?;
+        }
+    }
+
+    // Always reported, so the declared total is reached exactly whatever the
+    // throttle above skipped -- including when there were no keys at all (every
+    // list null or empty), where the loop never runs.
+    if let Some((progress, stage)) = progress {
+        progress.stage_progress(stage, consumed).await?;
+    }
+
+    Ok(())
+}
+
 pub async fn merge_bitmap_indices(
     source_indices: &[Arc<BitmapIndex>],
     dest_store: &dyn IndexStore,
@@ -1711,16 +1864,15 @@ pub async fn merge_bitmap_indices(
     }
 
     let value_type = source_indices[0].value_type().clone();
-    let mut merged_state = HashMap::<ScalarValue, RowAddrTreeMap>::new();
 
     progress
         .stage_start(
             "merge_bitmap_segments",
-            Some(source_indices.len() as u64),
-            "segments",
+            Some(merge_source_entry_count(source_indices)),
+            "entries",
         )
         .await?;
-    for (idx, source_index) in source_indices.iter().enumerate() {
+    for source_index in source_indices.iter() {
         if source_index.value_type() != &value_type {
             return Err(Error::invalid_input(format!(
                 "Bitmap segment has value type {:?}, expected {:?}",
@@ -1728,24 +1880,22 @@ pub async fn merge_bitmap_indices(
                 value_type
             )));
         }
-
-        let state = source_index.load_bitmap_index_state().await?;
-        for (key, bitmap) in state {
-            merged_state
-                .entry(key)
-                .and_modify(|existing| *existing |= &bitmap)
-                .or_insert(bitmap);
-        }
-        progress
-            .stage_progress("merge_bitmap_segments", (idx + 1) as u64)
-            .await?;
     }
+
+    let mut writer = new_bitmap_batch_writer(dest_store, BITMAP_LOOKUP_NAME, &value_type).await?;
+    merge_index_maps(
+        source_indices,
+        None,
+        &mut writer,
+        Some((progress.as_ref(), "merge_bitmap_segments")),
+    )
+    .await?;
     progress.stage_complete("merge_bitmap_segments").await?;
 
     progress
         .stage_start("write_bitmap_index", Some(1), "files")
         .await?;
-    let file = BitmapIndexPlugin::write_bitmap_index(merged_state, dest_store, &value_type).await?;
+    let file = writer.finish().await?;
     progress.stage_progress("write_bitmap_index", 1).await?;
     progress.stage_complete("write_bitmap_index").await?;
 
@@ -1921,6 +2071,83 @@ impl ScalarIndexPlugin for BitmapIndexPlugin {
         } else {
             Ok(None)
         }
+    }
+}
+
+/// Fixtures shared by the tests of every module that writes this file format.
+#[cfg(test)]
+pub(crate) mod test_util {
+    use std::sync::Arc;
+
+    use arrow_array::{Array, BinaryArray};
+    use datafusion_common::ScalarValue;
+    use lance_core::cache::LanceCache;
+    use lance_core::utils::tempfile::TempObjDir;
+    use lance_io::object_store::ObjectStore;
+    use lance_select::RowAddrTreeMap;
+
+    use crate::scalar::IndexStore;
+    use crate::scalar::lance_format::LanceIndexStore;
+
+    /// A local index store in a fresh temporary directory. The directory is
+    /// returned because dropping it deletes the store.
+    pub fn index_store() -> (TempObjDir, Arc<dyn IndexStore>) {
+        let tmpdir = TempObjDir::default();
+        let store = Arc::new(LanceIndexStore::new(
+            Arc::new(ObjectStore::local()),
+            tmpdir.clone(),
+            Arc::new(LanceCache::no_cache()),
+        ));
+        (tmpdir, store)
+    }
+
+    /// Every `(key, bitmap)` row of a bitmap-shaped index file, in file order.
+    ///
+    /// File order matters to callers: a fresh build emits the null key first (its
+    /// input is nulls-first sorted) then keys ascending, while indexes written
+    /// before spill-based builds are in arbitrary order, and some tests assert on
+    /// which of the two they are looking at.
+    ///
+    /// An update is the one exception: if the existing index has a null posting
+    /// and the new data contributes none, `build_index_map` appends that null key
+    /// last, after the ascending old-only tail. `BitmapIndex::load` finds the null
+    /// row by scanning, so readers are unaffected, and no file-order consumer sees
+    /// such a file -- `merge_shards` reads only shard files, which are always
+    /// built with no existing index.
+    pub async fn read_key_bitmaps(
+        store: &dyn IndexStore,
+        file_name: &str,
+    ) -> Vec<(Option<String>, RowAddrTreeMap)> {
+        let reader = store.open_index_file(file_name).await.unwrap();
+        let total = reader.num_rows();
+        if total == 0 {
+            return Vec::new();
+        }
+        let batch = reader.read_range(0..total, None).await.unwrap();
+        let bitmaps = batch
+            .column(1)
+            .as_any()
+            .downcast_ref::<BinaryArray>()
+            .unwrap();
+        (0..batch.num_rows())
+            .map(|idx| {
+                let key = match ScalarValue::try_from_array(batch.column(0), idx).unwrap() {
+                    ScalarValue::Utf8(value) => value,
+                    other => panic!("unexpected key type {other:?}"),
+                };
+                let bitmap = RowAddrTreeMap::deserialize_from(bitmaps.value(idx)).unwrap();
+                (key, bitmap)
+            })
+            .collect()
+    }
+
+    /// A bitmap's row addresses, ascending. Empty for a bitmap with no
+    /// enumerable addresses.
+    pub fn row_addrs(bitmap: &RowAddrTreeMap) -> Vec<u64> {
+        bitmap
+            .row_addrs()
+            .map(|iter| iter.map(u64::from).collect())
+            .unwrap_or_default()
     }
 }
 
@@ -2374,7 +2601,6 @@ mod tests {
         use lance_core::cache::LanceCache;
         use lance_io::object_store::ObjectStore;
         use lance_select::RowAddrTreeMap;
-        use std::collections::HashMap;
         use std::sync::Arc;
 
         // Adjust these numbers so that:
@@ -2385,15 +2611,6 @@ mod tests {
         let m: u32 = 2_500_000;
         let per_bitmap_size = 1000; // assumed bytes per bitmap
 
-        let mut state = HashMap::new();
-        for i in 0..m {
-            // Create a bitmap that contains, say, 1000 row IDs.
-            let bitmap = RowAddrTreeMap::from_iter(0..per_bitmap_size);
-
-            let key = ScalarValue::UInt32(Some(i));
-            state.insert(key, bitmap);
-        }
-
         // Create a temporary store.
         let tmpdir = TempObjDir::default();
         let test_store = LanceIndexStore::new(
@@ -2402,10 +2619,22 @@ mod tests {
             Arc::new(LanceCache::no_cache()),
         );
 
-        // This call should never trigger a "byte array offset overflow" error since now the code supports
-        // read by chunks
-        let result =
-            BitmapIndexPlugin::write_bitmap_index(state, &test_store, &DataType::UInt32).await;
+        // This should never trigger a "byte array offset overflow" error, since
+        // the writer flushes a batch once it reaches MAX_BUFFERED_BYTES, which is
+        // far below the i32 offset ceiling of either output column.
+        let mut writer =
+            new_bitmap_batch_writer(&test_store, BITMAP_LOOKUP_NAME, &DataType::UInt32)
+                .await
+                .unwrap();
+        for i in 0..m {
+            // Create a bitmap that contains, say, 1000 row IDs.
+            let bitmap = RowAddrTreeMap::from_iter(0..per_bitmap_size);
+            writer
+                .emit(ScalarValue::UInt32(Some(i)), &bitmap)
+                .await
+                .unwrap();
+        }
+        let result = writer.finish().await;
 
         assert!(
             result.is_ok(),
@@ -2795,6 +3024,78 @@ mod tests {
         }
     }
 
+    /// Remap must emit exactly what the pre-streaming path did: one row per
+    /// source key, nulls included, every address put through the same mapping.
+    ///
+    /// The old path materialized the index into a
+    /// `HashMap<ScalarValue, RowAddrTreeMap>`, remapped each entry and wrote the
+    /// whole map, so a key whose rows were all deleted still produced a row with
+    /// an empty bitmap. `remap_index_map` streams key-by-key instead and emits
+    /// unconditionally to preserve that -- deliberately unlike `merge_index_maps`,
+    /// which drops keys its filter empties.
+    #[tokio::test]
+    async fn test_bitmap_remap_matches_materialized_path() {
+        // frag 1 - { 0: null, 1: "a", 2: "b" }
+        // frag 2 - { 0: "a",  1: "c", 2: null }
+        let addrs: Vec<u64> = [(1, 0), (1, 1), (1, 2), (2, 0), (2, 1), (2, 2)]
+            .into_iter()
+            .map(|(frag, offset)| RowAddress::new_from_parts(frag, offset).into())
+            .collect();
+        let values = [None, Some("a"), Some("b"), Some("a"), Some("c"), None];
+
+        let (_src_dir, src_store) = test_util::index_store();
+        let stream = utf8_value_stream(values, addrs.clone());
+        BitmapIndexPlugin::train_bitmap_index(stream, src_store.as_ref())
+            .await
+            .unwrap();
+        let index = BitmapIndex::load(src_store, None, &LanceCache::no_cache())
+            .await
+            .unwrap();
+
+        // One key per arm of the mapping's tri-state: "a" keeps a remapped row
+        // and loses a deleted one, "b" loses its only row, "c" is absent from the
+        // mapping and passes through unchanged, and the null bitmap -- which lives
+        // outside `index_map` -- sees both a remap and a delete.
+        let mapping = RowAddrRemap::direct(HashMap::from([
+            (addrs[0], Some(RowAddress::new_from_parts(3, 0).into())),
+            (addrs[1], None),
+            (addrs[2], None),
+            (addrs[3], Some(RowAddress::new_from_parts(3, 1).into())),
+            (addrs[5], None),
+        ]));
+
+        let (_dest_dir, dest_store) = test_util::index_store();
+        index.remap(&mapping, dest_store.as_ref()).await.unwrap();
+
+        // Read in file order, so this pins the emitted order as well as the
+        // contents: the null key first, then keys ascending. The old path wrote
+        // a `HashMap`, in no particular order.
+        let frag_3 =
+            |offset: u32| -> Vec<u64> { vec![RowAddress::new_from_parts(3, offset).into()] };
+        let written: Vec<(Option<String>, Vec<u64>)> =
+            test_util::read_key_bitmaps(dest_store.as_ref(), BITMAP_LOOKUP_NAME)
+                .await
+                .into_iter()
+                .map(|(key, bitmap)| (key, test_util::row_addrs(&bitmap)))
+                .collect();
+        assert_eq!(
+            written,
+            vec![
+                (None, frag_3(0)),
+                (Some("a".to_string()), frag_3(1)),
+                // Every row of "b" was deleted, and it still emits a row.
+                (Some("b".to_string()), Vec::new()),
+                (Some("c".to_string()), vec![addrs[4]]),
+            ]
+        );
+
+        // The emptied key survives the round trip as a key rather than vanishing.
+        let reloaded = BitmapIndex::load(dest_store, None, &LanceCache::no_cache())
+            .await
+            .unwrap();
+        assert_eq!(reloaded.index_map.len(), 3);
+    }
+
     #[tokio::test]
     async fn test_bitmap_null_handling_in_queries() {
         // Test that bitmap index correctly returns null_list for queries
@@ -2805,10 +3106,12 @@ mod tests {
             Arc::new(LanceCache::no_cache()),
         ));
 
-        // Create test data: [0, 5, null]
+        // Row id -> value: 0 -> 0, 1 -> 5, 2 -> null. Listed value-sorted,
+        // nulls first, as `build_index_map` requires; row id order need not
+        // match value order.
         let batch = record_batch!(
-            ("value", Int64, [Some(0), Some(5), None]),
-            ("_rowid", UInt64, [0, 1, 2])
+            ("value", Int64, [None, Some(0), Some(5)]),
+            ("_rowid", UInt64, [2, 0, 1])
         )
         .unwrap();
         let schema = batch.schema();
@@ -2933,5 +3236,266 @@ mod tests {
             }
             _ => panic!("Expected Exact search result"),
         }
+    }
+
+    /// Merging bitmap segments must equal a single build over the same rows,
+    /// including the null bitmap, which lives outside `index_map`.
+    #[tokio::test]
+    async fn test_bitmap_segment_merge_matches_single_build() {
+        let values: Vec<Option<String>> = (0..600)
+            .map(|i| {
+                if i % 13 == 0 {
+                    None
+                } else {
+                    Some(format!("v-{:03}", i % 50))
+                }
+            })
+            .collect();
+
+        async fn build(
+            values: &[Option<String>],
+            offset: u64,
+        ) -> (TempObjDir, Arc<dyn IndexStore>) {
+            let (tmpdir, store) = test_util::index_store();
+            let stream = utf8_value_stream(
+                values.iter().cloned(),
+                (0..values.len() as u64).map(|i| i + offset),
+            );
+            BitmapIndexPlugin::train_bitmap_index(stream, store.as_ref())
+                .await
+                .unwrap();
+            (tmpdir, store)
+        }
+
+        let (_all_dir, all_store) = build(&values, 0).await;
+        let expected = read_bitmap_contents(all_store.as_ref()).await;
+        assert!(
+            expected.iter().any(|(key, _)| key.is_none()),
+            "fixture must exercise the null bitmap"
+        );
+
+        let (_left_dir, left_store) = build(&values[..300], 0).await;
+        let (_right_dir, right_store) = build(&values[300..], 300).await;
+        let left = BitmapIndex::load(left_store, None, &LanceCache::no_cache())
+            .await
+            .unwrap();
+        let right = BitmapIndex::load(right_store, None, &LanceCache::no_cache())
+            .await
+            .unwrap();
+
+        let (_dest_dir, dest_store) = test_util::index_store();
+        merge_bitmap_indices(
+            &[left, right],
+            dest_store.as_ref(),
+            crate::progress::noop_progress(),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(expected, read_bitmap_contents(dest_store.as_ref()).await);
+    }
+
+    /// The keys column counts toward the flush threshold, not just the bitmaps.
+    /// A column with a very large number of tiny bitmaps used to buffer without
+    /// limit: the old threshold charged the bitmap column only, so the keys could
+    /// grow until the writer held gigabytes and their Arrow i32 offsets overflowed.
+    #[tokio::test]
+    async fn test_batch_writer_charges_keys_against_flush_threshold() {
+        // Small enough to cross with a handful of keys; the production threshold
+        // is MAX_BUFFERED_BYTES, which no test wants to write out.
+        const THRESHOLD: usize = 4 * 1024;
+        const NUM_KEYS: u64 = 64;
+
+        let (_tmpdir, store) = test_util::index_store();
+        let mut writer =
+            new_bitmap_batch_writer(store.as_ref(), BITMAP_LOOKUP_NAME, &DataType::Utf8)
+                .await
+                .unwrap()
+                .with_max_buffered_bytes(THRESHOLD);
+
+        // Every bitmap holds one row, so all the bitmaps together stay under the
+        // threshold; only the keys can push the writer past it.
+        for i in 0..NUM_KEYS {
+            let key = format!("{i:08}{}", "k".repeat(512));
+            writer
+                .emit(
+                    ScalarValue::Utf8(Some(key)),
+                    &RowAddrTreeMap::from_iter([i]),
+                )
+                .await
+                .unwrap();
+        }
+        assert!(
+            writer.batches_written() > 1,
+            "keys must be charged against the flush threshold, but the writer \
+             buffered all {NUM_KEYS} keys in {} batch(es)",
+            writer.batches_written()
+        );
+        writer.finish().await.unwrap();
+
+        // Flushing part-way through must not disturb the file's contents.
+        let contents = read_bitmap_contents(store.as_ref()).await;
+        assert_eq!(contents.len() as u64, NUM_KEYS);
+        for (idx, (key, addrs)) in contents.iter().enumerate() {
+            let key = key.as_deref().expect("keys are non-null");
+            assert_eq!(&key[..8], format!("{idx:08}"), "keys must stay ascending");
+            assert_eq!(addrs, &vec![idx as u64]);
+        }
+    }
+
+    /// `build_index_map` writes into a caller-owned writer, so a caller that needs
+    /// its own global buffer in the same file can reuse the algorithm rather than
+    /// reimplementing it. LabelList's `list_nulls` buffer is the reason this split
+    /// exists.
+    #[tokio::test]
+    async fn test_build_index_map_writes_into_a_caller_owned_file() {
+        let (_tmpdir, store) = test_util::index_store();
+        let stream = utf8_value_stream([None, Some("a"), Some("b")], [0u64, 1, 2]);
+
+        let mut writer =
+            new_bitmap_batch_writer(store.as_ref(), BITMAP_LOOKUP_NAME, &DataType::Utf8)
+                .await
+                .unwrap();
+        build_index_map(stream, None, None, &mut writer)
+            .await
+            .unwrap();
+        writer
+            .add_global_buffer("test:buffer".to_string(), Bytes::from_static(b"payload"))
+            .await
+            .unwrap();
+        writer.finish().await.unwrap();
+
+        assert_eq!(
+            read_bitmap_contents(store.as_ref()).await,
+            vec![
+                (None, vec![0]),
+                (Some("a".to_string()), vec![1]),
+                (Some("b".to_string()), vec![2]),
+            ]
+        );
+
+        // The buffer is attached after the data pages, so this also pins that a
+        // buffer added last is still discoverable from the file metadata.
+        let reader = store.open_index_file(BITMAP_LOOKUP_NAME).await.unwrap();
+        let idx: u32 = reader
+            .schema()
+            .metadata
+            .get("test:buffer")
+            .expect("buffer index must be recorded in metadata")
+            .parse()
+            .unwrap();
+        assert_eq!(
+            &reader.read_global_buffer(idx).await.unwrap()[..],
+            b"payload"
+        );
+    }
+
+    /// Every branch of the merge-join against an existing index, in one fixture,
+    /// so their interaction is covered and not just each in isolation.
+    ///
+    /// Old index: null -> 50, "a" -> 100, "b" -> {10, 11}, "f" -> 99.
+    /// New data: "b" -> 20, "d" -> 30, and no nulls at all.
+    ///
+    /// That drives, in order: the before-key drain ("a" precedes the first new
+    /// key), the equal-key merge ("b" is in both, so its row sets must union
+    /// rather than replace), the non-empty tail drain ("f" outlives the last new
+    /// key), and the trailing-null branch (`emitted_null` stays false, so the old
+    /// null posting is emitted from the tail). Deleting any one of the four
+    /// changes the expectation below.
+    ///
+    /// Read in file order, which also pins the one shape where the null key lands
+    /// last rather than first -- see `read_key_bitmaps`.
+    #[tokio::test]
+    async fn test_build_index_map_merges_an_existing_index() {
+        let (_old_dir, old_store) = test_util::index_store();
+        BitmapIndexPlugin::train_bitmap_index(
+            utf8_value_stream(
+                [None, Some("a"), Some("b"), Some("b"), Some("f")],
+                [50u64, 100, 10, 11, 99],
+            ),
+            old_store.as_ref(),
+        )
+        .await
+        .unwrap();
+        let old_index = BitmapIndex::load(old_store, None, &LanceCache::no_cache())
+            .await
+            .unwrap();
+        assert!(
+            !old_index.null_map.is_empty(),
+            "fixture must give the old index a null posting"
+        );
+
+        let (_dest_dir, dest_store) = test_util::index_store();
+        let mut writer =
+            new_bitmap_batch_writer(dest_store.as_ref(), BITMAP_LOOKUP_NAME, &DataType::Utf8)
+                .await
+                .unwrap();
+        build_index_map(
+            utf8_value_stream([Some("b"), Some("d")], [20u64, 30]),
+            Some(old_index.as_ref()),
+            None,
+            &mut writer,
+        )
+        .await
+        .unwrap();
+        writer.finish().await.unwrap();
+
+        let contents: Vec<(Option<String>, Vec<u64>)> =
+            test_util::read_key_bitmaps(dest_store.as_ref(), BITMAP_LOOKUP_NAME)
+                .await
+                .into_iter()
+                .map(|(key, bitmap)| (key, test_util::row_addrs(&bitmap)))
+                .collect();
+        assert_eq!(
+            contents,
+            vec![
+                (Some("a".to_string()), vec![100]),
+                (Some("b".to_string()), vec![10, 11, 20]),
+                (Some("d".to_string()), vec![30]),
+                (Some("f".to_string()), vec![99]),
+                (None, vec![50]),
+            ]
+        );
+    }
+
+    /// A single-batch `(value, row_addr)` stream over nullable Utf8 keys -- the
+    /// input shape `train_bitmap_index` and `build_index_map` both consume.
+    ///
+    /// Sorts, because both consumers require value-sorted input; a helper that
+    /// did not would just be a footgun with fewer lines.
+    fn utf8_value_stream<S: AsRef<str>>(
+        values: impl IntoIterator<Item = Option<S>>,
+        addrs: impl IntoIterator<Item = u64>,
+    ) -> SendableRecordBatchStream {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new(VALUE_COLUMN_NAME, DataType::Utf8, true),
+            Field::new(ROW_ID, DataType::UInt64, false),
+        ]));
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(StringArray::from_iter(values)),
+                Arc::new(UInt64Array::from_iter_values(addrs)),
+            ],
+        )
+        .unwrap();
+        let batch = sort_batch_by_value(&batch);
+        Box::pin(RecordBatchStreamAdapter::new(
+            schema,
+            stream::once(async move { Ok(batch) }),
+        ))
+    }
+
+    /// Key to sorted row addresses, read from the file and sorted so the
+    /// comparison does not depend on the order keys happen to be written in.
+    async fn read_bitmap_contents(store: &dyn IndexStore) -> Vec<(Option<String>, Vec<u64>)> {
+        let mut out: Vec<(Option<String>, Vec<u64>)> =
+            test_util::read_key_bitmaps(store, BITMAP_LOOKUP_NAME)
+                .await
+                .into_iter()
+                .map(|(key, bitmap)| (key, test_util::row_addrs(&bitmap)))
+                .collect();
+        out.sort();
+        out
     }
 }

--- a/rust/lance-index/src/scalar/label_list.rs
+++ b/rust/lance-index/src/scalar/label_list.rs
@@ -4,7 +4,6 @@
 use lance_core::utils::row_addr_remap::RowAddrRemap;
 use std::{
     any::Any,
-    collections::HashMap,
     fmt::Debug,
     pin::Pin,
     sync::{Arc, Mutex},
@@ -12,12 +11,16 @@ use std::{
 
 use arrow::array::AsArray;
 use arrow_array::{Array, RecordBatch, UInt64Array};
-use arrow_schema::{DataType, Field, Fields, Schema, SchemaRef};
+use arrow_schema::{DataType, Field, Fields, Schema, SchemaRef, SortOptions};
 use async_trait::async_trait;
 use bytes::Bytes;
 use datafusion::execution::RecordBatchStream;
-use datafusion::physical_plan::{SendableRecordBatchStream, stream::RecordBatchStreamAdapter};
+use datafusion::physical_plan::{
+    ExecutionPlan, SendableRecordBatchStream, sorts::sort::SortExec,
+    stream::RecordBatchStreamAdapter,
+};
 use datafusion_common::ScalarValue;
+use datafusion_physical_expr::{PhysicalSortExpr, expressions::Column};
 use futures::{StreamExt, TryStream, TryStreamExt, stream::BoxStream};
 use lance_core::cache::{
     CacheCodec, CacheCodecImpl, CacheEntryReader, CacheEntryWriter, CacheKey, CacheKeySchema,
@@ -26,6 +29,9 @@ use lance_core::cache::{
 use lance_core::deepsize::DeepSizeOf;
 use lance_core::error::LanceOptionExt;
 use lance_core::{Error, ROW_ID, Result};
+use lance_datafusion::exec::{
+    HardCapBatchSizeExec, LanceExecutionOptions, OneShotExec, execute_plan,
+};
 use lance_select::{NullableRowAddrSet, RowAddrTreeMap, RowSetOps};
 use roaring::RoaringBitmap;
 use tracing::instrument;
@@ -37,7 +43,10 @@ use super::{
 use super::{BuiltinIndexType, SargableQuery, ScalarIndexParams};
 use super::{MetricsCollector, SearchResult};
 use crate::pbold;
-use crate::scalar::bitmap::{BitmapIndexPlugin, BitmapIndexState};
+use crate::scalar::bitmap::{
+    BitmapIndexState, build_index_map, merge_index_maps, merge_source_entry_count,
+    new_bitmap_batch_writer, remap_index_map, remap_row_addrs,
+};
 use crate::scalar::expression::{LabelListQueryParser, ScalarQueryParser};
 use crate::scalar::registry::{
     BasicTrainer, DefaultTrainingRequest, ScalarIndexLoad, ScalarIndexPlugin, TrainingCriteria,
@@ -217,20 +226,21 @@ impl ScalarIndex for LabelListIndex {
         mapping: &RowAddrRemap,
         dest_store: &dyn IndexStore,
     ) -> Result<CreatedIndex> {
-        let state = self.values_index.load_bitmap_index_state().await?;
-        let remapped_state = BitmapIndexPlugin::remap_bitmap_state(state, mapping);
-        let remapped_nulls =
-            RowAddrTreeMap::from_iter(self.list_nulls.row_addrs().unwrap().filter_map(|addr| {
-                let addr_as_u64 = u64::from(addr);
-                mapping.get(addr_as_u64).unwrap_or(Some(addr_as_u64))
-            }));
-        let file = write_label_list_bitmap_index(
-            remapped_state,
+        let remapped_nulls = remap_row_addrs(&self.list_nulls, mapping)?;
+        let mut writer = new_bitmap_batch_writer(
             dest_store,
+            BITMAP_LOOKUP_NAME,
             self.values_index.value_type(),
-            &remapped_nulls,
         )
         .await?;
+        writer
+            .add_global_buffer(
+                LABEL_LIST_NULLS_METADATA_KEY.to_string(),
+                serialize_list_nulls(&remapped_nulls)?,
+            )
+            .await?;
+        remap_index_map(&self.values_index, mapping, &mut writer).await?;
+        let file = writer.finish().await?;
 
         Ok(CreatedIndex {
             index_details: prost_types::Any::from_msg(&pbold::LabelListIndexDetails::default())
@@ -247,20 +257,15 @@ impl ScalarIndex for LabelListIndex {
         dest_store: &dyn IndexStore,
         old_data_filter: Option<super::OldIndexDataFilter>,
     ) -> Result<CreatedIndex> {
-        let state = self.values_index.load_bitmap_index_state().await?;
-        let list_nulls = Arc::new(Mutex::new(RowAddrTreeMap::new()));
-        let new_data = track_list_nulls(new_data, list_nulls.clone());
-        let (merged_state, value_type) =
-            BitmapIndexPlugin::build_bitmap_index_state(unnest_chunks(new_data)?, state).await?;
+        // Not applied, matching every other derived-key scalar index (ngram,
+        // fmindex, bloomfilter, zonemap, rtree). Only btree and bitmap -- one
+        // key per row -- prune retired rows here. The cost is real: postings for
+        // retired rows survive, so an update that rewrites rows in place can
+        // leave this index returning them. Preserved as-is rather than fixed,
+        // since changing it is a correctness change this memory work should not
+        // carry.
         let _ = old_data_filter;
-        let mut merged_nulls = (*self.list_nulls).clone();
-        let new_nulls = list_nulls.lock().unwrap().clone();
-        if !new_nulls.is_empty() {
-            merged_nulls |= &new_nulls;
-        }
-        let file =
-            write_label_list_bitmap_index(merged_state, dest_store, &value_type, &merged_nulls)
-                .await?;
+        let file = update_label_list_index(self, new_data, dest_store).await?;
 
         Ok(CreatedIndex {
             index_details: prost_types::Any::from_msg(&pbold::LabelListIndexDetails::default())
@@ -468,21 +473,199 @@ fn serialize_list_nulls(null_map: &RowAddrTreeMap) -> Result<Bytes> {
     Ok(Bytes::from(bytes))
 }
 
-async fn write_label_list_bitmap_index(
-    state: HashMap<ScalarValue, RowAddrTreeMap>,
+/// Sort unnested `(label, row_addr)` pairs by label so that
+/// [`build_index_map`] can stream one label at a time.
+///
+/// This is DataFusion's sort, so it spills under `LANCE_MEM_POOL_SIZE` to
+/// `LANCE_MAX_TEMP_DIRECTORY_SIZE` rather than through a mechanism belonging to
+/// this index. `JsonIndexPlugin::sort_stream_by_value` sorts its training
+/// stream the same way. Note this is a full blocking sort, which buffers or
+/// spills the whole unnested stream -- unlike `BTreeIndexPlugin::merge_segments`,
+/// whose `SortPreservingMergeExec` streams over already-ordered inputs and never
+/// buffers the data volume at all.
+///
+/// Nulls sort first because `OrderableScalarValue` orders them below every
+/// value, so [`build_index_map`]'s ascending-input `debug_assert!` rejects a
+/// stream that puts them last. Its runtime path would in fact tolerate a null
+/// run anywhere -- `finish_run` never advances the old-keys cursor for a null
+/// key -- but the assert is the contract, and null-first is also what
+/// [`remap_index_map`] emits and what the plain bitmap index's training scan
+/// produces.
+///
+/// `mem_pool_size`, when set, overrides the session's memory pool for this
+/// sort instead of leaving it to `LANCE_MEM_POOL_SIZE`. Production callers
+/// pass `None`; the spilling-equivalence test passes an explicit size so it
+/// can force a spill without mutating the process-wide environment variable
+/// that every other cached session shares.
+///
+/// Also returns the `SortExec` node itself (not just its output stream), so a
+/// caller can inspect its metrics -- e.g. `spill_count` -- once the stream is
+/// fully drained. Production call sites have no use for it and bind it as
+/// `_`; the spilling-equivalence test uses it to confirm a forced-spill build
+/// actually spilled, rather than trusting the pool-size math alone.
+fn sort_labels_by_value(
+    unnested: SendableRecordBatchStream,
+    mem_pool_size: Option<u64>,
+) -> Result<(SendableRecordBatchStream, Arc<dyn ExecutionPlan>)> {
+    let input: Arc<dyn ExecutionPlan> = Arc::new(OneShotExec::new(unnested));
+    // Resolved by name: `Column::evaluate` only bounds-checks the index it is
+    // given and never consults the name, so a hardcoded index would silently
+    // sort by whatever column ends up there if the unnest schema's column
+    // order ever changed.
+    let value_idx = input.schema().index_of(VALUE_COLUMN_NAME)?;
+    let sort_expr = PhysicalSortExpr {
+        expr: Arc::new(Column::new(VALUE_COLUMN_NAME, value_idx)),
+        options: SortOptions {
+            descending: false,
+            nulls_first: true,
+        },
+    };
+
+    let options = LanceExecutionOptions {
+        use_spilling: true,
+        mem_pool_size,
+        ..Default::default()
+    };
+
+    // Unnesting multiplies rows by list length, so one scan batch becomes a batch
+    // far larger than any other operator produces: 8,192 rows x 512 labels is
+    // 4.2M rows at once. DataFusion's sort cannot spill a batch it has not first
+    // admitted, so an oversized batch fails the build outright instead of
+    // spilling -- reproduced as `ResourcesExhausted` from `ExternalSorter` with
+    // only 512 distinct labels. Cap by bytes before the sort. Byte-aware rather
+    // than row-aware because list width and label width both vary, and
+    // deep-copying, because a sliced batch still reports its parent buffer's
+    // size to memory accounting.
+    //
+    // A sixth of the pool, derived rather than fixed: the sort reserves
+    // `min(pool / 3, 40 MiB)` up front, so at worst two thirds of the pool is
+    // left to admit a batch into, and a sixth is a quarter of that worst case --
+    // room for the sort to work in, not just to hold the batch. Deriving it also
+    // avoids restating that reservation formula, which lives in `lance-datafusion`
+    // and would silently drift. At the 150 MiB default this is 25 MiB, the value
+    // the merge-insert write path fixes above its own sort.
+    let max_batch_bytes = (options.mem_pool_size() / 6).max(1) as usize;
+    let capped: Arc<dyn ExecutionPlan> =
+        Arc::new(HardCapBatchSizeExec::new(input, max_batch_bytes));
+
+    let sorted: Arc<dyn ExecutionPlan> = Arc::new(SortExec::new([sort_expr].into(), capped));
+    let stream = execute_plan(sorted.clone(), options)?;
+    Ok((stream, sorted))
+}
+
+/// Write a LabelList index: a bitmap index over `sorted_labels`, plus the
+/// `list_nulls` set as a global buffer in the same file.
+///
+/// `list_nulls` is a closure, not a value, because it is only correct to read
+/// after `sorted_labels` is drained -- `track_list_nulls` fills its set as rows
+/// flow through it, and the sort upstream means no row reaches here until every
+/// input row has passed it. The buffer is attached after the data pages for the
+/// same reason; `add_global_buffer` records its index in the file metadata, so
+/// position does not matter to readers.
+async fn write_label_list_index(
     store: &dyn IndexStore,
     value_type: &DataType,
-    list_nulls: &RowAddrTreeMap,
+    sorted_labels: SendableRecordBatchStream,
+    old_index: Option<&BitmapIndex>,
+    list_nulls: impl FnOnce() -> Result<RowAddrTreeMap>,
 ) -> Result<IndexFile> {
-    BitmapIndexPlugin::write_bitmap_index_with_extras(
-        state,
-        store,
-        value_type,
-        HashMap::new(),
-        vec![(
+    let mut writer = new_bitmap_batch_writer(store, BITMAP_LOOKUP_NAME, value_type).await?;
+    // `None`: LabelList does not apply the old-data filter. See `update`.
+    build_index_map(sorted_labels, old_index, None, &mut writer).await?;
+    writer
+        .add_global_buffer(
             LABEL_LIST_NULLS_METADATA_KEY.to_string(),
-            serialize_list_nulls(list_nulls)?,
-        )],
+            serialize_list_nulls(&list_nulls()?)?,
+        )
+        .await?;
+    writer.finish().await
+}
+
+/// Build a LabelList index from a `(list column, row_addr)` stream, also
+/// returning the sort's `SortExec` node.
+///
+/// The list column is unnested and the resulting labels sorted, so the bitmap
+/// builder holds one label's bitmap at a time instead of the whole map. The sort
+/// is DataFusion's and spills under `LANCE_MEM_POOL_SIZE`.
+///
+/// [`train_label_list_index`] is a thin wrapper over this that discards the
+/// plan handle and always passes `None` for `mem_pool_size` -- production has
+/// no use for either. The spilling-equivalence test calls this directly,
+/// passing an explicit `mem_pool_size`, so its forced-spill build can assert
+/// on `spill_count` while still running the exact sequence production does,
+/// rather than a hand-maintained copy of it that could quietly drift out of
+/// step.
+async fn train_label_list_index_with_plan(
+    data: SendableRecordBatchStream,
+    index_store: &dyn IndexStore,
+    mem_pool_size: Option<u64>,
+) -> Result<(IndexFile, Arc<dyn ExecutionPlan>)> {
+    let list_nulls = Arc::new(Mutex::new(RowAddrTreeMap::new()));
+    let data = track_list_nulls(data, list_nulls.clone());
+    let data = unnest_chunks(data)?;
+    let value_type = data.schema().field(0).data_type().clone();
+    let (sorted, sort_plan) = sort_labels_by_value(data, mem_pool_size)?;
+
+    let file = write_label_list_index(index_store, &value_type, sorted, None, || {
+        Ok(list_nulls.lock().unwrap().clone())
+    })
+    .await?;
+    Ok((file, sort_plan))
+}
+
+/// Build a LabelList index from a `(list column, row_addr)` stream.
+async fn train_label_list_index(
+    data: SendableRecordBatchStream,
+    index_store: &dyn IndexStore,
+) -> Result<IndexFile> {
+    train_label_list_index_with_plan(data, index_store, None)
+        .await
+        .map(|(file, _sort_plan)| file)
+}
+
+/// Add `new_data` to an existing LabelList index, writing the result to
+/// `dest_store`.
+///
+/// The existing index joins the new labels through bitmap's merge-join, which
+/// walks its `index_map` and loads one old bitmap at a time. Files written before
+/// this change have their keys in arbitrary on-disk order, which does not matter:
+/// `BitmapIndex::load` builds `index_map` as a `BTreeMap` recording each key's
+/// file offset, so iteration is sorted regardless.
+async fn update_label_list_index(
+    existing: &LabelListIndex,
+    new_data: SendableRecordBatchStream,
+    dest_store: &dyn IndexStore,
+) -> Result<IndexFile> {
+    let list_nulls = Arc::new(Mutex::new(RowAddrTreeMap::new()));
+    let new_data = track_list_nulls(new_data, list_nulls.clone());
+    let new_data = unnest_chunks(new_data)?;
+
+    // The destination file's schema is declared from the existing index while
+    // every new key comes from the stream. If the two disagree the written
+    // batches would not match the schema they are declared under, so reject it
+    // here rather than emit a file whose schema lies about its key type.
+    let value_type = existing.values_index.value_type().clone();
+    let new_value_type = new_data.schema().field(0).data_type().clone();
+    if new_value_type != value_type {
+        return Err(Error::invalid_input(format!(
+            "Cannot update a LabelList index with value type {value_type} \
+             from new data whose list items are {new_value_type}"
+        )));
+    }
+
+    let (sorted, _sort_plan) = sort_labels_by_value(new_data, None)?;
+    let existing_nulls = existing.list_nulls.clone();
+
+    write_label_list_index(
+        dest_store,
+        &value_type,
+        sorted,
+        Some(&existing.values_index),
+        || {
+            let mut merged = (*existing_nulls).clone();
+            merged |= &*list_nulls.lock().unwrap();
+            Ok(merged)
+        },
     )
     .await
 }
@@ -491,11 +674,12 @@ async fn write_label_list_bitmap_index(
 ///
 /// A [`LabelListIndex`] is a [`BitmapIndex`] over the unnested list values plus a
 /// separate `list_nulls` row set. Because distributed segments cover disjoint rows
-/// (distinct fragments), merging is a cheap union of the underlying bitmap states
-/// and of the `list_nulls` sets — no re-scan of source data is required. This
-/// mirrors [`crate::scalar::bitmap::merge_bitmap_indices`] but also carries the
-/// per-segment `list_nulls`. When `old_data_filter` is provided, rows from
-/// retired fragments are removed from both the value bitmaps and `list_nulls`.
+/// (distinct fragments), merging streams and unions the bitmap payloads by key
+/// and separately unions the `list_nulls` sets; no source-data re-scan is
+/// required. This mirrors [`crate::scalar::bitmap::merge_bitmap_indices`] but
+/// also carries the per-segment `list_nulls`. When `old_data_filter` is provided,
+/// rows from retired fragments are removed from both the value bitmaps and
+/// `list_nulls`.
 pub async fn merge_label_list_indices(
     source_indices: &[Arc<LabelListIndex>],
     dest_store: &dyn IndexStore,
@@ -509,17 +693,10 @@ pub async fn merge_label_list_indices(
     }
 
     let value_type = source_indices[0].values_index.value_type().clone();
-    let mut merged_state = HashMap::<ScalarValue, RowAddrTreeMap>::new();
     let mut merged_nulls = RowAddrTreeMap::new();
 
-    progress
-        .stage_start(
-            "merge_label_list_segments",
-            Some(source_indices.len() as u64),
-            "segments",
-        )
-        .await?;
-    for (idx, source_index) in source_indices.iter().enumerate() {
+    let mut values_indices = Vec::with_capacity(source_indices.len());
+    for source_index in source_indices.iter() {
         if source_index.values_index.value_type() != &value_type {
             return Err(Error::invalid_input(format!(
                 "LabelList segment has value type {:?}, expected {:?}",
@@ -527,36 +704,50 @@ pub async fn merge_label_list_indices(
                 value_type
             )));
         }
+        values_indices.push(source_index.values_index.clone());
 
-        let state = source_index.values_index.load_bitmap_index_state().await?;
-        for (key, mut bitmap) in state {
-            if let Some(filter) = old_data_filter.as_ref() {
-                filter.retain_old_rows(&mut bitmap);
-            }
-            if bitmap.is_empty() {
-                continue;
-            }
-            merged_state
-                .entry(key)
-                .and_modify(|existing| *existing |= &bitmap)
-                .or_insert(bitmap);
-        }
-        let mut list_nulls = source_index.list_nulls.as_ref().clone();
+        // `list_nulls` records whole rows whose list was null, so it is a row
+        // set per segment rather than a per-label bitmap. It stays outside both
+        // the key merge and the aggregation-state budget.
+        // Only copy when there is a filter to apply: an unfiltered merge is the
+        // common case, and each copy is a whole segment's row set.
         if let Some(filter) = old_data_filter.as_ref() {
+            let mut list_nulls = source_index.list_nulls.as_ref().clone();
             filter.retain_old_rows(&mut list_nulls);
+            merged_nulls |= &list_nulls;
+        } else {
+            merged_nulls |= source_index.list_nulls.as_ref();
         }
-        merged_nulls |= &list_nulls;
-        progress
-            .stage_progress("merge_label_list_segments", (idx + 1) as u64)
-            .await?;
     }
+
+    progress
+        .stage_start(
+            "merge_label_list_segments",
+            Some(merge_source_entry_count(&values_indices)),
+            "entries",
+        )
+        .await?;
+
+    let mut writer = new_bitmap_batch_writer(dest_store, BITMAP_LOOKUP_NAME, &value_type).await?;
+    writer
+        .add_global_buffer(
+            LABEL_LIST_NULLS_METADATA_KEY.to_string(),
+            serialize_list_nulls(&merged_nulls)?,
+        )
+        .await?;
+    merge_index_maps(
+        &values_indices,
+        old_data_filter.as_ref(),
+        &mut writer,
+        Some((progress.as_ref(), "merge_label_list_segments")),
+    )
+    .await?;
     progress.stage_complete("merge_label_list_segments").await?;
 
     progress
         .stage_start("write_label_list_index", Some(1), "files")
         .await?;
-    let file =
-        write_label_list_bitmap_index(merged_state, dest_store, &value_type, &merged_nulls).await?;
+    let file = writer.finish().await?;
     progress.stage_progress("write_label_list_index", 1).await?;
     progress.stage_complete("write_label_list_index").await?;
 
@@ -752,14 +943,7 @@ impl BasicTrainer for LabelListIndexPlugin {
 
         validate_label_list_data_type(field.data_type())?;
 
-        let list_nulls = Arc::new(Mutex::new(RowAddrTreeMap::new()));
-        let data = track_list_nulls(data, list_nulls.clone());
-        let data = unnest_chunks(data)?;
-        let (state, value_type) =
-            BitmapIndexPlugin::build_bitmap_index_state(data, HashMap::new()).await?;
-        let list_nulls = list_nulls.lock().unwrap().clone();
-        let file =
-            write_label_list_bitmap_index(state, index_store, &value_type, &list_nulls).await?;
+        let file = train_label_list_index(data, index_store).await?;
         Ok(CreatedIndex {
             index_details: prost_types::Any::from_msg(&pbold::LabelListIndexDetails::default())
                 .unwrap(),
@@ -874,6 +1058,8 @@ mod tests {
     use super::super::bitmap::BitmapIndexState;
     use super::super::btree::OrderableScalarValue;
     use super::*;
+    use crate::scalar::bitmap::test_util::{self, row_addrs};
+    use lance_core::utils::tempfile::TempObjDir;
 
     #[rstest]
     #[case::list(DataType::List(Arc::new(Field::new(
@@ -978,5 +1164,841 @@ mod tests {
                 );
             }
         }
+    }
+
+    /// A wide list column must build whatever the memory pool is set to.
+    ///
+    /// `unnest_chunks` maps one input batch to one output batch, multiplying rows
+    /// by list length, so a scan's 8,192-row batch becomes 4.2M unnested rows in
+    /// a single batch. DataFusion's sort cannot spill a batch it has not first
+    /// admitted, so without the byte cap in `sort_labels_by_value` this fails
+    /// outright with `ResourcesExhausted` -- and with only 512 distinct labels,
+    /// so it is unrelated to the cardinality this index's memory work targets.
+    ///
+    /// Both pool sizes matter. The default case is the originally reported
+    /// failure; the small-pool case is what a cap fixed at 25 MiB gets wrong,
+    /// since 25 MiB does not fit in a 32 MiB pool's ~21 MiB of admittable space.
+    /// Each fixture is sized to exceed its own pool, so a cap that stopped
+    /// tracking the pool fails one case or the other.
+    ///
+    /// Deliberately one large batch: every other fixture here chunks input at 64
+    /// rows, which is why none of them can reach this. The default-pool case is
+    /// also the one test here that exceeds the one-second guideline (~1.6s), and
+    /// deliberately: it has to put more than ~110 MiB through a single batch, and
+    /// trimming it closer to the threshold would let it pass without the cap on a
+    /// machine with slightly different accounting. A memory test that quietly
+    /// stops reproducing is worse than a slow one.
+    #[rstest]
+    #[case::default_pool(None, 1024)]
+    #[case::small_pool(Some(32 * 1024 * 1024), 256)]
+    #[tokio::test]
+    #[serial_test::serial(LANCE_DF_SPILL_POOL)]
+    async fn test_train_index_handles_a_wide_list_in_one_scan_batch(
+        #[case] mem_pool_size: Option<u64>,
+        #[case] rows: usize,
+    ) {
+        // Sized for bytes, not rows: a wide label keeps the single batch over the
+        // pool while sorting far fewer rows than an 8,192-row scan batch would.
+        const LABELS_PER_ROW: usize = 512;
+        const LABEL_PAD: usize = 200;
+
+        let schema: SchemaRef = Arc::new(Schema::new(vec![
+            Field::new(
+                VALUE_COLUMN_NAME,
+                DataType::List(Arc::new(Field::new("item", DataType::Utf8, true))),
+                true,
+            ),
+            Field::new(ROW_ID, DataType::UInt64, false),
+        ]));
+        let mut builder =
+            arrow_array::builder::ListBuilder::new(arrow_array::builder::StringBuilder::new());
+        for _ in 0..rows {
+            for label in 0..LABELS_PER_ROW {
+                builder
+                    .values()
+                    .append_value(format!("label-{label:04}{}", "p".repeat(LABEL_PAD)));
+            }
+            builder.append(true);
+        }
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(builder.finish()),
+                Arc::new(UInt64Array::from_iter_values(0..rows as u64)),
+            ],
+        )
+        .unwrap();
+        let stream: SendableRecordBatchStream = Box::pin(RecordBatchStreamAdapter::new(
+            schema,
+            futures::stream::iter(vec![Ok(batch)]),
+        ));
+
+        let (_tmpdir, store) = test_util::index_store();
+        train_label_list_index_with_plan(stream, store.as_ref(), mem_pool_size)
+            .await
+            .expect("a wide list column must build whatever the pool is set to");
+
+        let contents = read_index_contents(store.as_ref()).await;
+        assert_eq!(
+            contents.labels.len(),
+            LABELS_PER_ROW,
+            "every label in the lists must be indexed"
+        );
+        // Every row carries every label, so each posting covers all rows.
+        assert!(
+            contents.labels.iter().all(|(_, addrs)| addrs.len() == rows),
+            "each label must cover all {rows} rows"
+        );
+        assert!(contents.list_nulls.is_empty());
+    }
+
+    // ---- shared fixtures for the spill-build tests ------------------------
+
+    /// One test row: its address, and either a null list or a list whose
+    /// elements may individually be null. Both null shapes matter — a null list
+    /// is recorded in `list_nulls`, a null element survives unnesting as a null
+    /// index key.
+    type SampleRow = (u64, Option<Vec<Option<String>>>);
+
+    /// Deterministic rows with heavy label reuse, a null list every 17th row,
+    /// and a null element every 11th, so every code path sees both.
+    fn sample_label_list_rows(count: usize, addr_offset: u64) -> Vec<SampleRow> {
+        let rows: Vec<SampleRow> = (0..count)
+            .map(|i| {
+                let addr = addr_offset + i as u64;
+                if i % 17 == 0 {
+                    return (addr, None);
+                }
+                let mut labels: Vec<Option<String>> = (0..(i % 4) + 1)
+                    .map(|k| Some(format!("label-{:04}", (i * 7 + k * 13) % 200)))
+                    .collect();
+                if i % 11 == 0 {
+                    labels.push(None);
+                }
+                (addr, Some(labels))
+            })
+            .collect();
+
+        // Guarded here rather than in each caller: several tests rely on this
+        // fixture carrying both null shapes, and a change to the pattern above
+        // would otherwise silently stop exercising them everywhere at once.
+        // That the shapes then reach the right places in the index is
+        // `test_null_element_null_list_and_empty_list_stay_distinct`'s job.
+        assert!(
+            rows.iter().any(|(_, labels)| labels.is_none()),
+            "fixture must contain a null list; {count} rows is too few"
+        );
+        assert!(
+            rows.iter()
+                .any(|(_, labels)| labels.as_ref().is_some_and(|l| l.contains(&None))),
+            "fixture must contain a null label; {count} rows is too few"
+        );
+        rows
+    }
+
+    fn label_list_schema() -> SchemaRef {
+        Arc::new(Schema::new(vec![
+            Field::new(
+                VALUE_COLUMN_NAME,
+                DataType::List(Arc::new(Field::new("item", DataType::Utf8, true))),
+                true,
+            ),
+            Field::new(ROW_ID, DataType::UInt64, false),
+        ]))
+    }
+
+    /// Chunk the rows into several batches so the builder crosses batch
+    /// boundaries the way a real scan does.
+    fn sample_rows_to_stream(rows: &[SampleRow]) -> SendableRecordBatchStream {
+        let schema = label_list_schema();
+        let batches: Vec<_> = rows
+            .chunks(64)
+            .map(|chunk| {
+                let mut builder = arrow_array::builder::ListBuilder::new(
+                    arrow_array::builder::StringBuilder::new(),
+                );
+                for (_, labels) in chunk {
+                    match labels {
+                        Some(labels) => {
+                            for label in labels {
+                                builder.values().append_option(label.as_deref());
+                            }
+                            builder.append(true);
+                        }
+                        None => builder.append(false),
+                    }
+                }
+                let addrs = UInt64Array::from_iter_values(chunk.iter().map(|(addr, _)| *addr));
+                RecordBatch::try_new(
+                    schema.clone(),
+                    vec![Arc::new(builder.finish()), Arc::new(addrs)],
+                )
+                .unwrap()
+            })
+            .collect();
+
+        Box::pin(RecordBatchStreamAdapter::new(
+            schema,
+            futures::stream::iter(batches.into_iter().map(Ok)),
+        ))
+    }
+
+    /// The index as a comparable value: labels (nulls included) each mapped to
+    /// their sorted row addresses, plus the separately-stored `list_nulls`.
+    /// Read from the file rather than the loaded index so that the on-disk
+    /// format itself is what the assertions compare.
+    #[derive(Debug, PartialEq, Eq)]
+    struct IndexContents {
+        labels: Vec<(Option<String>, Vec<u64>)>,
+        list_nulls: Vec<u64>,
+    }
+
+    /// Also asserts that the directory holds nothing but the index. Spill files
+    /// belong in local scratch, and every path that writes an index here --
+    /// build, update, remap, merge -- must leave none of them behind, so the
+    /// check lives where all of them are already read back.
+    async fn read_index_contents(store: &dyn IndexStore) -> IndexContents {
+        let files: Vec<String> = store
+            .list_files_with_sizes()
+            .await
+            .unwrap()
+            .into_iter()
+            .map(|file| file.path)
+            .collect();
+        assert_eq!(files, vec![BITMAP_LOOKUP_NAME.to_string()]);
+
+        let mut labels: Vec<(Option<String>, Vec<u64>)> =
+            test_util::read_key_bitmaps(store, BITMAP_LOOKUP_NAME)
+                .await
+                .into_iter()
+                .map(|(key, bitmap)| (key, row_addrs(&bitmap)))
+                .collect();
+        // The build path emits keys in sorted order; older indexes on disk are
+        // in arbitrary order. Sort so the comparison is order-independent.
+        labels.sort();
+
+        let list_nulls = read_list_nulls(store.clone_arc(), None).await.unwrap();
+        IndexContents {
+            labels,
+            list_nulls: row_addrs(&list_nulls),
+        }
+    }
+
+    async fn build_label_list_index(rows: &[SampleRow]) -> IndexContents {
+        let (_tmpdir, store) = test_util::index_store();
+        train_label_list_index(sample_rows_to_stream(rows), store.as_ref())
+            .await
+            .unwrap();
+        read_index_contents(store.as_ref()).await
+    }
+
+    // Every LabelList build or update now sorts through DataFusion with spilling
+    // enabled. Most tests below get that from the default, process-cached
+    // session, whose pool `LANCE_MEM_POOL_SIZE` governs, and so share that
+    // resource group -- see the same pattern in btree.rs, json.rs and rtree.rs.
+    // The spill-forcing test below passes an explicit `mem_pool_size` for the
+    // spilling half, but its baseline build goes through the default session
+    // like everything else, so it joins the group too.
+    /// A pool this small forces the sort below to spill: `new_session_context`
+    /// reserves `(pool / 3).min(40 MiB)` up front, leaving only `2 * pool / 3`
+    /// (about 171 KiB here) for in-memory accumulation, which the fixture's
+    /// unnested data clears. A smaller pool (tried down to 64 KiB) instead
+    /// fails the final spill-merge with `ResourcesExhausted`, since that step
+    /// also draws on the same budget -- this size was picked empirically to
+    /// leave it enough room. Measured at this size: 3 spills, 108,096 bytes and
+    /// 4,878 rows spilled, consistent across repeated runs.
+    const SPILL_FORCING_POOL_BYTES: u64 = 256 * 1024;
+
+    /// The sort spills through DataFusion's memory pool, so a build that spills
+    /// must produce the same index as one that does not. Forced via an explicit
+    /// `mem_pool_size` rather than by mutating the process-wide
+    /// `LANCE_MEM_POOL_SIZE` that every other cached session shares, so this
+    /// test needs no serialization against them.
+    ///
+    /// A small pool alone does not prove a spill happened -- the sort could stay
+    /// under budget, or a regression could silently drop `use_spilling` -- so this
+    /// also reads the `SortExec`'s own metrics after the build completes and
+    /// asserts `spill_count > 0`. Calling [`train_label_list_index_with_plan`]
+    /// directly (rather than the equivalent hand-written unnest/sort/write
+    /// sequence) is what lets the forced-spill build assert on the plan while
+    /// still running the exact production build path -- the same one `generous`
+    /// below runs through `build_label_list_index`, which uses the shared
+    /// default session and is why this joins the serial group.
+    #[tokio::test]
+    #[serial_test::serial(LANCE_DF_SPILL_POOL)]
+    async fn test_train_index_identical_when_the_sort_spills() {
+        // Large enough that the unnested data clears the spill-forcing pool's
+        // remaining budget with room to spare; small enough to sort and spill
+        // well within the one-second test budget.
+        const ROWS: usize = 2_000;
+        let rows = sample_label_list_rows(ROWS, 0);
+
+        let generous = build_label_list_index(&rows).await;
+
+        let (_tmpdir, store) = test_util::index_store();
+        let (_file, sort_plan) = train_label_list_index_with_plan(
+            sample_rows_to_stream(&rows),
+            store.as_ref(),
+            Some(SPILL_FORCING_POOL_BYTES),
+        )
+        .await
+        .unwrap();
+
+        let metrics = sort_plan.metrics().expect("SortExec must report metrics");
+        assert!(
+            metrics.spill_count().unwrap_or(0) > 0,
+            "fixture and pool size must force a real spill, or this test \
+             cannot tell a working spill path from a broken one; got \
+             metrics: {metrics:?}"
+        );
+
+        let tiny = read_index_contents(store.as_ref()).await;
+
+        assert_eq!(generous, tiny, "a spilling sort must not change the index");
+    }
+
+    async fn build_label_list_segment(rows: &[SampleRow]) -> (TempObjDir, Arc<LabelListIndex>) {
+        let (tmpdir, store) = test_util::index_store();
+        train_label_list_index(sample_rows_to_stream(rows), store.as_ref())
+            .await
+            .unwrap();
+        let index = LabelListIndex::load(store, None, &LanceCache::no_cache())
+            .await
+            .unwrap();
+        (tmpdir, index)
+    }
+
+    /// `remap` carries `list_nulls` in a global buffer written through the
+    /// streaming writer, and nothing else covers that path. If the buffer or its
+    /// metadata key were dropped, `read_list_nulls` would return an empty set and
+    /// the index would be classified as pre-nulls, so `NOT` filters over nullable
+    /// list columns would return wrong rows with only a warning -- no error.
+    #[tokio::test]
+    #[serial_test::serial(LANCE_DF_SPILL_POOL)]
+    async fn test_remap_rewrites_addresses_and_preserves_list_nulls() {
+        const OLD_FRAGMENT: u64 = 1 << 32;
+        const NEW_FRAGMENT: u64 = 3 << 32;
+        const ROWS: usize = 120;
+
+        let rows = sample_label_list_rows(ROWS, OLD_FRAGMENT);
+        // Built here rather than via build_label_list_segment so the source
+        // store stays reachable, to compare against after the remap.
+        let (_src_dir, src_store) = test_util::index_store();
+        train_label_list_index(sample_rows_to_stream(&rows), src_store.as_ref())
+            .await
+            .unwrap();
+        let index = LabelListIndex::load(src_store.clone(), None, &LanceCache::no_cache())
+            .await
+            .unwrap();
+
+        let before = read_index_contents(src_store.as_ref()).await;
+
+        // Move every row to a new fragment, and delete one so the dropped-row
+        // path is covered too.
+        let deleted = OLD_FRAGMENT + 1;
+        let mapping = RowAddrRemap::direct(
+            (0..ROWS as u64)
+                .map(|i| {
+                    let old = OLD_FRAGMENT + i;
+                    (old, (old != deleted).then_some(NEW_FRAGMENT + i))
+                })
+                .collect(),
+        );
+
+        let (_dest_dir, dest_store) = test_util::index_store();
+        index.remap(&mapping, dest_store.as_ref()).await.unwrap();
+        let after = read_index_contents(dest_store.as_ref()).await;
+
+        let remapped = |addrs: &[u64]| -> Vec<u64> {
+            addrs
+                .iter()
+                .filter(|addr| **addr != deleted)
+                .map(|addr| addr - OLD_FRAGMENT + NEW_FRAGMENT)
+                .collect()
+        };
+
+        // The nulls buffer must survive, remapped, not silently become empty.
+        assert_eq!(
+            after.list_nulls,
+            remapped(&before.list_nulls),
+            "list_nulls must be carried through remap with its addresses rewritten"
+        );
+
+        assert_eq!(
+            after.labels,
+            before
+                .labels
+                .iter()
+                .map(|(key, addrs)| (key.clone(), remapped(addrs)))
+                .collect::<Vec<_>>(),
+            "every label must survive with its addresses rewritten to the new fragment"
+        );
+    }
+
+    /// Many segments whose keys interleave without overlapping is the case key
+    /// selection must handle in `log(segments)` rather than by scanning every
+    /// segment for every key. Covers both shapes at once: a vocabulary unique to
+    /// each segment, plus one label every segment holds.
+    ///
+    /// The merge must equal a single build over the same rows, and being
+    /// key-driven it must also report progress as it goes -- reporting once on
+    /// return leaves a long merge indistinguishable from a hung one -- against a
+    /// denominator it actually reaches. Source entries give one; emitted keys do
+    /// not, since the shared label emits one row for `NUM_SEGMENTS` entries.
+    #[tokio::test]
+    #[serial_test::serial(LANCE_DF_SPILL_POOL)]
+    async fn test_segment_merge_matches_single_build_and_reports_progress() {
+        const NUM_SEGMENTS: usize = 5;
+        const ROWS_PER_SEGMENT: usize = 40;
+        const SHARED_LABEL: &str = "shared";
+
+        fn segment_rows(segment: usize) -> Vec<SampleRow> {
+            (0..ROWS_PER_SEGMENT)
+                .map(|i| {
+                    let addr = ((segment as u64) << 32) | i as u64;
+                    // A null list every 7th row and a null label every 5th, so
+                    // the merge carries both null shapes as well.
+                    if i % 7 == 0 {
+                        return (addr, None);
+                    }
+                    // Striding by the segment count interleaves the vocabularies,
+                    // so each segment's keys fall between its neighbours' rather
+                    // than alongside them.
+                    let mut labels = vec![
+                        Some(format!("label-{:04}", i * NUM_SEGMENTS + segment)),
+                        Some(SHARED_LABEL.to_string()),
+                    ];
+                    if i % 5 == 0 {
+                        labels.push(None);
+                    }
+                    (addr, Some(labels))
+                })
+                .collect()
+        }
+
+        let mut all_rows = Vec::new();
+        let mut segments = Vec::new();
+        let mut _dirs = Vec::new();
+        for segment in 0..NUM_SEGMENTS {
+            let rows = segment_rows(segment);
+            all_rows.extend(rows.clone());
+            let (dir, index) = build_label_list_segment(&rows).await;
+            _dirs.push(dir);
+            segments.push(index);
+        }
+
+        let (_dest_dir, dest_store) = test_util::index_store();
+        let progress = Arc::new(RecordingProgress::default());
+        merge_label_list_indices(&segments, dest_store.as_ref(), None, progress.clone())
+            .await
+            .unwrap();
+
+        let merged = read_index_contents(dest_store.as_ref()).await;
+        assert_eq!(
+            merged,
+            build_label_list_index(&all_rows).await,
+            "merging {NUM_SEGMENTS} interleaved segments must equal a single build"
+        );
+        assert!(
+            merged.labels.iter().any(|(key, _)| key.is_none()),
+            "fixture must exercise null labels"
+        );
+        assert!(
+            !merged.list_nulls.is_empty(),
+            "fixture must exercise null lists"
+        );
+
+        let merge_counts = progress.counts("merge_label_list_segments");
+        let declared_total = progress.declared_total("merge_label_list_segments");
+        let merged_keys = merged.labels.len() as u64;
+        // The shared label makes entries outnumber output rows. This is what an
+        // emitted-key denominator cannot express, and reverting to one fails here
+        // rather than silently under-reporting.
+        assert!(
+            declared_total > merged_keys,
+            "fixture must have segments sharing labels so entries ({declared_total}) \
+             exceed emitted keys ({merged_keys})"
+        );
+        // Pins "reports as it goes", which the monotonicity check below cannot:
+        // a throttle that collapsed to a single terminal report would satisfy
+        // both that and the declared-total check while leaving a long merge
+        // indistinguishable from a hung one.
+        assert!(
+            merge_counts.len() > 1,
+            "the merge must report incrementally, got {} report(s)",
+            merge_counts.len()
+        );
+        assert!(
+            merge_counts.windows(2).all(|pair| pair[0] <= pair[1]),
+            "reported progress must never go backwards: {merge_counts:?}"
+        );
+        assert_eq!(
+            merge_counts.last().copied(),
+            Some(declared_total),
+            "the merge must finish on exactly the total it declared"
+        );
+    }
+
+    /// Records what a build reported, so progress can be asserted on.
+    #[derive(Debug, Default)]
+    struct RecordingProgress {
+        /// `(stage, completed)` for every progress call, in order.
+        calls: std::sync::Mutex<Vec<(String, u64)>>,
+        /// `(stage, total)` for every stage start.
+        totals: std::sync::Mutex<Vec<(String, Option<u64>)>>,
+    }
+
+    impl RecordingProgress {
+        fn counts(&self, stage: &str) -> Vec<u64> {
+            self.calls
+                .lock()
+                .unwrap()
+                .iter()
+                .filter(|(reported, _)| reported == stage)
+                .map(|(_, completed)| *completed)
+                .collect()
+        }
+
+        fn declared_total(&self, stage: &str) -> u64 {
+            self.totals
+                .lock()
+                .unwrap()
+                .iter()
+                .find(|(reported, _)| reported == stage)
+                .unwrap_or_else(|| panic!("stage {stage} was never started"))
+                .1
+                .unwrap_or_else(|| panic!("stage {stage} declared no total"))
+        }
+    }
+
+    #[async_trait]
+    impl crate::progress::IndexBuildProgress for RecordingProgress {
+        async fn stage_start(&self, stage: &str, total: Option<u64>, _: &str) -> Result<()> {
+            self.totals.lock().unwrap().push((stage.to_string(), total));
+            Ok(())
+        }
+        async fn stage_progress(&self, stage: &str, completed: u64) -> Result<()> {
+            self.calls
+                .lock()
+                .unwrap()
+                .push((stage.to_string(), completed));
+            Ok(())
+        }
+        async fn stage_complete(&self, _: &str) -> Result<()> {
+            Ok(())
+        }
+    }
+
+    /// Segment merge prunes rows from retired fragments. This is existing
+    /// behaviour and the streaming merge must not quietly drop it.
+    ///
+    /// A key whose rows are all retired emits nothing but still consumed its
+    /// source entries. Progress has to count it, or a merge that drops a
+    /// segment's exclusive labels ends below the total it declared -- the
+    /// stalled bar this reporting exists to remove.
+    #[tokio::test]
+    #[serial_test::serial(LANCE_DF_SPILL_POOL)]
+    async fn test_segment_merge_applies_old_data_filter() {
+        const FRAGMENT_1: u64 = 1 << 32;
+        const RETIRED_ONLY: &str = "retired-only-";
+
+        let kept = sample_label_list_rows(150, 0);
+        let retired: Vec<SampleRow> = sample_label_list_rows(150, FRAGMENT_1)
+            .into_iter()
+            .enumerate()
+            .map(|(i, (addr, labels))| {
+                // A label the kept segment does not have, so the filter empties
+                // that key outright rather than merely trimming it. Rows with a
+                // null list keep it, so retired `list_nulls` are pruned too.
+                let labels = labels.map(|mut labels| {
+                    labels.push(Some(format!("{RETIRED_ONLY}{i:04}")));
+                    labels
+                });
+                (addr, labels)
+            })
+            .collect();
+
+        let expected = build_label_list_index(&kept).await;
+
+        let (_kept_dir, kept_index) = build_label_list_segment(&kept).await;
+        let (_retired_dir, retired_index) = build_label_list_segment(&retired).await;
+        let (_dest_dir, dest_store) = test_util::index_store();
+        let progress = Arc::new(RecordingProgress::default());
+        merge_label_list_indices(
+            &[kept_index, retired_index],
+            dest_store.as_ref(),
+            Some(OldIndexDataFilter::Fragments {
+                to_keep: RoaringBitmap::from_iter([0u32]),
+                to_remove: RoaringBitmap::from_iter([1u32]),
+            }),
+            progress.clone(),
+        )
+        .await
+        .unwrap();
+
+        assert!(
+            retired.iter().any(|(_, labels)| labels
+                .as_ref()
+                .is_some_and(|l| l.iter().flatten().any(|k| k.starts_with(RETIRED_ONLY)))),
+            "the retired segment must own labels the kept one lacks, or the filter \
+             only trims keys instead of emptying them outright"
+        );
+
+        let merged = read_index_contents(dest_store.as_ref()).await;
+        assert_eq!(
+            expected, merged,
+            "rows from the retired fragment must not survive the merge"
+        );
+
+        let declared_total = progress.declared_total("merge_label_list_segments");
+        assert_eq!(
+            progress.counts("merge_label_list_segments").last().copied(),
+            Some(declared_total),
+            "entries consumed by keys the filter emptied must still be reported"
+        );
+    }
+
+    /// The spill and destination file schemas are declared from the existing
+    /// index while the keys come from the new stream, so a disagreement must be
+    /// rejected rather than written as a file whose schema lies about its keys.
+    #[tokio::test]
+    #[serial_test::serial(LANCE_DF_SPILL_POOL)]
+    async fn test_update_rejects_a_mismatched_value_type() {
+        let (_src_dir, index) = build_label_list_segment(&sample_label_list_rows(64, 0)).await;
+        let (_dest_dir, dest_store) = test_util::index_store();
+
+        // The index above is List<Utf8>; feed the update List<LargeUtf8>.
+        let mut list_builder =
+            arrow_array::builder::ListBuilder::new(arrow_array::builder::LargeStringBuilder::new());
+        list_builder.values().append_value("a");
+        list_builder.append(true);
+        let labels = list_builder.finish();
+        let schema: SchemaRef = Arc::new(Schema::new(vec![
+            Field::new(VALUE_COLUMN_NAME, labels.data_type().clone(), true),
+            Field::new(ROW_ID, DataType::UInt64, false),
+        ]));
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(labels),
+                Arc::new(UInt64Array::from(vec![1u64 << 32])),
+            ],
+        )
+        .unwrap();
+        let new_data: SendableRecordBatchStream = Box::pin(RecordBatchStreamAdapter::new(
+            schema,
+            futures::stream::iter(vec![Ok(batch)]),
+        ));
+
+        let error = update_label_list_index(index.as_ref(), new_data, dest_store.as_ref())
+            .await
+            .expect_err("a value-type mismatch must be rejected");
+        let message = error.to_string();
+        assert!(
+            message.contains("value type Utf8") && message.contains("items are LargeUtf8"),
+            "the error must name both value types, got: {message}"
+        );
+    }
+
+    /// Every LabelList index written before spill-based builds landed has its
+    /// keys in arbitrary order on disk, because the old writer iterated a HashMap.
+    /// Nothing added here may assume sorted files: reading, updating and
+    /// merging such an index must all still be correct.
+    ///
+    /// This is also the primary update-equals-rebuild coverage. A separate test
+    /// over a current-format index would assert the same equality through the
+    /// same merge-join over strictly easier input, since `index_map` is sorted
+    /// regardless of file order.
+    #[tokio::test]
+    #[serial_test::serial(LANCE_DF_SPILL_POOL)]
+    async fn test_reads_updates_and_merges_an_unsorted_legacy_index() {
+        const FRAGMENT_1: u64 = 1 << 32;
+
+        /// Write the same index the old HashMap-consuming writer would have:
+        /// identical contents, keys in an order that is not sorted.
+        async fn write_unsorted_index(rows: &[SampleRow], store: &dyn IndexStore) {
+            let sorted = build_label_list_index(rows).await;
+            let mut writer = new_bitmap_batch_writer(store, BITMAP_LOOKUP_NAME, &DataType::Utf8)
+                .await
+                .unwrap();
+            writer
+                .add_global_buffer(
+                    LABEL_LIST_NULLS_METADATA_KEY.to_string(),
+                    serialize_list_nulls(&RowAddrTreeMap::from_iter(
+                        sorted.list_nulls.iter().copied(),
+                    ))
+                    .unwrap(),
+                )
+                .await
+                .unwrap();
+            // Reverse order is sorted-ness's clearest counterexample.
+            for (key, addrs) in sorted.labels.iter().rev() {
+                writer
+                    .emit(
+                        ScalarValue::Utf8(key.clone()),
+                        &RowAddrTreeMap::from_iter(addrs.iter().copied()),
+                    )
+                    .await
+                    .unwrap();
+            }
+            writer.finish().await.unwrap();
+        }
+
+        let initial = sample_label_list_rows(200, 0);
+        let expected_initial = build_label_list_index(&initial).await;
+
+        let (_legacy_dir, legacy_store) = test_util::index_store();
+        write_unsorted_index(&initial, legacy_store.as_ref()).await;
+
+        // Reading: the loaded index must match one built by the current path.
+        assert_eq!(
+            expected_initial,
+            read_index_contents(legacy_store.as_ref()).await,
+            "an unsorted file must carry the same contents"
+        );
+        let legacy = LabelListIndex::load(legacy_store.clone(), None, &LanceCache::no_cache())
+            .await
+            .unwrap();
+
+        // Updating: streaming the unsorted index in as a merge input must still
+        // produce the same index as a full rebuild.
+        let additional = sample_label_list_rows(100, FRAGMENT_1);
+        let mut all = initial.clone();
+        all.extend(additional.clone());
+        let (_updated_dir, updated_store) = test_util::index_store();
+        update_label_list_index(
+            legacy.as_ref(),
+            sample_rows_to_stream(&additional),
+            updated_store.as_ref(),
+        )
+        .await
+        .unwrap();
+        assert_eq!(
+            build_label_list_index(&all).await,
+            read_index_contents(updated_store.as_ref()).await,
+            "update over an unsorted index diverged from a full rebuild"
+        );
+
+        // Merging: an unsorted segment must merge correctly with a sorted one.
+        let (_other_dir, other_index) = build_label_list_segment(&additional).await;
+        let (_merged_dir, merged_store) = test_util::index_store();
+        merge_label_list_indices(
+            &[legacy, other_index],
+            merged_store.as_ref(),
+            None,
+            crate::progress::noop_progress(),
+        )
+        .await
+        .unwrap();
+        assert_eq!(
+            build_label_list_index(&all).await,
+            read_index_contents(merged_store.as_ref()).await,
+            "merging an unsorted segment diverged from a full build"
+        );
+    }
+
+    /// A null *element* inside a list, a null *list*, and an empty list are three
+    /// different things and must land in three different places. `track_list_nulls`
+    /// runs ahead of the unnest, where the list column's validity is still present,
+    /// which is the only reason they are separable -- after unnesting, a null list
+    /// and an empty list are both zero rows.
+    ///
+    /// Asserted through every path that writes an index, so moving the unnest
+    /// upstream of the null tracking fails here rather than silently misfiling
+    /// rows and breaking NOT filters on nullable list columns.
+    #[rstest]
+    #[case::build("build")]
+    #[case::update("update")]
+    #[case::merge("merge")]
+    #[case::remap("remap")]
+    #[tokio::test]
+    #[serial_test::serial(LANCE_DF_SPILL_POOL)]
+    async fn test_null_element_null_list_and_empty_list_stay_distinct(#[case] path: &str) {
+        let rows: Vec<SampleRow> = vec![
+            (0, Some(vec![Some("b".to_string()), Some("a".to_string())])),
+            (1, None),                                    // null list
+            (2, Some(vec![])),                            // empty list
+            (3, Some(vec![Some("a".to_string()), None])), // null element
+        ];
+
+        // `merge_label_list_indices` is documented to assume its segments cover
+        // disjoint fragments, and every other merge test in this file honors
+        // that by giving each segment its own fragment rather than by relying
+        // on addresses 0-3 happening not to collide. Follow the same
+        // convention here: the merge case's second segment (rows 2 and 3)
+        // moves to fragment 1, taking the null-element row's expected address
+        // with it. Every other path keeps the original addresses.
+        const FRAGMENT_1: u64 = 1 << 32;
+        let null_element_addr = if path == "merge" { FRAGMENT_1 + 1 } else { 3 };
+
+        let expected_labels = vec![
+            (None, vec![null_element_addr]), // the null element
+            (Some("a".to_string()), vec![0, null_element_addr]),
+            (Some("b".to_string()), vec![0]),
+        ];
+
+        let actual = match path {
+            "build" => build_label_list_index(&rows).await,
+            "update" => {
+                // Split so both halves carry one of the null shapes.
+                let (first, second) = rows.split_at(2);
+                let (_src_dir, index) = build_label_list_segment(first).await;
+                let (_dest_dir, dest_store) = test_util::index_store();
+                update_label_list_index(
+                    index.as_ref(),
+                    sample_rows_to_stream(second),
+                    dest_store.as_ref(),
+                )
+                .await
+                .unwrap();
+                read_index_contents(dest_store.as_ref()).await
+            }
+            "merge" => {
+                let (first, second) = rows.split_at(2);
+                let second: Vec<SampleRow> = second
+                    .iter()
+                    .map(|(addr, labels)| (*addr - 2 + FRAGMENT_1, labels.clone()))
+                    .collect();
+                let (_a_dir, a) = build_label_list_segment(first).await;
+                let (_b_dir, b) = build_label_list_segment(&second).await;
+                let (_dest_dir, dest_store) = test_util::index_store();
+                merge_label_list_indices(
+                    &[a, b],
+                    dest_store.as_ref(),
+                    None,
+                    crate::progress::noop_progress(),
+                )
+                .await
+                .unwrap();
+                read_index_contents(dest_store.as_ref()).await
+            }
+            "remap" => {
+                let (_src_dir, src_store) = test_util::index_store();
+                train_label_list_index(sample_rows_to_stream(&rows), src_store.as_ref())
+                    .await
+                    .unwrap();
+                let index = LabelListIndex::load(src_store, None, &LanceCache::no_cache())
+                    .await
+                    .unwrap();
+                // Identity mapping: the addresses must survive untouched.
+                let (_dest_dir, dest_store) = test_util::index_store();
+                let mapping =
+                    RowAddrRemap::direct((0..4u64).map(|addr| (addr, Some(addr))).collect());
+                index.remap(&mapping, dest_store.as_ref()).await.unwrap();
+                read_index_contents(dest_store.as_ref()).await
+            }
+            other => panic!("unknown path {other}"),
+        };
+
+        assert_eq!(
+            actual.labels, expected_labels,
+            "the null element belongs to the null key, and nothing else does"
+        );
+        assert_eq!(
+            actual.list_nulls,
+            vec![1],
+            "only the null list belongs to list_nulls -- not the empty list, \
+             and not the row with a null element"
+        );
     }
 }


### PR DESCRIPTION
LabelList materialized its whole label-to-bitmap map during build, update,
    merge and remap, so peak memory scaled with distinct-label cardinality and
    large list columns caused out-of-memory failures.

Build and update now unnest, sort with DataFusion, and feed bitmap's existing
    non-spilling streaming builder, so spilling is DataFusion's and is bounded by
    LANCE_MEM_POOL_SIZE instead of an index-specific budget. Bitmap's algorithms
    are split from output-file ownership -- build_index_map, remap_index_map and
    merge_index_maps each take a &mut BitmapBatchWriter -- so LabelList attaches
    its list_nulls buffer to the same file and each of its four paths becomes a
    thin wrapper. Update joins through bitmap's merge-join rather than rewriting
    the existing index into scratch.

 Also fixes a latent overflow in the shared bitmap writer: its flush threshold
    was the i32 offset ceiling itself and charged only serialized bitmaps, so a
    high-cardinality column with tiny bitmaps could exceed the keys column's
    offsets before ever tripping a flush. It now charges keys as well and flushes
    at 32 MiB, which changes the physical batching of every bitmap index file
    written from here on. The on-disk format and index version are unchanged.

 Build is bounded end to end. Update, merge and remap keep an O(distinct
    labels) floor, because opening a BitmapIndex loads every key into an
    in-memory BTreeMap -- this bounds aggregation state, not process RSS.