### PR TITLE
ci: run lance-linalg's tests under AddressSanitizer nightly

### DIFF
--- a/.github/workflows/nightly_run.yml
+++ b/.github/workflows/nightly_run.yml
@@ -45,6 +45,78 @@ jobs:
           # to avoid OOM issues (these tests use >5GiB memory each)
           cargo test --release --package lance-encoding -- --ignored jumbo --test-threads=1
 
+  # AddressSanitizer over lance-linalg's tests. Its public entry points validate
+  # the lengths a caller passes, but the SIMD kernels then walk the output buffer
+  # with their own pointer arithmetic, and nothing checks that. An off-by-one in
+  # a chunk count writes past the end while every entry assert still passes, and
+  # whether the process notices depends on the allocator. This job is here to
+  # make that class fail with a file and a line.
+  #
+  # Not in rust.yml because -Zsanitizer needs a nightly toolchain, which this
+  # repo otherwise only uses on a schedule. RUSTUP_TOOLCHAIN below says why the
+  # pin is set the way it is.
+  linalg-asan:
+    if: github.repository == 'lance-format/lance'
+    name: lance-linalg AddressSanitizer
+    runs-on: ubuntu-24.04
+    timeout-minutes: 60
+    permissions:
+      contents: read
+    env:
+      # build.rs compiles dist_table.c with whatever CC provides and only warns
+      # on failure, so CC decides whether kernel_support = "avx512_dist_table" is
+      # set, and with it whether an AVX-512 host runs the C kernel or the Rust
+      # arm. rust.yml's linux-build sets clang for the same reason.
+      #
+      # Default features, unlike linux-build's --features "${ALL_FEATURES}":
+      # turning on fp16kernels would route the f16 and bf16 dispatch into C that
+      # RUSTFLAGS cannot instrument, so leaving it off gives the sanitizer more
+      # Rust to check rather than less.
+      CC: clang
+      # Setting RUSTFLAGS replaces the per-target rustflags in
+      # .cargo/config.toml wholesale, so the baseline has to be repeated here:
+      # without it this would instrument a build no release ever ships, and the
+      # arms selected by all(target_feature = "avx2", target_feature = "fma")
+      # would not be compiled at all.
+      RUSTFLAGS: "-C target-cpu=haswell -C target-feature=+avx2,+fma,+f16c -Zsanitizer=address"
+      # This job is after memory errors. LeakSanitizer is on by default with
+      # ASan on Linux.
+      ASAN_OPTIONS: "detect_leaks=0"
+      # rust.yml sets this workflow-wide. It matters here once a Rust panic
+      # rather than a sanitizer report is the likely failure.
+      RUST_BACKTRACE: "1"
+      # rust-toolchain.toml pins 1.97.0, and a rustup override file outranks
+      # `rustup default`, so without this the sanitizer flag reaches a stable
+      # compiler and cargo stops at "the option `Z` is only accepted on the
+      # nightly compiler". daily-code-coverage.yml solves the same problem with
+      # `cargo +nightly-...`.
+      RUSTUP_TOOLCHAIN: nightly-2026-07-13
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - name: Setup rust toolchain
+        run: |
+          rustup toolchain install "$RUSTUP_TOOLCHAIN"
+      - uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2
+      # Without this the report is bare hex addresses and module offsets:
+      # ubuntu-24.04 ships llvm-symbolizer only under a versioned name, and ASan
+      # looks for the unversioned one on PATH.
+      - name: Point ASan at llvm-symbolizer
+        run: |
+          set -euo pipefail
+          symbolizer=$(command -v llvm-symbolizer \
+            || ls -1 /usr/lib/llvm-*/bin/llvm-symbolizer | sort -V | tail -1)
+          "$symbolizer" --version
+          echo "ASAN_SYMBOLIZER_PATH=$symbolizer" >> "$GITHUB_ENV"
+      # No protoc step: lance-linalg's dependency closure contains no
+      # prost-build or tonic-build, dev-dependencies included.
+      #
+      # --target keeps the sanitizer off build scripts and proc macros, which
+      # run on the host and do not need it.
+      - name: Run lance-linalg tests under AddressSanitizer
+        run: |
+          cargo test -p lance-linalg --tests --locked \
+            --target x86_64-unknown-linux-gnu
+
   # Cross-version index maintenance-sequence search (see python/tests/compat/compat_sequence.py).
   # Ages an index under the latest release of each of the two previous majors and exercises it
   # under this commit, searching op sequences for panics or correctness divergence. The search is


### PR DESCRIPTION
## What this changes

A `linalg-asan` job in `nightly_run.yml` runs `cargo test -p lance-linalg --lib --tests` under `-Zsanitizer=address`.

The public entry points already validate the lengths a caller passes: `sum_4bit_dist_table` asserts `dists.len() >= n`, and `hamming_batch_u64` asserts the output length with a comment explaining why it is not a `debug_assert`. What nothing checks is the pointer arithmetic the kernels then do inside those bounds. `vst1q_u16(dists.as_mut_ptr().add(24), ...)`, `_mm256_storeu_si256(dists.as_mut_ptr().add(16), ...)` and `*results_ptr.add(i) = ...` are all raw stores at offsets the kernel computes itself, so an off-by-one in a chunk count writes past the buffer while every entry assert still passes.

