### PR TITLE
fix: resolve clone sources with source commit handler

### DIFF
--- a/rust/lance/src/dataset/write/commit.rs
+++ b/rust/lance/src/dataset/write/commit.rs
@@ -45,6 +45,7 @@ pub struct CommitBuilder<'a> {
     store_params: Option<ObjectStoreParams>,
     object_store: Option<Arc<ObjectStore>>,
     source_store: Option<Arc<ObjectStore>>,
+    source_commit_handler: Option<Arc<dyn CommitHandler>>,
     session: Option<Arc<Session>>,
     detached: bool,
     commit_config: CommitConfig,
@@ -70,6 +71,7 @@ impl<'a> CommitBuilder<'a> {
             store_params: None,
             object_store: None,
             source_store: None,
+            source_commit_handler: None,
             session: None,
             detached: false,
             commit_config: Default::default(),
@@ -126,6 +128,17 @@ impl<'a> CommitBuilder<'a> {
     /// store when not set, preserving same-store behavior.
     pub fn with_source_store(mut self, source_store: Arc<ObjectStore>) -> Self {
         self.source_store = Some(source_store);
+        self
+    }
+
+    /// Pass the dataset being cloned from.
+    ///
+    /// Only used by `Operation::Clone`: the source manifest is resolved through
+    /// the dataset's commit handler and read through its object store. This is
+    /// required when the source and destination use different manifest stores.
+    pub fn with_source_dataset(mut self, source: &Dataset) -> Self {
+        self.source_store = Some(source.object_store.clone());
+        self.source_commit_handler = Some(source.commit_handler.clone());
         self
     }
 
@@ -298,8 +311,9 @@ impl<'a> CommitBuilder<'a> {
             .or_else(|| self.dest.dataset().map(|ds| ds.session.clone()))
             .unwrap_or_default();
 
-        // Store used to read the source manifest for a clone (see with_source_store).
+        // Store and handler used to read the source manifest for a clone.
         let source_store = self.source_store.clone();
+        let source_commit_handler = self.source_commit_handler.clone();
 
         let (object_store, base_path, commit_handler) = match &self.dest {
             WriteDestination::Dataset(dataset) => (
@@ -472,6 +486,7 @@ impl<'a> CommitBuilder<'a> {
             commit_new_dataset(
                 object_store.as_ref(),
                 source_store.as_deref(),
+                source_commit_handler.as_deref(),
                 commit_handler.as_ref(),
                 &base_path,
                 &transaction,
@@ -605,7 +620,9 @@ mod tests {
     use lance_table::format::{
         DataFile, Fragment, IndexMetadata, Manifest, Transaction as TableTransaction,
     };
-    use lance_table::io::commit::{CommitError, ManifestLocation, ManifestWriter};
+    use lance_table::io::commit::{
+        CommitError, ConditionalPutCommitHandler, ManifestLocation, ManifestWriter,
+    };
     use std::time::Duration;
 
     use object_store::throttle::ThrottleConfig;
@@ -674,6 +691,90 @@ mod tests {
             tokio::time::sleep(Duration::from_millis(100)).await;
             Err(CommitError::CommitConflict)
         }
+    }
+
+    #[derive(Debug)]
+    struct DestinationOnlyCommitHandler;
+
+    #[async_trait::async_trait]
+    impl CommitHandler for DestinationOnlyCommitHandler {
+        async fn resolve_version_location(
+            &self,
+            _base_path: &object_store::path::Path,
+            _version: u64,
+            _object_store: &dyn object_store::ObjectStore,
+        ) -> Result<ManifestLocation> {
+            Err(Error::invalid_input(
+                "destination commit handler cannot resolve source versions",
+            ))
+        }
+
+        async fn commit(
+            &self,
+            manifest: &mut Manifest,
+            indices: Option<Vec<IndexMetadata>>,
+            base_path: &object_store::path::Path,
+            object_store: &ObjectStore,
+            manifest_writer: ManifestWriter,
+            naming_scheme: ManifestNamingScheme,
+            transaction: Option<TableTransaction>,
+        ) -> std::result::Result<ManifestLocation, CommitError> {
+            ConditionalPutCommitHandler
+                .commit(
+                    manifest,
+                    indices,
+                    base_path,
+                    object_store,
+                    manifest_writer,
+                    naming_scheme,
+                    transaction,
+                )
+                .await
+        }
+    }
+
+    #[tokio::test]
+    async fn test_clone_uses_source_dataset_commit_handler() {
+        let session = Arc::new(Session::default());
+        let batch = RecordBatch::try_new(
+            Arc::new(ArrowSchema::new(vec![ArrowField::new(
+                "i",
+                DataType::Int32,
+                false,
+            )])),
+            vec![Arc::new(Int32Array::from_iter_values(0..10_i32))],
+        )
+        .unwrap();
+        let source = InsertBuilder::new("memory://clone-source-handler/source")
+            .with_params(&WriteParams {
+                session: Some(session.clone()),
+                ..Default::default()
+            })
+            .execute(vec![batch])
+            .await
+            .unwrap();
+        let version = source.version().version;
+        let transaction = Transaction::new(
+            version,
+            Operation::Clone {
+                is_shallow: true,
+                ref_name: None,
+                ref_version: version,
+                ref_path: source.uri().to_string(),
+                branch_name: None,
+            },
+            None,
+        );
+
+        let cloned = CommitBuilder::new("memory://clone-source-handler/target")
+            .with_session(session)
+            .with_commit_handler(Arc::new(DestinationOnlyCommitHandler))
+            .with_source_dataset(&source)
+            .execute(transaction)
+            .await
+            .unwrap();
+
+        assert_eq!(cloned.count_rows(None).await.unwrap(), 10);
     }
 
     #[tokio::test]

--- a/rust/lance/src/io/commit.rs
+++ b/rust/lance/src/io/commit.rs
@@ -348,6 +348,7 @@ pub(crate) const MAX_INLINE_TRANSACTION_BYTES: usize = 64 * 1024;
 async fn do_commit_new_dataset(
     object_store: &ObjectStore,
     source_store: Option<&ObjectStore>,
+    source_commit_handler: Option<&dyn CommitHandler>,
     commit_handler: &dyn CommitHandler,
     base_path: &Path,
     transaction: &Transaction,
@@ -372,9 +373,10 @@ async fn do_commit_new_dataset(
         // from the destination store when cloning across object stores/accounts. Falls
         // back to the destination store for same-store clones.
         let source_store = source_store.unwrap_or(object_store);
+        let source_commit_handler = source_commit_handler.unwrap_or(commit_handler);
         let source_base_path =
             ObjectStore::extract_path_from_uri(store_registry, ref_path.as_str())?;
-        let source_manifest_location = commit_handler
+        let source_manifest_location = source_commit_handler
             .resolve_version_location(&source_base_path, *ref_version, &source_store.inner)
             .await?;
         let source_manifest = Dataset::load_manifest(
@@ -623,6 +625,7 @@ async fn record_new_dataset_commit(
 pub(crate) async fn commit_new_dataset(
     object_store: &ObjectStore,
     source_store: Option<&ObjectStore>,
+    source_commit_handler: Option<&dyn CommitHandler>,
     commit_handler: &dyn CommitHandler,
     base_path: &Path,
     transaction: &Transaction,
@@ -634,6 +637,7 @@ pub(crate) async fn commit_new_dataset(
     do_commit_new_dataset(
         object_store,
         source_store,
+        source_commit_handler,
         commit_handler,
         base_path,
         transaction,


### PR DESCRIPTION
## Summary

- let clone callers provide the source dataset to `CommitBuilder`
- resolve the source manifest with the source dataset commit handler while committing the target with its own handler
- preserve existing `with_source_store` fallback behavior

## Why

A clone into a namespace-managed target has different source and destination commit handlers. The new-dataset commit path previously used the destination external-manifest handler to resolve the source version, so it rejected the source path as outside the target table root.

## Validation

- `cargo test -p lance dataset::write::commit::tests::test_clone_uses_source_dataset_commit_handler --lib`
- `cargo fmt --all`

`cargo clippy -p lance --lib --tests -- -D warnings` reaches unrelated existing Rust 1.97 lint failures in `lance-io` and `lance-encoding` (`implicit_clone` and `single_range_in_vec_init`).