### PR TITLE
fix(index): key metadata cache on manifest etag

### DIFF
--- a/rust/lance/src/dataset.rs
+++ b/rust/lance/src/dataset.rs
@@ -816,6 +816,7 @@ impl Dataset {
             let metadata_key = crate::session::index_caches::IndexMetadataKey {
                 version: manifest_location.version,
                 store_identity: &object_store.store_prefix,
+                e_tag: manifest_location.e_tag.as_deref(),
             };
             ds_index_cache
                 .insert_with_key(&metadata_key, Arc::new(indices))

--- a/rust/lance/src/dataset/index.rs
+++ b/rust/lance/src/dataset/index.rs
@@ -545,6 +545,7 @@ mod tests {
         let metadata_key = crate::session::index_caches::IndexMetadataKey {
             version: dataset.version().version,
             store_identity: &dataset.object_store.store_prefix,
+            e_tag: dataset.manifest_location.e_tag.as_deref(),
         };
         dataset
             .index_cache

--- a/rust/lance/src/index.rs
+++ b/rust/lance/src/index.rs
@@ -2774,6 +2774,7 @@ pub(crate) async fn load_all_indices(dataset: &Dataset) -> Result<Arc<Vec<IndexM
     let metadata_key = IndexMetadataKey {
         version: dataset.version().version,
         store_identity: &dataset.object_store.store_prefix,
+        e_tag: dataset.manifest_location.e_tag.as_deref(),
     };
     let mut indices = dataset
         .index_cache
@@ -5702,6 +5703,96 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_index_metadata_cache_does_not_survive_drop_recreate_same_uri() {
+        fn batch_with_schema_metadata(metadata_value: String) -> RecordBatch {
+            let field = Field::new("tag", DataType::Utf8, false);
+            let schema = Arc::new(Schema::new_with_metadata(
+                vec![field],
+                HashMap::from([("large_metadata".to_string(), metadata_value)]),
+            ));
+            let array = StringArray::from_iter_values((0..128).map(|i| ["a", "b", "c"][i % 3]));
+            RecordBatch::try_new(schema, vec![Arc::new(array)]).unwrap()
+        }
+
+        async fn write_indexed_dataset(uri: &str, session: Arc<Session>, metadata_value: String) {
+            let batch = batch_with_schema_metadata(metadata_value);
+            let schema = batch.schema();
+            let reader = RecordBatchIterator::new(vec![Ok(batch)], schema);
+            let write_params = WriteParams {
+                session: Some(session),
+                ..Default::default()
+            };
+            let mut dataset = Dataset::write(reader, uri, Some(write_params))
+                .await
+                .unwrap();
+            dataset
+                .create_index(
+                    &["tag"],
+                    IndexType::Bitmap,
+                    None,
+                    &ScalarIndexParams::default(),
+                    false,
+                )
+                .await
+                .unwrap();
+        }
+
+        let qn_session = Arc::new(Session::default());
+        let test_dir = TempStrDir::default();
+        let test_uri = test_dir.as_str();
+
+        write_indexed_dataset(test_uri, qn_session.clone(), "old".to_string()).await;
+        let first_dataset = DatasetBuilder::from_uri(test_uri)
+            .with_session(qn_session.clone())
+            .load()
+            .await
+            .unwrap();
+        let first_indices = first_dataset.load_indices().await.unwrap();
+        let first_uuid = first_indices[0].uuid;
+        assert_eq!(first_dataset.version().version, 2);
+        drop(first_dataset);
+
+        std::fs::remove_dir_all(test_uri).unwrap();
+
+        // Use a different writer session so the QN session keeps the previous
+        // incarnation's index metadata cache entry. The large schema metadata
+        // keeps the manifest index section outside the final read block during
+        // open, so the fresh manifest load cannot opportunistically overwrite
+        // the stale index metadata entry before load_indices().
+        write_indexed_dataset(
+            test_uri,
+            Arc::new(Session::default()),
+            "x".repeat(128 * 1024),
+        )
+        .await;
+        let second_dataset = DatasetBuilder::from_uri(test_uri)
+            .with_session(qn_session)
+            .load()
+            .await
+            .unwrap();
+        assert_eq!(second_dataset.version().version, 2);
+
+        let raw_second_indices = read_manifest_indexes(
+            second_dataset.object_store.as_ref(),
+            &second_dataset.manifest_location,
+            second_dataset.manifest(),
+        )
+        .await
+        .unwrap();
+        let raw_second_uuid = raw_second_indices[0].uuid;
+        assert_ne!(
+            raw_second_uuid, first_uuid,
+            "the recreated dataset should commit a new physical index UUID"
+        );
+
+        let cached_second_indices = second_dataset.load_indices().await.unwrap();
+        assert_eq!(
+            cached_second_indices[0].uuid, raw_second_uuid,
+            "load_indices should return index metadata from the recreated dataset, not the previous same-URI incarnation"
+        );
+    }
+
+    #[tokio::test]
     async fn test_load_indices_singleflights_concurrent_cache_misses() {
         let session = Arc::new(Session::default());
         let write_params = WriteParams {
@@ -5950,6 +6041,7 @@ mod tests {
         let metadata_key = crate::session::index_caches::IndexMetadataKey {
             version: dataset.version().version,
             store_identity: &dataset.object_store.store_prefix,
+            e_tag: dataset.manifest_location.e_tag.as_deref(),
         };
         dataset
             .index_cache
@@ -6359,6 +6451,7 @@ mod tests {
         let metadata_key = crate::session::index_caches::IndexMetadataKey {
             version: dataset.version().version,
             store_identity: &dataset.object_store.store_prefix,
+            e_tag: dataset.manifest_location.e_tag.as_deref(),
         };
         dataset
             .index_cache

--- a/rust/lance/src/io/commit.rs
+++ b/rust/lance/src/io/commit.rs
@@ -1314,6 +1314,7 @@ async fn record_successful_commit(
         let key = IndexMetadataKey {
             version: manifest.version,
             store_identity: &dataset.object_store.store_prefix,
+            e_tag: location.e_tag.as_deref(),
         };
         dataset
             .index_cache

--- a/rust/lance/src/session/index_caches.rs
+++ b/rust/lance/src/session/index_caches.rs
@@ -120,6 +120,7 @@ impl CacheKey for FragReuseIndexKey<'_> {
 pub struct IndexMetadataKey<'a> {
     pub version: u64,
     pub store_identity: &'a str,
+    pub e_tag: Option<&'a str>,
 }
 
 impl CacheKey for IndexMetadataKey<'_> {
@@ -127,10 +128,11 @@ impl CacheKey for IndexMetadataKey<'_> {
 
     fn key(&self) -> Cow<'_, str> {
         Cow::Owned(format!(
-            "{}:{}/{}",
+            "{}:{}/{}/{}",
             self.store_identity.len(),
             self.store_identity,
-            self.version
+            self.version,
+            self.e_tag.unwrap_or("")
         ))
     }
 
@@ -149,6 +151,13 @@ impl CacheKey for IndexMetadataKey<'_> {
     fn write_key(&self, builder: &mut KeyBuilder) {
         builder.write_str(self.store_identity);
         builder.write_u64(self.version);
+        match self.e_tag {
+            Some(e_tag) => {
+                builder.write_some();
+                builder.write_str(e_tag);
+            }
+            None => builder.write_none(),
+        }
     }
 
     fn codec() -> Option<lance_core::cache::CacheCodec> {
@@ -204,10 +213,28 @@ mod tests {
         let first = IndexMetadataKey {
             version: 7,
             store_identity: "s3$first-options",
+            e_tag: Some("manifest-etag"),
         };
         let second = IndexMetadataKey {
             version: 7,
             store_identity: "s3$second-options",
+            e_tag: Some("manifest-etag"),
+        };
+
+        assert_ne!(first.key(), second.key());
+    }
+
+    #[test]
+    fn index_metadata_key_isolates_manifest_generation() {
+        let first = IndexMetadataKey {
+            version: 7,
+            store_identity: "s3$options",
+            e_tag: Some("first-etag"),
+        };
+        let second = IndexMetadataKey {
+            version: 7,
+            store_identity: "s3$options",
+            e_tag: Some("second-etag"),
         };
 
         assert_ne!(first.key(), second.key());


### PR DESCRIPTION
This PR fixes a stale index metadata cache collision that can happen when a dataset is dropped and recreated at the same URI. The Lance session index metadata cache was keyed by dataset URI/store identity and dataset version, but a recreated dataset starts its version history over, so a long-lived session could reuse index metadata from the previous incarnation. 

This was accomplished with the following changes:
- `IndexMetadataKey` now includes the manifest ETag in addition to version and store identity.
- `Dataset::load_manifest` passes the manifest ETag when opportunistically caching decoded index metadata from the manifest tail block.
- `DatasetIndexExt::load_indices` passes the opened dataset manifest ETag when loading index metadata from the session cache.
- Commit/index helper paths that seed index metadata cache entries now use the current manifest location ETag.
- Added a shared-session drop/recreate regression that proves a recreated dataset's raw manifest index UUID is returned instead of the previous same-URI incarnation's cached UUID.
- Added key-level coverage that `IndexMetadataKey` isolates different manifest generations.
