### PR TITLE
perf(index): cap HNSW prefetch bytes and honor prefetch_distance

### DIFF
--- a/rust/lance-index/benches/hnsw.rs
+++ b/rust/lance-index/benches/hnsw.rs
@@ -19,11 +19,12 @@ use rayon::ThreadPoolBuilder;
 use lance_core::ROW_ID_FIELD;
 use lance_index::vector::{
     flat::storage::FlatFloatStorage,
+    graph::VisitedGenerator,
     hnsw::builder::{HNSW, HnswBuildParams, HnswQueryParams},
     pq::{PQBuildParams, ProductQuantizer},
     quantizer::Quantization,
     sq::{ScalarQuantizer, builder::SQBuildParams},
-    storage::StorageBuilder,
+    storage::{StorageBuilder, VectorStore},
 };
 use lance_linalg::distance::DistanceType;
 use lance_testing::datagen::generate_random_array_with_seed;
@@ -352,6 +353,68 @@ fn bench_hnsw_pq(c: &mut Criterion) {
     });
 }
 
+/// Measure how the look-ahead prefetch distance affects flat-storage search
+/// latency across vector sizes (issue #8275).
+///
+/// `search_basic` hardcodes its bottom-level prefetch distance, so this bench
+/// drives `search_inner` directly to vary it. All distances share one graph
+/// and one query set per dimension; only the prefetch distance changes.
+/// Queries rotate through 64 stored vectors so the per-iteration working set
+/// stays larger than the last-level cache and vector reads miss like they do
+/// on a real index.
+fn bench_hnsw_prefetch(c: &mut Criterion) {
+    const TOTAL: usize = 300_000;
+    const SEED: [u8; 32] = [42; 32];
+    const K: usize = 100;
+    const NUM_QUERIES: usize = 64;
+
+    for dimension in [128usize, 768] {
+        let data = generate_random_array_with_seed::<Float32Type>(TOTAL * dimension, SEED);
+        let fsl = FixedSizeListArray::try_new_from_values(data, dimension as i32).unwrap();
+        let vectors = Arc::new(FlatFloatStorage::new(fsl.clone(), DistanceType::L2));
+
+        let hnsw = HNSW::index_vectors(vectors.as_ref(), HnswBuildParams::default()).unwrap();
+
+        let queries: Vec<_> = (0..NUM_QUERIES)
+            .map(|i| fsl.value(i * (TOTAL / NUM_QUERIES)))
+            .collect();
+        let params = HnswQueryParams {
+            ef: 300,
+            lower_bound: None,
+            upper_bound: None,
+            dist_q_c: 0.0,
+            use_acorn: false,
+        };
+
+        for prefetch_distance in [None, Some(1), Some(2), Some(4), Some(8)] {
+            let name = format!(
+                "search_hnsw_prefetch({TOTAL}x{dimension},{})",
+                prefetch_distance.map_or("off".to_string(), |d| d.to_string())
+            );
+            let mut visited_generator = VisitedGenerator::new(vectors.len());
+            let mut next_query = 0;
+            c.bench_function(&name, |b| {
+                b.iter(|| {
+                    let query = queries[next_query % NUM_QUERIES].clone();
+                    next_query += 1;
+                    let result = hnsw
+                        .search_inner(
+                            query,
+                            K,
+                            &params,
+                            None,
+                            &mut visited_generator,
+                            vectors.as_ref(),
+                            prefetch_distance,
+                        )
+                        .unwrap();
+                    assert_eq!(result.len(), K);
+                })
+            });
+        }
+    }
+}
+
 #[cfg(target_os = "linux")]
 criterion_group!(
     name=benches;
@@ -359,7 +422,7 @@ criterion_group!(
         .measurement_time(Duration::from_secs(10))
         .sample_size(10)
         .with_profiler(PProfProfiler::new(100, Output::Flamegraph(None)));
-    targets = bench_hnsw, bench_hnsw_load, bench_hnsw_sq, bench_hnsw_pq);
+    targets = bench_hnsw, bench_hnsw_load, bench_hnsw_sq, bench_hnsw_pq, bench_hnsw_prefetch);
 
 // Non-linux version does not support pprof.
 #[cfg(not(target_os = "linux"))]
