### PR TITLE
ci: run the Rust suite when .cargo/config.toml or clippy.toml changes

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -15,6 +15,8 @@ on:
       - rust-toolchain.toml
       - Cargo.toml
       - Cargo.lock
+      - .cargo/config.toml
+      - clippy.toml
       - deny.toml
 
 permissions:


### PR DESCRIPTION
## What this changes

Adds `.cargo/config.toml` and `clippy.toml` to `rust.yml`'s `pull_request` `paths:` filter. Two lines.

## Why

Both files change what the Rust jobs do, and neither triggers them.

`.cargo/config.toml` sets the per-target SIMD baselines: `target-cpu=haswell` with `+avx2,+fma,+f16c` for `x86_64-unknown-linux-gnu`, and `target-cpu=apple-m1` with `+neon,+fp16,+fhm,+dotprod` for `aarch64-apple-darwin`. Five of the twelve jobs compile with them, `rustdoc`, `clippy`, `build-no-lock` and `msrv` on the x86 entry and `mac-build` on the aarch64-darwin one. The other seven are out for one of three reasons: `format`, `package` and `cargo-deny` compile nothing; `linux-arm` and `windows-build` build triples no entry names; `linux-build` and `qemu-pre-haswell` set `RUSTFLAGS` in the environment, which Cargo treats as a mutually exclusive source that replaces `target.<triple>.rustflags`.

The same file defines `[profile.release]`, which the root `Cargo.toml` does not. Only `qemu-pre-haswell` builds `--release`, so it is the one job that reads it.

`clippy.toml` holds the `disallowed-macros` list that forbids manual `snafu::location` construction, and the root `Cargo.toml` sets `disallowed_macros = "deny"`, so it is live config. Clippy starts at each crate's `CARGO_MANIFEST_DIR` and walks up, so the file applies to every member under `rust/`, and editing this list changes what the `clippy` job enforces with nothing on the pull request to say so. Tightening is the direction that turns the job red, by adding a path existing code invokes.

To be precise about the scope, since it is narrower than it first looks: the `push:` trigger has no `paths:` filter, so the whole suite runs on `main` and `release/**`. These files are tested, just after merge rather than before it.

## The instance this happened on

#8754, "revert default target back to haswell (avx2)", touched `.cargo/config.toml`, `CONTRIBUTING.md` and `python/.cargo/config.toml`, none of which matches an entry in this filter. None of `rust.yml`'s twelve jobs ran on it. What it changed was the x86 rustflags line, from `x86-64-v2` to `haswell` plus `avx2,fma,f16c`, so four of the five jobs above would have compiled differently.

## Cost

Three extra Rust runs across the whole history of the path.

`.cargo/config.toml` has six commits at that path, from 2024-02-27 to 2026-08-25. The file itself is older, but #1928 moved it up out of `rust/`, so everything before that already matched `rust/**`. Of the six, three already reached the suite through another entry here: #8377 and #3054 because they also touched files under `rust/`, and #1928 itself because it touched the root `Cargo.toml` and `rust.yml`. That leaves #5436, #7400 and #8754, dated 2025-12, 2026-06 and 2026-08. `clippy.toml` has one commit, #6071, which also touched the root `Cargo.toml`.

Two things that cut against the argument, since the numbers above are mine to present fairly. Of those three, only #8754 changed something a job compiles with: #5436 added `[profile.bench]` and #7400 added `[profile.release-no-lto]`, and no job here builds with either. And four of the six commits landed in the last nine months, so the forward rate is higher than an average over the path's whole life suggests.

## What I looked at and left out

Two more files change what the Rust jobs do and are still missing from the filter. Either is a one-line follow-up if you want it here instead.

`docker-compose.yml` brings up the S3 and DynamoDB emulators that `linux-build` and `linux-arm` wait on. A broken compose file fails the job loudly rather than changing what the code compiles to, and it has two commits in its history.

`test_data/` is the larger one. `copy_test_data_to_tmp` resolves `$CARGO_MANIFEST_DIR/../../test_data`, so the checked-in backward-compatibility datasets live at the repository root, outside `rust/**`. A pull request that only regenerates a fixture there changes what the Rust test jobs assert and triggers nothing. It has 25 commits, a different cost profile from the two lines here, so it deserves its own decision.

## Test plan

The suite runs on this pull request rather than skipping, because `.github/workflows/rust.yml` is itself an entry in the filter being edited and is the only file this touches. All twelve jobs passed, which is better evidence than a skip: it shows the edited YAML parses and still dispatches the same twelve. It also settles the one mechanical question `.cargo/config.toml` raises, since that entry is likewise a literal path whose first segment is a dot-directory and it matched.



