### PR TITLE
fix(linalg): enforce the cosine_u8 length contract in release

### DIFF
--- a/rust/lance-linalg/src/distance/cosine_u8.rs
+++ b/rust/lance-linalg/src/distance/cosine_u8.rs
@@ -15,6 +15,8 @@
 
 use std::sync::OnceLock;
 
+use super::assert_equal_lengths;
+
 /// Intermediate results from the fused u8 cosine kernel: (dot_ab, norm_a², norm_b²).
 ///
 /// Separated from the final normalization so SIMD backends can be tested
@@ -29,7 +31,7 @@ pub struct CosineAccumulators {
 /// Portable scalar fused cosine accumulation.
 #[inline]
 pub fn cosine_u8_accum_scalar(a: &[u8], b: &[u8]) -> CosineAccumulators {
-    debug_assert_eq!(a.len(), b.len());
+    assert_equal_lengths(a.len(), b.len());
     let (mut dot_ab, mut norm_a_sq, mut norm_b_sq) = (0u32, 0u32, 0u32);
     for (&x, &y) in a.iter().zip(b.iter()) {
         let (xu, yu) = (x as u32, y as u32);
@@ -211,6 +213,7 @@ fn select_backend() -> CosineU8AccumFn {
 /// Dispatched fused u8 cosine accumulation.
 #[inline]
 fn cosine_u8_accum(a: &[u8], b: &[u8]) -> CosineAccumulators {
+    assert_equal_lengths(a.len(), b.len());
     (DISPATCH.get_or_init(select_backend))(a, b)
 }
 
@@ -225,6 +228,12 @@ pub fn cosine_u8(a: &[u8], b: &[u8]) -> f32 {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn rejects_mismatched_lengths() {
+        assert!(std::panic::catch_unwind(|| cosine_u8_scalar(&[1, 2], &[1])).is_err());
+        assert!(std::panic::catch_unwind(|| cosine_u8(&[1, 2], &[1])).is_err());
+    }
 
     fn fill_random(buf: &mut [u8], seed: &mut u32) {
         for slot in buf.iter_mut() {


### PR DESCRIPTION
## What this changes

`cosine_u8`'s equal-length precondition was a `debug_assert_eq!`, so it disappeared from release builds. This replaces it with the always-on `assert_equal_lengths` that `dot_u8` and `l2_u8` have used since #8594, in `cosine_u8_accum_scalar` and in the dispatcher `cosine_u8_accum`, and adds a test. Twelve added lines, one removed, no doc or comment changes. Closes #8638.

## The bug

Both SIMD kernels drive their loop from `n = a.len()` and load from `b` at the same offset: `cosine_u8_accum_avx2` runs `while i + 32 <= n` and loads 32 bytes per iteration through `_mm256_loadu_si256`, and `cosine_u8_accum_avx512_vnni` does the same 64 bytes at a time. With `b` shorter than `a`, a load inside the vector loop can read past the end of `b`. The scalar path is memory-safe by accident, because it uses `zip`, but it truncates to the shorter slice and returns a cosine that means nothing.

The two sibling files were converted when the shared helper landed. `cosine_u8` is the one that kept `debug_assert_eq!`.

## How reachable is it

`cosine_u8`'s only non-test, non-bench caller is `impl Cosine for u8` at `cosine.rs:77`, reachable generically through `cosine_distance::<u8>` and `DistanceType::func::<u8>()`. But nothing in the workspace instantiates u8 cosine: `cosine_distance_arrow_batch` has arms for Float16/32/64 and Int8 only, so `UInt8` falls through to an `InvalidArgumentError`; `multivec_distance` allows `UInt8` only with Hamming; `FlatDistanceCal<UInt8Type>` is built only by `new_binary` and `new_binary_from_id`, both of which hardcode `distance_fn: hamming`; and SQ storage treats Cosine as normalized L2, calling `l2_u8` and `dot_u8`.

So no query path trips this today. What makes it worth fixing is that `cosine_u8` is public through `pub mod cosine_u8` and `DistanceType::func::<u8>()` hands out a callable that reaches it. The kernels themselves cannot be called from outside, because `mod x86` has no `pub`, and that is the other half of why a check in the dispatcher is sufficient.

## What changes for callers

Both scalar entries used to return a number computed over the shorter slice. The dispatched entry did the same on a host without AVX2, and on one with it read out of bounds at any length where the overrun falls inside the vector loop. All of them now panic.

The check asserts equality rather than `b.len() >= a.len()`, which is stricter than memory safety needs. That matches the siblings, and it is right here: in the other direction every read is in bounds, but the result is normalized by the norm of a prefix of `b`, so it is wrong rather than unsafe.

## Why the check sits in the private dispatcher

`dot_u8` and `l2_u8` each guard two functions, the public `*_scalar` at `dot_u8.rs:36` and `l2_u8.rs:30`, and the one that calls `DISPATCH` at `dot_u8.rs:151` and `l2_u8.rs:160`. This commit guards two as well. Cosine's dispatching function is the private `cosine_u8_accum`, because the accumulators are shared with `normalize` and there is an extra hop before the public `cosine_u8`. Guarding `cosine_u8_accum` makes "nothing reaches a kernel unchecked" something you can confirm by reading one function, rather than something that depends on `cosine_u8` happening to be its only caller.

## What the test pins

Two assertions, the same two entry points and the same inputs as `dot_u8`'s and `l2_u8`'s `rejects_mismatched_lengths`. Measured: replacing both `assert_equal_lengths` calls with a no-op takes the new test to failed under `--profile ci` and under `--release` alike, 389 passed and 1 failed in both. The first assertion is what catches it, in either profile, because the scalar accumulator's `zip` truncates instead of panicking once the check is gone.

## What this deliberately leaves alone

No documentation. I had `# Panics` on the three public functions and `# Safety` on the two kernels in this branch and took both out, because `dot_u8` and `l2_u8` carry the identical check and document neither, so documenting one file of three writes a false contrast into the module. The contracts belong in one cross-file change, along with the `# Panics` missing from the six `From<&[T]>` impls in `simd/` whose asserts landed in #8593.

Also left alone: the `rejects_mismatched_lengths` tests in all three u8 files assert only `is_err()`, which `rust/AGENTS.md:70` asks us not to do. `hamming.rs` does it properly, with a payload downcast written inline in `test_hamming_batch_u64_rejects_mismatched_lengths`. Pulling that out into something shareable is its own change.

## Test plan

- `cargo test --release -p lance-linalg --lib`: 390 passed, 1 ignored, on aarch64-apple-darwin
- `cargo test --profile ci -p lance-linalg --lib`: 390 passed, 1 ignored
- `cargo fmt --all -- --check`, `cargo clippy -p lance-linalg --all-targets -- -D warnings`, and `RUSTDOCFLAGS="-D warnings" cargo doc -p lance-linalg --no-deps --document-private-items`: clean
- The mutation above, to confirm the test fails without the fix

This machine is aarch64, so `mod x86` was not compiled and neither kernel ran locally.
