### PR TITLE
feat(python): return matched row offsets from fragment update_columns

### DIFF
--- a/python/python/lance/fragment.py
+++ b/python/python/lance/fragment.py
@@ -833,7 +833,11 @@ class LanceFragment(pa.dataset.Fragment):
         left_on: str = "_rowid",
         right_on: Optional[str] = None,
         schema=None,
-    ) -> Tuple[FragmentMetadata, List[int]]:
+        with_offsets: bool = False,
+    ) -> Union[
+        Tuple[FragmentMetadata, List[int]],
+        Tuple[FragmentMetadata, List[int], bytes],
+    ]:
         """
         Update existing columns in this fragment.
 
@@ -859,6 +863,14 @@ class LanceFragment(pa.dataset.Fragment):
             The name of the column in data_obj to join on. If None, defaults to left_on.
         schema: pa.Schema, optional
             The schema of the data. If not specified, the schema will be inferred.
+        with_offsets: bool, default False
+            If True, also return the physical row offsets (0-based within this
+            fragment) that matched the join, serialized in the portable
+            RoaringBitmap format. Pass them to
+            :class:`LanceOperation.Update <lance.LanceOperation.Update>` as
+            ``updated_fragment_offsets`` with ``update_mode="rewrite_columns"``
+            so a commit over stable row ids refreshes row-level version
+            metadata for the matched rows only.
 
         Returns
         -------
@@ -866,6 +878,10 @@ class LanceFragment(pa.dataset.Fragment):
             A tuple of:
             - FragmentMetadata: The updated fragment metadata
             - List[int]: The list of field IDs that were modified
+
+            When ``with_offsets`` is True, the tuple has a third element:
+            - bytes: The matched physical row offsets as portable
+              RoaringBitmap bytes
 
         Examples
         --------
@@ -922,9 +938,11 @@ class LanceFragment(pa.dataset.Fragment):
             right_on = left_on
 
         reader = _coerce_reader(data_obj, schema)
-        metadata, fields_modified = self._fragment.update_columns(
+        metadata, fields_modified, matched_offsets = self._fragment.update_columns(
             reader, left_on, right_on
         )
+        if with_offsets:
+            return metadata, fields_modified, matched_offsets
         return metadata, fields_modified
 
     def merge_columns(

--- a/python/python/lance/fragment.py
+++ b/python/python/lance/fragment.py
@@ -827,12 +827,35 @@ class LanceFragment(pa.dataset.Fragment):
         metadata, schema = self._fragment.merge(reader, left_on, right_on, max_field_id)
         return metadata, schema
 
+    @overload
     def update_columns(
         self,
         data_obj: ReaderLike,
         left_on: str = "_rowid",
         right_on: Optional[str] = None,
         schema=None,
+        *,
+        with_offsets: Literal[False] = False,
+    ) -> Tuple[FragmentMetadata, List[int]]: ...
+
+    @overload
+    def update_columns(
+        self,
+        data_obj: ReaderLike,
+        left_on: str = "_rowid",
+        right_on: Optional[str] = None,
+        schema=None,
+        *,
+        with_offsets: Literal[True],
+    ) -> Tuple[FragmentMetadata, List[int], bytes]: ...
+
+    def update_columns(
+        self,
+        data_obj: ReaderLike,
+        left_on: str = "_rowid",
+        right_on: Optional[str] = None,
+        schema=None,
+        *,
         with_offsets: bool = False,
     ) -> Union[
         Tuple[FragmentMetadata, List[int]],
@@ -939,9 +962,9 @@ class LanceFragment(pa.dataset.Fragment):
 
         reader = _coerce_reader(data_obj, schema)
         metadata, fields_modified, matched_offsets = self._fragment.update_columns(
-            reader, left_on, right_on
+            reader, left_on, right_on, with_offsets
         )
-        if with_offsets:
+        if matched_offsets is not None:
             return metadata, fields_modified, matched_offsets
         return metadata, fields_modified
 

--- a/python/python/tests/test_fragment.py
+++ b/python/python/tests/test_fragment.py
@@ -855,8 +855,12 @@ def test_fragment_update_columns_with_offsets_rewrite_columns(tmp_path):
     updated_fragment, fields_modified, matched_offsets = fragment.update_columns(
         update_data, left_on="id", with_offsets=True
     )
-    assert isinstance(matched_offsets, bytes)
-    assert len(matched_offsets) > 0
+    # Portable RoaringBitmap serialization of {1, 3}: ids 5 and 7 sit at those
+    # physical offsets within the second fragment.
+    assert matched_offsets == (
+        b"\x3a\x30\x00\x00\x01\x00\x00\x00\x00\x00\x01\x00"
+        b"\x10\x00\x00\x00\x01\x00\x03\x00"
+    )
 
     op = LanceOperation.Update(
         updated_fragments=[updated_fragment],
@@ -901,7 +905,10 @@ def test_fragment_update_columns_no_match(tmp_path):
 
     # Get the fragment and update columns
     fragment = dataset.get_fragment(0)
-    updated_fragment, fields_modified = fragment.update_columns(update_data)
+    updated_fragment, fields_modified, matched_offsets = fragment.update_columns(
+        update_data, with_offsets=True
+    )
+    assert matched_offsets == b"\x3a\x30\x00\x00\x00\x00\x00\x00"
 
     # Commit the changes
 

--- a/python/python/tests/test_fragment.py
+++ b/python/python/tests/test_fragment.py
@@ -833,6 +833,50 @@ def test_fragment_update_columns_partial_update(tmp_path):
     assert result["city"] == ["NYC", "LA", "SF"]  # Unchanged
 
 
+def test_fragment_update_columns_with_offsets_rewrite_columns(tmp_path):
+    """update_columns(with_offsets=True) returns matched row offsets that a
+    rewrite_columns commit uses to refresh row version metadata for the
+    matched rows only."""
+    data = pa.table(
+        {
+            "id": list(range(8)),
+            "value": [i * 10 for i in range(8)],
+        }
+    )
+    dataset_uri = tmp_path / "test_dataset_update_columns_with_offsets"
+    dataset = lance.write_dataset(
+        data, dataset_uri, max_rows_per_file=4, enable_stable_row_ids=True
+    )
+    assert len(dataset.get_fragments()) == 2
+
+    # Update two rows of the second fragment, joining on a user column.
+    fragment = dataset.get_fragments()[1]
+    update_data = pa.table({"id": [5, 7], "value": [500, 700]})
+    updated_fragment, fields_modified, matched_offsets = fragment.update_columns(
+        update_data, left_on="id", with_offsets=True
+    )
+    assert isinstance(matched_offsets, bytes)
+    assert len(matched_offsets) > 0
+
+    op = LanceOperation.Update(
+        updated_fragments=[updated_fragment],
+        fields_modified=fields_modified,
+        update_mode="rewrite_columns",
+        updated_fragment_offsets={updated_fragment.id: matched_offsets},
+    )
+    updated_dataset = lance.LanceDataset.commit(
+        str(dataset_uri), op, read_version=dataset.version
+    )
+
+    result = updated_dataset.to_table(
+        columns=["id", "value", "_row_last_updated_at_version"]
+    ).sort_by("id")
+    assert result["value"].to_pylist() == [0, 10, 20, 30, 40, 500, 60, 700]
+    # Only the matched rows carry the commit's version.
+    versions = result["_row_last_updated_at_version"].to_pylist()
+    assert versions == [1, 1, 1, 1, 1, 2, 1, 2]
+
+
 def test_fragment_update_columns_no_match(tmp_path):
     """Test update when no rows match the join condition."""
     # Create initial dataset

--- a/python/src/fragment.rs
+++ b/python/src/fragment.rs
@@ -363,15 +363,26 @@ impl FileFragment {
         reader: PyArrowType<ArrowArrayStreamReader>,
         left_on: String,
         right_on: String,
-    ) -> PyResult<(PyLance<Fragment>, Vec<u32>)> {
+    ) -> PyResult<(PyLance<Fragment>, Vec<u32>, Vec<u8>)> {
         let mut fragment = self.fragment.clone();
-        let (updated_fragment, fields_modified) = rt()
+        let result = rt()
             .spawn(None, async move {
-                fragment.update_columns(reader.0, &left_on, &right_on).await
+                fragment
+                    .update_columns_with_offsets(reader.0, &left_on, &right_on)
+                    .await
             })?
             .infer_error()?;
 
-        Ok((PyLance(updated_fragment), fields_modified))
+        let mut matched_offsets = Vec::with_capacity(result.matched_offsets.serialized_size());
+        result
+            .matched_offsets
+            .serialize_into(&mut matched_offsets)
+            .map_err(|err| PyIOError::new_err(err.to_string()))?;
+        Ok((
+            PyLance(result.fragment),
+            result.fields_modified,
+            matched_offsets,
+        ))
     }
 
     fn delete(&self, predicate: &str) -> PyResult<Option<Self>> {

--- a/python/src/fragment.rs
+++ b/python/src/fragment.rs
@@ -43,6 +43,8 @@ use crate::schema::{LanceSchema, logical_schema_from_lance};
 use crate::utils::{PyLance, export_vec, extract_vec};
 use crate::{Dataset, Scanner, rt};
 
+type UpdateColumnsResult = (PyLance<Fragment>, Vec<u32>, Option<Vec<u8>>);
+
 #[pyclass(name = "_Fragment", module = "_lib", from_py_object)]
 #[derive(Clone)]
 pub struct FileFragment {
@@ -363,7 +365,8 @@ impl FileFragment {
         reader: PyArrowType<ArrowArrayStreamReader>,
         left_on: String,
         right_on: String,
-    ) -> PyResult<(PyLance<Fragment>, Vec<u32>, Vec<u8>)> {
+        with_offsets: bool,
+    ) -> PyResult<UpdateColumnsResult> {
         let mut fragment = self.fragment.clone();
         let result = rt()
             .spawn(None, async move {
@@ -373,11 +376,14 @@ impl FileFragment {
             })?
             .infer_error()?;
 
-        let mut matched_offsets = Vec::with_capacity(result.matched_offsets.serialized_size());
-        result
-            .matched_offsets
-            .serialize_into(&mut matched_offsets)
-            .map_err(|err| PyIOError::new_err(err.to_string()))?;
+        let matched_offsets = with_offsets.then(|| {
+            let mut buf = Vec::with_capacity(result.matched_offsets.serialized_size());
+            result
+                .matched_offsets
+                .serialize_into(&mut buf)
+                .expect("RoaringBitmap serialization cannot fail");
+            buf
+        });
         Ok((
             PyLance(result.fragment),
             result.fields_modified,

--- a/python/src/fragment.rs
+++ b/python/src/fragment.rs
@@ -376,14 +376,18 @@ impl FileFragment {
             })?
             .infer_error()?;
 
-        let matched_offsets = with_offsets.then(|| {
+        let matched_offsets = if with_offsets {
             let mut buf = Vec::with_capacity(result.matched_offsets.serialized_size());
             result
                 .matched_offsets
                 .serialize_into(&mut buf)
-                .expect("RoaringBitmap serialization cannot fail");
-            buf
-        });
+                .map_err(|err| {
+                    PyIOError::new_err(format!("Failed to serialize matched row offsets: {err}"))
+                })?;
+            Some(buf)
+        } else {
+            None
+        };
         Ok((
             PyLance(result.fragment),
             result.fields_modified,


### PR DESCRIPTION
Expose the matched physical row offsets that the Rust core already computes in `update_columns_with_offsets`.

`LanceFragment.update_columns` gains `with_offsets=False`; when `True` the returned tuple carries the offsets as portable RoaringBitmap bytes, ready to pass to `LanceOperation.Update.updated_fragment_offsets` so a `rewrite_columns` commit over stable row ids refreshes row version metadata for the matched rows only.