### PR TITLE
build(deps)!: bump lance-namespace to 0.11.1 across Java and Python

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5046,9 +5046,9 @@ dependencies = [
 
 [[package]]
 name = "lance-namespace-reqwest-client"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a030196da1c994b63a96a4f0bf5b0cfa459fe6dadc9e962320246ca328da22a"
+checksum = "1d06b1fbb5d41f93bc652b61e2872af92e8a6c5f6b4ce8839a8ecfa05365d359"
 dependencies = [
  "reqwest 0.12.28",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,7 +73,7 @@ lance-io = { version = "=12.0.0-beta.5", path = "./rust/lance-io", default-featu
 lance-linalg = { version = "=12.0.0-beta.5", path = "./rust/lance-linalg" }
 lance-namespace = { version = "=12.0.0-beta.5", path = "./rust/lance-namespace" }
 lance-namespace-impls = { version = "=12.0.0-beta.5", path = "./rust/lance-namespace-impls" }
-lance-namespace-reqwest-client = "0.11.0"
+lance-namespace-reqwest-client = "0.11.1"
 lance-select = { version = "=12.0.0-beta.5", path = "./rust/lance-select" }
 lance-tokenizer = { version = "=12.0.0-beta.5", path = "./rust/lance-tokenizer" }
 lance-table = { version = "=12.0.0-beta.5", path = "./rust/lance-table" }

--- a/java/lance-jni/Cargo.lock
+++ b/java/lance-jni/Cargo.lock
@@ -4187,9 +4187,9 @@ dependencies = [
 
 [[package]]
 name = "lance-namespace-reqwest-client"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a030196da1c994b63a96a4f0bf5b0cfa459fe6dadc9e962320246ca328da22a"
+checksum = "1d06b1fbb5d41f93bc652b61e2872af92e8a6c5f6b4ce8839a8ecfa05365d359"
 dependencies = [
  "reqwest 0.12.28",
  "serde",

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -111,12 +111,12 @@
         <dependency>
             <groupId>org.lance</groupId>
             <artifactId>lance-namespace-core</artifactId>
-            <version>0.7.7</version>
+            <version>0.11.1</version>
         </dependency>
         <dependency>
             <groupId>org.lance</groupId>
             <artifactId>lance-namespace-apache-client</artifactId>
-            <version>0.7.7</version>
+            <version>0.11.1</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>

--- a/java/src/main/java/org/lance/namespace/DirectoryNamespace.java
+++ b/java/src/main/java/org/lance/namespace/DirectoryNamespace.java
@@ -26,6 +26,7 @@ import org.lance.namespace.model.AnalyzeTableQueryPlanRequest;
 import org.lance.namespace.model.BatchDeleteTableVersionsRequest;
 import org.lance.namespace.model.BatchDeleteTableVersionsResponse;
 import org.lance.namespace.model.CountTableRowsRequest;
+import org.lance.namespace.model.CountTableRowsResponse;
 import org.lance.namespace.model.CreateMaterializedViewRequest;
 import org.lance.namespace.model.CreateMaterializedViewResponse;
 import org.lance.namespace.model.CreateNamespaceRequest;
@@ -83,7 +84,9 @@ import org.lance.namespace.model.ListTablesResponse;
 import org.lance.namespace.model.MergeInsertIntoTableRequest;
 import org.lance.namespace.model.MergeInsertIntoTableResponse;
 import org.lance.namespace.model.NamespaceExistsRequest;
+import org.lance.namespace.model.NamespaceExistsResponse;
 import org.lance.namespace.model.QueryTableRequest;
+import org.lance.namespace.model.QueryTableResponse;
 import org.lance.namespace.model.RegisterTableRequest;
 import org.lance.namespace.model.RegisterTableResponse;
 import org.lance.namespace.model.RenameTableRequest;
@@ -91,6 +94,7 @@ import org.lance.namespace.model.RenameTableResponse;
 import org.lance.namespace.model.RestoreTableRequest;
 import org.lance.namespace.model.RestoreTableResponse;
 import org.lance.namespace.model.TableExistsRequest;
+import org.lance.namespace.model.TableExistsResponse;
 import org.lance.namespace.model.UpdateTableRequest;
 import org.lance.namespace.model.UpdateTableResponse;
 import org.lance.namespace.model.UpdateTableSchemaMetadataRequest;
@@ -101,6 +105,7 @@ import org.lance.namespace.model.UpdateTableTagResponse;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import org.apache.arrow.memory.BufferAllocator;
 
 import java.io.Closeable;
@@ -239,6 +244,7 @@ public class DirectoryNamespace implements LanceNamespace, Closeable {
 
   private static ObjectMapper createObjectMapper() {
     ObjectMapper mapper = new ObjectMapper();
+    mapper.registerModule(new JavaTimeModule());
     mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
     return mapper;
   }
@@ -329,10 +335,11 @@ public class DirectoryNamespace implements LanceNamespace, Closeable {
   }
 
   @Override
-  public void namespaceExists(NamespaceExistsRequest request) {
+  public NamespaceExistsResponse namespaceExists(NamespaceExistsRequest request) {
     ensureInitialized();
     String requestJson = toJson(request);
     namespaceExistsNative(nativeDirectoryNamespaceHandle, requestJson);
+    return new NamespaceExistsResponse();
   }
 
   @Override
@@ -360,10 +367,11 @@ public class DirectoryNamespace implements LanceNamespace, Closeable {
   }
 
   @Override
-  public void tableExists(TableExistsRequest request) {
+  public TableExistsResponse tableExists(TableExistsRequest request) {
     ensureInitialized();
     String requestJson = toJson(request);
     tableExistsNative(nativeDirectoryNamespaceHandle, requestJson);
+    return new TableExistsResponse();
   }
 
   @Override
@@ -383,10 +391,11 @@ public class DirectoryNamespace implements LanceNamespace, Closeable {
   }
 
   @Override
-  public Long countTableRows(CountTableRowsRequest request) {
+  public CountTableRowsResponse countTableRows(CountTableRowsRequest request) {
     ensureInitialized();
     String requestJson = toJson(request);
-    return countTableRowsNative(nativeDirectoryNamespaceHandle, requestJson);
+    Long count = countTableRowsNative(nativeDirectoryNamespaceHandle, requestJson);
+    return new CountTableRowsResponse().count(count);
   }
 
   @Override
@@ -451,10 +460,11 @@ public class DirectoryNamespace implements LanceNamespace, Closeable {
   }
 
   @Override
-  public byte[] queryTable(QueryTableRequest request) {
+  public QueryTableResponse queryTable(QueryTableRequest request) {
     ensureInitialized();
     String requestJson = toJson(request);
-    return queryTableNative(nativeDirectoryNamespaceHandle, requestJson);
+    byte[] data = queryTableNative(nativeDirectoryNamespaceHandle, requestJson);
+    return new QueryTableResponse().data(data);
   }
 
   @Override

--- a/java/src/main/java/org/lance/namespace/RestNamespace.java
+++ b/java/src/main/java/org/lance/namespace/RestNamespace.java
@@ -26,6 +26,7 @@ import org.lance.namespace.model.AnalyzeTableQueryPlanRequest;
 import org.lance.namespace.model.BatchDeleteTableVersionsRequest;
 import org.lance.namespace.model.BatchDeleteTableVersionsResponse;
 import org.lance.namespace.model.CountTableRowsRequest;
+import org.lance.namespace.model.CountTableRowsResponse;
 import org.lance.namespace.model.CreateMaterializedViewRequest;
 import org.lance.namespace.model.CreateMaterializedViewResponse;
 import org.lance.namespace.model.CreateNamespaceRequest;
@@ -83,7 +84,9 @@ import org.lance.namespace.model.ListTablesResponse;
 import org.lance.namespace.model.MergeInsertIntoTableRequest;
 import org.lance.namespace.model.MergeInsertIntoTableResponse;
 import org.lance.namespace.model.NamespaceExistsRequest;
+import org.lance.namespace.model.NamespaceExistsResponse;
 import org.lance.namespace.model.QueryTableRequest;
+import org.lance.namespace.model.QueryTableResponse;
 import org.lance.namespace.model.RegisterTableRequest;
 import org.lance.namespace.model.RegisterTableResponse;
 import org.lance.namespace.model.RenameTableRequest;
@@ -91,6 +94,7 @@ import org.lance.namespace.model.RenameTableResponse;
 import org.lance.namespace.model.RestoreTableRequest;
 import org.lance.namespace.model.RestoreTableResponse;
 import org.lance.namespace.model.TableExistsRequest;
+import org.lance.namespace.model.TableExistsResponse;
 import org.lance.namespace.model.UpdateTableRequest;
 import org.lance.namespace.model.UpdateTableResponse;
 import org.lance.namespace.model.UpdateTableSchemaMetadataRequest;
@@ -100,6 +104,7 @@ import org.lance.namespace.model.UpdateTableTagResponse;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import org.apache.arrow.memory.BufferAllocator;
 
 import java.io.Closeable;
@@ -149,7 +154,8 @@ public class RestNamespace implements LanceNamespace, Closeable {
     JniLoader.ensureLoaded();
   }
 
-  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+  private static final ObjectMapper OBJECT_MAPPER =
+      new ObjectMapper().registerModule(new JavaTimeModule());
 
   private long nativeRestNamespaceHandle;
   private BufferAllocator allocator;
@@ -241,10 +247,11 @@ public class RestNamespace implements LanceNamespace, Closeable {
   }
 
   @Override
-  public void namespaceExists(NamespaceExistsRequest request) {
+  public NamespaceExistsResponse namespaceExists(NamespaceExistsRequest request) {
     ensureInitialized();
     String requestJson = toJson(request);
     namespaceExistsNative(nativeRestNamespaceHandle, requestJson);
+    return new NamespaceExistsResponse();
   }
 
   @Override
@@ -272,10 +279,11 @@ public class RestNamespace implements LanceNamespace, Closeable {
   }
 
   @Override
-  public void tableExists(TableExistsRequest request) {
+  public TableExistsResponse tableExists(TableExistsRequest request) {
     ensureInitialized();
     String requestJson = toJson(request);
     tableExistsNative(nativeRestNamespaceHandle, requestJson);
+    return new TableExistsResponse();
   }
 
   @Override
@@ -295,10 +303,11 @@ public class RestNamespace implements LanceNamespace, Closeable {
   }
 
   @Override
-  public Long countTableRows(CountTableRowsRequest request) {
+  public CountTableRowsResponse countTableRows(CountTableRowsRequest request) {
     ensureInitialized();
     String requestJson = toJson(request);
-    return countTableRowsNative(nativeRestNamespaceHandle, requestJson);
+    Long count = countTableRowsNative(nativeRestNamespaceHandle, requestJson);
+    return new CountTableRowsResponse().count(count);
   }
 
   @Override
@@ -362,10 +371,11 @@ public class RestNamespace implements LanceNamespace, Closeable {
   }
 
   @Override
-  public byte[] queryTable(QueryTableRequest request) {
+  public QueryTableResponse queryTable(QueryTableRequest request) {
     ensureInitialized();
     String requestJson = toJson(request);
-    return queryTableNative(nativeRestNamespaceHandle, requestJson);
+    byte[] data = queryTableNative(nativeRestNamespaceHandle, requestJson);
+    return new QueryTableResponse().data(data);
   }
 
   @Override

--- a/java/src/test/java/org/lance/namespace/CustomNamespace.java
+++ b/java/src/test/java/org/lance/namespace/CustomNamespace.java
@@ -29,6 +29,7 @@ import org.lance.namespace.model.BatchCreateTableVersionsResponse;
 import org.lance.namespace.model.BatchDeleteTableVersionsRequest;
 import org.lance.namespace.model.BatchDeleteTableVersionsResponse;
 import org.lance.namespace.model.CountTableRowsRequest;
+import org.lance.namespace.model.CountTableRowsResponse;
 import org.lance.namespace.model.CreateNamespaceRequest;
 import org.lance.namespace.model.CreateNamespaceResponse;
 import org.lance.namespace.model.CreateTableIndexRequest;
@@ -84,7 +85,9 @@ import org.lance.namespace.model.ListTablesResponse;
 import org.lance.namespace.model.MergeInsertIntoTableRequest;
 import org.lance.namespace.model.MergeInsertIntoTableResponse;
 import org.lance.namespace.model.NamespaceExistsRequest;
+import org.lance.namespace.model.NamespaceExistsResponse;
 import org.lance.namespace.model.QueryTableRequest;
+import org.lance.namespace.model.QueryTableResponse;
 import org.lance.namespace.model.RegisterTableRequest;
 import org.lance.namespace.model.RegisterTableResponse;
 import org.lance.namespace.model.RenameTableRequest;
@@ -92,6 +95,7 @@ import org.lance.namespace.model.RenameTableResponse;
 import org.lance.namespace.model.RestoreTableRequest;
 import org.lance.namespace.model.RestoreTableResponse;
 import org.lance.namespace.model.TableExistsRequest;
+import org.lance.namespace.model.TableExistsResponse;
 import org.lance.namespace.model.UpdateTableRequest;
 import org.lance.namespace.model.UpdateTableResponse;
 import org.lance.namespace.model.UpdateTableSchemaMetadataRequest;
@@ -174,8 +178,8 @@ public class CustomNamespace implements LanceNamespace, Closeable {
   }
 
   @Override
-  public void namespaceExists(NamespaceExistsRequest request) {
-    inner.namespaceExists(request);
+  public NamespaceExistsResponse namespaceExists(NamespaceExistsRequest request) {
+    return inner.namespaceExists(request);
   }
 
   // Table operations
@@ -196,8 +200,8 @@ public class CustomNamespace implements LanceNamespace, Closeable {
   }
 
   @Override
-  public void tableExists(TableExistsRequest request) {
-    inner.tableExists(request);
+  public TableExistsResponse tableExists(TableExistsRequest request) {
+    return inner.tableExists(request);
   }
 
   @Override
@@ -211,7 +215,7 @@ public class CustomNamespace implements LanceNamespace, Closeable {
   }
 
   @Override
-  public Long countTableRows(CountTableRowsRequest request) {
+  public CountTableRowsResponse countTableRows(CountTableRowsRequest request) {
     return inner.countTableRows(request);
   }
 
@@ -250,7 +254,7 @@ public class CustomNamespace implements LanceNamespace, Closeable {
   }
 
   @Override
-  public byte[] queryTable(QueryTableRequest request) {
+  public QueryTableResponse queryTable(QueryTableRequest request) {
     return inner.queryTable(request);
   }
 

--- a/java/src/test/java/org/lance/namespace/DirectoryNamespaceTest.java
+++ b/java/src/test/java/org/lance/namespace/DirectoryNamespaceTest.java
@@ -1161,7 +1161,7 @@ public class DirectoryNamespaceTest {
     // Count rows
     CountTableRowsRequest countReq =
         new CountTableRowsRequest().id(Arrays.asList("workspace", "test_table"));
-    long count = namespaceClient.countTableRows(countReq);
+    long count = namespaceClient.countTableRows(countReq).getCount();
     assertEquals(3, count);
   }
 
@@ -1183,7 +1183,7 @@ public class DirectoryNamespaceTest {
         new CountTableRowsRequest()
             .id(Arrays.asList("workspace", "test_table"))
             .predicate("age > 28");
-    long count = namespaceClient.countTableRows(countReq);
+    long count = namespaceClient.countTableRows(countReq).getCount();
     assertEquals(2, count); // Alice (30) and Charlie (35)
   }
 
@@ -1210,7 +1210,7 @@ public class DirectoryNamespaceTest {
     // Verify row count increased
     CountTableRowsRequest countReq =
         new CountTableRowsRequest().id(Arrays.asList("workspace", "test_table"));
-    long count = namespaceClient.countTableRows(countReq);
+    long count = namespaceClient.countTableRows(countReq).getCount();
     assertEquals(6, count);
   }
 
@@ -1233,7 +1233,7 @@ public class DirectoryNamespaceTest {
             .id(Arrays.asList("workspace", "test_table"))
             .k(10)
             .vector(new QueryTableRequestVector());
-    byte[] resultBytes = namespaceClient.queryTable(queryReq);
+    byte[] resultBytes = namespaceClient.queryTable(queryReq).getData();
     assertNotNull(resultBytes);
     assertTrue(resultBytes.length > 0);
   }

--- a/python/Cargo.lock
+++ b/python/Cargo.lock
@@ -4492,9 +4492,9 @@ dependencies = [
 
 [[package]]
 name = "lance-namespace-reqwest-client"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a030196da1c994b63a96a4f0bf5b0cfa459fe6dadc9e962320246ca328da22a"
+checksum = "1d06b1fbb5d41f93bc652b61e2872af92e8a6c5f6b4ce8839a8ecfa05365d359"
 dependencies = [
  "reqwest 0.12.28",
  "serde",

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "pylance"
 dynamic = ["version"]
-dependencies = ["pyarrow>=14", "numpy>=1.22", "lance-namespace>=0.8.5,<0.9"]
+dependencies = ["pyarrow>=14", "numpy>=1.22", "lance-namespace>=0.11.1,<0.12"]
 description = "python wrapper for Lance columnar format"
 authors = [{ name = "Lance Devs", email = "dev@lance.org" }]
 license = { file = "LICENSE" }

--- a/python/python/lance/namespace.py
+++ b/python/python/lance/namespace.py
@@ -28,6 +28,7 @@ from lance_namespace import (
     AlterTransactionResponse,
     AnalyzeTableQueryPlanRequest,
     CountTableRowsRequest,
+    CountTableRowsResponse,
     CreateMaterializedViewRequest,
     CreateMaterializedViewResponse,
     CreateNamespaceRequest,
@@ -87,6 +88,8 @@ from lance_namespace import (
     MergeInsertIntoTableRequest,
     MergeInsertIntoTableResponse,
     NamespaceExistsRequest,
+    NamespaceExistsResponse,
+    QueryTableResponse,
     RefreshMaterializedViewRequest,
     RefreshMaterializedViewResponse,
     RegisterTableRequest,
@@ -96,6 +99,7 @@ from lance_namespace import (
     RestoreTableRequest,
     RestoreTableResponse,
     TableExistsRequest,
+    TableExistsResponse,
     UpdateTableRequest,
     UpdateTableResponse,
     UpdateTableSchemaMetadataRequest,
@@ -413,8 +417,11 @@ class DirectoryNamespace(LanceNamespace):
         response_dict = self._inner.drop_namespace(request.model_dump())
         return DropNamespaceResponse.from_dict(response_dict)
 
-    def namespace_exists(self, request: NamespaceExistsRequest) -> None:
+    def namespace_exists(
+        self, request: NamespaceExistsRequest
+    ) -> NamespaceExistsResponse:
         self._inner.namespace_exists(request.model_dump())
+        return NamespaceExistsResponse()
 
     # Table operations
 
@@ -430,8 +437,9 @@ class DirectoryNamespace(LanceNamespace):
         response_dict = self._inner.register_table(request.model_dump())
         return RegisterTableResponse.from_dict(response_dict)
 
-    def table_exists(self, request: TableExistsRequest) -> None:
+    def table_exists(self, request: TableExistsRequest) -> TableExistsResponse:
         self._inner.table_exists(request.model_dump())
+        return TableExistsResponse()
 
     def drop_table(self, request: DropTableRequest) -> DropTableResponse:
         response_dict = self._inner.drop_table(request.model_dump())
@@ -523,7 +531,9 @@ class DirectoryNamespace(LanceNamespace):
 
     # Data manipulation operations
 
-    def count_table_rows(self, request: CountTableRowsRequest) -> int:
+    def count_table_rows(
+        self, request: CountTableRowsRequest
+    ) -> CountTableRowsResponse:
         """Count the number of rows in a table, optionally filtered by a predicate.
 
         Parameters
@@ -533,10 +543,11 @@ class DirectoryNamespace(LanceNamespace):
 
         Returns
         -------
-        int
-            The number of rows matching the criteria
+        CountTableRowsResponse
+            Response whose ``count`` is the number of rows matching the criteria
         """
-        return self._inner.count_table_rows(request.model_dump())
+        count = self._inner.count_table_rows(request.model_dump())
+        return CountTableRowsResponse(count=count)
 
     def insert_into_table(
         self, request: InsertIntoTableRequest, request_data: bytes
@@ -616,7 +627,7 @@ class DirectoryNamespace(LanceNamespace):
         response_dict = self._inner.delete_from_table(request.model_dump())
         return DeleteFromTableResponse.from_dict(response_dict)
 
-    def query_table(self, request) -> bytes:
+    def query_table(self, request) -> QueryTableResponse:
         """Query a table and return results as Arrow IPC.
 
         Parameters
@@ -627,12 +638,13 @@ class DirectoryNamespace(LanceNamespace):
 
         Returns
         -------
-        bytes
-            Arrow IPC file format containing the query results
+        QueryTableResponse
+            Response whose ``data`` is the query results in Arrow IPC file format
         """
         if hasattr(request, "model_dump"):
             request = request.model_dump()
-        return self._inner.query_table(request)
+        data = self._inner.query_table(request)
+        return QueryTableResponse(data=data)
 
     # Index operations
 
@@ -1004,8 +1016,11 @@ class RestNamespace(LanceNamespace):
         response_dict = self._inner.drop_namespace(request.model_dump())
         return DropNamespaceResponse.from_dict(response_dict)
 
-    def namespace_exists(self, request: NamespaceExistsRequest) -> None:
+    def namespace_exists(
+        self, request: NamespaceExistsRequest
+    ) -> NamespaceExistsResponse:
         self._inner.namespace_exists(request.model_dump())
+        return NamespaceExistsResponse()
 
     # Table operations
 
@@ -1021,8 +1036,9 @@ class RestNamespace(LanceNamespace):
         response_dict = self._inner.register_table(request.model_dump())
         return RegisterTableResponse.from_dict(response_dict)
 
-    def table_exists(self, request: TableExistsRequest) -> None:
+    def table_exists(self, request: TableExistsRequest) -> TableExistsResponse:
         self._inner.table_exists(request.model_dump())
+        return TableExistsResponse()
 
     def drop_table(self, request: DropTableRequest) -> DropTableResponse:
         response_dict = self._inner.drop_table(request.model_dump())
@@ -1114,7 +1130,9 @@ class RestNamespace(LanceNamespace):
 
     # Data manipulation operations
 
-    def count_table_rows(self, request: CountTableRowsRequest) -> int:
+    def count_table_rows(
+        self, request: CountTableRowsRequest
+    ) -> CountTableRowsResponse:
         """Count the number of rows in a table, optionally filtered by a predicate.
 
         Parameters
@@ -1124,10 +1142,11 @@ class RestNamespace(LanceNamespace):
 
         Returns
         -------
-        int
-            The number of rows matching the criteria
+        CountTableRowsResponse
+            Response whose ``count`` is the number of rows matching the criteria
         """
-        return self._inner.count_table_rows(request.model_dump())
+        count = self._inner.count_table_rows(request.model_dump())
+        return CountTableRowsResponse(count=count)
 
     def insert_into_table(
         self, request: InsertIntoTableRequest, request_data: bytes
@@ -1207,7 +1226,7 @@ class RestNamespace(LanceNamespace):
         response_dict = self._inner.delete_from_table(request.model_dump())
         return DeleteFromTableResponse.from_dict(response_dict)
 
-    def query_table(self, request) -> bytes:
+    def query_table(self, request) -> QueryTableResponse:
         """Query a table and return results as Arrow IPC.
 
         Parameters
@@ -1218,12 +1237,13 @@ class RestNamespace(LanceNamespace):
 
         Returns
         -------
-        bytes
-            Arrow IPC file format containing the query results
+        QueryTableResponse
+            Response whose ``data`` is the query results in Arrow IPC file format
         """
         if hasattr(request, "model_dump"):
             request = request.model_dump()
-        return self._inner.query_table(request)
+        data = self._inner.query_table(request)
+        return QueryTableResponse(data=data)
 
     # Index operations
 

--- a/python/python/tests/compat/test_venv_manager.py
+++ b/python/python/tests/compat/test_venv_manager.py
@@ -18,7 +18,8 @@ from .venv_manager import _lance_namespace_dependency, _pip_install
         ("6.0.0", "lance-namespace>=0.7.2,<0.8"),
         ("7.2.0b5", "lance-namespace>=0.8.0,<0.9"),
         ("7.2.0", "lance-namespace>=0.8.0,<0.9"),
-        ("12.0.0b5", "lance-namespace>=0.11.1,<0.12"),
+        ("12.0.0b5", "lance-namespace>=0.8.0,<0.9"),
+        ("12.0.0b6", "lance-namespace>=0.11.1,<0.12"),
         ("12.0.0", "lance-namespace>=0.11.1,<0.12"),
     ],
 )

--- a/python/python/tests/compat/test_venv_manager.py
+++ b/python/python/tests/compat/test_venv_manager.py
@@ -18,6 +18,8 @@ from .venv_manager import _lance_namespace_dependency, _pip_install
         ("6.0.0", "lance-namespace>=0.7.2,<0.8"),
         ("7.2.0b5", "lance-namespace>=0.8.0,<0.9"),
         ("7.2.0", "lance-namespace>=0.8.0,<0.9"),
+        ("12.0.0b5", "lance-namespace>=0.11.1,<0.12"),
+        ("12.0.0", "lance-namespace>=0.11.1,<0.12"),
     ],
 )
 def test_lance_namespace_dependency(version: str, expected: str):

--- a/python/python/tests/compat/venv_manager.py
+++ b/python/python/tests/compat/venv_manager.py
@@ -76,9 +76,12 @@ def _pip_install(python: Union[str, Path], args: list[str]) -> None:
 NAMESPACE_0_6_DEPENDENCY = "lance-namespace<0.7"
 NAMESPACE_0_7_DEPENDENCY = "lance-namespace>=0.7.2,<0.8"
 NAMESPACE_0_8_DEPENDENCY = "lance-namespace>=0.8.0,<0.9"
+NAMESPACE_0_11_DEPENDENCY = "lance-namespace>=0.11.1,<0.12"
 
 
 def _lance_namespace_dependency(pylance_version: str) -> str:
+    if Version(pylance_version) >= Version("12.0.0b5"):
+        return NAMESPACE_0_11_DEPENDENCY
     if Version(pylance_version) >= Version("7.2.0b5"):
         return NAMESPACE_0_8_DEPENDENCY
     if Version(pylance_version) >= Version("6.0.0b0"):

--- a/python/python/tests/compat/venv_manager.py
+++ b/python/python/tests/compat/venv_manager.py
@@ -80,7 +80,9 @@ NAMESPACE_0_11_DEPENDENCY = "lance-namespace>=0.11.1,<0.12"
 
 
 def _lance_namespace_dependency(pylance_version: str) -> str:
-    if Version(pylance_version) >= Version("12.0.0b5"):
+    # 12.0.0b5 is the last release published while pylance still pinned
+    # lance-namespace <0.9; releases cut after that carry the 0.11 range.
+    if Version(pylance_version) > Version("12.0.0b5"):
         return NAMESPACE_0_11_DEPENDENCY
     if Version(pylance_version) >= Version("7.2.0b5"):
         return NAMESPACE_0_8_DEPENDENCY

--- a/python/python/tests/test_namespace_dir.py
+++ b/python/python/tests/test_namespace_dir.py
@@ -27,6 +27,7 @@ import pytest
 from lance.namespace import LanceNamespace
 from lance_namespace import (
     CountTableRowsRequest,
+    CountTableRowsResponse,
     CreateNamespaceRequest,
     CreateNamespaceResponse,
     CreateTableBranchRequest,
@@ -67,10 +68,13 @@ from lance_namespace import (
     ListTableVersionsRequest,
     ListTableVersionsResponse,
     NamespaceExistsRequest,
+    NamespaceExistsResponse,
     QueryTableRequest,
+    QueryTableResponse,
     RegisterTableRequest,
     RegisterTableResponse,
     TableExistsRequest,
+    TableExistsResponse,
     connect,
 )
 from lance_namespace.errors import (
@@ -107,7 +111,9 @@ class CustomNamespace(LanceNamespace):
     ) -> DescribeNamespaceResponse:
         return self._inner.describe_namespace(request)
 
-    def namespace_exists(self, request: NamespaceExistsRequest) -> None:
+    def namespace_exists(
+        self, request: NamespaceExistsRequest
+    ) -> NamespaceExistsResponse:
         return self._inner.namespace_exists(request)
 
     def drop_namespace(self, request: DropNamespaceRequest) -> DropNamespaceResponse:
@@ -127,7 +133,7 @@ class CustomNamespace(LanceNamespace):
     def describe_table(self, request: DescribeTableRequest) -> DescribeTableResponse:
         return self._inner.describe_table(request)
 
-    def table_exists(self, request: TableExistsRequest) -> None:
+    def table_exists(self, request: TableExistsRequest) -> TableExistsResponse:
         return self._inner.table_exists(request)
 
     def drop_table(self, request: DropTableRequest) -> DropTableResponse:
@@ -184,7 +190,9 @@ class CustomNamespace(LanceNamespace):
     ) -> ListTableIndicesResponse:
         return self._inner.list_table_indices(request)
 
-    def count_table_rows(self, request: CountTableRowsRequest) -> int:
+    def count_table_rows(
+        self, request: CountTableRowsRequest
+    ) -> CountTableRowsResponse:
         return self._inner.count_table_rows(request)
 
     def insert_into_table(
@@ -192,7 +200,7 @@ class CustomNamespace(LanceNamespace):
     ) -> InsertIntoTableResponse:
         return self._inner.insert_into_table(request, request_data)
 
-    def query_table(self, request) -> bytes:
+    def query_table(self, request) -> QueryTableResponse:
         # Accept both QueryTableRequest and dict, like DirectoryNamespace does
         if hasattr(request, "model_dump"):
             request = request.model_dump()
@@ -1416,7 +1424,7 @@ class TestDataManipulation:
 
         # Count rows
         count_req = CountTableRowsRequest(id=["workspace", "test_table"])
-        count = temp_ns_client.count_table_rows(count_req)
+        count = temp_ns_client.count_table_rows(count_req).count
         assert count == 3
 
     def test_count_table_rows_with_filter(self, temp_ns_client):
@@ -1434,7 +1442,7 @@ class TestDataManipulation:
         count_req = CountTableRowsRequest(
             id=["workspace", "test_table"], predicate="age > 28"
         )
-        count = temp_ns_client.count_table_rows(count_req)
+        count = temp_ns_client.count_table_rows(count_req).count
         assert count == 2  # Alice (30) and Charlie (35)
 
     def test_insert_into_table(self, temp_ns_client):
@@ -1464,7 +1472,7 @@ class TestDataManipulation:
 
         # Verify row count increased
         count_req = CountTableRowsRequest(id=["workspace", "test_table"])
-        count = temp_ns_client.count_table_rows(count_req)
+        count = temp_ns_client.count_table_rows(count_req).count
         assert count == 5
 
     def test_query_table(self, temp_ns_client):
@@ -1480,7 +1488,7 @@ class TestDataManipulation:
 
         # Query table with empty vector (for non-vector queries)
         query_req = QueryTableRequest(id=["workspace", "test_table"], k=10, vector={})
-        result_bytes = temp_ns_client.query_table(query_req)
+        result_bytes = temp_ns_client.query_table(query_req).data
         assert result_bytes is not None
         assert len(result_bytes) > 0
 
@@ -1506,7 +1514,7 @@ class TestDataManipulation:
         query_req = QueryTableRequest(
             id=["workspace", "test_table"], filter="age >= 30", k=10, vector={}
         )
-        result_bytes = temp_ns_client.query_table(query_req)
+        result_bytes = temp_ns_client.query_table(query_req).data
         reader = pa.ipc.open_file(pa.BufferReader(result_bytes))
         result_table = reader.read_all()
         assert result_table.num_rows == 2  # Alice and Charlie

--- a/python/python/tests/test_namespace_integration.py
+++ b/python/python/tests/test_namespace_integration.py
@@ -56,9 +56,11 @@ from lance_namespace import (
     ListTableVersionsRequest,
     ListTableVersionsResponse,
     NamespaceExistsRequest,
+    NamespaceExistsResponse,
     RegisterTableRequest,
     RegisterTableResponse,
     TableExistsRequest,
+    TableExistsResponse,
 )
 
 
@@ -86,7 +88,9 @@ class CustomNamespace(LanceNamespace):
     ) -> DescribeNamespaceResponse:
         return self._inner.describe_namespace(request)
 
-    def namespace_exists(self, request: NamespaceExistsRequest) -> None:
+    def namespace_exists(
+        self, request: NamespaceExistsRequest
+    ) -> NamespaceExistsResponse:
         return self._inner.namespace_exists(request)
 
     def drop_namespace(self, request: DropNamespaceRequest) -> DropNamespaceResponse:
@@ -106,7 +110,7 @@ class CustomNamespace(LanceNamespace):
     def describe_table(self, request: DescribeTableRequest) -> DescribeTableResponse:
         return self._inner.describe_table(request)
 
-    def table_exists(self, request: TableExistsRequest) -> None:
+    def table_exists(self, request: TableExistsRequest) -> TableExistsResponse:
         return self._inner.table_exists(request)
 
     def drop_table(self, request: DropTableRequest) -> DropTableResponse:

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -1055,19 +1055,19 @@ wheels = [
 
 [[package]]
 name = "lance-namespace"
-version = "0.8.6"
+version = "0.11.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "lance-namespace-urllib3-client" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/af/12/f7ab93b29be3edbf5fc3610714bf2d06088e7f4524bfb38dfd6852458b08/lance_namespace-0.8.6.tar.gz", hash = "sha256:18232e721c8188145f4ec9389cc2dfbeeabf54a619d94885ea1b3375bee9f4af", size = 11529, upload-time = "2026-06-12T17:36:41.651Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/bf/93/da5f7fcac690db9b282a3439ed9e34960c147619a0d6e1f4eb8cd240e7a5/lance_namespace-0.11.1.tar.gz", hash = "sha256:f67cfbbe0647b7cb42f23b673e7edf8a75b7d8a047265a916492f8d247ee1bc2", size = 11631, upload-time = "2026-08-18T17:40:06.294Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a0/1b/5b1668ee2dc8910965f390640359112a31157092fcf8e000b89c79b58708/lance_namespace-0.8.6-py3-none-any.whl", hash = "sha256:571eae34f9aad70e5b05020416c2860889b9ec82993ccd0eb015e7b39c3ea309", size = 13383, upload-time = "2026-06-12T17:36:43.456Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/bc/601f2b3cc4cfa0070d858a33223bc823fffdd7981a25c45984a5216ca952/lance_namespace-0.11.1-py3-none-any.whl", hash = "sha256:07643fce9a42ad4d58cc8bf91e3f592bc7f4cbd8d0ad5233223506debf67551c", size = 13507, upload-time = "2026-08-18T17:40:03.561Z" },
 ]
 
 [[package]]
 name = "lance-namespace-urllib3-client"
-version = "0.8.6"
+version = "0.11.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic" },
@@ -1075,9 +1075,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c7/80/fb224b4a89c1c1638cde949cb6cce6c3aca7759effbfea46a3d9c3960b21/lance_namespace_urllib3_client-0.8.6.tar.gz", hash = "sha256:b6fb1d306e74a7576e5309919020be744527de484a63dbf5eed10f8b368548df", size = 228772, upload-time = "2026-06-12T17:36:42.609Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e4/c5/2bdd0ff98b469894c8a73be809d26ffdad5402517b0e5f9e758026cba29e/lance_namespace_urllib3_client-0.11.1.tar.gz", hash = "sha256:145a9e9424d7597487249b5b95ee274423bf2910e1a9160b6a07b676b61ea46a", size = 237345, upload-time = "2026-08-18T17:40:07.308Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c5/90/1e27de15cd1b16785a1c7312beb0a59e75c8344a815f600f58173a565bd1/lance_namespace_urllib3_client-0.8.6-py3-none-any.whl", hash = "sha256:9d78249c3fb15aa3d15d668f78f04a275af3d08d800a7027492f37996ac4968b", size = 369950, upload-time = "2026-06-12T17:36:40.438Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/2a/eaaefd55d1190291207049fedc6b3eb22b506e57d6de91bae46bbaaa9c60/lance_namespace_urllib3_client-0.11.1-py3-none-any.whl", hash = "sha256:36537f529294da6d884ba0fe783704483f0a75463497c7705fd083a4d0257990", size = 406311, upload-time = "2026-08-18T17:40:04.842Z" },
 ]
 
 [[package]]
@@ -2472,7 +2472,7 @@ requires-dist = [
     { name = "duckdb", marker = "extra == 'tests'", specifier = ">=1.5.0,<1.6.0" },
     { name = "geoarrow-rust-core", marker = "extra == 'geo'" },
     { name = "geoarrow-rust-io", marker = "extra == 'geo'" },
-    { name = "lance-namespace", specifier = ">=0.8.5,<0.9" },
+    { name = "lance-namespace", specifier = ">=0.11.1,<0.12" },
     { name = "ml-dtypes", marker = "extra == 'tests'" },
     { name = "numpy", specifier = ">=1.22" },
     { name = "opentelemetry-api", marker = "extra == 'otel'" },


### PR DESCRIPTION
The Java and Python `lance-namespace` pins had drifted several releases behind the Rust one: `java/pom.xml` was on 0.7.7 and `python/pyproject.toml` on `>=0.8.5,<0.9`, while Rust was already on 0.11.0. This bumps all three to 0.11.1, so the bindings stop being four releases apart from the core.

No feature work — this isolates the dependency drift ahead of ENT-2084 (multiple columns for the merge-insert `on` key), which needs a namespace release newer than any of these pins.

The Java changes are taken from #8623 and rebased onto current main. That PR's `rest.rs` tests are left out, as they cover vector index params (ENT-1892) rather than the version bump.

## Breaking changes

0.11 changes four `LanceNamespace` methods to return a response object instead of a bare value. Both bindings are updated to match, and callers need to unwrap:

| method | before | after | unwrap with |
|---|---|---|---|
| `countTableRows` / `count_table_rows` | `Long` / `int` | `CountTableRowsResponse` | `.getCount()` / `.count` |
| `queryTable` / `query_table` | `byte[]` / `bytes` | `QueryTableResponse` | `.getData()` / `.data` |
| `namespaceExists` / `namespace_exists` | `void` / `None` | `NamespaceExistsResponse` | — |
| `tableExists` / `table_exists` | `void` / `None` | `TableExistsResponse` | — |

The implementations wrap the values the native layer already returns, so behavior is unchanged. Anyone implementing `LanceNamespace` themselves will need the same signature updates.

The compat harness also gains a tier in its namespace pin map, which tells it what `lance-namespace` range to install alongside each *published* pylance release. Releases cut after 12.0.0b5 will carry the new `>=0.11.1,<0.12` range, so the map needs an entry for them; 12.0.0b5 and earlier keep the old one.

## Testing

Ran the namespace integration suite against LocalStack (`--run-integration`, 30 passed), which is otherwise skipped by default.

## Not included

`jackson-databind` stays explicitly pinned at 2.15.2 in `java/pom.xml` while `jackson-core`, `jackson-annotations` and `jackson-datatype-jsr310` now arrive transitively from `lance-namespace-core` at 2.18.3. That skew predates this PR but widens with it, and registering a 2.18 module on a 2.15 databind is the kind of mismatch that surfaces at runtime rather than compile time. Worth aligning separately.

Separately, `[tool.pyright].include` in `python/pyproject.toml` is an explicit allowlist that does not cover `python/lance/namespace.py`, so nothing type-checks these Python signatures against the ABC — unlike Java, where the interface makes a mismatch a compile error. The file carries a `TODO: expand this list`; adding namespace.py to it is a reasonable follow-up.

