### PR TITLE
docs(linalg): document the SIMD conversion panics and fix the AVX2 kernel's algorithm name

### DIFF
--- a/rust/lance-linalg/src/distance/hamming.rs
+++ b/rust/lance-linalg/src/distance/hamming.rs
@@ -512,7 +512,7 @@ unsafe fn hamming_batch_avx512(query: u64, targets: &[u64], results: &mut [u32])
     }
 }
 
-/// AVX2 popcount using lookup table (Harley-Seal / PSHUFB method).
+/// AVX2 popcount via a PSHUFB nibble-lookup table.
 ///
 /// The chunk loop reaches only the first `targets.len() / 4 * 4` slots through a
 /// raw pointer, 4 x u32 per chunk with no bounds check; the trailing slots go

--- a/rust/lance-linalg/src/simd/f32.rs
+++ b/rust/lance-linalg/src/simd/f32.rs
@@ -147,6 +147,11 @@ fn gather_scalar_x86(slice: &[f32], indices: &[i32; 8]) -> f32x8 {
 }
 
 impl From<&[f32]> for f32x8 {
+    /// Loads the first 8 elements of `value`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `value` has fewer than 8 elements.
     fn from(value: &[f32]) -> Self {
         assert!(
             value.len() >= 8,
@@ -532,6 +537,11 @@ impl std::fmt::Debug for f32x16 {
 }
 
 impl From<&[f32]> for f32x16 {
+    /// Loads the first 16 elements of `value`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `value` has fewer than 16 elements.
     fn from(value: &[f32]) -> Self {
         assert!(
             value.len() >= 16,

--- a/rust/lance-linalg/src/simd/f64.rs
+++ b/rust/lance-linalg/src/simd/f64.rs
@@ -44,6 +44,11 @@ impl std::fmt::Debug for f64x4 {
 }
 
 impl From<&[f64]> for f64x4 {
+    /// Loads the first 4 elements of `value`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `value` has fewer than 4 elements.
     fn from(value: &[f64]) -> Self {
         assert!(
             value.len() >= 4,
@@ -393,6 +398,11 @@ impl std::fmt::Debug for f64x8 {
 }
 
 impl From<&[f64]> for f64x8 {
+    /// Loads the first 8 elements of `value`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `value` has fewer than 8 elements.
     fn from(value: &[f64]) -> Self {
         assert!(
             value.len() >= 8,

--- a/rust/lance-linalg/src/simd/i32.rs
+++ b/rust/lance-linalg/src/simd/i32.rs
@@ -49,6 +49,11 @@ impl std::fmt::Debug for i32x8 {
 }
 
 impl From<&[i32]> for i32x8 {
+    /// Loads the first 8 elements of `value`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `value` has fewer than 8 elements.
     fn from(value: &[i32]) -> Self {
         assert!(
             value.len() >= 8,

--- a/rust/lance-linalg/src/simd/u8.rs
+++ b/rust/lance-linalg/src/simd/u8.rs
@@ -84,6 +84,11 @@ impl std::fmt::Debug for u8x16 {
 }
 
 impl From<&[u8]> for u8x16 {
+    /// Loads the first 16 elements of `value`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `value` has fewer than 16 elements.
     fn from(value: &[u8]) -> Self {
         assert!(
             value.len() >= 16,


### PR DESCRIPTION
## What this changes

Adds a `# Panics` section to the six `From<&[T]>` conversions in `rust/lance-linalg/src/simd/`, and corrects one doc line in `hamming.rs` that names an algorithm the code does not use. Comment-only, 31 added lines and 1 removed. Addresses #8861.

## Why

#8593 gave every slice-to-register conversion an always-on `assert!`, so a short slice panics rather than reading out of bounds. None of the six said so, and `From` is the conversion a caller reaches for without reading the body: the signature is infallible and nothing in the rendered docs warned that `f32x8::from(&slice[..])` aborts the thread. The six are `f32x8`, `f32x16`, `f64x4`, `f64x8`, `i32x8` and `u8x16`, requiring 8, 16, 4, 8, 8 and 16 elements. The `From<&[T; N]>` impls beside them take an array reference and cannot be short, so they are left alone.

Separately, `hamming.rs` described the AVX2 kernel as "Harley-Seal / PSHUFB method". The body builds a nibble popcount table, looks both nibbles up with two `_mm256_shuffle_epi8` calls, and sums bytes with `_mm256_sad_epu8`. Harley-Seal is a carry-save-adder tree that folds several words together before any popcount runs, and there is none here: each 256-bit chunk is popcounted on its own. A grep for Harley-Seal across the crate now returns nothing, so that line was the only occurrence.

## Relationship to #8862

#8862 covers the same ground and was opened first. I have left review notes there rather than duplicating it, and this PR is the alternative if the placement question below is easier to take as a diff than as a comment.

The difference that matters is where the section goes. #8862 puts `# Panics` on the `impl` block; this puts it on `fn from`. I rendered both. On the impl block the heading attaches to the impl header and lands outside `impl-items`, so expanding `from` on the struct page shows nothing:

```html
<h3 class="code-header">impl From<&[f32]> for f32x8</h3>
<div class="docblock"><h4 id="panics-1">§Panics</h4>...
```

On the method it attaches to `from`, one heading level lower, with a summary line above it:

```html
<section id="method.from" class="method trait-impl">
  <h4 class="code-header">fn from(value: &[f32]) -> Self</h4>
</section></summary><div class="docblock">
  <p>Loads the first 8 elements of <code>value</code>.</p>
  <h5 id="panics-1">§Panics</h5>...
```

Both are valid rustdoc and neither warns under `-D warnings`.

## Test plan

Comment-only, so there is nothing to test beyond the doc build.

- `RUSTDOCFLAGS="-D warnings" cargo doc -p lance-linalg --no-deps`: clean, and all six sentences appear in the generated HTML under their `from` method
- `cargo fmt --all -- --check` and `cargo clippy -p lance-linalg --all-targets -- -D warnings`: clean
- `cargo test --profile ci -p lance-linalg --lib`: 389 passed, 1 ignored, unchanged

Not included, so it does not get lost: `dot_u8.rs`, `l2_u8.rs` and `cosine_u8.rs` have zero `# Panics` and zero `# Safety` between them despite the same always-on checks and `unsafe` kernels whose raw loads depend on the lengths matching. That wants one change across all three files, and it has to follow whichever cosine length-contract PR lands.
