### PR TITLE
feat(format): add blob reuse index

### DIFF
--- a/docs/src/format/table/.pages
+++ b/docs/src/format/table/.pages
@@ -7,4 +7,5 @@ nav:
   - Branch & Tag: branch_tag.md
   - Row ID & Lineage: row_id_lineage.md
   - Data Overlay Files: data_overlay_file.md
+  - Blob Reuse Index: blob_reuse_index.md
   - MemTable & WAL: mem_wal.md

--- a/docs/src/format/table/blob_reuse_index.md
+++ b/docs/src/format/table/blob_reuse_index.md
@@ -1,0 +1,112 @@
+# Blob Reuse Index
+
+## Scope
+
+A Blob Reuse Index (BRI) is optional metadata on a DataFile. It provides sparse
+redirects from file-local Blob v2 identifiers to existing physical sidecars.
+The index applies only to Packed and Dedicated descriptors. Inline payloads
+remain in the data file, and External descriptors retain their URI and base-path
+semantics.
+
+BRI changes the table manifest format only. It does not change the Blob v2
+descriptor layout or the sidecar file format.
+
+## Representation
+
+`DataFile.blob_reuse_index` contains one or more `BlobReuseSource` messages. A
+source identifies an optional base path, one sidecar directory, a sequence of
+output-local identifiers, and a positionally aligned sequence of physical
+identifiers. `local_ids` uses `RowIdSequence`; `physical_ids` uses
+`EncodedU64Array`.
+
+An absent source `base_id` means the containing DataFile's `base_id`. An absent
+DataFile `base_id` means the dataset's primary root. `blob_dir` is relative to
+the effective base's data directory and is exactly one non-empty path segment.
+
+The BRI field is absent when no redirects exist. A present BRI has at least one
+source, and every source has at least one mapping.
+
+## Validation
+
+A reader validates BRI metadata while opening the manifest:
+
+- Each effective `(base_id, blob_dir)` pair occurs at most once.
+- Every explicit or inherited non-primary base exists in
+  `Manifest.base_paths`.
+- Each source's local identifiers are strictly increasing, and local
+  identifiers do not overlap across sources.
+- The local and physical sequences have equal lengths.
+- Every local and physical identifier is in `1..=u32::MAX`.
+- Physical identifiers retain positional order and need not be sorted.
+
+BRI is an immutable part of physical DataFile identity. If a commit retains the
+same `(base_id, path)`, it retains a semantically identical sparse mapping.
+Adding, removing, or changing BRI metadata for that identity is invalid. A
+writer changes BRI only by writing a new physical DataFile.
+
+## Read Resolution
+
+For a Packed or Dedicated local identifier, a reader first searches the BRI. A
+hit selects the source containing that local identifier and the physical
+identifier at the same sequence position. The sidecar path is the effective
+base's data directory, followed by `blob_dir`, followed by the 32-bit binary
+representation of the physical identifier after bit reversal and the `.blob`
+suffix.
+
+A miss uses identity resolution: the containing DataFile's effective data
+directory, the DataFile stem, and the local identifier encoded with the same
+sidecar filename rule. Dedicated descriptors read the complete sidecar. Packed
+descriptors additionally apply their descriptor position and size.
+
+## Write and Compaction Requirements
+
+Each output DataFile uses one identifier allocator for reused references and
+new sidecars. Before allocation, a reused reference is resolved to its terminal
+physical `(base_id, blob_dir, physical_id)` tuple. Equal terminal references in
+one output DataFile receive one local identifier. A reused identifier is added
+to BRI and does not create a sidecar under the output stem. A new or repacked
+payload uses its allocated identifier under the output stem and does not receive
+a BRI entry. Sources therefore have increasing local identifiers even when
+their physical identifiers are unordered.
+
+Compaction reuses terminal Dedicated sidecars by default. For each input
+fragment, it computes `active_rows / physical_rows`. Packed sidecars are reused
+when that ratio is at least the configured repack threshold and are repacked
+under the output stem when it is below the threshold. The default threshold is
+0.3, so Packed payloads are rewritten only after more than 70% of the fragment's
+rows have been deleted. The descriptor keeps its original Packed position and
+size when the sidecar is reused.
+
+Inline values remain inline, and External descriptors remain external. An
+implementation may expose a mode that disables sidecar reuse; in that mode both
+Packed and Dedicated payloads are materialized like ordinary writes, and a
+complete rewrite can remove the last BRI from a manifest.
+
+## Cleanup, Rollback, and Clone
+
+Cleanup treats every retained DataFile's own stem directory as live. It also
+treats each exact BRI sidecar path in the current root as live. Other sidecars
+under a source stem may be collected once no retained DataFile or BRI entry
+references them. Cleanup of one root does not delete objects owned by another
+base.
+
+Rollback of an uncommitted output removes only that output's `.lance` file and
+its own stem directory. It does not traverse BRI sources.
+
+A shallow clone preserves BRI metadata. An implicit source base follows the
+containing DataFile into the clone's source base, so no Blob payload copy is
+required.
+
+A deep clone copies every DataFile and its complete own stem directory. It also
+copies each distinct explicit BRI physical reference. Distinct effective
+`(base_id, blob_dir)` sources receive distinct target directories. The cloned
+BRI uses those target directories with no source base, leaving the target
+independent of every source root.
+
+## Feature Flag
+
+If any DataFile contains BRI metadata, the manifest sets bit 512 in both
+`reader_feature_flags` and `writer_feature_flags`. Both bits are cleared after
+the last BRI disappears. A manifest with BRI metadata and missing bits, with
+bits but no BRI metadata, or with only one of the reader and writer bits is
+invalid.

