### PR TITLE
perf(linalg): let AVX-512 hosts fall back to the AVX2 dist_table kernel

### DIFF
--- a/rust/lance-linalg/src/simd/dist_table.rs
+++ b/rust/lance-linalg/src/simd/dist_table.rs
@@ -60,9 +60,10 @@ fn dist_table_backend(
             DistTableBackend::Avx2
         }
         SimdSupport::Neon => DistTableBackend::Neon,
-        // `Avx` and `AvxFma` land here. The AVX2 inner uses
-        // `_mm256_shuffle_epi8` / `_mm256_and_si256` / `_mm256_srli_epi16` /
-        // `_mm256_add_epi16`, integer ops that neither tier provides.
+        // Everything else, including `Avx` and `AvxFma`: the AVX2 inner uses
+        // integer ops (`_mm256_shuffle_epi8`, `_mm256_and_si256`,
+        // `_mm256_srli_epi16`, `_mm256_add_epi16`) that neither of those tiers
+        // provides.
         _ => DistTableBackend::Scalar,
     }
 }
@@ -168,7 +169,7 @@ pub unsafe fn sum_4bit_dist_table_uninit(
                 )
             }
         },
-        // Every backend this build has no arm for, plus `Scalar`.
+        // `Scalar`, plus any backend this build compiled no arm for.
         _ => {
             dists[..n].fill(MaybeUninit::new(0));
             // Every slot was initialized immediately above.
@@ -297,7 +298,8 @@ pub unsafe fn sum_4bit_hacc_dist_table_uninit(
     debug_assert!(hacc_dist_table.len() >= code_len * 64);
 
     // `false` for the AVX-512 kernel: this entry point has none, so an AVX-512
-    // host takes AVX2 here.
+    // host takes AVX2 here. It has no NEON kernel either, so an aarch64 host gets
+    // `Neon` from the selector and falls through to scalar below.
     let (has_avx512bw, has_avx2) = x86_dist_table_features();
     match dist_table_backend(*SIMD_SUPPORT, false, has_avx512bw, has_avx2) {
         #[cfg(target_arch = "x86_64")]
@@ -728,8 +730,6 @@ mod tests {
         true,
         DistTableBackend::Avx2
     )]
-    // The hacc entry point, where no tier can reach an AVX-512 kernel.
-    #[case::hacc_avx512(SimdSupport::Avx512, false, true, true, DistTableBackend::Avx2)]
     #[case::avx2_tier(SimdSupport::Avx2, true, false, true, DistTableBackend::Avx2)]
     // Without AVX2 there is nothing to fall back to.
     #[case::avx512_no_avx2(SimdSupport::Avx512, false, false, false, DistTableBackend::Scalar)]

--- a/rust/lance-linalg/src/simd/dist_table.rs
+++ b/rust/lance-linalg/src/simd/dist_table.rs
@@ -731,13 +731,28 @@ mod tests {
         DistTableBackend::Avx2
     )]
     #[case::avx2_tier(SimdSupport::Avx2, true, false, true, DistTableBackend::Avx2)]
+    // The tier alone must not authorize the AVX2 kernel: it is
+    // `#[target_feature(enable = "avx2")]` and called from an `unsafe` block that
+    // has only the detected feature to stand on.
+    #[case::avx2_tier_without_the_feature(
+        SimdSupport::Avx2,
+        false,
+        false,
+        false,
+        DistTableBackend::Scalar
+    )]
     // Without AVX2 there is nothing to fall back to.
     #[case::avx512_no_avx2(SimdSupport::Avx512, false, false, false, DistTableBackend::Scalar)]
     // `Avx` and `AvxFma` lack the integer ops the AVX2 inner uses.
     #[case::avx_fma(SimdSupport::AvxFma, false, false, false, DistTableBackend::Scalar)]
     #[case::avx(SimdSupport::Avx, false, false, false, DistTableBackend::Scalar)]
+    #[case::sse(SimdSupport::Sse, false, false, false, DistTableBackend::Scalar)]
     #[case::none(SimdSupport::None, false, false, false, DistTableBackend::Scalar)]
     #[case::neon(SimdSupport::Neon, false, false, false, DistTableBackend::Neon)]