It lands in `nightly_run.yml` rather than `rust.yml` because `-Zsanitizer` needs a nightly toolchain, and the only nightly this repo uses is in `daily-code-coverage.yml`, which is `schedule` plus `workflow_dispatch`. The pin is the same one that file uses, so there is one nightly date in the repo rather than two.

Three details in the job are load-bearing and each is there for a reason a reader would otherwise have to rediscover.

`RUSTUP_TOOLCHAIN` rather than `rustup default`. A rustup override file outranks the default toolchain, and `rust-toolchain.toml` pins 1.97.0, so `rustup default nightly-...` followed by `cargo test` runs the sanitizer flag into a stable compiler and stops at `error: the option 'Z' is only accepted on the nightly compiler`. Measured both ways in this worktree: with the variable set, `rustc -vV` reports `1.97.0-nightly` and `cargo check -p lance-linalg -Zsanitizer=address` exits 0; without it, `rustup show active-toolchain` reports `1.97.0 (overridden by rust-toolchain.toml)`. `daily-code-coverage.yml` solves the same problem the other way, with `cargo +nightly-...`.

`RUSTFLAGS` repeats the baseline from `.cargo/config.toml`. Setting the variable replaces that file's per-target `rustflags` wholesale rather than appending, so leaving it at just the sanitizer flag would instrument a build no release ships, and would compile out the arms selected by `all(target_feature = "avx2", target_feature = "fma")` entirely. Those arms are where the one batch call that writes into a heap buffer lives (`cosine_batch_avx512` into `vec![0.0; batch.len() / dimension]`), which is the case a sanitizer detects best.

`--target x86_64-unknown-linux-gnu` keeps the sanitizer off build scripts and proc macros, which run on the host.

There is no protoc step, unlike every other Rust job here. `lance-linalg`'s dependency closure contains no `prost-build` or `tonic-build`, dev-dependencies included, and the job runs green without it.

## Test plan

Verified on aarch64-apple-darwin, since I have no x86 host:

- `cargo +nightly test -p lance-linalg --target aarch64-apple-darwin` under `-Zsanitizer=address`: 394 passed, 1 ignored. No `-Zbuild-std` needed for heap errors in the crate's own code.
- Added one deliberate 2-byte store past the 32-slot output of `sum_dist_table_32bytes_batch_neon`. ASan reports `heap-buffer-overflow, WRITE of size 2` at `dist_table.rs:632` with the chain up through `sum_4bit_dist_table_uninit` to the test. The same binary without the sanitizer dies with a bare `SIGTRAP` and no location, so what this job adds on that mutation is the location rather than the detection.

It has run for real on Linux, four times, on a fork branch with the `github.repository` guard dropped since that guard is what stops it running anywhere but here.

Two clean runs: [33305364459](https://github.com/LuciferYang/lance/actions/runs/33305364459) and, after dropping the protoc step, [33312991796](https://github.com/LuciferYang/lance/actions/runs/33312991796). Both green, `457 passed; 0 failed; 1 ignored` out of 458 tests, about a minute and a half to build and three to four minutes to run.

Then two runs with a deliberate out-of-bounds store planted in a kernel, to check the claim that this job names a file and a line. That is where the `ASAN_SYMBOLIZER_PATH` step comes from. Without it the report was detected but useless:

```
WRITE of size 4 at 0x7cb5cf675100 thread T428
    #0 0x5620f81ba20f  (/home/runner/work/lance/lance/target/.../lance_linalg-...+0x...)
    #1 0x5620f81b1619  (/home/runner/work/lance/lance/target/.../lance_linalg-...+0x...)
```

ubuntu-24.04 ships `llvm-symbolizer` only under a versioned name, and ASan looks for the unversioned one on `PATH`. With the step, the same overflow reports:

```
WRITE of size 4 at 0x7ce193dcf280 thread T428
    #0 ... sum_hacc_dist_table_32bytes_batch_avx2 rust/lance-linalg/src/simd/dist_table.rs:479:5
    #1 ... sum_4bit_hacc_dist_table_avx2          rust/lance-linalg/src/simd/dist_table.rs:361:21
    #2 ... sum_4bit_hacc_dist_table_uninit        rust/lance-linalg/src/simd/dist_table.rs:244:13
    #3 ... sum_4bit_hacc_dist_table               rust/lance-linalg/src/simd/dist_table.rs:214:14
    #4 ... tests::test_sum_4bit_hacc_dist_table_matches_u16_reference_multi_batch
```

So the failing test names itself in the stack, which is why the run does not need `--test-threads=1` to attribute a report.

That exercise also turned up a coverage limit worth stating. I first planted the store in `sum_dist_table_32bytes_batch_avx2` and the job stayed green: on a runner with AVX-512BW, `sum_4bit_dist_table_uninit` selects the AVX-512 C kernel, so the Rust AVX2 one never executes. The hacc entry point has no AVX-512 kernel, which is why the planted store there did fire. So on an AVX-512 runner this job covers the hacc AVX2 kernel, the scalar paths and everything else in the crate, but not the AVX2 dist_table kernel that a smaller host would take.

One gap remains: the C is not instrumented. `dist_table.c` compiles without `-fsanitize=address`, so the AVX-512 dist_table kernel is not covered. I tried `CFLAGS=-fsanitize=address` and it broke a host link in `lance-arrow`'s build script, so it is left out rather than half-applied.

## Scope note

`--lib --tests` currently selects the same target as `--lib`, since `lance-linalg` has no `tests/` directory yet. `--tests` is there so an integration target added later is included without editing this job.



