### PR TITLE
fix(linalg): reject a null Int8 query instead of panicking

### DIFF
--- a/rust/lance-linalg/src/distance.rs
+++ b/rust/lance-linalg/src/distance.rs
@@ -30,9 +30,10 @@ pub mod norm_l2;
 
 /// Widens an `Int8` query vector to `f32`, rejecting nulls.
 ///
-/// The three `_arrow_batch` entry points take the query as a `&dyn Array` and
-/// widen an `Int8` one element at a time. A null element has no distance to
-/// compute, and what this replaced was an `unwrap`.
+/// The three `_arrow_batch` entry points take the query as a `&dyn Array`, so an
+/// `Int8` one has to be widened before it reaches a kernel. A null element has no
+/// distance to compute, and the widening this replaced resolved it with an
+/// `unwrap`.
 fn int8_query_to_f32(query: &PrimitiveArray<Int8Type>) -> Result<Float32Array> {
     if query.null_count() > 0 {
         return Err(ArrowError::InvalidArgumentError(format!(
@@ -615,7 +616,8 @@ mod tests {
         for dt in [DistanceType::L2, DistanceType::Cosine, DistanceType::Dot] {
             let err = dt.arrow_batch_func()(query.as_ref(), &targets).unwrap_err();
             assert!(
-                matches!(&err, ArrowError::InvalidArgumentError(m) if m.contains("must not contain nulls")),
+                matches!(&err, ArrowError::InvalidArgumentError(m)
+                    if m.contains("Int8 query vector `from`") && m.contains("found 1 in 2 values")),
                 "{dt} accepted a null Int8 query element, got: {err}"
             );
         }
@@ -643,11 +645,7 @@ mod tests {
             let want =
                 dt.arrow_batch_func()(Arc::new(Int8Array::from(vec![3_i8, 4])).as_ref(), &targets)
                     .unwrap();
-            assert_eq!(
-                got.values(),
-                want.values(),
-                "{dt} did not follow the query slice"
-            );
+            assert_eq!(got, want, "{dt} did not follow the query slice");
         }
     }
 

--- a/rust/lance-linalg/src/distance.rs
+++ b/rust/lance-linalg/src/distance.rs
@@ -12,8 +12,10 @@
 use std::sync::Arc;
 
 use arrow_array::cast::AsArray;
-use arrow_array::types::{Float16Type, Float32Type, Float64Type, UInt8Type};
-use arrow_array::{Array, ArrowPrimitiveType, FixedSizeListArray, Float32Array, ListArray};
+use arrow_array::types::{Float16Type, Float32Type, Float64Type, Int8Type, UInt8Type};
+use arrow_array::{
+    Array, ArrowPrimitiveType, FixedSizeListArray, Float32Array, ListArray, PrimitiveArray,
+};
 use arrow_schema::{ArrowError, DataType};
 
 pub mod cosine;
@@ -25,6 +27,24 @@ pub mod hamming;
 pub mod l2;
 pub mod l2_u8;
 pub mod norm_l2;
+
+/// Widens an `Int8` query vector to `f32`, rejecting nulls.
+///
+/// The three `_arrow_batch` entry points take the query as a `&dyn Array` and
+/// widen an `Int8` one element at a time. A null element has no distance to
+/// compute, and the only alternative to an error here is a panic.
+fn int8_query_to_f32(query: &PrimitiveArray<Int8Type>) -> Result<Float32Array> {
+    if query.null_count() > 0 {
+        return Err(ArrowError::InvalidArgumentError(format!(
+            "query vector must not contain nulls, found {} in {} values",
+            query.null_count(),
+            query.len()
+        )));
+    }
+    Ok(Float32Array::from(
+        query.values().iter().map(|&v| v as f32).collect::<Vec<_>>(),
+    ))
+}
 
 #[inline]
 fn assert_equal_lengths(left_len: usize, right_len: usize) {
@@ -501,6 +521,7 @@ mod tests {
     use arrow_buffer::{OffsetBuffer, ScalarBuffer};
     use arrow_schema::Field;
     use half::f16;
+    use lance_arrow::FixedSizeListArrayExt;
 
     #[cfg(target_arch = "x86_64")]
     #[test]
@@ -578,6 +599,39 @@ mod tests {
             matches!(&err, ArrowError::InvalidArgumentError(m) if m.contains("does not support query type")),
             "Float32 query with hamming must be rejected for the metric, got: {err}"
         );
+    }
+
+    /// The `_arrow_batch` entry points widen an `Int8` query element by element.
+    /// A null there used to reach an `unwrap`, so a query column with a null in
+    /// its values panicked instead of returning an error, on the metrics that
+    /// accept `Int8`.
+    #[test]
+    fn test_arrow_batch_rejects_null_int8_query() {
+        let targets =
+            FixedSizeListArray::try_new_from_values(Int8Array::from(vec![1_i8, 2, 3, 4]), 2)
+                .unwrap();
+        let query: Arc<dyn Array> = Arc::new(Int8Array::from(vec![Some(1_i8), None]));
+
+        for dt in [DistanceType::L2, DistanceType::Cosine, DistanceType::Dot] {
+            let err = dt.arrow_batch_func()(query.as_ref(), &targets).unwrap_err();
+            assert!(
+                matches!(&err, ArrowError::InvalidArgumentError(m) if m.contains("must not contain nulls")),
+                "{dt} accepted a null Int8 query element, got: {err}"
+            );
+        }
+
+        // The same query without nulls goes through, so the guard is not
+        // rejecting every `Int8` query.
+        let query: Arc<dyn Array> = Arc::new(Int8Array::from(vec![1_i8, 2]));
+        for dt in [DistanceType::L2, DistanceType::Cosine, DistanceType::Dot] {
+            assert_eq!(
+                dt.arrow_batch_func()(query.as_ref(), &targets)
+                    .unwrap()
+                    .len(),
+                2,
+                "{dt} rejected a well-formed Int8 query"
+            );
+        }
     }
 
     /// `Int8` is a valid vector element type elsewhere in the crate but has no

--- a/rust/lance-linalg/src/distance.rs
+++ b/rust/lance-linalg/src/distance.rs
@@ -31,9 +31,8 @@ pub mod norm_l2;
 /// Widens an `Int8` query vector to `f32`, rejecting nulls.
 ///
 /// The three `_arrow_batch` entry points that accept `Int8` take the query as a
-/// `&dyn Array`, so it has to be widened before it reaches a kernel. A null element has no
-/// distance to compute, and the widening this replaced resolved it with an
-/// `unwrap`.
+/// `&dyn Array`, so it has to be widened before it reaches a kernel. A null
+/// element has no distance to compute, so it is rejected rather than widened.
 fn int8_query_to_f32(query: &PrimitiveArray<Int8Type>) -> Result<Float32Array> {
     if query.null_count() > 0 {
         return Err(ArrowError::InvalidArgumentError(format!(

--- a/rust/lance-linalg/src/distance.rs
+++ b/rust/lance-linalg/src/distance.rs
@@ -32,11 +32,11 @@ pub mod norm_l2;
 ///
 /// The three `_arrow_batch` entry points take the query as a `&dyn Array` and
 /// widen an `Int8` one element at a time. A null element has no distance to
-/// compute, and the only alternative to an error here is a panic.
+/// compute, and what this replaced was an `unwrap`.
 fn int8_query_to_f32(query: &PrimitiveArray<Int8Type>) -> Result<Float32Array> {
     if query.null_count() > 0 {
         return Err(ArrowError::InvalidArgumentError(format!(
-            "query vector must not contain nulls, found {} in {} values",
+            "Int8 query vector `from` must not contain nulls, found {} in {} values",
             query.null_count(),
             query.len()
         )));
@@ -638,7 +638,7 @@ mod tests {
         // its two elements must be the ones the slice selects.
         let sliced = Int8Array::from(vec![None, Some(3_i8), Some(4), None]).slice(1, 2);
         let query: Arc<dyn Array> = Arc::new(sliced);
-        for dt in [DistanceType::L2, DistanceType::Dot] {
+        for dt in [DistanceType::L2, DistanceType::Cosine, DistanceType::Dot] {
             let got = dt.arrow_batch_func()(query.as_ref(), &targets).unwrap();
             let want =
                 dt.arrow_batch_func()(Arc::new(Int8Array::from(vec![3_i8, 4])).as_ref(), &targets)

--- a/rust/lance-linalg/src/distance.rs
+++ b/rust/lance-linalg/src/distance.rs
@@ -30,8 +30,8 @@ pub mod norm_l2;
 
 /// Widens an `Int8` query vector to `f32`, rejecting nulls.
 ///
-/// The three `_arrow_batch` entry points take the query as a `&dyn Array`, so an
-/// `Int8` one has to be widened before it reaches a kernel. A null element has no
+/// The three `_arrow_batch` entry points that accept `Int8` take the query as a
+/// `&dyn Array`, so it has to be widened before it reaches a kernel. A null element has no
 /// distance to compute, and the widening this replaced resolved it with an
 /// `unwrap`.
 fn int8_query_to_f32(query: &PrimitiveArray<Int8Type>) -> Result<Float32Array> {
@@ -602,7 +602,8 @@ mod tests {
         );
     }
 
-    /// The `_arrow_batch` entry points widen an `Int8` query element by element.
+    /// The `_arrow_batch` entry points that accept `Int8` widen the query element
+    /// by element.
     /// A null there used to reach an `unwrap`, so a query column with a null in
     /// its values panicked instead of returning an error, on the metrics that
     /// accept `Int8`.
@@ -659,9 +660,9 @@ mod tests {
     }
 
     /// An input that is both a length mismatch and a null query must reach the
-    /// null error on all three metrics. `dot` used to check the dimension in its
-    /// public entry point as well as in the shared body, which put that check
-    /// ahead of the `Int8` arm's null guard where the other two put it after.
+    /// null error on all three metrics. `dot` used to carry a second
+    /// `debug_assert_eq!` on the dimension in its public entry point, ahead of
+    /// the `Int8` arm's null guard.
     #[test]
     fn test_arrow_batch_null_and_length_mismatch_agree() {
         let targets =

--- a/rust/lance-linalg/src/distance.rs
+++ b/rust/lance-linalg/src/distance.rs
@@ -658,10 +658,10 @@ mod tests {
         }
     }
 
-    /// An input that is both a length mismatch and a null query must behave the
-    /// same on all three metrics. It did not: `dot` asserted the dimension in its
-    /// public entry point as well as in the shared body, so it panicked there
-    /// while l2 and cosine returned the null error.
+    /// An input that is both a length mismatch and a null query must reach the
+    /// null error on all three metrics. `dot` used to check the dimension in its
+    /// public entry point as well as in the shared body, which put that check
+    /// ahead of the `Int8` arm's null guard where the other two put it after.
     #[test]
     fn test_arrow_batch_null_and_length_mismatch_agree() {
         let targets =

--- a/rust/lance-linalg/src/distance.rs
+++ b/rust/lance-linalg/src/distance.rs
@@ -632,6 +632,19 @@ mod tests {
                 "{dt} rejected a well-formed Int8 query"
             );
         }
+
+        // A sliced query reads through `values()`, which has to follow the
+        // slice: the window here holds no nulls while the full buffer does, and
+        // its two elements must be the ones the slice selects.
+        let sliced = Int8Array::from(vec![None, Some(3_i8), Some(4), None]).slice(1, 2);
+        let query: Arc<dyn Array> = Arc::new(sliced);
+        for dt in [DistanceType::L2, DistanceType::Dot] {
+            let got = dt.arrow_batch_func()(query.as_ref(), &targets).unwrap();
+            let want =
+                dt.arrow_batch_func()(Arc::new(Int8Array::from(vec![3_i8, 4])).as_ref(), &targets)
+                    .unwrap();
+            assert_eq!(got.values(), want.values(), "{dt} mis-read a sliced query");
+        }
     }
 
     /// `Int8` is a valid vector element type elsewhere in the crate but has no

--- a/rust/lance-linalg/src/distance.rs
+++ b/rust/lance-linalg/src/distance.rs
@@ -643,7 +643,11 @@ mod tests {
             let want =
                 dt.arrow_batch_func()(Arc::new(Int8Array::from(vec![3_i8, 4])).as_ref(), &targets)
                     .unwrap();
-            assert_eq!(got.values(), want.values(), "{dt} mis-read a sliced query");
+            assert_eq!(
+                got.values(),
+                want.values(),
+                "{dt} did not follow the query slice"
+            );
         }
     }
 

--- a/rust/lance-linalg/src/distance.rs
+++ b/rust/lance-linalg/src/distance.rs
@@ -649,6 +649,26 @@ mod tests {
         }
     }
 
+    /// An input that is both a length mismatch and a null query must behave the
+    /// same on all three metrics. It did not: `dot` asserted the dimension in its
+    /// public entry point as well as in the shared body, so it panicked there
+    /// while l2 and cosine returned the null error.
+    #[test]
+    fn test_arrow_batch_null_and_length_mismatch_agree() {
+        let targets =
+            FixedSizeListArray::try_new_from_values(Int8Array::from(vec![1_i8, 2, 3, 4]), 2)
+                .unwrap();
+        let query: Arc<dyn Array> = Arc::new(Int8Array::from(vec![Some(1_i8), None, Some(2)]));
+
+        for dt in [DistanceType::L2, DistanceType::Cosine, DistanceType::Dot] {
+            let err = dt.arrow_batch_func()(query.as_ref(), &targets).unwrap_err();
+            assert!(
+                matches!(&err, ArrowError::InvalidArgumentError(m) if m.contains("must not contain nulls")),
+                "{dt} did not report the null query, got: {err}"
+            );
+        }
+    }
+
     /// `Int8` is a valid vector element type elsewhere in the crate but has no
     /// multivector kernel, so it must be rejected for the type, not the metric.
     #[test]

--- a/rust/lance-linalg/src/distance.rs
+++ b/rust/lance-linalg/src/distance.rs
@@ -635,12 +635,21 @@ mod tests {
             );
         }
 
-        // A sliced query reads through `values()`, which has to follow the
-        // slice: the window here holds no nulls while the full buffer does, and
-        // its two elements must be the ones the slice selects.
+        // A sliced query reads through `values()`, which has to follow the slice:
+        // the window here holds no nulls while the full buffer does. The L2
+        // distances are asserted literally rather than against a second call,
+        // since computing the expected values by the same route would hide a bug
+        // that transformed both alike. Query [3, 4] against [[1, 2], [3, 4]]
+        // gives (3-1)^2 + (4-2)^2 = 8 and 0.
         let sliced = Int8Array::from(vec![None, Some(3_i8), Some(4), None]).slice(1, 2);
         let query: Arc<dyn Array> = Arc::new(sliced);
-        for dt in [DistanceType::L2, DistanceType::Cosine, DistanceType::Dot] {
+        let got = DistanceType::L2.arrow_batch_func()(query.as_ref(), &targets).unwrap();
+        assert_eq!(
+            got.values(),
+            &[8.0_f32, 0.0],
+            "L2 did not follow the query slice"
+        );
+        for dt in [DistanceType::Cosine, DistanceType::Dot] {
             let got = dt.arrow_batch_func()(query.as_ref(), &targets).unwrap();
             let want =
                 dt.arrow_batch_func()(Arc::new(Int8Array::from(vec![3_i8, 4])).as_ref(), &targets)

--- a/rust/lance-linalg/src/distance/cosine.rs
+++ b/rust/lance-linalg/src/distance/cosine.rs
@@ -1370,9 +1370,8 @@ where
 ///
 /// # Panics
 ///
-/// With debug assertions on, panics if the length of `from` is not equal to the
-/// dimension (value length) of `to`, unless one of the errors above is returned
-/// first.
+/// Panics if the length of `from` is not equal to the dimension (value length)
+/// of `to`, unless one of the errors above is returned first.
 pub fn cosine_distance_arrow_batch(
     from: &dyn Array,
     to: &FixedSizeListArray,

--- a/rust/lance-linalg/src/distance/cosine.rs
+++ b/rust/lance-linalg/src/distance/cosine.rs
@@ -1372,8 +1372,8 @@ where
 ///
 /// With debug assertions on, panics if the length of `from` is not equal to the
 /// dimension (value length) of `to`, unless one of the errors above is returned
-/// first. Unlike the l2 and dot equivalents, cosine has no always-on layout
-/// assert, so without them a mismatch can read past the shorter vector instead.
+/// first. Without them the mismatch is not reliably caught, since cosine has no
+/// always-on layout assert of its own, unlike the l2 and dot equivalents.
 pub fn cosine_distance_arrow_batch(
     from: &dyn Array,
     to: &FixedSizeListArray,

--- a/rust/lance-linalg/src/distance/cosine.rs
+++ b/rust/lance-linalg/src/distance/cosine.rs
@@ -24,7 +24,7 @@ use lance_arrow::{ArrowFloatType, FixedSizeListArrayExt, FloatArray};
 #[allow(unused_imports)]
 use lance_core::utils::cpu::{SIMD_SUPPORT, SimdSupport};
 
-use super::{Dot, norm_l2::norm_l2};
+use super::{Dot, int8_query_to_f32, norm_l2::norm_l2};
 use super::{Normalize, dot::dot};
 #[cfg(all(target_arch = "x86_64", not(target_feature = "avx2")))]
 use crate::distance::BatchKind;
@@ -1374,11 +1374,7 @@ pub fn cosine_distance_arrow_batch(
         DataType::Float32 => do_cosine_distance_arrow_batch::<Float32Type>(from.as_primitive(), to),
         DataType::Float64 => do_cosine_distance_arrow_batch::<Float64Type>(from.as_primitive(), to),
         DataType::Int8 => do_cosine_distance_arrow_batch::<Float32Type>(
-            &from
-                .as_primitive::<Int8Type>()
-                .into_iter()
-                .map(|x| x.unwrap() as f32)
-                .collect(),
+            &int8_query_to_f32(from.as_primitive::<Int8Type>())?,
             &to.convert_to_floating_point()?,
         ),
         _ => Err(Error::InvalidArgumentError(format!(

--- a/rust/lance-linalg/src/distance/cosine.rs
+++ b/rust/lance-linalg/src/distance/cosine.rs
@@ -1370,7 +1370,9 @@ where
 ///
 /// # Panics
 ///
-/// Panics if the length of `from` is not equal to the dimension (value length) of `to`.
+/// With debug assertions on, panics if the length of `from` is not equal to the
+/// dimension (value length) of `to`, unless one of the errors above is returned
+/// first.
 pub fn cosine_distance_arrow_batch(
     from: &dyn Array,
     to: &FixedSizeListArray,

--- a/rust/lance-linalg/src/distance/cosine.rs
+++ b/rust/lance-linalg/src/distance/cosine.rs
@@ -1362,6 +1362,11 @@ where
 /// - `from`: the vector to compute distance from.
 /// - `to`: a list of vectors to compute distance to.
 ///
+/// # Errors
+///
+/// Returns `ArrowError::InvalidArgumentError` if `from` is an `Int8` array
+/// containing nulls: a null query element has no distance to compute.
+///
 /// # Panics
 ///
 /// Panics if the length of `from` is not equal to the dimension (value length) of `to`.

--- a/rust/lance-linalg/src/distance/cosine.rs
+++ b/rust/lance-linalg/src/distance/cosine.rs
@@ -1370,8 +1370,10 @@ where
 ///
 /// # Panics
 ///
-/// Panics if the length of `from` is not equal to the dimension (value length)
-/// of `to`, unless one of the errors above is returned first.
+/// With debug assertions on, panics if the length of `from` is not equal to the
+/// dimension (value length) of `to`, unless one of the errors above is returned
+/// first. Unlike the l2 and dot equivalents, cosine has no always-on layout
+/// assert, so without them a mismatch can read past the shorter vector instead.
 pub fn cosine_distance_arrow_batch(
     from: &dyn Array,
     to: &FixedSizeListArray,

--- a/rust/lance-linalg/src/distance/cosine.rs
+++ b/rust/lance-linalg/src/distance/cosine.rs
@@ -1371,9 +1371,9 @@ where
 /// # Panics
 ///
 /// With debug assertions on, panics if the length of `from` is not equal to the
-/// dimension (value length) of `to`, unless one of the errors above is returned
-/// first. Without them the mismatch is not reliably caught, since cosine has no
-/// always-on layout assert of its own, unlike the l2 and dot equivalents.
+/// dimension (value length) of `to`. Without them the mismatch is not reliably
+/// caught, since cosine has no always-on layout assert of its own, unlike the l2
+/// and dot equivalents.
 pub fn cosine_distance_arrow_batch(
     from: &dyn Array,
     to: &FixedSizeListArray,

--- a/rust/lance-linalg/src/distance/cosine.rs
+++ b/rust/lance-linalg/src/distance/cosine.rs
@@ -1364,8 +1364,9 @@ where
 ///
 /// # Errors
 ///
-/// Returns `ArrowError::InvalidArgumentError` if `from` is an `Int8` array
-/// containing nulls: a null query element has no distance to compute.
+/// Returns an error if `from` is an `Int8` array containing nulls, since a null
+/// query element has no distance to compute. The unsupported-type and downcast
+/// paths return errors of their own; this list is not exhaustive.
 ///
 /// # Panics
 ///

--- a/rust/lance-linalg/src/distance/dot.rs
+++ b/rust/lance-linalg/src/distance/dot.rs
@@ -812,8 +812,7 @@ where
 ///
 /// # Panics
 ///
-/// Panics if the length of `from` is not equal to the dimension (value length)
-/// of `to`.
+/// Panics if the length of `from` is not equal to the dimension (value length) of `to`.
 pub fn dot_distance_arrow_batch(
     from: &dyn Array,
     to: &FixedSizeListArray,

--- a/rust/lance-linalg/src/distance/dot.rs
+++ b/rust/lance-linalg/src/distance/dot.rs
@@ -28,7 +28,7 @@ use crate::Result;
     not(all(target_feature = "avx2", target_feature = "fma"))
 ))]
 use crate::distance::{BatchIter, BatchKernel, BatchKind, BatchOperation};
-use crate::distance::{assert_batch_layout, assert_equal_lengths};
+use crate::distance::{assert_batch_layout, assert_equal_lengths, int8_query_to_f32};
 #[cfg(all(
     target_arch = "x86_64",
     not(all(target_feature = "avx2", target_feature = "fma"))
@@ -819,11 +819,7 @@ pub fn dot_distance_arrow_batch(
         DataType::Float32 => do_dot_distance_arrow_batch::<Float32Type>(from.as_primitive(), to),
         DataType::Float64 => do_dot_distance_arrow_batch::<Float64Type>(from.as_primitive(), to),
         DataType::Int8 => do_dot_distance_arrow_batch::<Float32Type>(
-            &from
-                .as_primitive::<Int8Type>()
-                .into_iter()
-                .map(|x| x.unwrap() as f32)
-                .collect(),
+            &int8_query_to_f32(from.as_primitive::<Int8Type>())?,
             &to.convert_to_floating_point()?,
         ),
         _ => Err(Error::InvalidArgumentError(format!(

--- a/rust/lance-linalg/src/distance/dot.rs
+++ b/rust/lance-linalg/src/distance/dot.rs
@@ -817,9 +817,6 @@ pub fn dot_distance_arrow_batch(
     from: &dyn Array,
     to: &FixedSizeListArray,
 ) -> Result<Arc<Float32Array>> {
-    // `do_dot_distance_arrow_batch` already carries this `debug_assert_eq!`, and
-    // the copy that was here sat ahead of the `Int8` arm's null guard, where l2
-    // and cosine have theirs after it.
     match *from.data_type() {
         DataType::Float16 => do_dot_distance_arrow_batch::<Float16Type>(from.as_primitive(), to),
         DataType::Float32 => do_dot_distance_arrow_batch::<Float32Type>(from.as_primitive(), to),

--- a/rust/lance-linalg/src/distance/dot.rs
+++ b/rust/lance-linalg/src/distance/dot.rs
@@ -812,13 +812,15 @@ where
 ///
 /// # Panics
 ///
-/// Panics if the length of `from` is not equal to the dimension (value length) of `to`.
+/// With debug assertions on, panics if the length of `from` is not equal to the
+/// dimension (value length) of `to`, unless one of the errors above is returned
+/// first.
 pub fn dot_distance_arrow_batch(
     from: &dyn Array,
     to: &FixedSizeListArray,
 ) -> Result<Arc<Float32Array>> {
-    // The dimension check lives in `do_dot_distance_arrow_batch`, which every
-    // arm below reaches. Asserting here too made this the one metric of the
+    // The dimension check lives in `do_dot_distance_arrow_batch`, which the four
+    // typed arms reach. Asserting here as well made this the one metric of the
     // three that panicked on an input that is both a length mismatch and a null
     // query, where l2 and cosine returned the error.
     match *from.data_type() {

--- a/rust/lance-linalg/src/distance/dot.rs
+++ b/rust/lance-linalg/src/distance/dot.rs
@@ -812,17 +812,15 @@ where
 ///
 /// # Panics
 ///
-/// With debug assertions on, panics if the length of `from` is not equal to the
-/// dimension (value length) of `to`, unless one of the errors above is returned
-/// first.
+/// Panics if the length of `from` is not equal to the dimension (value length)
+/// of `to`, unless one of the errors above is returned first.
 pub fn dot_distance_arrow_batch(
     from: &dyn Array,
     to: &FixedSizeListArray,
 ) -> Result<Arc<Float32Array>> {
     // The dimension check lives in `do_dot_distance_arrow_batch`, which the four
-    // typed arms reach. Asserting here as well made this the one metric of the
-    // three that panicked on an input that is both a length mismatch and a null
-    // query, where l2 and cosine returned the error.
+    // typed arms reach. Asserting it here as well put it ahead of the `Int8`
+    // arm's null check, which neither l2 nor cosine does.
     match *from.data_type() {
         DataType::Float16 => do_dot_distance_arrow_batch::<Float16Type>(from.as_primitive(), to),
         DataType::Float32 => do_dot_distance_arrow_batch::<Float32Type>(from.as_primitive(), to),

--- a/rust/lance-linalg/src/distance/dot.rs
+++ b/rust/lance-linalg/src/distance/dot.rs
@@ -818,9 +818,9 @@ pub fn dot_distance_arrow_batch(
     from: &dyn Array,
     to: &FixedSizeListArray,
 ) -> Result<Arc<Float32Array>> {
-    // The dimension check lives in `do_dot_distance_arrow_batch`, which the four
-    // typed arms reach. Asserting it here as well put it ahead of the `Int8`
-    // arm's null check, which neither l2 nor cosine does.
+    // `do_dot_distance_arrow_batch` already carries this `debug_assert_eq!`, and
+    // the copy that was here sat ahead of the `Int8` arm's null guard, where l2
+    // and cosine have theirs after it.
     match *from.data_type() {
         DataType::Float16 => do_dot_distance_arrow_batch::<Float16Type>(from.as_primitive(), to),
         DataType::Float32 => do_dot_distance_arrow_batch::<Float32Type>(from.as_primitive(), to),

--- a/rust/lance-linalg/src/distance/dot.rs
+++ b/rust/lance-linalg/src/distance/dot.rs
@@ -813,7 +813,7 @@ where
 /// # Panics
 ///
 /// Panics if the length of `from` is not equal to the dimension (value length)
-/// of `to`, unless one of the errors above is returned first.
+/// of `to`.
 pub fn dot_distance_arrow_batch(
     from: &dyn Array,
     to: &FixedSizeListArray,

--- a/rust/lance-linalg/src/distance/dot.rs
+++ b/rust/lance-linalg/src/distance/dot.rs
@@ -806,8 +806,9 @@ where
 ///
 /// # Errors
 ///
-/// Returns `ArrowError::InvalidArgumentError` if `from` is an `Int8` array
-/// containing nulls: a null query element has no distance to compute.
+/// Returns an error if `from` is an `Int8` array containing nulls, since a null
+/// query element has no distance to compute. The unsupported-type and downcast
+/// paths return errors of their own; this list is not exhaustive.
 ///
 /// # Panics
 ///
@@ -816,9 +817,10 @@ pub fn dot_distance_arrow_batch(
     from: &dyn Array,
     to: &FixedSizeListArray,
 ) -> Result<Arc<Float32Array>> {
-    let dimension = to.value_length() as usize;
-    debug_assert_eq!(from.len(), dimension);
-
+    // The dimension check lives in `do_dot_distance_arrow_batch`, which every
+    // arm below reaches. Asserting here too made this the one metric of the
+    // three that panicked on an input that is both a length mismatch and a null
+    // query, where l2 and cosine returned the error.
     match *from.data_type() {
         DataType::Float16 => do_dot_distance_arrow_batch::<Float16Type>(from.as_primitive(), to),
         DataType::Float32 => do_dot_distance_arrow_batch::<Float32Type>(from.as_primitive(), to),

--- a/rust/lance-linalg/src/distance/dot.rs
+++ b/rust/lance-linalg/src/distance/dot.rs
@@ -804,6 +804,11 @@ where
 /// - `from`: the vector to compute distance from.
 /// - `to`: a list of vectors to compute distance to.
 ///
+/// # Errors
+///
+/// Returns `ArrowError::InvalidArgumentError` if `from` is an `Int8` array
+/// containing nulls: a null query element has no distance to compute.
+///
 /// # Panics
 ///
 /// Panics if the length of `from` is not equal to the dimension (value length) of `to`.

--- a/rust/lance-linalg/src/distance/l2.rs
+++ b/rust/lance-linalg/src/distance/l2.rs
@@ -977,8 +977,7 @@ where
 ///
 /// # Panics
 ///
-/// Panics if the length of `from` is not equal to the dimension (value length)
-/// of `to`.
+/// Panics if the length of `from` is not equal to the dimension (value length) of `to`.
 pub fn l2_distance_arrow_batch(
     from: &dyn Array,
     to: &FixedSizeListArray,

--- a/rust/lance-linalg/src/distance/l2.rs
+++ b/rust/lance-linalg/src/distance/l2.rs
@@ -977,9 +977,8 @@ where
 ///
 /// # Panics
 ///
-/// With debug assertions on, panics if the length of `from` is not equal to the
-/// dimension (value length) of `to`, unless one of the errors above is returned
-/// first.
+/// Panics if the length of `from` is not equal to the dimension (value length)
+/// of `to`, unless one of the errors above is returned first.
 pub fn l2_distance_arrow_batch(
     from: &dyn Array,
     to: &FixedSizeListArray,

--- a/rust/lance-linalg/src/distance/l2.rs
+++ b/rust/lance-linalg/src/distance/l2.rs
@@ -977,7 +977,9 @@ where
 ///
 /// # Panics
 ///
-/// Panics if the length of `from` is not equal to the dimension (value length) of `to`.
+/// With debug assertions on, panics if the length of `from` is not equal to the
+/// dimension (value length) of `to`, unless one of the errors above is returned
+/// first.
 pub fn l2_distance_arrow_batch(
     from: &dyn Array,
     to: &FixedSizeListArray,

--- a/rust/lance-linalg/src/distance/l2.rs
+++ b/rust/lance-linalg/src/distance/l2.rs
@@ -30,7 +30,7 @@ use lance_core::utils::cpu::SIMD_SUPPORT;
 use lance_core::utils::cpu::SimdSupport;
 use num_traits::{AsPrimitive, Num};
 
-use crate::distance::{assert_batch_layout, assert_equal_lengths};
+use crate::distance::{assert_batch_layout, assert_equal_lengths, int8_query_to_f32};
 
 #[cfg(all(
     target_arch = "x86_64",
@@ -981,11 +981,7 @@ pub fn l2_distance_arrow_batch(
         DataType::Float32 => do_l2_distance_arrow_batch::<Float32Type>(from.as_primitive(), to),
         DataType::Float64 => do_l2_distance_arrow_batch::<Float64Type>(from.as_primitive(), to),
         DataType::Int8 => do_l2_distance_arrow_batch::<Float32Type>(
-            &from
-                .as_primitive::<Int8Type>()
-                .into_iter()
-                .map(|x| x.unwrap() as f32)
-                .collect(),
+            &int8_query_to_f32(from.as_primitive::<Int8Type>())?,
             &to.convert_to_floating_point()?,
         ),
         _ => Err(Error::ComputeError(format!(

--- a/rust/lance-linalg/src/distance/l2.rs
+++ b/rust/lance-linalg/src/distance/l2.rs
@@ -971,8 +971,9 @@ where
 ///
 /// # Errors
 ///
-/// Returns `ArrowError::InvalidArgumentError` if `from` is an `Int8` array
-/// containing nulls: a null query element has no distance to compute.
+/// Returns an error if `from` is an `Int8` array containing nulls, since a null
+/// query element has no distance to compute. The unsupported-type and downcast
+/// paths return errors of their own; this list is not exhaustive.
 ///
 /// # Panics
 ///

--- a/rust/lance-linalg/src/distance/l2.rs
+++ b/rust/lance-linalg/src/distance/l2.rs
@@ -969,6 +969,11 @@ where
 /// - `from`: the vector to compute distance from.
 /// - `to`: a list of vectors to compute distance to.
 ///
+/// # Errors
+///
+/// Returns `ArrowError::InvalidArgumentError` if `from` is an `Int8` array
+/// containing nulls: a null query element has no distance to compute.
+///
 /// # Panics
 ///
 /// Panics if the length of `from` is not equal to the dimension (value length) of `to`.

--- a/rust/lance-linalg/src/distance/l2.rs
+++ b/rust/lance-linalg/src/distance/l2.rs
@@ -978,7 +978,7 @@ where
 /// # Panics
 ///
 /// Panics if the length of `from` is not equal to the dimension (value length)
-/// of `to`, unless one of the errors above is returned first.
+/// of `to`.
 pub fn l2_distance_arrow_batch(
     from: &dyn Array,
     to: &FixedSizeListArray,


### PR DESCRIPTION
## What this changes

`l2_distance_arrow_batch`, `dot_distance_arrow_batch` and `cosine_distance_arrow_batch` take the query as a `&dyn Array` and widen an `Int8` one element at a time. All three did it the same way:

```rust
DataType::Int8 => do_l2_distance_arrow_batch::<Float32Type>(
    &from
        .as_primitive::<Int8Type>()
        .into_iter()
        .map(|x| x.unwrap() as f32)
        .collect(),
    &to.convert_to_floating_point()?,
),
```

A null element in the query reaches that `unwrap` and panics, in every profile. The three functions all return `Result` and all document that the null buffer of `to` is propagated to the output, which says nothing about nulls in `from`, so a caller has no reason to expect a panic from the other side.

The three sites now share `int8_query_to_f32`, which rejects the input with `InvalidArgumentError` and names the count, then widens through `values()` so no `Option` remains. Returning an error rather than panicking is what the unsupported-type arm of the same `match` already does, though l2's is a `ComputeError` where dot's and cosine's are `InvalidArgumentError`. The arm is reachable from a real caller: `lance-index`'s flat search passes a user query straight into `DistanceType::arrow_batch_func()`.

Three smaller things travel with it.

`dot_distance_arrow_batch` carried a `debug_assert_eq!` on the dimension in its public entry point, ahead of the `Int8` arm. Once that arm returns an error instead of panicking, the copy preempts it in a debug build: a query that is both null-bearing and the wrong length would panic on dot and return the error on its two siblings. The copy is gone; `do_dot_distance_arrow_batch` still carries the same assert, which is where l2 and cosine have theirs.

All three functions gain an `# Errors` section, which none of them had. It names the new null rejection and says the list is not exhaustive, since the unsupported-type and downcast arms return errors of their own.

All three already had a `# Panics` section, and only cosine's changes: it now says the length mismatch is caught with debug assertions on, and not reliably without them, because cosine has no always-on layout assert of its own. l2 and dot keep theirs as written, since `assert_batch_layout` is a plain `assert!` on every batch path they reach.

The float arms are untouched. `Float16`, `Float32` and `Float64` hand the array to `do_*_arrow_batch` directly, which reads it through `as_slice()` and ignores the validity buffer, so a null there is read as whatever the slot holds rather than panicking. Changing that is a separate decision about what a null query element should mean.

## Test plan

`test_arrow_batch_rejects_null_int8_query` goes through `DistanceType::arrow_batch_func()` for L2, Cosine and Dot, so it covers all three sites through the public dispatch rather than each function directly. Three parts:

- a query of `[Some(1), None]` returns `InvalidArgumentError` whose message contains both `Int8 query vector \`from\`` and `found 1 in 2 values`
- the same query without nulls returns two distances, so the guard cannot pass by rejecting every `Int8` query
- a query sliced out of `[None, Some(3), Some(4), None]` at offset 1 goes through, because the slice window holds no nulls even though the full buffer does. Both the null count and the widening have to describe the same window or this either rejects a clean query or widens the wrong two elements. L2's result is asserted literally as `[8.0, 0.0]`, which is what pins the widening; Cosine and Dot are compared against a call on an unsliced `[3, 4]`, which pins the window but would agree with itself if the widening were wrong.

`test_arrow_batch_null_and_length_mismatch_agree` sends an input that is wrong in both ways at once, a three-element null-bearing query against a dimension-2 target, and asserts all three metrics reach the null error. Restoring dot's entry-point `debug_assert_eq!` makes that test fail on dot with `left: 3, right: 2`.

Measured: restoring the three `unwrap` call sites makes `test_arrow_batch_rejects_null_int8_query` fail with a panic at the `unwrap` in `l2.rs` rather than an error.

- `cargo test -p lance-linalg`: 396 passed, 1 ignored
- `cargo fmt --all -- --check` and `cargo clippy -p lance-linalg --all-targets -- -D warnings`: clean


