### PR TITLE
chore(build): retire stale recursion_limit attributes and document the real ones

### DIFF
--- a/rust/lance-io/src/lib.rs
+++ b/rust/lance-io/src/lib.rs
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright The Lance Authors
-#![recursion_limit = "512"]
 use std::{
     ops::{Range, RangeFrom, RangeFull, RangeTo},
     sync::Arc,

--- a/rust/lance-namespace-datafusion/tests/sql.rs
+++ b/rust/lance-namespace-datafusion/tests/sql.rs
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright The Lance Authors
 
-#![recursion_limit = "256"]
-
 use std::sync::Arc;
 
 use arrow_array::{Int32Array, Int64Array, RecordBatch, RecordBatchIterator, StringArray};

--- a/rust/lance/benches/fts_search.rs
+++ b/rust/lance/benches/fts_search.rs
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright The Lance Authors
 
-#![recursion_limit = "256"]
-
 /// This is a rust end-to-end benchmark for full text search.  It is meant to be supplementary to the
 /// python benchmark located at python/python/ci_benchmarks/benchmarks/test_fts_search.py.  You can use
 /// the python/python/ci_benchmarks/datagen/wikipedia.py script to generate the dataset.  You will need

--- a/rust/lance/benches/mem_wal/fts/mem_wal_fineweb_fts.rs
+++ b/rust/lance/benches/mem_wal/fts/mem_wal_fineweb_fts.rs
@@ -33,7 +33,6 @@
 //!   --cache-dir /tmp/fineweb-cache --output result.json
 //! ```
 
-#![recursion_limit = "256"]
 #![allow(clippy::print_stdout, clippy::print_stderr)]
 
 use std::collections::{HashMap, HashSet};

--- a/rust/lance/benches/mem_wal/fts/mem_wal_fts_bench.rs
+++ b/rust/lance/benches/mem_wal/fts/mem_wal_fts_bench.rs
@@ -23,7 +23,6 @@
 //! Emits one `result ...` human line and one JSON line tagged
 //! `impl=lance_fts`, matching the `mem_wal_hnsw_bench` output convention.
 
-#![recursion_limit = "256"]
 #![allow(clippy::print_stdout, clippy::print_stderr)]
 
 use std::collections::HashMap;

--- a/rust/lance/benches/mem_wal/fts/mem_wal_fts_read_bench.rs
+++ b/rust/lance/benches/mem_wal/fts/mem_wal_fts_read_bench.rs
@@ -42,7 +42,6 @@
 //!   --cache-dir /tmp/fineweb-cache --output result.json
 //! ```
 
-#![recursion_limit = "256"]
 #![allow(clippy::print_stdout, clippy::print_stderr)]
 
 use std::collections::{HashMap, HashSet};

--- a/rust/lance/benches/mem_wal/vector/hnsw/mem_wal_recall_hnsw.rs
+++ b/rust/lance/benches/mem_wal/vector/hnsw/mem_wal_recall_hnsw.rs
@@ -15,7 +15,6 @@
 //!       truth) vs HNSW top-k via `MemTableScanner::nearest`.
 //!     * Recall@k = |brute ∩ hnsw| / k aggregated over queries.
 
-#![recursion_limit = "256"]
 #![allow(clippy::print_stdout, clippy::print_stderr)]
 
 use std::sync::Arc;

--- a/rust/lance/benches/mem_wal/vector/mem_wal_index_micro.rs
+++ b/rust/lance/benches/mem_wal/vector/mem_wal_index_micro.rs
@@ -24,7 +24,6 @@
 //!
 //! Output is plain stdout, one line per checkpoint, captured by the runner.
 
-#![recursion_limit = "256"]
 #![allow(clippy::print_stdout, clippy::print_stderr)]
 
 use std::path::PathBuf;

--- a/rust/lance/benches/mem_wal/write/mem_wal_shard_writer_backpressure.rs
+++ b/rust/lance/benches/mem_wal/write/mem_wal_shard_writer_backpressure.rs
@@ -24,6 +24,9 @@
 //!   --threads 64
 //! ```
 
+// serde_json's `json_internal!` recurses once per nesting level of the config
+// literals below, which exceeds the default limit of 128. Async future depth
+// is not the reason; see issue #8416.
 #![recursion_limit = "256"]
 #![allow(clippy::print_stdout, clippy::print_stderr)]
 

--- a/rust/lance/benches/s3_file_reader_diagnostics.rs
+++ b/rust/lance/benches/s3_file_reader_diagnostics.rs
@@ -2,6 +2,10 @@
 // SPDX-FileCopyrightText: Copyright The Lance Authors
 
 #![allow(clippy::print_stdout)]
+// serde_json's `json_internal!` recurses once per nesting level of the
+// diagnostics payload literals below, which exceeds the default limit of 128.
+// Async future depth is not the reason: the crate compiles at the default
+// limit with the payloads flattened.
 #![recursion_limit = "256"]
 
 use std::collections::BTreeMap;

--- a/rust/lance/benches/streaming_ivf_training.rs
+++ b/rust/lance/benches/streaming_ivf_training.rs
@@ -1,6 +1,10 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright The Lance Authors
 
+// The streaming IVF training path still nests async frames past the default
+// recursion limit of 128 when the Linux io_uring reader types are in the
+// obligation graph (the failure does not reproduce on non-Linux hosts). Every
+// other bench now fits the default; see issue #8416.
 #![recursion_limit = "256"]
 
 use std::sync::Arc;

--- a/rust/lance/tests/mem_wal/future_depth.rs
+++ b/rust/lance/tests/mem_wal/future_depth.rs
@@ -1,0 +1,113 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+//! Compile-time canary for issue #8416.
+//!
+//! A downstream crate awaiting the mem_wal point-lookup futures must prove
+//! their auto traits within rustc's default `recursion_limit` of 128. This
+//! integration-test crate deliberately carries no `recursion_limit`
+//! attribute, so the `Send` obligations below are solved exactly as a
+//! consumer's would be, and the nested frames mirror the downstream call
+//! shape reported in the issue. A depth regression in the scanner's future
+//! nesting fails this crate's build instead of every consumer's.
+
+use std::future::Future;
+use std::sync::Arc;
+
+use arrow_array::RecordBatch;
+use datafusion::physical_plan::ExecutionPlan;
+use datafusion::scalar::ScalarValue;
+use lance::Result;
+use lance::dataset::mem_wal::scanner::{LsmPointLookupPlanner, LsmScanner};
+
+fn require_send<F: Future + Send>(future: F) -> F {
+    future
+}
+
+async fn lookup_one(
+    planner: &LsmPointLookupPlanner,
+    keys: &[ScalarValue],
+) -> Result<Option<RecordBatch>> {
+    planner.lookup(keys, None).await
+}
+
+async fn lookup_batch(
+    planner: &LsmPointLookupPlanner,
+    keys: &[ScalarValue],
+) -> Result<RecordBatch> {
+    planner.lookup_many(keys, None).await
+}
+
+async fn lookup_plan(
+    planner: &LsmPointLookupPlanner,
+    keys: &[ScalarValue],
+) -> Result<Arc<dyn ExecutionPlan>> {
+    planner.plan_point_lookup(keys, None).await
+}
+
+async fn scan_plan(scanner: &LsmScanner) -> Result<Arc<dyn ExecutionPlan>> {
+    scanner.create_plan().await
+}
+
+async fn service_layer(
+    planner: &LsmPointLookupPlanner,
+    scanner: &LsmScanner,
+    keys: &[ScalarValue],
+) -> Result<()> {
+    lookup_one(planner, keys).await?;
+    lookup_batch(planner, keys).await?;
+    lookup_plan(planner, keys).await?;
+    scan_plan(scanner).await?;
+    Ok(())
+}
+
+async fn handler_layer(
+    planner: &LsmPointLookupPlanner,
+    scanner: &LsmScanner,
+    keys: &[ScalarValue],
+) -> Result<()> {
+    service_layer(planner, scanner, keys).await
+}
+
+async fn middleware_layer(
+    planner: &LsmPointLookupPlanner,
+    scanner: &LsmScanner,
+    keys: &[ScalarValue],
+) -> Result<()> {
+    handler_layer(planner, scanner, keys).await
+}
+
+async fn request_layer(
+    planner: &LsmPointLookupPlanner,
+    scanner: &LsmScanner,
+    keys: &[ScalarValue],
+) -> Result<()> {
+    middleware_layer(planner, scanner, keys).await
+}
+
+async fn api_layer(
+    planner: &LsmPointLookupPlanner,
+    scanner: &LsmScanner,
+    keys: &[ScalarValue],
+) -> Result<()> {
+    request_layer(planner, scanner, keys).await
+}
+
+async fn app_layer(
+    planner: &LsmPointLookupPlanner,
+    scanner: &LsmScanner,
+    keys: &[ScalarValue],
+) -> Result<()> {
+    api_layer(planner, scanner, keys).await
+}
+
+// The Send proof at this call is the test: it walks every wrapper layer of
+// the six frames above plus the scanner's own nesting. Never executed.
+#[allow(dead_code)]
+fn downstream_futures_fit_default_recursion_limit(
+    planner: &LsmPointLookupPlanner,
+    scanner: &LsmScanner,
+    keys: &[ScalarValue],
+) {
+    let _ = require_send(app_layer(planner, scanner, keys));
+}

--- a/rust/lance/tests/mem_wal/future_depth.rs
+++ b/rust/lance/tests/mem_wal/future_depth.rs
@@ -109,5 +109,5 @@ fn downstream_futures_fit_default_recursion_limit(
     scanner: &LsmScanner,
     keys: &[ScalarValue],
 ) {
-    let _ = require_send(app_layer(planner, scanner, keys));
+    std::mem::drop(require_send(app_layer(planner, scanner, keys)));
 }

--- a/rust/lance/tests/mem_wal/mod.rs
+++ b/rust/lance/tests/mem_wal/mod.rs
@@ -14,6 +14,8 @@ use lance_core::FenceReason;
 use lance_io::object_store::ObjectStore;
 use uuid::Uuid;
 
+mod future_depth;
+
 fn durable_writer_config(shard_id: Uuid) -> ShardWriterConfig {
     ShardWriterConfig {
         shard_id,


### PR DESCRIPTION
## Problem

#8416 reported that deeply nested async fns in `mem_wal::scanner` push trait-solver obligation chains past the default `recursion_limit` of 128, forcing consumers to raise it. The repo itself carried eleven raised limits (nine benches, the `lance-namespace-datafusion` sql tests, and `lance-io` at 512).

## What re-verification found

Each attribute was removed and every affected target compiled on Rust 1.97.0, on both x86_64 Linux (where the io_uring reader's moka types — the root of the issue's quoted chain — are actually in the obligation graph) and Windows:

| Attribute site | Verdict |
| --- | --- |
| `lance-io` (512), namespace sql tests, `fts_search`, 5 `mem_wal` benches | **Stale — removed.** Compile at the default limit on both platforms. |
| `s3_file_reader_diagnostics`, `mem_wal_shard_writer_backpressure` | **Needed, but not for futures**: serde_json's `json_internal!` recurses per nesting level of their config literals. Kept, reason now recorded in a comment. |
| `streaming_ivf_training` | **Needed for future depth, Linux-only** (does not reproduce without the io_uring types). Kept, reason recorded. |

## Downstream evidence for the reported point-lookup path

Per review feedback, the closing claim is now backed by a direct check rather than a sibling-path inference: `rust/lance/tests/mem_wal/future_depth.rs` awaits `LsmPointLookupPlanner::{lookup, lookup_many, plan_point_lookup}` and `LsmScanner::create_plan` under six nested async frames mirroring the downstream call shape from the issue, and forces the `Send` proof via a `require_send` bound. The integration-test binary compiles as a separate crate and deliberately carries no `recursion_limit` attribute, so those obligations are solved exactly as a consumer's await site would solve them. It compiles at the default limit on Linux (io_uring types in the graph) and Windows — and any future depth regression in the scanner nesting now fails this in-repo build instead of every consumer's.

Secondary datapoint: the deepest scanner bench (`mem_wal_fts_read_bench`, FTS path) compiles with `recursion_limit = 96` and fails at 64, so that chain proves at depth ≤ 96.

## Why this shape of fix

Recursion depth has no lint (`clippy::large_futures` is already `deny` workspace-wide but measures size, not depth, and `-Z min-recursion-limit` can only raise limits), so a crate that compiles at the default limit is the only durable canary. The removed attributes' absence plus the new downstream-shaped test make depth regressions fail the build immediately instead of hiding behind raised limits.

Fixes #8416
