### PR TITLE
fix(linalg): point length-contract panics at the distance function

### DIFF
--- a/rust/lance-linalg/src/distance.rs
+++ b/rust/lance-linalg/src/distance.rs
@@ -26,7 +26,11 @@ pub mod l2;
 pub mod l2_u8;
 pub mod norm_l2;
 
+// `#[track_caller]` on both helpers is load-bearing. They are called from the
+// l2 and dot families only, and without it every panic from them reports this
+// file, which the shared use makes ambiguous between 20 call sites. See #8863.
 #[inline]
+#[track_caller]
 fn assert_equal_lengths(left_len: usize, right_len: usize) {
     assert_eq!(
         left_len, right_len,
@@ -34,7 +38,9 @@ fn assert_equal_lengths(left_len: usize, right_len: usize) {
     );
 }
 
+// `#[track_caller]` here for the same reason as above.
 #[inline]
+#[track_caller]
 fn assert_batch_layout(vector_len: usize, batch_len: usize, dimension: usize) {
     assert!(
         dimension > 0,

--- a/rust/lance-linalg/src/distance.rs
+++ b/rust/lance-linalg/src/distance.rs
@@ -26,9 +26,9 @@ pub mod l2;
 pub mod l2_u8;
 pub mod norm_l2;
 
-// `#[track_caller]` on both helpers is load-bearing. They are called from the
-// l2 and dot families only, and without it every panic from them reports this
-// file, which the shared use makes ambiguous between 20 call sites. See #8863.
+// `#[track_caller]` on both helpers is load-bearing: without it a length-contract
+// panic reports this file rather than the distance function the caller reached.
+// See #8863.
 #[inline]
 #[track_caller]
 fn assert_equal_lengths(left_len: usize, right_len: usize) {
@@ -38,7 +38,6 @@ fn assert_equal_lengths(left_len: usize, right_len: usize) {
     );
 }
 
-// `#[track_caller]` here for the same reason as above.
 #[inline]
 #[track_caller]
 fn assert_batch_layout(vector_len: usize, batch_len: usize, dimension: usize) {

--- a/rust/lance-linalg/tests/panic_location.rs
+++ b/rust/lance-linalg/tests/panic_location.rs
@@ -4,9 +4,9 @@
 //! Where a length-contract panic reports itself.
 //!
 //! This lives in its own integration binary because it replaces the global
-//! panic hook, which races with any other test that panics in the same
-//! process. `distance/dot_f16.rs` already swaps the hook inside the lib test
-//! binary, so this must not share that process.
+//! panic hook. Any other test that panics while the hook is installed lands in
+//! this one's sink instead, and the lib test binary runs its tests on threads of
+//! one process.
 
 use std::ffi::OsStr;
 use std::path::Path;

--- a/rust/lance-linalg/tests/panic_location.rs
+++ b/rust/lance-linalg/tests/panic_location.rs
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+//! Where a length-contract panic reports itself.
+//!
+//! This lives in its own integration binary because it replaces the global
+//! panic hook, which races with any other test that panics in the same
+//! process. `distance/dot_f16.rs` already swaps the hook inside the lib test
+//! binary, so this must not share that process.
+
+use std::ffi::OsStr;
+use std::path::Path;
+
+use lance_linalg::distance::{dot_u8::dot_u8, l2::l2_distance_batch};
+
+/// Runs `f`, which must panic, and returns where the panic was reported and
+/// what it said.
+fn panic_details(f: impl FnOnce() + std::panic::UnwindSafe) -> (String, u32, String) {
+    let captured = std::sync::Arc::new(std::sync::Mutex::new(None));
+    let sink = std::sync::Arc::clone(&captured);
+    let previous = std::panic::take_hook();
+    std::panic::set_hook(Box::new(move |info| {
+        // Both panics here come from `assert_eq!`, which always formats, so the
+        // payload is a `String`. A payload of any other type leaves this empty
+        // and the message assertions below fail rather than pass silently.
+        let message = info
+            .payload()
+            .downcast_ref::<String>()
+            .cloned()
+            .unwrap_or_default();
+        *sink.lock().unwrap() = info
+            .location()
+            .map(|loc| (loc.file().to_owned(), loc.line(), message));
+    }));
+    let outcome = std::panic::catch_unwind(f);
+    std::panic::set_hook(previous);
+    assert!(outcome.is_err(), "expected a panic");
+    captured.lock().unwrap().take().expect("no panic location")
+}
+
+/// Without `#[track_caller]` on the two helpers in `distance.rs`, both of these
+/// panics report `distance.rs` and the reader cannot tell which metric fired.
+/// The message is asserted too, so an unrelated panic in the same file does not
+/// satisfy the test.
+#[test]
+fn length_contract_panics_name_the_distance_function() {
+    let (file, line, message) = panic_details(|| {
+        dot_u8(&[1, 2], &[1]);
+    });
+    assert_eq!(
+        Path::new(&file).file_name(),
+        Some(OsStr::new("dot_u8.rs")),
+        "expected dot_u8.rs, got {file}:{line}"
+    );
+    assert!(
+        message.contains("equal lengths"),
+        "{file}:{line}: {message}"
+    );
+
+    let (file, line, message) = panic_details(|| {
+        l2_distance_batch(&[1.0f32, 2.0], &[1.0f32, 2.0, 3.0], 2).for_each(drop);
+    });
+    assert_eq!(
+        Path::new(&file).file_name(),
+        Some(OsStr::new("l2.rs")),
+        "expected l2.rs, got {file}:{line}"
+    );
+    assert!(
+        message.contains("divisible by dimension"),
+        "{file}:{line}: {message}"
+    );
+}


### PR DESCRIPTION
## What this changes

`assert_equal_lengths` and `assert_batch_layout` in `rust/lance-linalg/src/distance.rs` get `#[track_caller]`, so a length-contract panic reports the distance function that was called instead of the helper. Closes #8863.

Before, one of these panics reported a line in `distance.rs`, and the same line for every caller of whichever helper raised it. The message gave you the numbers and not the metric that asked for them. Both helpers came in with #8594, which made them plain asserts rather than `debug_assert`s so they fire in release, which is where a backtrace is least likely to be available.

The attribute moves the location one frame out, to the distance function.

Both helpers keep `#[inline]`. The attribute changes nothing about how often they are called, only whether the compiler may inline them, and every call site is the first statement of its function, ahead of a whole vector's work for the pairwise metrics and a whole batch's for the batch ones, which return an iterator the caller then drives.

## Test plan

`rust/lance-linalg/tests/panic_location.rs` is new. It captures the panic location and message through a hook and asserts, for `dot_u8` and for `l2_distance_batch`, that the file is `dot_u8.rs` and `l2.rs` rather than `distance.rs`, and that the message is the length-contract one rather than any other panic in the same file. It has to be an integration binary rather than a unit test, because replacing the global hook means any other test that panics while it is installed lands in this one's sink, and the lib test binary runs its tests on threads of one process.

Measured, one attribute at a time, since each is independently load-bearing:

- removing it from `assert_equal_lengths`: `expected dot_u8.rs, got rust/lance-linalg/src/distance.rs:34`
- removing it from `assert_batch_layout`: `expected l2.rs, got rust/lance-linalg/src/distance.rs:51`

- `cargo test -p lance-linalg`: 389 passed and 1 ignored in the lib, 1 passed in the new binary
- `cargo fmt --all -- --check` and `cargo clippy -p lance-linalg --all-targets -- -D warnings`: clean

Two limits worth stating. The location moves one frame, to the distance function, not to the caller's own line: for the batch path that is the trait-impl override body in `l2.rs`, not the `l2_distance_batch` the caller wrote. Reaching the caller would mean putting the attribute on every public wrapper and trait method, which is a separate cost to weigh. And because the new `tests/` directory is the crate's first, `--tests` now builds an integration target where it previously resolved to the lib alone; `qemu-pre-haswell` passes `--lib` and so will not run this test, which is correct, since that job exists to catch AVX2 leaking into the x86-64-v2 baseline and panic locations are not SIMD-dependent.

## Which metrics this covers

The `l2` and `dot` families call the two helpers directly, so those two are what moves.

`cosine` has no length assert of its own to relocate. Its SIMD-dispatching `cosine_fast` overrides check nothing, neither `cosine_batch` entry compares `x.len()` against `dimension`, and `do_cosine_distance_arrow_batch`'s `debug_assert_eq!` on the query length is compiled out in release. #8875 is what gives cosine its own asserts.

It is not untouched by this change, though. cosine reaches these helpers indirectly wherever no `cosine_fast` override exists: the trait default routes through `cosine_scalar`, whose `dot(x, y)` hits `assert_equal_lengths`. That is `u8` today, and there the report moves from `distance.rs` to `dot.rs`. #8875 gives the other types an assert at the cosine entry point, which preempts that route.

`hamming` is not covered either, and its two length checks sit on separate paths. `hamming_batch_u64`, which the pairwise hash functions drive, has an always-on `assert_eq!` that reports `hamming.rs` on its own, because the check sits in the function rather than in a shared helper; what it checks is one result slot per target rather than a vector length against a dimension. `hamming_distance_batch` is the byte-vector path, maps `hamming` over `chunks_exact`, and carries two `debug_assert_eq!` and nothing else.