+    // loongarch64 has LSX and LASX kernels elsewhere in this crate but none for
+    // this table, so both tiers belong on the scalar route.
+    #[case::lsx(SimdSupport::Lsx, false, false, false, DistTableBackend::Scalar)]
+    #[case::lasx(SimdSupport::Lasx, false, false, false, DistTableBackend::Scalar)]
     fn dist_table_backend_follows_the_tier_ladder(
         #[case] support: SimdSupport,
         #[case] avx512_kernel: bool,

--- a/rust/lance-linalg/src/simd/dist_table.rs
+++ b/rust/lance-linalg/src/simd/dist_table.rs
@@ -14,7 +14,8 @@ pub const PERM0: [usize; 16] = [0, 8, 1, 9, 2, 10, 3, 11, 4, 12, 5, 13, 6, 14, 7
 pub const PERM0_INVERSE: [usize; 16] = [0, 2, 4, 6, 8, 10, 12, 14, 1, 3, 5, 7, 9, 11, 13, 15];
 pub const BATCH_SIZE: usize = 32;
 
-/// Which kernel a `dist_table` entry point runs on this host.
+/// Which kernel a `dist_table` entry point prefers on this host. An entry point
+/// with no arm for the chosen backend falls through to scalar.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum DistTableBackend {
     Avx512,
@@ -23,8 +24,9 @@ enum DistTableBackend {
     Scalar,
 }
 
-/// Picks the kernel from the tier and the CPU features, reading neither, so the
-/// consequences of the tier ladder are testable without a host of each kind.
+/// Picks the kernel from a tier and two feature bits passed in, reading neither
+/// `SIMD_SUPPORT` nor the CPU, so the consequences of the tier ladder are
+/// testable without a host of each kind.
 ///
 /// `avx512_kernel` says whether the calling entry point has an AVX-512 kernel to
 /// offer: `sum_4bit_dist_table_uninit` has one behind
@@ -47,10 +49,6 @@ fn dist_table_backend(
             DistTableBackend::Avx2
         }
         SimdSupport::Neon => DistTableBackend::Neon,
-        // Everything else, including `Avx` and `AvxFma`: the AVX2 inner uses
-        // integer ops (`_mm256_shuffle_epi8`, `_mm256_and_si256`,
-        // `_mm256_srli_epi16`, `_mm256_add_epi16`) that neither of those tiers
-        // provides.
         _ => DistTableBackend::Scalar,
     }
 }
@@ -169,7 +167,7 @@ pub unsafe fn sum_4bit_dist_table_uninit(
                 )
             }
         },
