### PR TITLE
fix(linalg): stop FP16 hosts falling to scalar when the AVX-512 f16 kernel is absent

### DIFF
--- a/rust/lance-linalg/src/distance/cosine.rs
+++ b/rust/lance-linalg/src/distance/cosine.rs
@@ -121,6 +121,16 @@ impl Cosine for bf16 {
             SimdSupport::Avx512FP16 => unsafe {
                 bf16_kernel::cosine_bf16_avx512(x.as_ptr(), x_norm, y.as_ptr(), y.len() as u32)
             },
+            #[cfg(all(
+                feature = "fp16kernels",
+                not(kernel_support = "avx512_bf16"),
+                target_arch = "x86_64"
+            ))]
+            // `Avx512*` tier detection does not check FMA, and these kernels are
+            // compiled `-march=haswell`, which enables it.
+            SimdSupport::Avx512FP16 if std::is_x86_feature_detected!("fma") => unsafe {
+                bf16_kernel::cosine_bf16_avx2(x.as_ptr(), x_norm, y.as_ptr(), y.len() as u32)
+            },
             #[cfg(all(feature = "fp16kernels", target_arch = "x86_64"))]
             SimdSupport::Avx2 | SimdSupport::Avx512 => unsafe {
                 bf16_kernel::cosine_bf16_avx2(x.as_ptr(), x_norm, y.as_ptr(), y.len() as u32)
@@ -176,6 +186,16 @@ impl Cosine for f16 {
             ))]
             SimdSupport::Avx512FP16 => unsafe {
                 kernel::cosine_f16_avx512(x.as_ptr(), x_norm, y.as_ptr(), y.len() as u32)
+            },
+            #[cfg(all(
+                feature = "fp16kernels",
+                not(kernel_support = "avx512_f16"),
+                target_arch = "x86_64"
+            ))]
+            // `Avx512*` tier detection does not check FMA, and these kernels are
+            // compiled `-march=haswell`, which enables it.
+            SimdSupport::Avx512FP16 if std::is_x86_feature_detected!("fma") => unsafe {
+                kernel::cosine_f16_avx2(x.as_ptr(), x_norm, y.as_ptr(), y.len() as u32)
             },
             #[cfg(all(feature = "fp16kernels", target_arch = "x86_64"))]
             SimdSupport::Avx2 | SimdSupport::Avx512 => unsafe {

--- a/rust/lance-linalg/src/distance/dot.rs
+++ b/rust/lance-linalg/src/distance/dot.rs
@@ -153,6 +153,16 @@ impl Dot for bf16 {
             SimdSupport::Avx512FP16 => unsafe {
                 bf16_kernel::dot_bf16_avx512(x.as_ptr(), y.as_ptr(), x.len() as u32)
             },
+            #[cfg(all(
+                feature = "fp16kernels",
+                not(kernel_support = "avx512_bf16"),
+                target_arch = "x86_64"
+            ))]
+            // `Avx512*` tier detection does not check FMA, and these kernels are
+            // compiled `-march=haswell`, which enables it.
+            SimdSupport::Avx512FP16 if std::is_x86_feature_detected!("fma") => unsafe {
+                bf16_kernel::dot_bf16_avx2(x.as_ptr(), y.as_ptr(), x.len() as u32)
+            },
             #[cfg(all(feature = "fp16kernels", target_arch = "x86_64"))]
             SimdSupport::Avx2 | SimdSupport::Avx512 => unsafe {
                 bf16_kernel::dot_bf16_avx2(x.as_ptr(), y.as_ptr(), x.len() as u32)
@@ -209,6 +219,16 @@ impl Dot for f16 {
             ))]
             SimdSupport::Avx512FP16 => unsafe {
                 kernel::dot_f16_avx512(x.as_ptr(), y.as_ptr(), x.len() as u32)
+            },
+            #[cfg(all(
+                feature = "fp16kernels",
+                not(kernel_support = "avx512_f16"),
+                target_arch = "x86_64"
+            ))]
+            // `Avx512*` tier detection does not check FMA, and these kernels are
+            // compiled `-march=haswell`, which enables it.
+            SimdSupport::Avx512FP16 if std::is_x86_feature_detected!("fma") => unsafe {
+                kernel::dot_f16_avx2(x.as_ptr(), y.as_ptr(), x.len() as u32)
             },
             #[cfg(all(feature = "fp16kernels", target_arch = "x86_64"))]
             SimdSupport::Avx2 | SimdSupport::Avx512 => unsafe {

--- a/rust/lance-linalg/src/distance/l2.rs
+++ b/rust/lance-linalg/src/distance/l2.rs
@@ -185,6 +185,16 @@ impl L2 for bf16 {
             SimdSupport::Avx512FP16 => unsafe {
                 bf16_kernel::l2_bf16_avx512(x.as_ptr(), y.as_ptr(), x.len() as u32)
             },
+            #[cfg(all(
+                feature = "fp16kernels",
+                not(kernel_support = "avx512_bf16"),
+                target_arch = "x86_64"
+            ))]
+            // `Avx512*` tier detection does not check FMA, and these kernels are
+            // compiled `-march=haswell`, which enables it.
+            SimdSupport::Avx512FP16 if std::is_x86_feature_detected!("fma") => unsafe {
+                bf16_kernel::l2_bf16_avx2(x.as_ptr(), y.as_ptr(), x.len() as u32)
+            },
             #[cfg(all(feature = "fp16kernels", target_arch = "x86_64"))]
             SimdSupport::Avx2 | SimdSupport::Avx512 => unsafe {
                 bf16_kernel::l2_bf16_avx2(x.as_ptr(), y.as_ptr(), x.len() as u32)
@@ -241,6 +251,16 @@ impl L2 for f16 {
             ))]
             SimdSupport::Avx512FP16 => unsafe {
                 kernel::l2_f16_avx512(x.as_ptr(), y.as_ptr(), x.len() as u32)
+            },
+            #[cfg(all(
+                feature = "fp16kernels",
+                not(kernel_support = "avx512_f16"),
+                target_arch = "x86_64"
+            ))]
+            // `Avx512*` tier detection does not check FMA, and these kernels are
+            // compiled `-march=haswell`, which enables it.
+            SimdSupport::Avx512FP16 if std::is_x86_feature_detected!("fma") => unsafe {
+                kernel::l2_f16_avx2(x.as_ptr(), y.as_ptr(), x.len() as u32)
             },
             #[cfg(all(feature = "fp16kernels", target_arch = "x86_64"))]
             SimdSupport::Avx2 | SimdSupport::Avx512 => unsafe {

--- a/rust/lance-linalg/src/distance/norm_l2.rs
+++ b/rust/lance-linalg/src/distance/norm_l2.rs
@@ -61,6 +61,16 @@ impl Normalize for f16 {
             SimdSupport::Avx512FP16 => unsafe {
                 kernel::norm_l2_f16_avx512(vector.as_ptr(), vector.len() as u32)
             },
+            #[cfg(all(
+                feature = "fp16kernels",
+                not(kernel_support = "avx512_f16"),
+                target_arch = "x86_64"
+            ))]
+            // `Avx512*` tier detection does not check FMA, and these kernels are
+            // compiled `-march=haswell`, which enables it.
+            SimdSupport::Avx512FP16 if std::is_x86_feature_detected!("fma") => unsafe {
+                kernel::norm_l2_f16_avx2(vector.as_ptr(), vector.len() as u32)
+            },
             #[cfg(all(feature = "fp16kernels", target_arch = "x86_64"))]
             SimdSupport::Avx2 | SimdSupport::Avx512 => unsafe {
                 kernel::norm_l2_f16_avx2(vector.as_ptr(), vector.len() as u32)
@@ -114,6 +124,16 @@ impl Normalize for bf16 {
             ))]
             SimdSupport::Avx512FP16 => unsafe {
                 bf16_kernel::norm_l2_bf16_avx512(vector.as_ptr(), vector.len() as u32)
+            },
+            #[cfg(all(
+                feature = "fp16kernels",
+                not(kernel_support = "avx512_bf16"),
+                target_arch = "x86_64"
+            ))]
+            // `Avx512*` tier detection does not check FMA, and these kernels are
+            // compiled `-march=haswell`, which enables it.
+            SimdSupport::Avx512FP16 if std::is_x86_feature_detected!("fma") => unsafe {
+                bf16_kernel::norm_l2_bf16_avx2(vector.as_ptr(), vector.len() as u32)
             },
             #[cfg(all(feature = "fp16kernels", target_arch = "x86_64"))]
             SimdSupport::Avx2 | SimdSupport::Avx512 => unsafe {


### PR DESCRIPTION
## What this changes

Adds one match arm at each of eight f16 and bf16 dispatch sites, in `cosine.rs`, `dot.rs`, `l2.rs` and `norm_l2.rs`, so that an `Avx512FP16` host uses the AVX2 kernel instead of scalar when the AVX-512 f16 kernel was not built. Found while reviewing #8866, which fixes the same shape in `dist_table.rs`.

## The bug

Each site looks like this, and the fallback arm omits `Avx512FP16`:

```rust
#[cfg(all(feature = "fp16kernels", kernel_support = "avx512_bf16", target_arch = "x86_64"))]
SimdSupport::Avx512FP16 => ... l2_bf16_avx512 ...
#[cfg(all(feature = "fp16kernels", target_arch = "x86_64"))]
SimdSupport::Avx2 | SimdSupport::Avx512 => ... l2_bf16_avx2 ...
_ => l2_scalar::<Self, f32, 16>(x, y),
```

`SIMD_SUPPORT` is a single exclusive tier, so an FP16-capable host reports `Avx512FP16` and never `Avx2` or `Avx512`. When `kernel_support = "avx512_bf16"` is unset the first arm is compiled out, and that host then matches nothing and runs scalar bf16, even though the AVX2 kernel is present: `build.rs` builds it unconditionally on x86_64 and treats a failure there as a hard error, while the AVX-512 build only warns and continues.

The unset case is reachable. `build.rs` compiles the AVX-512 f16 C with `-march=sapphirerapids`, which needs clang 12 or gcc 11; older compilers get `cargo:warning=Skipping build of AVX-512 fp16 kernels` and the cfg stays unset.

## Why a separate arm rather than widening the existing one

Widening does not compile. With the cfg set, the `SimdSupport::Avx512FP16 =>` arm above has no guard, so it matches every value of that tier, and rustc rejects the addition at all eight sites:

```
error: unreachable pattern
121 |  SimdSupport::Avx512FP16 => unsafe {
    |  ----------------------- matches all the relevant values
125 |  SimdSupport::Avx2 | SimdSupport::Avx512 | SimdSupport::Avx512FP16
    |                                            ^^^^ no value can reach this
```

That is the difference from #8866, where the AVX-512 arm carries an `if avx512bw` guard and so is not exhaustive for its tier. So the new arm is gated on `not(kernel_support = ...)` and exists only in the configuration that has the bug.

The `is_x86_feature_detected!("fma")` guard is there because these kernels are compiled `-march=haswell`, which includes FMA, while `has_avx512()` is only `is_x86_feature_detected!("avx512f")` and never checks FMA. The precedent is `l2.rs:342`. Note the pre-existing arm below has the same unguarded exposure for the plain `Avx512` tier; I left it alone to keep this change to the bug, and it is worth a separate look.

## No test, and why

`CLAUDE.md` asks for a test with every bugfix, and there is none here. I do not think a host-independent one is constructible: the arm is selected by the `SIMD_SUPPORT` `LazyLock` static, which has no injection point, and by a build-time cfg, so neither input is reachable from a test on hardware that is not an FP16 AVX-512 part.

What does cover it, conditionally: `test_l2_norm_f16` and `_bf16`, `test_l2_distance_f16` and `_bf16`, `test_dot_f16` and `_bf16`, `test_cosine_f16` and `_bf16` all assert dispatched-against-scalar parity at `max_relative = 1e-3`. On any host that takes the new arm those catch a wrong kernel or a wrong argument order. On every other host they pass without exercising it.

## One more thing affected hosts will notice

The change is not only about speed. `build.rs` compiles these kernels with `-ffast-math`, so a host moving from the Rust scalar loop to the C AVX2 kernel gets a re-associated reduction and its distances shift, within the existing 1e-3 tolerance. The same shift already exists between `Avx512` and `Avx512FP16` hosts today, so this is not new for the codebase, but it is new for the hosts this unblocks: a recall number or a persisted distance measured on one of them is not bit-comparable afterwards.

## Test plan

The load-bearing check is compiling the configuration that has the bug, which needs the cfg genuinely unset. I forced that by making both AVX-512 f16 builds in `build.rs` fail with a bogus `-march`, confirmed the two skip warnings appeared, and compiled. Doing that caught two errors in my first attempt, which had assumed every site takes `(x, y)`: `norm_l2` takes a single vector, and `cosine` takes `(x, x_norm, y, len)`.

| configuration | result |
| --- | --- |
| default features, aarch64 and x86_64 | clean |
| `--features fp16kernels`, aarch64 | clean |
| `--features fp16kernels`, x86_64, cfg set | clean, new arms compiled out |
| `--features fp16kernels`, x86_64, cfg unset | clean, 2 skip warnings |

`cargo test --profile ci -p lance-linalg --lib`, with and without `fp16kernels`: 389 passed, 1 ignored. `cargo fmt --all -- --check` clean.

What none of this covers: no runner here has AVX-512, so the new arm is compiled but never executed. It is also not unit-testable, because the match reads the `SIMD_SUPPORT` static and the cfg is decided at build time.