@@ -368,6 +431,6 @@ criterion_group!(
     config = Criterion::default()
         .measurement_time(Duration::from_secs(10))
         .sample_size(10);
-    targets = bench_hnsw, bench_hnsw_load, bench_hnsw_sq, bench_hnsw_pq);
+    targets = bench_hnsw, bench_hnsw_load, bench_hnsw_sq, bench_hnsw_pq, bench_hnsw_prefetch);
 
 criterion_main!(benches);

--- a/rust/lance-index/src/vector/hnsw/builder.rs
+++ b/rust/lance-index/src/vector/hnsw/builder.rs
@@ -438,7 +438,7 @@ impl HNSW {
             bitset,
             &mut visited_generator,
             storage,
-            Some(2),
+            self.inner.params.prefetch_distance,
         );
 
         match self.inner.visited_generator_queue.push(visited_generator) {
@@ -480,7 +480,7 @@ impl HNSW {
             &mut visited_generator,
             &mut expanded_generator,
             storage,
-            Some(2),
+            self.inner.params.prefetch_distance,
         );
 
         // if the queue is full, we just don't push it back, so ignore the error here
@@ -2728,5 +2728,192 @@ mod tests {
             loaded.deep_size_of(),
             builder.deep_size_of(),
         );
+    }
+
+    /// Wraps [FlatFloatStorage] so tests can observe whether the search path
+    /// issued prefetches, which is otherwise invisible in the results.
+    #[derive(Clone)]
+    struct PrefetchCountingStorage {
+        inner: FlatFloatStorage,
+        prefetch_calls: Arc<AtomicUsize>,
+    }
+
+    struct PrefetchCountingCalc<'a> {
+        inner: <FlatFloatStorage as VectorStore>::DistanceCalculator<'a>,
+        prefetch_calls: &'a AtomicUsize,
+    }
+
+    impl DistCalculator for PrefetchCountingCalc<'_> {
+        fn distance(&self, id: u32) -> f32 {
+            self.inner.distance(id)
+        }
+
+        fn distance_all(&self, k_hint: usize) -> Vec<f32> {
+            self.inner.distance_all(k_hint)
+        }
+
+        fn prefetch(&self, id: u32) {
+            self.prefetch_calls.fetch_add(1, Ordering::Relaxed);
+            self.inner.prefetch(id);
+        }
+    }
+
+    impl VectorStore for PrefetchCountingStorage {
+        type DistanceCalculator<'a> = PrefetchCountingCalc<'a>;
+
+        fn as_any(&self) -> &dyn std::any::Any {
+            self
+        }
+
+        fn schema(&self) -> &arrow_schema::SchemaRef {
+            self.inner.schema()
+        }
+
+        fn to_batches(&self) -> Result<impl Iterator<Item = RecordBatch> + Send> {
+            self.inner.to_batches()
+        }
+
+        fn len(&self) -> usize {
+            self.inner.len()
+        }
+
+        fn distance_type(&self) -> DistanceType {
+            self.inner.distance_type()
+        }
+
+        fn row_id(&self, id: u32) -> u64 {
+            self.inner.row_id(id)
+        }
+
+        fn row_ids(&self) -> impl Iterator<Item = &u64> {
+            self.inner.row_ids()
+        }
+
+        fn append_batch(&self, _batch: RecordBatch, _vector_column: &str) -> Result<Self> {
+            unreachable!("not used by search tests")
+        }
+
+        fn dist_calculator(&self, query: ArrayRef, dist_q_c: f32) -> Self::DistanceCalculator<'_> {
+            PrefetchCountingCalc {
+                inner: self.inner.dist_calculator(query, dist_q_c),
+                prefetch_calls: &self.prefetch_calls,
+            }
+        }
+
+        fn dist_calculator_from_id(&self, id: u32) -> Self::DistanceCalculator<'_> {
+            PrefetchCountingCalc {
+                inner: self.inner.dist_calculator_from_id(id),
+                prefetch_calls: &self.prefetch_calls,
+            }
+        }
+    }
+
+    /// `search_basic` used to hardcode its bottom-level prefetch distance to
+    /// `Some(2)`, so `prefetch_distance: None` silently kept prefetching
+    /// (issue #8275). The counting storage observes what the results cannot.
+    #[rstest]
+    #[case::disabled(None, false)]
+    #[case::enabled(Some(2), true)]
+    fn test_search_basic_honors_prefetch_distance(
+        #[case] prefetch_distance: Option<usize>,
+        #[case] expect_prefetch: bool,
+    ) {
+        const DIM: usize = 16;
+        const TOTAL: usize = 256;
+        let fsl =
+            FixedSizeListArray::try_new_from_values(generate_random_array(TOTAL * DIM), DIM as i32)
+                .unwrap();
+        let storage = FlatFloatStorage::new(fsl.clone(), DistanceType::L2);
+        let hnsw = HNSW::index_vectors(
+            &storage,
+            HnswBuildParams {
+                prefetch_distance,
+                ..HnswBuildParams::default()
+            },
+        )
+        .unwrap();
+
+        let counting = PrefetchCountingStorage {
+            inner: storage,
+            prefetch_calls: Arc::new(AtomicUsize::new(0)),
+        };
+        let results = hnsw
+            .search_basic(
+                fsl.value(0),
+                10,
+                &HnswQueryParams {
+                    ef: 50,
+                    lower_bound: None,
+                    upper_bound: None,
+                    dist_q_c: 0.0,
+                    use_acorn: false,
+                },
+                None,
+                &counting,
+            )
+            .unwrap();
+        assert_eq!(results.len(), 10);
+        assert_eq!(
+            counting.prefetch_calls.load(Ordering::Relaxed) > 0,
+            expect_prefetch
+        );
+    }
+
+    /// Prefetch is a pure cache hint: any distance (and any `do_prefetch`
+    /// internals, such as its cache-line cap) must leave results identical.
+    #[test]
+    fn test_prefetch_distance_does_not_change_results() {
+        const DIM: usize = 16;
+        const TOTAL: usize = 256;
+        const K: usize = 10;
+        let fsl =
+            FixedSizeListArray::try_new_from_values(generate_random_array(TOTAL * DIM), DIM as i32)
+                .unwrap();
+        let storage = FlatFloatStorage::new(fsl.clone(), DistanceType::L2);
+        let hnsw = HNSW::index_vectors(&storage, HnswBuildParams::default()).unwrap();
+        let params = HnswQueryParams {
+            ef: 50,
+            lower_bound: None,
+            upper_bound: None,
+            dist_q_c: 0.0,
+            use_acorn: false,
+        };
+
+        let mut visited_generator = VisitedGenerator::new(storage.len());
+        let baseline: Vec<(u32, f32)> = hnsw
+            .search_inner(
+                fsl.value(1),
+                K,
+                &params,
+                None,
+                &mut visited_generator,
+                &storage,
+                None,
+            )
+            .unwrap()
+            .iter()
+            .map(|node| (node.id, node.dist.0))
+            .collect();
+
+        for prefetch_distance in [Some(1), Some(2), Some(64)] {
+            let with_prefetch: Vec<(u32, f32)> = hnsw
+                .search_inner(
+                    fsl.value(1),
+                    K,
+                    &params,
+                    None,
+                    &mut visited_generator,
+                    &storage,
+                    prefetch_distance,
+                )
+                .unwrap()
+                .iter()
+                .map(|node| (node.id, node.dist.0))
+                .collect();
+            assert_eq!(
+                baseline, with_prefetch,
+                "results changed with prefetch_distance={prefetch_distance:?}"
+            );
+        }
     }
 }

