### PR TITLE
perf(index): open fragment reuse indexes 10-2200x faster

### DIFF
--- a/rust/lance-core/src/utils/row_addr_remap.rs
+++ b/rust/lance-core/src/utils/row_addr_remap.rs
@@ -197,6 +197,8 @@ pub struct GroupInputWithLayout {
 /// Keep Roaring only when its serialized representation is substantially
 /// smaller than either rank-friendly representation. This preserves compact
 /// run containers while avoiding Roaring's linear word scan for dense rank.
+/// Binary-copy compaction creates these runs with `RoaringTreemap::insert_range`,
+/// and serialization preserves them without an explicit `optimize()` call.
 const ROARING_SIZE_ADVANTAGE_FOR_RANK: usize = 4;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -418,7 +420,7 @@ impl GroupRemap {
         for &(frag_id, physical_rows) in &old_frags {
             if !seen_frag_ids.insert(frag_id) {
                 return Err(Error::invalid_input(format!(
-                    "rewrite group contains old fragment {frag_id} more than once"
+                    "rewrite group {group_idx} contains old fragment {frag_id} more than once"
                 )));
             }
             let bitmap = per_frag.remove(&frag_id).unwrap_or_default();
@@ -426,7 +428,7 @@ impl GroupRemap {
                 && bitmap.max().is_some_and(|offset| offset >= physical_rows)
             {
                 return Err(Error::invalid_input(format!(
-                    "rewrite group contains a row offset outside old fragment {frag_id} with physical_rows={physical_rows}"
+                    "rewrite group {group_idx} contains a row offset outside old fragment {frag_id} with physical_rows={physical_rows}"
                 )));
             }
             let num_rewritten_rows = bitmap.len();
@@ -445,7 +447,7 @@ impl GroupRemap {
         // Rewritten old row addresses must reference only listed old fragments.
         if !per_frag.is_empty() {
             return Err(Error::invalid_input(format!(
-                "compaction rewritten old row addresses reference fragments {:?} not in the rewrite group's old fragments {:?}",
+                "compaction rewrite group {group_idx} references rewritten old row addresses from fragments {:?} not in its old fragments {:?}",
                 per_frag.keys().collect::<Vec<_>>(),
                 old_frags,
             )));
@@ -456,7 +458,7 @@ impl GroupRemap {
         let total_rewritten_old_rows = rewritten_old_row_addrs.len();
         if total_new_rows != total_rewritten_old_rows {
             return Err(Error::invalid_input(format!(
-                "compaction rewrote {total_rewritten_old_rows} old rows from fragments {:?} but the new fragments hold {total_new_rows} rows",
+                "compaction rewrite group {group_idx} rewrote {total_rewritten_old_rows} old rows from fragments {:?} but the new fragments hold {total_new_rows} rows",
                 old_frags,
             )));
         }
@@ -509,7 +511,7 @@ impl CompactRemapStep {
             for (frag_id, frag) in group_frags {
                 if frags.insert(frag_id, frag).is_some() {
                     return Err(Error::invalid_input(format!(
-                        "old fragment {frag_id} appears in more than one rewrite group"
+                        "old fragment {frag_id} appears in more than one rewrite group, including group {gi}"
                     )));
                 }
             }
@@ -530,7 +532,7 @@ impl CompactRemapStep {
             for (frag_id, frag) in group_frags {
                 if frags.insert(frag_id, frag).is_some() {
                     return Err(Error::invalid_input(format!(
-                        "old fragment {frag_id} appears in more than one rewrite group"
+                        "old fragment {frag_id} appears in more than one rewrite group, including group {gi}"
                     )));
                 }
             }
@@ -718,13 +720,12 @@ impl CompactRowAddrRemap {
     }
 
     fn fully_deleted_fragments(&self) -> Option<RoaringBitmap> {
-        match self.steps.as_slice() {
-            [] => Some(RoaringBitmap::new()),
-            [step] => step.fully_deleted_fragments(),
-            // Determining whether every baseline fragment is ultimately
-            // deleted requires composing fragment domains across steps.
-            _ => None,
-        }
+        self.steps
+            .iter()
+            .try_fold(RoaringBitmap::new(), |mut deleted, step| {
+                deleted |= step.fully_deleted_fragments()?;
+                Some(deleted)
+            })
     }
 }
 
@@ -740,6 +741,64 @@ mod tests {
 
     fn addr(frag: u32, offset: u32) -> u64 {
         u64::from(RowAddress::new_from_parts(frag, offset))
+    }
+
+    #[derive(Clone, Copy)]
+    enum ExpectedRankedOffsets {
+        Sparse,
+        Dense,
+        Roaring,
+    }
+
+    fn assert_layout_matches_legacy(
+        frag_id: u32,
+        physical_rows: u32,
+        rewritten_old_row_addrs: RoaringTreemap,
+        new_frags: Vec<(u32, u32)>,
+        expected_representation: ExpectedRankedOffsets,
+    ) {
+        let rewritten_addrs = rewritten_old_row_addrs.iter().collect::<Vec<_>>();
+        let new_addrs = new_frags
+            .iter()
+            .flat_map(|(new_frag_id, rows)| (0..*rows).map(|offset| addr(*new_frag_id, offset)))
+            .collect::<Vec<_>>();
+        assert_eq!(rewritten_addrs.len(), new_addrs.len());
+        let expected_moved = rewritten_addrs
+            .iter()
+            .copied()
+            .zip(new_addrs)
+            .collect::<HashMap<_, _>>();
+
+        let remap = RowAddrRemap::compact_with_layout([GroupInputWithLayout {
+            rewritten_old_row_addrs,
+            old_frags: vec![(frag_id, physical_rows)],
+            new_frags,
+        }])
+        .unwrap();
+
+        let RowAddrRemap::Compact(compact) = &remap else {
+            panic!("compact_with_layout must produce a compact remap");
+        };
+        let RemapStep::Compact(step) = &compact.steps[0] else {
+            panic!("compact_with_layout must produce a compact step");
+        };
+        let offsets = &step.frags[&frag_id].rewritten_offsets;
+        assert!(match expected_representation {
+            ExpectedRankedOffsets::Sparse => matches!(offsets, RankedOffsets::Sparse(_)),
+            ExpectedRankedOffsets::Dense => matches!(offsets, RankedOffsets::Dense(_)),
+            ExpectedRankedOffsets::Roaring => matches!(offsets, RankedOffsets::Roaring(_)),
+        });
+
+        for offset in 0..physical_rows {
+            let old_addr = addr(frag_id, offset);
+            assert_eq!(
+                remap.get(old_addr),
+                Some(expected_moved.get(&old_addr).copied()),
+                "mismatch at ({frag_id}, {offset})"
+            );
+        }
+        assert_eq!(remap.get(addr(frag_id, physical_rows)), None);
+        assert_eq!(remap.get(addr(frag_id + 1, 0)), None);
     }
 
     #[test]
@@ -781,13 +840,56 @@ mod tests {
     fn test_run_compressed_ranked_offsets() {
         let mut rewritten = RoaringBitmap::new();
         rewritten.insert_range(100..9_900);
-        rewritten.optimize();
         let offsets = RankedOffsets::try_new(rewritten, Some(10_000)).unwrap();
         assert!(matches!(offsets, RankedOffsets::Roaring(_)));
         assert_eq!(offsets.rank_if_present(99), None);
         assert_eq!(offsets.rank_if_present(100), Some(0));
         assert_eq!(offsets.rank_if_present(9_899), Some(9_799));
         assert_eq!(offsets.rank_if_present(9_900), None);
+    }
+
+    #[test]
+    fn test_compact_with_layout_matches_legacy_across_rank_representations() {
+        assert_layout_matches_legacy(
+            1,
+            10_000,
+            RoaringTreemap::from_iter(
+                [1u32, 63, 511, 9_999]
+                    .into_iter()
+                    .map(|offset| addr(1, offset)),
+            ),
+            vec![(10, 2), (11, 2)],
+            ExpectedRankedOffsets::Sparse,
+        );
+
+        let dense = (0..1_024u32)
+            .filter(|offset| offset % 10 != 0)
+            .map(|offset| addr(2, offset))
+            .collect::<RoaringTreemap>();
+        let dense_rows = u32::try_from(dense.len()).unwrap();
+        assert_layout_matches_legacy(
+            2,
+            1_024,
+            dense,
+            vec![(20, 400), (21, dense_rows - 400)],
+            ExpectedRankedOffsets::Dense,
+        );
+
+        // Binary-copy compaction captures complete fragment ranges with
+        // `RoaringTreemap::insert_range`, then persists that bitmap. The
+        // serialized round trip retains run containers without `optimize()`.
+        let mut captured = RoaringTreemap::new();
+        captured.insert_range(addr(3, 100)..addr(3, 9_900));
+        let mut serialized = Vec::with_capacity(captured.serialized_size());
+        captured.serialize_into(&mut serialized).unwrap();
+        let persisted = RoaringTreemap::deserialize_from(std::io::Cursor::new(serialized)).unwrap();
+        assert_layout_matches_legacy(
+            3,
+            10_000,
+            persisted,
+            vec![(31, 5_000), (30, 4_800)],
+            ExpectedRankedOffsets::Roaring,
+        );
     }
 
     #[test]
@@ -834,13 +936,21 @@ mod tests {
 
     #[test]
     fn test_fragment_sets() {
-        // No rewritten rows at all: every covered fragment is fully deleted.
-        let dead = RowAddrRemap::compact([GroupInput {
+        // Each deferred version deletes a different covered fragment. The
+        // chain must retain the flat direct map's union semantics.
+        let first_dead = RowAddrRemap::compact([GroupInput {
             rewritten_old_row_addrs: RoaringTreemap::new(),
-            old_frag_ids: vec![3, 7],
+            old_frag_ids: vec![3],
             new_frags: vec![],
         }])
         .unwrap();
+        let second_dead = RowAddrRemap::compact([GroupInput {
+            rewritten_old_row_addrs: RoaringTreemap::new(),
+            old_frag_ids: vec![7],
+            new_frags: vec![],
+        }])
+        .unwrap();
+        let dead = RowAddrRemap::chained([first_dead.clone(), second_dead]);
         assert_eq!(
             dead.fully_deleted_fragments(),
             Some(RoaringBitmap::from_iter([3u32, 7u32]))
@@ -862,6 +972,11 @@ mod tests {
         assert_eq!(
             alive.affected_fragments(),
             RoaringBitmap::from_iter([0u32, 1u32])
+        );
+        assert!(
+            RowAddrRemap::chained([first_dead, alive])
+                .fully_deleted_fragments()
+                .is_none()
         );
     }
 

--- a/rust/lance-core/src/utils/row_addr_remap.rs
+++ b/rust/lance-core/src/utils/row_addr_remap.rs
@@ -21,8 +21,10 @@
 //! * An address whose fragment was not rewritten returns `None`.
 //! * For an address whose fragment was rewritten:
 //!     * Read `(old_offsets, old_rows_before)` from the old-row layout.
-//!     * If `offset` is not in `old_offsets`, return `Some(None)` because the
-//!       row was deleted.
+//!     * If `offset` is outside the old fragment's physical row range, return
+//!       `None`; the direct-map representation would not contain that address.
+//!     * If a valid `offset` is not in `old_offsets`, return `Some(None)`
+//!       because the row was deleted.
 //!     * Otherwise, `old_offsets.rank(offset) - 1` is this row's 0-based
 //!       position among rewritten old rows in this old fragment. Add
 //!       `old_rows_before` to get `k`, the row's 0-based position among all
@@ -44,10 +46,11 @@
 //! * Current compaction satisfies this because it scans selected fragments in
 //!   order and writes the resulting stream without reordering rows.
 
+use crate::deepsize::{Context, DeepSizeOf};
 use crate::utils::address::RowAddress;
 use crate::{Error, Result};
 use roaring::{RoaringBitmap, RoaringTreemap};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 /// A queryable row-address remapping with the exact semantics of
 /// `HashMap<u64, Option<u64>>::get(&addr).copied()`:
@@ -55,7 +58,7 @@ use std::collections::HashMap;
 /// * `None` — the address is not affected by this remap (keep it unchanged)
 /// * `Some(None)` — the row was deleted
 /// * `Some(Some(addr))` — the row moved to `addr`
-#[derive(Clone)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum RowAddrRemap {
     /// Compact, `O(#fragments)` remap built from per-group rewritten-row
     /// bitmaps and new-fragment layouts.
@@ -69,9 +72,32 @@ impl RowAddrRemap {
         Ok(Self::Compact(CompactRowAddrRemap::new(groups)?))
     }
 
+    /// Build a compact remap with physical row counts for exact validation of
+    /// addresses loaded from persisted fragment layouts.
+    #[doc(hidden)]
+    pub fn compact_with_layout(
+        groups: impl IntoIterator<Item = GroupInputWithLayout>,
+    ) -> Result<Self> {
+        Ok(Self::Compact(CompactRowAddrRemap::new_with_layout(groups)?))
+    }
+
     /// Build a remap from a fully materialized old-to-new address map.
     pub fn direct(map: HashMap<u64, Option<u64>>) -> Self {
         Self::Direct(map)
+    }
+
+    /// Build an ordered remap chain, flattening nested chains and omitting
+    /// empty remaps.
+    pub fn chained(remaps: impl IntoIterator<Item = Self>) -> Self {
+        let mut remaps = remaps
+            .into_iter()
+            .filter(|remap| !remap.is_empty())
+            .collect::<Vec<_>>();
+        match remaps.len() {
+            0 => Self::empty(),
+            1 => remaps.pop().unwrap(),
+            _ => Self::Compact(CompactRowAddrRemap::chained(remaps)),
+        }
     }
 
     /// An empty remap that leaves every address unchanged.
@@ -88,6 +114,27 @@ impl RowAddrRemap {
         }
     }
 
+    /// Apply this remap to a batch in place.
+    ///
+    /// A `None` input remains deleted. An address missing from a remap remains
+    /// unchanged. Chained remaps are applied version-by-version so this path is
+    /// suitable for bulk index and transaction remapping without materializing
+    /// a composed per-row map.
+    pub fn remap_in_place(&self, row_addrs: &mut [Option<u64>]) {
+        match self {
+            Self::Compact(compact) => compact.remap_in_place(row_addrs),
+            Self::Direct(_) => {
+                for row_addr in row_addrs {
+                    if let Some(addr) = *row_addr
+                        && let Some(mapped) = self.get(addr)
+                    {
+                        *row_addr = mapped;
+                    }
+                }
+            }
+        }
+    }
+
     pub fn is_empty(&self) -> bool {
         match self {
             Self::Compact(c) => c.is_empty(),
@@ -97,7 +144,7 @@ impl RowAddrRemap {
 
     pub fn affected_fragments(&self) -> RoaringBitmap {
         match self {
-            Self::Compact(c) => RoaringBitmap::from_iter(c.frag_to_group.keys().copied()),
+            Self::Compact(c) => c.affected_fragments(),
             Self::Direct(m) => RoaringBitmap::from_iter(m.keys().map(|addr| (addr >> 32) as u32)),
         }
     }
@@ -118,6 +165,15 @@ impl RowAddrRemap {
     }
 }
 
+impl DeepSizeOf for RowAddrRemap {
+    fn deep_size_of_children(&self, context: &mut Context) -> usize {
+        match self {
+            Self::Compact(compact) => compact.deep_size_of_children(context),
+            Self::Direct(map) => map.deep_size_of_children(context),
+        }
+    }
+}
+
 /// Input describing one rewrite group: the old row addresses that were
 /// rewritten plus the fragment layout before/after the rewrite.
 pub struct GroupInput {
@@ -129,83 +185,140 @@ pub struct GroupInput {
     pub new_frags: Vec<(u32, u32)>,
 }
 
-#[derive(Clone)]
+/// Internal compact-remap input that includes old-fragment physical row counts.
+#[doc(hidden)]
+pub struct GroupInputWithLayout {
+    pub rewritten_old_row_addrs: RoaringTreemap,
+    pub old_frags: Vec<(u32, u32)>,
+    pub new_frags: Vec<(u32, u32)>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct OldFragmentRemap {
+    group_idx: usize,
+    rewritten_offsets: RoaringBitmap,
+    rewritten_rows_before: u64,
+    physical_rows: Option<u32>,
+}
+
+impl DeepSizeOf for OldFragmentRemap {
+    fn deep_size_of_children(&self, _context: &mut Context) -> usize {
+        // Roaring does not expose its allocation capacity. Its serialized size
+        // is a stable, density-sensitive proxy for the retained containers.
+        self.rewritten_offsets.serialized_size()
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
 struct GroupRemap {
-    /// Old fragment id -> (rewritten old row offsets in that fragment,
-    /// rewritten row count before this fragment in the group).
-    frags: HashMap<u32, (RoaringBitmap, u64)>,
     /// New fragment ranges as `(fragment_id, rewritten_rows_before, physical_rows)`,
     /// used to map a rewritten row's group-local index to its new address via binary search.
     new_frag_row_ranges: Vec<(u32, u64, u32)>,
 }
 
 impl GroupRemap {
-    fn new(input: GroupInput) -> Result<Self> {
-        // `compute_new_addr` maps a rewritten row's group-local index to a new
-        // address by accumulating `physical_rows` in `new_frags` order, so that
-        // order must be the order rows were written. New fragment ids are
-        // reserved monotonically in write order (see `reserve_fragment_ids` in
-        // compaction), so ascending id is a proxy for write order; reject any
-        // input that violates it before it can silently misplace addresses.
-        let mut new_frag_row_ranges = Vec::with_capacity(input.new_frags.len());
+    fn new(input: GroupInput, group_idx: usize) -> Result<(Self, Vec<(u32, OldFragmentRemap)>)> {
+        Self::new_with_old_frags(
+            input.rewritten_old_row_addrs,
+            input.old_frag_ids.into_iter().map(|id| (id, None)),
+            input.new_frags,
+            group_idx,
+        )
+    }
+
+    fn new_with_layout(
+        input: GroupInputWithLayout,
+        group_idx: usize,
+    ) -> Result<(Self, Vec<(u32, OldFragmentRemap)>)> {
+        Self::new_with_old_frags(
+            input.rewritten_old_row_addrs,
+            input
+                .old_frags
+                .into_iter()
+                .map(|(id, rows)| (id, Some(rows))),
+            input.new_frags,
+            group_idx,
+        )
+    }
+
+    fn new_with_old_frags(
+        rewritten_old_row_addrs: RoaringTreemap,
+        old_frags: impl IntoIterator<Item = (u32, Option<u32>)>,
+        new_frags: Vec<(u32, u32)>,
+        group_idx: usize,
+    ) -> Result<(Self, Vec<(u32, OldFragmentRemap)>)> {
+        // `compute_new_addr` maps a rewritten row's group-local index by
+        // accumulating `physical_rows` in the caller-provided write order.
+        let mut new_frag_row_ranges = Vec::with_capacity(new_frags.len());
         let mut rewritten_rows_before = 0u64;
-        let mut prev_frag_id: Option<u32> = None;
-        for (frag_id, physical_rows) in input.new_frags {
+        for (frag_id, physical_rows) in new_frags {
             if physical_rows == 0 {
                 continue;
             }
-            if let Some(prev) = prev_frag_id
-                && frag_id <= prev
-            {
-                return Err(Error::invalid_input(format!(
-                    "compaction new fragments must be in ascending id (write) order, but fragment {frag_id} follows {prev}",
-                )));
-            }
-            prev_frag_id = Some(frag_id);
             new_frag_row_ranges.push((frag_id, rewritten_rows_before, physical_rows));
             rewritten_rows_before += physical_rows as u64;
         }
         let total_new_rows = rewritten_rows_before;
 
-        let mut per_frag: HashMap<u32, RoaringBitmap> = input
-            .rewritten_old_row_addrs
+        let mut per_frag: HashMap<u32, RoaringBitmap> = rewritten_old_row_addrs
             .bitmaps()
             .map(|(frag_id, bitmap)| (frag_id, bitmap.clone()))
             .collect();
-        let mut frags = HashMap::new();
+        let old_frags = old_frags.into_iter().collect::<Vec<_>>();
+        let mut frags = Vec::with_capacity(old_frags.len());
+        let mut seen_frag_ids = HashSet::with_capacity(old_frags.len());
         let mut rewritten_rows_before = 0u64;
-        for &frag_id in &input.old_frag_ids {
-            // A fragment with no rewritten rows (fully deleted) contributes
-            // nothing to the rewritten row sequence.
-            if let Some(bitmap) = per_frag.remove(&frag_id) {
-                let num_rewritten_rows = bitmap.len();
-                frags.insert(frag_id, (bitmap, rewritten_rows_before));
-                rewritten_rows_before += num_rewritten_rows;
+        for &(frag_id, physical_rows) in &old_frags {
+            if !seen_frag_ids.insert(frag_id) {
+                return Err(Error::invalid_input(format!(
+                    "rewrite group contains old fragment {frag_id} more than once"
+                )));
             }
+            let bitmap = per_frag.remove(&frag_id).unwrap_or_default();
+            if let Some(physical_rows) = physical_rows
+                && bitmap.max().is_some_and(|offset| offset >= physical_rows)
+            {
+                return Err(Error::invalid_input(format!(
+                    "rewrite group contains a row offset outside old fragment {frag_id} with physical_rows={physical_rows}"
+                )));
+            }
+            let num_rewritten_rows = bitmap.len();
+            frags.push((
+                frag_id,
+                OldFragmentRemap {
+                    group_idx,
+                    rewritten_offsets: bitmap,
+                    rewritten_rows_before,
+                    physical_rows,
+                },
+            ));
+            rewritten_rows_before += num_rewritten_rows;
         }
-        // Rewritten old row addresses must reference only fragments listed in `old_frag_ids`.
+        // Rewritten old row addresses must reference only listed old fragments.
         if !per_frag.is_empty() {
             return Err(Error::invalid_input(format!(
                 "compaction rewritten old row addresses reference fragments {:?} not in the rewrite group's old fragments {:?}",
                 per_frag.keys().collect::<Vec<_>>(),
-                input.old_frag_ids,
+                old_frags,
             )));
         }
 
         // Rewritten old rows are mapped positionally onto the new rows, so the
         // two counts must match exactly
-        let total_rewritten_old_rows = input.rewritten_old_row_addrs.len();
+        let total_rewritten_old_rows = rewritten_old_row_addrs.len();
         if total_new_rows != total_rewritten_old_rows {
             return Err(Error::invalid_input(format!(
                 "compaction rewrote {total_rewritten_old_rows} old rows from fragments {:?} but the new fragments hold {total_new_rows} rows",
-                input.old_frag_ids,
+                old_frags,
             )));
         }
 
-        Ok(Self {
+        Ok((
+            Self {
+                new_frag_row_ranges,
+            },
             frags,
-            new_frag_row_ranges,
-        })
+        ))
     }
 
     fn compute_new_addr(&self, rewritten_row_index: u64) -> u64 {
@@ -222,43 +335,62 @@ impl GroupRemap {
         let offset = (rewritten_row_index - rewritten_rows_before) as u32;
         u64::from(RowAddress::new_from_parts(frag_id, offset))
     }
+}
 
-    /// Compute the new address for an old row in this group.
-    /// Returns `None` if the old row was not rewritten.
-    #[inline]
-    fn get(&self, frag: u32, offset: u32) -> Option<u64> {
-        match self.frags.get(&frag) {
-            Some((bitmap, rewritten_rows_before)) if bitmap.contains(offset) => {
-                let rewritten_row_index = rewritten_rows_before + bitmap.rank(offset) - 1;
-                Some(self.compute_new_addr(rewritten_row_index))
-            }
-            _ => None,
-        }
+impl DeepSizeOf for GroupRemap {
+    fn deep_size_of_children(&self, context: &mut Context) -> usize {
+        self.new_frag_row_ranges.deep_size_of_children(context)
     }
 }
 
-/// Compact remap backed by per-group rewritten row bitmaps + new-fragment layouts.
-#[derive(Clone)]
-pub struct CompactRowAddrRemap {
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct CompactRemapStep {
     groups: Vec<GroupRemap>,
-    /// Old fragment id -> index into `groups`. Size is O(#fragments), not rows.
-    frag_to_group: HashMap<u32, usize>,
+    /// Old fragment id -> its bitmap/rank layout and rewrite group. Size is
+    /// O(#fragments), not rows.
+    frags: HashMap<u32, OldFragmentRemap>,
 }
 
-impl CompactRowAddrRemap {
+impl CompactRemapStep {
     fn new(groups: impl IntoIterator<Item = GroupInput>) -> Result<Self> {
-        let mut frag_to_group = HashMap::new();
+        let mut frags = HashMap::new();
         let mut group_remaps = Vec::new();
         for input in groups {
             let gi = group_remaps.len();
-            for &frag_id in &input.old_frag_ids {
-                frag_to_group.insert(frag_id, gi);
+            let (group_remap, group_frags) = GroupRemap::new(input, gi)?;
+            for (frag_id, frag) in group_frags {
+                if frags.insert(frag_id, frag).is_some() {
+                    return Err(Error::invalid_input(format!(
+                        "old fragment {frag_id} appears in more than one rewrite group"
+                    )));
+                }
             }
-            group_remaps.push(GroupRemap::new(input)?);
+            group_remaps.push(group_remap);
         }
         Ok(Self {
             groups: group_remaps,
-            frag_to_group,
+            frags,
+        })
+    }
+
+    fn new_with_layout(groups: impl IntoIterator<Item = GroupInputWithLayout>) -> Result<Self> {
+        let mut frags = HashMap::new();
+        let mut group_remaps = Vec::new();
+        for input in groups {
+            let gi = group_remaps.len();
+            let (group_remap, group_frags) = GroupRemap::new_with_layout(input, gi)?;
+            for (frag_id, frag) in group_frags {
+                if frags.insert(frag_id, frag).is_some() {
+                    return Err(Error::invalid_input(format!(
+                        "old fragment {frag_id} appears in more than one rewrite group"
+                    )));
+                }
+            }
+            group_remaps.push(group_remap);
+        }
+        Ok(Self {
+            groups: group_remaps,
+            frags,
         })
     }
 
@@ -266,8 +398,22 @@ impl CompactRowAddrRemap {
     pub fn get(&self, addr: u64) -> Option<Option<u64>> {
         let frag = (addr >> 32) as u32;
         // Not in any rewrite group -> unaffected by this remap.
-        let gi = *self.frag_to_group.get(&frag)?;
-        Some(self.groups[gi].get(frag, addr as u32))
+        let old_frag = self.frags.get(&frag)?;
+        let offset = addr as u32;
+        if old_frag
+            .physical_rows
+            .is_some_and(|physical_rows| offset >= physical_rows)
+        {
+            return None;
+        }
+        if !old_frag.rewritten_offsets.contains(offset) {
+            return Some(None);
+        }
+        let rewritten_row_index =
+            old_frag.rewritten_rows_before + old_frag.rewritten_offsets.rank(offset) - 1;
+        Some(Some(
+            self.groups[old_frag.group_idx].compute_new_addr(rewritten_row_index),
+        ))
     }
 
     pub fn is_empty(&self) -> bool {
@@ -276,10 +422,168 @@ impl CompactRowAddrRemap {
 
     fn fully_deleted_fragments(&self) -> Option<RoaringBitmap> {
         // A group with any rewritten row moved at least one row.
-        if self.groups.iter().any(|g| !g.frags.is_empty()) {
+        if self
+            .frags
+            .values()
+            .any(|frag| !frag.rewritten_offsets.is_empty())
+        {
             return None;
         }
-        Some(RoaringBitmap::from_iter(self.frag_to_group.keys().copied()))
+        Some(RoaringBitmap::from_iter(self.frags.keys().copied()))
+    }
+
+    fn affected_fragments(&self) -> RoaringBitmap {
+        RoaringBitmap::from_iter(self.frags.keys().copied())
+    }
+}
+
+impl DeepSizeOf for CompactRemapStep {
+    fn deep_size_of_children(&self, context: &mut Context) -> usize {
+        self.groups.deep_size_of_children(context) + self.frags.deep_size_of_children(context)
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+enum RemapStep {
+    Compact(CompactRemapStep),
+    Direct(HashMap<u64, Option<u64>>),
+}
+
+impl RemapStep {
+    fn get(&self, addr: u64) -> Option<Option<u64>> {
+        match self {
+            Self::Compact(compact) => compact.get(addr),
+            Self::Direct(direct) => direct.get(&addr).copied(),
+        }
+    }
+
+    fn is_empty(&self) -> bool {
+        match self {
+            Self::Compact(compact) => compact.is_empty(),
+            Self::Direct(direct) => direct.is_empty(),
+        }
+    }
+
+    fn affected_fragments(&self) -> RoaringBitmap {
+        match self {
+            Self::Compact(compact) => compact.affected_fragments(),
+            Self::Direct(direct) => {
+                RoaringBitmap::from_iter(direct.keys().map(|addr| (addr >> 32) as u32))
+            }
+        }
+    }
+
+    fn fully_deleted_fragments(&self) -> Option<RoaringBitmap> {
+        match self {
+            Self::Compact(compact) => compact.fully_deleted_fragments(),
+            Self::Direct(direct) if direct.values().all(Option::is_none) => Some(
+                RoaringBitmap::from_iter(direct.keys().map(|addr| (addr >> 32) as u32)),
+            ),
+            Self::Direct(_) => None,
+        }
+    }
+}
+
+impl DeepSizeOf for RemapStep {
+    fn deep_size_of_children(&self, context: &mut Context) -> usize {
+        match self {
+            Self::Compact(compact) => compact.deep_size_of_children(context),
+            Self::Direct(direct) => direct.deep_size_of_children(context),
+        }
+    }
+}
+
+/// Compact remap backed by per-group rewritten row bitmaps + new-fragment layouts.
+///
+/// Multiple remaps are retained as ordered private steps so a version chain
+/// does not require another public [`RowAddrRemap`] variant.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct CompactRowAddrRemap {
+    steps: Vec<RemapStep>,
+}
+
+impl CompactRowAddrRemap {
+    fn new(groups: impl IntoIterator<Item = GroupInput>) -> Result<Self> {
+        Ok(Self {
+            steps: vec![RemapStep::Compact(CompactRemapStep::new(groups)?)],
+        })
+    }
+
+    fn new_with_layout(groups: impl IntoIterator<Item = GroupInputWithLayout>) -> Result<Self> {
+        Ok(Self {
+            steps: vec![RemapStep::Compact(CompactRemapStep::new_with_layout(
+                groups,
+            )?)],
+        })
+    }
+
+    fn chained(remaps: Vec<RowAddrRemap>) -> Self {
+        let mut steps = Vec::with_capacity(remaps.len());
+        for remap in remaps {
+            match remap {
+                RowAddrRemap::Compact(compact) => steps.extend(compact.steps),
+                RowAddrRemap::Direct(direct) => steps.push(RemapStep::Direct(direct)),
+            }
+        }
+        Self { steps }
+    }
+
+    #[inline]
+    pub fn get(&self, addr: u64) -> Option<Option<u64>> {
+        let mut current = addr;
+        let mut was_affected = false;
+        for step in &self.steps {
+            match step.get(current) {
+                None => {}
+                Some(None) => return Some(None),
+                Some(Some(mapped)) => {
+                    current = mapped;
+                    was_affected = true;
+                }
+            }
+        }
+        was_affected.then_some(Some(current))
+    }
+
+    fn remap_in_place(&self, row_addrs: &mut [Option<u64>]) {
+        for step in &self.steps {
+            for row_addr in row_addrs.iter_mut() {
+                if let Some(addr) = *row_addr
+                    && let Some(mapped) = step.get(addr)
+                {
+                    *row_addr = mapped;
+                }
+            }
+        }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.steps.iter().all(RemapStep::is_empty)
+    }
+
+    fn affected_fragments(&self) -> RoaringBitmap {
+        self.steps
+            .iter()
+            .fold(RoaringBitmap::new(), |mut affected, step| {
+                affected |= step.affected_fragments();
+                affected
+            })
+    }
+
+    fn fully_deleted_fragments(&self) -> Option<RoaringBitmap> {
+        match self.steps.as_slice() {
+            [] => Some(RoaringBitmap::new()),
+            [step] => step.fully_deleted_fragments(),
+            // Determining whether every baseline fragment is ultimately
+            // deleted requires composing fragment domains across steps.
+            _ => None,
+        }
+    }
+}
+
+impl DeepSizeOf for CompactRowAddrRemap {
+    fn deep_size_of_children(&self, context: &mut Context) -> usize {
+        self.steps.deep_size_of_children(context)
     }
 }
 
@@ -329,6 +633,7 @@ mod tests {
         assert_eq!(remap.get(addr(7, 0)), Some(None));
         // Fragment in no group -> unaffected.
         assert_eq!(remap.get(addr(9, 0)), None);
+        assert_eq!(remap.get(addr(4, 5)), Some(None));
         assert!(!remap.is_empty());
     }
 
@@ -367,7 +672,7 @@ mod tests {
 
     #[test]
     fn test_compact_rejects_rewritten_addrs_outside_old_frags() {
-        // Rewritten addresses reference frag 5, not in old_frag_ids. The count
+        // Rewritten addresses reference frag 5, not in old_frags. The count
         // still matches (2 == 2), so only the per-fragment split catches it.
         let input = GroupInput {
             rewritten_old_row_addrs: RoaringTreemap::from_iter([addr(0, 0), addr(5, 0)]),
@@ -378,16 +683,15 @@ mod tests {
     }
 
     #[test]
-    fn test_compact_rejects_new_frags_out_of_write_order() {
-        // New fragments out of ascending id (write) order would make
-        // `compute_new_addr` accumulate rows in the wrong order, silently
-        // misplacing addresses. A zero-row fragment between them is ignored.
-        let input = GroupInput {
+    fn test_compact_preserves_explicit_fragment_order() {
+        let remap = RowAddrRemap::compact([GroupInput {
             rewritten_old_row_addrs: RoaringTreemap::from_iter([addr(0, 0), addr(0, 1)]),
             old_frag_ids: vec![0],
             new_frags: vec![(12, 1), (11, 1)],
-        };
-        assert!(RowAddrRemap::compact([input]).is_err());
+        }])
+        .unwrap();
+        assert_eq!(remap.get(addr(0, 0)), Some(Some(addr(12, 0))));
+        assert_eq!(remap.get(addr(0, 1)), Some(Some(addr(11, 0))));
     }
 
     #[test]
@@ -409,5 +713,40 @@ mod tests {
         let empty = RowAddrRemap::empty();
         assert!(empty.is_empty());
         assert_eq!(empty.get(addr(0, 0)), None);
+    }
+
+    #[test]
+    fn test_chained_lookup_and_batch() {
+        let first = RowAddrRemap::compact([GroupInput {
+            rewritten_old_row_addrs: RoaringTreemap::from_iter([addr(0, 0), addr(0, 2)]),
+            old_frag_ids: vec![0],
+            new_frags: vec![(10, 2)],
+        }])
+        .unwrap();
+        let second = RowAddrRemap::compact([GroupInput {
+            rewritten_old_row_addrs: RoaringTreemap::from_iter([addr(10, 1)]),
+            old_frag_ids: vec![10],
+            new_frags: vec![(20, 1)],
+        }])
+        .unwrap();
+        let chain = RowAddrRemap::chained([first, second]);
+
+        assert_eq!(chain.get(addr(0, 0)), Some(None));
+        assert_eq!(chain.get(addr(0, 1)), Some(None));
+        assert_eq!(chain.get(addr(0, 2)), Some(Some(addr(20, 0))));
+        assert_eq!(chain.get(addr(1, 0)), None);
+
+        let mut batch = vec![
+            Some(addr(0, 0)),
+            Some(addr(0, 1)),
+            Some(addr(0, 2)),
+            Some(addr(1, 0)),
+            None,
+        ];
+        chain.remap_in_place(&mut batch);
+        assert_eq!(
+            batch,
+            vec![None, None, Some(addr(20, 0)), Some(addr(1, 0)), None]
+        );
     }
 }

--- a/rust/lance-core/src/utils/row_addr_remap.rs
+++ b/rust/lance-core/src/utils/row_addr_remap.rs
@@ -51,6 +51,7 @@ use crate::utils::address::RowAddress;
 use crate::{Error, Result};
 use roaring::{RoaringBitmap, RoaringTreemap};
 use std::collections::{HashMap, HashSet};
+use std::mem::size_of;
 
 /// A queryable row-address remapping with the exact semantics of
 /// `HashMap<u64, Option<u64>>::get(&addr).copied()`:
@@ -193,19 +194,165 @@ pub struct GroupInputWithLayout {
     pub new_frags: Vec<(u32, u32)>,
 }
 
+/// Keep Roaring only when its serialized representation is substantially
+/// smaller than either rank-friendly representation. This preserves compact
+/// run containers while avoiding Roaring's linear word scan for dense rank.
+const ROARING_SIZE_ADVANTAGE_FOR_RANK: usize = 4;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+enum RankedOffsets {
+    /// Retained for highly compressible run layouts.
+    Roaring(RoaringBitmap),
+    /// Sorted rewritten offsets. Binary search returns membership and rank in
+    /// one operation.
+    Sparse(Vec<u32>),
+    /// Dense bits with the number of rewritten rows before every word.
+    Dense(DenseRankedOffsets),
+}
+
+impl RankedOffsets {
+    fn try_new(offsets: RoaringBitmap, physical_rows: Option<u32>) -> Result<Self> {
+        let universe_rows = physical_rows.map(u64::from).unwrap_or_else(|| {
+            offsets
+                .max()
+                .map(|offset| u64::from(offset) + 1)
+                .unwrap_or(0)
+        });
+        let word_count = usize::try_from(universe_rows.div_ceil(64)).map_err(|_| {
+            Error::invalid_input(format!(
+                "fragment row range {universe_rows} is too large for compact rank lookup"
+            ))
+        })?;
+        let sparse_bytes = usize::try_from(offsets.len())
+            .ok()
+            .and_then(|len| len.checked_mul(size_of::<u32>()))
+            .ok_or_else(|| {
+                Error::invalid_input(format!(
+                    "rewritten row count {} is too large for sparse rank lookup",
+                    offsets.len()
+                ))
+            })?;
+        let dense_bytes = word_count
+            .checked_mul(size_of::<u64>() + size_of::<u32>())
+            .ok_or_else(|| {
+                Error::invalid_input(format!(
+                    "fragment row range {universe_rows} is too large for dense rank lookup"
+                ))
+            })?;
+        let rank_friendly_bytes = sparse_bytes.min(dense_bytes);
+        if offsets
+            .serialized_size()
+            .checked_mul(ROARING_SIZE_ADVANTAGE_FOR_RANK)
+            .is_some_and(|roaring_bytes| roaring_bytes < rank_friendly_bytes)
+        {
+            return Ok(Self::Roaring(offsets));
+        }
+        if sparse_bytes <= dense_bytes {
+            return Ok(Self::Sparse(offsets.into_iter().collect()));
+        }
+        Ok(Self::Dense(DenseRankedOffsets::try_new(
+            offsets, word_count,
+        )?))
+    }
+
+    /// Return the zero-based rank when `offset` was rewritten.
+    #[inline]
+    fn rank_if_present(&self, offset: u32) -> Option<u64> {
+        match self {
+            Self::Roaring(offsets) => offsets.contains(offset).then(|| offsets.rank(offset) - 1),
+            Self::Sparse(offsets) => offsets.binary_search(&offset).ok().map(|rank| rank as u64),
+            Self::Dense(offsets) => offsets.rank_if_present(offset),
+        }
+    }
+
+    fn is_empty(&self) -> bool {
+        match self {
+            Self::Roaring(offsets) => offsets.is_empty(),
+            Self::Sparse(offsets) => offsets.is_empty(),
+            Self::Dense(offsets) => offsets.words.is_empty(),
+        }
+    }
+}
+
+impl DeepSizeOf for RankedOffsets {
+    fn deep_size_of_children(&self, context: &mut Context) -> usize {
+        match self {
+            // Roaring does not expose its allocation capacity. Its serialized
+            // size is a stable proxy for the retained containers.
+            Self::Roaring(offsets) => offsets.serialized_size(),
+            Self::Sparse(offsets) => offsets.deep_size_of_children(context),
+            Self::Dense(offsets) => offsets.deep_size_of_children(context),
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct DenseRankedOffsets {
+    words: Vec<u64>,
+    rank_before_word: Vec<u32>,
+}
+
+impl DenseRankedOffsets {
+    fn try_new(offsets: RoaringBitmap, word_count: usize) -> Result<Self> {
+        let mut words = vec![0u64; word_count];
+        for offset in offsets {
+            let word_idx = (offset / 64) as usize;
+            let Some(word) = words.get_mut(word_idx) else {
+                return Err(Error::invalid_input(format!(
+                    "rewritten row offset {offset} is outside dense rank word_count={word_count}"
+                )));
+            };
+            *word |= 1u64 << (offset % 64);
+        }
+
+        let mut rank_before_word = Vec::with_capacity(word_count);
+        let mut rewritten_rows_before = 0u64;
+        for word in &words {
+            rank_before_word.push(u32::try_from(rewritten_rows_before).map_err(|_| {
+                Error::invalid_input(format!(
+                    "rewritten row count {rewritten_rows_before} exceeds the row-address offset range"
+                ))
+            })?);
+            rewritten_rows_before += u64::from(word.count_ones());
+        }
+        Ok(Self {
+            words,
+            rank_before_word,
+        })
+    }
+
+    #[inline]
+    fn rank_if_present(&self, offset: u32) -> Option<u64> {
+        let word_idx = (offset / 64) as usize;
+        let word = *self.words.get(word_idx)?;
+        let bit = 1u64 << (offset % 64);
+        if word & bit == 0 {
+            return None;
+        }
+        Some(
+            u64::from(self.rank_before_word[word_idx]) + u64::from((word & (bit - 1)).count_ones()),
+        )
+    }
+}
+
+impl DeepSizeOf for DenseRankedOffsets {
+    fn deep_size_of_children(&self, context: &mut Context) -> usize {
+        self.words.deep_size_of_children(context)
+            + self.rank_before_word.deep_size_of_children(context)
+    }
+}
+
 #[derive(Clone, Debug, PartialEq, Eq)]
 struct OldFragmentRemap {
     group_idx: usize,
-    rewritten_offsets: RoaringBitmap,
+    rewritten_offsets: RankedOffsets,
     rewritten_rows_before: u64,
     physical_rows: Option<u32>,
 }
 
 impl DeepSizeOf for OldFragmentRemap {
-    fn deep_size_of_children(&self, _context: &mut Context) -> usize {
-        // Roaring does not expose its allocation capacity. Its serialized size
-        // is a stable, density-sensitive proxy for the retained containers.
-        self.rewritten_offsets.serialized_size()
+    fn deep_size_of_children(&self, context: &mut Context) -> usize {
+        self.rewritten_offsets.deep_size_of_children(context)
     }
 }
 
@@ -283,11 +430,12 @@ impl GroupRemap {
                 )));
             }
             let num_rewritten_rows = bitmap.len();
+            let rewritten_offsets = RankedOffsets::try_new(bitmap, physical_rows)?;
             frags.push((
                 frag_id,
                 OldFragmentRemap {
                     group_idx,
-                    rewritten_offsets: bitmap,
+                    rewritten_offsets,
                     rewritten_rows_before,
                     physical_rows,
                 },
@@ -406,11 +554,10 @@ impl CompactRemapStep {
         {
             return None;
         }
-        if !old_frag.rewritten_offsets.contains(offset) {
+        let Some(rewritten_rank) = old_frag.rewritten_offsets.rank_if_present(offset) else {
             return Some(None);
-        }
-        let rewritten_row_index =
-            old_frag.rewritten_rows_before + old_frag.rewritten_offsets.rank(offset) - 1;
+        };
+        let rewritten_row_index = old_frag.rewritten_rows_before + rewritten_rank;
         Some(Some(
             self.groups[old_frag.group_idx].compute_new_addr(rewritten_row_index),
         ))
@@ -593,6 +740,54 @@ mod tests {
 
     fn addr(frag: u32, offset: u32) -> u64 {
         u64::from(RowAddress::new_from_parts(frag, offset))
+    }
+
+    #[test]
+    fn test_sparse_ranked_offsets() {
+        let offsets = RankedOffsets::try_new(
+            RoaringBitmap::from_iter([1u32, 63, 511, 9_999]),
+            Some(10_000),
+        )
+        .unwrap();
+        assert!(matches!(offsets, RankedOffsets::Sparse(_)));
+        assert_eq!(offsets.rank_if_present(0), None);
+        assert_eq!(offsets.rank_if_present(1), Some(0));
+        assert_eq!(offsets.rank_if_present(63), Some(1));
+        assert_eq!(offsets.rank_if_present(511), Some(2));
+        assert_eq!(offsets.rank_if_present(9_999), Some(3));
+    }
+
+    #[test]
+    fn test_dense_ranked_offsets_across_words() {
+        let rewritten = (0..1_024u32)
+            .filter(|offset| offset % 10 != 0)
+            .collect::<RoaringBitmap>();
+        let offsets = RankedOffsets::try_new(rewritten.clone(), Some(1_024)).unwrap();
+        assert!(matches!(offsets, RankedOffsets::Dense(_)));
+
+        let mut expected_rank = 0u64;
+        for offset in 0..1_024 {
+            if rewritten.contains(offset) {
+                assert_eq!(offsets.rank_if_present(offset), Some(expected_rank));
+                expected_rank += 1;
+            } else {
+                assert_eq!(offsets.rank_if_present(offset), None);
+            }
+        }
+        assert_eq!(expected_rank, rewritten.len());
+    }
+
+    #[test]
+    fn test_run_compressed_ranked_offsets() {
+        let mut rewritten = RoaringBitmap::new();
+        rewritten.insert_range(100..9_900);
+        rewritten.optimize();
+        let offsets = RankedOffsets::try_new(rewritten, Some(10_000)).unwrap();
+        assert!(matches!(offsets, RankedOffsets::Roaring(_)));
+        assert_eq!(offsets.rank_if_present(99), None);
+        assert_eq!(offsets.rank_if_present(100), Some(0));
+        assert_eq!(offsets.rank_if_present(9_899), Some(9_799));
+        assert_eq!(offsets.rank_if_present(9_900), None);
     }
 
     #[test]

--- a/rust/lance-index/src/frag_reuse.rs
+++ b/rust/lance-index/src/frag_reuse.rs
@@ -29,6 +29,10 @@ use crate::{Index, IndexType};
 /// them directly in `lance-table`).
 pub struct FragReuseIndexHandle(pub Arc<FragReuseIndex>);
 
+/// Adapter for the compact runtime representation loaded from persisted FRI details.
+#[doc(hidden)]
+pub struct CompactFragReuseIndexHandle(pub Arc<CompactFragReuseIndex>);
+
 impl std::fmt::Debug for FragReuseIndexHandle {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_tuple("FragReuseIndexHandle")
@@ -84,6 +88,77 @@ impl Index for FragReuseIndexHandle {
 }
 
 impl RowIdRemapper for FragReuseIndexHandle {
+    fn remap_row_id(&self, row_id: u64) -> Option<u64> {
+        self.0.remap_row_id(row_id)
+    }
+
+    fn remap_row_addrs_tree_map(&self, row_addrs: &RowAddrTreeMap) -> RowAddrTreeMap {
+        self.0.remap_row_addrs_tree_map(row_addrs)
+    }
+
+    fn remap_row_ids_roaring_tree_map(&self, row_ids: &RoaringTreemap) -> RoaringTreemap {
+        self.0.remap_row_ids_roaring_tree_map(row_ids)
+    }
+
+    fn remap_row_ids_record_batch(
+        &self,
+        batch: RecordBatch,
+        row_id_idx: usize,
+    ) -> Result<RecordBatch> {
+        self.0.remap_row_ids_record_batch(batch, row_id_idx)
+    }
+}
+
+impl std::fmt::Debug for CompactFragReuseIndexHandle {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_tuple("CompactFragReuseIndexHandle")
+            .field(&self.0)
+            .finish()
+    }
+}
+
+impl DeepSizeOf for CompactFragReuseIndexHandle {
+    fn deep_size_of_children(&self, context: &mut lance_core::deepsize::Context) -> usize {
+        self.0.deep_size_of_children(context)
+    }
+}
+
+#[async_trait]
+impl Index for CompactFragReuseIndexHandle {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn as_index(self: Arc<Self>) -> Arc<dyn Index> {
+        self
+    }
+
+    fn statistics(&self) -> Result<serde_json::Value> {
+        let stats = FragReuseStatistics {
+            num_versions: self.0.details.versions.len(),
+        };
+        serde_json::to_value(stats).map_err(|e| {
+            lance_core::Error::internal(format!(
+                "failed to serialize fragment reuse index statistics: {}",
+                e
+            ))
+        })
+    }
+
+    async fn prewarm(&self) -> Result<()> {
+        Ok(())
+    }
+
+    fn index_type(&self) -> IndexType {
+        IndexType::FragmentReuse
+    }
+
+    async fn calculate_included_frags(&self) -> Result<RoaringBitmap> {
+        unimplemented!()
+    }
+}
+
+impl RowIdRemapper for CompactFragReuseIndexHandle {
     fn remap_row_id(&self, row_id: u64) -> Option<u64> {
         self.0.remap_row_id(row_id)
     }

--- a/rust/lance-index/src/scalar/ngram.rs
+++ b/rust/lance-index/src/scalar/ngram.rs
@@ -17,7 +17,7 @@ use super::{
     AnyQuery, BuiltinIndexType, IndexFile, IndexReader, IndexStore, IndexWriter, MetricsCollector,
     ScalarIndex, ScalarIndexParams, SearchResult, TextQuery,
 };
-use crate::frag_reuse::FragReuseIndex;
+use crate::frag_reuse::{FragReuseIndex, FragReuseIndexHandle};
 use crate::metrics::NoOpMetricsCollector;
 use crate::pbold;
 use crate::scalar::expression::{ScalarQueryParser, TextQueryParser};
@@ -412,6 +412,26 @@ impl NGramIndex {
         dest_store: &dyn IndexStore,
         old_data_filters: &[Option<super::OldIndexDataFilter>],
         frag_reuse_index: Option<Arc<FragReuseIndex>>,
+    ) -> Result<CreatedIndex> {
+        let frag_reuse_index = frag_reuse_index
+            .map(|index| Arc::new(FragReuseIndexHandle(index)) as Arc<dyn RowIdRemapper>);
+        Self::merge_segments_with_remapper(
+            segment_stores,
+            new_data,
+            dest_store,
+            old_data_filters,
+            frag_reuse_index,
+        )
+        .await
+    }
+
+    #[doc(hidden)]
+    pub async fn merge_segments_with_remapper(
+        segment_stores: &[Arc<dyn IndexStore>],
+        new_data: Option<SendableRecordBatchStream>,
+        dest_store: &dyn IndexStore,
+        old_data_filters: &[Option<super::OldIndexDataFilter>],
+        frag_reuse_index: Option<Arc<dyn RowIdRemapper>>,
     ) -> Result<CreatedIndex> {
         let mut builder = NGramIndexBuilder::try_new(NGramIndexBuilderOptions::default())?;
         // Pure consolidation has no new rows, so skip `train` (and its
@@ -852,7 +872,7 @@ impl NGramIndexSpillState {
 
     fn remap_and_filter_rows(
         self,
-        frag_reuse_index: Option<&Arc<FragReuseIndex>>,
+        frag_reuse_index: Option<&dyn RowIdRemapper>,
         filter: Option<&super::OldIndexDataFilter>,
     ) -> Self {
         if let Some(fri) = frag_reuse_index {
@@ -868,7 +888,7 @@ impl NGramIndexSpillState {
     /// `filter`. Used only under a pending deferred-remap compaction.
     fn remap_then_keep(
         self,
-        fri: &Arc<FragReuseIndex>,
+        fri: &dyn RowIdRemapper,
         filter: Option<&super::OldIndexDataFilter>,
     ) -> Self {
         let mut tokens = UInt32Builder::with_capacity(self.tokens.len());
@@ -1561,14 +1581,14 @@ impl NGramIndexBuilder {
 
     async fn open_segment_stream(
         store: Arc<dyn IndexStore>,
-        frag_reuse_index: Option<Arc<FragReuseIndex>>,
+        frag_reuse_index: Option<Arc<dyn RowIdRemapper>>,
         filter: Option<super::OldIndexDataFilter>,
     ) -> Result<Pin<Box<dyn Stream<Item = Result<NGramIndexSpillState>> + Send>>> {
         let reader = store.open_index_file(POSTINGS_FILENAME).await?;
         let stream =
             Self::stream_spill_reader(reader, MAX_POSTING_LIST_BATCH_BYTES)?.map(move |res| {
                 res.map(|state| {
-                    state.remap_and_filter_rows(frag_reuse_index.as_ref(), filter.as_ref())
+                    state.remap_and_filter_rows(frag_reuse_index.as_deref(), filter.as_ref())
                 })
             });
         Ok(Box::pin(stream))
@@ -1581,7 +1601,7 @@ impl NGramIndexBuilder {
         new_data_spills: Vec<usize>,
         segment_stores: &[Arc<dyn IndexStore>],
         old_data_filters: &[Option<super::OldIndexDataFilter>],
-        frag_reuse_index: Option<Arc<FragReuseIndex>>,
+        frag_reuse_index: Option<Arc<dyn RowIdRemapper>>,
         dest_store: &dyn IndexStore,
     ) -> Result<IndexFile> {
         if old_data_filters.len() != segment_stores.len() {
@@ -2453,7 +2473,7 @@ mod tests {
         use uuid::Uuid;
 
         use super::NGramIndexSpillState;
-        use crate::frag_reuse::{FragReuseIndex, FragReuseIndexDetails};
+        use crate::frag_reuse::{FragReuseIndex, FragReuseIndexDetails, FragReuseIndexHandle};
         use crate::scalar::OldIndexDataFilter;
 
         let addr = |frag: u32, local: u32| ((frag as u64) << 32) | local as u64;
@@ -2471,14 +2491,14 @@ mod tests {
         // Compaction fused fragment 0 into fragment 2: row (0,0) survives at
         // (2,0), row (0,1) was deleted (maps to None). Row (1,0) isn't in the
         // map, so remap passes it through unchanged.
-        let fri = Arc::new(FragReuseIndex::new(
+        let fri = FragReuseIndexHandle(Arc::new(FragReuseIndex::new(
             Uuid::new_v4(),
             vec![HashMap::from([
                 (addr(0, 0), Some(addr(2, 0))),
                 (addr(0, 1), None),
             ])],
             FragReuseIndexDetails { versions: vec![] },
-        ));
+        )));
 
         // After remap the live rows sit in fragments 2 and 1; fragment 1 is retired.
         let filter = OldIndexDataFilter::Fragments {

--- a/rust/lance-index/src/vector/bq/storage.rs
+++ b/rust/lance-index/src/vector/bq/storage.rs
@@ -40,8 +40,9 @@ use num_traits::AsPrimitive;
 use prost::Message;
 use serde::{Deserialize, Serialize};
 
-use crate::frag_reuse::FragReuseIndex;
+use crate::frag_reuse::{FragReuseIndex, FragReuseIndexHandle};
 use crate::pb;
+use crate::scalar::RowIdRemapper;
 use crate::vector::ApproxMode;
 use crate::vector::bq::dist_table_quant::{
     DistTableDequant, quantize_dist_table_into, quantize_dist_table_u16_into,
@@ -2391,13 +2392,10 @@ pub fn unpack_codes(codes: &FixedSizeListArray) -> FixedSizeListArray {
 /// to `Some(new_id)` for surviving rows or `None` for rows whose covering
 /// fragment was compacted away, suitable for `RabitQuantizationStorage::remap`.
 fn build_frag_reuse_mapping(
-    fri: Option<&FragReuseIndex>,
+    fri: Option<&dyn RowIdRemapper>,
     row_ids: &UInt64Array,
 ) -> Option<HashMap<u64, Option<u64>>> {
     let fri = fri?;
-    if fri.row_id_maps.is_empty() {
-        return None;
-    }
     let mut mapping: HashMap<u64, Option<u64>> = HashMap::new();
     for row_id in row_ids.values().iter() {
         match fri.remap_row_id(*row_id) {
@@ -2423,6 +2421,16 @@ impl QuantizerStorage for RabitQuantizationStorage {
         metadata: &Self::Metadata,
         distance_type: DistanceType,
         fri: Option<Arc<FragReuseIndex>>,
+    ) -> Result<Self> {
+        let fri = fri.map(|index| Arc::new(FragReuseIndexHandle(index)) as Arc<dyn RowIdRemapper>);
+        Self::try_from_batch_with_remapper(batch, metadata, distance_type, fri)
+    }
+
+    fn try_from_batch_with_remapper(
+        batch: RecordBatch,
+        metadata: &Self::Metadata,
+        distance_type: DistanceType,
+        fri: Option<Arc<dyn RowIdRemapper>>,
     ) -> Result<Self> {
         let distance_type = match (metadata.query_estimator, distance_type) {
             (RabitQueryEstimator::RawQuery, DistanceType::Cosine) => DistanceType::L2,

--- a/rust/lance-index/src/vector/flat/storage.rs
+++ b/rust/lance-index/src/vector/flat/storage.rs
@@ -4,7 +4,8 @@
 use std::{borrow::Cow, sync::Arc};
 
 use super::index::FlatMetadata;
-use crate::frag_reuse::FragReuseIndex;
+use crate::frag_reuse::{FragReuseIndex, FragReuseIndexHandle};
+use crate::scalar::RowIdRemapper;
 use crate::vector::quantizer::QuantizerStorage;
 use crate::vector::storage::{DistCalculator, VectorStore};
 use crate::vector::utils::do_prefetch;
@@ -71,6 +72,17 @@ impl QuantizerStorage for FlatFloatStorage {
         metadata: &Self::Metadata,
         distance_type: DistanceType,
         frag_reuse_index: Option<Arc<FragReuseIndex>>,
+    ) -> Result<Self> {
+        let frag_reuse_index = frag_reuse_index
+            .map(|index| Arc::new(FragReuseIndexHandle(index)) as Arc<dyn RowIdRemapper>);
+        Self::try_from_batch_with_remapper(batch, metadata, distance_type, frag_reuse_index)
+    }
+
+    fn try_from_batch_with_remapper(
+        batch: RecordBatch,
+        metadata: &Self::Metadata,
+        distance_type: DistanceType,
+        frag_reuse_index: Option<Arc<dyn RowIdRemapper>>,
     ) -> Result<Self> {
         let batch = if let Some(frag_reuse_index_ref) = frag_reuse_index.as_ref() {
             frag_reuse_index_ref.remap_row_ids_record_batch(batch, 0)?
@@ -240,6 +252,17 @@ impl QuantizerStorage for FlatBinStorage {
         metadata: &Self::Metadata,
         distance_type: DistanceType,
         frag_reuse_index: Option<Arc<FragReuseIndex>>,
+    ) -> Result<Self> {
+        let frag_reuse_index = frag_reuse_index
+            .map(|index| Arc::new(FragReuseIndexHandle(index)) as Arc<dyn RowIdRemapper>);
+        Self::try_from_batch_with_remapper(batch, metadata, distance_type, frag_reuse_index)
+    }
+
+    fn try_from_batch_with_remapper(
+        batch: RecordBatch,
+        metadata: &Self::Metadata,
+        distance_type: DistanceType,
+        frag_reuse_index: Option<Arc<dyn RowIdRemapper>>,
     ) -> Result<Self> {
         let batch = if let Some(frag_reuse_index_ref) = frag_reuse_index.as_ref() {
             frag_reuse_index_ref.remap_row_ids_record_batch(batch, 0)?

--- a/rust/lance-index/src/vector/pq/storage.rs
+++ b/rust/lance-index/src/vector/pq/storage.rs
@@ -37,7 +37,8 @@ use serde::{Deserialize, Serialize};
 
 use super::ProductQuantizer;
 use super::distance::{build_distance_table_dot, build_distance_table_l2, compute_pq_distance};
-use crate::frag_reuse::FragReuseIndex;
+use crate::frag_reuse::{FragReuseIndex, FragReuseIndexHandle};
+use crate::scalar::RowIdRemapper;
 use crate::vector::graph::{OrderedFloat, OrderedNode};
 use crate::{
     INDEX_METADATA_SCHEMA_KEY, IndexMetadata, pb,
@@ -196,13 +197,38 @@ impl ProductQuantizationStorage {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         codebook: FixedSizeListArray,
-        mut batch: RecordBatch,
+        batch: RecordBatch,
         num_bits: u32,
         num_sub_vectors: usize,
         dimension: usize,
         distance_type: DistanceType,
         transposed: bool,
         frag_reuse_index: Option<Arc<FragReuseIndex>>,
+    ) -> Result<Self> {
+        let frag_reuse_index = frag_reuse_index
+            .map(|index| Arc::new(FragReuseIndexHandle(index)) as Arc<dyn RowIdRemapper>);
+        Self::new_with_remapper(
+            codebook,
+            batch,
+            num_bits,
+            num_sub_vectors,
+            dimension,
+            distance_type,
+            transposed,
+            frag_reuse_index,
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn new_with_remapper(
+        codebook: FixedSizeListArray,
+        mut batch: RecordBatch,
+        num_bits: u32,
+        num_sub_vectors: usize,
+        dimension: usize,
+        distance_type: DistanceType,
+        transposed: bool,
+        frag_reuse_index: Option<Arc<dyn RowIdRemapper>>,
     ) -> Result<Self> {
         if batch.num_columns() != 2 {
             log::warn!(
@@ -533,6 +559,36 @@ impl QuantizerStorage for ProductQuantizationStorage {
         };
 
         Self::new(
+            codebook,
+            batch,
+            metadata.nbits,
+            metadata.num_sub_vectors,
+            metadata.dimension,
+            distance_type,
+            metadata.transposed,
+            frag_reuse_index,
+        )
+    }
+
+    fn try_from_batch_with_remapper(
+        batch: RecordBatch,
+        metadata: &Self::Metadata,
+        distance_type: DistanceType,
+        frag_reuse_index: Option<Arc<dyn RowIdRemapper>>,
+    ) -> Result<Self> {
+        let distance_type = match distance_type {
+            DistanceType::Cosine => DistanceType::L2,
+            _ => distance_type,
+        };
+        let codebook = match &metadata.codebook {
+            Some(codebook) => codebook.clone(),
+            None => {
+                debug_assert!(!metadata.codebook_tensor.is_empty());
+                let codebook_tensor = pb::Tensor::decode(metadata.codebook_tensor.as_slice())?;
+                FixedSizeListArray::try_from(&codebook_tensor)?
+            }
+        };
+        Self::new_with_remapper(
             codebook,
             batch,
             metadata.nbits,

--- a/rust/lance-index/src/vector/quantizer.rs
+++ b/rust/lance-index/src/vector/quantizer.rs
@@ -25,6 +25,7 @@ use super::flat::index::{FlatBinQuantizer, FlatQuantizer};
 use super::pq::ProductQuantizer;
 use super::{ivf::storage::IvfModel, sq::ScalarQuantizer, storage::VectorStore};
 use crate::frag_reuse::FragReuseIndex;
+use crate::scalar::RowIdRemapper;
 use crate::vector::bq::builder::RabitQuantizer;
 use crate::{INDEX_METADATA_SCHEMA_KEY, IndexMetadata};
 
@@ -262,6 +263,23 @@ pub trait QuantizerStorage: Clone + Sized + DeepSizeOf + VectorStore {
         distance_type: DistanceType,
         frag_reuse_index: Option<Arc<FragReuseIndex>>,
     ) -> Result<Self>;
+
+    /// Internal entry point for compact FRI loading without changing the
+    /// existing concrete-type API.
+    #[doc(hidden)]
+    fn try_from_batch_with_remapper(
+        batch: RecordBatch,
+        metadata: &Self::Metadata,
+        distance_type: DistanceType,
+        frag_reuse_index: Option<Arc<dyn RowIdRemapper>>,
+    ) -> Result<Self> {
+        if frag_reuse_index.is_some() {
+            return Err(Error::not_supported(
+                "this quantization storage does not support a generic row-id remapper".to_string(),
+            ));
+        }
+        Self::try_from_batch(batch, metadata, distance_type, None)
+    }
 
     fn metadata(&self) -> &Self::Metadata;
 

--- a/rust/lance-index/src/vector/sq/storage.rs
+++ b/rust/lance-index/src/vector/sq/storage.rs
@@ -25,7 +25,8 @@ use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
 use super::{ScalarQuantizer, scale_to_u8};
-use crate::frag_reuse::FragReuseIndex;
+use crate::frag_reuse::{FragReuseIndex, FragReuseIndexHandle};
+use crate::scalar::RowIdRemapper;
 use crate::{
     INDEX_METADATA_SCHEMA_KEY, IndexMetadata,
     vector::{
@@ -175,6 +176,18 @@ impl ScalarQuantizationStorage {
         batches: impl IntoIterator<Item = RecordBatch>,
         frag_reuse_index: Option<Arc<FragReuseIndex>>,
     ) -> Result<Self> {
+        let frag_reuse_index = frag_reuse_index
+            .map(|index| Arc::new(FragReuseIndexHandle(index)) as Arc<dyn RowIdRemapper>);
+        Self::try_new_with_remapper(num_bits, distance_type, bounds, batches, frag_reuse_index)
+    }
+
+    fn try_new_with_remapper(
+        num_bits: u16,
+        distance_type: DistanceType,
+        bounds: Range<f64>,
+        batches: impl IntoIterator<Item = RecordBatch>,
+        frag_reuse_index: Option<Arc<dyn RowIdRemapper>>,
+    ) -> Result<Self> {
         let mut chunks = Vec::with_capacity(SQ_CHUNK_CAPACITY);
         let mut offsets = Vec::with_capacity(SQ_CHUNK_CAPACITY + 1);
         offsets.push(0);
@@ -271,6 +284,21 @@ impl QuantizerStorage for ScalarQuantizationStorage {
         Self: Sized,
     {
         Self::try_new(
+            metadata.num_bits,
+            distance_type,
+            metadata.bounds.clone(),
+            [batch],
+            frag_reuse_index,
+        )
+    }
+
+    fn try_from_batch_with_remapper(
+        batch: RecordBatch,
+        metadata: &Self::Metadata,
+        distance_type: DistanceType,
+        frag_reuse_index: Option<Arc<dyn RowIdRemapper>>,
+    ) -> Result<Self> {
+        Self::try_new_with_remapper(
             metadata.num_bits,
             distance_type,
             metadata.bounds.clone(),

--- a/rust/lance-index/src/vector/storage.rs
+++ b/rust/lance-index/src/vector/storage.rs
@@ -28,7 +28,8 @@ use std::{
 
 use crossbeam_queue::ArrayQueue;
 
-use crate::frag_reuse::FragReuseIndex;
+use crate::frag_reuse::{FragReuseIndex, FragReuseIndexHandle};
+use crate::scalar::RowIdRemapper;
 use crate::{
     pb,
     vector::{
@@ -448,7 +449,7 @@ pub struct StorageBuilder<Q: Quantization> {
     distance_type: DistanceType,
     quantizer: Q,
 
-    frag_reuse_index: Option<Arc<FragReuseIndex>>,
+    frag_reuse_index: Option<Arc<dyn RowIdRemapper>>,
 }
 
 impl<Q: Quantization> StorageBuilder<Q> {
@@ -457,6 +458,18 @@ impl<Q: Quantization> StorageBuilder<Q> {
         distance_type: DistanceType,
         quantizer: Q,
         frag_reuse_index: Option<Arc<FragReuseIndex>>,
+    ) -> Result<Self> {
+        let frag_reuse_index = frag_reuse_index
+            .map(|index| Arc::new(FragReuseIndexHandle(index)) as Arc<dyn RowIdRemapper>);
+        Self::new_with_remapper(vector_column, distance_type, quantizer, frag_reuse_index)
+    }
+
+    #[doc(hidden)]
+    pub fn new_with_remapper(
+        vector_column: String,
+        distance_type: DistanceType,
+        quantizer: Q,
+        frag_reuse_index: Option<Arc<dyn RowIdRemapper>>,
     ) -> Result<Self> {
         Ok(Self {
             vector_column,
@@ -486,7 +499,7 @@ impl<Q: Quantization> StorageBuilder<Q> {
         debug_assert!(batch.column_by_name(ROW_ID).is_some());
         debug_assert!(batch.column_by_name(self.quantizer.column()).is_some());
 
-        Q::Storage::try_from_batch(
+        Q::Storage::try_from_batch_with_remapper(
             batch,
             &self.quantizer.metadata(None),
             self.distance_type,
@@ -504,7 +517,7 @@ pub struct IvfQuantizationStorage<Q: Quantization> {
     metadata: Q::Metadata,
 
     ivf: IvfModel,
-    frag_reuse_index: Option<Arc<FragReuseIndex>>,
+    frag_reuse_index: Option<Arc<dyn RowIdRemapper>>,
 }
 
 impl<Q: Quantization> DeepSizeOf for IvfQuantizationStorage<Q> {
@@ -520,6 +533,16 @@ impl<Q: Quantization> IvfQuantizationStorage<Q> {
     pub async fn try_new(
         reader: FileReader,
         frag_reuse_index: Option<Arc<FragReuseIndex>>,
+    ) -> Result<Self> {
+        let frag_reuse_index = frag_reuse_index
+            .map(|index| Arc::new(FragReuseIndexHandle(index)) as Arc<dyn RowIdRemapper>);
+        Self::try_new_with_remapper(reader, frag_reuse_index).await
+    }
+
+    #[doc(hidden)]
+    pub async fn try_new_with_remapper(
+        reader: FileReader,
+        frag_reuse_index: Option<Arc<dyn RowIdRemapper>>,
     ) -> Result<Self> {
         let schema = reader.schema();
 
@@ -577,6 +600,19 @@ impl<Q: Quantization> IvfQuantizationStorage<Q> {
         metadata: Q::Metadata,
         distance_type: DistanceType,
         frag_reuse_index: Option<Arc<FragReuseIndex>>,
+    ) -> Self {
+        let frag_reuse_index = frag_reuse_index
+            .map(|index| Arc::new(FragReuseIndexHandle(index)) as Arc<dyn RowIdRemapper>);
+        Self::from_cached_with_remapper(reader, ivf, metadata, distance_type, frag_reuse_index)
+    }
+
+    #[doc(hidden)]
+    pub fn from_cached_with_remapper(
+        reader: FileReader,
+        ivf: IvfModel,
+        metadata: Q::Metadata,
+        distance_type: DistanceType,
+        frag_reuse_index: Option<Arc<dyn RowIdRemapper>>,
     ) -> Self {
         Self {
             reader,
@@ -660,7 +696,7 @@ impl<Q: Quantization> IvfQuantizationStorage<Q> {
             let schema = Arc::new(self.reader.schema().as_ref().into());
             concat_batches(&schema, batches.iter())?
         };
-        Q::Storage::try_from_batch(
+        Q::Storage::try_from_batch_with_remapper(
             batch,
             self.metadata(),
             self.distance_type,

--- a/rust/lance-table/src/system_index/frag_reuse.rs
+++ b/rust/lance-table/src/system_index/frag_reuse.rs
@@ -340,21 +340,6 @@ impl CompactFragReuseIndex {
                     .iter()
                     .map(|frag| fragment_layout(frag, "old", version_idx, group_idx))
                     .collect::<Result<Vec<_>>>()?;
-                for (frag_id, bitmap) in changed_row_addrs.bitmaps() {
-                    let Some((_, physical_rows)) = old_frags
-                        .iter()
-                        .find(|(old_frag_id, _)| *old_frag_id == frag_id)
-                    else {
-                        return Err(Error::index(format!(
-                            "FRI version {version_idx}, group {group_idx} contains changed rows for old fragment {frag_id} that is not in its fragment layout"
-                        )));
-                    };
-                    if bitmap.max().is_some_and(|offset| offset >= *physical_rows) {
-                        return Err(Error::index(format!(
-                            "FRI version {version_idx}, group {group_idx} contains a changed row offset outside old fragment {frag_id} with physical_rows={physical_rows}"
-                        )));
-                    }
-                }
                 let new_frags = group
                     .new_frags
                     .iter()
@@ -366,7 +351,12 @@ impl CompactFragReuseIndex {
                     new_frags,
                 });
             }
-            version_remaps.push(RowAddrRemap::compact_with_layout(groups)?);
+            let remap = RowAddrRemap::compact_with_layout(groups).map_err(|error| {
+                Error::index(format!(
+                    "failed to build compact remap for FRI version {version_idx}: {error}"
+                ))
+            })?;
+            version_remaps.push(remap);
         }
 
         Ok(Self {
@@ -558,6 +548,7 @@ fn fragment_layout(
 mod tests {
 
     use super::*;
+    use rstest::rstest;
 
     fn addr(fragment_id: u32, offset: u32) -> u64 {
         u64::from(lance_core::utils::address::RowAddress::new_from_parts(
@@ -665,7 +656,54 @@ mod tests {
                 }],
             }],
         };
-        assert!(CompactFragReuseIndex::try_new(Uuid::new_v4(), details).is_err());
+        let error = CompactFragReuseIndex::try_new(Uuid::new_v4(), details).unwrap_err();
+        assert!(matches!(error, Error::Index { .. }));
+        assert!(
+            error
+                .to_string()
+                .contains("failed to deserialize changed row addresses for FRI version 0, group 0"),
+            "{error}"
+        );
+    }
+
+    #[rstest]
+    #[case::unknown_fragment(
+        vec![addr(2, 0)],
+        vec![digest(1, 1)],
+        "from fragments [2] not in its old fragments"
+    )]
+    #[case::offset_out_of_range(
+        vec![addr(1, 1)],
+        vec![digest(1, 1)],
+        "row offset outside old fragment 1 with physical_rows=1"
+    )]
+    #[case::duplicate_old_fragment(
+        vec![addr(1, 0)],
+        vec![digest(1, 1), digest(1, 1)],
+        "old fragment 1 more than once"
+    )]
+    fn test_compact_fri_preserves_layout_validation(
+        #[case] changed_addrs: Vec<u64>,
+        #[case] old_frags: Vec<FragDigest>,
+        #[case] expected_message: &str,
+    ) {
+        let details = FragReuseIndexDetails {
+            versions: vec![FragReuseVersion {
+                dataset_version: 1,
+                groups: vec![FragReuseGroup {
+                    changed_row_addrs: serialize_changed(changed_addrs),
+                    old_frags,
+                    new_frags: vec![digest(10, 1)],
+                }],
+            }],
+        };
+
+        let error = CompactFragReuseIndex::try_new(Uuid::new_v4(), details).unwrap_err();
+        assert!(matches!(error, Error::Index { .. }));
+        let message = error.to_string();
+        assert!(message.contains("FRI version 0"), "{message}");
+        assert!(message.contains("rewrite group 0"), "{message}");
+        assert!(message.contains(expected_message), "{message}");
     }
 
     #[tokio::test]

--- a/rust/lance-table/src/system_index/frag_reuse.rs
+++ b/rust/lance-table/src/system_index/frag_reuse.rs
@@ -1,12 +1,13 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright The Lance Authors
 
-use std::{collections::HashMap, sync::Arc};
+use std::{collections::HashMap, io::Cursor, sync::Arc};
 
 use arrow_array::cast::AsArray;
 use arrow_array::types::UInt64Type;
 use arrow_array::{Array, ArrayRef, PrimitiveArray, RecordBatch, UInt64Array};
 use lance_core::deepsize::{Context, DeepSizeOf};
+use lance_core::utils::row_addr_remap::{GroupInputWithLayout, RowAddrRemap};
 use lance_core::{Error, Result};
 use lance_select::RowAddrTreeMap;
 use roaring::{RoaringBitmap, RoaringTreemap};
@@ -196,9 +197,11 @@ impl FragReuseIndexDetails {
     }
 }
 
-/// An index that stores row ID maps.
-/// A row ID map describes the mapping from old row address to new address after compactions.
-/// Each version contains the mapping for one round of compaction.
+/// An index that stores materialized row ID maps.
+///
+/// This type is retained for API and serde compatibility. Dataset loading uses
+/// [`CompactFragReuseIndex`] so persisted FRI details are not expanded into a
+/// hash-map entry for every affected row.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct FragReuseIndex {
     pub uuid: Uuid,
@@ -225,18 +228,172 @@ impl FragReuseIndex {
         }
     }
 
+    pub fn is_empty(&self) -> bool {
+        self.row_id_maps.iter().all(HashMap::is_empty)
+    }
+
     pub fn remap_row_id(&self, row_id: u64) -> Option<u64> {
-        let mut mapped_value = Some(row_id);
-        for row_id_map in self.row_id_maps.iter() {
-            if mapped_value.is_some() {
-                mapped_value = row_id_map
-                    .get(&mapped_value.unwrap())
-                    .copied()
-                    .unwrap_or(mapped_value);
+        let mut mapped = Some(row_id);
+        for row_id_map in &self.row_id_maps {
+            if let Some(current) = mapped {
+                mapped = row_id_map.get(&current).copied().unwrap_or(mapped);
             }
         }
+        mapped
+    }
 
-        mapped_value
+    pub fn remap_row_ids_in_place(&self, row_ids: &mut [Option<u64>]) {
+        for row_id_map in &self.row_id_maps {
+            for row_id in row_ids.iter_mut() {
+                if let Some(current) = *row_id
+                    && let Some(mapped) = row_id_map.get(&current)
+                {
+                    *row_id = *mapped;
+                }
+            }
+        }
+    }
+
+    pub fn remap_row_addrs_tree_map(&self, row_addrs: &RowAddrTreeMap) -> RowAddrTreeMap {
+        RowAddrTreeMap::from_iter(
+            row_addrs
+                .row_addrs()
+                .unwrap()
+                .filter_map(|addr| self.remap_row_id(u64::from(addr))),
+        )
+    }
+
+    pub fn remap_row_ids_roaring_tree_map(&self, row_ids: &RoaringTreemap) -> RoaringTreemap {
+        RoaringTreemap::from_iter(row_ids.iter().filter_map(|addr| self.remap_row_id(addr)))
+    }
+
+    pub fn remap_row_ids_record_batch(
+        &self,
+        batch: RecordBatch,
+        row_id_idx: usize,
+    ) -> Result<RecordBatch> {
+        remap_row_ids_record_batch(batch, row_id_idx, |row_ids| {
+            self.remap_row_ids_in_place(row_ids)
+        })
+    }
+
+    pub fn remap_row_ids_array(&self, array: ArrayRef) -> PrimitiveArray<UInt64Type> {
+        remap_row_ids_array(array, |row_ids| self.remap_row_ids_in_place(row_ids))
+    }
+
+    pub fn remap_fragment_bitmap(&self, fragment_bitmap: &mut RoaringBitmap) -> Result<()> {
+        remap_fragment_bitmap(&self.details, fragment_bitmap)
+    }
+}
+
+/// A compact row-address remap chain for deferred compactions.
+///
+/// Each FRI version retains rewritten-row bitmaps and fragment layouts. Queries
+/// use bitmap rank plus the ordered new-fragment ranges instead of storing one
+/// hash-map entry per affected row.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CompactFragReuseIndex {
+    pub uuid: Uuid,
+    row_addr_remap: RowAddrRemap,
+    pub details: FragReuseIndexDetails,
+}
+
+impl DeepSizeOf for CompactFragReuseIndex {
+    fn deep_size_of_children(&self, cx: &mut Context) -> usize {
+        self.row_addr_remap.deep_size_of_children(cx) + self.details.deep_size_of_children(cx)
+    }
+}
+
+impl CompactFragReuseIndex {
+    #[doc(hidden)]
+    pub fn from_row_id_maps(
+        uuid: Uuid,
+        row_id_maps: Vec<HashMap<u64, Option<u64>>>,
+        details: FragReuseIndexDetails,
+    ) -> Self {
+        Self {
+            uuid,
+            row_addr_remap: RowAddrRemap::chained(
+                row_id_maps.into_iter().map(RowAddrRemap::direct),
+            ),
+            details,
+        }
+    }
+
+    /// Build a queryable index directly from serialized FRI details without
+    /// expanding each affected row into a hash map.
+    pub fn try_new(uuid: Uuid, details: FragReuseIndexDetails) -> Result<Self> {
+        let mut version_remaps = Vec::with_capacity(details.versions.len());
+        for (version_idx, version) in details.versions.iter().enumerate() {
+            let mut groups = Vec::with_capacity(version.groups.len());
+            for (group_idx, group) in version.groups.iter().enumerate() {
+                let changed_row_addrs = RoaringTreemap::deserialize_from(Cursor::new(
+                    &group.changed_row_addrs,
+                ))
+                .map_err(|error| {
+                    Error::index(format!(
+                        "failed to deserialize changed row addresses for FRI version {version_idx}, group {group_idx}: {error}"
+                    ))
+                })?;
+                let old_frags = group
+                    .old_frags
+                    .iter()
+                    .map(|frag| fragment_layout(frag, "old", version_idx, group_idx))
+                    .collect::<Result<Vec<_>>>()?;
+                for (frag_id, bitmap) in changed_row_addrs.bitmaps() {
+                    let Some((_, physical_rows)) = old_frags
+                        .iter()
+                        .find(|(old_frag_id, _)| *old_frag_id == frag_id)
+                    else {
+                        return Err(Error::index(format!(
+                            "FRI version {version_idx}, group {group_idx} contains changed rows for old fragment {frag_id} that is not in its fragment layout"
+                        )));
+                    };
+                    if bitmap.max().is_some_and(|offset| offset >= *physical_rows) {
+                        return Err(Error::index(format!(
+                            "FRI version {version_idx}, group {group_idx} contains a changed row offset outside old fragment {frag_id} with physical_rows={physical_rows}"
+                        )));
+                    }
+                }
+                let new_frags = group
+                    .new_frags
+                    .iter()
+                    .map(|frag| fragment_layout(frag, "new", version_idx, group_idx))
+                    .collect::<Result<Vec<_>>>()?;
+                groups.push(GroupInputWithLayout {
+                    rewritten_old_row_addrs: changed_row_addrs,
+                    old_frags,
+                    new_frags,
+                });
+            }
+            version_remaps.push(RowAddrRemap::compact_with_layout(groups)?);
+        }
+
+        Ok(Self {
+            uuid,
+            row_addr_remap: RowAddrRemap::chained(version_remaps),
+            details,
+        })
+    }
+
+    /// The ordered remap chain used by index and transaction remapping paths.
+    pub fn row_addr_remap(&self) -> &RowAddrRemap {
+        &self.row_addr_remap
+    }
+
+    /// Returns whether the index contains no row-address remapping.
+    pub fn is_empty(&self) -> bool {
+        self.row_addr_remap.is_empty()
+    }
+
+    pub fn remap_row_id(&self, row_id: u64) -> Option<u64> {
+        self.row_addr_remap.get(row_id).unwrap_or(Some(row_id))
+    }
+
+    /// Apply all FRI versions to row addresses in place. `None` values remain
+    /// deleted and missing mappings pass through unchanged.
+    pub fn remap_row_ids_in_place(&self, row_ids: &mut [Option<u64>]) {
+        self.row_addr_remap.remap_in_place(row_ids);
     }
 
     pub fn remap_row_addrs_tree_map(&self, row_addrs: &RowAddrTreeMap) -> RowAddrTreeMap {
@@ -260,98 +417,256 @@ impl FragReuseIndex {
         batch: RecordBatch,
         row_id_idx: usize,
     ) -> Result<RecordBatch> {
-        assert_eq!(batch.schema().fields().len(), 2);
-        let other_column_idx = 1 - row_id_idx;
-        let row_ids = batch.column(row_id_idx).as_primitive::<UInt64Type>();
-        let (val_indices, new_row_ids): (Vec<u64>, Vec<u64>) = row_ids
-            .values()
-            .iter()
-            .enumerate()
-            .filter_map(|(idx, old_id)| {
-                self.remap_row_id(*old_id)
-                    .map(|new_id| (idx as u64, new_id))
-            })
-            .unzip();
-        let new_val_indices = UInt64Array::from_iter_values(val_indices);
-        let new_vals =
-            arrow::compute::take(batch.column(other_column_idx), &new_val_indices, None)?;
-
-        let mut batch_data: Vec<(usize, ArrayRef)> = vec![
-            (
-                row_id_idx,
-                Arc::new(UInt64Array::from_iter_values(new_row_ids)) as ArrayRef,
-            ),
-            (other_column_idx, Arc::new(new_vals)),
-        ];
-        batch_data.sort_by_key(|(i, _)| *i);
-        Ok(RecordBatch::try_new(
-            batch.schema(),
-            batch_data.into_iter().map(|(_, item)| item).collect(),
-        )?)
+        remap_row_ids_record_batch(batch, row_id_idx, |row_ids| {
+            self.remap_row_ids_in_place(row_ids)
+        })
     }
 
     pub fn remap_row_ids_array(&self, array: ArrayRef) -> PrimitiveArray<UInt64Type> {
-        let primitive_array = array
-            .as_any()
-            .downcast_ref::<PrimitiveArray<UInt64Type>>()
-            .expect("expected row IDs to be uint64 array");
-        (0..primitive_array.len())
-            .map(|i| {
-                if primitive_array.is_null(i) {
-                    None
-                } else {
-                    self.remap_row_id(primitive_array.value(i))
-                }
-            })
-            .collect()
+        remap_row_ids_array(array, |row_ids| self.remap_row_ids_in_place(row_ids))
     }
 
     pub fn remap_fragment_bitmap(&self, fragment_bitmap: &mut RoaringBitmap) -> Result<()> {
-        for version in self.details.versions.iter() {
-            for group in version.groups.iter() {
-                let mut removed = 0;
-                for old_frag in group.old_frags.iter() {
-                    if fragment_bitmap.remove(old_frag.id as u32) {
-                        removed += 1;
-                    }
-                }
+        remap_fragment_bitmap(&self.details, fragment_bitmap)
+    }
+}
 
-                if removed > 0 {
-                    if removed != group.old_frags.len() {
-                        // Straddle: the index covered only part of this rewrite
-                        // group. Caused by the bug fixed in
-                        // <https://github.com/lance-format/lance/pull/6610>.
-                        // We've already removed the indexed old_frags from the
-                        // bitmap above; deliberately do NOT insert new_frags,
-                        // since the merged fragment also contains rows that
-                        // were never indexed. Affected rows fall through to
-                        // flat scan until the next optimize_indices. The fix
-                        // is persisted on the next write via build_manifest.
-                        tracing::warn!(
-                            "Healing straddling fragment-reuse rewrite group in index bitmap: \
+fn remap_row_ids_record_batch(
+    batch: RecordBatch,
+    row_id_idx: usize,
+    remap: impl FnOnce(&mut [Option<u64>]),
+) -> Result<RecordBatch> {
+    assert_eq!(batch.schema().fields().len(), 2);
+    let other_column_idx = 1 - row_id_idx;
+    let row_ids = batch.column(row_id_idx).as_primitive::<UInt64Type>();
+    let mut remapped_row_ids = row_ids
+        .values()
+        .iter()
+        .copied()
+        .map(Some)
+        .collect::<Vec<_>>();
+    remap(&mut remapped_row_ids);
+    let (val_indices, new_row_ids): (Vec<u64>, Vec<u64>) = remapped_row_ids
+        .iter()
+        .enumerate()
+        .filter_map(|(idx, new_id)| new_id.map(|new_id| (idx as u64, new_id)))
+        .unzip();
+    let new_val_indices = UInt64Array::from_iter_values(val_indices);
+    let new_vals = arrow::compute::take(batch.column(other_column_idx), &new_val_indices, None)?;
+
+    let mut batch_data: Vec<(usize, ArrayRef)> = vec![
+        (
+            row_id_idx,
+            Arc::new(UInt64Array::from_iter_values(new_row_ids)) as ArrayRef,
+        ),
+        (other_column_idx, Arc::new(new_vals)),
+    ];
+    batch_data.sort_by_key(|(i, _)| *i);
+    Ok(RecordBatch::try_new(
+        batch.schema(),
+        batch_data.into_iter().map(|(_, item)| item).collect(),
+    )?)
+}
+
+fn remap_row_ids_array(
+    array: ArrayRef,
+    remap: impl FnOnce(&mut [Option<u64>]),
+) -> PrimitiveArray<UInt64Type> {
+    let primitive_array = array
+        .as_any()
+        .downcast_ref::<PrimitiveArray<UInt64Type>>()
+        .expect("expected row IDs to be uint64 array");
+    let mut remapped = (0..primitive_array.len())
+        .map(|i| {
+            if primitive_array.is_null(i) {
+                None
+            } else {
+                Some(primitive_array.value(i))
+            }
+        })
+        .collect::<Vec<_>>();
+    remap(&mut remapped);
+    PrimitiveArray::from(remapped)
+}
+
+fn remap_fragment_bitmap(
+    details: &FragReuseIndexDetails,
+    fragment_bitmap: &mut RoaringBitmap,
+) -> Result<()> {
+    for version in details.versions.iter() {
+        for group in version.groups.iter() {
+            let mut removed = 0;
+            for old_frag in group.old_frags.iter() {
+                if fragment_bitmap.remove(old_frag.id as u32) {
+                    removed += 1;
+                }
+            }
+
+            if removed > 0 {
+                if removed != group.old_frags.len() {
+                    // Straddle: the index covered only part of this rewrite
+                    // group. Caused by the bug fixed in
+                    // <https://github.com/lance-format/lance/pull/6610>.
+                    // We've already removed the indexed old_frags from the
+                    // bitmap above; deliberately do NOT insert new_frags,
+                    // since the merged fragment also contains rows that
+                    // were never indexed. Affected rows fall through to
+                    // flat scan until the next optimize_indices. The fix
+                    // is persisted on the next write via build_manifest.
+                    tracing::warn!(
+                        "Healing straddling fragment-reuse rewrite group in index bitmap: \
                              group {:?} was only partially indexed ({} of {} old fragments). \
                              Affected rows will use flat scan until the next optimize_indices.",
-                            group.old_frags,
-                            removed,
-                            group.old_frags.len(),
-                        );
-                        continue;
-                    }
+                        group.old_frags,
+                        removed,
+                        group.old_frags.len(),
+                    );
+                    continue;
+                }
 
-                    for new_frag in group.new_frags.iter() {
-                        fragment_bitmap.insert(new_frag.id as u32);
-                    }
+                for new_frag in group.new_frags.iter() {
+                    fragment_bitmap.insert(new_frag.id as u32);
                 }
             }
         }
-        Ok(())
     }
+    Ok(())
+}
+
+fn fragment_layout(
+    frag: &FragDigest,
+    role: &str,
+    version_idx: usize,
+    group_idx: usize,
+) -> Result<(u32, u32)> {
+    let fragment_id = u32::try_from(frag.id).map_err(|_| {
+        Error::index(format!(
+            "FRI version {version_idx}, group {group_idx} has {role} fragment id {} outside the row-address range",
+            frag.id
+        ))
+    })?;
+    let physical_rows = u32::try_from(frag.physical_rows).map_err(|_| {
+        Error::index(format!(
+            "FRI version {version_idx}, group {group_idx} has {role} fragment {fragment_id} with physical_rows={} outside the row-address range",
+            frag.physical_rows
+        ))
+    })?;
+    Ok((fragment_id, physical_rows))
 }
 
 #[cfg(test)]
 mod tests {
 
     use super::*;
+
+    fn addr(fragment_id: u32, offset: u32) -> u64 {
+        u64::from(lance_core::utils::address::RowAddress::new_from_parts(
+            fragment_id,
+            offset,
+        ))
+    }
+
+    fn serialize_changed(addrs: impl IntoIterator<Item = u64>) -> Vec<u8> {
+        let changed = RoaringTreemap::from_iter(addrs);
+        let mut bytes = Vec::with_capacity(changed.serialized_size());
+        changed.serialize_into(&mut bytes).unwrap();
+        bytes
+    }
+
+    fn digest(id: u64, physical_rows: usize) -> FragDigest {
+        FragDigest {
+            id,
+            physical_rows,
+            num_deleted_rows: 0,
+        }
+    }
+
+    #[test]
+    fn test_compact_fri_tristate_one_to_many_and_chain() {
+        let details = FragReuseIndexDetails {
+            versions: vec![
+                FragReuseVersion {
+                    dataset_version: 1,
+                    groups: vec![
+                        // One old fragment is split into two new fragments.
+                        FragReuseGroup {
+                            changed_row_addrs: serialize_changed([
+                                addr(1, 0),
+                                addr(1, 2),
+                                addr(1, 3),
+                            ]),
+                            old_frags: vec![digest(1, 4)],
+                            new_frags: vec![digest(10, 1), digest(11, 2)],
+                        },
+                        // A separate rewrite group deletes an entire fragment.
+                        FragReuseGroup {
+                            changed_row_addrs: serialize_changed([]),
+                            old_frags: vec![digest(3, 2)],
+                            new_frags: vec![],
+                        },
+                    ],
+                },
+                FragReuseVersion {
+                    dataset_version: 2,
+                    groups: vec![FragReuseGroup {
+                        changed_row_addrs: serialize_changed([addr(10, 0), addr(11, 1)]),
+                        old_frags: vec![digest(10, 1), digest(11, 2)],
+                        new_frags: vec![digest(20, 2)],
+                    }],
+                },
+            ],
+        };
+        let details = FragReuseIndexDetails::try_from(InlineContent::from(&details)).unwrap();
+        let fri = CompactFragReuseIndex::try_new(Uuid::new_v4(), details).unwrap();
+
+        // Surviving rows follow both versions in oldest-to-newest order.
+        assert_eq!(fri.remap_row_id(addr(1, 0)), Some(addr(20, 0)));
+        assert_eq!(fri.remap_row_id(addr(1, 3)), Some(addr(20, 1)));
+        // Deletes can happen in either the first or a later version.
+        assert_eq!(fri.remap_row_id(addr(1, 1)), None);
+        assert_eq!(fri.remap_row_id(addr(1, 2)), None);
+        assert_eq!(fri.remap_row_id(addr(3, 0)), None);
+        // Uncovered fragments and out-of-range offsets retain the existing
+        // missing-map pass-through semantics.
+        assert_eq!(fri.remap_row_id(addr(2, 0)), Some(addr(2, 0)));
+        assert_eq!(fri.remap_row_id(addr(1, 4)), Some(addr(1, 4)));
+
+        let mut batch = vec![
+            Some(addr(1, 0)),
+            Some(addr(1, 1)),
+            Some(addr(1, 2)),
+            Some(addr(1, 3)),
+            Some(addr(2, 0)),
+            None,
+        ];
+        fri.remap_row_ids_in_place(&mut batch);
+        assert_eq!(
+            batch,
+            vec![
+                Some(addr(20, 0)),
+                None,
+                None,
+                Some(addr(20, 1)),
+                Some(addr(2, 0)),
+                None,
+            ]
+        );
+    }
+
+    #[test]
+    fn test_compact_fri_rejects_invalid_changed_row_bitmap() {
+        let details = FragReuseIndexDetails {
+            versions: vec![FragReuseVersion {
+                dataset_version: 1,
+                groups: vec![FragReuseGroup {
+                    changed_row_addrs: vec![1, 2, 3],
+                    old_frags: vec![digest(1, 1)],
+                    new_frags: vec![digest(2, 1)],
+                }],
+            }],
+        };
+        assert!(CompactFragReuseIndex::try_new(Uuid::new_v4(), details).is_err());
+    }
 
     #[tokio::test]
     async fn test_serialize_deserialize_index_details() {

--- a/rust/lance/Cargo.toml
+++ b/rust/lance/Cargo.toml
@@ -243,6 +243,10 @@ name = "distributed_vector_build"
 harness = false
 
 [[bench]]
+name = "frag_reuse"
+harness = false
+
+[[bench]]
 name = "mem_wal_write"
 path = "benches/mem_wal/write/mem_wal_write.rs"
 harness = false

--- a/rust/lance/benches/frag_reuse.rs
+++ b/rust/lance/benches/frag_reuse.rs
@@ -1,0 +1,530 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+//! Reproducible comparison of the legacy per-row FRI maps and the compact
+//! bitmap/rank representation.
+//!
+//! This benchmark starts from the same decoded `FragReuseIndexDetails` for
+//! both implementations. The open measurement includes Roaring deserialization
+//! and construction of the queryable runtime representation, but excludes
+//! object-store I/O and protobuf decoding.
+
+#![allow(clippy::print_stdout)]
+
+use std::collections::HashMap;
+use std::hint::black_box;
+use std::io::Cursor;
+use std::time::Instant;
+
+use lance::dataset::optimize::remapping::transpose_row_ids_from_digest;
+use lance_core::deepsize::{Context, DeepSizeOf};
+use lance_core::utils::address::RowAddress;
+use lance_index::frag_reuse::{
+    CompactFragReuseIndex, FragDigest, FragReuseGroup, FragReuseIndexDetails, FragReuseVersion,
+};
+use roaring::RoaringTreemap;
+use serde_json::json;
+use uuid::Uuid;
+
+#[derive(Clone, Copy)]
+struct Case {
+    name: &'static str,
+    rows: usize,
+    changed_basis_points: u32,
+    chain_len: usize,
+    old_fragment_count: usize,
+    groups_per_version: usize,
+}
+
+struct Config {
+    repeats: usize,
+    lookups: usize,
+    batch_size: usize,
+    quick: bool,
+}
+
+struct LegacyFragReuseIndex {
+    row_id_maps: Vec<HashMap<u64, Option<u64>>>,
+    details: FragReuseIndexDetails,
+}
+
+impl LegacyFragReuseIndex {
+    fn open(details: &FragReuseIndexDetails) -> Self {
+        let mut row_id_maps = Vec::with_capacity(details.versions.len());
+        for version in &details.versions {
+            let mut row_id_map = HashMap::new();
+            for group in &version.groups {
+                let changed_row_addrs =
+                    RoaringTreemap::deserialize_from(Cursor::new(&group.changed_row_addrs))
+                        .unwrap();
+                row_id_map.extend(transpose_row_ids_from_digest(
+                    changed_row_addrs,
+                    &group.old_frags,
+                    &group.new_frags,
+                ));
+            }
+            row_id_maps.push(row_id_map);
+        }
+        Self {
+            row_id_maps,
+            details: details.clone(),
+        }
+    }
+
+    fn remap_row_id(&self, row_id: u64) -> Option<u64> {
+        let mut mapped = Some(row_id);
+        for row_id_map in &self.row_id_maps {
+            if let Some(current) = mapped {
+                mapped = row_id_map.get(&current).copied().unwrap_or(mapped);
+            }
+        }
+        mapped
+    }
+
+    fn remap_row_ids_in_place(&self, row_ids: &mut [Option<u64>]) {
+        for row_id in row_ids {
+            if let Some(current) = *row_id {
+                *row_id = self.remap_row_id(current);
+            }
+        }
+    }
+}
+
+impl DeepSizeOf for LegacyFragReuseIndex {
+    fn deep_size_of_children(&self, context: &mut Context) -> usize {
+        self.row_id_maps.deep_size_of_children(context)
+            + self.details.deep_size_of_children(context)
+    }
+}
+
+fn main() {
+    let config = parse_config();
+    let cases = if config.quick {
+        vec![Case {
+            name: "quick",
+            rows: 100_000,
+            changed_basis_points: 5_000,
+            chain_len: 2,
+            old_fragment_count: 16,
+            groups_per_version: 2,
+        }]
+    } else {
+        vec![
+            Case {
+                name: "small_very_sparse",
+                rows: 100_000,
+                changed_basis_points: 10,
+                chain_len: 1,
+                old_fragment_count: 16,
+                groups_per_version: 1,
+            },
+            Case {
+                name: "small_sparse",
+                rows: 100_000,
+                changed_basis_points: 100,
+                chain_len: 1,
+                old_fragment_count: 16,
+                groups_per_version: 1,
+            },
+            Case {
+                name: "medium_sparse_chain",
+                rows: 1_000_000,
+                changed_basis_points: 1_000,
+                chain_len: 4,
+                old_fragment_count: 64,
+                groups_per_version: 8,
+            },
+            Case {
+                name: "medium_balanced",
+                rows: 1_000_000,
+                changed_basis_points: 5_000,
+                chain_len: 1,
+                old_fragment_count: 64,
+                groups_per_version: 8,
+            },
+            Case {
+                name: "medium_dense",
+                rows: 1_000_000,
+                changed_basis_points: 9_000,
+                chain_len: 1,
+                old_fragment_count: 64,
+                groups_per_version: 8,
+            },
+            Case {
+                name: "fragmented_sparse",
+                rows: 1_000_000,
+                changed_basis_points: 100,
+                chain_len: 1,
+                old_fragment_count: 4_096,
+                groups_per_version: 256,
+            },
+            Case {
+                name: "fragmented_dense_chain",
+                rows: 500_000,
+                changed_basis_points: 9_000,
+                chain_len: 4,
+                old_fragment_count: 1_024,
+                groups_per_version: 128,
+            },
+            Case {
+                name: "long_dense_chain",
+                rows: 250_000,
+                changed_basis_points: 9_000,
+                chain_len: 8,
+                old_fragment_count: 128,
+                groups_per_version: 16,
+            },
+            Case {
+                name: "large_sparse",
+                rows: 10_000_000,
+                changed_basis_points: 100,
+                chain_len: 1,
+                old_fragment_count: 128,
+                groups_per_version: 16,
+            },
+            Case {
+                name: "large_balanced_chain",
+                rows: 5_000_000,
+                changed_basis_points: 5_000,
+                chain_len: 4,
+                old_fragment_count: 256,
+                groups_per_version: 32,
+            },
+        ]
+    };
+
+    println!(
+        "{}",
+        json!({
+            "type": "environment",
+            "os": std::env::consts::OS,
+            "arch": std::env::consts::ARCH,
+            "repeats": config.repeats,
+            "lookups": config.lookups,
+            "batch_size": config.batch_size,
+            "unaffected_query_percent": 10,
+            "profile": "cargo bench (release)",
+            "memory_metric": "DeepSizeOf retained-bytes proxy; Roaring containers use serialized_size",
+        })
+    );
+
+    for case in cases {
+        run_case(case, &config);
+    }
+}
+
+fn parse_config() -> Config {
+    let mut config = Config {
+        repeats: 30,
+        lookups: 200_000,
+        batch_size: 65_536,
+        quick: false,
+    };
+    let mut args = std::env::args().skip(1);
+    while let Some(arg) = args.next() {
+        match arg.as_str() {
+            // `cargo bench` passes this libtest-compatible marker even for a
+            // custom harness.
+            "--bench" => {}
+            "--quick" => {
+                config.quick = true;
+                config.repeats = 5;
+                config.lookups = 20_000;
+                config.batch_size = 8_192;
+            }
+            "--repeats" => config.repeats = parse_value(&mut args, "--repeats"),
+            "--lookups" => config.lookups = parse_value(&mut args, "--lookups"),
+            "--batch-size" => config.batch_size = parse_value(&mut args, "--batch-size"),
+            other => panic!("unknown argument: {other}"),
+        }
+    }
+    assert!(config.repeats > 0, "--repeats must be greater than zero");
+    assert!(config.lookups > 0, "--lookups must be greater than zero");
+    assert!(
+        config.batch_size > 0,
+        "--batch-size must be greater than zero"
+    );
+    config
+}
+
+fn parse_value(args: &mut impl Iterator<Item = String>, name: &str) -> usize {
+    args.next()
+        .unwrap_or_else(|| panic!("{name} requires a value"))
+        .parse()
+        .unwrap_or_else(|_| panic!("{name} requires a positive integer"))
+}
+
+fn run_case(case: Case, config: &Config) {
+    let (details, baseline_frags) = generate_details(case);
+    let queries = sample_queries(&baseline_frags, config.lookups);
+    let batch_source = queries
+        .iter()
+        .take(config.batch_size)
+        .copied()
+        .map(Some)
+        .collect::<Vec<_>>();
+
+    let legacy = LegacyFragReuseIndex::open(&details);
+    let compact =
+        CompactFragReuseIndex::try_new(Uuid::nil(), details.clone()).expect("valid benchmark FRI");
+    for row_id in &queries {
+        assert_eq!(
+            legacy.remap_row_id(*row_id),
+            compact.remap_row_id(*row_id),
+            "legacy and compact semantics differ for case {} at row address {}",
+            case.name,
+            row_id
+        );
+    }
+
+    emit_memory(case, "legacy_hash_map", legacy.deep_size_of());
+    emit_memory(case, "compact_rank", compact.deep_size_of());
+
+    // Warm allocator and code paths before collecting samples.
+    black_box(LegacyFragReuseIndex::open(&details));
+    black_box(CompactFragReuseIndex::try_new(Uuid::nil(), details.clone()).unwrap());
+
+    let legacy_open = measure(config.repeats, || {
+        black_box(LegacyFragReuseIndex::open(black_box(&details)));
+    });
+    let compact_open = measure(config.repeats, || {
+        black_box(CompactFragReuseIndex::try_new(Uuid::nil(), black_box(details.clone())).unwrap());
+    });
+    emit_timing(case, "open_ns", "legacy_hash_map", 1, legacy_open);
+    emit_timing(case, "open_ns", "compact_rank", 1, compact_open);
+
+    let legacy_lookup = measure(config.repeats, || {
+        for row_id in &queries {
+            black_box(legacy.remap_row_id(black_box(*row_id)));
+        }
+    });
+    let compact_lookup = measure(config.repeats, || {
+        for row_id in &queries {
+            black_box(compact.remap_row_id(black_box(*row_id)));
+        }
+    });
+    emit_timing(
+        case,
+        "single_lookup_ns_per_row",
+        "legacy_hash_map",
+        queries.len(),
+        legacy_lookup,
+    );
+    emit_timing(
+        case,
+        "single_lookup_ns_per_row",
+        "compact_rank",
+        queries.len(),
+        compact_lookup,
+    );
+
+    let legacy_batch = measure(config.repeats, || {
+        let mut batch = batch_source.clone();
+        legacy.remap_row_ids_in_place(black_box(&mut batch));
+        black_box(batch);
+    });
+    let compact_batch = measure(config.repeats, || {
+        let mut batch = batch_source.clone();
+        compact.remap_row_ids_in_place(black_box(&mut batch));
+        black_box(batch);
+    });
+    emit_timing(
+        case,
+        "batch_remap_ns_per_row",
+        "legacy_hash_map",
+        batch_source.len(),
+        legacy_batch,
+    );
+    emit_timing(
+        case,
+        "batch_remap_ns_per_row",
+        "compact_rank",
+        batch_source.len(),
+        compact_batch,
+    );
+}
+
+fn measure(mut repeats: usize, mut operation: impl FnMut()) -> Vec<u128> {
+    let mut samples = Vec::with_capacity(repeats);
+    while repeats > 0 {
+        let start = Instant::now();
+        operation();
+        samples.push(start.elapsed().as_nanos());
+        repeats -= 1;
+    }
+    samples
+}
+
+fn emit_memory(case: Case, implementation: &str, bytes: usize) {
+    println!(
+        "{}",
+        json!({
+            "type": "memory",
+            "case": case.name,
+            "rows": case.rows,
+            "changed_basis_points": case.changed_basis_points,
+            "chain_len": case.chain_len,
+            "old_fragment_count": case.old_fragment_count,
+            "groups_per_version": case.groups_per_version,
+            "implementation": implementation,
+            "retained_bytes_proxy": bytes,
+        })
+    );
+}
+
+fn emit_timing(
+    case: Case,
+    metric: &str,
+    implementation: &str,
+    operations: usize,
+    samples_ns: Vec<u128>,
+) {
+    let mut normalized = samples_ns
+        .iter()
+        .map(|sample| *sample as f64 / operations as f64)
+        .collect::<Vec<_>>();
+    normalized.sort_by(f64::total_cmp);
+    println!(
+        "{}",
+        json!({
+            "type": "timing",
+            "case": case.name,
+            "rows": case.rows,
+            "changed_basis_points": case.changed_basis_points,
+            "chain_len": case.chain_len,
+            "old_fragment_count": case.old_fragment_count,
+            "groups_per_version": case.groups_per_version,
+            "implementation": implementation,
+            "metric": metric,
+            "operations_per_sample": operations,
+            "repeats": samples_ns.len(),
+            "p50": percentile(&normalized, 0.50),
+            "p99": percentile(&normalized, 0.99),
+            "raw_total_ns": samples_ns,
+        })
+    );
+}
+
+fn percentile(sorted: &[f64], percentile: f64) -> f64 {
+    let index = ((sorted.len() as f64 * percentile).ceil() as usize)
+        .saturating_sub(1)
+        .min(sorted.len() - 1);
+    sorted[index]
+}
+
+fn generate_details(case: Case) -> (FragReuseIndexDetails, Vec<FragDigest>) {
+    let mut next_fragment_id = 1u64;
+    let mut old_frags = distribute_rows(case.rows, case.old_fragment_count, &mut next_fragment_id);
+    let baseline_frags = old_frags.clone();
+    let mut versions = Vec::with_capacity(case.chain_len);
+
+    for version_idx in 0..case.chain_len {
+        let mut groups = Vec::new();
+        let mut next_old_frags = Vec::new();
+        let mut ordinal = 0u64;
+        let group_size = old_frags.len().div_ceil(case.groups_per_version).max(1);
+        for old_group in old_frags.chunks(group_size) {
+            let mut changed = RoaringTreemap::new();
+            let mut old_with_deletions = Vec::with_capacity(old_group.len());
+            for frag in old_group {
+                let mut num_changed = 0usize;
+                for offset in 0..frag.physical_rows as u32 {
+                    let hash = ordinal
+                        .wrapping_mul(6_364_136_223_846_793_005)
+                        .wrapping_add((version_idx as u64 + 1) * 1_442_695_040_888_963_407);
+                    if (hash >> 32) % 10_000 < case.changed_basis_points as u64 {
+                        changed.insert(u64::from(RowAddress::new_from_parts(
+                            frag.id as u32,
+                            offset,
+                        )));
+                        num_changed += 1;
+                    }
+                    ordinal += 1;
+                }
+                old_with_deletions.push(FragDigest {
+                    id: frag.id,
+                    physical_rows: frag.physical_rows,
+                    num_deleted_rows: frag.physical_rows - num_changed,
+                });
+            }
+
+            let num_changed = changed.len() as usize;
+            let new_fragment_count = if num_changed == 0 {
+                0
+            } else {
+                (old_group.len() + old_group.len() / 2)
+                    .max(1)
+                    .min(num_changed)
+            };
+            let new_frags = distribute_rows(num_changed, new_fragment_count, &mut next_fragment_id);
+            let mut changed_row_addrs = Vec::with_capacity(changed.serialized_size());
+            changed.serialize_into(&mut changed_row_addrs).unwrap();
+            groups.push(FragReuseGroup {
+                changed_row_addrs,
+                old_frags: old_with_deletions,
+                new_frags: new_frags.clone(),
+            });
+            next_old_frags.extend(new_frags);
+        }
+
+        versions.push(FragReuseVersion {
+            dataset_version: version_idx as u64 + 1,
+            groups,
+        });
+        old_frags = next_old_frags;
+    }
+
+    (FragReuseIndexDetails { versions }, baseline_frags)
+}
+
+fn distribute_rows(total_rows: usize, count: usize, next_id: &mut u64) -> Vec<FragDigest> {
+    if count == 0 {
+        return Vec::new();
+    }
+    let base = total_rows / count;
+    let remainder = total_rows % count;
+    (0..count)
+        .map(|index| {
+            let digest = FragDigest {
+                id: *next_id,
+                physical_rows: base + usize::from(index < remainder),
+                num_deleted_rows: 0,
+            };
+            *next_id += 1;
+            digest
+        })
+        .collect()
+}
+
+fn sample_queries(fragments: &[FragDigest], count: usize) -> Vec<u64> {
+    let total_rows = fragments
+        .iter()
+        .map(|frag| frag.physical_rows)
+        .sum::<usize>();
+    let unaffected_fragment = u32::MAX - 1;
+    let mut state = 0x4d595df4d0f33173u64;
+    (0..count)
+        .map(|index| {
+            state = state
+                .wrapping_mul(6_364_136_223_846_793_005)
+                .wrapping_add(1_442_695_040_888_963_407);
+            if index % 10 == 0 {
+                return u64::from(RowAddress::new_from_parts(
+                    unaffected_fragment,
+                    state as u32,
+                ));
+            }
+            let mut logical_row = state as usize % total_rows;
+            for frag in fragments {
+                if logical_row < frag.physical_rows {
+                    return u64::from(RowAddress::new_from_parts(
+                        frag.id as u32,
+                        logical_row as u32,
+                    ));
+                }
+                logical_row -= frag.physical_rows;
+            }
+            unreachable!("logical row is bounded by total_rows")
+        })
+        .collect()
+}

--- a/rust/lance/benches/frag_reuse.rs
+++ b/rust/lance/benches/frag_reuse.rs
@@ -7,13 +7,16 @@
 //! This benchmark starts from the same decoded `FragReuseIndexDetails` for
 //! both implementations. The open measurement includes Roaring deserialization
 //! and construction of the queryable runtime representation, but excludes
-//! object-store I/O and protobuf decoding.
+//! object-store I/O and protobuf decoding. Pass `--storage-uri` to additionally
+//! measure external FRI detail fetch, protobuf decode, and runtime open on local
+//! storage or an object store such as S3.
 
 #![allow(clippy::print_stdout)]
 
 use std::collections::HashMap;
 use std::hint::black_box;
 use std::io::Cursor;
+use std::sync::Arc;
 use std::time::Instant;
 
 use lance::dataset::optimize::remapping::transpose_row_ids_from_digest;
@@ -22,9 +25,16 @@ use lance_core::utils::address::RowAddress;
 use lance_index::frag_reuse::{
     CompactFragReuseIndex, FragDigest, FragReuseGroup, FragReuseIndexDetails, FragReuseVersion,
 };
+use lance_io::object_store::ObjectStore as LanceObjectStore;
+use lance_table::format::pb::fragment_reuse_index_details::InlineContent;
+use object_store::path::Path;
+use prost::Message;
 use roaring::RoaringTreemap;
 use serde_json::json;
+use tokio::io::AsyncWriteExt;
 use uuid::Uuid;
+
+const EXTERNAL_DETAILS_THRESHOLD: usize = 204_800;
 
 #[derive(Clone, Copy)]
 struct Case {
@@ -40,7 +50,15 @@ struct Config {
     repeats: usize,
     lookups: usize,
     batch_size: usize,
+    storage_repeats: usize,
+    storage_uri: Option<String>,
     quick: bool,
+}
+
+struct StorageTarget {
+    kind: &'static str,
+    store: Arc<LanceObjectStore>,
+    base_path: Path,
 }
 
 struct LegacyFragReuseIndex {
@@ -97,7 +115,8 @@ impl DeepSizeOf for LegacyFragReuseIndex {
     }
 }
 
-fn main() {
+#[tokio::main]
+async fn main() {
     let config = parse_config();
     let cases = if config.quick {
         vec![Case {
@@ -127,10 +146,26 @@ fn main() {
                 groups_per_version: 1,
             },
             Case {
+                name: "medium_density_5",
+                rows: 1_000_000,
+                changed_basis_points: 500,
+                chain_len: 1,
+                old_fragment_count: 64,
+                groups_per_version: 8,
+            },
+            Case {
                 name: "medium_sparse_chain",
                 rows: 1_000_000,
                 changed_basis_points: 1_000,
                 chain_len: 4,
+                old_fragment_count: 64,
+                groups_per_version: 8,
+            },
+            Case {
+                name: "medium_density_25",
+                rows: 1_000_000,
+                changed_basis_points: 2_500,
+                chain_len: 1,
                 old_fragment_count: 64,
                 groups_per_version: 8,
             },
@@ -143,9 +178,25 @@ fn main() {
                 groups_per_version: 8,
             },
             Case {
+                name: "medium_density_75",
+                rows: 1_000_000,
+                changed_basis_points: 7_500,
+                chain_len: 1,
+                old_fragment_count: 64,
+                groups_per_version: 8,
+            },
+            Case {
                 name: "medium_dense",
                 rows: 1_000_000,
                 changed_basis_points: 9_000,
+                chain_len: 1,
+                old_fragment_count: 64,
+                groups_per_version: 8,
+            },
+            Case {
+                name: "medium_density_99",
+                rows: 1_000_000,
+                changed_basis_points: 9_900,
                 chain_len: 1,
                 old_fragment_count: 64,
                 groups_per_version: 8,
@@ -190,7 +241,20 @@ fn main() {
                 old_fragment_count: 256,
                 groups_per_version: 32,
             },
+            Case {
+                name: "large_dense",
+                rows: 5_000_000,
+                changed_basis_points: 9_000,
+                chain_len: 1,
+                old_fragment_count: 128,
+                groups_per_version: 16,
+            },
         ]
+    };
+
+    let storage = match config.storage_uri.as_deref() {
+        Some(uri) => Some(StorageTarget::open(uri).await),
+        None => None,
     };
 
     println!(
@@ -202,14 +266,16 @@ fn main() {
             "repeats": config.repeats,
             "lookups": config.lookups,
             "batch_size": config.batch_size,
+            "storage_repeats": config.storage_repeats,
+            "storage_kind": storage.as_ref().map(|target| target.kind),
             "unaffected_query_percent": 10,
             "profile": "cargo bench (release)",
-            "memory_metric": "DeepSizeOf retained-bytes proxy; Roaring containers use serialized_size",
+            "memory_metric": "DeepSizeOf retained-bytes proxy; retained Roaring containers use serialized_size",
         })
     );
 
     for case in cases {
-        run_case(case, &config);
+        run_case(case, &config, storage.as_ref()).await;
     }
 }
 
@@ -218,6 +284,8 @@ fn parse_config() -> Config {
         repeats: 30,
         lookups: 200_000,
         batch_size: 65_536,
+        storage_repeats: 10,
+        storage_uri: None,
         quick: false,
     };
     let mut args = std::env::args().skip(1);
@@ -231,10 +299,20 @@ fn parse_config() -> Config {
                 config.repeats = 5;
                 config.lookups = 20_000;
                 config.batch_size = 8_192;
+                config.storage_repeats = 3;
             }
             "--repeats" => config.repeats = parse_value(&mut args, "--repeats"),
             "--lookups" => config.lookups = parse_value(&mut args, "--lookups"),
             "--batch-size" => config.batch_size = parse_value(&mut args, "--batch-size"),
+            "--storage-repeats" => {
+                config.storage_repeats = parse_value(&mut args, "--storage-repeats")
+            }
+            "--storage-uri" => {
+                config.storage_uri = Some(
+                    args.next()
+                        .unwrap_or_else(|| panic!("--storage-uri requires a URI")),
+                )
+            }
             other => panic!("unknown argument: {other}"),
         }
     }
@@ -243,6 +321,10 @@ fn parse_config() -> Config {
     assert!(
         config.batch_size > 0,
         "--batch-size must be greater than zero"
+    );
+    assert!(
+        config.storage_repeats > 0,
+        "--storage-repeats must be greater than zero"
     );
     config
 }
@@ -254,15 +336,19 @@ fn parse_value(args: &mut impl Iterator<Item = String>, name: &str) -> usize {
         .unwrap_or_else(|_| panic!("{name} requires a positive integer"))
 }
 
-fn run_case(case: Case, config: &Config) {
+async fn run_case(case: Case, config: &Config, storage: Option<&StorageTarget>) {
     let (details, baseline_frags) = generate_details(case);
     let queries = sample_queries(&baseline_frags, config.lookups);
-    let batch_source = queries
+    let random_batch = queries
         .iter()
         .take(config.batch_size)
         .copied()
         .map(Some)
         .collect::<Vec<_>>();
+    let mut fragment_grouped_batch = random_batch.clone();
+    fragment_grouped_batch.sort_by_key(|row_id| row_id.map(|row_id| row_id >> 32));
+    let mut monotonic_batch = random_batch.clone();
+    monotonic_batch.sort_unstable();
 
     let legacy = LegacyFragReuseIndex::open(&details);
     let compact =
@@ -318,30 +404,205 @@ fn run_case(case: Case, config: &Config) {
         compact_lookup,
     );
 
-    let legacy_batch = measure(config.repeats, || {
-        let mut batch = batch_source.clone();
+    measure_batch_order(
+        case,
+        config.repeats,
+        "batch_random_ns_per_row",
+        &random_batch,
+        &legacy,
+        &compact,
+    );
+    measure_batch_order(
+        case,
+        config.repeats,
+        "batch_fragment_grouped_ns_per_row",
+        &fragment_grouped_batch,
+        &legacy,
+        &compact,
+    );
+    measure_batch_order(
+        case,
+        config.repeats,
+        "batch_monotonic_ns_per_row",
+        &monotonic_batch,
+        &legacy,
+        &compact,
+    );
+
+    if let Some(storage) = storage {
+        storage
+            .benchmark_external_open(case, &details, config.storage_repeats)
+            .await;
+    }
+}
+
+fn measure_batch_order(
+    case: Case,
+    repeats: usize,
+    metric: &str,
+    batch_source: &[Option<u64>],
+    legacy: &LegacyFragReuseIndex,
+    compact: &CompactFragReuseIndex,
+) {
+    let legacy_batch = measure(repeats, || {
+        let mut batch = batch_source.to_vec();
         legacy.remap_row_ids_in_place(black_box(&mut batch));
         black_box(batch);
     });
-    let compact_batch = measure(config.repeats, || {
-        let mut batch = batch_source.clone();
+    let compact_batch = measure(repeats, || {
+        let mut batch = batch_source.to_vec();
         compact.remap_row_ids_in_place(black_box(&mut batch));
         black_box(batch);
     });
     emit_timing(
         case,
-        "batch_remap_ns_per_row",
+        metric,
         "legacy_hash_map",
         batch_source.len(),
         legacy_batch,
     );
     emit_timing(
         case,
-        "batch_remap_ns_per_row",
+        metric,
         "compact_rank",
         batch_source.len(),
         compact_batch,
     );
+}
+
+impl StorageTarget {
+    async fn open(uri: &str) -> Self {
+        let (store, base_path) = LanceObjectStore::from_uri(uri)
+            .await
+            .unwrap_or_else(|error| panic!("failed to open benchmark storage URI {uri}: {error}"));
+        let kind = if uri.starts_with("s3://") {
+            "s3"
+        } else if uri.starts_with("file://") || !uri.contains("://") {
+            "local"
+        } else {
+            "object_store"
+        };
+        Self {
+            kind,
+            store,
+            base_path,
+        }
+    }
+
+    async fn benchmark_external_open(
+        &self,
+        case: Case,
+        details: &FragReuseIndexDetails,
+        repeats: usize,
+    ) {
+        let encoded = InlineContent::from(details).encode_to_vec();
+        if encoded.len() <= EXTERNAL_DETAILS_THRESHOLD {
+            println!(
+                "{}",
+                json!({
+                    "type": "storage_skip",
+                    "case": case.name,
+                    "storage": self.kind,
+                    "encoded_bytes": encoded.len(),
+                    "reason": "FRI details remain inline at the production external-file threshold",
+                })
+            );
+            return;
+        }
+
+        let path = self
+            .base_path
+            .clone()
+            .join(format!("{}.details.binpb", case.name));
+        let mut writer = self.store.create(&path).await.unwrap_or_else(|error| {
+            panic!(
+                "failed to create {} benchmark object {}: {error}",
+                self.kind, path
+            )
+        });
+        writer.write_all(&encoded).await.unwrap_or_else(|error| {
+            panic!(
+                "failed to write {} benchmark object {}: {error}",
+                self.kind, path
+            )
+        });
+        writer.shutdown().await.unwrap_or_else(|error| {
+            panic!(
+                "failed to finish {} benchmark object {}: {error}",
+                self.kind, path
+            )
+        });
+
+        let loaded = self.load_details(&path, encoded.len()).await;
+        assert_eq!(
+            &loaded, details,
+            "{} storage roundtrip changed FRI details for case {}",
+            self.kind, case.name
+        );
+
+        let mut legacy_samples = Vec::with_capacity(repeats);
+        let mut compact_samples = Vec::with_capacity(repeats);
+        for repeat in 0..repeats {
+            if repeat % 2 == 0 {
+                legacy_samples.push(self.measure_legacy_open(&path, encoded.len()).await);
+                compact_samples.push(self.measure_compact_open(&path, encoded.len()).await);
+            } else {
+                compact_samples.push(self.measure_compact_open(&path, encoded.len()).await);
+                legacy_samples.push(self.measure_legacy_open(&path, encoded.len()).await);
+            }
+        }
+        emit_storage_timing(
+            case,
+            self.kind,
+            encoded.len(),
+            "legacy_hash_map",
+            legacy_samples,
+        );
+        emit_storage_timing(
+            case,
+            self.kind,
+            encoded.len(),
+            "compact_rank",
+            compact_samples,
+        );
+    }
+
+    async fn load_details(&self, path: &Path, encoded_len: usize) -> FragReuseIndexDetails {
+        let data = self
+            .store
+            .open(path)
+            .await
+            .unwrap_or_else(|error| panic!("failed to open {} object {path}: {error}", self.kind))
+            .get_range(0..encoded_len)
+            .await
+            .unwrap_or_else(|error| panic!("failed to read {} object {path}: {error}", self.kind));
+        let content = InlineContent::decode(data).unwrap_or_else(|error| {
+            panic!("failed to decode {} FRI details {path}: {error}", self.kind)
+        });
+        FragReuseIndexDetails::try_from(content).unwrap_or_else(|error| {
+            panic!(
+                "failed to convert {} FRI details {path}: {error}",
+                self.kind
+            )
+        })
+    }
+
+    async fn measure_legacy_open(&self, path: &Path, encoded_len: usize) -> u128 {
+        let start = Instant::now();
+        let details = self.load_details(path, encoded_len).await;
+        black_box(LegacyFragReuseIndex::open(&details));
+        start.elapsed().as_nanos()
+    }
+
+    async fn measure_compact_open(&self, path: &Path, encoded_len: usize) -> u128 {
+        let start = Instant::now();
+        let details = self.load_details(path, encoded_len).await;
+        black_box(
+            CompactFragReuseIndex::try_new(Uuid::nil(), details)
+                .expect("valid stored benchmark FRI"),
+        );
+        start.elapsed().as_nanos()
+    }
 }
 
 fn measure(mut repeats: usize, mut operation: impl FnMut()) -> Vec<u128> {
@@ -397,6 +658,41 @@ fn emit_timing(
             "implementation": implementation,
             "metric": metric,
             "operations_per_sample": operations,
+            "repeats": samples_ns.len(),
+            "p50": percentile(&normalized, 0.50),
+            "p99": percentile(&normalized, 0.99),
+            "raw_total_ns": samples_ns,
+        })
+    );
+}
+
+fn emit_storage_timing(
+    case: Case,
+    storage: &str,
+    encoded_bytes: usize,
+    implementation: &str,
+    samples_ns: Vec<u128>,
+) {
+    let mut normalized = samples_ns
+        .iter()
+        .map(|sample| *sample as f64)
+        .collect::<Vec<_>>();
+    normalized.sort_by(f64::total_cmp);
+    println!(
+        "{}",
+        json!({
+            "type": "storage_timing",
+            "case": case.name,
+            "rows": case.rows,
+            "changed_basis_points": case.changed_basis_points,
+            "chain_len": case.chain_len,
+            "old_fragment_count": case.old_fragment_count,
+            "groups_per_version": case.groups_per_version,
+            "storage": storage,
+            "encoded_bytes": encoded_bytes,
+            "implementation": implementation,
+            "metric": "external_details_fetch_decode_open_ns",
+            "operations_per_sample": 1,
             "repeats": samples_ns.len(),
             "p50": percentile(&normalized, 0.50),
             "p99": percentile(&normalized, 0.99),

--- a/rust/lance/src/dataset/optimize.rs
+++ b/rust/lance/src/dataset/optimize.rs
@@ -2873,7 +2873,19 @@ pub async fn commit_compaction(
                                         f.id
                                     ))
                                 })?;
-                                Ok((f.id as u32, physical_rows as u32))
+                                let fragment_id = u32::try_from(f.id).map_err(|_| {
+                                    Error::invalid_input(format!(
+                                        "compacted fragment id {} is outside the row-address range",
+                                        f.id
+                                    ))
+                                })?;
+                                let physical_rows = u32::try_from(physical_rows).map_err(|_| {
+                                    Error::invalid_input(format!(
+                                        "compacted fragment {} has physical_rows={} outside the row-address range",
+                                        f.id, physical_rows
+                                    ))
+                                })?;
+                                Ok((fragment_id, physical_rows))
                             })
                             .collect::<Result<Vec<_>>>()?;
 
@@ -2882,8 +2894,15 @@ pub async fn commit_compaction(
                             old_frag_ids: task
                                 .original_fragments
                                 .iter()
-                                .map(|f| f.id as u32)
-                                .collect(),
+                                .map(|f| {
+                                    u32::try_from(f.id).map_err(|_| {
+                                        Error::invalid_input(format!(
+                                            "compacted source fragment id {} is outside the row-address range",
+                                            f.id
+                                        ))
+                                    })
+                                })
+                                .collect::<Result<Vec<_>>>()?,
                             new_frags,
                         });
                     }
@@ -3045,8 +3064,8 @@ mod tests {
     use lance_core::utils::tempfile::TempStrDir;
     use lance_datagen::Dimension;
     use lance_file::version::LanceFileVersion;
+    use lance_index::frag_reuse::CompactFragReuseIndexHandle;
     use lance_index::frag_reuse::FRAG_REUSE_INDEX_NAME;
-    use lance_index::frag_reuse::FragReuseIndexHandle;
     use lance_index::scalar::{
         BuiltinIndexType, FullTextSearchQuery, InvertedIndexParams, ScalarIndexParams,
     };
@@ -4693,7 +4712,7 @@ mod tests {
             open_frag_reuse_index(frag_reuse_index_meta.uuid, frag_reuse_details.as_ref())
                 .await
                 .unwrap();
-        let stats = FragReuseIndexHandle(Arc::new(frag_reuse_index.clone()))
+        let stats = CompactFragReuseIndexHandle(Arc::new(frag_reuse_index.clone()))
             .statistics()
             .unwrap();
         assert_eq!(

--- a/rust/lance/src/dataset/optimize/remapping.rs
+++ b/rust/lance/src/dataset/optimize/remapping.rs
@@ -203,7 +203,7 @@ pub fn transpose_row_ids_from_digest(
 /// If the frag reuse index does not exist, the operation fails with [Error::NotSupported]
 /// If the frag reuse index exists but is empty, the operation succeeds without a commit.
 async fn remap_index(dataset: &mut Dataset, index_id: &Uuid) -> Result<()> {
-    let indices = dataset.load_indices().await.unwrap();
+    let indices = dataset.load_indices().await?;
     let frag_reuse_index_meta = match indices.iter().find(|idx| idx.name == FRAG_REUSE_INDEX_NAME) {
         None => Err(Error::not_supported_source(
             "Fragment reuse index not found, cannot remap an index post compaction".into(),
@@ -211,13 +211,9 @@ async fn remap_index(dataset: &mut Dataset, index_id: &Uuid) -> Result<()> {
         Some(frag_reuse_index_meta) => Ok(frag_reuse_index_meta),
     }?;
 
-    let frag_reuse_details = load_frag_reuse_index_details(dataset, frag_reuse_index_meta)
-        .await
-        .unwrap();
+    let frag_reuse_details = load_frag_reuse_index_details(dataset, frag_reuse_index_meta).await?;
     let frag_reuse_index =
-        open_frag_reuse_index(frag_reuse_index_meta.uuid, frag_reuse_details.as_ref())
-            .await
-            .unwrap();
+        open_frag_reuse_index(frag_reuse_index_meta.uuid, frag_reuse_details.as_ref()).await?;
 
     if frag_reuse_index.is_empty() {
         return Ok(());
@@ -450,7 +446,7 @@ mod tests {
 
     #[test]
     fn test_compact_matches_transpose() {
-        use lance_core::utils::row_addr_remap::GroupInput;
+        use lance_core::utils::row_addr_remap::GroupInputWithLayout;
         // Ascending old fragments (compaction's scan order), with deletions.
         let old = vec![
             FragDigest {
@@ -501,9 +497,12 @@ mod tests {
         ];
 
         let expected = transpose_row_ids_from_digest(addrs.clone(), &old, &new);
-        let compact = RowAddrRemap::compact([GroupInput {
+        let compact = RowAddrRemap::compact_with_layout([GroupInputWithLayout {
             rewritten_old_row_addrs: addrs,
-            old_frag_ids: old.iter().map(|f| f.id as u32).collect(),
+            old_frags: old
+                .iter()
+                .map(|f| (f.id as u32, f.physical_rows as u32))
+                .collect(),
             new_frags: new
                 .iter()
                 .map(|f| (f.id as u32, f.physical_rows as u32))

--- a/rust/lance/src/dataset/optimize/remapping.rs
+++ b/rust/lance/src/dataset/optimize/remapping.rs
@@ -219,7 +219,7 @@ async fn remap_index(dataset: &mut Dataset, index_id: &Uuid) -> Result<()> {
             .await
             .unwrap();
 
-    if frag_reuse_index.row_id_maps.is_empty() {
+    if frag_reuse_index.is_empty() {
         return Ok(());
     }
 
@@ -299,27 +299,13 @@ async fn remap_index(dataset: &mut Dataset, index_id: &Uuid) -> Result<()> {
         return Ok(());
     }
 
-    // Compose the row-address remap across all versions. `remap_row_id` already
-    // chains every version (and passes through addresses a version does not
-    // touch), so mapping the union of all versions' keys yields a single
-    // baseline -> final address map applied in one rebuild.
-    //
-    // Map every old address; do NOT filter by the current `fragment_bitmap`. In
-    // the sibling-coverage-remap case the bitmap was already advanced onto the
-    // new fragments while the index data still holds old addresses, so filtering
-    // by it would drop exactly the keys this index needs and leave its data
-    // stale (an empty map makes `index::remap_index` return `Keep`). The map is
-    // bounded by the rows the reuse index touched; addresses this index does not
-    // store are simply never looked up.
-    let composed_row_id_map: HashMap<u64, Option<u64>> = frag_reuse_index
-        .row_id_maps
-        .iter()
-        .flat_map(|row_id_map| row_id_map.keys().copied())
-        .map(|old_addr| (old_addr, frag_reuse_index.remap_row_id(old_addr)))
-        .collect();
-
-    let remapper = RowAddrRemap::direct(composed_row_id_map);
-    let remap_result = index::remap_index(dataset, index_id, &remapper).await?;
+    // Apply the compact version chain directly while rebuilding the index. The
+    // remapper passes intermediate moved addresses into later FRI versions and
+    // leaves missing mappings unchanged, so no composed per-row map is needed.
+    // This also handles the sibling-coverage-remap case: remapping is driven by
+    // the row addresses stored in the index, not by its already-advanced bitmap.
+    let remap_result =
+        index::remap_index(dataset, index_id, frag_reuse_index.row_addr_remap()).await?;
 
     // Remapping advances the index watermark for fragment-reuse cleanup, but it
     // does not incorporate overlays committed after the source index was built.

--- a/rust/lance/src/index.rs
+++ b/rust/lance/src/index.rs
@@ -25,7 +25,9 @@ use lance_file::reader::FileReaderOptions;
 use lance_file::versions::v1::reader::FileReader as V1FileReader;
 use lance_index::INDEX_METADATA_SCHEMA_KEY;
 pub use lance_index::IndexParams;
-use lance_index::frag_reuse::{FRAG_REUSE_INDEX_NAME, FragReuseIndex, FragReuseIndexHandle};
+use lance_index::frag_reuse::{
+    CompactFragReuseIndex, CompactFragReuseIndexHandle, FRAG_REUSE_INDEX_NAME,
+};
 use lance_index::mem_wal::{MEM_WAL_INDEX_NAME, MemWalIndex, MemWalIndexHandle};
 use lance_index::optimize::OptimizeOptions;
 use lance_index::pb::index::Implementation;
@@ -969,7 +971,7 @@ impl<'a> FragReuseIndexCacheKey<'a> {
 }
 
 impl CacheKey for FragReuseIndexCacheKey<'_> {
-    type ValueType = FragReuseIndex;
+    type ValueType = CompactFragReuseIndex;
 
     fn key(&self) -> std::borrow::Cow<'_, str> {
         if let Some(fri_uuid) = self.fri_uuid {
@@ -2473,7 +2475,7 @@ async fn index_statistics_frag_reuse(ds: &Dataset) -> Result<String> {
         .open_frag_reuse_index(&NoOpMetricsCollector)
         .await?
         .expect("FragmentReuse index does not exist");
-    serialize_index_statistics(&FragReuseIndexHandle(index).statistics()?)
+    serialize_index_statistics(&CompactFragReuseIndexHandle(index).statistics()?)
 }
 
 async fn index_statistics_mem_wal(ds: &Dataset) -> Result<String> {
@@ -2794,7 +2796,7 @@ pub trait DatasetIndexInternalExt: DatasetIndexExt {
     async fn open_frag_reuse_index(
         &self,
         metrics: &dyn MetricsCollector,
-    ) -> Result<Option<Arc<FragReuseIndex>>>;
+    ) -> Result<Option<Arc<CompactFragReuseIndex>>>;
 
     /// Opens the MemWAL index
     async fn open_mem_wal_index(
@@ -2851,7 +2853,7 @@ impl DatasetIndexInternalExt for Dataset {
 
         let frag_reuse_cache_key = FragReuseIndexCacheKey::new(uuid, frag_reuse_uuid.as_ref());
         if let Some(index) = self.index_cache.get_with_key(&frag_reuse_cache_key).await {
-            return Ok(Arc::new(FragReuseIndexHandle(index)).as_index());
+            return Ok(Arc::new(CompactFragReuseIndexHandle(index)).as_index());
         }
 
         // Sometimes we want to open an index and we don't care if it is a scalar or vector index.
@@ -3255,7 +3257,7 @@ impl DatasetIndexInternalExt for Dataset {
     async fn open_frag_reuse_index(
         &self,
         metrics: &dyn MetricsCollector,
-    ) -> Result<Option<Arc<FragReuseIndex>>> {
+    ) -> Result<Option<Arc<CompactFragReuseIndex>>> {
         if let Some(frag_reuse_index_meta) = self.load_index_by_name(FRAG_REUSE_INDEX_NAME).await? {
             let frag_reuse_uuid = frag_reuse_index_meta.uuid;
             let frag_reuse_key = FragReuseIndexKey {

--- a/rust/lance/src/index.rs
+++ b/rust/lance/src/index.rs
@@ -5617,7 +5617,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_remap_empty() {
+    async fn test_remap_empty_chain() {
         let data = gen_batch()
             .col("int", array::step::<Int32Type>())
             .col(
@@ -5634,10 +5634,18 @@ mod tests {
             .unwrap();
 
         let index_uuid = dataset.load_indices().await.unwrap()[0].uuid;
-        let remap_to_empty = (0..dataset.count_all_rows().await.unwrap())
+        let row_count = dataset.count_all_rows().await.unwrap();
+        let first_half = (0..row_count / 2)
             .map(|i| (i as u64, None))
             .collect::<HashMap<_, _>>();
-        let new_uuid = remap_index(&dataset, &index_uuid, &RowAddrRemap::direct(remap_to_empty))
+        let second_half = (row_count / 2..row_count)
+            .map(|i| (i as u64, None))
+            .collect::<HashMap<_, _>>();
+        let remap_to_empty = RowAddrRemap::chained([
+            RowAddrRemap::direct(first_half),
+            RowAddrRemap::direct(second_half),
+        ]);
+        let new_uuid = remap_index(&dataset, &index_uuid, &remap_to_empty)
             .await
             .unwrap();
         assert_eq!(new_uuid, RemapResult::Keep(index_uuid));

--- a/rust/lance/src/index/append.rs
+++ b/rust/lance/src/index/append.rs
@@ -8,7 +8,7 @@ use lance_core::{Error, Result};
 use lance_file::reader::FileReaderOptions;
 use lance_index::{
     INDEX_FILE_NAME, IndexType,
-    frag_reuse::FragReuseIndex,
+    frag_reuse::CompactFragReuseIndex,
     metrics::NoOpMetricsCollector,
     optimize::OptimizeOptions,
     progress::{IndexBuildProgress, NoopIndexBuildProgress},
@@ -162,7 +162,7 @@ pub fn split_segment_coverage<'a>(
 }
 
 pub fn fragment_reuse_affects_segments<'a>(
-    frag_reuse_index: &FragReuseIndex,
+    frag_reuse_index: &CompactFragReuseIndex,
     segments: impl IntoIterator<Item = &'a IndexMetadata>,
 ) -> bool {
     segments.into_iter().any(|segment| {
@@ -174,7 +174,7 @@ pub fn fragment_reuse_affects_segments<'a>(
 }
 
 pub fn fragment_reuse_affects_segment(
-    frag_reuse_index: &FragReuseIndex,
+    frag_reuse_index: &CompactFragReuseIndex,
     coverage: &RoaringBitmap,
     dataset_version: u64,
 ) -> bool {
@@ -1418,10 +1418,10 @@ mod tests {
             base_id: None,
             files: None,
         };
-        let frag_reuse_index = FragReuseIndex {
-            uuid: Uuid::new_v4(),
-            row_id_maps: vec![],
-            details: FragReuseIndexDetails {
+        let frag_reuse_index = CompactFragReuseIndex::from_row_id_maps(
+            Uuid::new_v4(),
+            vec![],
+            FragReuseIndexDetails {
                 versions: vec![FragReuseVersion {
                     dataset_version: 5,
                     groups: vec![FragReuseGroup {
@@ -1439,7 +1439,7 @@ mod tests {
                     }],
                 }],
             },
-        };
+        );
 
         assert!(fragment_reuse_affects_segments(
             &frag_reuse_index,

--- a/rust/lance/src/index/frag_reuse.rs
+++ b/rust/lance/src/index/frag_reuse.rs
@@ -2,20 +2,17 @@
 // SPDX-FileCopyrightText: Copyright The Lance Authors
 
 use crate::Dataset;
-use crate::dataset::optimize::remapping::transpose_row_ids_from_digest;
 use crate::index::DatasetIndexExt;
 use lance_core::Error;
 use lance_index::frag_reuse::{
-    FRAG_REUSE_DETAILS_FILE_NAME, FRAG_REUSE_INDEX_NAME, FragReuseGroup, FragReuseIndex,
+    CompactFragReuseIndex, FRAG_REUSE_DETAILS_FILE_NAME, FRAG_REUSE_INDEX_NAME, FragReuseGroup,
     FragReuseIndexDetails, FragReuseVersion,
 };
 use lance_table::format::IndexMetadata;
 use lance_table::format::pb::fragment_reuse_index_details::{Content, InlineContent};
 use lance_table::format::pb::{ExternalFile, FragmentReuseIndexDetails};
 use prost::Message;
-use roaring::{RoaringBitmap, RoaringTreemap};
-use std::collections::HashMap;
-use std::io::Cursor;
+use roaring::RoaringBitmap;
 use std::sync::Arc;
 use tokio::io::AsyncWriteExt;
 use uuid::Uuid;
@@ -71,25 +68,8 @@ pub async fn load_frag_reuse_index_details(
 pub(crate) async fn open_frag_reuse_index(
     uuid: Uuid,
     details: &FragReuseIndexDetails,
-) -> lance_core::Result<FragReuseIndex> {
-    let mut row_id_maps: Vec<HashMap<u64, Option<u64>>> =
-        Vec::with_capacity(details.versions.len());
-    for version in &details.versions {
-        let mut row_id_map = HashMap::<u64, Option<u64>>::new();
-        for group in version.groups.iter() {
-            let cursor = Cursor::new(&group.changed_row_addrs);
-            let changed_row_addrs = RoaringTreemap::deserialize_from(cursor).unwrap();
-            let group_row_id_map = transpose_row_ids_from_digest(
-                changed_row_addrs,
-                &group.old_frags,
-                &group.new_frags,
-            );
-            row_id_map.extend(group_row_id_map);
-        }
-        row_id_maps.push(row_id_map);
-    }
-
-    Ok(FragReuseIndex::new(uuid, row_id_maps, details.clone()))
+) -> lance_core::Result<CompactFragReuseIndex> {
+    CompactFragReuseIndex::try_new(uuid, details.clone())
 }
 
 pub(crate) async fn build_new_frag_reuse_index(

--- a/rust/lance/src/index/scalar.rs
+++ b/rust/lance/src/index/scalar.rs
@@ -39,7 +39,7 @@ use lance_core::datatypes::Field;
 use lance_core::utils::tracing::{IO_TYPE_OPEN_SCALAR, TRACE_IO_EVENTS};
 use lance_core::{Error, ROW_ADDR, ROW_ID, Result};
 use lance_datafusion::exec::LanceExecutionOptions;
-use lance_index::frag_reuse::FragReuseIndexHandle;
+use lance_index::frag_reuse::CompactFragReuseIndexHandle;
 use lance_index::metrics::{MetricsCollector, NoOpMetricsCollector};
 use lance_index::pbold::{
     BTreeIndexDetails, BitmapIndexDetails, InvertedIndexDetails, LabelListIndexDetails,
@@ -560,8 +560,8 @@ pub async fn open_scalar_index(
         .index_cache
         .for_index(&index.uuid, frag_reuse_index.as_ref().map(|f| &f.uuid));
 
-    let frag_reuse_index: Option<Arc<dyn RowIdRemapper>> =
-        frag_reuse_index.map(|f| Arc::new(FragReuseIndexHandle(f)) as Arc<dyn RowIdRemapper>);
+    let frag_reuse_index: Option<Arc<dyn RowIdRemapper>> = frag_reuse_index
+        .map(|f| Arc::new(CompactFragReuseIndexHandle(f)) as Arc<dyn RowIdRemapper>);
 
     // Runs only on a cold miss, and at most once even under concurrent opens
     // (the plugin coalesces). The compat check lives here because a warm hit was

--- a/rust/lance/src/index/scalar/ngram.rs
+++ b/rust/lance/src/index/scalar/ngram.rs
@@ -4,13 +4,14 @@
 use std::sync::Arc;
 
 use datafusion::physical_plan::SendableRecordBatchStream;
+use lance_index::frag_reuse::CompactFragReuseIndexHandle;
 use lance_index::metrics::NoOpMetricsCollector;
 use lance_index::progress::NoopIndexBuildProgress;
 use lance_index::scalar::lance_format::LanceIndexStore;
 use lance_index::scalar::ngram::NGramIndex;
 use lance_index::scalar::{
-    BuiltinIndexType, CreatedIndex, IndexStore, OldIndexDataFilter, ScalarIndexParams,
-    index_files_to_table,
+    BuiltinIndexType, CreatedIndex, IndexStore, OldIndexDataFilter, RowIdRemapper,
+    ScalarIndexParams, index_files_to_table,
 };
 use lance_table::format::IndexMetadata;
 use roaring::RoaringBitmap;
@@ -160,7 +161,9 @@ pub(in crate::index) async fn open_and_merge_segments(
     let segments = segments.iter().map(|&s| s.clone()).collect::<Vec<_>>();
     let segment_stores = collect_ngram_segment_stores(dataset, &segments).await?;
     let frag_reuse_index = dataset.open_frag_reuse_index(&NoOpMetricsCollector).await?;
-    NGramIndex::merge_segments(
+    let frag_reuse_index = frag_reuse_index
+        .map(|index| Arc::new(CompactFragReuseIndexHandle(index)) as Arc<dyn RowIdRemapper>);
+    NGramIndex::merge_segments_with_remapper(
         &segment_stores,
         new_data,
         new_store,

--- a/rust/lance/src/index/vector.rs
+++ b/rust/lance/src/index/vector.rs
@@ -27,7 +27,7 @@ use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
 use futures::stream;
 use lance_core::utils::tempfile::TempStdDir;
 use lance_file::versions::v1::reader::FileReader as V1FileReader;
-use lance_index::frag_reuse::FragReuseIndex;
+use lance_index::frag_reuse::CompactFragReuseIndex;
 use lance_index::metrics::NoOpMetricsCollector;
 use lance_index::optimize::OptimizeOptions;
 use lance_index::progress::{IndexBuildProgress, noop_progress};
@@ -607,7 +607,7 @@ pub(crate) async fn build_distributed_vector_index(
     _name: &str,
     uuid: Uuid,
     params: &VectorIndexParams,
-    frag_reuse_index: Option<Arc<FragReuseIndex>>,
+    frag_reuse_index: Option<Arc<CompactFragReuseIndex>>,
     fragment_ids: &[u32],
     progress: Arc<dyn IndexBuildProgress>,
 ) -> Result<(Uuid, Vec<IndexFile>)> {
@@ -960,7 +960,7 @@ pub(crate) async fn build_vector_index(
     name: &str,
     uuid: Uuid,
     params: &VectorIndexParams,
-    frag_reuse_index: Option<Arc<FragReuseIndex>>,
+    frag_reuse_index: Option<Arc<CompactFragReuseIndex>>,
     progress: Arc<dyn IndexBuildProgress>,
 ) -> Result<Vec<IndexFile>> {
     build_vector_index_impl(
@@ -984,7 +984,7 @@ pub(crate) async fn build_filtered_vector_index(
     name: &str,
     uuid: Uuid,
     params: &VectorIndexParams,
-    frag_reuse_index: Option<Arc<FragReuseIndex>>,
+    frag_reuse_index: Option<Arc<CompactFragReuseIndex>>,
     fragment_ids: &[u32],
     progress: Arc<dyn IndexBuildProgress>,
 ) -> Result<Vec<IndexFile>> {
@@ -1008,7 +1008,7 @@ async fn build_vector_index_impl(
     name: &str,
     uuid: Uuid,
     params: &VectorIndexParams,
-    frag_reuse_index: Option<Arc<FragReuseIndex>>,
+    frag_reuse_index: Option<Arc<CompactFragReuseIndex>>,
     progress: Arc<dyn IndexBuildProgress>,
     fragment_ids: Option<&[u32]>,
 ) -> Result<Vec<IndexFile>> {
@@ -1295,7 +1295,7 @@ pub(crate) async fn build_vector_index_incremental(
     uuid: Uuid,
     params: &VectorIndexParams,
     existing_index: Arc<dyn VectorIndex>,
-    frag_reuse_index: Option<Arc<FragReuseIndex>>,
+    frag_reuse_index: Option<Arc<CompactFragReuseIndex>>,
     progress: Arc<dyn IndexBuildProgress>,
 ) -> Result<VectorIndexBuildSummary> {
     let stages = &params.stages;
@@ -1617,7 +1617,7 @@ pub(crate) async fn open_vector_index(
     uuid: &Uuid,
     vec_idx: &lance_index::pb::VectorIndex,
     reader: Arc<dyn Reader>,
-    frag_reuse_index: Option<Arc<FragReuseIndex>>,
+    frag_reuse_index: Option<Arc<CompactFragReuseIndex>>,
 ) -> Result<Arc<dyn VectorIndex>> {
     let metric_type = pb::VectorMetricType::try_from(vec_idx.metric_type)?.into();
 
@@ -1712,7 +1712,7 @@ pub(crate) async fn open_vector_index_v2(
     column: &str,
     uuid: &Uuid,
     reader: V1FileReader,
-    frag_reuse_index: Option<Arc<FragReuseIndex>>,
+    frag_reuse_index: Option<Arc<CompactFragReuseIndex>>,
 ) -> Result<Arc<dyn VectorIndex>> {
     let index_metadata = reader
         .schema()

--- a/rust/lance/src/index/vector/builder.rs
+++ b/rust/lance/src/index/vector/builder.rs
@@ -30,10 +30,11 @@ use lance_core::{Error, ROW_ID_FIELD, Result};
 use lance_file::version::ConcreteFileVersion;
 use lance_file::versions as file_versions;
 use lance_file::writer::FileWriterOptions;
-use lance_index::frag_reuse::FragReuseIndex;
+use lance_index::frag_reuse::{CompactFragReuseIndex, CompactFragReuseIndexHandle};
 use lance_index::metrics::NoOpMetricsCollector;
 use lance_index::optimize::OptimizeOptions;
 use lance_index::progress::{IndexBuildProgress, NoopIndexBuildProgress};
+use lance_index::scalar::RowIdRemapper;
 use lance_index::vector::bq::storage::{RABIT_CODE_COLUMN, unpack_codes};
 use lance_index::vector::kmeans::KMeansParams;
 use lance_index::vector::pq::storage::transpose;
@@ -237,7 +238,7 @@ pub struct IvfIndexBuilder<S: IvfSubIndex, Q: Quantization> {
     // fields for merging indices / remapping
     existing_indices: Vec<ExistingIndex>,
 
-    frag_reuse_index: Option<Arc<FragReuseIndex>>,
+    frag_reuse_index: Option<Arc<CompactFragReuseIndex>>,
 
     // fragments for distributed indexing
     fragment_filter: Option<Vec<u32>>,
@@ -276,7 +277,7 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
         ivf_params: Option<IvfBuildParams>,
         quantizer_params: Option<Q::BuildParams>,
         sub_index_params: S::BuildParams,
-        frag_reuse_index: Option<Arc<FragReuseIndex>>,
+        frag_reuse_index: Option<Arc<CompactFragReuseIndex>>,
     ) -> Result<Self> {
         let temp_dir = TempStdDir::default();
         let temp_dir_path = Path::from_filesystem_path(&temp_dir)?;
@@ -317,7 +318,7 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
         distance_type: DistanceType,
         shuffler: Box<dyn Shuffler>,
         sub_index_params: S::BuildParams,
-        frag_reuse_index: Option<Arc<FragReuseIndex>>,
+        frag_reuse_index: Option<Arc<CompactFragReuseIndex>>,
         optimize_options: OptimizeOptions,
     ) -> Result<Self> {
         let mut builder = Self::new(
@@ -1107,10 +1108,13 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
         sub_index_params: S::BuildParams,
         batches: Vec<RecordBatch>,
         column: String,
-        frag_reuse_index: Option<Arc<FragReuseIndex>>,
+        frag_reuse_index: Option<Arc<CompactFragReuseIndex>>,
     ) -> Result<(Q::Storage, S)> {
-        let storage = StorageBuilder::new(column, distance_type, quantizer, frag_reuse_index)?
-            .build(batches)?;
+        let frag_reuse_index = frag_reuse_index
+            .map(|index| Arc::new(CompactFragReuseIndexHandle(index)) as Arc<dyn RowIdRemapper>);
+        let storage =
+            StorageBuilder::new_with_remapper(column, distance_type, quantizer, frag_reuse_index)?
+                .build(batches)?;
         let sub_index = S::index_vectors(&storage, sub_index_params)?;
 
         Ok((storage, sub_index))

--- a/rust/lance/src/index/vector/ivf/v2.rs
+++ b/rust/lance/src/index/vector/ivf/v2.rs
@@ -38,8 +38,9 @@ use lance_encoding::decoder::{DecoderPlugins, FilterExpression};
 use lance_file::LanceEncodingsIo;
 use lance_file::reader::{CachedFileMetadata, FileReader, FileReaderOptions, ReaderProjection};
 use lance_index::cache_pb::IvfStateHeader;
-use lance_index::frag_reuse::FragReuseIndex;
+use lance_index::frag_reuse::{CompactFragReuseIndex, CompactFragReuseIndexHandle};
 use lance_index::metrics::{LocalMetricsCollector, MetricsCollector, NoOpMetricsCollector};
+use lance_index::scalar::RowIdRemapper;
 use lance_index::vector::VectorIndexCacheEntry;
 use lance_index::vector::bq::builder::RabitQuantizer;
 use lance_index::vector::bq::ex_dot::{blocked_ex_code_bytes, padded_query_len};
@@ -266,7 +267,7 @@ pub(crate) trait IvfStateEntry: DeepSizeOf + Send + Sync + 'static {
         object_store: Arc<ObjectStore>,
         file_metadata_cache: &'a LanceCache,
         index_cache: LanceCache,
-        frag_reuse_index: Option<Arc<FragReuseIndex>>,
+        frag_reuse_index: Option<Arc<CompactFragReuseIndex>>,
     ) -> BoxFuture<'a, Result<Arc<dyn VectorIndex>>>;
 }
 
@@ -442,7 +443,7 @@ impl<Q: Quantization + 'static> IvfStateEntry for IvfIndexState<Q> {
         object_store: Arc<ObjectStore>,
         file_metadata_cache: &'a LanceCache,
         index_cache: LanceCache,
-        frag_reuse_index: Option<Arc<FragReuseIndex>>,
+        frag_reuse_index: Option<Arc<CompactFragReuseIndex>>,
     ) -> BoxFuture<'a, Result<Arc<dyn VectorIndex>>> {
         Box::pin(async move {
             match self.sub_index_type {
@@ -1006,7 +1007,7 @@ impl<S: IvfSubIndex + 'static, Q: Quantization> IVFIndex<S, Q> {
         object_store: Arc<ObjectStore>,
         index_dir: Path,
         uuid: Uuid,
-        frag_reuse_index: Option<Arc<FragReuseIndex>>,
+        frag_reuse_index: Option<Arc<CompactFragReuseIndex>>,
         file_metadata_cache: &LanceCache,
         index_cache: LanceCache,
         file_sizes: HashMap<String, u64>,
@@ -1079,8 +1080,11 @@ impl<S: IvfSubIndex + 'static, Q: Quantization> IVFIndex<S, Q> {
             FileReaderOptions::default(),
         )
         .await?;
+        let frag_reuse_index = frag_reuse_index
+            .clone()
+            .map(|index| Arc::new(CompactFragReuseIndexHandle(index)) as Arc<dyn RowIdRemapper>);
         let storage =
-            IvfQuantizationStorage::try_new(storage_reader, frag_reuse_index.clone()).await?;
+            IvfQuantizationStorage::try_new_with_remapper(storage_reader, frag_reuse_index).await?;
 
         // Cache file metadata so reconstructions from IvfIndexState can skip
         // footer reads.
@@ -1965,7 +1969,7 @@ async fn reconstruct_typed<S: IvfSubIndex + 'static, Q: Quantization + 'static>(
     object_store: Arc<ObjectStore>,
     file_metadata_cache: &LanceCache,
     index_cache: LanceCache,
-    frag_reuse_index: Option<Arc<FragReuseIndex>>,
+    frag_reuse_index: Option<Arc<CompactFragReuseIndex>>,
 ) -> Result<Arc<dyn VectorIndex>> {
     let io_parallelism = object_store.io_parallelism();
 
@@ -1998,7 +2002,9 @@ async fn reconstruct_typed<S: IvfSubIndex + 'static, Q: Quantization + 'static>(
     )
     .await?;
 
-    let storage = IvfQuantizationStorage::from_cached(
+    let frag_reuse_index = frag_reuse_index
+        .map(|index| Arc::new(CompactFragReuseIndexHandle(index)) as Arc<dyn RowIdRemapper>);
+    let storage = IvfQuantizationStorage::from_cached_with_remapper(
         aux_reader,
         state.aux_ivf.clone(),
         state.metadata.clone(),

--- a/rust/lance/src/index/vector/pq.rs
+++ b/rust/lance/src/index/vector/pq.rs
@@ -27,7 +27,7 @@ use lance_core::deepsize::DeepSizeOf;
 use lance_core::utils::address::RowAddress;
 use lance_core::utils::tokio::spawn_cpu;
 use lance_core::{ROW_ID, ROW_ID_FIELD};
-use lance_index::frag_reuse::FragReuseIndex;
+use lance_index::frag_reuse::CompactFragReuseIndex;
 use lance_index::metrics::MetricsCollector;
 use lance_index::vector::ivf::storage::IvfModel;
 use lance_index::vector::pq::storage::{ProductQuantizationStorage, transpose};
@@ -72,7 +72,7 @@ pub struct PQIndex {
     /// Metric type.
     metric_type: MetricType,
 
-    frag_reuse_index: Option<Arc<FragReuseIndex>>,
+    frag_reuse_index: Option<Arc<CompactFragReuseIndex>>,
 }
 
 async fn read_legacy_index_values(
@@ -150,7 +150,7 @@ impl PQIndex {
     pub(crate) fn new(
         pq: ProductQuantizer,
         metric_type: MetricType,
-        frag_reuse_index: Option<Arc<FragReuseIndex>>,
+        frag_reuse_index: Option<Arc<CompactFragReuseIndex>>,
     ) -> Self {
         Self {
             code: None,

--- a/rust/lance/src/session/index_caches.rs
+++ b/rust/lance/src/session/index_caches.rs
@@ -14,7 +14,7 @@ use std::{borrow::Cow, ops::Deref, sync::Arc};
 
 use lance_core::cache::{CacheKey, CacheKeySchema, KeyBuilder, LanceCache};
 use lance_core::deepsize::{Context, DeepSizeOf};
-use lance_index::frag_reuse::FragReuseIndex;
+use lance_index::frag_reuse::CompactFragReuseIndex;
 use lance_table::format::IndexMetadata;
 use uuid::Uuid;
 
@@ -97,7 +97,7 @@ pub struct FragReuseIndexKey<'a> {
 }
 
 impl CacheKey for FragReuseIndexKey<'_> {
-    type ValueType = FragReuseIndex;
+    type ValueType = CompactFragReuseIndex;
 
     fn key(&self) -> Cow<'_, str> {
         Cow::Owned(format!("frag_reuse/{}", self.uuid))


### PR DESCRIPTION
## Problem

Opening a fragment reuse index expands every affected row in every retained version into `HashMap<u64, Option<u64>>`. Large or deferred compaction chains can therefore consume hundreds of MB and spend more than a second rebuilding maps before the index is usable.

## Design

Apply the persisted remap chain directly. Each old fragment selects one private rank representation when the FRI is opened:

- sorted offsets for sparse layouts;
- dense words with per-word prefix counts for constant-time dense rank; or
- Roaring containers when they are at least 4x smaller than the rank-friendly alternatives.

Lookups preserve the existing tri-state behavior: unaffected rows pass through, deleted rows are dropped, and moved rows continue through later FRI versions. New-fragment ranges preserve writer order; fragment IDs do not need to be ascending because cumulative row positions, rather than ID ordering, determine remapping.

## Compatibility

The protobuf schema, inline/external encoding, public API, and serde representation are unchanged. Files written by existing releases remain readable; the adaptive rank representation is private and rebuilt when the FRI is opened.

## Performance

Measured at commit `f2e48591cecc5a3f8d33f2dbb746eb2a581469fc` on a dedicated AWS `c7i.4xlarge` with the repository release profile. The four complete runs cover 15 workloads, two Local stores, two S3 stores, and 30 CPU samples per workload. Every workload verifies identical legacy and compact results before timing. CPU ranges use each workload's minimum speedup across all four runs to avoid reporting phase-dependent outliers.

| Metric | Result |
|---|---:|
| Retained-memory proxy | **11.8-594.2x smaller** |
| Runtime open p50 | **10.5-2219.8x faster** |
| Random batch p50, 14/15 workloads | **1.03-2.58x faster** |
| Fragment-grouped batch p50 | **1.14-2.66x faster** |
| Monotonic batch p50 | **1.13-2.78x faster** |
| Dense single-version random batch, 75%-99% changed | **1.43-1.68x faster** |

The remaining tradeoff is limited to small sparse inputs: at 0.1% changed, random-batch throughput is **0.84-0.90x** of legacy; scalar throughput for the 0.1%-1% cases is **0.70-0.88x** of legacy.

### S3 external details

This metric includes the S3 read, protobuf decode, and runtime open for externally stored FRI details. Both implementations read the same object, with 10 samples each and alternating measurement order.

| Workload | Encoded details | Speedup |
|---|---:|---:|
| 1M dense | 0.53 MB | **4.50-5.21x** |
| 500K fragmented dense chain | 3.44 MB | **3.36-3.41x** |
| 10M sparse | 0.21 MB | **46.39-53.81x** |
| 5M balanced chain | 6.56 MB | **11.30-11.33x** |
| 5M dense | 1.05 MB | **12.37-13.50x** |

All 11 external-detail workloads improve, with an overall S3 speedup of **3.36-53.81x**.

Raw JSONL results and the benchmark manifest are retained at:

```text
s3://lance-fri-rank-bench-054483968661-20260831/pr8887/f2e48591ce/results/
```

## Validation

- `cargo fmt --all`
- `cargo clippy --all --tests --benches -- -D warnings`
- `cargo test -p lance-core -p lance-table`
- targeted differential and multi-step remap tests in `lance-core`, `lance-table`, and `lance`
