### PR TITLE
fix(index): reject RabitQ indices whose dimension is not a multiple of 8

### DIFF
--- a/rust/lance-index/src/vector/bq/storage.rs
+++ b/rust/lance-index/src/vector/bq/storage.rs
@@ -2429,6 +2429,24 @@ impl QuantizerStorage for RabitQuantizationStorage {
             _ => distance_type,
         };
         validate_rq_num_bits(metadata.num_bits)?;
+        // The FastScan LUT is `4 * rotated_dim` bytes while the kernels index it
+        // as `BATCH_SIZE * rotated_dim.div_ceil(8)`, so the two agree only when
+        // the dimension is a multiple of 8. `RabitQuantizer::build` has rejected
+        // a non-multiple since #6024, but an index written before that still
+        // loads here, and the AVX-512, AVX2 and NEON kernels read the LUT
+        // through unchecked raw pointers. Only the scalar fallback panics.
+        //
+        // This has to go through `rotated_dim()`, not `metadata.code_dim`:
+        // `code_dim` was added by #6024 itself, so it deserializes to 0 for the
+        // very indices this rejects, and `rotated_dim()` recovers the real
+        // dimension from the rotation matrix that `parse_buffer` backfills.
+        let rotated_dim = metadata.rotated_dim();
+        if rotated_dim % 8 != 0 {
+            return Err(Error::invalid_input(format!(
+                "RabitQ vector dimension must be divisible by 8, got {rotated_dim}. \
+                 Rebuild the index."
+            )));
+        }
         let row_ids = batch[ROW_ID].as_primitive::<UInt64Type>().clone();
         let codes = batch[RABIT_CODE_COLUMN].as_fixed_size_list().clone();
         let expected_code_bytes = metadata.binary_code_bytes();
@@ -2980,6 +2998,37 @@ mod tests {
     fn make_test_metadata(code_dim: usize) -> RabitQuantizationMetadata {
         RabitQuantizer::new_with_rotation::<Float32Type>(1, code_dim as i32, RQRotationType::Fast)
             .metadata(None)
+    }
+
+    /// Indices written before #6024 could carry a `code_dim` that is not a
+    /// multiple of 8. The FastScan LUT is sized `4 * code_dim` while the kernels
+    /// index it as `BATCH_SIZE * code_dim.div_ceil(8)`, so loading one made the
+    /// kernels read past the LUT through raw pointers.
+    #[test]
+    fn test_try_from_batch_rejects_dim_not_multiple_of_eight() {
+        let code_dim = 12usize;
+        let metadata = make_test_metadata(code_dim);
+        assert_eq!(metadata.code_dim as usize, code_dim);
+        let code_bytes = metadata.binary_code_bytes();
+        let codes = FixedSizeListArray::try_new_from_values(
+            UInt8Array::from(vec![0u8; 2 * code_bytes]),
+            code_bytes as i32,
+        )
+        .unwrap();
+        let batch = make_test_batch(codes);
+
+        let err =
+            RabitQuantizationStorage::try_from_batch(batch, &metadata, DistanceType::L2, None)
+                .expect_err("a dimension that is not a multiple of 8 must be rejected");
+        assert!(
+            matches!(err, Error::InvalidInput { .. }),
+            "unexpected variant: {err:?}"
+        );
+        let message = err.to_string();
+        assert!(
+            message.contains("divisible by 8") && message.contains("12"),
+            "unexpected error: {message}"
+        );
     }
 
     #[test]

--- a/rust/lance-linalg/src/simd/dist_table.rs
+++ b/rust/lance-linalg/src/simd/dist_table.rs
@@ -67,6 +67,7 @@ pub unsafe fn sum_4bit_dist_table_uninit(
     debug_assert!(n.is_multiple_of(BATCH_SIZE));
     debug_assert!(dists.len() >= n);
     debug_assert!(codes.len() >= n * code_len);
+    debug_assert!(dist_table.len() >= BATCH_SIZE * code_len);
 
     match *SIMD_SUPPORT {
         #[cfg(all(kernel_support = "avx512_dist_table", target_arch = "x86_64"))]


### PR DESCRIPTION
## What this changes

`RabitQuantizationStorage::try_from_batch` now rejects an index whose `rotated_dim` is not a multiple of 8, and `sum_4bit_dist_table_uninit` gains the `debug_assert!` its own `# Safety` section already promises.

## Why

The FastScan LUT is allocated `4 * code_dim` bytes, while the kernels index it as `BATCH_SIZE * code_dim.div_ceil(8)` with `BATCH_SIZE = 32`. Those agree only when `code_dim % 8 == 0`, and then exactly, with no slack. For `code_dim = 8q + r` with `1 <= r <= 7` the table is `32 - 4r` bytes short: 28 at `r = 1`, 4 at `r = 7`.

`RabitQuantizer::build` has rejected a non-multiple since #6024, so no current writer can produce one. But IVF_RQ shipped in #4344 and that gate landed five months later, and `try_from_batch` validates `num_bits` and the code byte width without ever checking the dimension. `binary_code_bytes()` is itself `div_ceil(8)`, so a `code_dim = 100` index with 13-byte codes passes the existing width check.

Loading one is not a clean failure. `sum_4bit_dist_table_uninit` reads the LUT through `_mm256_loadu_si256(dist_table.as_ptr().add(i))` on AVX2, the equivalent on AVX-512, and `vld1q_u8` on NEON, none of which is length-checked, so all three read past the allocation and return distances computed from whatever follows. Only the scalar fallback panics. This is `ApproxMode::Normal`, the default query path.

## What changes for callers

An index in that state stops loading and returns `invalid_input` naming the dimension. It used to load and give wrong distances on any host with SIMD, so failing is the better of the two, but it is a behaviour change for anyone holding such an index rather than a pure hardening.

## The `debug_assert!`

`sum_4bit_dist_table_uninit`'s `# Safety` section lists four obligations and the body checked three. The missing one is the table bound, which is the only one no slice re-checks. Its sibling `sum_4bit_hacc_dist_table_uninit` has had the equivalent all along.

## Test plan

`test_try_from_batch_rejects_dim_not_multiple_of_eight` builds metadata at `code_dim = 12` with a matching 2-byte code column, so it clears the existing width check, and asserts the load fails with a message naming the dimension.

Measured: replacing the new condition with `if false` takes that test to failed. With the fix, `cargo test --profile ci -p lance-index --lib vector::bq` is 223 passed and `-p lance-linalg --lib simd::dist_table` is 9 passed. `cargo fmt --all -- --check` and `cargo clippy -p lance-linalg -p lance-index --all-targets -- -D warnings` are clean.

Not covered: the over-read itself. Reproducing it needs a host with SIMD and an index that current code cannot write, so the test pins the rejection rather than the behaviour it prevents.

## Provenance

Found while re-checking an old note of mine that claimed the shortfall was a fixed 16 bytes and that the fix belonged at index creation. Both were wrong: the shortfall varies with the dimension, and the creation-time gate already exists. The read path was the part still open.
