### PR TITLE
test(linalg): cover the hamming kernel remainder loops per width

### DIFF
--- a/rust/lance-linalg/src/distance/hamming.rs
+++ b/rust/lance-linalg/src/distance/hamming.rs
@@ -1205,9 +1205,8 @@ mod tests {
     #[case::one_hundred_twenty_eight(128)]
     fn test_hamming_batch_u64(#[case] n: usize) {
         check_kernel_tail(n, hamming_batch_u64);
-        // Also directly, because on an x86_64 host with AVX2 the dispatcher never
-        // reaches the scalar kernel, and that is the host every Linux x86 job runs
-        // on.
+        // Also directly, because an x86_64 host with AVX2 takes an earlier branch
+        // and never reaches the scalar kernel through the dispatcher.
         check_kernel_tail(n, hamming_batch_scalar);
     }
 
@@ -1810,6 +1809,8 @@ mod tests {
     #[case::three(3)]
     #[case::four(4)]
     #[case::five(5)]
+    // Remainder 2 with a chunk ahead of it, which `two` alone does not reach.
+    #[case::six(6)]
     #[case::seven(7)]
     fn test_avx2_covers_tail(#[case] n: usize) {
         if !is_x86_feature_detected!("avx2") {

--- a/rust/lance-linalg/src/distance/hamming.rs
+++ b/rust/lance-linalg/src/distance/hamming.rs
@@ -1152,10 +1152,10 @@ mod tests {
     /// Runs `kernel` over `n` targets, with 8 guard slots past the output it is
     /// handed, then checks every value and every guard.
     ///
-    /// 8 is the widest chunk store in the file, so one extra chunk iteration
-    /// lands inside this allocation rather than on unrelated memory. The
-    /// remainder loops cannot trip the guards at all: all three index through
-    /// bounds-checked `results[..]` and would panic instead.
+    /// 8 is the widest unchecked chunk store in the file, so an unchecked chunk
+    /// store that overruns by one chunk lands inside this allocation instead of
+    /// past it. The remainder loops cannot trip the guards at all: all three
+    /// index through bounds-checked `results[..]` and would panic instead.
     fn check_kernel_tail(n: usize, kernel: impl FnOnce(u64, &[u64], &mut [u32])) {
         const GUARD: u32 = u32::MAX;
         const GUARD_SLOTS: usize = 8;
@@ -1184,11 +1184,12 @@ mod tests {
     /// `hamming_batch_avx2`, 8 for `hamming_batch_avx512` and for the unrolled
     /// scalar fallback.
     ///
-    /// Those loops do run today, but only through the pairwise tests, whose row
-    /// sweep passes every width from `n - 1` down to 1 and so covers every
-    /// residue incidentally. A tail bug surfaces there as a mismatch somewhere
-    /// among hundreds of thousands of pairs. This asserts every slot at each
-    /// width instead.
+    /// The pairwise tests reach a remainder loop only when they are large enough
+    /// to take a parallel path. There the row ranges together pass every width
+    /// from one below the row count down to 1, so whichever kernel the host
+    /// dispatches has every residue covered incidentally, and a dropped or
+    /// out-of-bounds tail write surfaces somewhere in thousands of pairs, as a
+    /// mismatch or a panic. This asserts every slot at each width instead.
     #[rstest]
     #[case::one(1)]
     #[case::two(2)]
@@ -1795,10 +1796,10 @@ mod tests {
     // =========================================================================
 
     // `hamming_batch_simd` returns early on the AVX-512 branch when
-    // `avx512vpopcntdq` and `avx512f` are both present, so on a VPOPCNTDQ host
+    // `avx512vpopcntdq` and `avx512f` are both present, so on a host with both
     // nothing reaches `hamming_batch_avx2` through `hamming_batch_u64`. This
     // calls it directly. The AVX-512 kernel needs no such test: it only runs
-    // where the dispatched test already drives it, over a wider set of widths.
+    // where the dispatched test already drives it.
 
     /// `hamming_batch_avx2` consumes 4 targets per chunk, so `n % 4` covers its
     /// remainder loop.
@@ -1808,8 +1809,9 @@ mod tests {
     #[case::two(2)]
     #[case::three(3)]
     #[case::four(4)]
+    // Five, six and seven repeat remainders 1 through 3 with a chunk ahead of
+    // them, which one, two and three alone do not reach.
     #[case::five(5)]
-    // Remainder 2 with a chunk ahead of it, which `two` alone does not reach.
     #[case::six(6)]
     #[case::seven(7)]
     fn test_avx2_covers_tail(#[case] n: usize) {

--- a/rust/lance-linalg/src/distance/hamming.rs
+++ b/rust/lance-linalg/src/distance/hamming.rs
@@ -1149,18 +1149,63 @@ mod tests {
         assert_eq!(hamming_u64(0xAAAAAAAAAAAAAAAA, 0x5555555555555555), 64);
     }
 
-    #[test]
-    fn test_hamming_batch_u64() {
-        let query = 0u64;
-        let targets: Vec<u64> = (0..128).collect();
-        let mut results = vec![0u32; 128];
+    /// Runs `kernel` over `n` targets, with 8 guard slots past the output it is
+    /// handed, then checks every value and every guard.
+    ///
+    /// 8 is the widest chunk store in the file, so one extra chunk iteration
+    /// lands inside this allocation rather than on unrelated memory. Two extra
+    /// iterations would still escape it. The remainder loops cannot trip the
+    /// guards at all: all three index through bounds-checked `results[..]` and
+    /// would panic instead.
+    fn check_kernel_tail(n: usize, kernel: impl FnOnce(u64, &[u64], &mut [u32])) {
+        const GUARD: u32 = u32::MAX;
+        const GUARD_SLOTS: usize = 8;
+        let query = 0xDEAD_BEEF_CAFE_F00D_u64;
+        let targets: Vec<u64> = (0..n as u64)
+            .map(|i| i.wrapping_mul(0x9E37_79B9_7F4A_7C15))
+            .collect();
+        let mut results = vec![GUARD; n + GUARD_SLOTS];
 
-        hamming_batch_u64(query, &targets, &mut results);
+        kernel(query, &targets, &mut results[..n]);
 
-        assert_eq!(results[0], 0);
-        assert_eq!(results[1], 1);
-        assert_eq!(results[3], 2); // 0b11 has 2 bits set
-        assert_eq!(results[7], 3); // 0b111 has 3 bits set
+        for (slot, &target) in targets.iter().enumerate() {
+            assert_eq!(
+                results[slot],
+                (query ^ target).count_ones(),
+                "n={n}, slot {slot}"
+            );
+        }
+        for (slot, &guard) in results.iter().enumerate().skip(n) {
+            assert_eq!(guard, GUARD, "n={n}: wrote past results, at {slot}");
+        }
+    }
+
+    /// Each kernel behind `hamming_batch_u64` takes a fixed number of targets per
+    /// chunk and finishes the rest in a remainder loop: 4 for
+    /// `hamming_batch_avx2`, 8 for `hamming_batch_avx512` and for the unrolled
+    /// scalar fallback.
+    ///
+    /// Those loops do run today, but only through the pairwise tests, whose row
+    /// sweep passes every width from `n - 1` down to 1 and so covers every
+    /// residue incidentally. A tail bug surfaces there as a mismatch somewhere
+    /// among hundreds of thousands of pairs. This asserts every slot at each
+    /// width instead.
+    #[rstest]
+    #[case::one(1)]
+    #[case::two(2)]
+    #[case::three(3)]
+    #[case::four(4)]
+    #[case::five(5)]
+    #[case::six(6)]
+    #[case::seven(7)]
+    #[case::eight(8)]
+    #[case::nine(9)]
+    #[case::fifteen(15)]
+    #[case::sixteen(16)]
+    #[case::seventeen(17)]
+    #[case::one_hundred_twenty_eight(128)]
+    fn test_hamming_batch_u64(#[case] n: usize) {
+        check_kernel_tail(n, hamming_batch_u64);
     }
 
     #[rstest]
@@ -1746,6 +1791,33 @@ mod tests {
     // =========================================================================
     // SIMD-specific tests
     // =========================================================================
+
+    // `hamming_batch_simd` returns early on the AVX-512 branch when
+    // `avx512vpopcntdq` and `avx512f` are both present, so on a VPOPCNTDQ host
+    // nothing reaches `hamming_batch_avx2` through `hamming_batch_u64`. This
+    // calls it directly. The AVX-512 kernel needs no such test: it only runs
+    // where the dispatched test already drives it, over a wider set of widths.
+
+    /// `hamming_batch_avx2` consumes 4 targets per chunk, so `n % 4` covers its
+    /// remainder loop.
+    #[rstest]
+    #[cfg(target_arch = "x86_64")]
+    #[case::one(1)]
+    #[case::two(2)]
+    #[case::three(3)]
+    #[case::four(4)]
+    #[case::five(5)]
+    #[case::seven(7)]
+    fn test_avx2_covers_tail(#[case] n: usize) {
+        if !is_x86_feature_detected!("avx2") {
+            return;
+        }
+        check_kernel_tail(n, |query, targets, results| {
+            // SAFETY: AVX2 was just detected, and `check_kernel_tail` passes a
+            // `results` of exactly `targets.len()`.
+            unsafe { hamming_batch_avx2(query, targets, results) }
+        });
+    }
 
     #[test]
     #[cfg(target_arch = "x86_64")]

--- a/rust/lance-linalg/src/distance/hamming.rs
+++ b/rust/lance-linalg/src/distance/hamming.rs
@@ -1153,10 +1153,9 @@ mod tests {
     /// handed, then checks every value and every guard.
     ///
     /// 8 is the widest chunk store in the file, so one extra chunk iteration
-    /// lands inside this allocation rather than on unrelated memory. Two extra
-    /// iterations would still escape it. The remainder loops cannot trip the
-    /// guards at all: all three index through bounds-checked `results[..]` and
-    /// would panic instead.
+    /// lands inside this allocation rather than on unrelated memory. The
+    /// remainder loops cannot trip the guards at all: all three index through
+    /// bounds-checked `results[..]` and would panic instead.
     fn check_kernel_tail(n: usize, kernel: impl FnOnce(u64, &[u64], &mut [u32])) {
         const GUARD: u32 = u32::MAX;
         const GUARD_SLOTS: usize = 8;
@@ -1206,6 +1205,10 @@ mod tests {
     #[case::one_hundred_twenty_eight(128)]
     fn test_hamming_batch_u64(#[case] n: usize) {
         check_kernel_tail(n, hamming_batch_u64);
+        // Also directly, because on an x86_64 host with AVX2 the dispatcher never
+        // reaches the scalar kernel, and that is the host every Linux x86 job runs
+        // on.
+        check_kernel_tail(n, hamming_batch_scalar);
     }
 
     #[rstest]


### PR DESCRIPTION
## What this changes

Replaces `test_hamming_batch_u64` with an `rstest` over 13 widths that asserts every output slot, drives the scalar kernel directly alongside the dispatcher, and adds a direct test for `hamming_batch_avx2`'s remainder loop. Tests only.

## Why

The pairwise tests already reach the dispatched kernel's remainder loop, but only the ones big enough to take a parallel path: the sequential functions are per-pair `hamming_u64` loops, and at or above the 10,000-pair cutoff the parallel paths call `process_row_range` or `process_row_range_binary`, which hand `hamming_batch_u64` a tail of width `n - i - 1` starting at `i + 1`, where `n` there is the row count, per lane in the binary case. Their row ranges together cover every width from one below the row count down to 1. On this aarch64 host, where the dispatcher selects the scalar kernel, replacing that kernel's remainder loop with `while false` fails 3 existing tests in this crate's lib suite against `upstream/main`, and changing the scalar kernel's `chunks = n / 8` to `n.div_ceil(8)` fails 5; the same line appears in the AVX-512 kernel, which is not the one mutated here. On an AVX2 host neither mutation can fail anything: the dispatcher takes an earlier branch, and on `upstream/main` nothing calls `hamming_batch_scalar` directly. That is one of the two gaps below.

So what this buys is two narrower things.

Per-width, per-slot assertions. The old test used `n = 128` and checked 4 of 128 slots against hardcoded values. This asserts every slot at each of 13 widths against `(query ^ target).count_ones()`. The scalar kernel gets that regardless of dispatch, since the sweep calls it directly, and `test_avx2_covers_tail` does the same for AVX2 where the guard passes; the AVX-512 kernel is asserted only where the host dispatches it.

Two kernels a host can run but the dispatcher skips. `hamming_batch_simd` takes the AVX-512 branch when `avx512vpopcntdq` and `avx512f` are both present, so on a host with both nothing reaches `hamming_batch_avx2` through `hamming_batch_u64`. Before this change `hamming_batch_avx2`'s only other callers were `test_avx2_popcount` at `n = 8` and `test_avx2_max_distance` at `n = 4`, both chunk-exact, so on such a host the AVX2 remainder loop was executed by no test at all. `test_avx2_covers_tail` closes that.

The same shape one feature level down hides the scalar kernel: an x86_64 host with AVX2 takes an earlier branch, so whether the sweep's dispatched call reaches the unrolled scalar body depends on which job it runs in. The sweep now calls `hamming_batch_scalar` directly as well, which takes the host out of it.

## What the helper does

`check_kernel_tail` allocates `n + 8` output slots, hands the kernel only `&mut results[..n]`, checks every value against `(query ^ target).count_ones()`, and checks the 8 guard slots. 8 is the widest unchecked chunk store in the file, `_mm256_storeu_si256` in the AVX-512 kernel, so an unchecked chunk store that overruns by one chunk lands inside the allocation instead of past it. Everything else writes through bounds-checked `results[..]`, the scalar kernel's chunk loop and all three remainder loops, so those panic instead of reaching the guards.

Query and target values are `0xDEAD_BEEF_CAFE_F00D` against golden-ratio multiples, rather than the old `query = 0` with `targets = 0..128`. Two things the old data could not catch. Every old target was under 0x80, so seven of the eight byte positions never contributed a set bit. And a query of zero makes a broadcast bug invisible: `_mm256_set1_epi32` where the kernel wants `_mm256_set1_epi64x` gives the same answer for a zero query and a different one here: the two halves have different popcounts, 24 against 18, so at any width the chunk loop reaches, the `i = 0` target alone is enough to show it: 36 instead of 42.

On the four literal expectations the old test made: the sweep's oracle is `(query ^ target).count_ones()`, which is the same expression the kernels' remainder loops use, so for the scalar path it compares the code against the formula rather than against a known number. Several tests still pin that formula against literals, `test_hamming` and `test_hamming_u64` among them, but none of them reaches `hamming_batch_u64`. Literal counts through a batch kernel survive only on an x86 host that detects the feature, in `test_avx2_popcount`, `test_avx2_max_distance` and `test_avx512_popcount`, and literal-pinned lane order only in the two that expect a different count in each slot, `test_avx2_popcount` and `test_avx512_popcount`. No test pins the scalar kernel's output to a literal count.

## Test plan

- `cargo test --profile ci -p lance-linalg --lib distance::hamming`: 56 passed on aarch64, 66 on `x86_64-apple-darwin`
- `cargo clippy -p lance-linalg --all-targets -- -D warnings` and the same for `--target x86_64-apple-darwin`: clean
- `cargo fmt --all -- --check`: clean
- Mutation, on the scalar kernel because it is the one this host runs: dropping the last element from its remainder loop fails all ten widths that are not multiples of 8 and leaves 8, 16 and 128 green

Found while writing this, and out of scope here: `process_row_range_binary`'s per-lane accumulation is pinned by no test. Zeroing it leaves lance-linalg's lib suite green, because the only test that reaches that function repeats the same second lane in both rows of every near-duplicate pair, so the second lane never decides a pair. Only the sequential twin's accumulation is pinned, by `test_pairwise_binary_hashes_32_with_row_ids`.

Not covered: this machine is aarch64 and the x86_64 target runs under Rosetta, which reports no AVX2, so `test_avx2_covers_tail` compiles and runs on the `x86_64-apple-darwin` target here but skips the kernel behind its runtime guard; the kernel body first runs wherever the guard passes, which in `rust.yml` is `linux-build` and `windows-build` detecting AVX2 at runtime on hardware the repository does not choose, and outside it the nightly `daily-code-coverage.yml`, which runs the workspace on x86_64 with `RUSTFLAGS` set the same way. `.cargo/config.toml`'s `+avx2` would make that guard compile-time true instead, but `linux-build` sets `RUSTFLAGS` and displaces it, and no config entry covers the Windows triple. The AVX-512 kernel gets no direct tail test because it would add nothing: wherever that kernel runs, the dispatched sweep already drives it over 13 widths. A direct one would be one more runtime-guarded test, and nothing here guarantees a runner that would execute it. `qemu-pre-haswell` sets `RUSTFLAGS: -C target-cpu=x86-64-v2`, which displaces the `+avx2` default `.cargo/config.toml` gives that triple, and runs the binary under `qemu-x86_64 -cpu Nehalem`. Both halves matter: without the `RUSTFLAGS` override `is_x86_feature_detected!("avx2")` is true at compile time and no AVX2 guard skips. The config enables no AVX-512 feature, so those guards resolve at runtime and skip either way. With them, every AVX2 and AVX-512 guard skips and the dispatcher takes the scalar path.
























