### PR TITLE
perf(index): prevent two-file shuffle starvation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4850,6 +4850,7 @@ dependencies = [
  "lance-table",
  "lance-testing",
  "lance-tokenizer",
+ "libc",
  "libsais-rs",
  "log",
  "ndarray",

--- a/rust/lance-index/Cargo.toml
+++ b/rust/lance-index/Cargo.toml
@@ -82,6 +82,7 @@ geo-traits.workspace = true
 lance-datagen.workspace = true
 lance-datafusion = { workspace = true, features = ["datagen"] }
 lance-testing.workspace = true
+libc.workspace = true
 test-log.workspace = true
 rstest.workspace = true
 serial_test.workspace = true
@@ -167,6 +168,10 @@ required-features = ["geo"]
 
 [[bench]]
 name = "residual_transform"
+harness = false
+
+[[bench]]
+name = "two_file_shuffle_read"
 harness = false
 
 [lints]

--- a/rust/lance-index/benches/two_file_shuffle_read.rs
+++ b/rust/lance-index/benches/two_file_shuffle_read.rs
@@ -1,0 +1,751 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+//! Reproducible read benchmark for the two-file IVF shuffle format.
+//!
+//! The fixture is deliberately generated once, before Criterion starts timing,
+//! and is then reopened for every end-to-end sample.  Each input `RecordBatch` is forced to
+//! become one flush group, so both scenarios contain exactly 20 physical groups.
+//! The payload has the same column topology as a 5-bit RQ build (row ID, binary
+//! and extra codes, and five floating-point factors), scaled to 256 dimensions
+//! so the benchmark remains practical on a developer laptop.
+//!
+//! Run both the benchmark-local pre-change reader and the current reader against
+//! one persistent fixture:
+//!
+//! ```text
+//! LANCE_SHUFFLE_BENCH_FIXTURE_ROOT=/tmp/lance-two-file-fixture \
+//! cargo bench --profile release-with-debug -p lance-index \
+//!   --bench two_file_shuffle_read
+//! ```
+//!
+//! The optional fixture root makes later invocations reopen the exact same files
+//! and manifest. Without it, each process regenerates byte-equivalent
+//! deterministic fixtures in temporary directories.
+//! A benchmark-local copy of the pre-change on-demand offsets reader runs next
+//! to the current reader, so every invocation also provides a same-process,
+//! same-file baseline/current comparison.
+//!
+//! Criterion reports separate reopen, read-only, and reopen-plus-read timings;
+//! the latter two report rows/s.  Before each scenario it also prints one
+//! cache-hot diagnostic pass containing separate init/read/total wall time,
+//! process CPU time, peak RSS, scheduler IOPS, scheduler bytes read, and the
+//! number of logical data ranges requested.  Scheduler counters are split by
+//! phase but aggregate data and offsets files; exact per-file calls require the
+//! scheduler's per-file trace events.  For kernel syscall counts on Linux, wrap
+//! either command with `strace -f -c -e pread64`.
+//! `LANCE_SHUFFLE_BENCH_DISTRIBUTION` (`uniform` or `hotspot`) and
+//! `LANCE_SHUFFLE_BENCH_IMPLEMENTATION` (`baseline` or `current`) can isolate a
+//! scenario in a fresh process so peak RSS is comparable.
+
+use std::hint::black_box;
+use std::io::Write;
+use std::ops::Range;
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use arrow::{array::AsArray, compute::concat_batches, datatypes::UInt64Type};
+use arrow_array::{
+    ArrayRef, FixedSizeListArray, Float32Array, RecordBatch, UInt8Array, UInt32Array, UInt64Array,
+};
+use arrow_schema::Schema;
+use async_trait::async_trait;
+use criterion::{Criterion, Throughput};
+use futures::{StreamExt, TryStreamExt, stream};
+use lance_arrow::FixedSizeListArrayExt;
+use lance_core::cache::LanceCache;
+use lance_core::utils::tempfile::TempDir;
+use lance_core::utils::tokio::get_num_compute_intensive_cpus;
+use lance_core::{Error, ROW_ID};
+use lance_encoding::decoder::{DecoderPlugins, FilterExpression};
+use lance_file::reader::{FileReader, FileReaderOptions};
+use lance_index::vector::PART_ID_COLUMN;
+use lance_index::vector::bq::ex_dot::blocked_ex_code_bytes;
+use lance_index::vector::bq::storage::{RABIT_BLOCKED_EX_CODE_COLUMN, RABIT_CODE_COLUMN};
+use lance_index::vector::bq::transform::{
+    ADD_FACTORS_COLUMN, ERROR_FACTORS_COLUMN, EX_ADD_FACTORS_COLUMN, EX_SCALE_FACTORS_COLUMN,
+    SCALE_FACTORS_COLUMN,
+};
+use lance_index::vector::bq::{rabit_binary_code_bytes, rabit_ex_bits};
+use lance_index::vector::v3::shuffle_bench::{
+    TwoFileShuffleFixtureManifest, open_two_file_shuffle_fixture,
+};
+use lance_index::vector::v3::shuffler::{
+    DEFAULT_PARTITION_WINDOW_BYTES, ShuffleReader, Shuffler, TwoFileShuffler,
+};
+use lance_io::ReadBatchParams;
+use lance_io::object_store::ObjectStore;
+use lance_io::scheduler::{ScanScheduler, SchedulerConfig};
+use lance_io::scheduler::{bytes_read_counter, iops_counter};
+use lance_io::stream::{RecordBatchStream, RecordBatchStreamAdapter};
+use lance_io::utils::CachedFileSize;
+use object_store::path::Path;
+
+const NUM_FLUSH_GROUPS: usize = 20;
+const NUM_PARTITIONS: usize = 4_096;
+const ROWS_PER_PARTITION: usize = 64;
+const RQ_DIMENSION: usize = 256;
+const RQ_NUM_BITS: u8 = 5;
+const HOTSPOT_TARGET_CV: f64 = 3.6;
+
+#[derive(Clone, Copy, Debug)]
+enum Distribution {
+    Uniform,
+    Hotspot,
+}
+
+#[derive(Clone, Copy, Debug)]
+enum ReaderImplementation {
+    Baseline,
+    Current,
+}
+
+impl ReaderImplementation {
+    fn name(self) -> &'static str {
+        match self {
+            Self::Baseline => "baseline_on_demand_offsets",
+            Self::Current => "current",
+        }
+    }
+}
+
+/// The pre-change two-file reader, kept local to the benchmark so baseline and
+/// current read the exact same files in the same process.
+struct BaselineTwoFileShuffleReader {
+    _scheduler: Arc<ScanScheduler>,
+    file_reader: FileReader,
+    offsets_reader: FileReader,
+    num_partitions: usize,
+    num_flush_groups: u64,
+    partition_counts: Vec<u64>,
+    total_loss: f64,
+}
+
+impl BaselineTwoFileShuffleReader {
+    async fn try_new(
+        output_dir: Path,
+        manifest: &TwoFileShuffleFixtureManifest,
+    ) -> lance_core::Result<Arc<dyn ShuffleReader>> {
+        let object_store = Arc::new(ObjectStore::local());
+        let scheduler_config = SchedulerConfig::max_bandwidth(&object_store);
+        let scheduler = ScanScheduler::new(object_store, scheduler_config);
+
+        let data_path = output_dir.clone().join("shuffle_data.lance");
+        let file_reader = FileReader::try_open(
+            scheduler
+                .open_file(&data_path, &CachedFileSize::unknown())
+                .await?,
+            None,
+            Arc::<DecoderPlugins>::default(),
+            &LanceCache::no_cache(),
+            FileReaderOptions::default(),
+        )
+        .await?;
+
+        let offsets_path = output_dir.join("shuffle_offsets.lance");
+        let offsets_reader = FileReader::try_open(
+            scheduler
+                .open_file(&offsets_path, &CachedFileSize::unknown())
+                .await?,
+            None,
+            Arc::<DecoderPlugins>::default(),
+            &LanceCache::no_cache(),
+            FileReaderOptions::default(),
+        )
+        .await?;
+
+        Ok(Arc::new(Self {
+            _scheduler: scheduler,
+            file_reader,
+            offsets_reader,
+            num_partitions: manifest.num_partitions,
+            num_flush_groups: manifest.num_flush_groups,
+            partition_counts: manifest.partition_counts.clone(),
+            total_loss: manifest.total_loss,
+        }))
+    }
+
+    async fn partition_ranges(&self, partition_id: usize) -> lance_core::Result<Vec<Range<u64>>> {
+        let mut positions = Vec::with_capacity(self.num_flush_groups as usize * 2);
+        for group in 0..self.num_flush_groups {
+            let end_position = u32::try_from(group as usize * self.num_partitions + partition_id)
+                .map_err(|_| {
+                Error::invalid_input(
+                    "There are more than 2^32 partition offsets in the spill file. Need to support 64-bit take",
+                )
+            })?;
+            if end_position != 0 {
+                positions.push(end_position - 1);
+            }
+            positions.push(end_position);
+        }
+
+        let num_positions = positions.len() as u32;
+        let positions = UInt32Array::from(positions);
+        let offsets_stream = self
+            .offsets_reader
+            .read_stream(
+                ReadBatchParams::Indices(positions),
+                num_positions,
+                1,
+                FilterExpression::no_filter(),
+            )
+            .await?;
+        let schema = offsets_stream.schema().clone();
+        let offsets = offsets_stream.try_collect::<Vec<_>>().await?;
+        let offsets = if offsets.len() == 1 {
+            offsets.into_iter().next().expect("one offsets batch")
+        } else {
+            concat_batches(&schema, &offsets)?
+        };
+        let offsets = offsets.column(0).as_primitive::<UInt64Type>();
+        let mut offsets_iter = offsets.values().iter().copied();
+
+        let mut ranges = Vec::with_capacity(self.num_flush_groups as usize);
+        for group in 0..self.num_flush_groups {
+            if group == 0 && partition_id == 0 {
+                ranges.push(0..offsets_iter.next().expect("partition end offset"));
+            } else {
+                ranges.push(
+                    offsets_iter.next().expect("partition start offset")
+                        ..offsets_iter.next().expect("partition end offset"),
+                );
+            }
+        }
+        Ok(ranges)
+    }
+}
+
+#[async_trait]
+impl ShuffleReader for BaselineTwoFileShuffleReader {
+    async fn read_partition(
+        &self,
+        partition_id: usize,
+    ) -> lance_core::Result<Option<Box<dyn RecordBatchStream + Unpin + 'static>>> {
+        if partition_id >= self.num_partitions || self.partition_counts[partition_id] == 0 {
+            return Ok(None);
+        }
+
+        let ranges = self.partition_ranges(partition_id).await?;
+        let schema: Schema = self.file_reader.schema().as_ref().into();
+        let stream = self
+            .file_reader
+            .read_stream(
+                ReadBatchParams::Ranges(ranges.into()),
+                u32::MAX,
+                16,
+                FilterExpression::no_filter(),
+            )
+            .await?;
+        Ok(Some(Box::new(RecordBatchStreamAdapter::new(
+            Arc::new(schema),
+            stream,
+        ))))
+    }
+
+    fn partition_size(&self, partition_id: usize) -> lance_core::Result<usize> {
+        Ok(self
+            .partition_counts
+            .get(partition_id)
+            .copied()
+            .unwrap_or(0) as usize)
+    }
+
+    fn total_loss(&self) -> Option<f64> {
+        Some(self.total_loss)
+    }
+}
+
+impl Distribution {
+    fn name(self) -> &'static str {
+        match self {
+            Self::Uniform => "uniform",
+            Self::Hotspot => "hotspot_cv_3_6",
+        }
+    }
+}
+
+struct Fixture {
+    _temporary_directory: Option<TempDir>,
+    output_dir: Path,
+    manifest_path: PathBuf,
+    manifest: TwoFileShuffleFixtureManifest,
+    baseline_reader: Arc<dyn ShuffleReader>,
+    current_reader: Arc<dyn ShuffleReader>,
+    total_rows: u64,
+    coefficient_of_variation: f64,
+}
+
+fn partition_counts(distribution: Distribution) -> Vec<usize> {
+    match distribution {
+        Distribution::Uniform => vec![ROWS_PER_PARTITION; NUM_PARTITIONS],
+        Distribution::Hotspot => {
+            let total_rows = NUM_PARTITIONS * ROWS_PER_PARTITION;
+            let hotspot_rows = (ROWS_PER_PARTITION as f64
+                * (1.0 + HOTSPOT_TARGET_CV * ((NUM_PARTITIONS - 1) as f64).sqrt()))
+            .round() as usize;
+            let other_rows = total_rows - hotspot_rows;
+            let base = other_rows / (NUM_PARTITIONS - 1);
+            let remainder = other_rows % (NUM_PARTITIONS - 1);
+
+            let hotspot_partition = NUM_PARTITIONS / 2;
+            let mut counts = Vec::with_capacity(NUM_PARTITIONS);
+            for partition_id in 0..NUM_PARTITIONS {
+                if partition_id == hotspot_partition {
+                    counts.push(hotspot_rows);
+                } else {
+                    let non_hotspot_index = if partition_id < hotspot_partition {
+                        partition_id
+                    } else {
+                        partition_id - 1
+                    };
+                    counts.push(base + usize::from(non_hotspot_index < remainder));
+                }
+            }
+            counts
+        }
+    }
+}
+
+fn coefficient_of_variation(counts: &[usize]) -> f64 {
+    let mean = counts.iter().sum::<usize>() as f64 / counts.len() as f64;
+    let variance = counts
+        .iter()
+        .map(|&count| {
+            let delta = count as f64 - mean;
+            delta * delta
+        })
+        .sum::<f64>()
+        / counts.len() as f64;
+    variance.sqrt() / mean
+}
+
+fn rows_in_flush_group(partition_rows: usize, partition_id: usize, group: usize) -> usize {
+    let base = partition_rows / NUM_FLUSH_GROUPS;
+    let remainder = partition_rows % NUM_FLUSH_GROUPS;
+    base + usize::from((group + partition_id * 7) % NUM_FLUSH_GROUPS < remainder)
+}
+
+fn make_rq5_like_batch(counts: &[usize], group: usize, next_row_id: &mut u64) -> RecordBatch {
+    let num_rows = counts
+        .iter()
+        .enumerate()
+        .map(|(partition_id, &rows)| rows_in_flush_group(rows, partition_id, group))
+        .sum::<usize>();
+    let mut partition_ids = Vec::with_capacity(num_rows);
+    let mut row_ids = Vec::with_capacity(num_rows);
+
+    // 4051 is coprime to 4096, so every group visits each partition exactly
+    // once but starts with a different deterministic, non-sorted order.
+    for slot in 0..NUM_PARTITIONS {
+        let partition_id = (slot * 4_051 + group * 997) % NUM_PARTITIONS;
+        let group_rows = rows_in_flush_group(counts[partition_id], partition_id, group);
+        for _ in 0..group_rows {
+            partition_ids.push(partition_id as u32);
+            row_ids.push(*next_row_id);
+            *next_row_id += 1;
+        }
+    }
+
+    let binary_code_bytes = rabit_binary_code_bytes(RQ_DIMENSION);
+    let ex_bits = rabit_ex_bits(RQ_NUM_BITS).expect("RQ5 must be a valid configuration");
+    let ex_code_bytes = blocked_ex_code_bytes(RQ_DIMENSION, ex_bits);
+    let make_codes = |width: usize, salt: u8| {
+        let values = (0..num_rows * width)
+            .map(|index| (index as u8).wrapping_mul(31).wrapping_add(salt))
+            .collect::<Vec<_>>();
+        Arc::new(
+            FixedSizeListArray::try_new_from_values(UInt8Array::from(values), width as i32)
+                .expect("valid fixed-size RQ code array"),
+        ) as ArrayRef
+    };
+    let make_factors = |salt: f32| {
+        Arc::new(Float32Array::from_iter_values(
+            (0..num_rows).map(|row| salt + (row % 257) as f32 / 257.0),
+        )) as ArrayRef
+    };
+
+    RecordBatch::try_from_iter(vec![
+        (
+            PART_ID_COLUMN,
+            Arc::new(UInt32Array::from(partition_ids)) as ArrayRef,
+        ),
+        (ROW_ID, Arc::new(UInt64Array::from(row_ids)) as ArrayRef),
+        (RABIT_CODE_COLUMN, make_codes(binary_code_bytes, 11)),
+        (ADD_FACTORS_COLUMN, make_factors(1.0)),
+        (SCALE_FACTORS_COLUMN, make_factors(2.0)),
+        (ERROR_FACTORS_COLUMN, make_factors(3.0)),
+        (RABIT_BLOCKED_EX_CODE_COLUMN, make_codes(ex_code_bytes, 19)),
+        (EX_ADD_FACTORS_COLUMN, make_factors(4.0)),
+        (EX_SCALE_FACTORS_COLUMN, make_factors(5.0)),
+    ])
+    .expect("all deterministic fixture columns have equal length")
+}
+
+fn batches_to_stream(batches: Vec<RecordBatch>) -> Box<dyn RecordBatchStream + Unpin + 'static> {
+    let schema = batches
+        .first()
+        .expect("the fixture always has 20 flush groups")
+        .schema();
+    Box::new(RecordBatchStreamAdapter::new(
+        schema,
+        stream::iter(batches.into_iter().map(Ok)),
+    ))
+}
+
+async fn build_fixture(distribution: Distribution) -> Fixture {
+    let counts = partition_counts(distribution);
+    let coefficient_of_variation = coefficient_of_variation(&counts);
+    match distribution {
+        Distribution::Uniform => assert_eq!(coefficient_of_variation, 0.0),
+        Distribution::Hotspot => assert!(
+            (coefficient_of_variation - HOTSPOT_TARGET_CV).abs() < 0.01,
+            "hotspot fixture CV was {coefficient_of_variation}"
+        ),
+    }
+
+    let total_rows = counts.iter().sum::<usize>() as u64;
+    let manifest = TwoFileShuffleFixtureManifest {
+        num_partitions: NUM_PARTITIONS,
+        num_flush_groups: NUM_FLUSH_GROUPS as u64,
+        partition_counts: counts.iter().map(|&count| count as u64).collect(),
+        total_loss: 0.0,
+    };
+
+    let (temporary_directory, fixture_path) =
+        if let Some(root) = std::env::var_os("LANCE_SHUFFLE_BENCH_FIXTURE_ROOT") {
+            let fixture_path = PathBuf::from(root).join(distribution.name());
+            std::fs::create_dir_all(&fixture_path).expect("create persistent shuffle fixture root");
+            (None, fixture_path)
+        } else {
+            let directory = TempDir::default();
+            let fixture_path = directory.std_path().to_owned();
+            (Some(directory), fixture_path)
+        };
+    let output_dir = Path::from_filesystem_path(&fixture_path)
+        .expect("shuffle fixture path must be a valid object-store path");
+    let manifest_path = fixture_path.join("shuffle_manifest.json");
+
+    if manifest_path.exists() {
+        let stored: TwoFileShuffleFixtureManifest = serde_json::from_slice(
+            &std::fs::read(&manifest_path).expect("read existing shuffle fixture manifest"),
+        )
+        .expect("parse existing shuffle fixture manifest");
+        assert_eq!(
+            stored.num_partitions, manifest.num_partitions,
+            "existing fixture has a different partition count"
+        );
+        assert_eq!(
+            stored.num_flush_groups, manifest.num_flush_groups,
+            "existing fixture has a different flush-group count"
+        );
+        assert_eq!(
+            stored.partition_counts, manifest.partition_counts,
+            "existing fixture has a different partition distribution"
+        );
+    } else {
+        let mut next_row_id = 0;
+        let batches = (0..NUM_FLUSH_GROUPS)
+            .map(|group| make_rq5_like_batch(&counts, group, &mut next_row_id))
+            .collect::<Vec<_>>();
+        assert_eq!(next_row_id, total_rows);
+
+        let shuffler = TwoFileShuffler::new(output_dir.clone(), NUM_PARTITIONS);
+        let initial_reader = shuffler
+            .shuffle(batches_to_stream(batches))
+            .await
+            .expect("write and reopen deterministic two-file shuffle fixture");
+        drop(initial_reader);
+        std::fs::write(
+            &manifest_path,
+            serde_json::to_vec_pretty(&manifest).expect("serialize deterministic shuffle manifest"),
+        )
+        .expect("write deterministic shuffle manifest");
+    }
+
+    let current_reader = open_two_file_shuffle_fixture(output_dir.clone(), &manifest)
+        .await
+        .expect("reopen frozen two-file shuffle fixture");
+    let baseline_reader = BaselineTwoFileShuffleReader::try_new(output_dir.clone(), &manifest)
+        .await
+        .expect("reopen frozen fixture with baseline reader");
+
+    Fixture {
+        _temporary_directory: temporary_directory,
+        output_dir,
+        manifest_path,
+        manifest,
+        baseline_reader,
+        current_reader: Arc::from(current_reader),
+        total_rows,
+        coefficient_of_variation,
+    }
+}
+
+async fn reopen_fixture(
+    fixture: &Fixture,
+    implementation: ReaderImplementation,
+) -> Arc<dyn ShuffleReader> {
+    let manifest_bytes =
+        std::fs::read(&fixture.manifest_path).expect("read frozen shuffle fixture manifest");
+    let manifest: TwoFileShuffleFixtureManifest =
+        serde_json::from_slice(&manifest_bytes).expect("parse frozen shuffle fixture manifest");
+    assert_eq!(manifest.num_partitions, fixture.manifest.num_partitions);
+    match implementation {
+        ReaderImplementation::Baseline => {
+            BaselineTwoFileShuffleReader::try_new(fixture.output_dir.clone(), &manifest)
+                .await
+                .expect("reopen fixture with baseline reader")
+        }
+        ReaderImplementation::Current => Arc::from(
+            open_two_file_shuffle_fixture(fixture.output_dir.clone(), &manifest)
+                .await
+                .expect("reopen fixture with current reader"),
+        ),
+    }
+}
+
+struct ReadResult {
+    rows: u64,
+    windows: usize,
+}
+
+async fn read_all_partitions_baseline(
+    reader: Arc<dyn ShuffleReader>,
+    concurrency: usize,
+) -> lance_core::Result<ReadResult> {
+    let rows = stream::iter(0..NUM_PARTITIONS)
+        .map(|partition_id| {
+            let reader = reader.clone();
+            async move {
+                let Some(mut batches) = reader.read_partition(partition_id).await? else {
+                    return Ok::<_, lance_core::Error>(0u64);
+                };
+                let mut rows = 0u64;
+                while let Some(batch) = batches.try_next().await? {
+                    rows += batch.num_rows() as u64;
+                    black_box(batch);
+                }
+                Ok(rows)
+            }
+        })
+        .buffered(concurrency)
+        .try_fold(0u64, |total, rows| async move { Ok(total + rows) })
+        .await?;
+    Ok(ReadResult {
+        rows,
+        windows: NUM_PARTITIONS,
+    })
+}
+
+async fn read_all_partitions_current(
+    reader: Arc<dyn ShuffleReader>,
+) -> lance_core::Result<ReadResult> {
+    let mut rows = 0u64;
+    let mut windows = 0usize;
+    let mut next_partition_id = 0usize;
+    while next_partition_id < NUM_PARTITIONS {
+        let window = reader
+            .read_partition_window(next_partition_id, DEFAULT_PARTITION_WINDOW_BYTES)
+            .await?;
+        assert_eq!(window.partition_range.start, next_partition_id);
+        assert!(window.partition_range.end > next_partition_id);
+        assert!(window.partition_range.end <= NUM_PARTITIONS);
+        assert_eq!(window.partition_range.len(), window.partitions.len());
+        next_partition_id = window.partition_range.end;
+        windows += 1;
+
+        for partition in window.partitions {
+            if let Some(mut batches) = partition.data {
+                while let Some(batch) = batches.try_next().await? {
+                    rows += batch.num_rows() as u64;
+                    black_box(batch);
+                }
+            }
+        }
+    }
+    Ok(ReadResult { rows, windows })
+}
+
+async fn read_all_partitions(
+    reader: Arc<dyn ShuffleReader>,
+    implementation: ReaderImplementation,
+    concurrency: usize,
+) -> lance_core::Result<ReadResult> {
+    match implementation {
+        ReaderImplementation::Baseline => read_all_partitions_baseline(reader, concurrency).await,
+        ReaderImplementation::Current => read_all_partitions_current(reader).await,
+    }
+}
+
+#[cfg(unix)]
+fn process_resources() -> (f64, u64) {
+    // SAFETY: getrusage initializes the provided rusage value and does not
+    // retain its pointer.  RUSAGE_SELF is valid on all Unix targets.
+    unsafe {
+        let mut usage: libc::rusage = std::mem::zeroed();
+        if libc::getrusage(libc::RUSAGE_SELF, &mut usage) != 0 {
+            return (0.0, 0);
+        }
+        let user_seconds =
+            usage.ru_utime.tv_sec as f64 + usage.ru_utime.tv_usec as f64 / 1_000_000.0;
+        let system_seconds =
+            usage.ru_stime.tv_sec as f64 + usage.ru_stime.tv_usec as f64 / 1_000_000.0;
+        #[cfg(target_os = "macos")]
+        let peak_rss_bytes = usage.ru_maxrss as u64;
+        #[cfg(not(target_os = "macos"))]
+        let peak_rss_bytes = usage.ru_maxrss as u64 * 1024;
+        (user_seconds + system_seconds, peak_rss_bytes)
+    }
+}
+
+#[cfg(not(unix))]
+fn process_resources() -> (f64, u64) {
+    (0.0, 0)
+}
+
+async fn print_diagnostic(
+    distribution: Distribution,
+    implementation: ReaderImplementation,
+    fixture: &Fixture,
+    concurrency: usize,
+) {
+    let init_iops_before = iops_counter();
+    let init_bytes_before = bytes_read_counter();
+    let (cpu_before, _) = process_resources();
+    let started = Instant::now();
+    let reader = reopen_fixture(fixture, implementation).await;
+    let init_elapsed = started.elapsed();
+    let init_iops = iops_counter() - init_iops_before;
+    let init_bytes_read = bytes_read_counter() - init_bytes_before;
+
+    let read_iops_before = iops_counter();
+    let read_bytes_before = bytes_read_counter();
+    let read_started = Instant::now();
+    let read_result = read_all_partitions(reader, implementation, concurrency)
+        .await
+        .expect("read every deterministic partition");
+    let read_elapsed = read_started.elapsed();
+    let total_elapsed = started.elapsed();
+    let (cpu_after, peak_rss_bytes) = process_resources();
+    assert_eq!(read_result.rows, fixture.total_rows);
+
+    writeln!(
+        std::io::stderr().lock(),
+        "two_file_shuffle_read scenario={} implementation={} flush_groups={} partitions={} rows={} cv={:.4} concurrency={} init_ms={:.3} read_ms={:.3} total_ms={:.3} rows_per_second={:.0} cpu_seconds={:.6} peak_rss_mib={:.1} init_scheduler_iops={} init_scheduler_bytes_read={} read_scheduler_iops={} read_scheduler_bytes_read={} logical_partition_reads={} logical_data_ranges={} offset_entries={} per_file_read_calls=unavailable_use_scheduler_trace",
+        distribution.name(),
+        implementation.name(),
+        NUM_FLUSH_GROUPS,
+        NUM_PARTITIONS,
+        read_result.rows,
+        fixture.coefficient_of_variation,
+        concurrency,
+        init_elapsed.as_secs_f64() * 1_000.0,
+        read_elapsed.as_secs_f64() * 1_000.0,
+        total_elapsed.as_secs_f64() * 1_000.0,
+        read_result.rows as f64 / total_elapsed.as_secs_f64(),
+        cpu_after - cpu_before,
+        peak_rss_bytes as f64 / (1024.0 * 1024.0),
+        init_iops,
+        init_bytes_read,
+        iops_counter() - read_iops_before,
+        bytes_read_counter() - read_bytes_before,
+        read_result.windows,
+        read_result.windows * NUM_FLUSH_GROUPS,
+        NUM_PARTITIONS * NUM_FLUSH_GROUPS,
+    )
+    .expect("write shuffle benchmark diagnostic");
+}
+
+fn bench_two_file_shuffle_read(criterion: &mut Criterion) {
+    let runtime = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .expect("create benchmark runtime");
+    let concurrency = get_num_compute_intensive_cpus();
+
+    let distributions = match std::env::var("LANCE_SHUFFLE_BENCH_DISTRIBUTION").as_deref() {
+        Ok("uniform") => vec![Distribution::Uniform],
+        Ok("hotspot") => vec![Distribution::Hotspot],
+        Ok(value) => panic!("unknown LANCE_SHUFFLE_BENCH_DISTRIBUTION={value}"),
+        Err(_) => vec![Distribution::Uniform, Distribution::Hotspot],
+    };
+    let implementations = match std::env::var("LANCE_SHUFFLE_BENCH_IMPLEMENTATION").as_deref() {
+        Ok("baseline") => vec![ReaderImplementation::Baseline],
+        Ok("current") => vec![ReaderImplementation::Current],
+        Ok(value) => panic!("unknown LANCE_SHUFFLE_BENCH_IMPLEMENTATION={value}"),
+        Err(_) => vec![
+            ReaderImplementation::Baseline,
+            ReaderImplementation::Current,
+        ],
+    };
+
+    for distribution in distributions {
+        let fixture = runtime.block_on(build_fixture(distribution));
+        for implementation in implementations.iter().copied() {
+            runtime.block_on(print_diagnostic(
+                distribution,
+                implementation,
+                &fixture,
+                concurrency,
+            ));
+            let benchmark_id = format!("{}/{}", distribution.name(), implementation.name());
+
+            let mut reopen_group = criterion.benchmark_group("two_file_shuffle_reopen");
+            reopen_group.bench_function(&benchmark_id, |bencher| {
+                bencher
+                    .to_async(&runtime)
+                    .iter(|| async { black_box(reopen_fixture(&fixture, implementation).await) });
+            });
+            reopen_group.finish();
+
+            let reader = match implementation {
+                ReaderImplementation::Baseline => fixture.baseline_reader.clone(),
+                ReaderImplementation::Current => fixture.current_reader.clone(),
+            };
+            let mut read_group = criterion.benchmark_group("two_file_shuffle_read_only");
+            read_group.throughput(Throughput::Elements(fixture.total_rows));
+            read_group.bench_function(&benchmark_id, |bencher| {
+                bencher.to_async(&runtime).iter(|| async {
+                    let result = read_all_partitions(reader.clone(), implementation, concurrency)
+                        .await
+                        .expect("read every deterministic partition");
+                    assert_eq!(result.rows, fixture.total_rows);
+                    black_box(result.rows)
+                });
+            });
+            read_group.finish();
+
+            let mut total_group = criterion.benchmark_group("two_file_shuffle_reopen_and_read");
+            total_group.throughput(Throughput::Elements(fixture.total_rows));
+            total_group.bench_function(&benchmark_id, |bencher| {
+                bencher.to_async(&runtime).iter(|| async {
+                    let reader = reopen_fixture(&fixture, implementation).await;
+                    let result = read_all_partitions(reader, implementation, concurrency)
+                        .await
+                        .expect("read every deterministic partition");
+                    assert_eq!(result.rows, fixture.total_rows);
+                    black_box(result.rows)
+                });
+            });
+            total_group.finish();
+        }
+    }
+}
+
+fn main() {
+    // SAFETY: this is the first action in this single-purpose benchmark binary,
+    // before the Tokio runtime or any other worker threads are created.
+    unsafe {
+        std::env::set_var("LANCE_SHUFFLE_BATCH_BYTES", "1");
+    }
+
+    let mut criterion = Criterion::default()
+        .sample_size(10)
+        .warm_up_time(Duration::from_secs(2))
+        .measurement_time(Duration::from_secs(8))
+        .configure_from_args();
+    bench_two_file_shuffle_read(&mut criterion);
+    criterion.final_summary();
+}

