### PR TITLE
fix(linalg): enforce the cosine length contract

### DIFF
--- a/rust/lance-linalg/src/distance/cosine.rs
+++ b/rust/lance-linalg/src/distance/cosine.rs
@@ -1453,8 +1453,8 @@ mod tests {
         assert!(message.contains(expected), "f64: {message}");
     }
 
-    /// Returns the panic message, so a case pins which contract was violated
-    /// rather than passing on any panic from the same call.
+    /// Returns the panic message, so a case can assert which contract was
+    /// violated instead of accepting any panic from the same call.
     fn panic_message(f: impl FnOnce() + std::panic::UnwindSafe) -> String {
         let payload = std::panic::catch_unwind(f).expect_err("expected a panic");
         payload
@@ -1480,37 +1480,62 @@ mod tests {
 
     /// A mismatch has to stop at the boundary rather than reach a kernel that
     /// takes one length and reads both vectors with it.
+    ///
+    /// The f32 and f64 cases assert both lengths, not just the contract. Without
+    /// the entry assert an f32 kernel reaches `dot` on its scalar tail, and `dot`
+    /// reports the tail lengths instead of these.
     #[test]
     fn cosine_rejects_mismatched_lengths() {
         let long_f32 = [1.0f32; 16];
         let short_f32 = [1.0f32; 15];
-        for message in [
-            panic_message(|| {
-                f32::cosine_fast(&long_f32, 1.0, &short_f32);
-            }),
-            panic_message(|| {
-                f32::cosine_fast(&short_f32, 1.0, &long_f32);
-            }),
-            panic_message(|| {
-                f32::cosine_with_norms(&long_f32, 1.0, 1.0, &short_f32);
-            }),
+        for (message, expected) in [
+            (
+                panic_message(|| {
+                    f32::cosine_fast(&long_f32, 1.0, &short_f32);
+                }),
+                "left=16, right=15",
+            ),
+            (
+                panic_message(|| {
+                    f32::cosine_fast(&short_f32, 1.0, &long_f32);
+                }),
+                "left=15, right=16",
+            ),
+            (
+                panic_message(|| {
+                    f32::cosine_with_norms(&long_f32, 1.0, 1.0, &short_f32);
+                }),
+                "left=16, right=15",
+            ),
         ] {
             assert!(message.contains("equal lengths"), "f32: {message}");
+            assert!(message.contains(expected), "f32: {message}");
         }
 
         let long_f64 = [1.0f64; 16];
         let short_f64 = [1.0f64; 15];
-        for message in [
-            panic_message(|| {
-                f64::cosine_fast(&long_f64, 1.0, &short_f64);
-            }),
-            panic_message(|| {
-                f64::cosine_fast(&short_f64, 1.0, &long_f64);
-            }),
+        for (message, expected) in [
+            (
+                panic_message(|| {
+                    f64::cosine_fast(&long_f64, 1.0, &short_f64);
+                }),
+                "left=16, right=15",
+            ),
+            (
+                panic_message(|| {
+                    f64::cosine_fast(&short_f64, 1.0, &long_f64);
+                }),
+                "left=15, right=16",
+            ),
         ] {
             assert!(message.contains("equal lengths"), "f64: {message}");
+            assert!(message.contains(expected), "f64: {message}");
         }
 
+        // Half precision asserts the contract only, not where it was enforced.
+        // With `fp16kernels` off, which is the default, `cosine_fast` here is
+        // `cosine_scalar`, and that hands `dot` the same two slices, so the entry
+        // assert and `dot`'s produce the same message.
         let long_f16 = [f16::from_f32(1.0); 16];
         let short_f16 = [f16::from_f32(1.0); 15];
         let long_bf16 = [bf16::from_f32(1.0); 16];

--- a/rust/lance-linalg/src/distance/cosine.rs
+++ b/rust/lance-linalg/src/distance/cosine.rs
@@ -1453,8 +1453,8 @@ mod tests {
         assert!(message.contains(expected), "f64: {message}");
     }
 
-    /// Returns the panic message, so a case pins the assert that fired rather
-    /// than passing on any panic from the same call.
+    /// Returns the panic message, so a case pins which contract was violated
+    /// rather than passing on any panic from the same call.
     fn panic_message(f: impl FnOnce() + std::panic::UnwindSafe) -> String {
         let payload = std::panic::catch_unwind(f).expect_err("expected a panic");
         payload
@@ -1511,8 +1511,6 @@ mod tests {
             assert!(message.contains("equal lengths"), "f64: {message}");
         }
 
-        // Both directions, because the kernels take `y.len()` and read `x` with
-        // it, so a short `x` is the operand that reads out of bounds.
         let long_f16 = [f16::from_f32(1.0); 16];
         let short_f16 = [f16::from_f32(1.0); 15];
         let long_bf16 = [bf16::from_f32(1.0); 16];

--- a/rust/lance-linalg/src/distance/cosine.rs
+++ b/rust/lance-linalg/src/distance/cosine.rs
@@ -1480,7 +1480,13 @@ mod tests {
 
     /// A mismatch has to stop at the boundary rather than reach a kernel that
     /// takes one length and reads both vectors with it. The lengths are 16 and 15
-    /// so the wider loops run instead of only a scalar remainder.
+    /// so a dispatch tier with wide loops enters one.
+    ///
+    /// Which construct reports the mismatch depends on the build. Where no SIMD
+    /// arm is compiled or dispatched, these calls reach `cosine_scalar` and
+    /// `dot` rejects the pair first with the same message: for f16 and bf16 that
+    /// is any build without `fp16kernels`, and for f32 and f64 any host below the
+    /// `Avx` tier.
     #[test]
     fn cosine_rejects_mismatched_lengths() {
         let long_f32 = [1.0f32; 16];
@@ -1512,11 +1518,8 @@ mod tests {
             assert!(message.contains("equal lengths"), "f64: {message}");
         }
 
-        // Both directions for f16 and bf16. With `fp16kernels` on, the kernels
-        // take `y.len()` and read `x` with it, so a short `x` is the operand that
-        // reads out of bounds and these two asserts are what stops it. Without
-        // the feature these arms reach `cosine_scalar`, where `dot` rejects the
-        // pair first and produces the same message.
+        // Both directions, because the kernels take `y.len()` and read `x` with
+        // it, so a short `x` is the operand that reads out of bounds.
         let long_f16 = [f16::from_f32(1.0); 16];
         let short_f16 = [f16::from_f32(1.0); 15];
         let long_bf16 = [bf16::from_f32(1.0); 16];

--- a/rust/lance-linalg/src/distance/cosine.rs
+++ b/rust/lance-linalg/src/distance/cosine.rs
@@ -109,8 +109,6 @@ mod bf16_kernel {
 
 impl Cosine for bf16 {
     fn cosine_fast(x: &[Self], x_norm: f32, y: &[Self]) -> f32 {
-        // The kernels below take one length and read both vectors with it
-        // through raw pointers, so this is the only bound on either read.
         assert_equal_lengths(x.len(), y.len());
         match *SIMD_SUPPORT {
             #[cfg(all(feature = "fp16kernels", target_arch = "aarch64"))]
@@ -168,8 +166,6 @@ mod kernel {
 
 impl Cosine for f16 {
     fn cosine_fast(x: &[Self], x_norm: f32, y: &[Self]) -> f32 {
-        // The kernels below take one length and read both vectors with it
-        // through raw pointers, so this is the only bound on either read.
         assert_equal_lengths(x.len(), y.len());
         match *SIMD_SUPPORT {
             #[cfg(all(feature = "fp16kernels", target_arch = "aarch64"))]
@@ -572,8 +568,6 @@ mod f32_baseline {
 impl Cosine for f32 {
     #[inline]
     fn cosine_fast(x: &[Self], x_norm: Self, other: &[Self]) -> f32 {
-        // The kernels behind this dispatch derive their loop bound from one
-        // vector and offset a raw pointer into the other.
         assert_equal_lengths(x.len(), other.len());
         // Trait methods cannot carry `#[target_feature]` attributes, so the body
         // lives in a free function that runtime-dispatches via `*SIMD_SUPPORT`
@@ -595,8 +589,6 @@ impl Cosine for f32 {
         batch: &'a [Self],
         dimension: usize,
     ) -> Box<dyn Iterator<Item = f32> + 'a> {
-        // Every branch below reaches a kernel that takes `dimension` as its
-        // stride and offsets a raw pointer into `x` with it.
         assert_batch_layout(x.len(), batch.len(), dimension);
         let x_norm = norm_l2(x);
 
@@ -855,8 +847,6 @@ impl ExactSizeIterator for CosineBatchIter<'_> {
 impl Cosine for f64 {
     #[inline]
     fn cosine_fast(x: &[Self], x_norm: f32, y: &[Self]) -> f32 {
-        // The kernels behind this dispatch derive their loop bound from one
-        // vector and offset a raw pointer into the other.
         assert_equal_lengths(x.len(), y.len());
         // Trait methods cannot carry `#[target_feature]` attributes, so the body
         // lives in a free function that runtime-dispatches via `*SIMD_SUPPORT`
@@ -1436,8 +1426,7 @@ mod tests {
     /// `cosine_batch` takes `dimension` as the stride for both operands, so a
     /// key that does not match it, or a batch that is not a whole number of
     /// vectors, has to stop at the boundary. Covers the trait default through
-    /// `f64` and the `f32` override, including the fixed dimensions 8 and 16 that
-    /// the override special-cases.
+    /// `f64` and the `f32` override.
     #[rstest::rstest]
     #[case::key_longer_than_dimension(32, 64, 16)]
     #[case::key_shorter_than_dimension(8, 64, 16)]
@@ -1471,9 +1460,8 @@ mod tests {
     /// reads both vectors with it, so a mismatch has to stop at the boundary
     /// rather than read past the shorter one.
     ///
-    /// The lengths are 16 and 15 because the f32 and f64 kernels step 16 and 8
-    /// elements at a time through raw pointers: a pair too short for one full
-    /// step never enters the loop that does the reading.
+    /// The lengths are 16 and 15 so both directions enter a vector loop rather
+    /// than only its scalar remainder.
     #[test]
     fn cosine_rejects_mismatched_lengths() {
         let long_f32 = [1.0f32; 16];
@@ -1489,18 +1477,20 @@ mod tests {
         let short_f64 = [1.0f64; 15];
         assert!(std::panic::catch_unwind(|| f64::cosine_fast(&long_f64, 1.0, &short_f64)).is_err());
 
+        // Both directions for f16 and bf16: the kernels take `y.len()` and read
+        // `x` with it, so a short `x` is the one that reads out of bounds.
         let long_f16 = [f16::from_f32(1.0); 16];
         let short_f16 = [f16::from_f32(1.0); 15];
         assert!(std::panic::catch_unwind(|| f16::cosine_fast(&long_f16, 1.0, &short_f16)).is_err());
+        assert!(std::panic::catch_unwind(|| f16::cosine_fast(&short_f16, 1.0, &long_f16)).is_err());
 
-        let long_bf16 = [
-            bf16::from_f32(1.0),
-            bf16::from_f32(2.0),
-            bf16::from_f32(3.0),
-        ];
-        let short_bf16 = [bf16::from_f32(1.0), bf16::from_f32(2.0)];
+        let long_bf16 = [bf16::from_f32(1.0); 16];
+        let short_bf16 = [bf16::from_f32(1.0); 15];
         assert!(
             std::panic::catch_unwind(|| bf16::cosine_fast(&long_bf16, 1.0, &short_bf16)).is_err()
+        );
+        assert!(
+            std::panic::catch_unwind(|| bf16::cosine_fast(&short_bf16, 1.0, &long_bf16)).is_err()
         );
     }
 

--- a/rust/lance-linalg/src/distance/cosine.rs
+++ b/rust/lance-linalg/src/distance/cosine.rs
@@ -1481,10 +1481,8 @@ mod tests {
     /// A mismatch has to stop at the boundary rather than reach a kernel that
     /// takes one length and reads both vectors with it.
     ///
-    /// The f32 and f64 cases assert both lengths rather than just `equal lengths`,
-    /// because `dot` carries that same message. Where a kernel hands `dot` only a
-    /// scalar tail the two lengths differ from these, and that is what separates
-    /// the entry assert from `dot`'s.
+    /// The f32 and f64 cases assert the two lengths as well as `equal lengths`,
+    /// because `dot` emits that same message on some paths.
     #[test]
     fn cosine_rejects_mismatched_lengths() {
         let long_f32 = [1.0f32; 16];

--- a/rust/lance-linalg/src/distance/cosine.rs
+++ b/rust/lance-linalg/src/distance/cosine.rs
@@ -1424,9 +1424,9 @@ mod tests {
     use num_traits::AsPrimitive;
     use proptest::prelude::*;
 
-    /// A key that does not match `dimension`, or a batch that is not a whole
-    /// number of vectors, has to stop at the boundary. Covers the trait default
-    /// through `f64` and the `f32` override.
+    /// A key that does not match `dimension`, a batch that is not a whole number
+    /// of vectors, or a zero `dimension`, has to stop at the boundary. Covers the
+    /// trait default through `f64` and the `f32` override.
     #[rstest::rstest]
     #[case::key_longer_than_dimension(32, 64, 16, "must match dimension")]
     #[case::key_shorter_than_dimension(8, 64, 16, "must match dimension")]
@@ -1464,10 +1464,10 @@ mod tests {
             .unwrap_or_default()
     }
 
-    /// The free functions are the surface most callers reach, so pin them too
-    /// rather than only the trait methods they forward to.
+    /// `DistanceType::func()` hands out `cosine_distance`, so pin the free
+    /// function too rather than only the trait method it forwards to.
     #[test]
-    fn cosine_free_functions_reject_bad_input() {
+    fn cosine_distance_rejects_mismatched_lengths() {
         let long = [1.0f32; 16];
         let short = [1.0f32; 15];
         assert!(
@@ -1481,8 +1481,10 @@ mod tests {
     /// A mismatch has to stop at the boundary rather than reach a kernel that
     /// takes one length and reads both vectors with it.
     ///
-    /// The f32 and f64 cases assert the two lengths as well as `equal lengths`,
-    /// because `dot` emits that same message on some paths.
+    /// The f32 cases assert the two lengths as well as `equal lengths`, because
+    /// an f32 kernel tail hands `dot` a shorter pair and `dot` emits the same
+    /// message with different numbers. The f64 cases assert them too, where the
+    /// numbers are redundant, since no f64 tail calls `dot`.
     #[test]
     fn cosine_rejects_mismatched_lengths() {
         let long_f32 = [1.0f32; 16];
@@ -1532,9 +1534,9 @@ mod tests {
         }
 
         // Half precision asserts the contract only, not where it was enforced.
-        // With `fp16kernels` off, which is the default, `cosine_fast` here is
-        // `cosine_scalar`, and that hands `dot` the same two slices, so the entry
-        // assert and `dot`'s produce the same message.
+        // With `fp16kernels` off, which is the default, `cosine_fast` here routes
+        // to `cosine_scalar`, and that hands `dot` the same two slices, so the
+        // entry assert and `dot`'s produce the same message.
         let long_f16 = [f16::from_f32(1.0); 16];
         let short_f16 = [f16::from_f32(1.0); 15];
         let long_bf16 = [bf16::from_f32(1.0); 16];

--- a/rust/lance-linalg/src/distance/cosine.rs
+++ b/rust/lance-linalg/src/distance/cosine.rs
@@ -1479,14 +1479,7 @@ mod tests {
     }
 
     /// A mismatch has to stop at the boundary rather than reach a kernel that
-    /// takes one length and reads both vectors with it. The lengths are 16 and 15
-    /// so a dispatch tier with wide loops enters one.
-    ///
-    /// Which construct reports the mismatch depends on the build. Where no SIMD
-    /// arm is compiled or dispatched, these calls reach `cosine_scalar` and
-    /// `dot` rejects the pair first with the same message: for f16 and bf16 that
-    /// is any build without `fp16kernels`, and for f32 and f64 any host below the
-    /// `Avx` tier.
+    /// takes one length and reads both vectors with it.
     #[test]
     fn cosine_rejects_mismatched_lengths() {
         let long_f32 = [1.0f32; 16];

--- a/rust/lance-linalg/src/distance/cosine.rs
+++ b/rust/lance-linalg/src/distance/cosine.rs
@@ -1481,9 +1481,10 @@ mod tests {
     /// A mismatch has to stop at the boundary rather than reach a kernel that
     /// takes one length and reads both vectors with it.
     ///
-    /// The f32 and f64 cases assert both lengths, not just the contract. Without
-    /// the entry assert an f32 kernel reaches `dot` on its scalar tail, and `dot`
-    /// reports the tail lengths instead of these.
+    /// The f32 and f64 cases assert both lengths rather than just `equal lengths`,
+    /// because `dot` carries that same message. Where a kernel hands `dot` only a
+    /// scalar tail the two lengths differ from these, and that is what separates
+    /// the entry assert from `dot`'s.
     #[test]
     fn cosine_rejects_mismatched_lengths() {
         let long_f32 = [1.0f32; 16];

--- a/rust/lance-linalg/src/distance/cosine.rs
+++ b/rust/lance-linalg/src/distance/cosine.rs
@@ -1428,30 +1428,40 @@ mod tests {
     /// number of vectors, has to stop at the boundary. Covers the trait default
     /// through `f64` and the `f32` override.
     #[rstest::rstest]
-    #[case::key_longer_than_dimension(32, 64, 16)]
-    #[case::key_shorter_than_dimension(8, 64, 16)]
-    #[case::batch_remainder(16, 63, 16)]
-    #[case::zero_dimension(16, 64, 0)]
+    #[case::key_longer_than_dimension(32, 64, 16, "must match dimension")]
+    #[case::key_shorter_than_dimension(8, 64, 16, "must match dimension")]
+    #[case::batch_remainder(16, 63, 16, "divisible by dimension")]
+    #[case::zero_dimension(16, 64, 0, "greater than zero")]
     fn cosine_batch_rejects_bad_layout(
         #[case] key_len: usize,
         #[case] batch_len: usize,
         #[case] dimension: usize,
+        #[case] expected: &str,
     ) {
         let key = vec![1.0f32; key_len];
         let batch = vec![1.0f32; batch_len];
-        assert!(
-            std::panic::catch_unwind(|| cosine_distance_batch(&key, &batch, dimension).count())
-                .is_err(),
-            "f32 accepted key={key_len} batch={batch_len} dimension={dimension}"
-        );
+        let message = panic_message(|| {
+            cosine_distance_batch(&key, &batch, dimension).count();
+        });
+        assert!(message.contains(expected), "f32: {message}");
 
         let key = vec![1.0f64; key_len];
         let batch = vec![1.0f64; batch_len];
-        assert!(
-            std::panic::catch_unwind(|| cosine_distance_batch(&key, &batch, dimension).count())
-                .is_err(),
-            "f64 accepted key={key_len} batch={batch_len} dimension={dimension}"
-        );
+        let message = panic_message(|| {
+            cosine_distance_batch(&key, &batch, dimension).count();
+        });
+        assert!(message.contains(expected), "f64: {message}");
+    }
+
+    /// Returns the panic message, so a case pins the assert that fired rather
+    /// than passing on any panic from the same call.
+    fn panic_message(f: impl FnOnce() + std::panic::UnwindSafe) -> String {
+        let payload = std::panic::catch_unwind(f).expect_err("expected a panic");
+        payload
+            .downcast_ref::<String>()
+            .cloned()
+            .or_else(|| payload.downcast_ref::<&str>().map(|s| (*s).to_owned()))
+            .unwrap_or_default()
     }
 
     /// The free functions are the surface most callers reach, so pin them too
@@ -1460,9 +1470,11 @@ mod tests {
     fn cosine_free_functions_reject_bad_input() {
         let long = [1.0f32; 16];
         let short = [1.0f32; 15];
-        assert!(std::panic::catch_unwind(|| cosine_distance(&long, &short)).is_err());
         assert!(
-            std::panic::catch_unwind(|| cosine_distance_batch(&long, &short, 16).count()).is_err()
+            panic_message(|| {
+                cosine_distance(&long, &short);
+            })
+            .contains("equal lengths")
         );
     }
 
@@ -1473,33 +1485,55 @@ mod tests {
     fn cosine_rejects_mismatched_lengths() {
         let long_f32 = [1.0f32; 16];
         let short_f32 = [1.0f32; 15];
-        assert!(std::panic::catch_unwind(|| f32::cosine_fast(&long_f32, 1.0, &short_f32)).is_err());
-        assert!(std::panic::catch_unwind(|| f32::cosine_fast(&short_f32, 1.0, &long_f32)).is_err());
-        assert!(
-            std::panic::catch_unwind(|| f32::cosine_with_norms(&long_f32, 1.0, 1.0, &short_f32))
-                .is_err()
-        );
+        for message in [
+            panic_message(|| {
+                f32::cosine_fast(&long_f32, 1.0, &short_f32);
+            }),
+            panic_message(|| {
+                f32::cosine_fast(&short_f32, 1.0, &long_f32);
+            }),
+            panic_message(|| {
+                f32::cosine_with_norms(&long_f32, 1.0, 1.0, &short_f32);
+            }),
+        ] {
+            assert!(message.contains("equal lengths"), "f32: {message}");
+        }
 
         let long_f64 = [1.0f64; 16];
         let short_f64 = [1.0f64; 15];
-        assert!(std::panic::catch_unwind(|| f64::cosine_fast(&long_f64, 1.0, &short_f64)).is_err());
-        assert!(std::panic::catch_unwind(|| f64::cosine_fast(&short_f64, 1.0, &long_f64)).is_err());
+        for message in [
+            panic_message(|| {
+                f64::cosine_fast(&long_f64, 1.0, &short_f64);
+            }),
+            panic_message(|| {
+                f64::cosine_fast(&short_f64, 1.0, &long_f64);
+            }),
+        ] {
+            assert!(message.contains("equal lengths"), "f64: {message}");
+        }
 
         // Both directions for f16 and bf16: the kernels take `y.len()` and read
         // `x` with it, so a short `x` is the one that reads out of bounds.
         let long_f16 = [f16::from_f32(1.0); 16];
         let short_f16 = [f16::from_f32(1.0); 15];
-        assert!(std::panic::catch_unwind(|| f16::cosine_fast(&long_f16, 1.0, &short_f16)).is_err());
-        assert!(std::panic::catch_unwind(|| f16::cosine_fast(&short_f16, 1.0, &long_f16)).is_err());
-
         let long_bf16 = [bf16::from_f32(1.0); 16];
         let short_bf16 = [bf16::from_f32(1.0); 15];
-        assert!(
-            std::panic::catch_unwind(|| bf16::cosine_fast(&long_bf16, 1.0, &short_bf16)).is_err()
-        );
-        assert!(
-            std::panic::catch_unwind(|| bf16::cosine_fast(&short_bf16, 1.0, &long_bf16)).is_err()
-        );
+        for message in [
+            panic_message(|| {
+                f16::cosine_fast(&long_f16, 1.0, &short_f16);
+            }),
+            panic_message(|| {
+                f16::cosine_fast(&short_f16, 1.0, &long_f16);
+            }),
+            panic_message(|| {
+                bf16::cosine_fast(&long_bf16, 1.0, &short_bf16);
+            }),
+            panic_message(|| {
+                bf16::cosine_fast(&short_bf16, 1.0, &long_bf16);
+            }),
+        ] {
+            assert!(message.contains("equal lengths"), "half: {message}");
+        }
     }
 
     fn cosine_dist_brute_force(x: &[f32], y: &[f32]) -> f32 {

--- a/rust/lance-linalg/src/distance/cosine.rs
+++ b/rust/lance-linalg/src/distance/cosine.rs
@@ -24,7 +24,7 @@ use lance_arrow::{ArrowFloatType, FixedSizeListArrayExt, FloatArray};
 #[allow(unused_imports)]
 use lance_core::utils::cpu::{SIMD_SUPPORT, SimdSupport};
 
-use super::{Dot, norm_l2::norm_l2};
+use super::{Dot, assert_equal_lengths, norm_l2::norm_l2};
 use super::{Normalize, dot::dot};
 #[cfg(all(target_arch = "x86_64", not(target_feature = "avx2")))]
 use crate::distance::BatchKind;
@@ -108,6 +108,9 @@ mod bf16_kernel {
 
 impl Cosine for bf16 {
     fn cosine_fast(x: &[Self], x_norm: f32, y: &[Self]) -> f32 {
+        // The kernels below take one length and read both vectors with it
+        // through raw pointers, so this is the only bound on either read.
+        assert_equal_lengths(x.len(), y.len());
         match *SIMD_SUPPORT {
             #[cfg(all(feature = "fp16kernels", target_arch = "aarch64"))]
             SimdSupport::Neon => unsafe {
@@ -164,6 +167,9 @@ mod kernel {
 
 impl Cosine for f16 {
     fn cosine_fast(x: &[Self], x_norm: f32, y: &[Self]) -> f32 {
+        // The kernels below take one length and read both vectors with it
+        // through raw pointers, so this is the only bound on either read.
+        assert_equal_lengths(x.len(), y.len());
         match *SIMD_SUPPORT {
             #[cfg(all(feature = "fp16kernels", target_arch = "aarch64"))]
             SimdSupport::Neon => unsafe {
@@ -565,6 +571,9 @@ mod f32_baseline {
 impl Cosine for f32 {
     #[inline]
     fn cosine_fast(x: &[Self], x_norm: Self, other: &[Self]) -> f32 {
+        // The kernels behind this dispatch derive their loop bound from one
+        // vector and offset a raw pointer into the other.
+        assert_equal_lengths(x.len(), other.len());
         // Trait methods cannot carry `#[target_feature]` attributes, so the body
         // lives in a free function that runtime-dispatches via `*SIMD_SUPPORT`
         // to an AVX2 inner kernel on capable hosts, or a portable scalar fallback.
@@ -573,6 +582,7 @@ impl Cosine for f32 {
 
     #[inline]
     fn cosine_with_norms(x: &[Self], x_norm: Self, y_norm: Self, y: &[Self]) -> Self {
+        assert_equal_lengths(x.len(), y.len());
         // Trait methods cannot carry `#[target_feature]` attributes, so the body
         // lives in a free function that runtime-dispatches via `*SIMD_SUPPORT`
         // to an AVX2 inner kernel on capable hosts, or a portable scalar fallback.
@@ -844,6 +854,9 @@ impl ExactSizeIterator for CosineBatchIter<'_> {
 impl Cosine for f64 {
     #[inline]
     fn cosine_fast(x: &[Self], x_norm: f32, y: &[Self]) -> f32 {
+        // The kernels behind this dispatch derive their loop bound from one
+        // vector and offset a raw pointer into the other.
+        assert_equal_lengths(x.len(), y.len());
         // Trait methods cannot carry `#[target_feature]` attributes, so the body
         // lives in a free function that runtime-dispatches via `*SIMD_SUPPORT`
         // to an AVX2 inner kernel on capable hosts, or a portable scalar fallback.
@@ -1418,6 +1431,43 @@ mod tests {
     use approx::assert_relative_eq;
     use num_traits::AsPrimitive;
     use proptest::prelude::*;
+
+    /// Every `cosine_fast` override reaches a kernel that takes one length and
+    /// reads both vectors with it, so a mismatch has to stop at the boundary
+    /// rather than read past the shorter one.
+    ///
+    /// The lengths are 16 and 15 because the f32 and f64 kernels step 16 and 8
+    /// elements at a time through raw pointers: a pair too short for one full
+    /// step never enters the loop that does the reading.
+    #[test]
+    fn cosine_rejects_mismatched_lengths() {
+        let long_f32 = [1.0f32; 16];
+        let short_f32 = [1.0f32; 15];
+        assert!(std::panic::catch_unwind(|| f32::cosine_fast(&long_f32, 1.0, &short_f32)).is_err());
+        assert!(std::panic::catch_unwind(|| f32::cosine_fast(&short_f32, 1.0, &long_f32)).is_err());
+        assert!(
+            std::panic::catch_unwind(|| f32::cosine_with_norms(&long_f32, 1.0, 1.0, &short_f32))
+                .is_err()
+        );
+
+        let long_f64 = [1.0f64; 16];
+        let short_f64 = [1.0f64; 15];
+        assert!(std::panic::catch_unwind(|| f64::cosine_fast(&long_f64, 1.0, &short_f64)).is_err());
+
+        let long_f16 = [f16::from_f32(1.0); 16];
+        let short_f16 = [f16::from_f32(1.0); 15];
+        assert!(std::panic::catch_unwind(|| f16::cosine_fast(&long_f16, 1.0, &short_f16)).is_err());
+
+        let long_bf16 = [
+            bf16::from_f32(1.0),
+            bf16::from_f32(2.0),
+            bf16::from_f32(3.0),
+        ];
+        let short_bf16 = [bf16::from_f32(1.0), bf16::from_f32(2.0)];
+        assert!(
+            std::panic::catch_unwind(|| bf16::cosine_fast(&long_bf16, 1.0, &short_bf16)).is_err()
+        );
+    }
 
     fn cosine_dist_brute_force(x: &[f32], y: &[f32]) -> f32 {
         let xy = x

--- a/rust/lance-linalg/src/distance/cosine.rs
+++ b/rust/lance-linalg/src/distance/cosine.rs
@@ -639,9 +639,10 @@ impl Cosine for f32 {
         // once per vector without materializing the full batch.
         #[cfg(all(target_arch = "x86_64", not(target_feature = "avx2")))]
         {
-            if dimension == 8 && x.len() >= 8 {
-                // SAFETY: both loads read from the verified eight-element key,
-                // and x86_64 guarantees SSE.
+            if dimension == 8 {
+                // SAFETY: `assert_batch_layout` above established
+                // `x.len() == dimension == 8`, so both loads stay in bounds, and
+                // x86_64 guarantees SSE.
                 return Box::new(unsafe { CosineBatch8Iter::new(x, x_norm, batch) });
             }
 
@@ -1450,6 +1451,18 @@ mod tests {
             std::panic::catch_unwind(|| cosine_distance_batch(&key, &batch, dimension).count())
                 .is_err(),
             "f64 accepted key={key_len} batch={batch_len} dimension={dimension}"
+        );
+    }
+
+    /// The free functions are the surface most callers reach, so pin them too
+    /// rather than only the trait methods they forward to.
+    #[test]
+    fn cosine_free_functions_reject_bad_input() {
+        let long = [1.0f32; 16];
+        let short = [1.0f32; 15];
+        assert!(std::panic::catch_unwind(|| cosine_distance(&long, &short)).is_err());
+        assert!(
+            std::panic::catch_unwind(|| cosine_distance_batch(&long, &short, 16).count()).is_err()
         );
     }
 

--- a/rust/lance-linalg/src/distance/cosine.rs
+++ b/rust/lance-linalg/src/distance/cosine.rs
@@ -1423,17 +1423,14 @@ mod tests {
     use num_traits::AsPrimitive;
     use proptest::prelude::*;
 
-    /// `cosine_batch` takes `dimension` as the stride for both operands, so a
-    /// key that does not match it, or a batch that is not a whole number of
-    /// vectors, has to stop at the boundary. Covers the trait default through
-    /// `f64` and the `f32` override.
+    /// A key that does not match `dimension`, or a batch that is not a whole
+    /// number of vectors, has to stop at the boundary. Covers the trait default
+    /// through `f64` and the `f32` override.
     #[rstest::rstest]
     #[case::key_longer_than_dimension(32, 64, 16)]
     #[case::key_shorter_than_dimension(8, 64, 16)]
     #[case::batch_remainder(16, 63, 16)]
     #[case::zero_dimension(16, 64, 0)]
-    #[case::dim8_key_mismatch(9, 64, 8)]
-    #[case::dim16_key_mismatch(17, 64, 16)]
     fn cosine_batch_rejects_bad_layout(
         #[case] key_len: usize,
         #[case] batch_len: usize,
@@ -1456,12 +1453,9 @@ mod tests {
         );
     }
 
-    /// Every `cosine_fast` override reaches a kernel that takes one length and
-    /// reads both vectors with it, so a mismatch has to stop at the boundary
-    /// rather than read past the shorter one.
-    ///
-    /// The lengths are 16 and 15 so both directions enter a vector loop rather
-    /// than only its scalar remainder.
+    /// A mismatch has to stop at the boundary rather than reach a kernel that
+    /// takes one length and reads both vectors with it. The lengths are 16 and 15
+    /// so the wider loops run instead of only a scalar remainder.
     #[test]
     fn cosine_rejects_mismatched_lengths() {
         let long_f32 = [1.0f32; 16];
@@ -1476,6 +1470,7 @@ mod tests {
         let long_f64 = [1.0f64; 16];
         let short_f64 = [1.0f64; 15];
         assert!(std::panic::catch_unwind(|| f64::cosine_fast(&long_f64, 1.0, &short_f64)).is_err());
+        assert!(std::panic::catch_unwind(|| f64::cosine_fast(&short_f64, 1.0, &long_f64)).is_err());
 
         // Both directions for f16 and bf16: the kernels take `y.len()` and read
         // `x` with it, so a short `x` is the one that reads out of bounds.

--- a/rust/lance-linalg/src/distance/cosine.rs
+++ b/rust/lance-linalg/src/distance/cosine.rs
@@ -1512,8 +1512,11 @@ mod tests {
             assert!(message.contains("equal lengths"), "f64: {message}");
         }
 
-        // Both directions for f16 and bf16: the kernels take `y.len()` and read
-        // `x` with it, so a short `x` is the one that reads out of bounds.
+        // Both directions for f16 and bf16. With `fp16kernels` on, the kernels
+        // take `y.len()` and read `x` with it, so a short `x` is the operand that
+        // reads out of bounds and these two asserts are what stops it. Without
+        // the feature these arms reach `cosine_scalar`, where `dot` rejects the
+        // pair first and produces the same message.
         let long_f16 = [f16::from_f32(1.0); 16];
         let short_f16 = [f16::from_f32(1.0); 15];
         let long_bf16 = [bf16::from_f32(1.0); 16];

--- a/rust/lance-linalg/src/distance/cosine.rs
+++ b/rust/lance-linalg/src/distance/cosine.rs
@@ -24,7 +24,7 @@ use lance_arrow::{ArrowFloatType, FixedSizeListArrayExt, FloatArray};
 #[allow(unused_imports)]
 use lance_core::utils::cpu::{SIMD_SUPPORT, SimdSupport};
 
-use super::{Dot, assert_equal_lengths, norm_l2::norm_l2};
+use super::{Dot, assert_batch_layout, assert_equal_lengths, norm_l2::norm_l2};
 use super::{Normalize, dot::dot};
 #[cfg(all(target_arch = "x86_64", not(target_feature = "avx2")))]
 use crate::distance::BatchKind;
@@ -61,6 +61,7 @@ pub trait Cosine: Dot + Normalize {
         batch: &'a [Self],
         dimension: usize,
     ) -> Box<dyn Iterator<Item = f32> + 'a> {
+        assert_batch_layout(x.len(), batch.len(), dimension);
         let x_norm = norm_l2(x);
 
         Box::new(
@@ -594,9 +595,9 @@ impl Cosine for f32 {
         batch: &'a [Self],
         dimension: usize,
     ) -> Box<dyn Iterator<Item = f32> + 'a> {
-        // Preserve the original `chunks_exact` validation before constructing
-        // a specialized iterator.
-        let _ = batch.chunks_exact(dimension);
+        // Every branch below reaches a kernel that takes `dimension` as its
+        // stride and offsets a raw pointer into `x` with it.
+        assert_batch_layout(x.len(), batch.len(), dimension);
         let x_norm = norm_l2(x);
 
         // On a build whose baseline already guarantees AVX2, avoid the
@@ -1431,6 +1432,40 @@ mod tests {
     use approx::assert_relative_eq;
     use num_traits::AsPrimitive;
     use proptest::prelude::*;
+
+    /// `cosine_batch` takes `dimension` as the stride for both operands, so a
+    /// key that does not match it, or a batch that is not a whole number of
+    /// vectors, has to stop at the boundary. Covers the trait default through
+    /// `f64` and the `f32` override, including the fixed dimensions 8 and 16 that
+    /// the override special-cases.
+    #[rstest::rstest]
+    #[case::key_longer_than_dimension(32, 64, 16)]
+    #[case::key_shorter_than_dimension(8, 64, 16)]
+    #[case::batch_remainder(16, 63, 16)]
+    #[case::zero_dimension(16, 64, 0)]
+    #[case::dim8_key_mismatch(9, 64, 8)]
+    #[case::dim16_key_mismatch(17, 64, 16)]
+    fn cosine_batch_rejects_bad_layout(
+        #[case] key_len: usize,
+        #[case] batch_len: usize,
+        #[case] dimension: usize,
+    ) {
+        let key = vec![1.0f32; key_len];
+        let batch = vec![1.0f32; batch_len];
+        assert!(
+            std::panic::catch_unwind(|| cosine_distance_batch(&key, &batch, dimension).count())
+                .is_err(),
+            "f32 accepted key={key_len} batch={batch_len} dimension={dimension}"
+        );
+
+        let key = vec![1.0f64; key_len];
+        let batch = vec![1.0f64; batch_len];
+        assert!(
+            std::panic::catch_unwind(|| cosine_distance_batch(&key, &batch, dimension).count())
+                .is_err(),
+            "f64 accepted key={key_len} batch={batch_len} dimension={dimension}"
+        );
+    }
 
     /// Every `cosine_fast` override reaches a kernel that takes one length and
     /// reads both vectors with it, so a mismatch has to stop at the boundary


### PR DESCRIPTION
## What this changes

The five pairwise float `Cosine` overrides now call `assert_equal_lengths` first: `cosine_fast` for `bf16`, `f16`, `f32` and `f64`, plus `cosine_with_norms` for `f32`. Both `cosine_batch` entries, the trait default and the `f32` override, now call `assert_batch_layout`; the `f32` one previously had only `let _ = batch.chunks_exact(dimension)`, which enforced just `dimension > 0`.

## Why

Each kernel behind the pairwise overrides derives one loop bound from one of its two arguments and then indexes both vectors with it. For the f32 and f64 kernels that bound is `x.len()`; for the fp16 C kernels, which only exist with the non-default `fp16kernels` feature, it is `y.len()`, passed in as `dimension`. So a mismatch could reach a load past the end of the shorter vector, or return a distance computed over the shorter count, from safe Rust with no `unsafe` at the call site. Some pairs were already caught: where a kernel's tail hands `dot` two slices of unequal length, `dot`'s own assert fired. Which outcome a given pair got depends on the type, the tier, which argument is short and by how much. I am not tabulating that, because the entry assert makes the whole matrix unreachable.

The batch path is measurable without that matrix. Built with `RUSTFLAGS="-C debug-assertions=off"`, a batch of dimension-8 targets with a length-3 `f32` query returned large negative floats from all-small-positive inputs, because `cosine_once_8` loads eight lanes from a three-element query. Those particular values are whatever was adjacent in memory, so they are one observation rather than something to reproduce. With this PR the same input panics at `distance.rs:43` with `distance vector length must match dimension: vector=3, dimension=8`, from `assert_batch_layout`. l2 and dot already behaved that way, since both batch traits call that helper.

Two of the three pairwise trait defaults need nothing of their own: `cosine_fast` and `cosine_with_norms` bottom out in `cosine_scalar` and `cosine_scalar_fast`, which go through `dot`, which asserts. The `cosine` default forwards to `Self::cosine_fast`, so for the four float types it is covered by the asserts this pull request adds, and `cosine_distance_rejects_mismatched_lengths` is that path, for `f32`. Only the batch default gains a check.

## Where cosine sat relative to the other metrics

`L2::l2` and `Dot::dot` assert in all five of their impls, and both batch traits call `assert_batch_layout`. Cosine's float entries are what this brings in line with them.

Two gaps nearby stay open, and neither is this pull request's. `Cosine for u8` overrides only `cosine`, and nothing on that path checks the two lengths outside debug assertions; #8737 closes that, and its description is the place for which kernel does what. Hamming is the milder shape: `hamming` truncates silently through `chunks_exact` and `zip`, and `hamming_distance_batch` carries only `debug_assert_eq!`, while what #8639 added to `hamming_batch_u64` is an always-on assert on result slots per target rather than on equal input lengths.

## Which assert a test catches

`distance inputs must have equal lengths` exists in exactly one place in the crate, so that text alone cannot separate the assert this adds from the one `dot` already had. The two lengths in the message can, wherever a kernel hands `dot` only a scalar tail: `dot` then reports 7 and 8 where the entry assert reports 15 and 16. That is an f32 path, and the f32 cases assert the full `left=..., right=...` for that reason. The f64 cases assert the lengths too, where they are redundant rather than load-bearing, since no f64 tail calls `dot`.

Where a call reaches `cosine_scalar` or `cosine_scalar_fast` instead of a kernel, `dot` gets the same two slices and reports the same numbers, so no assertion on the message can tell the two asserts apart. That is f32 and f64 on an x86_64 host below the `Avx` tier, and f16 and bf16 either without `fp16kernels` or with them wherever `SIMD_SUPPORT` names no tier that has a compiled C kernel. The half-precision cases assert the contract only, and the test says so; the f32 and f64 cases keep asserting the two lengths even on the hosts where those numbers no longer separate the two asserts.

Measured on this aarch64 host, one assert at a time. Deleting `f32::cosine_fast`'s fails `cosine_rejects_mismatched_lengths`, and two of its cases would each catch it independently: long-then-short panics inside the kernel with a slice range error, which is the failure the run reports, and short-then-long reaches `dot`, which reports `left=7, right=8` against the asserted `left=15, right=16`. Deleting `f64::cosine_fast`'s also fails it, by a different route: long-then-short panics inside the kernel on the same out-of-range tail slice as f32, and short-then-long returns a value, because the f64 tail zips instead of calling `dot`.

| assert | aarch64 host | `--target x86_64-apple-darwin`, where Rosetta reports no AVX, run for the f32 and batch rows and derived for the rest | with `--features fp16kernels`, derived rather than run |
|---|---|---|---|
| `f32::cosine_fast`, `f32::cosine_with_norms`, `f64::cosine_fast` | caught | not caught | caught |
| `f16::cosine_fast`, `bf16::cosine_fast` | not caught | not caught | caught |
| both `cosine_batch` entries | caught | caught | caught |

The batch cases need no length in the assertion. `must match dimension`, `divisible by dimension` and `greater than zero` exist only in `assert_batch_layout`, so deleting it fails all four cases on both targets. Three of them fail on this host by producing no panic at all: both key-length cases reach `cosine_once_16`, which reads a fixed sixteen lanes from the key without consulting its length, past the end of the short key and ignoring the surplus of the long one, and the remainder case is dropped by `chunks_exact`. The fourth panics somewhere else with another message, so that case fails on the message assertion rather than on the missing panic.

## Does this reject anything that used to work

Only inputs that were already wrong. The batch remainder used to return correct distances: `chunks_exact` dropped the partial trailing vector and computed the whole ones correctly. A key longer than `dimension` also returned defined output on the dimension-8 and dimension-16 batch paths, since `cosine_once_8` and `cosine_once_16` read only the key's first lanes, but the distance was computed against a norm taken over the whole key, so it was wrong unless the surplus was all zeros. The batch entries now reject `dimension == 0` with a different message; both previous paths already panicked on it, the `f32` override through the `chunks_exact` probe this replaces and the trait default through its own `chunks_exact`, which asserts a non-zero chunk size in its constructor.

Every in-workspace production caller passes two vectors of the same length: `lance-index`'s flat search through `arrow_batch_func()`, the two `arrow_batch_func()` sites in `index/vector/builder.rs`, the memtable brute-force scan, `flat::storage`'s `cosine_with_norms` and its `distance_fn` arms, `pq::storage`'s `build_pairwise_distance_table`, `multivec_distance`, and the memtable HNSW store's `compute_f32_distance`. The benches pass equal lengths too, though they are not production. `lance-index`'s HNSW reaches `flat::storage` through `dist_calculator` rather than calling cosine itself.

The memtable HNSW store is worth naming separately for a different reason. Its two entries compare a query against a stored vector, or two stored vectors, and the same `compute_f32_distance` sends L2 and Dot to `l2_f32` and `dot_f32`, which forward to `f32::l2` and `f32::dot`, whose entry asserts are always on. So a mismatch there would already panic under L2 or Dot, while the fourth arm returns `f32::INFINITY` for Hamming without reading either slice. Cosine was the one with no entry check.

The flat search path also runs inside `spawn_blocking`, so a panic there surfaces as an error rather than taking the process down.

## Test plan

`cosine_rejects_mismatched_lengths` uses 16 and 15 rather than something smaller so the f32 and f64 cases reach a kernel body on this host rather than only a tail; the mutation results above are what establish that it catches a missing assert. `cosine_batch_rejects_bad_layout` covers the three layout conditions in four cases, key too long, key too short, batch remainder and zero dimension, for `f32` and `f64`, and `cosine_distance_rejects_mismatched_lengths` covers `cosine_distance`, which `DistanceType::func()` hands out, rather than only the trait method behind it.

- `cargo test -p lance-linalg`: 400 passed, 1 ignored
- `cargo test -p lance-linalg --target x86_64-apple-darwin`: 459 passed, 1 ignored. That target is where the sub-AVX2 `cosine_batch` branch is live, and `test_cosine_batch_matches_per_vector` has a `dim_8` case, so the `dimension == 8` branch whose guard this drops executes in a test there rather than only compiling. The input the guard rejected is now stopped by `assert_batch_layout`; no test reaches that branch with a mismatched key
- `cargo test -p lance-index`: 1180 passed and 3 ignored in the lib, 9 doc-tests
- `cargo fmt --all -- --check` and `cargo clippy -p lance-linalg --all-targets -- -D warnings`: clean

Not run: the AVX, AVX+FMA and AVX-512 kernels themselves. I have no x86 host, and Rosetta reports no AVX at all, so on the `x86_64-apple-darwin` target `SIMD_SUPPORT` is `None` and those arms are unreachable even though that target's test run is real. What those kernels do on a mismatch comes from reading them.



