-        // `Scalar`, plus any backend this build compiled no arm for.
+        // `Scalar`.
         _ => {
             dists[..n].fill(MaybeUninit::new(0));
             // Every slot was initialized immediately above.
@@ -298,8 +296,9 @@ pub unsafe fn sum_4bit_hacc_dist_table_uninit(
     debug_assert!(hacc_dist_table.len() >= code_len * 64);
 
     // `false` for the AVX-512 kernel: this entry point has none, so an AVX-512
-    // host takes AVX2 here. It has no NEON kernel either, so an aarch64 host gets
-    // `Neon` from the selector and falls through to scalar below.
+    // host with AVX2 takes AVX2 here. It has no NEON kernel either, and an
+    // aarch64 tier is `Neon` or `None`, so the selector returns `Neon` or
+    // `Scalar` and both land on the scalar `_` arm.
     let (has_avx512bw, has_avx2) = x86_dist_table_features();
     match dist_table_backend(*SIMD_SUPPORT, false, has_avx512bw, has_avx2) {
         #[cfg(target_arch = "x86_64")]
@@ -710,18 +709,18 @@ unsafe extern "C" {
 mod tests {
     use super::*;
 
-    /// The tier ladder is exclusive, so most of these combinations cannot be
-    /// produced by any one host and the selector is the only place they can be
-    /// checked. `avx512_kernel` false covers both callers that reach it: the hacc
-    /// entry point, which has no AVX-512 kernel at all, and
-    /// `sum_4bit_dist_table_uninit` in a build where
-    /// `kernel_support = "avx512_dist_table"` is unset.
+    /// `avx512_kernel` false covers both callers that reach it: the hacc entry
+    /// point, which has no AVX-512 kernel at all, and
+    /// `sum_4bit_dist_table_uninit` wherever its
+    /// `cfg!(all(kernel_support = "avx512_dist_table", target_arch = "x86_64"))`
+    /// is false, which is every non-x86_64 build as well as an x86_64 one that
+    /// compiled no AVX-512 C.
     #[rstest::rstest]
-    // An AVX-512 host with the C kernel built takes it.
+    // An AVX-512 host with the C kernel built and `avx512bw` present takes it.
     #[case::avx512_ready(SimdSupport::Avx512, true, true, true, DistTableBackend::Avx512)]
     #[case::avx512fp16_ready(SimdSupport::Avx512FP16, true, true, true, DistTableBackend::Avx512)]
-    // The two ways an AVX-512 host misses that arm. Both must reach AVX2, which
-    // it has, rather than scalar.
+    // The two ways an AVX-512 host with AVX2 misses the AVX-512 arm. Both must
+    // reach AVX2 rather than scalar.
     #[case::avx512_no_bw(SimdSupport::Avx512, true, false, true, DistTableBackend::Avx2)]
     #[case::avx512_kernel_absent(SimdSupport::Avx512, false, true, true, DistTableBackend::Avx2)]
     #[case::avx512fp16_no_bw(SimdSupport::Avx512FP16, true, false, true, DistTableBackend::Avx2)]
@@ -734,8 +733,9 @@ mod tests {
     )]
     #[case::avx2_tier(SimdSupport::Avx2, true, false, true, DistTableBackend::Avx2)]
     // The tier alone must not authorize the AVX2 kernel: it is
-    // `#[target_feature(enable = "avx2")]` and called from an `unsafe` block that
-    // has only the detected feature to stand on.
+    // `#[target_feature(enable = "avx2")]`. No host produces this pair, since
+    // `cpu.rs` selects `Avx2` only when the same `avx2` detection returned true,
+    // so this row pins the selector's contract rather than a real configuration.
     #[case::avx2_tier_without_the_feature(
         SimdSupport::Avx2,
         false,
@@ -743,14 +743,17 @@ mod tests {
         false,
         DistTableBackend::Scalar
     )]
-    // Without AVX2 there is nothing to fall back to.
+    // Without AVX2 there is nothing to fall back to; this row pins the selector.
     #[case::avx512_no_avx2(SimdSupport::Avx512, false, false, false, DistTableBackend::Scalar)]
-    // `Avx` and `AvxFma` lack the integer ops the AVX2 inner uses.
     #[case::avx_fma(SimdSupport::AvxFma, false, false, false, DistTableBackend::Scalar)]
     #[case::avx(SimdSupport::Avx, false, false, false, DistTableBackend::Scalar)]
-    // AVX2 present but the tier says otherwise, which is what an AVX2 host
-    // without FMA reports. The tier gate has to hold on its own here.
+    // An `Avx` tier that reports AVX2. `cpu.rs` notes that every shipping AVX2
+    // part has FMA, so no shipping part produces this pair, though a masked or
+    // feature-forced build can: the tier alone leaves it on scalar, even though
+    // the kernel needs no FMA.
     #[case::avx_tier_with_avx2(SimdSupport::Avx, false, false, true, DistTableBackend::Scalar)]
+    // `Sse` is a variant the x86 ladder never produces, so this row pins the
+    // selector rather than a real host.
     #[case::sse(SimdSupport::Sse, false, false, false, DistTableBackend::Scalar)]
     #[case::none(SimdSupport::None, false, false, false, DistTableBackend::Scalar)]
     #[case::neon(SimdSupport::Neon, false, false, false, DistTableBackend::Neon)]

--- a/rust/lance-linalg/src/simd/dist_table.rs
+++ b/rust/lance-linalg/src/simd/dist_table.rs
@@ -27,6 +27,62 @@ pub const BATCH_SIZE: usize = 32;
 // | bits 4..7| 16 | 24 | 17 | 25 | 18 | 26 | 19 | 27 | 20 | 28 | 21 | 29 | 22 | 30 | 23 | 31 |
 // +----------+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+
 // so that we can use SIMD instruction (especially _mm256_shuffle_epi8) to do the summation.
+/// Which kernel a `dist_table` entry point runs on this host.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum DistTableBackend {
+    Avx512,
+    Avx2,
+    Neon,
+    Scalar,
+}
+
+/// Picks the kernel from the tier and the CPU features, reading neither, so the
+/// consequences of the tier ladder are testable without a host of each kind.
+///
+/// `avx512_kernel` says whether the calling entry point has an AVX-512 kernel to
+/// offer: `sum_4bit_dist_table_uninit` has one behind
+/// `kernel_support = "avx512_dist_table"`, and the hacc entry point has none.
+fn dist_table_backend(
+    support: SimdSupport,
+    avx512_kernel: bool,
+    has_avx512bw: bool,
+    has_avx2: bool,
+) -> DistTableBackend {
+    match support {
+        SimdSupport::Avx512 | SimdSupport::Avx512FP16 if avx512_kernel && has_avx512bw => {
+            DistTableBackend::Avx512
+        }
+        // `SIMD_SUPPORT` is a single exclusive tier, so an AVX-512 host reports
+        // `Avx512` or `Avx512FP16` and never `Avx2`. Naming only `Avx2` here
+        // would send an AVX-512 host that missed the arm above down the scalar
+        // path while it has AVX2.
+        SimdSupport::Avx512 | SimdSupport::Avx512FP16 | SimdSupport::Avx2 if has_avx2 => {
+            DistTableBackend::Avx2
+        }
+        SimdSupport::Neon => DistTableBackend::Neon,
+        // `Avx` and `AvxFma` land here. The AVX2 inner uses
+        // `_mm256_shuffle_epi8` / `_mm256_and_si256` / `_mm256_srli_epi16` /
+        // `_mm256_add_epi16`, integer ops that neither tier provides.
+        _ => DistTableBackend::Scalar,
+    }
+}
+
+/// The two feature bits [`dist_table_backend`] needs, or `false` off x86_64.
+#[inline]
+fn x86_dist_table_features() -> (bool, bool) {
+    #[cfg(target_arch = "x86_64")]
+    {
+        (
+            std::arch::is_x86_feature_detected!("avx512bw"),
+            std::arch::is_x86_feature_detected!("avx2"),
+        )
+    }
+    #[cfg(not(target_arch = "x86_64"))]
+    {
+        (false, false)
+    }
+}
+
 #[inline]
 pub fn sum_4bit_dist_table(
     n: usize,
@@ -68,11 +124,18 @@ pub unsafe fn sum_4bit_dist_table_uninit(
     debug_assert!(dists.len() >= n);
     debug_assert!(codes.len() >= n * code_len);
 
-    match *SIMD_SUPPORT {
+    let (has_avx512bw, has_avx2) = x86_dist_table_features();
+    match dist_table_backend(
+        *SIMD_SUPPORT,
+        cfg!(all(
+            kernel_support = "avx512_dist_table",
+            target_arch = "x86_64"
+        )),
+        has_avx512bw,
+        has_avx2,
+    ) {
         #[cfg(all(kernel_support = "avx512_dist_table", target_arch = "x86_64"))]
-        SimdSupport::Avx512 | SimdSupport::Avx512FP16
-            if std::arch::is_x86_feature_detected!("avx512bw") =>
-        {
+        DistTableBackend::Avx512 => {
             for i in (0..n).step_by(BATCH_SIZE) {
                 let codes = &codes[i * code_len..(i + BATCH_SIZE) * code_len];
                 unsafe {
@@ -85,17 +148,8 @@ pub unsafe fn sum_4bit_dist_table_uninit(
                 }
             }
         }
-        // `SIMD_SUPPORT` is a single exclusive tier, so an AVX-512 host reports
-        // `Avx512` or `Avx512FP16` and never `Avx2`. Matching only `Avx2` here
-        // would send every AVX-512 host that misses the arm above, because
-        // `avx512bw` is absent or because `kernel_support = "avx512_dist_table"`
-        // was not set, down the scalar path while it has AVX2.
-        // `sum_4bit_hacc_dist_table_uninit` already matches the three tiers
-        // together.
         #[cfg(target_arch = "x86_64")]
-        SimdSupport::Avx512 | SimdSupport::Avx512FP16 | SimdSupport::Avx2
-            if std::arch::is_x86_feature_detected!("avx2") =>
-        unsafe {
+        DistTableBackend::Avx2 => unsafe {
             for i in (0..n).step_by(BATCH_SIZE) {
                 sum_dist_table_32bytes_batch_avx2(
                     &codes[i * code_len..(i + BATCH_SIZE) * code_len],
@@ -105,7 +159,7 @@ pub unsafe fn sum_4bit_dist_table_uninit(
             }
         },
         #[cfg(target_arch = "aarch64")]
-        SimdSupport::Neon => unsafe {
+        DistTableBackend::Neon => unsafe {
             for i in (0..n).step_by(BATCH_SIZE) {
                 sum_dist_table_32bytes_batch_neon(
                     &codes[i * code_len..(i + BATCH_SIZE) * code_len],
@@ -114,10 +168,7 @@ pub unsafe fn sum_4bit_dist_table_uninit(
                 )
             }
         },
-        // SimdSupport::AvxFma and SimdSupport::Avx fall through here:
-        // the AVX2 inner uses `_mm256_shuffle_epi8` / `_mm256_and_si256` /
-        // `_mm256_srli_epi16` / `_mm256_add_epi16` integer ops which
-        // neither AVX nor AVX+FMA provides. Scalar is the correct route.
+        // Every backend this build has no arm for, plus `Scalar`.
         _ => {
             dists[..n].fill(MaybeUninit::new(0));
             // Every slot was initialized immediately above.
@@ -245,11 +296,12 @@ pub unsafe fn sum_4bit_hacc_dist_table_uninit(
     debug_assert!(codes.len() >= n * code_len);
     debug_assert!(hacc_dist_table.len() >= code_len * 64);
 
-    match *SIMD_SUPPORT {
+    // `false` for the AVX-512 kernel: this entry point has none, so an AVX-512
+    // host takes AVX2 here.
+    let (has_avx512bw, has_avx2) = x86_dist_table_features();
+    match dist_table_backend(*SIMD_SUPPORT, false, has_avx512bw, has_avx2) {
         #[cfg(target_arch = "x86_64")]
-        SimdSupport::Avx512 | SimdSupport::Avx512FP16 | SimdSupport::Avx2
-            if std::arch::is_x86_feature_detected!("avx2") =>
-        {
+        DistTableBackend::Avx2 => {
             sum_4bit_hacc_dist_table_avx2(n, code_len, codes, hacc_dist_table, dists);
         }
         _ => {
@@ -655,6 +707,49 @@ unsafe extern "C" {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The tier ladder is exclusive, so most of these combinations cannot be
+    /// produced by any one host and the selector is the only place they can be
+    /// checked. `avx512_kernel` false is the hacc entry point, which has no
+    /// AVX-512 kernel of its own.
+    #[rstest::rstest]
+    // An AVX-512 host with the C kernel built takes it.
+    #[case::avx512_ready(SimdSupport::Avx512, true, true, true, DistTableBackend::Avx512)]
+    #[case::avx512fp16_ready(SimdSupport::Avx512FP16, true, true, true, DistTableBackend::Avx512)]
+    // The two ways an AVX-512 host misses that arm. Both must reach AVX2, which
+    // it has, rather than scalar.
+    #[case::avx512_no_bw(SimdSupport::Avx512, true, false, true, DistTableBackend::Avx2)]
+    #[case::avx512_kernel_absent(SimdSupport::Avx512, false, true, true, DistTableBackend::Avx2)]
+    #[case::avx512fp16_no_bw(SimdSupport::Avx512FP16, true, false, true, DistTableBackend::Avx2)]
+    #[case::avx512fp16_kernel_absent(
+        SimdSupport::Avx512FP16,
+        false,
+        true,
+        true,
+        DistTableBackend::Avx2
+    )]
+    // The hacc entry point, where no tier can reach an AVX-512 kernel.
+    #[case::hacc_avx512(SimdSupport::Avx512, false, true, true, DistTableBackend::Avx2)]
+    #[case::avx2_tier(SimdSupport::Avx2, true, false, true, DistTableBackend::Avx2)]
+    // Without AVX2 there is nothing to fall back to.
+    #[case::avx512_no_avx2(SimdSupport::Avx512, false, false, false, DistTableBackend::Scalar)]
+    // `Avx` and `AvxFma` lack the integer ops the AVX2 inner uses.
+    #[case::avx_fma(SimdSupport::AvxFma, false, false, false, DistTableBackend::Scalar)]
+    #[case::avx(SimdSupport::Avx, false, false, false, DistTableBackend::Scalar)]
+    #[case::none(SimdSupport::None, false, false, false, DistTableBackend::Scalar)]
+    #[case::neon(SimdSupport::Neon, false, false, false, DistTableBackend::Neon)]
+    fn dist_table_backend_follows_the_tier_ladder(
+        #[case] support: SimdSupport,
+        #[case] avx512_kernel: bool,
+        #[case] has_avx512bw: bool,
+        #[case] has_avx2: bool,
+        #[case] expected: DistTableBackend,
+    ) {
+        assert_eq!(
+            dist_table_backend(support, avx512_kernel, has_avx512bw, has_avx2),
+            expected
+        );
+    }
 
     #[test]
     fn test_perm0_inverse_matches_perm0() {

--- a/rust/lance-linalg/src/simd/dist_table.rs
+++ b/rust/lance-linalg/src/simd/dist_table.rs
@@ -14,19 +14,6 @@ pub const PERM0: [usize; 16] = [0, 8, 1, 9, 2, 10, 3, 11, 4, 12, 5, 13, 6, 14, 7
 pub const PERM0_INVERSE: [usize; 16] = [0, 2, 4, 6, 8, 10, 12, 14, 1, 3, 5, 7, 9, 11, 13, 15];
 pub const BATCH_SIZE: usize = 32;
 
-// This function is used to sum the distance table for 4-bit codes.
-// the distance table is a 2D array, that dist_table[i][j] is the distance between the i-th subvector and the code j,
-// the distance table is stored as a flat array for better cache locality and SIMD instruction usage.
-//
-// The codes are organized in the order of PERM0:
-// +----------+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+
-// | address  |  0 |  1 |  2 |  3 |  4 |  5 |  6 |  7 |  8 |  9 | 10 | 11 | 12 | 13 | 14 | 15 |
-// | (bytes)  |    |    |    |    |    |    |    |    |    |    |    |    |    |    |    |    |
-// +----------+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+
-// | bits 0..3|  0 |  8 |  1 |  9 |  2 | 10 |  3 | 11 |  4 | 12 |  5 | 13 |  6 | 14 |  7 | 15 |
-// | bits 4..7| 16 | 24 | 17 | 25 | 18 | 26 | 19 | 27 | 20 | 28 | 21 | 29 | 22 | 30 | 23 | 31 |
-// +----------+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+
-// so that we can use SIMD instruction (especially _mm256_shuffle_epi8) to do the summation.
 /// Which kernel a `dist_table` entry point runs on this host.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum DistTableBackend {
@@ -84,6 +71,19 @@ fn x86_dist_table_features() -> (bool, bool) {
     }
 }
 
+// This function is used to sum the distance table for 4-bit codes.
+// the distance table is a 2D array, that dist_table[i][j] is the distance between the i-th subvector and the code j,
+// the distance table is stored as a flat array for better cache locality and SIMD instruction usage.
+//
+// The codes are organized in the order of PERM0:
+// +----------+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+
+// | address  |  0 |  1 |  2 |  3 |  4 |  5 |  6 |  7 |  8 |  9 | 10 | 11 | 12 | 13 | 14 | 15 |
+// | (bytes)  |    |    |    |    |    |    |    |    |    |    |    |    |    |    |    |    |
+// +----------+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+
+// | bits 0..3|  0 |  8 |  1 |  9 |  2 | 10 |  3 | 11 |  4 | 12 |  5 | 13 |  6 | 14 |  7 | 15 |
+// | bits 4..7| 16 | 24 | 17 | 25 | 18 | 26 | 19 | 27 | 20 | 28 | 21 | 29 | 22 | 30 | 23 | 31 |
+// +----------+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+----+
+// so that we can use SIMD instruction (especially _mm256_shuffle_epi8) to do the summation.
 #[inline]
 pub fn sum_4bit_dist_table(
     n: usize,
@@ -712,8 +712,10 @@ mod tests {
 
     /// The tier ladder is exclusive, so most of these combinations cannot be
     /// produced by any one host and the selector is the only place they can be
-    /// checked. `avx512_kernel` false is the hacc entry point, which has no
-    /// AVX-512 kernel of its own.
+    /// checked. `avx512_kernel` false covers both callers that reach it: the hacc
+    /// entry point, which has no AVX-512 kernel at all, and
+    /// `sum_4bit_dist_table_uninit` in a build where
+    /// `kernel_support = "avx512_dist_table"` is unset.
     #[rstest::rstest]
     // An AVX-512 host with the C kernel built takes it.
     #[case::avx512_ready(SimdSupport::Avx512, true, true, true, DistTableBackend::Avx512)]
@@ -746,6 +748,9 @@ mod tests {
     // `Avx` and `AvxFma` lack the integer ops the AVX2 inner uses.
     #[case::avx_fma(SimdSupport::AvxFma, false, false, false, DistTableBackend::Scalar)]
     #[case::avx(SimdSupport::Avx, false, false, false, DistTableBackend::Scalar)]
+    // AVX2 present but the tier says otherwise, which is what an AVX2 host
+    // without FMA reports. The tier gate has to hold on its own here.
+    #[case::avx_tier_with_avx2(SimdSupport::Avx, false, false, true, DistTableBackend::Scalar)]
     #[case::sse(SimdSupport::Sse, false, false, false, DistTableBackend::Scalar)]
     #[case::none(SimdSupport::None, false, false, false, DistTableBackend::Scalar)]
     #[case::neon(SimdSupport::Neon, false, false, false, DistTableBackend::Neon)]

--- a/rust/lance-linalg/src/simd/dist_table.rs
+++ b/rust/lance-linalg/src/simd/dist_table.rs
@@ -85,8 +85,17 @@ pub unsafe fn sum_4bit_dist_table_uninit(
                 }
             }
         }
+        // `SIMD_SUPPORT` is a single exclusive tier, so an AVX-512 host reports
+        // `Avx512` or `Avx512FP16` and never `Avx2`. Matching only `Avx2` here
+        // would send every AVX-512 host that misses the arm above, because
+        // `avx512bw` is absent or because `kernel_support = "avx512_dist_table"`
+        // was not set, down the scalar path while it has AVX2.
+        // `sum_4bit_hacc_dist_table_uninit` already matches the three tiers
+        // together.
         #[cfg(target_arch = "x86_64")]
-        SimdSupport::Avx2 => unsafe {
+        SimdSupport::Avx512 | SimdSupport::Avx512FP16 | SimdSupport::Avx2
+            if std::arch::is_x86_feature_detected!("avx2") =>
+        unsafe {
             for i in (0..n).step_by(BATCH_SIZE) {
                 sum_dist_table_32bytes_batch_avx2(
                     &codes[i * code_len..(i + BATCH_SIZE) * code_len],


### PR DESCRIPTION
## What this changes

Two things, in `rust/lance-linalg/src/simd/dist_table.rs`.

`sum_4bit_dist_table_uninit`'s AVX2 arm matched only `SimdSupport::Avx2`. It now covers `Avx512`, `Avx512FP16` and `Avx2` behind one `is_x86_feature_detected!("avx2")` guard, which is what its sibling `sum_4bit_hacc_dist_table_uninit` in the same file already did. That also puts the previously unguarded `Avx2` arm behind the check.

The choice itself moves out of the `match` into `dist_table_backend`, a pure function of the tier, two feature bits, and whether the calling entry point has an AVX-512 kernel to offer, returning a `DistTableBackend`. It reads no static and probes no CPU, so the ladder can be tested without a host of each kind, and both entry points now share one description of it instead of two hand-kept `match` heads.

## Why the AVX2 arm needed to widen

`SIMD_SUPPORT` is a single exclusive tier. The initializer in `lance-core/src/utils/cpu.rs` is `if x86::has_avx512() { Avx512FP16 or Avx512 } else if avx2 && fma { Avx2 }`, so an AVX-512 host reports `Avx512` or `Avx512FP16` and never `Avx2`. That made the AVX2 arm unreachable on AVX-512 hardware, and since the `_` arm is scalar, any AVX-512 host that missed the AVX-512 arm ran the scalar kernel while holding perfectly good AVX2.

Ways to miss the AVX-512 arm, both of them real:

- `has_avx512()` is exactly `is_x86_feature_detected!("avx512f")`, and `avx512f` does not imply `avx512bw`.
- `kernel_support = "avx512_dist_table"` is unset on any x86_64 build that did not compile the AVX-512 C. That happens whenever the `cc` build of `dist_table.c` fails, and `build.rs` turns any such failure into a `cargo:warning` and keeps going, and it is also every Windows build: `build.rs` returns at its `target_os == "windows"` check before reaching the dist_table compile at all, and the warning it prints there talks about fp16 kernels rather than this. So every AVX-512 Windows host was on the scalar kernel in this entry point regardless of toolchain.

The AVX2 kernel needs nothing beyond what the guard checks: `sum_dist_table_32bytes_batch_avx2` is `#[target_feature(enable = "avx2")]` and everything it uses is an AVX or AVX2 op, load or store. No FMA, no gather, no VNNI.

## One behaviour change worth naming

On the hosts this newly covers, overflow goes from saturating to wrapping. The scalar kernel accumulates with `saturating_add` and the AVX2 kernel wraps, so on inputs that overflow a `u16` accumulator the result changes. What it changes to is what every other AVX2 and NEON host already produces, so this aligns those hosts rather than introducing anything new.

I am not claiming the overflowing set is negligible. The file's one note on the divergence, on the doc comment of `test_simd_matches_scalar_varied_dimensions`, says overflow never occurs with real quantized data; each row accumulates two 0..255 lookups per code byte, so a row's sum runs to `510 * code_len`, and that parenthetical does not obviously hold at production dimensions. Settling it is a separate question from which kernel runs.

## On moving the feature probes out of the match guard

`x86_dist_table_features()` runs on every call now. Off x86_64 it is `(false, false)` at compile time, so those builds pay nothing. On x86_64 the call already dereferenced the `*SIMD_SUPPORT` `LazyLock`, so the probes sit alongside work that was already there. At the hacc entry point the `avx512bw` probe is new rather than moved, and its result is unused there, because that call passes `avx512_kernel = false`.

It is also not per row. The only call sites of either entry point outside this file's own `pub` wrappers, and the bench that calls those, are in `lance-index/src/vector/bq/storage.rs` (lines 988, 1056 and 1169; the first two are mutually exclusive per call, since the accurate mode delegates to the hacc one), once per partition pass, and the `n` they receive is already rounded down to a multiple of 32. For a partition of at least 32 rows that one call walks the rounded-down count times `code_len` bytes through the kernel. At the two `binary_distances_*` sites the remainder then goes row by row through `compute_single_rq_distance`; the fast-scan site reuses the binary pass's rounded count and takes its remainder through `ex_code_dot`. Below 32 rows the rounded count is zero, and at the two binary sites the call is the probes, the match and a zero-length body, still once per scan rather than per row. The fast-scan site skips the call outright there, since it is guarded on `simd_len > 0`, on `supports_ex_fastscan`, and on `packed_ex_codes` being present.

## Test plan

`dist_table_backend_follows_the_tier_ladder` parametrizes 17 cases over the extracted selector, covering every `SimdSupport` variant. The ones that carry the argument:

- an AVX-512 tier with the C kernel built and `avx512bw` present takes AVX-512, and both AVX-512 tiers are checked, not just one
- the two ways to miss the AVX-512 arm, no `avx512bw` and no compiled kernel, each land on AVX2 rather than scalar, for both AVX-512 tiers. These four are the regression this pull request is about. Narrowing the selector's second arm back to `SimdSupport::Avx2` alone fails exactly those four, `case_03_avx512_no_bw` through `case_06_avx512fp16_kernel_absent`, and leaves the other 22 tests in the module passing
- `Avx2` as a tier with `has_avx2` false lands on scalar. No host produces that pair, since `cpu.rs` selects `Avx2` only when `is_x86_feature_detected!("avx2")` is true, so the row pins the selector rather than closing a live hole
- `Avx` and `AvxFma` land on scalar. Neither is named in the second arm, so the tier alone decides. `case_11_avx` is a real Sandy Bridge or Ivy Bridge host; `case_12_avx_tier_with_avx2` pins the selector instead, since `cpu.rs` notes every shipping AVX2 part has FMA, so no shipping part produces this pair, though a masked or feature-forced build can. `Lsx`, `Lasx` and `None` land there too, as does `Sse`, which the x86 ladder never produces

What is still not covered, since the extraction does not reach it: the two entry points read `*SIMD_SUPPORT` directly, so nothing tests that they hand the selector the right `avx512_kernel` flag or the right feature bits.

Neither target I ran reaches the AVX2 kernel. This machine is aarch64 and takes the `Neon` arm in the widened entry point; on this machine the `x86_64-apple-darwin` target reports no AVX and takes the scalar arm.

Five jobs in `rust.yml` run `test_simd_matches_scalar_varied_dimensions` and `test_simd_matches_scalar_multi_batch`, which compare whatever the selector picks against the scalar reference: `linux-build`, `windows-build` and `qemu-pre-haswell` on x86_64, plus `linux-arm` and `mac-build`, which are aarch64. `mac-build` exercises the NEON arm, since `cpu.rs` reports NEON f16 support unconditionally on macOS; `linux-arm` does too if its runner reports `HWCAP_FPHP`, and takes the scalar arm otherwise. `daily-code-coverage.yml` runs them on x86_64 too, nightly rather than per pull request. `linux-build` and `windows-build` both build with a real runtime check, so which arm they reach depends on the runner's features, which nothing here fixes: `linux-build` sets `RUSTFLAGS` in the environment, displacing the `+avx2` baseline `.cargo/config.toml` gives that triple, and `windows-build` has no entry there at all. `windows-build` also compiles no AVX-512 kernel, since `build.rs` returns at its Windows check, so an AVX-512 runner there goes through exactly the arm this widens. `qemu-pre-haswell` is the deterministic one: `-cpu Nehalem` reports no AVX, so the tier is `None` and the scalar arm runs.

That the kernel is correct rests on it being the same kernel that already serves the `Avx2` tier, reached under the same `avx2` guard the sibling `hacc` function already used.

- `cargo fmt --all -- --check`: clean
- `cargo clippy -p lance-linalg --all-targets -- -D warnings`, and the same with `--target x86_64-apple-darwin`, which is the configuration where both x86 arms compile: clean
- `cargo test --profile ci -p lance-linalg --lib simd::dist_table`, both targets: 26 passed

## Follow-up found while reviewing this

The same shape is unfixed at 8 sites in the f16 and bf16 dispatches, in `cosine.rs`, `norm_l2.rs`, `l2.rs` and `dot.rs`. There the AVX-512 arm is cfg'd on `kernel_support = "avx512_f16"` or `"avx512_bf16"` and the next arm lists `Avx2 | Avx512`, omitting `Avx512FP16`. With `fp16kernels` on and a compiler that could not build the AVX-512 C, an `Avx512FP16` host matches no arm and runs scalar f16, even though the AVX2 f16 kernel is built on every non-Windows x86_64 build with `fp16kernels` on, and a failure there is a hard build error. That one needs an FMA guard as well, because those kernels are compiled `-march=haswell` while the `Avx512*` tiers are not FMA-checked. I will send it separately.

