--- a/rust/lance-index/src/vector/bq/builder.rs
+++ b/rust/lance-index/src/vector/bq/builder.rs
@@ -81,6 +81,42 @@ fn pack_sign_bits(codes: &mut [u8], rotated: &[f32]) {
 const EX_QUANTIZATION_EPSILON: f32 = 1.0e-5;
 const EX_TIGHT_START: [f32; 9] = [0.0, 0.15, 0.20, 0.52, 0.59, 0.71, 0.75, 0.77, 0.81];
 
+/// Sort packed `(positive_f32_bits, index)` values by their floating-point key.
+///
+/// All thresholds emitted by [`best_ex_rescale_factor`] are positive and finite,
+/// so their IEEE-754 bit patterns have the same order as the represented values.
+/// Four stable byte-wise passes avoid the comparison-heavy tuple sort on every
+/// vector while preserving the exact threshold order.
+fn radix_sort_positive_f32_indices(values: &mut [u64]) {
+    if values.len() < 2 {
+        return;
+    }
+
+    fn pass(source: &[u64], destination: &mut [u64], shift: u32) {
+        let mut offsets = [0usize; 256];
+        for &value in source {
+            offsets[((value >> shift) & 0xff) as usize] += 1;
+        }
+        let mut next_offset = 0;
+        for offset in &mut offsets {
+            let count = *offset;
+            *offset = next_offset;
+            next_offset += count;
+        }
+        for &value in source {
+            let bucket = ((value >> shift) & 0xff) as usize;
+            destination[offsets[bucket]] = value;
+            offsets[bucket] += 1;
+        }
+    }
+
+    let mut scratch = vec![0u64; values.len()];
+    pass(values, &mut scratch, 32);
+    pass(&scratch, values, 40);
+    pass(values, &mut scratch, 48);
+    pass(&scratch, values, 56);
+}
+
 fn best_ex_rescale_factor(abs_normalized: &[f32], ex_bits: u8) -> f32 {
     let max_value = abs_normalized
         .iter()
@@ -117,17 +153,20 @@ fn best_ex_rescale_factor(abs_normalized: &[f32], ex_bits: u8) -> f32 {
         while next <= max_code {
             let threshold = next as f32 / value;
             if threshold < t_end {
-                thresholds.push((threshold, idx));
+                debug_assert!(u32::try_from(idx).is_ok());
+                thresholds.push(((threshold.to_bits() as u64) << u32::BITS) | idx as u64);
             }
             next += 1;
         }
     }
 
-    thresholds.sort_unstable_by(|(left, _), (right, _)| left.total_cmp(right));
+    radix_sort_positive_f32_indices(&mut thresholds);
 
     let mut best_inner_product = numerator / squared_denominator.sqrt();
     let mut best_t = t_start;
-    for (threshold, idx) in thresholds {
+    for packed_threshold in thresholds {
+        let threshold = f32::from_bits((packed_threshold >> u32::BITS) as u32);
+        let idx = packed_threshold as u32 as usize;
         current_codes[idx] += 1;
         let updated = current_codes[idx];
         squared_denominator += (2 * updated) as f32;
@@ -891,6 +930,100 @@ mod tests {
     use rstest::rstest;
 
     use crate::vector::bq::storage::RABIT_BLOCKED_EX_CODE_COLUMN;
+
+    fn reference_best_ex_rescale_factor(abs_normalized: &[f32], ex_bits: u8) -> f32 {
+        let max_value = abs_normalized
+            .iter()
+            .copied()
+            .filter(|value| value.is_finite())
+            .fold(0.0f32, f32::max);
+        if max_value <= 0.0 {
+            return 0.0;
+        }
+
+        let max_code = (1usize << ex_bits) - 1;
+        let t_end = ((max_code + 10) as f32) / max_value;
+        let t_start = t_end * EX_TIGHT_START[ex_bits as usize];
+        let mut current_codes = Vec::with_capacity(abs_normalized.len());
+        let mut squared_denominator = abs_normalized.len() as f32 * 0.25;
+        let mut numerator = 0.0f32;
+        let mut thresholds = Vec::with_capacity(abs_normalized.len() * max_code);
+
+        for (idx, &value) in abs_normalized.iter().enumerate() {
+            if value <= 0.0 || !value.is_finite() {
+                current_codes.push(0usize);
+                continue;
+            }
+            let current = ((t_start * value) + EX_QUANTIZATION_EPSILON)
+                .floor()
+                .clamp(0.0, max_code as f32) as usize;
+            current_codes.push(current);
+            squared_denominator += (current * current + current) as f32;
+            numerator += (current as f32 + 0.5) * value;
+
+            for next in (current + 1)..=max_code {
+                let threshold = next as f32 / value;
+                if threshold < t_end {
+                    thresholds.push((threshold, idx));
+                }
+            }
+        }
+
+        thresholds.sort_unstable_by(|(left, _), (right, _)| left.total_cmp(right));
+        let mut best_inner_product = numerator / squared_denominator.sqrt();
+        let mut best_t = t_start;
+        for (threshold, idx) in thresholds {
+            current_codes[idx] += 1;
+            let updated = current_codes[idx];
+            squared_denominator += (2 * updated) as f32;
+            numerator += abs_normalized[idx];
+            let current_inner_product = numerator / squared_denominator.sqrt();
+            if current_inner_product > best_inner_product {
+                best_inner_product = current_inner_product;
+                best_t = threshold;
+            }
+        }
+        best_t
+    }
+
+    #[test]
+    fn test_radix_sort_positive_f32_indices_matches_float_order() {
+        let mut values = (0..4096u32)
+            .map(|idx| {
+                let key = ((idx.wrapping_mul(2654435761) % 997) + 1) as f32 / 37.0;
+                ((key.to_bits() as u64) << u32::BITS) | idx as u64
+            })
+            .collect::<Vec<_>>();
+        let mut expected = values.clone();
+        expected.sort_by_key(|value| *value >> u32::BITS);
+
+        radix_sort_positive_f32_indices(&mut values);
+
+        assert_eq!(values, expected);
+    }
+
+    #[test]
+    fn test_best_ex_rescale_factor_matches_comparison_sort() {
+        let mut values = (0..1536u32)
+            .map(|idx| {
+                let mixed = idx
+                    .wrapping_mul(747796405)
+                    .wrapping_add(2891336453)
+                    .rotate_right((idx % 31) + 1);
+                (mixed as f32 / u32::MAX as f32) * 0.1
+            })
+            .collect::<Vec<_>>();
+        values[0] = 0.0;
+        values[1] = f32::NAN;
+        values[2] = f32::INFINITY;
+        values[3] = values[4];
+
+        for ex_bits in 1..=8 {
+            let expected = reference_best_ex_rescale_factor(&values, ex_bits);
+            let actual = best_ex_rescale_factor(&values, ex_bits);
+            assert_eq!(actual.to_bits(), expected.to_bits(), "ex_bits={ex_bits}");
+        }
+    }
 
     #[rstest]
     #[case(8)]

--- a/rust/lance-index/src/vector/bq/builder.rs
+++ b/rust/lance-index/src/vector/bq/builder.rs
@@ -81,42 +81,6 @@ fn pack_sign_bits(codes: &mut [u8], rotated: &[f32]) {
 const EX_QUANTIZATION_EPSILON: f32 = 1.0e-5;
 const EX_TIGHT_START: [f32; 9] = [0.0, 0.15, 0.20, 0.52, 0.59, 0.71, 0.75, 0.77, 0.81];
 
-/// Sort packed `(positive_f32_bits, index)` values by their floating-point key.
-///
-/// All thresholds emitted by [`best_ex_rescale_factor`] are positive and finite,
-/// so their IEEE-754 bit patterns have the same order as the represented values.
-/// Four stable byte-wise passes avoid the comparison-heavy tuple sort on every
-/// vector while preserving the exact threshold order.
-fn radix_sort_positive_f32_indices(values: &mut [u64]) {
-    if values.len() < 2 {
-        return;
-    }
-
-    fn pass(source: &[u64], destination: &mut [u64], shift: u32) {
-        let mut offsets = [0usize; 256];
-        for &value in source {
-            offsets[((value >> shift) & 0xff) as usize] += 1;
-        }
-        let mut next_offset = 0;
-        for offset in &mut offsets {
-            let count = *offset;
-            *offset = next_offset;
-            next_offset += count;
-        }
-        for &value in source {
-            let bucket = ((value >> shift) & 0xff) as usize;
-            destination[offsets[bucket]] = value;
-            offsets[bucket] += 1;
-        }
-    }
-
-    let mut scratch = vec![0u64; values.len()];
-    pass(values, &mut scratch, 32);
-    pass(&scratch, values, 40);
-    pass(values, &mut scratch, 48);
-    pass(&scratch, values, 56);
-}
-
 fn best_ex_rescale_factor(abs_normalized: &[f32], ex_bits: u8) -> f32 {
     let max_value = abs_normalized
         .iter()
@@ -153,20 +117,17 @@ fn best_ex_rescale_factor(abs_normalized: &[f32], ex_bits: u8) -> f32 {
         while next <= max_code {
             let threshold = next as f32 / value;
             if threshold < t_end {
-                debug_assert!(u32::try_from(idx).is_ok());
-                thresholds.push(((threshold.to_bits() as u64) << u32::BITS) | idx as u64);
+                thresholds.push((threshold, idx));
             }
             next += 1;
         }
     }
 
-    radix_sort_positive_f32_indices(&mut thresholds);
+    thresholds.sort_unstable_by(|(left, _), (right, _)| left.total_cmp(right));
 
     let mut best_inner_product = numerator / squared_denominator.sqrt();
     let mut best_t = t_start;
-    for packed_threshold in thresholds {
-        let threshold = f32::from_bits((packed_threshold >> u32::BITS) as u32);
-        let idx = packed_threshold as u32 as usize;
+    for (threshold, idx) in thresholds {
         current_codes[idx] += 1;
         let updated = current_codes[idx];
         squared_denominator += (2 * updated) as f32;
@@ -930,100 +891,6 @@ mod tests {
     use rstest::rstest;
 
     use crate::vector::bq::storage::RABIT_BLOCKED_EX_CODE_COLUMN;
-
-    fn reference_best_ex_rescale_factor(abs_normalized: &[f32], ex_bits: u8) -> f32 {
-        let max_value = abs_normalized
-            .iter()
-            .copied()
-            .filter(|value| value.is_finite())
-            .fold(0.0f32, f32::max);
-        if max_value <= 0.0 {
-            return 0.0;
-        }
-
-        let max_code = (1usize << ex_bits) - 1;
-        let t_end = ((max_code + 10) as f32) / max_value;
-        let t_start = t_end * EX_TIGHT_START[ex_bits as usize];
-        let mut current_codes = Vec::with_capacity(abs_normalized.len());
-        let mut squared_denominator = abs_normalized.len() as f32 * 0.25;
-        let mut numerator = 0.0f32;
-        let mut thresholds = Vec::with_capacity(abs_normalized.len() * max_code);
-
-        for (idx, &value) in abs_normalized.iter().enumerate() {
-            if value <= 0.0 || !value.is_finite() {
-                current_codes.push(0usize);
-                continue;
-            }
-            let current = ((t_start * value) + EX_QUANTIZATION_EPSILON)
-                .floor()
-                .clamp(0.0, max_code as f32) as usize;
-            current_codes.push(current);
-            squared_denominator += (current * current + current) as f32;
-            numerator += (current as f32 + 0.5) * value;
-
-            for next in (current + 1)..=max_code {
-                let threshold = next as f32 / value;
-                if threshold < t_end {
-                    thresholds.push((threshold, idx));
-                }
-            }
-        }
-
-        thresholds.sort_unstable_by(|(left, _), (right, _)| left.total_cmp(right));
-        let mut best_inner_product = numerator / squared_denominator.sqrt();
-        let mut best_t = t_start;
-        for (threshold, idx) in thresholds {
-            current_codes[idx] += 1;
-            let updated = current_codes[idx];
-            squared_denominator += (2 * updated) as f32;
-            numerator += abs_normalized[idx];
-            let current_inner_product = numerator / squared_denominator.sqrt();
-            if current_inner_product > best_inner_product {
-                best_inner_product = current_inner_product;
-                best_t = threshold;
-            }
-        }
-        best_t
-    }
-
-    #[test]
-    fn test_radix_sort_positive_f32_indices_matches_float_order() {
-        let mut values = (0..4096u32)
-            .map(|idx| {
-                let key = ((idx.wrapping_mul(2654435761) % 997) + 1) as f32 / 37.0;
-                ((key.to_bits() as u64) << u32::BITS) | idx as u64
-            })
-            .collect::<Vec<_>>();
-        let mut expected = values.clone();
-        expected.sort_by_key(|value| *value >> u32::BITS);
-
-        radix_sort_positive_f32_indices(&mut values);
-
-        assert_eq!(values, expected);
-    }
-
-    #[test]
-    fn test_best_ex_rescale_factor_matches_comparison_sort() {
-        let mut values = (0..1536u32)
-            .map(|idx| {
-                let mixed = idx
-                    .wrapping_mul(747796405)
-                    .wrapping_add(2891336453)
-                    .rotate_right((idx % 31) + 1);
-                (mixed as f32 / u32::MAX as f32) * 0.1
-            })
-            .collect::<Vec<_>>();
-        values[0] = 0.0;
-        values[1] = f32::NAN;
-        values[2] = f32::INFINITY;
-        values[3] = values[4];
-
-        for ex_bits in 1..=8 {
-            let expected = reference_best_ex_rescale_factor(&values, ex_bits);
-            let actual = best_ex_rescale_factor(&values, ex_bits);
-            assert_eq!(actual.to_bits(), expected.to_bits(), "ex_bits={ex_bits}");
-        }
-    }
 
     #[rstest]
     #[case(8)]

--- a/rust/lance-index/src/vector/v3.rs
+++ b/rust/lance-index/src/vector/v3.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright The Lance Authors
 
+#[doc(hidden)]
+pub mod shuffle_bench;
 pub mod shuffler;
 pub mod subindex;

--- a/rust/lance-index/src/vector/v3/shuffle_bench.rs
+++ b/rust/lance-index/src/vector/v3/shuffle_bench.rs
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+//! Benchmark-only support for reopening a frozen two-file shuffle fixture.
+
+use std::sync::Arc;
+
+use lance_core::Result;
+use lance_io::object_store::ObjectStore;
+use object_store::path::Path;
+use serde::{Deserialize, Serialize};
+
+use super::shuffler::{ShuffleReader, TwoFileShuffleReader};
+/// The path-independent metadata needed to reopen a two-file shuffle fixture.
+///
+/// This is public only so the external Criterion benchmark can serialize the
+/// manifest on one revision and reopen the same data from another revision.
+#[doc(hidden)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct TwoFileShuffleFixtureManifest {
+    pub num_partitions: usize,
+    pub num_flush_groups: u64,
+    pub partition_counts: Vec<u64>,
+    pub total_loss: f64,
+}
+
+/// Reopen a frozen local two-file shuffle fixture.
+///
+/// `output_dir` is deliberately separate from the manifest so a fixture can be
+/// copied without embedding a machine-specific absolute path.
+#[doc(hidden)]
+pub async fn open_two_file_shuffle_fixture(
+    output_dir: Path,
+    manifest: &TwoFileShuffleFixtureManifest,
+) -> Result<Box<dyn ShuffleReader>> {
+    TwoFileShuffleReader::try_new(
+        Arc::new(ObjectStore::local()),
+        output_dir,
+        manifest.num_partitions,
+        manifest.num_flush_groups,
+        manifest.partition_counts.clone(),
+        manifest.total_loss,
+    )
+    .await
+}

--- a/rust/lance-index/src/vector/v3/shuffler.rs
+++ b/rust/lance-index/src/vector/v3/shuffler.rs
@@ -51,6 +51,17 @@ pub struct ShufflePartitionWindow {
     pub partition_range: Range<usize>,
     /// One entry per partition in `partition_range`, including empty ones.
     pub partitions: Vec<ShufflePartition>,
+    /// Decoded bytes already materialized by the reader, counted once per
+    /// backing Arrow allocation. `None` means the returned streams are lazy.
+    pub materialized_decoded_bytes: Option<usize>,
+}
+
+/// Metadata-only plan for a contiguous shuffle partition window.
+pub struct ShufflePartitionWindowPlan {
+    /// Half-open partition range that the subsequent read will return.
+    pub partition_range: Range<usize>,
+    /// Conservative decoded-memory admission charge for the read.
+    pub estimated_decoded_bytes: usize,
 }
 
 #[async_trait::async_trait]
@@ -63,6 +74,33 @@ pub trait ShuffleReader: Send + Sync {
         &self,
         partition_id: usize,
     ) -> Result<Option<Box<dyn RecordBatchStream + Unpin + 'static>>>;
+
+    /// Plan a partition window without reading or decoding partition data.
+    ///
+    /// Readers without a decoded-size estimate use an oversized admission
+    /// charge for non-empty partitions so the read runs exclusively.
+    fn plan_partition_window(
+        &self,
+        start_partition_id: usize,
+        max_decoded_bytes: usize,
+    ) -> Result<ShufflePartitionWindowPlan> {
+        if max_decoded_bytes == 0 {
+            return Err(Error::invalid_input(
+                "max_decoded_bytes must be greater than 0",
+            ));
+        }
+        let end = start_partition_id.checked_add(1).ok_or_else(|| {
+            Error::invalid_input(format!(
+                "start_partition_id={} cannot be advanced",
+                start_partition_id
+            ))
+        })?;
+        let partition_rows = self.partition_size(start_partition_id)?;
+        Ok(ShufflePartitionWindowPlan {
+            partition_range: start_partition_id..end,
+            estimated_decoded_bytes: if partition_rows == 0 { 0 } else { usize::MAX },
+        })
+    }
 
     /// Read a contiguous partition window starting at `start_partition_id`.
     ///
@@ -96,6 +134,7 @@ pub trait ShuffleReader: Send + Sync {
                 partition_id: start_partition_id,
                 data,
             }],
+            materialized_decoded_bytes: None,
         })
     }
 
@@ -1160,6 +1199,7 @@ impl<'a> ShuffleOffsetsValidator<'a> {
 /// keeps window planning bounded when one is present without claiming an exact
 /// decoded size for values that have no fixed Arrow stride.
 const VARIABLE_WIDTH_ROW_ESTIMATE_BYTES: usize = 64;
+const WINDOW_ADMISSION_FIXED_HEADROOM_BYTES: usize = 1024 * 1024;
 
 fn estimate_decoded_row_bytes(schema: &Schema) -> Result<usize> {
     let mut row_bytes = 0usize;
@@ -1249,6 +1289,42 @@ fn plan_partition_window_end(
     Ok(end_partition_id)
 }
 
+fn conservative_window_admission_bytes(
+    partition_counts: &[u64],
+    partition_range: Range<usize>,
+    estimated_row_bytes: usize,
+) -> Result<usize> {
+    let rows = partition_counts[partition_range]
+        .iter()
+        .try_fold(0usize, |total, count| {
+            let count = usize::try_from(*count).map_err(|_| {
+                Error::invalid_input(format!(
+                    "partition row count {} cannot be represented as usize",
+                    count
+                ))
+            })?;
+            total
+                .checked_add(count)
+                .ok_or_else(|| Error::invalid_input("partition window row count overflows usize"))
+        })?;
+    if rows == 0 {
+        return Ok(0);
+    }
+    let value_bytes = rows.checked_mul(estimated_row_bytes).ok_or_else(|| {
+        Error::invalid_input(format!(
+            "decoded byte estimate overflows for {} rows at {} bytes per row",
+            rows, estimated_row_bytes
+        ))
+    })?;
+    // Arrow buffers and batch/array allocations add a small amount beyond the
+    // fixed-width values. Reserve 25% plus fixed headroom before decoding; the
+    // charge is reconciled to the allocation-backed size immediately after.
+    value_bytes
+        .checked_add(value_bytes / 4)
+        .and_then(|bytes| bytes.checked_add(WINDOW_ADMISSION_FIXED_HEADROOM_BYTES))
+        .ok_or_else(|| Error::invalid_input("partition window admission estimate overflows usize"))
+}
+
 type PartitionWindowReadPlan = (Vec<Range<u64>>, Vec<Vec<usize>>);
 
 fn preloaded_window_ranges(
@@ -1302,7 +1378,7 @@ async fn split_partition_window_stream<S>(
     mut stream: S,
     window_len: usize,
     group_partition_counts: &[Vec<usize>],
-) -> Result<Vec<Vec<RecordBatch>>>
+) -> Result<(Vec<Vec<RecordBatch>>, usize)>
 where
     S: Stream<Item = Result<RecordBatch>> + Unpin,
 {
@@ -1320,9 +1396,21 @@ where
     let mut current_segment = segments.next();
     let mut segment_rows_read = 0usize;
     let mut actual_rows = 0usize;
+    let mut materialized_decoded_bytes = 0usize;
     let mut partition_batches = vec![Vec::new(); window_len];
 
     while let Some(batch) = stream.try_next().await? {
+        materialized_decoded_bytes =
+            batch
+                .columns()
+                .iter()
+                .try_fold(materialized_decoded_bytes, |total, array| {
+                    total
+                        .checked_add(array.get_array_memory_size())
+                        .ok_or_else(|| {
+                            Error::internal("decoded partition window byte count overflows usize")
+                        })
+                })?;
         let mut batch_offset = 0usize;
         while batch_offset < batch.num_rows() {
             let Some((partition_offset, segment_rows)) = current_segment else {
@@ -1361,7 +1449,7 @@ where
             ),
         ));
     }
-    Ok(partition_batches)
+    Ok((partition_batches, materialized_decoded_bytes))
 }
 
 #[async_trait::async_trait]
@@ -1398,6 +1486,43 @@ impl ShuffleReader for TwoFileShuffleReader {
         ))))
     }
 
+    fn plan_partition_window(
+        &self,
+        start_partition_id: usize,
+        max_decoded_bytes: usize,
+    ) -> Result<ShufflePartitionWindowPlan> {
+        if start_partition_id >= self.num_partitions {
+            return Err(Error::invalid_input(format!(
+                "start_partition_id={} is out of range [0, {})",
+                start_partition_id, self.num_partitions
+            )));
+        }
+        let end_partition_id = match &self.offsets {
+            ShuffleOffsets::Preloaded(_) => plan_partition_window_end(
+                &self.partition_counts,
+                start_partition_id,
+                self.estimated_row_bytes,
+                max_decoded_bytes,
+            )?,
+            ShuffleOffsets::OnDemand(_) => start_partition_id.checked_add(1).ok_or_else(|| {
+                Error::invalid_input(format!(
+                    "start_partition_id={} cannot be advanced",
+                    start_partition_id
+                ))
+            })?,
+        };
+        let partition_range = start_partition_id..end_partition_id;
+        let estimated_decoded_bytes = conservative_window_admission_bytes(
+            &self.partition_counts,
+            partition_range.clone(),
+            self.estimated_row_bytes,
+        )?;
+        Ok(ShufflePartitionWindowPlan {
+            partition_range,
+            estimated_decoded_bytes,
+        })
+    }
+
     async fn read_partition_window(
         &self,
         start_partition_id: usize,
@@ -1425,16 +1550,13 @@ impl ShuffleReader for TwoFileShuffleReader {
                     partition_id: start_partition_id,
                     data,
                 }],
+                materialized_decoded_bytes: None,
             });
         };
 
