### PR TITLE
test(torch): stabilize ground truth fixture

### DIFF
--- a/python/python/tests/torch_tests/test_bench_utils.py
+++ b/python/python/tests/torch_tests/test_bench_utils.py
@@ -10,7 +10,6 @@ import pytest
 
 torch = pytest.importorskip("torch")
 from lance.torch.bench_utils import ground_truth, sort_tensors  # noqa: E402
-from lance.torch.distance import pairwise_l2  # noqa: E402
 
 
 def test_sort_tensor():
@@ -31,23 +30,36 @@ def test_ground_truth(tmp_path: Path):
     N = 1000
     NUM_QUERIES = 50
     DIM = 128
+    K = 20
 
     device = "cpu"  # Github action friendly.
-    data = np.random.rand(N * DIM).astype(np.float32)
-    fsl = pa.FixedSizeListArray.from_arrays(data, DIM)
-    data = torch.from_numpy(data.reshape((-1, DIM))).to(device)
+    # Keep the fixture independent of other tests that seed NumPy's global RNG.
+    # This seed also keeps every top-20 boundary more than 8e-3 apart.
+    rng = np.random.RandomState(4415)
+    data = rng.rand(N, DIM).astype(np.float32)
+    fsl = pa.FixedSizeListArray.from_arrays(data.reshape(-1), DIM)
+    torch_data = torch.from_numpy(data).to(device)
 
     tbl = pa.Table.from_arrays([fsl], ["vec"])
 
     ds = lance.write_dataset(tbl, tmp_path)
 
-    idx = np.random.choice(range(N), NUM_QUERIES)
-    keys = data[idx, :]
+    idx = rng.choice(N, NUM_QUERIES)
+    keys = torch_data[idx, :]
 
-    gt = ground_truth(ds, "vec", keys, k=20, batch_size=128, device=device)
+    gt = ground_truth(ds, "vec", keys, k=K, batch_size=128, device=device)
     gt, _ = torch.sort(gt, dim=1)
 
-    actual_dists = pairwise_l2(keys, data)
-    expected, _ = torch.sort(torch.argsort(actual_dists, 1)[:, :20], dim=1)
+    # Use direct float64 distances as an oracle, independent of pairwise_l2's
+    # float32 matrix-multiplication reduction order.
+    data64 = data.astype(np.float64)
+    expected = []
+    boundary_gaps = []
+    for query in data64[idx]:
+        distances = np.sum(np.square(data64 - query), axis=1)
+        row_ids = np.argsort(distances, kind="stable")
+        expected.append(np.sort(row_ids[:K]))
+        boundary_gaps.append(distances[row_ids[K]] - distances[row_ids[K - 1]])
 
-    assert torch.allclose(expected, gt)
+    assert min(boundary_gaps) > 8e-3, "fixture is too close to the top-k boundary"
+    np.testing.assert_array_equal(np.stack(expected), gt.cpu().numpy())


### PR DESCRIPTION
## What is the bug?

`test_ground_truth` used NumPy's process-global random state, so its fixture depended on which tests ran first in the same xdist worker. It then compared the row IDs from batched 128-row float32 distance calculations with an oracle computed as one 1,000-row float32 matrix multiplication. Different matrix shapes can use different reduction orders and swap nearly equal candidates at the top-k boundary.

This is not specific to Linux ARM and was not introduced by #8893. Failures on Linux ARM and x86_64 consistently retained 19 of 20 neighbors and swapped only the cutoff candidate; reruns of the same configuration also passed.

## What issues does it cause?

The test fails intermittently on unrelated PRs and main. For example, the Linux ARM / Python 3.14 job from #8893 swapped row IDs 18 and 602 for one query, while all other queries matched.

This is tracked as part of #8789 and Linear OSS-2118.

## How does this PR fix the problem?

- use a local fixed NumPy RNG so the fixture is independent of test order
- compute the expected neighbors directly in float64, independently of the production float32 matrix-multiplication path
- assert that every 20th/21st distance gap is greater than `8e-3`
- retain exact row-ID equality rather than weakening the assertion

Production distance and ground-truth code is unchanged.

## Validation

- `uv run pytest python/tests/torch_tests/test_bench_utils.py python/tests/torch_tests/test_distance.py -q` (`6 passed, 3 skipped`)
- polluted-order regression: run the global-RNG-seeding vector-index test before `test_ground_truth` with one xdist worker (`2 passed`)
- `uv run make lint`
- pre-commit hooks
- Linux ARM / Python 3.14 CI attempts 1 and 2 (`1382 passed, 503 skipped` in each attempt)

Local validation used macOS ARM, Python 3.14.6, NumPy 2.5.1, and torch 2.13.0. CI used Linux ARM, Python 3.14.7, NumPy 2.5.2, and torch 2.13.0+cpu.
