### PR TITLE
docs(linalg): document the length contract on the public distance entry points

### DIFF
--- a/rust/lance-linalg/src/distance/dot.rs
+++ b/rust/lance-linalg/src/distance/dot.rs
@@ -72,6 +72,10 @@ fn dot_scalar<
 }
 
 /// Dot product.
+///
+/// # Panics
+///
+/// Panics under the conditions [`Dot::dot`] documents.
 #[inline]
 pub fn dot<T: Dot>(from: &[T], to: &[T]) -> f32 {
     T::dot(from, to)
@@ -80,12 +84,20 @@ pub fn dot<T: Dot>(from: &[T], to: &[T]) -> f32 {
 /// Dot product between two f32 slices, dispatched to the widest SIMD backend
 /// available at runtime. See [`crate::distance::l2::l2_f32`] for why this is
 /// needed on top of the generic [`dot`].
+///
+/// # Panics
+///
+/// Panics if `x` and `y` have different lengths.
 #[inline]
 pub fn dot_f32(x: &[f32], y: &[f32]) -> f32 {
     f32::dot(x, y)
 }
 
 /// Negative [Dot] distance.
+///
+/// # Panics
+///
+/// Panics under the conditions [`Dot::dot`] documents.
 #[inline]
 pub fn dot_distance<T: Dot>(from: &[T], to: &[T]) -> f32 {
     1.0 - T::dot(from, to)
@@ -94,6 +106,10 @@ pub fn dot_distance<T: Dot>(from: &[T], to: &[T]) -> f32 {
 /// Dot product
 pub trait Dot: Num {
     /// Dot product.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `x` and `y` have different lengths.
     fn dot(x: &[Self], y: &[Self]) -> f32;
 
     /// Dot product of `x` against each `dimension`-sized vector in `batch`.
@@ -106,6 +122,11 @@ pub trait Dot: Num {
     /// Returns `impl Iterator` rather than a trait object: hot consumers drive
     /// this one element at a time, so a `Box<dyn Iterator>` would cost a
     /// virtual call per element and an allocation per batch.
+    ///
+    /// # Panics
+    ///
+    /// Panics unless `dimension` is non-zero, `x.len()` equals `dimension`, and
+    /// `batch.len()` is a multiple of `dimension`.
     fn dot_batch<'a>(
         x: &'a [Self],
         batch: &'a [Self],
@@ -756,6 +777,10 @@ impl Dot for u8 {
 }
 
 /// Negative dot product, to present the relative order of dot distance.
+///
+/// # Panics
+///
+/// Panics under the conditions [`Dot::dot_batch`] documents.
 pub fn dot_distance_batch<'a, T: Dot>(
     from: &'a [T],
     to: &'a [T],

--- a/rust/lance-linalg/src/distance/dot.rs
+++ b/rust/lance-linalg/src/distance/dot.rs
@@ -109,7 +109,9 @@ pub trait Dot: Num {
     ///
     /// # Panics
     ///
-    /// Panics if `x` and `y` have different lengths.
+    /// `x` and `y` must have the same length. An implementation is required to
+    /// reject a mismatch rather than read past the shorter slice; the five in
+    /// this crate do it by panicking.
     fn dot(x: &[Self], y: &[Self]) -> f32;
 
     /// Dot product of `x` against each `dimension`-sized vector in `batch`.

--- a/rust/lance-linalg/src/distance/dot_u8.rs
+++ b/rust/lance-linalg/src/distance/dot_u8.rs
@@ -31,6 +31,10 @@ use std::sync::OnceLock;
 use super::assert_equal_lengths;
 
 /// Portable scalar u8 dot product, also used for SIMD tail elements.
+///
+/// # Panics
+///
+/// Panics if `a` and `b` have different lengths.
 #[inline]
 pub fn dot_u8_scalar(a: &[u8], b: &[u8]) -> u32 {
     assert_equal_lengths(a.len(), b.len());
@@ -146,6 +150,10 @@ fn select_backend() -> DotU8Fn {
 }
 
 /// Dispatched u8 dot product, selecting the best available SIMD backend.
+///
+/// # Panics
+///
+/// Panics if `a` and `b` have different lengths.
 #[inline]
 pub fn dot_u8(a: &[u8], b: &[u8]) -> u32 {
     assert_equal_lengths(a.len(), b.len());

--- a/rust/lance-linalg/src/distance/l2.rs
+++ b/rust/lance-linalg/src/distance/l2.rs
@@ -47,6 +47,10 @@ use crate::simd::x86::hsum256_ps;
 ///
 pub trait L2: Num {
     /// Calculate the L2 distance between two vectors.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `x` and `y` have different lengths.
     fn l2(x: &[Self], y: &[Self]) -> f32;
 
     /// L2 distance from `x` to each `dimension`-sized vector in `y`.
@@ -60,6 +64,11 @@ pub trait L2: Num {
     /// assignment loop drives this one element at a time, so a
     /// `Box<dyn Iterator>` would cost a virtual call per element and an
     /// allocation per batch.
+    ///
+    /// # Panics
+    ///
+    /// Panics unless `dimension` is non-zero, `x.len()` equals `dimension`, and
+    /// `y.len()` is a multiple of `dimension`.
     fn l2_batch<'a>(
         x: &'a [Self],
         y: &'a [Self],
@@ -70,6 +79,11 @@ pub trait L2: Num {
     }
 }
 
+/// L2 distance between two vectors of any [`L2`] element type.
+///
+/// # Panics
+///
+/// Panics under the conditions [`L2::l2`] documents.
 #[inline]
 pub fn l2<T: L2>(from: &[T], to: &[T]) -> f32 {
     T::l2(from, to)
@@ -82,12 +96,20 @@ pub fn l2<T: L2>(from: &[T], to: &[T]) -> f32 {
 /// to [`l2`], whose x86_64 implementation selects the best runtime-supported
 /// kernel. This entry point gives hot-path callers such as the in-memory HNSW
 /// index an explicit f32 API.
+///
+/// # Panics
+///
+/// Panics if `x` and `y` have different lengths.
 #[inline]
 pub fn l2_f32(x: &[f32], y: &[f32]) -> f32 {
     f32::l2(x, y)
 }
 
 /// Calculate L2 distance between two uint8 slices.
+///
+/// # Panics
+///
+/// Panics if `key` and `target` have different lengths.
 #[inline]
 pub fn l2_distance_uint_scalar(key: &[u8], target: &[u8]) -> f32 {
     assert_equal_lengths(key.len(), target.len());
@@ -102,6 +124,10 @@ pub fn l2_distance_uint_scalar(key: &[u8], target: &[u8]) -> f32 {
 /// It relies on LLVM for auto-vectorization and unrolling.
 ///
 /// This is pub for test/benchmark only. use [l2] instead.
+///
+/// # Panics
+///
+/// Panics if `from` and `to` have different lengths.
 #[inline]
 pub fn l2_scalar<
     T: AsPrimitive<Output>,
@@ -908,6 +934,10 @@ impl L2Prepared {
 }
 
 /// Compute L2 distance between two vectors.
+///
+/// # Panics
+///
+/// Panics if `from` and `to` have different lengths.
 #[inline]
 pub fn l2_distance(from: &[f32], to: &[f32]) -> f32 {
     l2(from, to)
@@ -924,6 +954,10 @@ pub fn l2_distance(from: &[f32], to: &[f32]) -> f32 {
 /// Returns
 ///
 /// An iterator of pair-wise distance between `from` vector to each vector in the batch.
+///
+/// # Panics
+///
+/// Panics under the conditions [`L2::l2_batch`] documents.
 pub fn l2_distance_batch<'a, T: L2>(
     from: &'a [T],
     to: &'a [T],

--- a/rust/lance-linalg/src/distance/l2.rs
+++ b/rust/lance-linalg/src/distance/l2.rs
@@ -869,8 +869,7 @@ pub struct L2Prepared {
 impl L2Prepared {
     /// Transpose `targets` from AoS `[num_targets][dimension]` to SoA layout.
     ///
-    /// `targets.len()` must be a multiple of `dimension`, since `num_targets`
-    /// comes from an integer division.
+    /// `targets.len()` must be a multiple of `dimension`.
     ///
     /// # Panics
     ///
@@ -899,6 +898,11 @@ impl L2Prepared {
     ///
     /// `query` must have length `dimension` and `out` must have length
     /// `num_targets`. `out` will be zeroed before accumulation.
+    ///
+    /// # Panics
+    ///
+    /// With debug assertions on, panics unless both lengths match. A `query`
+    /// longer than `dimension` can also panic on a slice range without them.
     pub fn distances_into(&self, query: &[f32], out: &mut [f32]) {
         debug_assert_eq!(query.len(), self.dimension);
         debug_assert_eq!(out.len(), self.num_targets);

--- a/rust/lance-linalg/src/distance/l2.rs
+++ b/rust/lance-linalg/src/distance/l2.rs
@@ -81,7 +81,7 @@ pub trait L2: Num {
     }
 }
 
-/// L2 distance between two vectors of any [`L2`] element type.
+/// Squared L2 distance between two vectors of any [`L2`] element type.
 ///
 /// # Panics
 ///

--- a/rust/lance-linalg/src/distance/l2.rs
+++ b/rust/lance-linalg/src/distance/l2.rs
@@ -50,7 +50,9 @@ pub trait L2: Num {
     ///
     /// # Panics
     ///
-    /// Panics if `x` and `y` have different lengths.
+    /// `x` and `y` must have the same length. An implementation is required to
+    /// reject a mismatch rather than read past the shorter slice; the five in
+    /// this crate do it by panicking.
     fn l2(x: &[Self], y: &[Self]) -> f32;
 
     /// L2 distance from `x` to each `dimension`-sized vector in `y`.
@@ -867,13 +869,14 @@ pub struct L2Prepared {
 impl L2Prepared {
     /// Transpose `targets` from AoS `[num_targets][dimension]` to SoA layout.
     ///
-    /// `targets.len()` must be a multiple of `dimension`; a remainder is
-    /// dropped rather than reported, since `num_targets` comes from an integer
-    /// division.
+    /// `targets.len()` must be a multiple of `dimension`, since `num_targets`
+    /// comes from an integer division.
     ///
     /// # Panics
     ///
-    /// Panics if `dimension` is zero.
+    /// Panics if `dimension` is zero. With debug assertions on, also panics if
+    /// `targets.len()` is not a multiple of `dimension`; without them the
+    /// trailing partial vector is dropped.
     pub fn new(targets: &[f32], dimension: usize) -> Self {
         let num_targets = targets.len() / dimension;
         debug_assert_eq!(targets.len(), num_targets * dimension);

--- a/rust/lance-linalg/src/distance/l2.rs
+++ b/rust/lance-linalg/src/distance/l2.rs
@@ -127,7 +127,8 @@ pub fn l2_distance_uint_scalar(key: &[u8], target: &[u8]) -> f32 {
 ///
 /// # Panics
 ///
-/// Panics if `from` and `to` have different lengths.
+/// Panics if `from` and `to` have different lengths, and separately if `LANES`
+/// is zero, which `chunks_exact` rejects.
 #[inline]
 pub fn l2_scalar<
     T: AsPrimitive<Output>,

--- a/rust/lance-linalg/src/distance/l2.rs
+++ b/rust/lance-linalg/src/distance/l2.rs
@@ -866,6 +866,14 @@ pub struct L2Prepared {
 
 impl L2Prepared {
     /// Transpose `targets` from AoS `[num_targets][dimension]` to SoA layout.
+    ///
+    /// `targets.len()` must be a multiple of `dimension`; a remainder is
+    /// dropped rather than reported, since `num_targets` comes from an integer
+    /// division.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `dimension` is zero.
     pub fn new(targets: &[f32], dimension: usize) -> Self {
         let num_targets = targets.len() / dimension;
         debug_assert_eq!(targets.len(), num_targets * dimension);
@@ -886,7 +894,8 @@ impl L2Prepared {
 
     /// Compute L2 distances from `query` to every target, writing into `out`.
     ///
-    /// `out` must have length `num_targets`. It will be zeroed before accumulation.
+    /// `query` must have length `dimension` and `out` must have length
+    /// `num_targets`. `out` will be zeroed before accumulation.
     pub fn distances_into(&self, query: &[f32], out: &mut [f32]) {
         debug_assert_eq!(query.len(), self.dimension);
         debug_assert_eq!(out.len(), self.num_targets);

--- a/rust/lance-linalg/src/distance/l2_u8.rs
+++ b/rust/lance-linalg/src/distance/l2_u8.rs
@@ -25,6 +25,10 @@ use std::sync::OnceLock;
 use super::assert_equal_lengths;
 
 /// Portable scalar u8 squared L2 distance, also used for SIMD tail elements.
+///
+/// # Panics
+///
+/// Panics if `a` and `b` have different lengths.
 #[inline]
 pub fn l2_u8_scalar(a: &[u8], b: &[u8]) -> u32 {
     assert_equal_lengths(a.len(), b.len());
@@ -155,6 +159,10 @@ fn select_backend() -> L2U8Fn {
 }
 
 /// Dispatched u8 squared L2 distance, selecting the best available SIMD backend.
+///
+/// # Panics
+///
+/// Panics if `a` and `b` have different lengths.
 #[inline]
 pub fn l2_u8(a: &[u8], b: &[u8]) -> u32 {
     assert_equal_lengths(a.len(), b.len());


### PR DESCRIPTION
## What this changes

Eighteen public items in `lance-linalg`'s distance module gain a `# Panics` section. All of them already panic; none of them said so.

`assert_equal_lengths` and `assert_batch_layout` are always-on asserts, promoted in #8593, #8594 and #8639 precisely so they fire in release. Every public entry point that reaches one now documents it, so `cargo doc` shows the contract where the caller looks rather than only in the source of a private helper. The two `_arrow_batch` functions already had a section and are untouched.

The wording splits three ways, and the split is deliberate.

Concrete signatures state the panic directly: `l2_f32`, `l2_distance`, `l2_distance_uint_scalar`, `l2_scalar`, `dot_f32`, `dot_u8`, `dot_u8_scalar`, `l2_u8`, `l2_u8_scalar`.

Generic forwarders point at the trait method instead of repeating it, since what they do depends on the `T` a caller supplies: `l2`, `dot`, `dot_distance`, `l2_distance_batch`, `dot_distance_batch`.

The two trait methods `L2::l2` and `Dot::dot` state a requirement on implementors rather than a fact. Both traits are public and unsealed, so a downstream `impl L2 for MyType` could zip to the shorter slice and a flat "panics if the lengths differ" would be a claim about code this crate does not control. The five impls in the crate do panic, and the section says so.

`L2::l2_batch` and `Dot::dot_batch` spell out all three conditions `assert_batch_layout` checks, since a reader cannot see them from the signature: non-zero dimension, `x.len()` equal to it, and a batch length that is a whole multiple.

`L2Prepared` is the one place where the contract is enforced by `debug_assert_eq!` rather than by those helpers, so its section says which panic is unconditional and which needs debug assertions, instead of implying it validates as much as `l2_distance_batch` does.

## Test plan

No behavior changes, so the checks are the documentation ones:

- `RUSTDOCFLAGS="-D warnings -D rustdoc::broken_intra_doc_links" cargo doc -p lance-linalg --no-deps`: clean, so every `[`L2::l2`]`-style reference resolves
- `cargo test -p lance-linalg`: 394 passed, 1 ignored
- `cargo fmt --all -- --check` and `cargo clippy -p lance-linalg --all-targets -- -D warnings`: clean
- `cargo clippy -p lance-linalg --lib -- -W clippy::missing_panics_doc` reports nothing in these four files. That lint only sees panics in a function's own body, so it confirms the direct-assert layer; the delegating chains were traced by hand.

Verified against the code rather than assumed, since a `# Panics` section that overstates is worse than none:

- `l2_scalar` panics twice, and the length assert runs before `chunks_exact(LANES)`, which rejects a zero chunk size even on an empty slice. Both are documented, in that order.
- `L2Prepared::new` panics on `dimension == 0` in every profile, since integer division by zero always traps. The remainder case is reported only with debug assertions, which for this repo means `dev`, `test` and `ci`: `[profile.ci]` inherits `dev`, and the `debug-assertions = false` in `[profile.ci.package."*"]` applies to dependencies, not to workspace members.
- Every one of the five `impl L2` and five `impl Dot` blocks calls `assert_equal_lengths` as the first statement of its `l2`/`dot`, ahead of the fp16 FFI calls and the x86 runtime tiers, and the only batch override in either family, `f32`, calls `assert_batch_layout` before all of its cfg branches.
- Both asserts are eager. `l2_batch` is a plain function returning `impl Iterator`, so it panics at the call rather than at the first `next()`, which is what makes "panics" the right word for a caller that never polls.