-        let end_partition_id = plan_partition_window_end(
-            &self.partition_counts,
-            start_partition_id,
-            self.estimated_row_bytes,
-            max_decoded_bytes,
-        )?;
-        let partition_range = start_partition_id..end_partition_id;
+        let partition_range = self
+            .plan_partition_window(start_partition_id, max_decoded_bytes)?
+            .partition_range;
         let (ranges, group_partition_counts) = preloaded_window_ranges(
             offsets,
             self.num_batches,
@@ -1444,8 +1566,8 @@ impl ShuffleReader for TwoFileShuffleReader {
         let schema: Schema = self.file_reader.schema().as_ref().into();
         let schema = Arc::new(schema);
 
-        let partition_batches = if ranges.is_empty() {
-            vec![Vec::new(); partition_range.len()]
+        let (partition_batches, materialized_decoded_bytes) = if ranges.is_empty() {
+            (vec![Vec::new(); partition_range.len()], 0)
         } else {
             let stream = self
                 .file_reader
@@ -1480,6 +1602,7 @@ impl ShuffleReader for TwoFileShuffleReader {
         Ok(ShufflePartitionWindow {
             partition_range,
             partitions,
+            materialized_decoded_bytes: Some(materialized_decoded_bytes),
         })
     }
 
@@ -1866,14 +1989,19 @@ mod tests {
         // into a singleton window.
         let mut next_partition_id = 0;
         let mut ranges = Vec::new();
+        let mut admission_bytes = Vec::new();
         let mut window_values = vec![Vec::new(); num_partitions];
         while next_partition_id < num_partitions {
+            let plan = reader.plan_partition_window(next_partition_id, 12).unwrap();
             let window = reader
                 .read_partition_window(next_partition_id, 12)
                 .await
                 .unwrap();
+            assert_eq!(window.partition_range, plan.partition_range);
+            assert!(window.materialized_decoded_bytes.is_some());
             assert_eq!(window.partitions.len(), window.partition_range.len());
             ranges.push(window.partition_range.clone());
+            admission_bytes.push(plan.estimated_decoded_bytes);
             next_partition_id = window.partition_range.end;
             for partition in window.partitions {
                 if let Some(stream) = partition.data {
@@ -1883,6 +2011,8 @@ mod tests {
         }
 
         assert_eq!(ranges, vec![0..2, 2..3, 3..6]);
+        assert!(admission_bytes[1] > admission_bytes[0]);
+        assert!(admission_bytes[1] > admission_bytes[2]);
         assert_eq!(window_values, singleton_values);
         assert_eq!(window_values[0], Vec::<i32>::new());
         assert_eq!(window_values[2].len(), 10);

--- a/rust/lance-index/src/vector/v3/shuffler.rs
+++ b/rust/lance-index/src/vector/v3/shuffler.rs
@@ -200,6 +200,7 @@ impl Shuffler for IvfShuffler {
         let num_partitions = self.num_partitions;
         let mut partition_sizes = vec![0; num_partitions];
         let schema = data.schema().without_column(PART_ID_COLUMN);
+        let estimated_row_bytes = estimate_decoded_row_bytes(&schema)?;
         let mut writers = stream::iter(0..num_partitions)
             .map(|partition_id| {
                 let part_path = self
@@ -293,12 +294,15 @@ impl Shuffler for IvfShuffler {
             writer.finish().await?;
         }
 
-        Ok(Box::new(IvfShufflerReader::new(
-            self.object_store.clone(),
-            self.output_dir.clone(),
-            partition_sizes,
-            total_loss,
-        )))
+        Ok(Box::new(
+            IvfShufflerReader::new(
+                self.object_store.clone(),
+                self.output_dir.clone(),
+                partition_sizes,
+                total_loss,
+            )
+            .with_estimated_row_bytes(estimated_row_bytes),
+        ))
     }
 }
 
@@ -306,6 +310,7 @@ pub struct IvfShufflerReader {
     scheduler: Arc<ScanScheduler>,
     output_dir: Path,
     partition_sizes: Vec<usize>,
+    estimated_row_bytes: Option<usize>,
     loss: f64,
 }
 
@@ -322,8 +327,14 @@ impl IvfShufflerReader {
             scheduler,
             output_dir,
             partition_sizes,
+            estimated_row_bytes: None,
             loss,
         }
+    }
+
+    fn with_estimated_row_bytes(mut self, estimated_row_bytes: usize) -> Self {
+        self.estimated_row_bytes = Some(estimated_row_bytes);
+        self
     }
 }
 
@@ -365,6 +376,42 @@ impl ShuffleReader for IvfShufflerReader {
             Arc::new(schema),
             stream,
         ))))
+    }
+
+    fn plan_partition_window(
+        &self,
+        start_partition_id: usize,
+        max_decoded_bytes: usize,
+    ) -> Result<ShufflePartitionWindowPlan> {
+        if max_decoded_bytes == 0 {
+            return Err(Error::invalid_input(
+                "max_decoded_bytes must be greater than 0",
+            ));
+        }
+        let Some(&partition_rows) = self.partition_sizes.get(start_partition_id) else {
+            return Err(Error::invalid_input(format!(
+                "start_partition_id={} is out of range [0, {})",
+                start_partition_id,
+                self.partition_sizes.len()
+            )));
+        };
+        let end_partition_id = start_partition_id.checked_add(1).ok_or_else(|| {
+            Error::invalid_input(format!(
+                "start_partition_id={} cannot be advanced",
+                start_partition_id
+            ))
+        })?;
+        let estimated_decoded_bytes = match (partition_rows, self.estimated_row_bytes) {
+            (0, _) => 0,
+            (_, Some(estimated_row_bytes)) => {
+                conservative_partition_admission_bytes(partition_rows, estimated_row_bytes)?
+            }
+            (_, None) => usize::MAX,
+        };
+        Ok(ShufflePartitionWindowPlan {
+            partition_range: start_partition_id..end_partition_id,
+            estimated_decoded_bytes,
+        })
     }
 
     fn partition_size(&self, partition_id: usize) -> Result<usize> {
@@ -1310,6 +1357,13 @@ fn conservative_window_admission_bytes(
     if rows == 0 {
         return Ok(0);
     }
+    conservative_partition_admission_bytes(rows, estimated_row_bytes)
+}
+
+fn conservative_partition_admission_bytes(
+    rows: usize,
+    estimated_row_bytes: usize,
+) -> Result<usize> {
     let value_bytes = rows.checked_mul(estimated_row_bytes).ok_or_else(|| {
         Error::invalid_input(format!(
             "decoded byte estimate overflows for {} rows at {} bytes per row",
@@ -2072,6 +2126,32 @@ mod tests {
         let error = plan_partition_window_end(&partition_counts, 0, 4, 0).unwrap_err();
         assert!(matches!(error, Error::InvalidInput { .. }));
         assert!(error.to_string().contains("must be greater than 0"));
+    }
+
+    #[tokio::test]
+    async fn legacy_shuffler_uses_schema_estimate_for_parallel_admission() {
+        let dir = TempStrDir::default();
+        let output_dir = Path::from(dir.as_ref());
+        let part_ids = vec![0; 32];
+        let values = (0..32).collect::<Vec<_>>();
+        let reader = IvfShuffler::new(output_dir, 2)
+            .shuffle(batches_to_stream(vec![make_batch(
+                &part_ids, &values, None,
+            )]))
+            .await
+            .unwrap();
+
+        let non_empty = reader.plan_partition_window(0, 128 * 1024 * 1024).unwrap();
+        assert_eq!(non_empty.partition_range, 0..1);
+        assert_eq!(
+            non_empty.estimated_decoded_bytes,
+            32 * 4 + 32 * 4 / 4 + WINDOW_ADMISSION_FIXED_HEADROOM_BYTES
+        );
+        assert_ne!(non_empty.estimated_decoded_bytes, usize::MAX);
+
+        let empty = reader.plan_partition_window(1, 128 * 1024 * 1024).unwrap();
+        assert_eq!(empty.partition_range, 1..2);
+        assert_eq!(empty.estimated_decoded_bytes, 0);
     }
 
     #[test]

--- a/rust/lance-index/src/vector/v3/shuffler.rs
+++ b/rust/lance-index/src/vector/v3/shuffler.rs
@@ -85,7 +85,11 @@ pub trait ShuffleReader: Send + Sync {
                 start_partition_id
             ))
         })?;
-        let data = self.read_partition(start_partition_id).await?;
+        let data = if self.partition_size(start_partition_id)? == 0 {
+            None
+        } else {
+            self.read_partition(start_partition_id).await?
+        };
         Ok(ShufflePartitionWindow {
             partition_range: start_partition_id..end,
             partitions: vec![ShufflePartition {

--- a/rust/lance-index/src/vector/v3/shuffler.rs
+++ b/rust/lance-index/src/vector/v3/shuffler.rs
@@ -7,13 +7,11 @@
 use std::ops::Range;
 use std::sync::{Arc, LazyLock};
 
-use arrow::compute::concat_batches;
-use arrow::datatypes::UInt64Type;
 use arrow::{array::AsArray, compute::sort_to_indices};
-use arrow_array::{RecordBatch, UInt32Array, UInt64Array};
+use arrow_array::{Array, RecordBatch, UInt32Array, UInt64Array};
 use arrow_schema::{DataType, Field, Schema, SchemaRef};
 use futures::{future::try_join_all, prelude::*};
-use lance_arrow::{RecordBatchExt, SchemaExt, interleave_batches};
+use lance_arrow::{DataTypeExt, RecordBatchExt, SchemaExt, interleave_batches};
 use lance_core::{
     Error, Result,
     cache::LanceCache,
@@ -36,6 +34,25 @@ use object_store::path::Path;
 
 use crate::vector::{LOSS_METADATA_KEY, PART_ID_COLUMN};
 
+/// Target decoded size for a contiguous shuffle partition window.
+pub const DEFAULT_PARTITION_WINDOW_BYTES: usize = 128 * 1024 * 1024;
+
+/// One partition returned by [`ShuffleReader::read_partition_window`].
+pub struct ShufflePartition {
+    /// Zero-based IVF partition identifier.
+    pub partition_id: usize,
+    /// Partition rows, or `None` when the partition is empty.
+    pub data: Option<Box<dyn RecordBatchStream + Unpin + 'static>>,
+}
+
+/// A contiguous range of shuffled partitions read as one I/O window.
+pub struct ShufflePartitionWindow {
+    /// Half-open range covered by `partitions`.
+    pub partition_range: Range<usize>,
+    /// One entry per partition in `partition_range`, including empty ones.
+    pub partitions: Vec<ShufflePartition>,
+}
+
 #[async_trait::async_trait]
 /// A reader that can read the shuffled partitions.
 pub trait ShuffleReader: Send + Sync {
@@ -46,6 +63,37 @@ pub trait ShuffleReader: Send + Sync {
         &self,
         partition_id: usize,
     ) -> Result<Option<Box<dyn RecordBatchStream + Unpin + 'static>>>;
+
+    /// Read a contiguous partition window starting at `start_partition_id`.
+    ///
+    /// Readers that cannot coalesce adjacent partitions return a singleton
+    /// window. The byte budget is a decoded-memory target, not an encoded I/O
+    /// size. A partition larger than the budget is returned as a singleton.
+    async fn read_partition_window(
+        &self,
+        start_partition_id: usize,
+        max_decoded_bytes: usize,
+    ) -> Result<ShufflePartitionWindow> {
+        if max_decoded_bytes == 0 {
+            return Err(Error::invalid_input(
+                "max_decoded_bytes must be greater than 0",
+            ));
+        }
+        let end = start_partition_id.checked_add(1).ok_or_else(|| {
+            Error::invalid_input(format!(
+                "start_partition_id={} cannot be advanced",
+                start_partition_id
+            ))
+        })?;
+        let data = self.read_partition(start_partition_id).await?;
+        Ok(ShufflePartitionWindow {
+            partition_range: start_partition_id..end,
+            partitions: vec![ShufflePartition {
+                partition_id: start_partition_id,
+                data,
+            }],
+        })
+    }
 
     /// Get the size of the partition by partition_id
     fn partition_size(&self, partition_id: usize) -> Result<usize>;
@@ -348,6 +396,13 @@ static OFFSETS_SCHEMA: LazyLock<SchemaRef> = LazyLock::new(|| {
 
 const DEFAULT_SHUFFLE_BATCH_BYTES: usize = 128 * 1024 * 1024;
 
+/// Maximum resident size of the preloaded offsets table.
+///
+/// This covers tens of millions of offsets while bounding the additional memory
+/// held for unusually large shuffles. Larger tables are still validated once as
+/// a stream and then read on demand.
+const MAX_PRELOADED_OFFSETS_BYTES: usize = 256 * 1024 * 1024;
+
 /// Number of rows per output batch when streaming sorted data via interleave.
 /// Small enough to keep the output chunk's memory footprint modest relative to
 /// the accumulated source data.
@@ -637,21 +692,48 @@ async fn flush_shuffle_batch(
 pub struct TwoFileShuffleReader {
     _scheduler: Arc<ScanScheduler>,
     file_reader: FileReader,
-    offsets_reader: FileReader,
     num_partitions: usize,
-    num_batches: u64,
+    num_batches: usize,
+    offsets: ShuffleOffsets,
     partition_counts: Vec<u64>,
+    estimated_row_bytes: usize,
     total_loss: f64,
 }
 
+enum ShuffleOffsets {
+    Preloaded(Vec<u64>),
+    OnDemand(FileReader),
+}
+
 impl TwoFileShuffleReader {
-    async fn try_new(
+    pub(super) async fn try_new(
         object_store: Arc<ObjectStore>,
         output_dir: Path,
         num_partitions: usize,
         num_batches: u64,
         partition_counts: Vec<u64>,
         total_loss: f64,
+    ) -> Result<Box<dyn ShuffleReader>> {
+        Self::try_new_with_preload_limit(
+            object_store,
+            output_dir,
+            num_partitions,
+            num_batches,
+            partition_counts,
+            total_loss,
+            MAX_PRELOADED_OFFSETS_BYTES,
+        )
+        .await
+    }
+
+    async fn try_new_with_preload_limit(
+        object_store: Arc<ObjectStore>,
+        output_dir: Path,
+        num_partitions: usize,
+        num_batches: u64,
+        partition_counts: Vec<u64>,
+        total_loss: f64,
+        max_preloaded_offsets_bytes: usize,
     ) -> Result<Box<dyn ShuffleReader>> {
         if num_batches == 0 {
             return Ok(Box::new(EmptyReader));
@@ -684,63 +766,598 @@ impl TwoFileShuffleReader {
         )
         .await?;
 
+        if partition_counts.len() != num_partitions {
+            return Err(Error::invalid_input(format!(
+                "partition_counts has {} entries, expected num_partitions={}",
+                partition_counts.len(),
+                num_partitions
+            )));
+        }
+
+        let num_batches = usize::try_from(num_batches).map_err(|_| {
+            Error::invalid_input(format!(
+                "num_batches={} cannot be represented as usize",
+                num_batches
+            ))
+        })?;
+        let expected_offsets = num_batches.checked_mul(num_partitions).ok_or_else(|| {
+            Error::invalid_input(format!(
+                "num_batches={} * num_partitions={} overflows usize",
+                num_batches, num_partitions
+            ))
+        })?;
+        let expected_offsets_u64 = u64::try_from(expected_offsets).map_err(|_| {
+            Error::invalid_input(format!(
+                "expected offset count {} cannot be represented as u64",
+                expected_offsets
+            ))
+        })?;
+        if offsets_reader.num_rows() != expected_offsets_u64 {
+            return Err(Error::corrupt_file(
+                offsets_path.clone(),
+                format!(
+                    "offset count is {}, expected num_batches={} * num_partitions={} = {}",
+                    offsets_reader.num_rows(),
+                    num_batches,
+                    num_partitions,
+                    expected_offsets
+                ),
+            ));
+        }
+
+        let offsets_schema = offsets_reader.schema();
+        let offset_field = offsets_schema.field("offset").ok_or_else(|| {
+            Error::corrupt_file(
+                offsets_path.clone(),
+                "required non-null UInt64 column 'offset' is missing",
+            )
+        })?;
+        if offset_field.data_type() != DataType::UInt64 || offset_field.nullable {
+            return Err(Error::corrupt_file(
+                offsets_path.clone(),
+                format!(
+                    "column 'offset' must be non-null UInt64, found {:?} (nullable={})",
+                    offset_field.data_type(),
+                    offset_field.nullable
+                ),
+            ));
+        }
+
+        let should_preload_offsets =
+            should_preload_offsets(expected_offsets, max_preloaded_offsets_bytes)?;
+        let mut offsets = should_preload_offsets.then(|| Vec::with_capacity(expected_offsets));
+        let mut validator = ShuffleOffsetsValidator::new(
+            expected_offsets,
+            num_partitions,
+            file_reader.num_rows(),
+            &partition_counts,
+            &offsets_path,
+        );
+        let mut offsets_stream = offsets_reader
+            .read_stream(
+                ReadBatchParams::RangeFull,
+                1024 * 1024,
+                16,
+                FilterExpression::no_filter(),
+            )
+            .await?;
+        while let Some(batch) = offsets_stream.try_next().await? {
+            let offset_column = batch
+                .column_by_name("offset")
+                .and_then(|column| column.as_any().downcast_ref::<UInt64Array>())
+                .ok_or_else(|| {
+                    Error::corrupt_file(
+                        offsets_path.clone(),
+                        "required UInt64 column 'offset' is missing from decoded batch",
+                    )
+                })?;
+            if offset_column.null_count() != 0 {
+                return Err(Error::corrupt_file(
+                    offsets_path.clone(),
+                    format!(
+                        "column 'offset' contains {} null values",
+                        offset_column.null_count()
+                    ),
+                ));
+            }
+            validator.push(offset_column.values())?;
+            if let Some(offsets) = offsets.as_mut() {
+                offsets.extend_from_slice(offset_column.values());
+            }
+        }
+        validator.finish()?;
+        let offsets = match offsets {
+            Some(offsets) => ShuffleOffsets::Preloaded(offsets),
+            None => ShuffleOffsets::OnDemand(offsets_reader),
+        };
+        let decoded_schema: Schema = file_reader.schema().as_ref().into();
+        let estimated_row_bytes = estimate_decoded_row_bytes(&decoded_schema)?;
+
         Ok(Box::new(Self {
             _scheduler: scheduler,
             file_reader,
-            offsets_reader,
             num_partitions,
             num_batches,
+            offsets,
             partition_counts,
+            estimated_row_bytes,
             total_loss,
         }))
     }
 
     async fn partition_ranges(&self, partition_id: usize) -> Result<Vec<Range<u64>>> {
-        let mut positions = Vec::with_capacity(self.num_batches as usize * 2);
-        for batch_idx in 0..self.num_batches {
-            let end_pos = u32::try_from(batch_idx as usize * self.num_partitions + partition_id)
-                .map_err(|_| Error::invalid_input("There are more than 2^32 partition offsets in the spill file.  Need to support 64-bit take"))?;
-            if end_pos != 0 {
-                positions.push(end_pos - 1);
-            }
-            positions.push(end_pos);
+        if partition_id >= self.num_partitions {
+            return Err(Error::invalid_input(format!(
+                "partition_id={} is out of range [0, {})",
+                partition_id, self.num_partitions
+            )));
         }
-        let positions = UInt32Array::from(positions);
-        let num_positions = positions.len() as u32;
-        let offsets_stream = self
-            .offsets_reader
+
+        match &self.offsets {
+            ShuffleOffsets::Preloaded(offsets) => {
+                let mut ranges = Vec::with_capacity(self.num_batches);
+                for batch_idx in 0..self.num_batches {
+                    let end_index = batch_idx * self.num_partitions + partition_id;
+                    let start = if end_index == 0 {
+                        0
+                    } else {
+                        offsets[end_index - 1]
+                    };
+                    ranges.push(start..offsets[end_index]);
+                }
+                Ok(ranges)
+            }
+            ShuffleOffsets::OnDemand(offsets_reader) => {
+                self.read_partition_ranges(offsets_reader, partition_id)
+                    .await
+            }
+        }
+    }
+
+    async fn read_partition_ranges(
+        &self,
+        offsets_reader: &FileReader,
+        partition_id: usize,
+    ) -> Result<Vec<Range<u64>>> {
+        let max_offset_values = self.num_batches.checked_mul(2).ok_or_else(|| {
+            Error::invalid_input(format!(
+                "num_batches={} overflows on-demand offset count",
+                self.num_batches
+            ))
+        })?;
+        let mut offset_ranges = Vec::with_capacity(max_offset_values);
+        for batch_idx in 0..self.num_batches {
+            let end_index = batch_idx * self.num_partitions + partition_id;
+            if end_index != 0 {
+                let start_index = u64::try_from(end_index - 1).map_err(|_| {
+                    Error::invalid_input(format!(
+                        "offset index {} cannot be represented as u64",
+                        end_index - 1
+                    ))
+                })?;
+                offset_ranges.push(start_index..start_index + 1);
+            }
+            let end_index = u64::try_from(end_index).map_err(|_| {
+                Error::invalid_input(format!(
+                    "offset index {} cannot be represented as u64",
+                    end_index
+                ))
+            })?;
+            offset_ranges.push(end_index..end_index + 1);
+        }
+
+        let mut offsets_stream = offsets_reader
             .read_stream(
-                ReadBatchParams::Indices(positions),
-                num_positions,
+                ReadBatchParams::Ranges(offset_ranges.into()),
+                u32::MAX,
                 1,
                 FilterExpression::no_filter(),
             )
             .await?;
-        let schema = offsets_stream.schema().clone();
-        let offsets = offsets_stream.try_collect::<Vec<_>>().await?;
-        let offsets = if offsets.is_empty() {
-            // We should not hit this path if there is no batches
-            unreachable!()
-        } else if offsets.len() == 1 {
-            offsets.into_iter().next().unwrap()
-        } else {
-            concat_batches(&schema, &offsets)?
-        };
+        let expected_values = max_offset_values - usize::from(partition_id == 0);
+        let mut offsets = Vec::with_capacity(expected_values);
+        while let Some(batch) = offsets_stream.try_next().await? {
+            let offset_column = batch
+                .column_by_name("offset")
+                .and_then(|column| column.as_any().downcast_ref::<UInt64Array>())
+                .ok_or_else(|| {
+                    Error::corrupt_file_named(
+                        "shuffle_offsets.lance",
+                        "required UInt64 column 'offset' is missing from decoded batch",
+                    )
+                })?;
+            offsets.extend_from_slice(offset_column.values());
+        }
+        if offsets.len() != expected_values {
+            return Err(Error::corrupt_file_named(
+                "shuffle_offsets.lance",
+                format!(
+                    "decoded {} on-demand offsets for partition {}, expected {}",
+                    offsets.len(),
+                    partition_id,
+                    expected_values
+                ),
+            ));
+        }
 
-        let offsets = offsets.column(0).as_primitive::<UInt64Type>();
-        let mut offsets_iter = offsets.values().iter().copied();
-
-        let mut ranges = Vec::with_capacity(self.num_batches as usize);
+        let mut offsets = offsets.into_iter();
+        let mut ranges = Vec::with_capacity(self.num_batches);
         for batch_idx in 0..self.num_batches {
-            if batch_idx == 0 && partition_id == 0 {
-                // Implicit 0 for start-of-file
-                ranges.push(0..offsets_iter.next().unwrap());
+            let start = if batch_idx == 0 && partition_id == 0 {
+                0
             } else {
-                ranges.push(offsets_iter.next().unwrap()..offsets_iter.next().unwrap());
-            }
+                offsets.next().ok_or_else(|| {
+                    Error::corrupt_file_named(
+                        "shuffle_offsets.lance",
+                        format!("missing start offset for partition {}", partition_id),
+                    )
+                })?
+            };
+            let end = offsets.next().ok_or_else(|| {
+                Error::corrupt_file_named(
+                    "shuffle_offsets.lance",
+                    format!("missing end offset for partition {}", partition_id),
+                )
+            })?;
+            ranges.push(start..end);
         }
         Ok(ranges)
     }
+}
+
+#[cfg(test)]
+fn validate_shuffle_offsets(
+    offsets: &[u64],
+    num_batches: usize,
+    num_partitions: usize,
+    data_rows: u64,
+    partition_counts: &[u64],
+    offsets_path: &Path,
+) -> Result<()> {
+    let expected_offsets = num_batches.checked_mul(num_partitions).ok_or_else(|| {
+        Error::invalid_input(format!(
+            "num_batches={} * num_partitions={} overflows usize",
+            num_batches, num_partitions
+        ))
+    })?;
+    let mut validator = ShuffleOffsetsValidator::new(
+        expected_offsets,
+        num_partitions,
+        data_rows,
+        partition_counts,
+        offsets_path,
+    );
+    validator.push(offsets)?;
+    validator.finish()
+}
+
+fn should_preload_offsets(expected_offsets: usize, max_bytes: usize) -> Result<bool> {
+    let offsets_bytes = expected_offsets
+        .checked_mul(std::mem::size_of::<u64>())
+        .ok_or_else(|| {
+            Error::invalid_input(format!(
+                "expected offset count {} overflows byte-size calculation",
+                expected_offsets
+            ))
+        })?;
+    Ok(offsets_bytes <= max_bytes)
+}
+
+struct ShuffleOffsetsValidator<'a> {
+    expected_offsets: usize,
+    num_partitions: usize,
+    data_rows: u64,
+    partition_counts: &'a [u64],
+    offsets_path: &'a Path,
+    decoded_offsets: usize,
+    previous_offset: u64,
+    decoded_partition_counts: Vec<u64>,
+}
+
+impl<'a> ShuffleOffsetsValidator<'a> {
+    fn new(
+        expected_offsets: usize,
+        num_partitions: usize,
+        data_rows: u64,
+        partition_counts: &'a [u64],
+        offsets_path: &'a Path,
+    ) -> Self {
+        Self {
+            expected_offsets,
+            num_partitions,
+            data_rows,
+            partition_counts,
+            offsets_path,
+            decoded_offsets: 0,
+            previous_offset: 0,
+            decoded_partition_counts: vec![0; num_partitions],
+        }
+    }
+
+    fn push(&mut self, offsets: &[u64]) -> Result<()> {
+        for &offset in offsets {
+            if self.decoded_offsets >= self.expected_offsets {
+                return Err(Error::corrupt_file(
+                    self.offsets_path.clone(),
+                    format!(
+                        "decoded more than the expected {} offsets",
+                        self.expected_offsets
+                    ),
+                ));
+            }
+            if self.previous_offset > offset {
+                return Err(Error::corrupt_file(
+                    self.offsets_path.clone(),
+                    format!(
+                        "offsets are not monotonic at indices {} and {}: {} > {}",
+                        self.decoded_offsets - 1,
+                        self.decoded_offsets,
+                        self.previous_offset,
+                        offset
+                    ),
+                ));
+            }
+
+            let partition_id = self.decoded_offsets % self.num_partitions;
+            self.decoded_partition_counts[partition_id] = self.decoded_partition_counts
+                [partition_id]
+                .checked_add(offset - self.previous_offset)
+                .ok_or_else(|| {
+                    Error::corrupt_file(
+                        self.offsets_path.clone(),
+                        format!("row count for partition {} overflows u64", partition_id),
+                    )
+                })?;
+            self.previous_offset = offset;
+            self.decoded_offsets += 1;
+        }
+        Ok(())
+    }
+
+    fn finish(self) -> Result<()> {
+        if self.decoded_offsets != self.expected_offsets {
+            return Err(Error::corrupt_file(
+                self.offsets_path.clone(),
+                format!(
+                    "decoded {} offsets, expected {}",
+                    self.decoded_offsets, self.expected_offsets
+                ),
+            ));
+        }
+        if self.previous_offset != self.data_rows {
+            return Err(Error::corrupt_file(
+                self.offsets_path.clone(),
+                format!(
+                    "final offset {} does not match shuffle data row count {}",
+                    self.previous_offset, self.data_rows
+                ),
+            ));
+        }
+        if let Some((partition_id, (&decoded, &expected))) = self
+            .decoded_partition_counts
+            .iter()
+            .zip(self.partition_counts)
+            .enumerate()
+            .find(|(_, (decoded, expected))| decoded != expected)
+        {
+            return Err(Error::corrupt_file(
+                self.offsets_path.clone(),
+                format!(
+                    "offset-derived count {} for partition {} does not match expected count {}",
+                    decoded, partition_id, expected
+                ),
+            ));
+        }
+        Ok(())
+    }
+}
+
+/// Variable-width columns are uncommon in vector shuffle data. This fallback
+/// keeps window planning bounded when one is present without claiming an exact
+/// decoded size for values that have no fixed Arrow stride.
+const VARIABLE_WIDTH_ROW_ESTIMATE_BYTES: usize = 64;
+
+fn estimate_decoded_row_bytes(schema: &Schema) -> Result<usize> {
+    let mut row_bytes = 0usize;
+    for field in schema.fields() {
+        let value_bytes = match field.data_type() {
+            DataType::Boolean => 1,
+            data_type => data_type
+                .byte_width_opt()
+                .unwrap_or(VARIABLE_WIDTH_ROW_ESTIMATE_BYTES),
+        };
+        row_bytes = row_bytes.checked_add(value_bytes).ok_or_else(|| {
+            Error::invalid_input(format!(
+                "decoded row-size estimate overflows usize at field '{}'",
+                field.name()
+            ))
+        })?;
+        if field.is_nullable() {
+            // Arrow validity is bit-packed. One byte per row is deliberately
+            // conservative and also covers small-buffer alignment overhead.
+            row_bytes = row_bytes.checked_add(1).ok_or_else(|| {
+                Error::invalid_input(format!(
+                    "decoded row-size estimate overflows usize at nullable field '{}'",
+                    field.name()
+                ))
+            })?;
+        }
+    }
+    Ok(row_bytes.max(1))
+}
+
+fn plan_partition_window_end(
+    partition_counts: &[u64],
+    start_partition_id: usize,
+    estimated_row_bytes: usize,
+    max_decoded_bytes: usize,
+) -> Result<usize> {
+    if max_decoded_bytes == 0 {
+        return Err(Error::invalid_input(
+            "max_decoded_bytes must be greater than 0",
+        ));
+    }
+    if start_partition_id >= partition_counts.len() {
+        return Err(Error::invalid_input(format!(
+            "start_partition_id={} is out of range [0, {})",
+            start_partition_id,
+            partition_counts.len()
+        )));
+    }
+
+    let mut decoded_bytes = 0usize;
+    let mut end_partition_id = start_partition_id;
+    while end_partition_id < partition_counts.len() {
+        let partition_rows = usize::try_from(partition_counts[end_partition_id]).map_err(|_| {
+            Error::invalid_input(format!(
+                "partition {} row count {} cannot be represented as usize",
+                end_partition_id, partition_counts[end_partition_id]
+            ))
+        })?;
+        let partition_bytes = partition_rows
+            .checked_mul(estimated_row_bytes)
+            .ok_or_else(|| {
+                Error::invalid_input(format!(
+                    "decoded byte estimate overflows for partition {} with {} rows at {} bytes per row",
+                    end_partition_id, partition_rows, estimated_row_bytes
+                ))
+            })?;
+
+        if end_partition_id > start_partition_id
+            && partition_bytes > max_decoded_bytes.saturating_sub(decoded_bytes)
+        {
+            break;
+        }
+        decoded_bytes = decoded_bytes.checked_add(partition_bytes).ok_or_else(|| {
+            Error::invalid_input(format!(
+                "decoded window byte estimate overflows at partition {}",
+                end_partition_id
+            ))
+        })?;
+        end_partition_id += 1;
+
+        // A partition that exceeds the budget must make progress as a
+        // singleton. Otherwise stop as soon as the target has been filled.
+        if decoded_bytes >= max_decoded_bytes {
+            break;
+        }
+    }
+    Ok(end_partition_id)
+}
+
+type PartitionWindowReadPlan = (Vec<Range<u64>>, Vec<Vec<usize>>);
+
+fn preloaded_window_ranges(
+    offsets: &[u64],
+    num_batches: usize,
+    num_partitions: usize,
+    partition_range: Range<usize>,
+) -> Result<PartitionWindowReadPlan> {
+    let window_len = partition_range.end - partition_range.start;
+    let mut ranges = Vec::with_capacity(num_batches);
+    let mut group_partition_counts = Vec::with_capacity(num_batches);
+
+    for batch_idx in 0..num_batches {
+        let group_base = batch_idx * num_partitions;
+        let range_start_index = group_base + partition_range.start;
+        let range_start = if range_start_index == 0 {
+            0
+        } else {
+            offsets[range_start_index - 1]
+        };
+        let range_end = offsets[group_base + partition_range.end - 1];
+        if range_start == range_end {
+            continue;
+        }
+
+        let mut counts = Vec::with_capacity(window_len);
+        let mut previous = range_start;
+        for partition_id in partition_range.clone() {
+            let end = offsets[group_base + partition_id];
+            let count = usize::try_from(end - previous).map_err(|_| {
+                Error::corrupt_file_named(
+                    "shuffle_offsets.lance",
+                    format!(
+                        "row count {} for flush group {} partition {} cannot be represented as usize",
+                        end - previous,
+                        batch_idx,
+                        partition_id
+                    ),
+                )
+            })?;
+            counts.push(count);
+            previous = end;
+        }
+        ranges.push(range_start..range_end);
+        group_partition_counts.push(counts);
+    }
+    Ok((ranges, group_partition_counts))
+}
+
+async fn split_partition_window_stream<S>(
+    mut stream: S,
+    window_len: usize,
+    group_partition_counts: &[Vec<usize>],
+) -> Result<Vec<Vec<RecordBatch>>>
+where
+    S: Stream<Item = Result<RecordBatch>> + Unpin,
+{
+    let expected_rows = group_partition_counts
+        .iter()
+        .flatten()
+        .try_fold(0usize, |total, count| total.checked_add(*count))
+        .ok_or_else(|| {
+            Error::corrupt_file_named("shuffle_data.lance", "window row count overflows usize")
+        })?;
+    let mut segments = group_partition_counts
+        .iter()
+        .flat_map(|counts| counts.iter().copied().enumerate())
+        .filter(|(_, count)| *count != 0);
+    let mut current_segment = segments.next();
+    let mut segment_rows_read = 0usize;
+    let mut actual_rows = 0usize;
+    let mut partition_batches = vec![Vec::new(); window_len];
+
+    while let Some(batch) = stream.try_next().await? {
+        let mut batch_offset = 0usize;
+        while batch_offset < batch.num_rows() {
+            let Some((partition_offset, segment_rows)) = current_segment else {
+                return Err(Error::corrupt_file_named(
+                    "shuffle_data.lance",
+                    format!(
+                        "decoded more than the expected {} rows for partition window",
+                        expected_rows
+                    ),
+                ));
+            };
+            let remaining_in_segment = segment_rows - segment_rows_read;
+            let rows_to_take = remaining_in_segment.min(batch.num_rows() - batch_offset);
+            partition_batches[partition_offset].push(batch.slice(batch_offset, rows_to_take));
+            batch_offset += rows_to_take;
+            actual_rows = actual_rows.checked_add(rows_to_take).ok_or_else(|| {
+                Error::corrupt_file_named(
+                    "shuffle_data.lance",
+                    "decoded window row count overflows usize",
+                )
+            })?;
+            segment_rows_read += rows_to_take;
+            if segment_rows_read == segment_rows {
+                current_segment = segments.next();
+                segment_rows_read = 0;
+            }
+        }
+    }
+
+    if current_segment.is_some() {
+        return Err(Error::corrupt_file_named(
+            "shuffle_data.lance",
+            format!(
+                "decoded {} rows for partition window, expected {}",
+                actual_rows, expected_rows
+            ),
+        ));
+    }
+    Ok(partition_batches)
 }
 
 #[async_trait::async_trait]
@@ -775,6 +1392,91 @@ impl ShuffleReader for TwoFileShuffleReader {
             Arc::new(schema),
             stream,
         ))))
+    }
+
+    async fn read_partition_window(
+        &self,
+        start_partition_id: usize,
+        max_decoded_bytes: usize,
+    ) -> Result<ShufflePartitionWindow> {
+        if max_decoded_bytes == 0 {
+            return Err(Error::invalid_input(
+                "max_decoded_bytes must be greater than 0",
+            ));
+        }
+
+        let ShuffleOffsets::Preloaded(offsets) = &self.offsets else {
+            // The bounded-memory offsets fallback retains the legacy singleton
+            // path because coalescing would otherwise re-read many offset rows.
+            let end = start_partition_id.checked_add(1).ok_or_else(|| {
+                Error::invalid_input(format!(
+                    "start_partition_id={} cannot be advanced",
+                    start_partition_id
+                ))
+            })?;
+            let data = self.read_partition(start_partition_id).await?;
+            return Ok(ShufflePartitionWindow {
+                partition_range: start_partition_id..end,
+                partitions: vec![ShufflePartition {
+                    partition_id: start_partition_id,
+                    data,
+                }],
+            });
+        };
+
+        let end_partition_id = plan_partition_window_end(
+            &self.partition_counts,
+            start_partition_id,
+            self.estimated_row_bytes,
+            max_decoded_bytes,
+        )?;
+        let partition_range = start_partition_id..end_partition_id;
+        let (ranges, group_partition_counts) = preloaded_window_ranges(
+            offsets,
+            self.num_batches,
+            self.num_partitions,
+            partition_range.clone(),
+        )?;
+        let schema: Schema = self.file_reader.schema().as_ref().into();
+        let schema = Arc::new(schema);
+
+        let partition_batches = if ranges.is_empty() {
+            vec![Vec::new(); partition_range.len()]
+        } else {
+            let stream = self
+                .file_reader
+                .read_stream(
+                    ReadBatchParams::Ranges(ranges.into()),
+                    u32::MAX,
+                    16,
+                    FilterExpression::no_filter(),
+                )
+                .await?;
+            split_partition_window_stream(stream, partition_range.len(), &group_partition_counts)
+                .await?
+        };
+
+        let partitions = partition_range
+            .clone()
+            .zip(partition_batches)
+            .map(|(partition_id, batches)| {
+                let data = if batches.is_empty() {
+                    None
+                } else {
+                    let stream = futures::stream::iter(batches.into_iter().map(Ok));
+                    Some(
+                        Box::new(RecordBatchStreamAdapter::new(schema.clone(), stream))
+                            as Box<dyn RecordBatchStream + Unpin + 'static>,
+                    )
+                };
+                ShufflePartition { partition_id, data }
+            })
+            .collect();
+
+        Ok(ShufflePartitionWindow {
+            partition_range,
+            partitions,
+        })
     }
 
     fn partition_size(&self, partition_id: usize) -> Result<usize> {
@@ -845,6 +1547,15 @@ mod tests {
             return None;
         }
         Some(arrow::compute::concat_batches(&batches[0].schema(), &batches).unwrap())
+    }
+
+    async fn collect_values(mut stream: Box<dyn RecordBatchStream + Unpin + 'static>) -> Vec<i32> {
+        let mut values = Vec::new();
+        while let Some(batch) = stream.try_next().await.unwrap() {
+            let batch_values: &Int32Array = batch["val"].as_primitive();
+            values.extend_from_slice(batch_values.values());
+        }
+        values
     }
 
     #[tokio::test]
@@ -1058,6 +1769,306 @@ mod tests {
         assert_eq!(v, vec![30, 40, 80]);
 
         assert!((reader.total_loss().unwrap() - 6.0).abs() < 1e-10);
+    }
+
+    #[tokio::test]
+    async fn test_two_file_shuffler_four_flush_groups_with_empty_partitions() {
+        let dir = TempStrDir::default();
+        let output_dir = Path::from(dir.as_ref());
+        let num_partitions = 5;
+
+        // Each input batch is flushed independently. Partition 4 is empty in
+        // every group, while the other partitions exercise empty ranges at the
+        // beginning, middle, and end of individual groups.
+        let batch1 = make_batch(&[0, 2], &[10, 20], None);
+        let batch2 = make_batch(&[1, 3], &[30, 40], None);
+        let batch3 = make_batch(&[0, 3], &[50, 60], None);
+        let batch4 = make_batch(&[3], &[70], None);
+
+        let shuffler =
+            TwoFileShuffler::new(output_dir.clone(), num_partitions).with_batch_size_bytes(1);
+        let reader = shuffler
+            .shuffle(batches_to_stream(vec![batch1, batch2, batch3, batch4]))
+            .await
+            .unwrap();
+
+        let expected = [vec![10, 50], vec![30], vec![20], vec![40, 60, 70]];
+        for (partition_id, expected_values) in expected.iter().enumerate() {
+            assert_eq!(
+                reader.partition_size(partition_id).unwrap(),
+                expected_values.len()
+            );
+            let partition = collect_partition(reader.as_ref(), partition_id)
+                .await
+                .unwrap();
+            let values: &Int32Array = partition["val"].as_primitive();
+            assert_eq!(values.values(), expected_values);
+        }
+        assert_eq!(reader.partition_size(4).unwrap(), 0);
+        assert!(reader.read_partition(4).await.unwrap().is_none());
+
+        // Force the bounded-memory fallback and verify its u64 range reads
+        // produce the same partition order and empty-partition behavior.
+        let fallback_reader = TwoFileShuffleReader::try_new_with_preload_limit(
+            Arc::new(ObjectStore::local()),
+            output_dir,
+            num_partitions,
+            4,
+            vec![2, 1, 1, 3, 0],
+            0.0,
+            0,
+        )
+        .await
+        .unwrap();
+        for (partition_id, expected_values) in expected.iter().enumerate() {
+            let partition = collect_partition(fallback_reader.as_ref(), partition_id)
+                .await
+                .unwrap();
+            let values: &Int32Array = partition["val"].as_primitive();
+            assert_eq!(values.values(), expected_values);
+        }
+        assert!(fallback_reader.read_partition(4).await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn test_partition_windows_match_singletons_with_hotspot_and_empty_boundaries() {
+        let dir = TempStrDir::default();
+        let output_dir = Path::from(dir.as_ref());
+        let num_partitions = 6;
+
+        // Four flush groups, with empty partitions at the beginning, middle,
+        // and end. Partition 2 is deliberately much larger than its neighbors.
+        let batch1 = make_batch(&[1, 2, 2, 2], &[10, 20, 21, 22], None);
+        let batch2 = make_batch(&[2, 2, 4], &[23, 24, 40], None);
+        let batch3 = make_batch(&[1, 2, 2], &[11, 25, 26], None);
+        let batch4 = make_batch(&[2, 2, 2], &[27, 28, 29], None);
+        let reader = TwoFileShuffler::new(output_dir, num_partitions)
+            .with_batch_size_bytes(1)
+            .shuffle(batches_to_stream(vec![batch1, batch2, batch3, batch4]))
+            .await
+            .unwrap();
+
+        let mut singleton_values = Vec::with_capacity(num_partitions);
+        for partition_id in 0..num_partitions {
+            let values = match reader.read_partition(partition_id).await.unwrap() {
+                Some(stream) => collect_values(stream).await,
+                None => Vec::new(),
+            };
+            singleton_values.push(values);
+        }
+
+        // The decoded schema is one Int32 (4 bytes). A 12-byte target fits the
+        // first empty + two-row partition, while the ten-row hotspot is forced
+        // into a singleton window.
+        let mut next_partition_id = 0;
+        let mut ranges = Vec::new();
+        let mut window_values = vec![Vec::new(); num_partitions];
+        while next_partition_id < num_partitions {
+            let window = reader
+                .read_partition_window(next_partition_id, 12)
+                .await
+                .unwrap();
+            assert_eq!(window.partitions.len(), window.partition_range.len());
+            ranges.push(window.partition_range.clone());
+            next_partition_id = window.partition_range.end;
+            for partition in window.partitions {
+                if let Some(stream) = partition.data {
+                    window_values[partition.partition_id] = collect_values(stream).await;
+                }
+            }
+        }
+
+        assert_eq!(ranges, vec![0..2, 2..3, 3..6]);
+        assert_eq!(window_values, singleton_values);
+        assert_eq!(window_values[0], Vec::<i32>::new());
+        assert_eq!(window_values[2].len(), 10);
+        assert_eq!(window_values[5], Vec::<i32>::new());
+    }
+
+    #[tokio::test]
+    async fn test_on_demand_offsets_window_falls_back_to_singleton() {
+        let dir = TempStrDir::default();
+        let output_dir = Path::from(dir.as_ref());
+        let reader = TwoFileShuffler::new(output_dir.clone(), 3)
+            .with_batch_size_bytes(1)
+            .shuffle(batches_to_stream(vec![
+                make_batch(&[0, 1], &[10, 20], None),
+                make_batch(&[1, 2], &[30, 40], None),
+            ]))
+            .await
+            .unwrap();
+        drop(reader);
+
+        let fallback_reader = TwoFileShuffleReader::try_new_with_preload_limit(
+            Arc::new(ObjectStore::local()),
+            output_dir,
+            3,
+            2,
+            vec![1, 2, 1],
+            0.0,
+            0,
+        )
+        .await
+        .unwrap();
+        let window = fallback_reader
+            .read_partition_window(1, DEFAULT_PARTITION_WINDOW_BYTES)
+            .await
+            .unwrap();
+        assert_eq!(window.partition_range, 1..2);
+        assert_eq!(window.partitions.len(), 1);
+        assert_eq!(window.partitions[0].partition_id, 1);
+    }
+
+    #[test]
+    fn test_window_planning_uses_decoded_bytes_and_isolates_hotspot() {
+        let partition_counts = [0, 2, 10, 0, 1, 0];
+        assert_eq!(
+            plan_partition_window_end(&partition_counts, 0, 4, 12).unwrap(),
+            2
+        );
+        assert_eq!(
+            plan_partition_window_end(&partition_counts, 2, 4, 12).unwrap(),
+            3
+        );
+        assert_eq!(
+            plan_partition_window_end(&partition_counts, 3, 4, 12).unwrap(),
+            6
+        );
+
+        let error = plan_partition_window_end(&partition_counts, 0, 4, 0).unwrap_err();
+        assert!(matches!(error, Error::InvalidInput { .. }));
+        assert!(error.to_string().contains("must be greater than 0"));
+    }
+
+    #[test]
+    fn test_preloaded_window_ranges_coalesce_each_nonempty_flush_group() {
+        // Three groups x five partitions. Window [1, 4) is empty in the last
+        // group, so only two ranges are submitted.
+        let offsets = [1, 3, 3, 4, 4, 4, 4, 6, 7, 8, 9, 9, 9, 9, 10];
+        let (ranges, counts) = preloaded_window_ranges(&offsets, 3, 5, 1..4).unwrap();
+        assert_eq!(ranges, vec![1..4, 4..7]);
+        assert_eq!(counts, vec![vec![2, 0, 1], vec![0, 2, 1]]);
+    }
+
+    #[tokio::test]
+    async fn test_partition_window_split_rejects_short_and_extra_rows() {
+        let data = make_batch(&[0, 0, 0, 0, 0], &[10, 20, 30, 40, 50], None)
+            .drop_column(PART_ID_COLUMN)
+            .unwrap();
+        let group_counts = vec![vec![1, 2], vec![0, 1]];
+
+        let short_stream = stream::iter(vec![Ok(data.slice(0, 3))]);
+        let error = split_partition_window_stream(short_stream, 2, &group_counts)
+            .await
+            .unwrap_err();
+        assert!(matches!(error, Error::CorruptFile { .. }));
+        assert!(
+            error
+                .to_string()
+                .contains("decoded 3 rows for partition window, expected 4"),
+            "unexpected error: {error}"
+        );
+
+        let extra_stream = stream::iter(vec![Ok(data)]);
+        let error = split_partition_window_stream(extra_stream, 2, &group_counts)
+            .await
+            .unwrap_err();
+        assert!(matches!(error, Error::CorruptFile { .. }));
+        assert!(
+            error
+                .to_string()
+                .contains("decoded more than the expected 4 rows"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_partition_window_split_propagates_stream_error() {
+        let injected = Error::io("injected window read failure");
+        let error = split_partition_window_stream(stream::iter(vec![Err(injected)]), 1, &[vec![1]])
+            .await
+            .unwrap_err();
+        assert!(matches!(error, Error::IO { .. }));
+        assert!(error.to_string().contains("injected window read failure"));
+    }
+
+    #[test]
+    fn test_validate_shuffle_offsets_rejects_truncated_offsets() {
+        let offsets_path = Path::from("shuffle_offsets.lance");
+        let offsets = [2, 2, 3, 3, 3, 6, 6, 7, 8, 8, 8];
+        let error =
+            validate_shuffle_offsets(&offsets, 3, 4, 10, &[3, 3, 1, 3], &offsets_path).unwrap_err();
+
+        assert!(matches!(error, Error::CorruptFile { .. }));
+        assert!(
+            error
+                .to_string()
+                .contains("decoded 11 offsets, expected 12"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn test_validate_shuffle_offsets_rejects_non_monotonic_offsets() {
+        let offsets_path = Path::from("shuffle_offsets.lance");
+        let offsets = [2, 2, 3, 3, 3, 2, 6, 7, 8, 8, 8, 10];
+        let error =
+            validate_shuffle_offsets(&offsets, 3, 4, 10, &[3, 3, 1, 3], &offsets_path).unwrap_err();
+
+        assert!(matches!(error, Error::CorruptFile { .. }));
+        assert!(
+            error
+                .to_string()
+                .contains("offsets are not monotonic at indices 4 and 5: 3 > 2"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn test_validate_shuffle_offsets_rejects_data_boundary_mismatch() {
+        let offsets_path = Path::from("shuffle_offsets.lance");
+        let offsets = [2, 2, 3, 3, 3, 6, 6, 7, 8, 8, 8, 11];
+        let error =
+            validate_shuffle_offsets(&offsets, 3, 4, 10, &[3, 3, 1, 4], &offsets_path).unwrap_err();
+
+        assert!(matches!(error, Error::CorruptFile { .. }));
+        assert!(
+            error
+                .to_string()
+                .contains("final offset 11 does not match shuffle data row count 10"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn test_validate_shuffle_offsets_checks_partition_counts() {
+        let offsets_path = Path::from("shuffle_offsets.lance");
+        let offsets = [2, 2, 3, 3, 3, 6, 6, 7, 8, 8, 8, 10];
+        let error =
+            validate_shuffle_offsets(&offsets, 3, 4, 10, &[3, 2, 1, 4], &offsets_path).unwrap_err();
+
+        assert!(matches!(error, Error::CorruptFile { .. }));
+        assert!(
+            error
+                .to_string()
+                .contains("offset-derived count 3 for partition 1 does not match expected count 2"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn test_should_preload_offsets_enforces_byte_limit_and_checks_overflow() {
+        assert!(should_preload_offsets(4, 4 * std::mem::size_of::<u64>()).unwrap());
+        assert!(!should_preload_offsets(5, 4 * std::mem::size_of::<u64>()).unwrap());
+
+        let error = should_preload_offsets(usize::MAX, usize::MAX).unwrap_err();
+        assert!(matches!(error, Error::InvalidInput { .. }));
+        assert!(
+            error
+                .to_string()
+                .contains("overflows byte-size calculation"),
+            "unexpected error: {error}"
+        );
     }
 
     #[tokio::test]

--- a/rust/lance/src/index/vector.rs
+++ b/rust/lance/src/index/vector.rs
@@ -8,6 +8,7 @@ use lance_core::utils::row_addr_remap::RowAddrRemap;
 use std::sync::Arc;
 use std::{any::Any, collections::HashMap};
 
+mod bounded_partition_stream;
 pub mod builder;
 pub(crate) mod details;
 pub mod hamming;

--- a/rust/lance/src/index/vector/bounded_partition_stream.rs
+++ b/rust/lance/src/index/vector/bounded_partition_stream.rs
@@ -1,0 +1,501 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+use std::collections::BTreeMap;
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::task::{Context, Poll};
+
+use futures::future::BoxFuture;
+use futures::stream::FuturesUnordered;
+use futures::task::AtomicWaker;
+use futures::{Stream, StreamExt};
+use lance_core::{Error, Result};
+
+/// Work admitted to [`BoundedPartitionStream`].
+pub(super) struct WeightedJob<T> {
+    weight_bytes: usize,
+    future: BoxFuture<'static, Result<T>>,
+}
+
+impl<T> WeightedJob<T> {
+    pub(super) fn new(
+        weight_bytes: usize,
+        future: impl Future<Output = Result<T>> + Send + 'static,
+    ) -> Self {
+        Self {
+            weight_bytes,
+            future: Box::pin(future),
+        }
+    }
+}
+
+/// A completed job whose admission charge remains held until the result is dropped.
+///
+/// Keeping the permit with a result bounds both active builds and results waiting for
+/// an earlier partition to finish.
+pub(super) struct Budgeted<T> {
+    pub(super) value: T,
+    pub(super) _permit: Option<AdmissionPermit>,
+}
+
+impl<T> Budgeted<T> {
+    pub(super) fn untracked(value: T) -> Self {
+        Self {
+            value,
+            _permit: None,
+        }
+    }
+}
+
+/// Buffers out-of-order partition results and exposes only the next id to write.
+pub(super) struct OrderedPartitionResults<T> {
+    next_partition_id: usize,
+    num_partitions: usize,
+    pending: BTreeMap<usize, T>,
+}
+
+impl<T> OrderedPartitionResults<T> {
+    pub(super) fn new(num_partitions: usize) -> Self {
+        Self {
+            next_partition_id: 0,
+            num_partitions,
+            pending: BTreeMap::new(),
+        }
+    }
+
+    pub(super) fn push(&mut self, partition_id: usize, value: T) -> Result<()> {
+        if partition_id >= self.num_partitions {
+            return Err(Error::internal(format!(
+                "partition build returned out-of-range partition id {} for {} partitions",
+                partition_id, self.num_partitions
+            )));
+        }
+        if partition_id < self.next_partition_id
+            || self.pending.insert(partition_id, value).is_some()
+        {
+            return Err(Error::internal(format!(
+                "partition build returned duplicate partition id {}",
+                partition_id
+            )));
+        }
+        Ok(())
+    }
+
+    pub(super) fn pop_next(&mut self) -> Option<(usize, T)> {
+        let partition_id = self.next_partition_id;
+        let value = self.pending.remove(&partition_id)?;
+        self.next_partition_id += 1;
+        Some((partition_id, value))
+    }
+
+    pub(super) fn finish(&self) -> Result<()> {
+        if self.next_partition_id != self.num_partitions {
+            return Err(Error::internal(format!(
+                "partition build stream ended before partition {} of {}; buffered partition ids: {:?}",
+                self.next_partition_id,
+                self.num_partitions,
+                self.pending.keys().copied().collect::<Vec<_>>()
+            )));
+        }
+        Ok(())
+    }
+}
+
+pub(super) struct AdmissionPermit {
+    budget: Arc<Budget>,
+    charged_bytes: usize,
+}
+
+impl Drop for AdmissionPermit {
+    fn drop(&mut self) {
+        self.budget
+            .current_bytes
+            .fetch_sub(self.charged_bytes, Ordering::AcqRel);
+        self.budget.current_entries.fetch_sub(1, Ordering::AcqRel);
+        self.budget.waker.wake();
+    }
+}
+
+struct Budget {
+    max_bytes: usize,
+    max_entries: usize,
+    current_bytes: AtomicUsize,
+    current_entries: AtomicUsize,
+    waker: AtomicWaker,
+    #[cfg(test)]
+    peak_bytes: AtomicUsize,
+    #[cfg(test)]
+    peak_entries: AtomicUsize,
+}
+
+impl Budget {
+    fn can_admit(&self, weight_bytes: usize) -> bool {
+        let current_bytes = self.current_bytes.load(Ordering::Acquire);
+        let current_entries = self.current_entries.load(Ordering::Acquire);
+        if current_entries >= self.max_entries {
+            return false;
+        }
+        if weight_bytes > self.max_bytes {
+            // An oversized (hotspot) partition is charged at the cap and must run
+            // alone. It cannot strand the oldest partition behind later work.
+            return current_entries == 0;
+        }
+        current_bytes
+            .checked_add(weight_bytes)
+            .is_some_and(|total| total <= self.max_bytes)
+    }
+
+    fn admit(self: &Arc<Self>, weight_bytes: usize) -> AdmissionPermit {
+        let charged_bytes = weight_bytes.min(self.max_bytes);
+        let current_bytes = self
+            .current_bytes
+            .fetch_add(charged_bytes, Ordering::AcqRel)
+            + charged_bytes;
+        let current_entries = self.current_entries.fetch_add(1, Ordering::AcqRel) + 1;
+        #[cfg(not(test))]
+        let _ = (current_bytes, current_entries);
+        #[cfg(test)]
+        {
+            self.peak_bytes.fetch_max(current_bytes, Ordering::AcqRel);
+            self.peak_entries
+                .fetch_max(current_entries, Ordering::AcqRel);
+        }
+        AdmissionPermit {
+            budget: self.clone(),
+            charged_bytes,
+        }
+    }
+}
+
+/// Runs partition jobs out of order while bounding active and completed work.
+///
+/// The input is polled in partition order. A job is admitted only when both its
+/// byte charge and the total number of active/completed entries fit. Oversized
+/// jobs are charged at the byte cap and admitted only when the budget is empty.
+pub(super) struct BoundedPartitionStream<S, T> {
+    input: S,
+    pending: Option<WeightedJob<T>>,
+    in_flight: FuturesUnordered<BoxFuture<'static, Result<Budgeted<T>>>>,
+    budget: Arc<Budget>,
+    max_concurrency: usize,
+    is_input_done: bool,
+    is_failed: bool,
+}
+
+impl<S, T> BoundedPartitionStream<S, T>
+where
+    S: Stream<Item = Result<WeightedJob<T>>> + Unpin,
+{
+    pub(super) fn try_new(
+        input: S,
+        max_concurrency: usize,
+        max_bytes: usize,
+        max_entries: usize,
+    ) -> Result<Self> {
+        if max_concurrency == 0 || max_bytes == 0 || max_entries == 0 {
+            return Err(Error::invalid_input(format!(
+                "bounded partition stream limits must be non-zero: max_concurrency={}, max_bytes={}, max_entries={}",
+                max_concurrency, max_bytes, max_entries
+            )));
+        }
+        Ok(Self {
+            input,
+            pending: None,
+            in_flight: FuturesUnordered::new(),
+            budget: Arc::new(Budget {
+                max_bytes,
+                max_entries,
+                current_bytes: AtomicUsize::new(0),
+                current_entries: AtomicUsize::new(0),
+                waker: AtomicWaker::new(),
+                #[cfg(test)]
+                peak_bytes: AtomicUsize::new(0),
+                #[cfg(test)]
+                peak_entries: AtomicUsize::new(0),
+            }),
+            max_concurrency,
+            is_input_done: false,
+            is_failed: false,
+        })
+    }
+
+    fn fail(&mut self) {
+        self.is_failed = true;
+        self.pending = None;
+        self.in_flight = FuturesUnordered::new();
+    }
+
+    #[cfg(test)]
+    fn stats(&self) -> (usize, usize, usize, usize) {
+        (
+            self.budget.current_bytes.load(Ordering::Acquire),
+            self.budget.peak_bytes.load(Ordering::Acquire),
+            self.budget.current_entries.load(Ordering::Acquire),
+            self.budget.peak_entries.load(Ordering::Acquire),
+        )
+    }
+}
+
+impl<S, T: 'static> Stream for BoundedPartitionStream<S, T>
+where
+    S: Stream<Item = Result<WeightedJob<T>>> + Unpin,
+{
+    type Item = Result<Budgeted<T>>;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        if self.is_failed {
+            return Poll::Ready(None);
+        }
+        self.budget.waker.register(cx.waker());
+
+        loop {
+            if self.in_flight.len() >= self.max_concurrency {
+                break;
+            }
+
+            if let Some(job) = self.pending.take() {
+                if !self.budget.can_admit(job.weight_bytes) {
+                    self.pending = Some(job);
+                    break;
+                }
+                let permit = self.budget.admit(job.weight_bytes);
+                self.in_flight.push(Box::pin(async move {
+                    job.future.await.map(|value| Budgeted {
+                        value,
+                        _permit: Some(permit),
+                    })
+                }));
+                continue;
+            }
+
+            if self.is_input_done {
+                break;
+            }
+            match Pin::new(&mut self.input).poll_next(cx) {
+                Poll::Ready(Some(Ok(job))) => self.pending = Some(job),
+                Poll::Ready(Some(Err(error))) => {
+                    self.fail();
+                    return Poll::Ready(Some(Err(error)));
+                }
+                Poll::Ready(None) => self.is_input_done = true,
+                Poll::Pending => break,
+            }
+        }
+
+        match self.in_flight.poll_next_unpin(cx) {
+            Poll::Ready(Some(Ok(output))) => Poll::Ready(Some(Ok(output))),
+            Poll::Ready(Some(Err(error))) => {
+                self.fail();
+                Poll::Ready(Some(Err(error)))
+            }
+            Poll::Ready(None) if self.is_input_done && self.pending.is_none() => Poll::Ready(None),
+            Poll::Ready(None) | Poll::Pending => Poll::Pending,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::time::Duration;
+
+    use futures::StreamExt;
+    use futures::stream;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn slow_head_does_not_block_later_jobs() {
+        let jobs = (0..4).map(|partition_id| {
+            Ok(WeightedJob::new(1, async move {
+                tokio::time::sleep(Duration::from_millis(if partition_id == 0 {
+                    40
+                } else {
+                    1
+                }))
+                .await;
+                Ok(partition_id)
+            }))
+        });
+        let mut output = BoundedPartitionStream::try_new(stream::iter(jobs), 4, 4, 4).unwrap();
+        let first = output.next().await.unwrap().unwrap();
+        assert_ne!(first.value, 0);
+        let mut completed = vec![first.value];
+        completed.extend(
+            output
+                .map(|result| result.unwrap().value)
+                .collect::<Vec<_>>()
+                .await,
+        );
+        completed.sort_unstable();
+        assert_eq!(completed, vec![0, 1, 2, 3]);
+    }
+
+    #[tokio::test]
+    async fn byte_and_entry_caps_include_completed_results() {
+        let jobs =
+            (0..5).map(|partition_id| Ok(WeightedJob::new(3, async move { Ok(partition_id) })));
+        let mut output = BoundedPartitionStream::try_new(stream::iter(jobs), 5, 6, 2).unwrap();
+        let first = output.next().await.unwrap().unwrap();
+        let second = output.next().await.unwrap().unwrap();
+        let (_, peak_bytes, current_entries, peak_entries) = output.stats();
+        assert_eq!(peak_bytes, 6);
+        assert_eq!(current_entries, 2);
+        assert_eq!(peak_entries, 2);
+        drop((first, second));
+        let mut remaining = 0;
+        while let Some(result) = output.next().await {
+            drop(result.unwrap());
+            remaining += 1;
+        }
+        assert_eq!(remaining, 3);
+        let (current_bytes, peak_bytes, current_entries, peak_entries) = output.stats();
+        assert_eq!(current_bytes, 0);
+        assert_eq!(peak_bytes, 6);
+        assert_eq!(current_entries, 0);
+        assert_eq!(peak_entries, 2);
+    }
+
+    #[tokio::test]
+    async fn oversized_job_is_exclusive() {
+        let jobs = vec![
+            Ok(WeightedJob::new(2, async { Ok(0) })),
+            Ok(WeightedJob::new(20, async { Ok(1) })),
+            Ok(WeightedJob::new(2, async { Ok(2) })),
+        ];
+        let mut output = BoundedPartitionStream::try_new(stream::iter(jobs), 3, 8, 3).unwrap();
+        let first = output.next().await.unwrap().unwrap();
+        assert_eq!(first.value, 0);
+        drop(first);
+        let oversized = output.next().await.unwrap().unwrap();
+        assert_eq!(oversized.value, 1);
+        let (current_bytes, peak_bytes, current_entries, _) = output.stats();
+        assert_eq!(current_bytes, 8);
+        assert_eq!(peak_bytes, 8);
+        assert_eq!(current_entries, 1);
+        drop(oversized);
+        assert_eq!(output.next().await.unwrap().unwrap().value, 2);
+    }
+
+    #[tokio::test]
+    async fn dropping_a_held_result_wakes_budget_blocked_stream() {
+        let jobs = vec![
+            Ok(WeightedJob::new(1, async { Ok(0) })),
+            Ok(WeightedJob::new(1, async { Ok(1) })),
+        ];
+        let mut output = BoundedPartitionStream::try_new(stream::iter(jobs), 2, 1, 1).unwrap();
+        let first = output.next().await.unwrap().unwrap();
+        let next = output.next();
+        tokio::pin!(next);
+        assert!(
+            tokio::time::timeout(Duration::from_millis(10), &mut next)
+                .await
+                .is_err()
+        );
+        drop(first);
+        let second = tokio::time::timeout(Duration::from_millis(100), &mut next)
+            .await
+            .unwrap()
+            .unwrap()
+            .unwrap();
+        assert_eq!(second.value, 1);
+    }
+
+    #[tokio::test]
+    async fn error_drops_pending_work() {
+        let was_dropped = Arc::new(AtomicBool::new(false));
+        struct DropFlag(Arc<AtomicBool>);
+        impl Drop for DropFlag {
+            fn drop(&mut self) {
+                self.0.store(true, Ordering::Release);
+            }
+        }
+
+        let guard = DropFlag(was_dropped.clone());
+        let jobs = vec![
+            Ok(WeightedJob::new(1, async {
+                Err::<usize, _>(Error::internal("build failed"))
+            })),
+            Ok(WeightedJob::new(1, async move {
+                let _guard = guard;
+                futures::future::pending::<()>().await;
+                Ok(1)
+            })),
+        ];
+        let mut output = BoundedPartitionStream::try_new(stream::iter(jobs), 2, 2, 2).unwrap();
+        let Err(error) = output.next().await.unwrap() else {
+            panic!("expected build failure");
+        };
+        assert!(error.to_string().contains("build failed"));
+        assert!(was_dropped.load(Ordering::Acquire));
+        assert!(output.next().await.is_none());
+    }
+
+    #[tokio::test]
+    async fn dropping_stream_cancels_in_flight_work() {
+        let was_dropped = Arc::new(AtomicBool::new(false));
+        struct DropFlag(Arc<AtomicBool>);
+        impl Drop for DropFlag {
+            fn drop(&mut self) {
+                self.0.store(true, Ordering::Release);
+            }
+        }
+
+        let guard = DropFlag(was_dropped.clone());
+        let jobs = vec![Ok(WeightedJob::new(1, async move {
+            let _guard = guard;
+            futures::future::pending::<()>().await;
+            Ok(0)
+        }))];
+        let mut output = BoundedPartitionStream::try_new(stream::iter(jobs), 1, 1, 1).unwrap();
+        assert!(
+            tokio::time::timeout(Duration::from_millis(10), output.next())
+                .await
+                .is_err()
+        );
+        drop(output);
+        assert!(was_dropped.load(Ordering::Acquire));
+    }
+
+    #[test]
+    fn ordered_results_drain_in_partition_order_and_include_empty_values() {
+        let mut results = OrderedPartitionResults::new(4);
+        results.push(2, Some(2)).unwrap();
+        assert!(results.pop_next().is_none());
+        results.push(0, Some(0)).unwrap();
+        assert_eq!(results.pop_next(), Some((0, Some(0))));
+        results.push(1, None).unwrap();
+        assert_eq!(results.pop_next(), Some((1, None)));
+        assert_eq!(results.pop_next(), Some((2, Some(2))));
+        results.push(3, Some(3)).unwrap();
+        assert_eq!(results.pop_next(), Some((3, Some(3))));
+        results.finish().unwrap();
+    }
+
+    #[test]
+    fn ordered_results_reject_duplicate_out_of_range_and_missing() {
+        let mut pending_duplicate = OrderedPartitionResults::new(2);
+        pending_duplicate.push(1, 1).unwrap();
+        let error = pending_duplicate.push(1, 1).unwrap_err();
+        assert!(error.to_string().contains("duplicate partition id 1"));
+
+        let mut written_duplicate = OrderedPartitionResults::new(2);
+        written_duplicate.push(0, 0).unwrap();
+        assert_eq!(written_duplicate.pop_next(), Some((0, 0)));
+        let error = written_duplicate.push(0, 0).unwrap_err();
+        assert!(error.to_string().contains("duplicate partition id 0"));
+
+        let mut out_of_range = OrderedPartitionResults::new(2);
+        let error = out_of_range.push(2, 2).unwrap_err();
+        assert!(error.to_string().contains("out-of-range partition id 2"));
+
+        let mut missing = OrderedPartitionResults::new(3);
+        missing.push(1, 1).unwrap();
+        let error = missing.finish().unwrap_err();
+        assert!(error.to_string().contains("ended before partition 0 of 3"));
+        assert!(error.to_string().contains("[1]"));
+    }
+}

--- a/rust/lance/src/index/vector/bounded_partition_stream.rs
+++ b/rust/lance/src/index/vector/bounded_partition_stream.rs
@@ -15,19 +15,39 @@ use futures::{Stream, StreamExt};
 use lance_core::{Error, Result};
 
 /// Work admitted to [`BoundedPartitionStream`].
+type WeightedJobStarter<T> = Box<
+    dyn FnOnce(AdmissionPermit) -> BoxFuture<'static, Result<(T, AdmissionPermit)>>
+        + Send
+        + 'static,
+>;
+
 pub(super) struct WeightedJob<T> {
     weight_bytes: usize,
-    future: BoxFuture<'static, Result<T>>,
+    start: WeightedJobStarter<T>,
 }
 
 impl<T> WeightedJob<T> {
+    #[cfg(test)]
     pub(super) fn new(
         weight_bytes: usize,
         future: impl Future<Output = Result<T>> + Send + 'static,
     ) -> Self {
         Self {
             weight_bytes,
-            future: Box::pin(future),
+            start: Box::new(move |permit| {
+                Box::pin(async move { future.await.map(|value| (value, permit)) })
+            }),
+        }
+    }
+
+    pub(super) fn with_permit<F, Fut>(weight_bytes: usize, start: F) -> Self
+    where
+        F: FnOnce(AdmissionPermit) -> Fut + Send + 'static,
+        Fut: Future<Output = Result<(T, AdmissionPermit)>> + Send + 'static,
+    {
+        Self {
+            weight_bytes,
+            start: Box::new(move |permit| Box::pin(start(permit))),
         }
     }
 }
@@ -38,7 +58,7 @@ impl<T> WeightedJob<T> {
 /// an earlier partition to finish.
 pub(super) struct Budgeted<T> {
     pub(super) value: T,
-    pub(super) _permit: Option<AdmissionPermit>,
+    pub(super) _permit: Option<Arc<AdmissionPermit>>,
 }
 
 impl<T> Budgeted<T> {
@@ -107,6 +127,41 @@ impl<T> OrderedPartitionResults<T> {
 pub(super) struct AdmissionPermit {
     budget: Arc<Budget>,
     charged_bytes: usize,
+}
+
+impl AdmissionPermit {
+    /// Reconcile the pre-decode admission charge to the materialized size.
+    ///
+    /// Oversized values remain charged at the cap. Estimates are conservative,
+    /// so this normally releases capacity; an underestimate is still reflected
+    /// in the budget to prevent admitting additional work against stale usage.
+    pub(super) fn reconcile(&mut self, actual_bytes: usize) {
+        let charged_bytes = actual_bytes.min(self.budget.max_bytes);
+        match charged_bytes.cmp(&self.charged_bytes) {
+            std::cmp::Ordering::Less => {
+                self.budget
+                    .current_bytes
+                    .fetch_sub(self.charged_bytes - charged_bytes, Ordering::AcqRel);
+            }
+            std::cmp::Ordering::Greater => {
+                let additional_bytes = charged_bytes - self.charged_bytes;
+                let current_bytes = self
+                    .budget
+                    .current_bytes
+                    .fetch_add(additional_bytes, Ordering::AcqRel)
+                    + additional_bytes;
+                #[cfg(not(test))]
+                let _ = current_bytes;
+                #[cfg(test)]
+                self.budget
+                    .peak_bytes
+                    .fetch_max(current_bytes, Ordering::AcqRel);
+            }
+            std::cmp::Ordering::Equal => {}
+        }
+        self.charged_bytes = charged_bytes;
+        self.budget.waker.wake();
+    }
 }
 
 impl Drop for AdmissionPermit {
@@ -262,10 +317,11 @@ where
                     break;
                 }
                 let permit = self.budget.admit(job.weight_bytes);
+                let future = (job.start)(permit);
                 self.in_flight.push(Box::pin(async move {
-                    job.future.await.map(|value| Budgeted {
+                    future.await.map(|(value, permit)| Budgeted {
                         value,
-                        _permit: Some(permit),
+                        _permit: Some(Arc::new(permit)),
                     })
                 }));
                 continue;
@@ -378,6 +434,65 @@ mod tests {
         assert_eq!(current_entries, 1);
         drop(oversized);
         assert_eq!(output.next().await.unwrap().unwrap().value, 2);
+    }
+
+    #[tokio::test]
+    async fn oversized_materialization_starts_only_after_exclusive_admission() {
+        let oversized_materialized = Arc::new(AtomicBool::new(false));
+        let marker = oversized_materialized.clone();
+        let jobs = vec![
+            Ok(WeightedJob::new(2, async { Ok(0) })),
+            Ok(WeightedJob::with_permit(
+                20,
+                move |mut admission| async move {
+                    marker.store(true, Ordering::Release);
+                    admission.reconcile(20);
+                    Ok((1, admission))
+                },
+            )),
+        ];
+        let mut output = BoundedPartitionStream::try_new(stream::iter(jobs), 2, 8, 2).unwrap();
+
+        let first = output.next().await.unwrap().unwrap();
+        assert_eq!(first.value, 0);
+        assert!(!oversized_materialized.load(Ordering::Acquire));
+
+        drop(first);
+        let oversized = output.next().await.unwrap().unwrap();
+        assert_eq!(oversized.value, 1);
+        assert!(oversized_materialized.load(Ordering::Acquire));
+        let (current_bytes, peak_bytes, current_entries, _) = output.stats();
+        assert_eq!(current_bytes, 8);
+        assert_eq!(peak_bytes, 8);
+        assert_eq!(current_entries, 1);
+    }
+
+    #[tokio::test]
+    async fn actual_size_reconciliation_releases_admission_capacity() {
+        let jobs = vec![
+            Ok(WeightedJob::with_permit(8, |mut admission| async move {
+                admission.reconcile(2);
+                Ok((0, admission))
+            })),
+            Ok(WeightedJob::new(6, async { Ok(1) })),
+        ];
+        let mut output = BoundedPartitionStream::try_new(stream::iter(jobs), 2, 8, 2).unwrap();
+
+        let first = output.next().await.unwrap().unwrap();
+        assert_eq!(first.value, 0);
+        let (current_bytes, peak_bytes, current_entries, peak_entries) = output.stats();
+        assert_eq!(current_bytes, 2);
+        assert_eq!(peak_bytes, 8);
+        assert_eq!(current_entries, 1);
+        assert_eq!(peak_entries, 1);
+
+        let second = output.next().await.unwrap().unwrap();
+        assert_eq!(second.value, 1);
+        let (current_bytes, _, current_entries, peak_entries) = output.stats();
+        assert_eq!(current_bytes, 8);
+        assert_eq!(current_entries, 2);
+        assert_eq!(peak_entries, 2);
+        drop((first, second));
     }
 
     #[tokio::test]

--- a/rust/lance/src/index/vector/bounded_partition_stream.rs
+++ b/rust/lance/src/index/vector/bounded_partition_stream.rs
@@ -59,16 +59,16 @@ impl<T> WeightedJob<T> {
 /// an earlier partition to finish.
 pub(super) struct Budgeted<T> {
     pub(super) value: T,
-    pub(super) _permit: Option<Arc<AdmissionPermit>>,
-    pub(super) _entry_permit: Option<OwnedSemaphorePermit>,
+    pub(super) permit: Option<Arc<AdmissionPermit>>,
+    pub(super) entry_permit: Option<OwnedSemaphorePermit>,
 }
 
 impl<T> Budgeted<T> {
     pub(super) fn untracked(value: T) -> Self {
         Self {
             value,
-            _permit: None,
-            _entry_permit: None,
+            permit: None,
+            entry_permit: None,
         }
     }
 }
@@ -324,8 +324,8 @@ where
                 self.in_flight.push(Box::pin(async move {
                     future.await.map(|(value, permit)| Budgeted {
                         value,
-                        _permit: Some(Arc::new(permit)),
-                        _entry_permit: None,
+                        permit: Some(Arc::new(permit)),
+                        entry_permit: None,
                     })
                 }));
                 continue;
@@ -541,14 +541,14 @@ mod tests {
             .map_ok(|window| {
                 let Budgeted {
                     value: builds,
-                    _permit,
-                    _entry_permit,
+                    permit,
+                    entry_permit,
                 } = window;
-                assert!(_entry_permit.is_none());
+                assert!(entry_permit.is_none());
                 builds.map_ok(move |(value, entry_permit)| Budgeted {
                     value,
-                    _permit: _permit.clone(),
-                    _entry_permit: Some(entry_permit),
+                    permit: permit.clone(),
+                    entry_permit: Some(entry_permit),
                 })
             })
             .try_flatten_unordered(Some(1))

--- a/rust/lance/src/index/vector/bounded_partition_stream.rs
+++ b/rust/lance/src/index/vector/bounded_partition_stream.rs
@@ -13,6 +13,7 @@ use futures::stream::FuturesUnordered;
 use futures::task::AtomicWaker;
 use futures::{Stream, StreamExt};
 use lance_core::{Error, Result};
+use tokio::sync::OwnedSemaphorePermit;
 
 /// Work admitted to [`BoundedPartitionStream`].
 type WeightedJobStarter<T> = Box<
@@ -59,6 +60,7 @@ impl<T> WeightedJob<T> {
 pub(super) struct Budgeted<T> {
     pub(super) value: T,
     pub(super) _permit: Option<Arc<AdmissionPermit>>,
+    pub(super) _entry_permit: Option<OwnedSemaphorePermit>,
 }
 
 impl<T> Budgeted<T> {
@@ -66,6 +68,7 @@ impl<T> Budgeted<T> {
         Self {
             value,
             _permit: None,
+            _entry_permit: None,
         }
     }
 }
@@ -322,6 +325,7 @@ where
                     future.await.map(|(value, permit)| Budgeted {
                         value,
                         _permit: Some(Arc::new(permit)),
+                        _entry_permit: None,
                     })
                 }));
                 continue;
@@ -358,8 +362,8 @@ mod tests {
     use std::sync::atomic::{AtomicBool, Ordering};
     use std::time::Duration;
 
-    use futures::StreamExt;
     use futures::stream;
+    use futures::{StreamExt, TryStreamExt};
 
     use super::*;
 
@@ -493,6 +497,79 @@ mod tests {
         assert_eq!(current_entries, 2);
         assert_eq!(peak_entries, 2);
         drop((first, second));
+    }
+
+    #[tokio::test]
+    async fn expanded_window_results_respect_partition_entry_cap() {
+        struct ResidentResult(usize, Arc<AtomicUsize>);
+
+        impl ResidentResult {
+            fn new(value: usize, resident: Arc<AtomicUsize>) -> Self {
+                resident.fetch_add(1, Ordering::AcqRel);
+                Self(value, resident)
+            }
+        }
+
+        impl Drop for ResidentResult {
+            fn drop(&mut self) {
+                self.1.fetch_sub(1, Ordering::AcqRel);
+            }
+        }
+
+        let resident = Arc::new(AtomicUsize::new(0));
+        let partition_entries = Arc::new(tokio::sync::Semaphore::new(1));
+        let resident_for_job = resident.clone();
+        let entries_for_job = partition_entries.clone();
+        let jobs = vec![Ok(WeightedJob::with_permit(
+            1,
+            move |admission| async move {
+                let builds = stream::iter((0..8).map(move |value| {
+                    let resident = resident_for_job.clone();
+                    let partition_entries = entries_for_job.clone();
+                    async move {
+                        let entry_permit = partition_entries.acquire_owned().await.unwrap();
+                        Ok::<_, Error>((ResidentResult::new(value, resident), entry_permit))
+                    }
+                }))
+                .buffer_unordered(8)
+                .boxed();
+                Ok((builds, admission))
+            },
+        ))];
+        let windows = BoundedPartitionStream::try_new(stream::iter(jobs), 1, 1, 1).unwrap();
+        let mut output = windows
+            .map_ok(|window| {
+                let Budgeted {
+                    value: builds,
+                    _permit,
+                    _entry_permit,
+                } = window;
+                assert!(_entry_permit.is_none());
+                builds.map_ok(move |(value, entry_permit)| Budgeted {
+                    value,
+                    _permit: _permit.clone(),
+                    _entry_permit: Some(entry_permit),
+                })
+            })
+            .try_flatten_unordered(Some(1))
+            .boxed();
+
+        let first = output.next().await.unwrap().unwrap();
+        assert!(first.value.0 < 8);
+        assert_eq!(resident.load(Ordering::Acquire), 1);
+        assert!(
+            tokio::time::timeout(Duration::from_millis(10), output.next())
+                .await
+                .is_err()
+        );
+
+        drop(first);
+        while let Some(result) = output.next().await {
+            let result = result.unwrap();
+            assert_eq!(resident.load(Ordering::Acquire), 1);
+            drop(result);
+        }
+        assert_eq!(resident.load(Ordering::Acquire), 0);
     }
 
     #[tokio::test]

--- a/rust/lance/src/index/vector/builder.rs
+++ b/rust/lance/src/index/vector/builder.rs
@@ -270,6 +270,26 @@ type BuildStream<S, Q> =
 
 type FreshWindowBuildStream<S, Q> =
     Pin<Box<dyn Stream<Item = Result<(PartitionBuildResult<S, Q>, OwnedSemaphorePermit)>> + Send>>;
+type PartitionInputAdmissionStream<T> =
+    Pin<Box<dyn Stream<Item = Result<(T, OwnedSemaphorePermit)>> + Send>>;
+
+fn admit_partition_inputs<T: Send + 'static>(
+    inputs: Vec<T>,
+    entry_permits: Arc<Semaphore>,
+) -> PartitionInputAdmissionStream<T> {
+    stream::iter(inputs)
+        .then(move |input| {
+            let entry_permits = entry_permits.clone();
+            async move {
+                let entry_permit = entry_permits
+                    .acquire_owned()
+                    .await
+                    .map_err(|_| Error::internal("partition build entry semaphore was closed"))?;
+                Ok((input, entry_permit))
+            }
+        })
+        .boxed()
+}
 
 struct PartitionBuildResult<S: IvfSubIndex, Q: Quantization> {
     partition_id: usize,
@@ -1266,56 +1286,53 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
                         // slot needed for the oldest window to make ordered progress.
                         let window_entry_limit = max_entries.div_ceil(concurrency);
                         let entry_permits = Arc::new(Semaphore::new(window_entry_limit));
-                        let builds = stream::iter(inputs.into_iter().map(move |input| {
-                            let quantizer = quantizer.clone();
-                            let sub_index_params = sub_index_params.clone();
-                            let column = column.clone();
-                            let frag_reuse_index = frag_reuse_index.clone();
-                            let cpu_permits = cpu_permits.clone();
-                            let entry_permits = entry_permits.clone();
-                            async move {
-                                let partition_id = input.partition_id;
-                                let loss = input.loss;
-                                let entry_permit =
-                                    entry_permits.acquire_owned().await.map_err(|_| {
-                                        Error::internal(
-                                            "partition build entry semaphore was closed",
-                                        )
-                                    })?;
-                                let _cpu_permit = cpu_permits.acquire_owned().await.map_err(|_| {
-                                    Error::internal("partition build CPU semaphore was closed")
-                                })?;
-                                let built = spawn_cpu(move || -> Result<_> {
-                                    let num_rows = input
-                                        .batches
-                                        .iter()
-                                        .map(|batch| batch.num_rows())
-                                        .sum::<usize>();
-                                    if num_rows == 0 {
-                                        return Ok(None);
-                                    }
-                                    let (storage, sub_index) = Self::build_index(
-                                        distance_type,
-                                        quantizer,
-                                        sub_index_params,
-                                        input.batches,
-                                        column,
-                                        frag_reuse_index,
-                                    )?;
-                                    Ok(Some((storage, sub_index, loss)))
-                                })
-                                .await?;
-                                Ok::<_, Error>((
-                                    PartitionBuildResult {
-                                        partition_id,
-                                        built,
-                                    },
-                                    entry_permit,
-                                ))
-                            }
-                        }))
-                        .buffer_unordered(concurrency)
-                        .boxed();
+                        let builds = admit_partition_inputs(inputs, entry_permits)
+                            .map_ok(move |(input, entry_permit)| {
+                                let quantizer = quantizer.clone();
+                                let sub_index_params = sub_index_params.clone();
+                                let column = column.clone();
+                                let frag_reuse_index = frag_reuse_index.clone();
+                                let cpu_permits = cpu_permits.clone();
+                                async move {
+                                    let partition_id = input.partition_id;
+                                    let loss = input.loss;
+                                    let _cpu_permit =
+                                        cpu_permits.acquire_owned().await.map_err(|_| {
+                                            Error::internal(
+                                                "partition build CPU semaphore was closed",
+                                            )
+                                        })?;
+                                    let built = spawn_cpu(move || -> Result<_> {
+                                        let num_rows = input
+                                            .batches
+                                            .iter()
+                                            .map(|batch| batch.num_rows())
+                                            .sum::<usize>();
+                                        if num_rows == 0 {
+                                            return Ok(None);
+                                        }
+                                        let (storage, sub_index) = Self::build_index(
+                                            distance_type,
+                                            quantizer,
+                                            sub_index_params,
+                                            input.batches,
+                                            column,
+                                            frag_reuse_index,
+                                        )?;
+                                        Ok(Some((storage, sub_index, loss)))
+                                    })
+                                    .await?;
+                                    Ok::<_, Error>((
+                                        PartitionBuildResult {
+                                            partition_id,
+                                            built,
+                                        },
+                                        entry_permit,
+                                    ))
+                                }
+                            })
+                            .try_buffer_unordered(concurrency)
+                            .boxed();
                         Ok::<(FreshWindowBuildStream<S, Q>, _), Error>((builds, admission))
                     },
                 );
@@ -2664,6 +2681,46 @@ mod tests {
     // Helper to read centroid i from a FixedSizeListArray as a Vec<f32>
     fn centroid_values(arr: &FixedSizeListArray, i: usize) -> Vec<f32> {
         arr.value(i).as_primitive::<Float32Type>().values().to_vec()
+    }
+
+    #[tokio::test]
+    async fn partition_entry_admission_preserves_input_order() {
+        let entry_permits = Arc::new(Semaphore::new(1));
+        let held_permit = entry_permits.clone().acquire_owned().await.unwrap();
+        let mut admitted = admit_partition_inputs(vec![0, 1, 2], entry_permits);
+
+        let first = admitted.next();
+        tokio::pin!(first);
+        assert!(
+            tokio::time::timeout(std::time::Duration::from_millis(10), &mut first)
+                .await
+                .is_err()
+        );
+
+        drop(held_permit);
+        let (partition_id, first_permit) =
+            tokio::time::timeout(std::time::Duration::from_millis(100), &mut first)
+                .await
+                .unwrap()
+                .unwrap()
+                .unwrap();
+        assert_eq!(partition_id, 0);
+
+        let second = admitted.next();
+        tokio::pin!(second);
+        assert!(
+            tokio::time::timeout(std::time::Duration::from_millis(10), &mut second)
+                .await
+                .is_err()
+        );
+        drop(first_permit);
+        let (partition_id, _second_permit) =
+            tokio::time::timeout(std::time::Duration::from_millis(100), &mut second)
+                .await
+                .unwrap()
+                .unwrap()
+                .unwrap();
+        assert_eq!(partition_id, 1);
     }
 
     #[test]

--- a/rust/lance/src/index/vector/builder.rs
+++ b/rust/lance/src/index/vector/builder.rs
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright The Lance Authors
 
 use lance_core::utils::row_addr_remap::RowAddrRemap;
-use std::collections::HashSet;
+use std::collections::{HashSet, VecDeque};
 use std::sync::{Arc, Mutex};
 use std::{collections::HashMap, pin::Pin};
 
@@ -44,7 +44,10 @@ use lance_index::vector::quantizer::{QuantizerMetadata, QuantizerStorage};
 use lance_index::vector::shared::{SupportedIvfIndexType, write_unified_ivf_and_index_metadata};
 use lance_index::vector::storage::STORAGE_METADATA_KEY;
 use lance_index::vector::transform::Flatten;
-use lance_index::vector::v3::shuffler::{EmptyReader, IvfShufflerReader, create_ivf_shuffler};
+use lance_index::vector::v3::shuffler::{
+    DEFAULT_PARTITION_WINDOW_BYTES, EmptyReader, IvfShufflerReader, ShufflePartition,
+    create_ivf_shuffler,
+};
 use lance_index::vector::v3::subindex::SubIndexType;
 use lance_index::vector::{LOSS_METADATA_KEY, PART_ID_COLUMN, PQ_CODE_COLUMN, VectorIndex};
 use lance_index::vector::{PART_ID_FIELD, ivf::storage::IvfModel};
@@ -83,6 +86,9 @@ use crate::Dataset;
 use crate::dataset::ProjectionRequest;
 use crate::dataset::index::dataset_format_version;
 use crate::index::append::build_old_data_filter;
+use crate::index::vector::bounded_partition_stream::{
+    BoundedPartitionStream, Budgeted, OrderedPartitionResults, WeightedJob,
+};
 use crate::index::vector::ivf::v2::PartitionEntry;
 use crate::index::vector::utils::infer_vector_dim;
 
@@ -96,6 +102,11 @@ use super::{
 const REASSIGN_RANGE: usize = 64;
 // sample size for kmeans training when splitting a partition (sample_rate * k = 256 * 2)
 const SPLIT_SAMPLE_SIZE: usize = 512;
+/// Maximum decoded input bytes admitted across active builds and completed
+/// partitions waiting for their turn to be written.
+const PARTITION_BUILD_BUDGET_BYTES: usize = 512 * 1024 * 1024;
+/// Bound ready-map overhead even when many consecutive partitions are empty.
+const PARTITION_BUILD_ENTRIES_PER_WORKER: usize = 2;
 
 /// Build a new centroid array that incorporates the results of partition splits.
 ///
@@ -256,7 +267,26 @@ pub struct IvfIndexBuilder<S: IvfSubIndex, Q: Quantization> {
 }
 
 type BuildStream<S, Q> =
-    Pin<Box<dyn Stream<Item = Result<Option<(<Q as Quantization>::Storage, S, f64)>>> + Send>>;
+    Pin<Box<dyn Stream<Item = Result<Budgeted<PartitionBuildResult<S, Q>>>> + Send>>;
+
+struct PartitionBuildResult<S: IvfSubIndex, Q: Quantization> {
+    partition_id: usize,
+    built: Option<(Q::Storage, S, f64)>,
+}
+
+struct FreshPartitionReadState {
+    reader: Arc<dyn ShuffleReader>,
+    num_partitions: usize,
+    next_window_partition_id: usize,
+    pending: VecDeque<ShufflePartition>,
+}
+
+struct FreshPartitionInput {
+    partition_id: usize,
+    batches: Vec<RecordBatch>,
+    loss: f64,
+    decoded_bytes: usize,
+}
 
 type UnindexedStream = Box<dyn Stream<Item = Result<RecordBatch>> + Send + Unpin + 'static>;
 
@@ -451,7 +481,10 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
 
                     let storage = part.storage.remap(&mapping)?;
                     let index = part.index.remap(&mapping, &storage)?;
-                    Result::Ok(Some((storage, index, 0.0)))
+                    Result::Ok(Budgeted::untracked(PartitionBuildResult {
+                        partition_id: part_id,
+                        built: Some((storage, index, 0.0)),
+                    }))
                 }
             });
 
@@ -985,12 +1018,28 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
         let distance_type = self.distance_type;
         let column = self.column.clone();
         let frag_reuse_index = self.frag_reuse_index.clone();
+        if self.optimize_options.is_none()
+            && self.existing_indices.is_empty()
+            && partition_adjustment.is_none()
+        {
+            let num_partitions = assign_batches.len();
+            return Self::build_fresh_partitions_windowed(
+                reader,
+                num_partitions,
+                distance_type,
+                quantizer,
+                sub_index_params,
+                column,
+                frag_reuse_index,
+            );
+        }
         let partition_adjustment = Arc::new(partition_adjustment);
         let build_iter =
             assign_batches
                 .into_iter()
                 .enumerate()
                 .map(move |(partition, assign_batch)| {
+                    let output_partition_id = partition;
                     let reader = reader.clone();
                     let indices = merge_indices.clone();
                     let distance_type = distance_type;
@@ -1078,7 +1127,10 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
 
                             let num_rows = batches.iter().map(|b| b.num_rows()).sum::<usize>();
                             if num_rows == 0 {
-                                return Ok(None);
+                                return Ok(Budgeted::untracked(PartitionBuildResult {
+                                    partition_id: output_partition_id,
+                                    built: None,
+                                }));
                             }
 
                             let (storage, sub_index) = Self::build_index(
@@ -1089,7 +1141,10 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
                                 column,
                                 frag_reuse_index,
                             )?;
-                            Ok(Some((storage, sub_index, loss)))
+                            Ok(Budgeted::untracked(PartitionBuildResult {
+                                partition_id: output_partition_id,
+                                built: Some((storage, sub_index, loss)),
+                            }))
                         })
                         .await
                     }
@@ -1097,6 +1152,150 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
         Ok(stream::iter(build_iter)
             .buffered(get_num_compute_intensive_cpus())
             .boxed())
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn build_fresh_partitions_windowed(
+        reader: Arc<dyn ShuffleReader>,
+        num_partitions: usize,
+        distance_type: DistanceType,
+        quantizer: Q,
+        sub_index_params: S::BuildParams,
+        column: String,
+        frag_reuse_index: Option<Arc<FragReuseIndex>>,
+    ) -> Result<BuildStream<S, Q>> {
+        let state = FreshPartitionReadState {
+            reader,
+            num_partitions,
+            next_window_partition_id: 0,
+            pending: VecDeque::new(),
+        };
+        let partition_inputs = stream::try_unfold(state, |mut state| async move {
+            if state.pending.is_empty() {
+                if state.next_window_partition_id == state.num_partitions {
+                    return Ok(None);
+                }
+                let window = state
+                    .reader
+                    .read_partition_window(
+                        state.next_window_partition_id,
+                        DEFAULT_PARTITION_WINDOW_BYTES,
+                    )
+                    .await?;
+                if window.partition_range.start != state.next_window_partition_id
+                    || window.partition_range.end <= window.partition_range.start
+                    || window.partition_range.end > state.num_partitions
+                    || window.partitions.len() != window.partition_range.len()
+                {
+                    return Err(Error::internal(format!(
+                        "shuffle reader returned invalid partition window {:?} with {} entries; expected a non-empty window starting at {} within {} partitions",
+                        window.partition_range,
+                        window.partitions.len(),
+                        state.next_window_partition_id,
+                        state.num_partitions
+                    )));
+                }
+                for (expected_partition_id, partition) in
+                    window.partition_range.clone().zip(&window.partitions)
+                {
+                    if partition.partition_id != expected_partition_id {
+                        return Err(Error::internal(format!(
+                            "shuffle reader window {:?} returned partition id {} at position {}",
+                            window.partition_range,
+                            partition.partition_id,
+                            expected_partition_id - window.partition_range.start
+                        )));
+                    }
+                }
+                state.next_window_partition_id = window.partition_range.end;
+                state.pending = window.partitions.into();
+            }
+
+            let mut partition = state.pending.pop_front().ok_or_else(|| {
+                Error::internal("validated shuffle partition window contained no entries")
+            })?;
+            let mut batches = Vec::new();
+            let mut loss = 0.0;
+            let mut decoded_bytes = 0usize;
+            if let Some(mut data) = partition.data.take() {
+                while let Some(batch) = data.try_next().await? {
+                    loss += batch
+                        .metadata()
+                        .get(LOSS_METADATA_KEY)
+                        .map(|value| value.parse::<f64>().unwrap_or(0.0))
+                        .unwrap_or(0.0);
+                    let batch = batch.drop_column(PART_ID_COLUMN)?;
+                    decoded_bytes =
+                        batch
+                            .columns()
+                            .iter()
+                            .try_fold(decoded_bytes, |total, array| {
+                                total
+                                    .checked_add(array.get_array_memory_size())
+                                    .ok_or_else(|| {
+                                        Error::internal(format!(
+                                            "decoded byte count overflow for partition {}",
+                                            partition.partition_id
+                                        ))
+                                    })
+                            })?;
+                    batches.push(batch);
+                }
+            }
+            Ok(Some((
+                FreshPartitionInput {
+                    partition_id: partition.partition_id,
+                    batches,
+                    loss,
+                    decoded_bytes,
+                },
+                state,
+            )))
+        });
+
+        let jobs = partition_inputs
+            .map_ok(move |input| {
+                let quantizer = quantizer.clone();
+                let sub_index_params = sub_index_params.clone();
+                let column = column.clone();
+                let frag_reuse_index = frag_reuse_index.clone();
+                WeightedJob::new(input.decoded_bytes, async move {
+                    let partition_id = input.partition_id;
+                    let loss = input.loss;
+                    let built = spawn_cpu(move || -> Result<Option<(Q::Storage, S, f64)>> {
+                        let num_rows: usize =
+                            input.batches.iter().map(|batch| batch.num_rows()).sum();
+                        if num_rows == 0 {
+                            return Ok(None);
+                        }
+                        let (storage, sub_index) = Self::build_index(
+                            distance_type,
+                            quantizer,
+                            sub_index_params,
+                            input.batches,
+                            column,
+                            frag_reuse_index,
+                        )?;
+                        Ok(Some((storage, sub_index, loss)))
+                    })
+                    .await?;
+                    Ok(PartitionBuildResult {
+                        partition_id,
+                        built,
+                    })
+                })
+            })
+            .boxed();
+
+        let concurrency = get_num_compute_intensive_cpus().max(1);
+        let max_entries = concurrency.saturating_mul(PARTITION_BUILD_ENTRIES_PER_WORKER);
+        Ok(BoundedPartitionStream::try_new(
+            jobs,
+            concurrency,
+            PARTITION_BUILD_BUDGET_BYTES,
+            max_entries,
+        )?
+        .boxed())
     }
 
     #[instrument(name = "build_index", level = "debug", skip_all)]
@@ -1273,96 +1472,110 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
         let mut index_ivf = IvfModel::new(ivf.centroids.clone().unwrap(), ivf.loss);
         let mut partition_index_metadata = Vec::with_capacity(ivf.num_partitions());
 
-        let mut part_id = 0;
+        let num_partitions = ivf.num_partitions();
+        let mut ordered_results = OrderedPartitionResults::new(num_partitions);
         let mut total_loss = 0.0;
         let progress = self.progress.clone();
-        log::info!("merging {} partitions", ivf.num_partitions());
-        while let Some(part) = build_stream.try_next().await? {
-            part_id += 1;
-            progress.stage_progress("merge_partitions", part_id).await?;
-            let Some((storage, index, loss)) = part else {
-                log::warn!("partition {} is empty, skipping", part_id);
+        log::info!("merging {} partitions", num_partitions);
+        while let Some(result) = build_stream.try_next().await? {
+            let partition_id = result.value.partition_id;
+            ordered_results.push(partition_id, result)?;
 
-                storage_ivf.add_partition(0);
-                index_ivf.add_partition(0);
-                partition_index_metadata.push(String::new());
+            while let Some((partition_id, result)) = ordered_results.pop_next() {
+                let Budgeted {
+                    value: PartitionBuildResult { built: part, .. },
+                    _permit,
+                } = result;
+                let completed_partitions = partition_id + 1;
+                progress
+                    .stage_progress("merge_partitions", completed_partitions as u64)
+                    .await?;
+                let Some((storage, index, loss)) = part else {
+                    log::warn!("partition {} is empty, skipping", partition_id);
 
-                continue;
-            };
-            total_loss += loss;
+                    storage_ivf.add_partition(0);
+                    index_ivf.add_partition(0);
+                    partition_index_metadata.push(String::new());
 
-            if storage.len() == 0 {
-                storage_ivf.add_partition(0);
-            } else {
-                for mut batch in storage.to_batches()? {
-                    if is_pq
-                        && !self.transpose_codes
-                        && batch.num_rows() > 0
-                        && batch.column_by_name(PQ_CODE_COLUMN).is_some()
-                    {
-                        let codes_fsl = batch
-                            .column_by_name(PQ_CODE_COLUMN)
-                            .unwrap()
-                            .as_fixed_size_list();
-                        let num_rows = batch.num_rows();
-                        let bytes_per_code = codes_fsl.value_length() as usize;
-                        let codes = codes_fsl.values().as_primitive::<datatypes::UInt8Type>();
-                        let original_codes = transpose(codes, bytes_per_code, num_rows);
-                        let original_fsl = Arc::new(FixedSizeListArray::try_new_from_values(
-                            original_codes,
-                            bytes_per_code as i32,
-                        )?);
-                        batch = batch.replace_column_by_name(PQ_CODE_COLUMN, original_fsl)?;
+                    continue;
+                };
+                total_loss += loss;
+
+                if storage.len() == 0 {
+                    storage_ivf.add_partition(0);
+                } else {
+                    for mut batch in storage.to_batches()? {
+                        if is_pq
+                            && !self.transpose_codes
+                            && batch.num_rows() > 0
+                            && batch.column_by_name(PQ_CODE_COLUMN).is_some()
+                        {
+                            let codes_fsl = batch
+                                .column_by_name(PQ_CODE_COLUMN)
+                                .unwrap()
+                                .as_fixed_size_list();
+                            let num_rows = batch.num_rows();
+                            let bytes_per_code = codes_fsl.value_length() as usize;
+                            let codes = codes_fsl.values().as_primitive::<datatypes::UInt8Type>();
+                            let original_codes = transpose(codes, bytes_per_code, num_rows);
+                            let original_fsl = Arc::new(FixedSizeListArray::try_new_from_values(
+                                original_codes,
+                                bytes_per_code as i32,
+                            )?);
+                            batch = batch.replace_column_by_name(PQ_CODE_COLUMN, original_fsl)?;
+                        }
+
+                        if is_rq
+                            && !self.transpose_codes
+                            && batch.num_rows() > 0
+                            && batch.column_by_name(RABIT_CODE_COLUMN).is_some()
+                        {
+                            let codes_fsl = batch
+                                .column_by_name(RABIT_CODE_COLUMN)
+                                .unwrap()
+                                .as_fixed_size_list();
+                            let unpacked = Arc::new(unpack_codes(codes_fsl));
+                            batch = batch.replace_column_by_name(RABIT_CODE_COLUMN, unpacked)?;
+                        }
+
+                        if storage_writer.is_none() {
+                            let storage_schema: Schema = batch.schema_ref().as_ref().try_into()?;
+                            storage_writer = Some(file_versions::create_writer(
+                                self.format_version,
+                                self.store.create(&storage_path).await?,
+                                storage_schema,
+                                writer_options.clone(),
+                            )?);
+                        }
+                        storage_writer
+                            .as_mut()
+                            .expect("storage writer must be initialized before write")
+                            .write_batch(&batch)
+                            .await?;
+                        storage_ivf.add_partition(batch.num_rows() as u32);
                     }
+                }
 
-                    if is_rq
-                        && !self.transpose_codes
-                        && batch.num_rows() > 0
-                        && batch.column_by_name(RABIT_CODE_COLUMN).is_some()
-                    {
-                        let codes_fsl = batch
-                            .column_by_name(RABIT_CODE_COLUMN)
-                            .unwrap()
-                            .as_fixed_size_list();
-                        let unpacked = Arc::new(unpack_codes(codes_fsl));
-                        batch = batch.replace_column_by_name(RABIT_CODE_COLUMN, unpacked)?;
-                    }
-
-                    if storage_writer.is_none() {
-                        let storage_schema: Schema = batch.schema_ref().as_ref().try_into()?;
-                        storage_writer = Some(file_versions::create_writer(
-                            self.format_version,
-                            self.store.create(&storage_path).await?,
-                            storage_schema,
-                            writer_options.clone(),
-                        )?);
-                    }
-                    storage_writer
-                        .as_mut()
-                        .expect("storage writer must be initialized before write")
-                        .write_batch(&batch)
-                        .await?;
-                    storage_ivf.add_partition(batch.num_rows() as u32);
+                let index_batch = index.to_batch()?;
+                if index_batch.num_rows() == 0 {
+                    index_ivf.add_partition(0);
+                    partition_index_metadata.push(String::new());
+                } else {
+                    index_writer.write_batch(&index_batch).await?;
+                    index_ivf.add_partition(index_batch.num_rows() as u32);
+                    partition_index_metadata.push(
+                        index_batch
+                            .schema()
+                            .metadata
+                            .get(S::metadata_key())
+                            .cloned()
+                            .unwrap_or_default(),
+                    );
                 }
             }
-
-            let index_batch = index.to_batch()?;
-            if index_batch.num_rows() == 0 {
-                index_ivf.add_partition(0);
-                partition_index_metadata.push(String::new());
-            } else {
-                index_writer.write_batch(&index_batch).await?;
-                index_ivf.add_partition(index_batch.num_rows() as u32);
-                partition_index_metadata.push(
-                    index_batch
-                        .schema()
-                        .metadata
-                        .get(S::metadata_key())
-                        .cloned()
-                        .unwrap_or_default(),
-                );
-            }
         }
+
+        ordered_results.finish()?;
 
         match self.shuffle_reader.as_ref() {
             Some(reader) => {

--- a/rust/lance/src/index/vector/builder.rs
+++ b/rust/lance/src/index/vector/builder.rs
@@ -107,6 +107,21 @@ const PARTITION_BUILD_BUDGET_BYTES: usize = 512 * 1024 * 1024;
 /// Bound ready-map overhead even when many consecutive partitions are empty.
 const PARTITION_BUILD_ENTRIES_PER_WORKER: usize = 2;
 
+#[derive(Debug, Clone, Copy)]
+struct FreshPartitionBuildLimits {
+    window_bytes: usize,
+    decoded_budget_bytes: usize,
+}
+
+impl Default for FreshPartitionBuildLimits {
+    fn default() -> Self {
+        Self {
+            window_bytes: DEFAULT_PARTITION_WINDOW_BYTES,
+            decoded_budget_bytes: PARTITION_BUILD_BUDGET_BYTES,
+        }
+    }
+}
+
 /// Build a new centroid array that incorporates the results of partition splits.
 ///
 /// For each `(part_idx, centroid1, centroid2)` in `splits`:
@@ -289,6 +304,19 @@ fn admit_partition_inputs<T: Send + 'static>(
             }
         })
         .boxed()
+}
+
+fn partition_window_entry_limit(
+    partition_range: &std::ops::Range<usize>,
+    num_partitions: usize,
+    max_entries: usize,
+    concurrency: usize,
+) -> usize {
+    if partition_range.start == 0 && partition_range.end == num_partitions {
+        max_entries
+    } else {
+        max_entries.div_ceil(concurrency)
+    }
 }
 
 struct PartitionBuildResult<S: IvfSubIndex, Q: Quantization> {
@@ -1045,6 +1073,7 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
                 sub_index_params,
                 column,
                 frag_reuse_index,
+                FreshPartitionBuildLimits::default(),
             );
         }
         let partition_adjustment = Arc::new(partition_adjustment);
@@ -1177,6 +1206,7 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
         sub_index_params: S::BuildParams,
         column: String,
         frag_reuse_index: Option<Arc<FragReuseIndex>>,
+        limits: FreshPartitionBuildLimits,
     ) -> Result<BuildStream<S, Q>> {
         let concurrency = get_num_compute_intensive_cpus().max(1);
         let max_entries = concurrency.saturating_mul(PARTITION_BUILD_ENTRIES_PER_WORKER);
@@ -1194,7 +1224,7 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
                 }
                 let plan = reader.plan_partition_window(
                     next_partition_id,
-                    DEFAULT_PARTITION_WINDOW_BYTES,
+                    limits.window_bytes,
                 )?;
                 if plan.partition_range.start != next_partition_id
                     || plan.partition_range.end <= plan.partition_range.start
@@ -1207,13 +1237,19 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
                 }
                 let next_partition_id = plan.partition_range.end;
                 let planned_range = plan.partition_range;
+                let window_entry_limit = partition_window_entry_limit(
+                    &planned_range,
+                    num_partitions,
+                    max_entries,
+                    concurrency,
+                );
                 let job = WeightedJob::with_permit(
                     plan.estimated_decoded_bytes,
                     move |mut admission| async move {
                         let mut window = reader
                             .read_partition_window(
                                 planned_range.start,
-                                DEFAULT_PARTITION_WINDOW_BYTES,
+                                limits.window_bytes,
                             )
                             .await?;
                         if window.partition_range != planned_range
@@ -1279,12 +1315,11 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
                         }
                         admission.reconcile(decoded_bytes);
 
-                        // Each concurrently polled window owns a small FIFO entry
-                        // budget. With at most `concurrency` active window streams,
-                        // their combined active/completed results remain bounded by
-                        // `max_entries`, while a later window cannot consume every
-                        // slot needed for the oldest window to make ordered progress.
-                        let window_entry_limit = max_entries.div_ceil(concurrency);
+                        // Multiple windows each own a small FIFO entry budget so a
+                        // later window cannot consume every slot needed for the
+                        // oldest window to make ordered progress. If the whole
+                        // shuffle fits in one window, that window owns the complete
+                        // entry budget and can use the full CPU concurrency.
                         let entry_permits = Arc::new(Semaphore::new(window_entry_limit));
                         let builds = admit_partition_inputs(inputs, entry_permits)
                             .map_ok(move |(input, entry_permit)| {
@@ -1344,7 +1379,7 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
         let windows = BoundedPartitionStream::try_new(
             jobs,
             concurrency,
-            PARTITION_BUILD_BUDGET_BYTES,
+            limits.decoded_budget_bytes,
             // One admission entry per outstanding window. Together with each
             // window's entry limit above, this bounds partition results by
             // `max_entries` even after an inner stream has finished.
@@ -1354,14 +1389,14 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
             .map_ok(|window| {
                 let Budgeted {
                     value: builds,
-                    _permit,
-                    _entry_permit,
+                    permit,
+                    entry_permit,
                 } = window;
-                debug_assert!(_entry_permit.is_none());
+                debug_assert!(entry_permit.is_none());
                 builds.map_ok(move |(value, entry_permit)| Budgeted {
                     value,
-                    _permit: _permit.clone(),
-                    _entry_permit: Some(entry_permit),
+                    permit: permit.clone(),
+                    entry_permit: Some(entry_permit),
                 })
             })
             .try_flatten_unordered(Some(concurrency))
@@ -1554,8 +1589,8 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
             while let Some((partition_id, result)) = ordered_results.pop_next() {
                 let Budgeted {
                     value: PartitionBuildResult { built: part, .. },
-                    _permit,
-                    _entry_permit,
+                    permit: _permit,
+                    entry_permit: _entry_permit,
                 } = result;
                 let completed_partitions = partition_id + 1;
                 progress
@@ -2639,9 +2674,14 @@ pub(crate) fn index_type_string(sub_index: SubIndexType, quantizer: Quantization
 
 #[cfg(test)]
 mod tests {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
     use super::*;
     use arrow_array::{Array, Float32Array, NullArray};
     use lance_index::vector::flat::index::{FlatIndex, FlatQuantizer};
+    use lance_index::vector::v3::shuffler::{
+        ShufflePartition, ShufflePartitionWindow, ShufflePartitionWindowPlan,
+    };
 
     struct SingleBatchReader {
         batch: RecordBatch,
@@ -2676,6 +2716,121 @@ mod tests {
         fn total_loss(&self) -> Option<f64> {
             None
         }
+    }
+
+    struct WindowedBatchReader {
+        batches: Vec<RecordBatch>,
+        windows_read: Arc<AtomicUsize>,
+    }
+
+    #[async_trait::async_trait]
+    impl ShuffleReader for WindowedBatchReader {
+        async fn read_partition(
+            &self,
+            partition_id: usize,
+        ) -> Result<Option<Box<dyn RecordBatchStream + Unpin + 'static>>> {
+            let Some(batch) = self.batches.get(partition_id) else {
+                return Ok(None);
+            };
+            Ok(Some(Box::new(RecordBatchStreamAdapter::new(
+                batch.schema(),
+                stream::iter(vec![Ok(batch.clone())]),
+            ))))
+        }
+
+        fn plan_partition_window(
+            &self,
+            start_partition_id: usize,
+            max_decoded_bytes: usize,
+        ) -> Result<ShufflePartitionWindowPlan> {
+            if max_decoded_bytes == 0 {
+                return Err(Error::invalid_input(
+                    "max_decoded_bytes must be greater than 0",
+                ));
+            }
+            if start_partition_id >= self.batches.len() {
+                return Err(Error::invalid_input(format!(
+                    "start_partition_id={} is out of range [0, {})",
+                    start_partition_id,
+                    self.batches.len()
+                )));
+            }
+            let end_partition_id = start_partition_id
+                .saturating_add(max_decoded_bytes)
+                .min(self.batches.len());
+            Ok(ShufflePartitionWindowPlan {
+                partition_range: start_partition_id..end_partition_id,
+                estimated_decoded_bytes: end_partition_id - start_partition_id,
+            })
+        }
+
+        async fn read_partition_window(
+            &self,
+            start_partition_id: usize,
+            max_decoded_bytes: usize,
+        ) -> Result<ShufflePartitionWindow> {
+            let plan = self.plan_partition_window(start_partition_id, max_decoded_bytes)?;
+            self.windows_read.fetch_add(1, Ordering::Relaxed);
+            if start_partition_id == 0 {
+                tokio::time::timeout(std::time::Duration::from_secs(1), async {
+                    while self.windows_read.load(Ordering::Relaxed) < 2 {
+                        tokio::task::yield_now().await;
+                    }
+                })
+                .await
+                .map_err(|_| Error::internal("second partition window was not admitted"))?;
+            }
+            let partitions = plan
+                .partition_range
+                .clone()
+                .map(|partition_id| {
+                    let batch = self.batches[partition_id].clone();
+                    ShufflePartition {
+                        partition_id,
+                        data: Some(Box::new(RecordBatchStreamAdapter::new(
+                            batch.schema(),
+                            stream::iter(vec![Ok(batch)]),
+                        ))),
+                    }
+                })
+                .collect();
+            Ok(ShufflePartitionWindow {
+                materialized_decoded_bytes: Some(plan.partition_range.len()),
+                partition_range: plan.partition_range,
+                partitions,
+            })
+        }
+
+        fn partition_size(&self, partition_id: usize) -> Result<usize> {
+            Ok(self
+                .batches
+                .get(partition_id)
+                .map(RecordBatch::num_rows)
+                .unwrap_or(0))
+        }
+
+        fn total_loss(&self) -> Option<f64> {
+            None
+        }
+    }
+
+    fn flat_partition_batch(partition_id: usize) -> RecordBatch {
+        let vectors = FixedSizeListArray::try_new_from_values(
+            Float32Array::from(vec![partition_id as f32, partition_id as f32 + 0.5]),
+            2,
+        )
+        .unwrap();
+        RecordBatch::try_new(
+            Arc::new(arrow_schema::Schema::new(vec![
+                ROW_ID_FIELD.clone(),
+                Field::new("vector", vectors.data_type().clone(), false),
+            ])),
+            vec![
+                Arc::new(UInt64Array::from(vec![partition_id as u64])),
+                Arc::new(vectors),
+            ],
+        )
+        .unwrap()
     }
 
     // Helper to read centroid i from a FixedSizeListArray as a Vec<f32>
@@ -2721,6 +2876,57 @@ mod tests {
                 .unwrap()
                 .unwrap();
         assert_eq!(partition_id, 1);
+    }
+
+    #[test]
+    fn single_partition_window_uses_full_entry_budget() {
+        assert_eq!(partition_window_entry_limit(&(0..64), 64, 32, 16), 32);
+        assert_eq!(partition_window_entry_limit(&(0..32), 64, 32, 16), 2);
+        assert_eq!(partition_window_entry_limit(&(32..64), 64, 32, 16), 2);
+    }
+
+    #[tokio::test]
+    async fn fresh_partition_build_runs_multiple_windows_end_to_end() {
+        let num_partitions = 6;
+        let windows_read = Arc::new(AtomicUsize::new(0));
+        let reader = Arc::new(WindowedBatchReader {
+            batches: (0..num_partitions).map(flat_partition_batch).collect(),
+            windows_read: windows_read.clone(),
+        });
+        let mut build_stream =
+            IvfIndexBuilder::<FlatIndex, FlatQuantizer>::build_fresh_partitions_windowed(
+                reader,
+                num_partitions,
+                DistanceType::L2,
+                FlatQuantizer::new(2, DistanceType::L2),
+                (),
+                "vector".to_string(),
+                None,
+                FreshPartitionBuildLimits {
+                    window_bytes: 2,
+                    decoded_budget_bytes: 4,
+                },
+            )
+            .unwrap();
+
+        let mut ordered_results = OrderedPartitionResults::new(num_partitions);
+        let mut merged_partition_ids = Vec::with_capacity(num_partitions);
+        while let Some(result) = build_stream.try_next().await.unwrap() {
+            ordered_results
+                .push(result.value.partition_id, result)
+                .unwrap();
+            while let Some((partition_id, result)) = ordered_results.pop_next() {
+                assert!(result.value.built.is_some());
+                merged_partition_ids.push(partition_id);
+            }
+        }
+        ordered_results.finish().unwrap();
+
+        assert_eq!(windows_read.load(Ordering::Relaxed), 3);
+        assert_eq!(
+            merged_partition_ids,
+            (0..num_partitions).collect::<Vec<_>>()
+        );
     }
 
     #[test]

--- a/rust/lance/src/index/vector/builder.rs
+++ b/rust/lance/src/index/vector/builder.rs
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: Copyright The Lance Authors
 
 use lance_core::utils::row_addr_remap::RowAddrRemap;
-use std::collections::{HashSet, VecDeque};
+use std::collections::HashSet;
 use std::sync::{Arc, Mutex};
 use std::{collections::HashMap, pin::Pin};
 
@@ -45,8 +45,7 @@ use lance_index::vector::shared::{SupportedIvfIndexType, write_unified_ivf_and_i
 use lance_index::vector::storage::STORAGE_METADATA_KEY;
 use lance_index::vector::transform::Flatten;
 use lance_index::vector::v3::shuffler::{
-    DEFAULT_PARTITION_WINDOW_BYTES, EmptyReader, IvfShufflerReader, ShufflePartition,
-    create_ivf_shuffler,
+    DEFAULT_PARTITION_WINDOW_BYTES, EmptyReader, IvfShufflerReader, create_ivf_shuffler,
 };
 use lance_index::vector::v3::subindex::SubIndexType;
 use lance_index::vector::{LOSS_METADATA_KEY, PART_ID_COLUMN, PQ_CODE_COLUMN, VectorIndex};
@@ -79,7 +78,7 @@ use log::info;
 use object_store::path::Path;
 use prost::Message;
 use roaring::RoaringBitmap;
-use tokio::sync::OnceCell;
+use tokio::sync::{OnceCell, Semaphore};
 use tracing::{Level, instrument, span};
 
 use crate::Dataset;
@@ -274,18 +273,10 @@ struct PartitionBuildResult<S: IvfSubIndex, Q: Quantization> {
     built: Option<(Q::Storage, S, f64)>,
 }
 
-struct FreshPartitionReadState {
-    reader: Arc<dyn ShuffleReader>,
-    num_partitions: usize,
-    next_window_partition_id: usize,
-    pending: VecDeque<ShufflePartition>,
-}
-
 struct FreshPartitionInput {
     partition_id: usize,
     batches: Vec<RecordBatch>,
     loss: f64,
-    decoded_bytes: usize,
 }
 
 type UnindexedStream = Box<dyn Stream<Item = Result<RecordBatch>> + Send + Unpin + 'static>;
@@ -1164,138 +1155,176 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
         column: String,
         frag_reuse_index: Option<Arc<FragReuseIndex>>,
     ) -> Result<BuildStream<S, Q>> {
-        let state = FreshPartitionReadState {
-            reader,
-            num_partitions,
-            next_window_partition_id: 0,
-            pending: VecDeque::new(),
-        };
-        let partition_inputs = stream::try_unfold(state, |mut state| async move {
-            if state.pending.is_empty() {
-                if state.next_window_partition_id == state.num_partitions {
-                    return Ok(None);
-                }
-                let window = state
-                    .reader
-                    .read_partition_window(
-                        state.next_window_partition_id,
-                        DEFAULT_PARTITION_WINDOW_BYTES,
-                    )
-                    .await?;
-                if window.partition_range.start != state.next_window_partition_id
-                    || window.partition_range.end <= window.partition_range.start
-                    || window.partition_range.end > state.num_partitions
-                    || window.partitions.len() != window.partition_range.len()
-                {
-                    return Err(Error::internal(format!(
-                        "shuffle reader returned invalid partition window {:?} with {} entries; expected a non-empty window starting at {} within {} partitions",
-                        window.partition_range,
-                        window.partitions.len(),
-                        state.next_window_partition_id,
-                        state.num_partitions
-                    )));
-                }
-                for (expected_partition_id, partition) in
-                    window.partition_range.clone().zip(&window.partitions)
-                {
-                    if partition.partition_id != expected_partition_id {
-                        return Err(Error::internal(format!(
-                            "shuffle reader window {:?} returned partition id {} at position {}",
-                            window.partition_range,
-                            partition.partition_id,
-                            expected_partition_id - window.partition_range.start
-                        )));
-                    }
-                }
-                state.next_window_partition_id = window.partition_range.end;
-                state.pending = window.partitions.into();
-            }
-
-            let mut partition = state.pending.pop_front().ok_or_else(|| {
-                Error::internal("validated shuffle partition window contained no entries")
-            })?;
-            let mut batches = Vec::new();
-            let mut loss = 0.0;
-            let mut decoded_bytes = 0usize;
-            if let Some(mut data) = partition.data.take() {
-                while let Some(batch) = data.try_next().await? {
-                    loss += batch
-                        .metadata()
-                        .get(LOSS_METADATA_KEY)
-                        .map(|value| value.parse::<f64>().unwrap_or(0.0))
-                        .unwrap_or(0.0);
-                    let batch = batch.drop_column(PART_ID_COLUMN)?;
-                    decoded_bytes =
-                        batch
-                            .columns()
-                            .iter()
-                            .try_fold(decoded_bytes, |total, array| {
-                                total
-                                    .checked_add(array.get_array_memory_size())
-                                    .ok_or_else(|| {
-                                        Error::internal(format!(
-                                            "decoded byte count overflow for partition {}",
-                                            partition.partition_id
-                                        ))
-                                    })
-                            })?;
-                    batches.push(batch);
-                }
-            }
-            Ok(Some((
-                FreshPartitionInput {
-                    partition_id: partition.partition_id,
-                    batches,
-                    loss,
-                    decoded_bytes,
-                },
-                state,
-            )))
-        });
-
-        let jobs = partition_inputs
-            .map_ok(move |input| {
-                let quantizer = quantizer.clone();
-                let sub_index_params = sub_index_params.clone();
-                let column = column.clone();
-                let frag_reuse_index = frag_reuse_index.clone();
-                WeightedJob::new(input.decoded_bytes, async move {
-                    let partition_id = input.partition_id;
-                    let loss = input.loss;
-                    let built = spawn_cpu(move || -> Result<Option<(Q::Storage, S, f64)>> {
-                        let num_rows: usize =
-                            input.batches.iter().map(|batch| batch.num_rows()).sum();
-                        if num_rows == 0 {
-                            return Ok(None);
-                        }
-                        let (storage, sub_index) = Self::build_index(
-                            distance_type,
-                            quantizer,
-                            sub_index_params,
-                            input.batches,
-                            column,
-                            frag_reuse_index,
-                        )?;
-                        Ok(Some((storage, sub_index, loss)))
-                    })
-                    .await?;
-                    Ok(PartitionBuildResult {
-                        partition_id,
-                        built,
-                    })
-                })
-            })
-            .boxed();
-
         let concurrency = get_num_compute_intensive_cpus().max(1);
         let max_entries = concurrency.saturating_mul(PARTITION_BUILD_ENTRIES_PER_WORKER);
-        Ok(BoundedPartitionStream::try_new(
+        let cpu_permits = Arc::new(Semaphore::new(concurrency));
+        let jobs = stream::try_unfold(0usize, move |next_partition_id| {
+            let reader = reader.clone();
+            let quantizer = quantizer.clone();
+            let sub_index_params = sub_index_params.clone();
+            let column = column.clone();
+            let frag_reuse_index = frag_reuse_index.clone();
+            let cpu_permits = cpu_permits.clone();
+            async move {
+                if next_partition_id == num_partitions {
+                    return Ok(None);
+                }
+                let plan = reader.plan_partition_window(
+                    next_partition_id,
+                    DEFAULT_PARTITION_WINDOW_BYTES,
+                )?;
+                if plan.partition_range.start != next_partition_id
+                    || plan.partition_range.end <= plan.partition_range.start
+                    || plan.partition_range.end > num_partitions
+                {
+                    return Err(Error::internal(format!(
+                        "shuffle reader planned invalid partition window {:?}; expected a non-empty window starting at {} within {} partitions",
+                        plan.partition_range, next_partition_id, num_partitions
+                    )));
+                }
+                let next_partition_id = plan.partition_range.end;
+                let planned_range = plan.partition_range;
+                let job = WeightedJob::with_permit(
+                    plan.estimated_decoded_bytes,
+                    move |mut admission| async move {
+                        let mut window = reader
+                            .read_partition_window(
+                                planned_range.start,
+                                DEFAULT_PARTITION_WINDOW_BYTES,
+                            )
+                            .await?;
+                        if window.partition_range != planned_range
+                            || window.partitions.len() != planned_range.len()
+                        {
+                            return Err(Error::internal(format!(
+                                "shuffle reader returned partition window {:?} with {} entries after planning {:?}",
+                                window.partition_range,
+                                window.partitions.len(),
+                                planned_range
+                            )));
+                        }
+                        for (expected_partition_id, partition) in
+                            planned_range.clone().zip(&window.partitions)
+                        {
+                            if partition.partition_id != expected_partition_id {
+                                return Err(Error::internal(format!(
+                                    "shuffle reader window {:?} returned partition id {} at position {}",
+                                    planned_range,
+                                    partition.partition_id,
+                                    expected_partition_id - planned_range.start
+                                )));
+                            }
+                        }
+
+                        let count_stream_bytes = window.materialized_decoded_bytes.is_none();
+                        let mut decoded_bytes =
+                            window.materialized_decoded_bytes.unwrap_or_default();
+                        let mut inputs = Vec::with_capacity(window.partitions.len());
+                        for mut partition in window.partitions.drain(..) {
+                            let mut batches = Vec::new();
+                            let mut loss = 0.0;
+                            if let Some(mut data) = partition.data.take() {
+                                while let Some(batch) = data.try_next().await? {
+                                    loss += batch
+                                        .metadata()
+                                        .get(LOSS_METADATA_KEY)
+                                        .map(|value| value.parse::<f64>().unwrap_or(0.0))
+                                        .unwrap_or(0.0);
+                                    if count_stream_bytes {
+                                        decoded_bytes = batch.columns().iter().try_fold(
+                                            decoded_bytes,
+                                            |total, array| {
+                                                total
+                                                    .checked_add(array.get_array_memory_size())
+                                                    .ok_or_else(|| {
+                                                        Error::internal(format!(
+                                                            "decoded byte count overflow for partition {}",
+                                                            partition.partition_id
+                                                        ))
+                                                    })
+                                            },
+                                        )?;
+                                    }
+                                    batches.push(batch.drop_column(PART_ID_COLUMN)?);
+                                }
+                            }
+                            inputs.push(FreshPartitionInput {
+                                partition_id: partition.partition_id,
+                                batches,
+                                loss,
+                            });
+                        }
+                        admission.reconcile(decoded_bytes);
+
+                        let builds = stream::iter(inputs.into_iter().map(|input| {
+                            let quantizer = quantizer.clone();
+                            let sub_index_params = sub_index_params.clone();
+                            let column = column.clone();
+                            let frag_reuse_index = frag_reuse_index.clone();
+                            let cpu_permits = cpu_permits.clone();
+                            async move {
+                                let partition_id = input.partition_id;
+                                let loss = input.loss;
+                                let _cpu_permit = cpu_permits.acquire_owned().await.map_err(|_| {
+                                    Error::internal("partition build CPU semaphore was closed")
+                                })?;
+                                let built = spawn_cpu(move || -> Result<_> {
+                                    let num_rows = input
+                                        .batches
+                                        .iter()
+                                        .map(|batch| batch.num_rows())
+                                        .sum::<usize>();
+                                    if num_rows == 0 {
+                                        return Ok(None);
+                                    }
+                                    let (storage, sub_index) = Self::build_index(
+                                        distance_type,
+                                        quantizer,
+                                        sub_index_params,
+                                        input.batches,
+                                        column,
+                                        frag_reuse_index,
+                                    )?;
+                                    Ok(Some((storage, sub_index, loss)))
+                                })
+                                .await?;
+                                Ok::<PartitionBuildResult<S, Q>, Error>(PartitionBuildResult {
+                                    partition_id,
+                                    built,
+                                })
+                            }
+                        }))
+                        .buffer_unordered(concurrency)
+                        .try_collect::<Vec<_>>()
+                        .await?;
+                        let mut builds = builds;
+                        builds.sort_unstable_by_key(|result| result.partition_id);
+                        Ok((builds, admission))
+                    },
+                );
+                Ok(Some((job, next_partition_id)))
+            }
+        })
+        .boxed();
+
+        let windows = BoundedPartitionStream::try_new(
             jobs,
             concurrency,
             PARTITION_BUILD_BUDGET_BYTES,
             max_entries,
-        )?
-        .boxed())
+        )?;
+        Ok(windows
+            .map_ok(|window| {
+                let Budgeted { value, _permit } = window;
+                stream::iter(value.into_iter().map(move |value| {
+                    Ok(Budgeted {
+                        value,
+                        _permit: _permit.clone(),
+                    })
+                }))
+            })
+            .try_flatten()
+            .boxed())
     }
 
     #[instrument(name = "build_index", level = "debug", skip_all)]

--- a/rust/lance/src/index/vector/builder.rs
+++ b/rust/lance/src/index/vector/builder.rs
@@ -78,7 +78,7 @@ use log::info;
 use object_store::path::Path;
 use prost::Message;
 use roaring::RoaringBitmap;
-use tokio::sync::{OnceCell, Semaphore};
+use tokio::sync::{OnceCell, OwnedSemaphorePermit, Semaphore};
 use tracing::{Level, instrument, span};
 
 use crate::Dataset;
@@ -267,6 +267,9 @@ pub struct IvfIndexBuilder<S: IvfSubIndex, Q: Quantization> {
 
 type BuildStream<S, Q> =
     Pin<Box<dyn Stream<Item = Result<Budgeted<PartitionBuildResult<S, Q>>>> + Send>>;
+
+type FreshWindowBuildStream<S, Q> =
+    Pin<Box<dyn Stream<Item = Result<(PartitionBuildResult<S, Q>, OwnedSemaphorePermit)>> + Send>>;
 
 struct PartitionBuildResult<S: IvfSubIndex, Q: Quantization> {
     partition_id: usize,
@@ -1256,15 +1259,29 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
                         }
                         admission.reconcile(decoded_bytes);
 
-                        let builds = stream::iter(inputs.into_iter().map(|input| {
+                        // Each concurrently polled window owns a small FIFO entry
+                        // budget. With at most `concurrency` active window streams,
+                        // their combined active/completed results remain bounded by
+                        // `max_entries`, while a later window cannot consume every
+                        // slot needed for the oldest window to make ordered progress.
+                        let window_entry_limit = max_entries.div_ceil(concurrency);
+                        let entry_permits = Arc::new(Semaphore::new(window_entry_limit));
+                        let builds = stream::iter(inputs.into_iter().map(move |input| {
                             let quantizer = quantizer.clone();
                             let sub_index_params = sub_index_params.clone();
                             let column = column.clone();
                             let frag_reuse_index = frag_reuse_index.clone();
                             let cpu_permits = cpu_permits.clone();
+                            let entry_permits = entry_permits.clone();
                             async move {
                                 let partition_id = input.partition_id;
                                 let loss = input.loss;
+                                let entry_permit =
+                                    entry_permits.acquire_owned().await.map_err(|_| {
+                                        Error::internal(
+                                            "partition build entry semaphore was closed",
+                                        )
+                                    })?;
                                 let _cpu_permit = cpu_permits.acquire_owned().await.map_err(|_| {
                                     Error::internal("partition build CPU semaphore was closed")
                                 })?;
@@ -1288,18 +1305,18 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
                                     Ok(Some((storage, sub_index, loss)))
                                 })
                                 .await?;
-                                Ok::<PartitionBuildResult<S, Q>, Error>(PartitionBuildResult {
-                                    partition_id,
-                                    built,
-                                })
+                                Ok::<_, Error>((
+                                    PartitionBuildResult {
+                                        partition_id,
+                                        built,
+                                    },
+                                    entry_permit,
+                                ))
                             }
                         }))
                         .buffer_unordered(concurrency)
-                        .try_collect::<Vec<_>>()
-                        .await?;
-                        let mut builds = builds;
-                        builds.sort_unstable_by_key(|result| result.partition_id);
-                        Ok((builds, admission))
+                        .boxed();
+                        Ok::<(FreshWindowBuildStream<S, Q>, _), Error>((builds, admission))
                     },
                 );
                 Ok(Some((job, next_partition_id)))
@@ -1311,19 +1328,26 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
             jobs,
             concurrency,
             PARTITION_BUILD_BUDGET_BYTES,
-            max_entries,
+            // One admission entry per outstanding window. Together with each
+            // window's entry limit above, this bounds partition results by
+            // `max_entries` even after an inner stream has finished.
+            concurrency,
         )?;
         Ok(windows
             .map_ok(|window| {
-                let Budgeted { value, _permit } = window;
-                stream::iter(value.into_iter().map(move |value| {
-                    Ok(Budgeted {
-                        value,
-                        _permit: _permit.clone(),
-                    })
-                }))
+                let Budgeted {
+                    value: builds,
+                    _permit,
+                    _entry_permit,
+                } = window;
+                debug_assert!(_entry_permit.is_none());
+                builds.map_ok(move |(value, entry_permit)| Budgeted {
+                    value,
+                    _permit: _permit.clone(),
+                    _entry_permit: Some(entry_permit),
+                })
             })
-            .try_flatten()
+            .try_flatten_unordered(Some(concurrency))
             .boxed())
     }
 
@@ -1514,6 +1538,7 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
                 let Budgeted {
                     value: PartitionBuildResult { built: part, .. },
                     _permit,
+                    _entry_permit,
                 } = result;
                 let completed_partitions = partition_id + 1;
                 progress


### PR DESCRIPTION
## What is the performance issue?

`TwoFileShuffleReader` resolves offsets and reads data independently for every IVF partition. With many partitions and flush groups this creates millions of small ranges. The ordered partition build stream also stops admitting useful work when an early partition is slow, even if later partitions have already completed.

## How does this PR improve performance?

- Validate and sequentially preload the complete offsets table once, with a 256 MiB preload limit and validated on-demand fallback.
- Read contiguous partition windows with a 128 MiB decoded-size target, issuing at most one data range per non-empty flush group, then split the decoded stream back into exact partition order.
- Build fresh partitions with bounded unordered scheduling per index build: 512 MiB decoded-input admission, at most `2 * workers` admitted entries, and exclusive admission for an oversized hotspot partition. A shuffle contained in one window can use the complete entry budget; multiple windows retain per-window reservations to prevent ordered-write starvation.
- Admit partition inputs in source order before unordered decoding/building, preventing later partitions from consuming every entry permit while the ordered writer waits for an earlier partition.
- Give the legacy one-file-per-partition reader a conservative schema-based admission estimate instead of forcing every non-empty partition through exclusive admission.
- Carry partition IDs through build results and drain a bounded reorder map strictly in partition order before writing.
- Preserve the existing singleton/ordered behavior for incremental, split, join, and remap paths.

This does not change HNSW graph quality parameters.

## Benchmark

The reader benchmark uses the same persistent local files for both implementations and includes a benchmark-local copy of the pre-change reader. It contains 4,096 partitions, 20 flush groups, 262,144 rows, and a 256-dimensional RQ5-like payload, with uniform and CV=3.6001 hotspot distributions.

Environment: Apple arm64, 10 CPU cores / 8 compute workers, 24 GiB RAM, local object store, `release-with-debug`, cache-hot diagnostic pass. Values are the median of three fresh processes per implementation at PR head `04a64651f`. Lower is better for elapsed time, I/O, ranges, and RSS; higher is better for throughput.

| Scenario / metric | Baseline | This PR | Benefit |
| --- | ---: | ---: | ---: |
| Uniform total elapsed | 6,800.322 ms | 82.961 ms | 81.97x speedup |
| Uniform throughput | 38,549 rows/s | 3,159,827 rows/s | 81.97x higher |
| Hotspot total elapsed | 6,726.514 ms | 50.202 ms | 133.99x speedup |
| Hotspot throughput | 38,972 rows/s | 5,221,832 rows/s | 133.99x higher |
| Uniform logical data ranges | 81,920 ranges | 20 ranges | 4,096x fewer |
| Uniform scheduler read IOPS | 786,424 operations | 22 operations | 35,746.55x fewer |
| Uniform physical bytes read | 2,783,291,368 B | 47,680,010 B | 58.37x fewer |
| Uniform peak RSS | 24.7 MiB | 222.7 MiB | 9.02x higher (tradeoff) |
| Hotspot peak RSS | 30.7 MiB | 222.2 MiB | 7.24x higher (tradeoff) |

These measurements cover the two-file shuffle read path, not full IVF-HNSW-RQ build throughput. The 128 MiB reader window is materialized, so the speedup intentionally trades additional bounded memory for much lower I/O amplification. The 512 MiB decoded-input admission budget and entry limit apply independently to each index build; they are not a process-global admission budget or a strict bound on graph/output RSS.

### Concurrent full-build resource check

At PR head `9c96131d9` (before the single-window and legacy concurrency follow-up), a separate full IVF_RQ check used two independent local datasets, each with 262,144 rows, 4,096 partitions, 256 dimensions, 5-bit RQ, and precomputed centroids. A single fresh process sampled its own RSS and OS thread count while running either one build or two concurrent builds. These are single-run observations under `release-with-debug`, not baseline-versus-PR performance claims, and have not been remeasured at the current head.

| Scenario / metric | Single build | Two concurrent builds | Observation |
| --- | ---: | ---: | ---: |
| Total input | 262,144 rows | 524,288 rows | 2.00x work |
| Wall elapsed | 1.916 s | 4.002 s | 2.09x elapsed |
| Aggregate throughput | 136,817 rows/s | 131,009 rows/s | 0.96x throughput |
| Peak process RSS | 718.4 MiB | 996.8 MiB | 1.39x RSS |
| Peak OS threads | 50 threads | 65 threads | 1.30x threads |

The observed process resources remained below 2x in this bounded run, but the implementation does not establish a hard process-global limit: decoded-input and CPU admission objects are instantiated per build. Therefore this PR makes no global-admission or arbitrary-concurrency resource-bound claim.

## Testing

- `cargo test -p lance-index vector::v3::shuffler::tests --lib --no-fail-fast` (21 passed)
- `cargo test -p lance bounded_partition_stream --lib --no-fail-fast` (11 passed)
- `cargo test -p lance index::vector::builder::tests::partition_entry_admission_preserves_input_order -- --exact --nocapture`
- `cargo test -p lance index::vector::builder::tests::single_partition_window_uses_full_entry_budget -- --exact --nocapture`
- `cargo test -p lance index::vector::builder::tests::fresh_partition_build_runs_multiple_windows_end_to_end -- --exact --nocapture`
- `cargo test -p lance-index vector::v3::shuffler::tests::legacy_shuffler_uses_schema_estimate_for_parallel_admission -- --exact --nocapture`
- `cargo test -p lance index::vector::ivf::v2::tests::test_optimize_with_empty_partition -- --exact --nocapture`
- `cargo test -p lance 'index::vector::ivf::v2::tests::test_knn::test_dataset_too_small::num_deltas_1_1' -- --exact --nocapture`
- `cargo test -p lance 'index::vector::ivf::v2::tests::test_knn::test_fewer_than_k_results::num_deltas_1_1' -- --exact --nocapture`
- `uv run pytest -v -s python/tests/test_dataset.py::test_commit_existing_index_segments_accepts_index_metadata`
- `cargo fmt --all -- --check`
- `cargo clippy --all --tests --benches -- -D warnings`
- `cargo bench --profile release-with-debug -p lance-index --bench two_file_shuffle_read -- --test`