--- a/docs/src/format/table/index.md
+++ b/docs/src/format/table/index.md
@@ -146,6 +146,14 @@ or independently of column indices due to variable encoding widths (for Lance fi
 
     See the [5.0.0 migration guide](../../guide/migration.md#500) for a detailed example.
 
+### Blob Reuse Index
+
+A DataFile may carry a Blob Reuse Index (BRI) that redirects selected file-local
+Blob v2 identifiers to immutable Packed or Dedicated sidecars owned by another
+data file. Unmapped identifiers continue to resolve under the containing data
+file's own stem. See the [Blob Reuse Index Specification](blob_reuse_index.md)
+for validation, resolution, compaction, cleanup, and clone requirements.
+
 ## Deletion Files
 
 Deletion files (a.k.a. deletion vectors) track deleted rows without rewriting data files.

--- a/docs/src/format/table/versioning.md
+++ b/docs/src/format/table/versioning.md
@@ -31,7 +31,9 @@ they should return an "unsupported" error on any read or write operation.
 | 32       | `FLAG_DISABLE_TRANSACTION_FILE` | No              | Yes             | Transactions are recorded in the manifest rather than in a separate transaction file.                       |
 | 64       | `FLAG_UNSTABLE_DATA_OVERLAY_FILES` | Yes          | Yes             | Fragments may carry data overlay files. Unstable: release builds reject it unless explicitly opted in.      |
 | 128      | `FLAG_COVERED_INDEX_METADATA`   | Yes             | Yes             | Some index declares covering columns (`IndexMetadata.covering_fields`), so `fields` means keyed columns followed by carried ones. An implementation without this flag selects an index by membership of `fields` and would answer a query on a merely-carried column with an index keyed on a different one. |
+| 256      | `FLAG_MIXED_DATA_FILE_VERSIONS` | Unsupported     | Unsupported     | Reserved for manifests containing recognized V2 data files with different exact versions. Implementations must reject this flag until the capability is defined. |
+| 512      | `FLAG_BLOB_REUSE_INDEX`         | Yes             | Yes             | At least one DataFile contains a Blob Reuse Index that redirects file-local Blob v2 identifiers to sidecars owned by another data file. |
 
 </div>
 
-Flags with bit values 256 and above are unknown and will cause implementations to reject the dataset with an "unsupported" error.
+Flag values at or above 1024 are unknown and cause implementations to reject the dataset with an "unsupported" error. Bit 256 is reserved but unsupported and must be rejected as well.

--- a/protos/table.proto
+++ b/protos/table.proto
@@ -8,6 +8,7 @@ package lance.table;
 import "google/protobuf/any.proto";
 import "google/protobuf/timestamp.proto";
 import "file.proto";
+import "rowids.proto";
 
 /*
 
@@ -481,7 +482,30 @@ message DataFile {
   // The base path index of the data file. Used when the file is imported or referred from another dataset.
   // Lance use it as key of the base_paths field in Manifest to determine the actual base path of the data file.
   optional uint32 base_id = 7;
+
+  // Sparse redirects from file-local blob ids to reused Blob v2 sidecars.
+  // Absent means every Packed or Dedicated blob id resolves below this data
+  // file's own stem directory.
+  BlobReuseIndex blob_reuse_index = 8;
 } // DataFile
+
+// Sparse physical-sidecar redirects used by Blob v2 compaction and cloning.
+message BlobReuseIndex {
+  // Non-empty when BlobReuseIndex is present.
+  repeated BlobReuseSource sources = 1;
+}
+
+message BlobReuseSource {
+  // The base path containing the reused sidecars. Absent means the same base
+  // as the DataFile that contains this source.
+  optional uint32 base_id = 1;
+  // One sidecar directory name relative to the base's data directory.
+  string blob_dir = 2;
+  // Strictly increasing output-local blob ids redirected by this source.
+  RowIdSequence local_ids = 3;
+  // Physical blob ids aligned positionally with local_ids.
+  EncodedU64Array physical_ids = 4;
+}
 
 // An overlay file supplies new values for a subset of (row offset, field) cells
 // within a fragment, without rewriting the fragment's base data files. It is


### PR DESCRIPTION
## Problem

Blob v2 Packed and Dedicated descriptors use DataFile-local blob IDs. After compaction writes a new DataFile, those descriptors cannot reference immutable sidecars owned by an older DataFile, forcing payload rewrites and preventing precise lifecycle tracking.

## Format contract

This adds an optional sparse Blob Reuse Index to DataFile. A hit redirects a local blob ID to a terminal (base_id, blob_dir, physical_id) source; a miss retains the existing identity mapping under the containing DataFile stem. The descriptor and sidecar formats remain unchanged, and Packed descriptors continue applying their stored position and size.

A manifest containing BRI metadata sets reader and writer feature flag bit 512. Implementations that do not understand the mapping must reject the current dataset version rather than read an incorrect identity path.

## Compatibility

Existing datasets and historical versions remain unchanged. BRI can be removed by a complete rewrite that materializes all referenced sidecars. This format change requires the normal PMC vote before the implementation PR is merged.