--- a/rust/lance-index/src/vector/utils.rs
+++ b/rust/lance-index/src/vector/utils.rs
@@ -182,23 +182,36 @@ impl SimpleIndex {
     }
 }
 
+/// Cap on how many cache lines one `do_prefetch` call touches.
+///
+/// Distance kernels read a vector sequentially, so once its head is resident
+/// the hardware stream prefetcher covers the tail; issuing one prefetch
+/// instruction per line of a large vector (48 for a 768-dim f32 vector) costs
+/// more in issue overhead and cache pollution than the misses it hides. Eight
+/// lines is one full 128-dim f32 vector, so smaller vectors are prefetched
+/// exactly as before, while at 768 dims the cap turns a within-noise effect
+/// into a 20-28% search speedup on the `search_hnsw_prefetch` bench
+/// (issue #8275).
+const PREFETCH_MAX_CACHE_LINES: usize = 8;
+
 #[inline]
 pub(crate) fn do_prefetch<T>(ptrs: Range<*const T>) {
     // TODO use rust intrinsics instead of x86 intrinsics
-    // TODO finish this
+    #[cfg(target_arch = "x86_64")]
     unsafe {
-        let (ptr, end_ptr) = (ptrs.start as *const i8, ptrs.end as *const i8);
-        let mut current_ptr = ptr;
-        while current_ptr < end_ptr {
-            const CACHE_LINE_SIZE: usize = 64;
-            #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-            {
-                use core::arch::x86_64::{_MM_HINT_T0, _mm_prefetch};
-                _mm_prefetch(current_ptr, _MM_HINT_T0);
-            }
+        use core::arch::x86_64::{_MM_HINT_T0, _mm_prefetch};
+        const CACHE_LINE_SIZE: usize = 64;
+        let start = ptrs.start as *const i8;
+        let end =
+            (ptrs.end as *const i8).min(start.add(PREFETCH_MAX_CACHE_LINES * CACHE_LINE_SIZE));
+        let mut current_ptr = start;
+        while current_ptr < end {
+            _mm_prefetch(current_ptr, _MM_HINT_T0);
             current_ptr = current_ptr.add(CACHE_LINE_SIZE);
         }
     }
+    #[cfg(not(target_arch = "x86_64"))]
+    let _ = ptrs;
 }
 
 impl From<pb::tensor::DataType> for DataType {

--- a/rust/lance-index/src/vector/utils.rs
+++ b/rust/lance-index/src/vector/utils.rs
@@ -201,13 +201,18 @@ pub(crate) fn do_prefetch<T>(ptrs: Range<*const T>) {
     unsafe {
         use core::arch::x86_64::{_MM_HINT_T0, _mm_prefetch};
         const CACHE_LINE_SIZE: usize = 64;
+        // Cap the byte length before any pointer arithmetic: `ptr::add` must
+        // stay within the allocation even for intermediate values, and a
+        // short vector at the end of its backing buffer has fewer bytes left
+        // than the cap.
         let start = ptrs.start as *const i8;
-        let end =
-            (ptrs.end as *const i8).min(start.add(PREFETCH_MAX_CACHE_LINES * CACHE_LINE_SIZE));
-        let mut current_ptr = start;
-        while current_ptr < end {
-            _mm_prefetch(current_ptr, _MM_HINT_T0);
-            current_ptr = current_ptr.add(CACHE_LINE_SIZE);
+        let len = (ptrs.end as usize)
+            .saturating_sub(ptrs.start as usize)
+            .min(PREFETCH_MAX_CACHE_LINES * CACHE_LINE_SIZE);
+        let mut offset = 0;
+        while offset < len {
+            _mm_prefetch(start.add(offset), _MM_HINT_T0);
+            offset += CACHE_LINE_SIZE;
         }
     }
     #[cfg(not(target_arch = "x86_64"))]
@@ -359,6 +364,19 @@ pub fn is_finite(fsl: &FixedSizeListArray) -> BooleanArray {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// A vector shorter than the prefetch cap whose slice ends exactly at its
+    /// allocation must not make `do_prefetch` form an out-of-allocation
+    /// pointer, and neither may a range that is not a multiple of the cache
+    /// line (UB under Miri; caught in review of #8882).
+    #[test]
+    fn test_do_prefetch_stays_in_short_allocations() {
+        let one_line: Vec<f32> = vec![0.0; 16]; // 64 bytes, far below the cap
+        do_prefetch(one_line.as_ptr_range());
+
+        let odd_length: Vec<f32> = vec![0.0; 24]; // 96 bytes, not line-aligned
+        do_prefetch(odd_length.as_ptr_range());
+    }
 
     use arrow_array::{Float16Array, Float32Array, Float64Array, UInt8Array};
     use half::f16;


### PR DESCRIPTION
## Problem

For HNSW over flat (unquantized) storage, `do_prefetch` issued one prefetch instruction per 64-byte cache line of each look-ahead neighbor's full vector — 48 instructions per neighbor at 768-dim f32. The issue overhead and cache pollution cancelled the benefit. On the new `search_hnsw_prefetch` bench (300K vectors, flat storage, working set far larger than LLC), prefetch improved 768-dim search by only 1.7% over no prefetch, and larger look-ahead distances made it slower — matching the report in #8275.

Separately, `search_basic` and `search_acorn` hardcoded their bottom-level look-ahead to `Some(2)`, so the persisted `HnswBuildParams::prefetch_distance` never reached the hot path: building with `prefetch_distance: None` did not actually disable prefetch at query time.

## Fix

1. Cap each `do_prefetch` call at 8 cache lines. Distance kernels read a vector sequentially, so the hardware stream prefetcher covers the tail once the head is resident; software prefetch only needs to beat the initial demand miss. Eight lines is one full 128-dim f32 vector, so smaller vectors are prefetched exactly as before. The non-x86_64 loop (which iterated per line with no prefetch instruction to issue) is compiled out.
2. `search_basic`/`search_acorn` now honor `HnswBuildParams::prefetch_distance`. The default (`Some(2)`) is unchanged.

A query-time override (the issue's third question) is left for a follow-up since it extends `HnswQueryParams`.

## Benchmark

`cargo bench -p lance-index --bench hnsw -- search_hnsw_prefetch` (new bench in this PR): 300K vectors, flat f32 storage, ef=300, k=100, 64 rotating queries so vector reads miss cache. Windows x86_64 (AVX2), comparisons within-run against the no-prefetch baseline on the same graph:

| look-ahead distance | 128-dim | 768-dim (before) | 768-dim (after) |
|---|---|---|---|
| off | 1.57 ms | 4.08 ms | 4.41 ms |
| 1 | 1.16 ms (-26%) | -0.2% | 3.21 ms (-27%) |
| 2 (default) | 1.18 ms (-25%) | -1.7% | 3.10 ms (-30%) |
| 4 | 1.28 ms | +2.5% | 3.33 ms |
| 8 | 1.14 ms | +13% | 3.34 ms |

The cap turns 768-dim prefetch from within-noise into a 30% search speedup at the default distance, mirroring the benefit prefetch already delivered at 128 dims.

## Tests

- `test_search_basic_honors_prefetch_distance`: a prefetch-counting storage wrapper asserts `prefetch_distance: None` issues no prefetches and `Some(2)` does (fails against the previous hardcode).
- `test_prefetch_distance_does_not_change_results`: prefetch is a pure hint; results are asserted identical across off/1/2/64.
- `bench_hnsw_prefetch` stays as the regression guard for both dimensions.

Fixes #8275
