### PR TITLE
perf(io): read large metadata msgs as concurrent chunked range requests

### DIFF
--- a/rust/lance-io/src/object_reader.rs
+++ b/rust/lance-io/src/object_reader.rs
@@ -71,6 +71,7 @@ pub struct CloudObjectReader {
     size: OnceCell<usize>,
 
     block_size: usize,
+    io_parallelism: usize,
     download_retry_count: usize,
 }
 
@@ -95,8 +96,20 @@ impl CloudObjectReader {
             path,
             size: OnceCell::new_with(known_size),
             block_size,
+            io_parallelism: DEFAULT_CLOUD_IO_PARALLELISM,
             download_retry_count,
         })
+    }
+
+    /// Override the I/O parallelism this reader advertises.
+    ///
+    /// `ObjectStore::open` / `open_with_size` pass their normalized effective
+    /// parallelism (`LANCE_IO_THREADS` override applied, at least 1) so
+    /// consumers that size concurrency windows off the reader honor the
+    /// configured request limit instead of the hardcoded cloud default.
+    pub fn with_io_parallelism(mut self, io_parallelism: usize) -> Self {
+        self.io_parallelism = io_parallelism;
+        self
     }
 }
 
@@ -170,7 +183,7 @@ impl Reader for CloudObjectReader {
     }
 
     fn io_parallelism(&self) -> usize {
-        DEFAULT_CLOUD_IO_PARALLELISM
+        self.io_parallelism
     }
 
     /// Object/File Size.

--- a/rust/lance-io/src/object_store.rs
+++ b/rust/lance-io/src/object_store.rs
@@ -880,13 +880,16 @@ impl ObjectStore {
                     .await
                 }
             }
-            _ => Ok(Box::new(CloudObjectReader::new(
-                self.inner.clone(),
-                path.clone(),
-                self.block_size,
-                None,
-                self.download_retry_count,
-            )?)),
+            _ => Ok(Box::new(
+                CloudObjectReader::new(
+                    self.inner.clone(),
+                    path.clone(),
+                    self.block_size,
+                    None,
+                    self.download_retry_count,
+                )?
+                .with_io_parallelism(self.io_parallelism()),
+            )),
         }
     }
 
@@ -942,13 +945,16 @@ impl ObjectStore {
                     .await
                 }
             }
-            _ => Ok(Box::new(CloudObjectReader::new(
-                self.inner.clone(),
-                path.clone(),
-                self.block_size,
-                Some(known_size),
-                self.download_retry_count,
-            )?)),
+            _ => Ok(Box::new(
+                CloudObjectReader::new(
+                    self.inner.clone(),
+                    path.clone(),
+                    self.block_size,
+                    Some(known_size),
+                    self.download_retry_count,
+                )?
+                .with_io_parallelism(self.io_parallelism()),
+            )),
         }
     }
 
@@ -1918,11 +1924,16 @@ mod tests {
         assert!(!store.exists(&path).await.unwrap());
     }
 
-    #[test]
-    fn test_io_parallelism_clamped_to_nonzero() {
+    #[tokio::test]
+    async fn test_io_parallelism_clamped_to_nonzero() {
         // `io_parallelism()` feeds `buffered`/`buffer_unordered` windows; a value of 0 makes those
         // streams never poll, hanging callers (e.g. a metadata-only `count_rows`). It must clamp.
         let store = ObjectStore::local();
+        // Readers opened by the store must advertise the store's normalized
+        // effective parallelism, not the hardcoded cloud default.
+        let mem_store = ObjectStore::memory();
+        let path = Path::from("/io_parallelism_probe");
+        mem_store.put(&path, b"x").await.unwrap();
 
         // SAFETY: process-global env var, set and restored within this test. `io_parallelism()`
         // only reads it, and a concurrent reader observes a valid clamped value, never 0.
@@ -1932,12 +1943,31 @@ mod tests {
             1,
             "LANCE_IO_THREADS=0 must clamp to 1"
         );
+        assert_eq!(
+            mem_store.open(&path).await.unwrap().io_parallelism(),
+            1,
+            "an opened reader must report the store's clamped parallelism"
+        );
 
         unsafe { std::env::set_var("LANCE_IO_THREADS", "8") };
         assert_eq!(
             store.io_parallelism(),
             8,
             "a positive override must pass through unchanged"
+        );
+        assert_eq!(
+            mem_store.open(&path).await.unwrap().io_parallelism(),
+            8,
+            "an opened reader must honor the configured request limit"
+        );
+        assert_eq!(
+            mem_store
+                .open_with_size(&path, 1024 * 1024)
+                .await
+                .unwrap()
+                .io_parallelism(),
+            8,
+            "a sized reader must honor the configured request limit"
         );
 
         unsafe { std::env::remove_var("LANCE_IO_THREADS") };

--- a/rust/lance-io/src/utils.rs
+++ b/rust/lance-io/src/utils.rs
@@ -1,10 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright The Lance Authors
 
-use std::{cmp::min, num::NonZero, sync::atomic::AtomicU64};
+use std::{cmp::min, num::NonZero, ops::Range, sync::atomic::AtomicU64};
 
 use byteorder::{ByteOrder, LittleEndian};
-use bytes::Bytes;
+use bytes::{Bytes, BytesMut};
+use futures::{Stream, StreamExt, TryStreamExt};
 use lance_core::deepsize::DeepSizeOf;
 use prost::Message;
 use serde::{Deserialize, Serialize};
@@ -13,6 +14,34 @@ use crate::traits::{ProtoStruct, Reader};
 use lance_core::{Error, Result};
 
 pub mod tracking_store;
+
+/// Chunk size for splitting a large metadata read into concurrent range requests.
+///
+/// A single object-store GET streams its body over one connection, so its
+/// throughput is capped by the TCP window over the round-trip time; on
+/// high-latency links that tops out in the tens of MB/s. Fetching the range as
+/// a window of concurrent chunk requests multiplies that per-connection limit.
+/// 16 MiB keeps per-request overhead negligible (a ~1 GiB manifest costs ~64
+/// GET requests) while a `Reader::io_parallelism` window of such chunks is
+/// enough to saturate the link.
+pub const METADATA_READ_CHUNK_SIZE: usize = 16 * 1024 * 1024;
+
+/// Read `range` from `reader` as `chunk_size`-sized concurrent range requests,
+/// yielding the chunks in file order. Concurrency is bounded by
+/// [`Reader::io_parallelism`].
+pub fn read_range_in_chunks(
+    reader: &dyn Reader,
+    range: Range<usize>,
+    chunk_size: usize,
+) -> impl Stream<Item = object_store::Result<Bytes>> + Send + '_ {
+    debug_assert!(chunk_size > 0, "chunk_size must be positive");
+    let end = range.end;
+    let chunk_ranges = range
+        .step_by(chunk_size)
+        .map(move |start| start..min(start + chunk_size, end));
+    futures::stream::iter(chunk_ranges.map(|chunk| reader.get_range(chunk)))
+        .buffered(reader.io_parallelism())
+}
 
 /// Read a protobuf message at file position 'pos'.
 ///
@@ -34,12 +63,19 @@ pub async fn read_message<M: Message + Default>(reader: &dyn Reader, pos: usize)
 
     if msg_len + 4 > buf.len() {
         let remaining_range = range.end..min(4 + pos + msg_len, file_size);
-        let remaining_bytes = reader.get_range(remaining_range).await?;
-        let buf = [buf, remaining_bytes].concat();
-        if buf.len() < msg_len + 4 {
+        // Assemble into one pre-allocated buffer; fetching the remainder as
+        // concurrent chunks lifts the single-connection throughput cap on
+        // large messages (e.g. manifests of datasets with many fragments).
+        let mut full = BytesMut::with_capacity(buf.len() + remaining_range.len());
+        full.extend_from_slice(&buf);
+        let mut chunks = read_range_in_chunks(reader, remaining_range, METADATA_READ_CHUNK_SIZE);
+        while let Some(chunk) = chunks.try_next().await? {
+            full.extend_from_slice(&chunk);
+        }
+        if full.len() < msg_len + 4 {
             return Err(Error::io("file size is too small".to_string()));
         }
-        Ok(M::decode(&buf[4..4 + msg_len])?)
+        Ok(M::decode(&full[4..4 + msg_len])?)
     } else {
         Ok(M::decode(&buf[4..4 + msg_len])?)
     }
@@ -199,7 +235,8 @@ impl CachedFileSize {
 
 #[cfg(test)]
 mod tests {
-    use bytes::Bytes;
+    use bytes::{Bytes, BytesMut};
+    use futures::TryStreamExt;
     use object_store::path::Path;
 
     use crate::{
@@ -208,7 +245,7 @@ mod tests {
         object_store::{DEFAULT_DOWNLOAD_RETRY_COUNT, ObjectStore},
         object_writer::ObjectWriter,
         traits::{ProtoStruct, WriteExt, Writer},
-        utils::read_struct,
+        utils::{METADATA_READ_CHUNK_SIZE, read_range_in_chunks, read_struct},
     };
 
     // Bytes is a prost::Message, since we don't have any .proto files in this crate we
@@ -252,6 +289,48 @@ mod tests {
                 .unwrap();
         let actual: BytesWrapper = read_struct(&object_reader, pos).await.unwrap();
         assert_eq!(some_message, actual);
+    }
+
+    #[tokio::test]
+    async fn test_read_range_in_chunks_reassembles_in_order() {
+        let store = ObjectStore::memory();
+        let path = Path::from("/chunked");
+        // Patterned data with a range that neither starts nor ends on a chunk
+        // boundary, so ordering or off-by-one mistakes change the bytes.
+        let data: Vec<u8> = (0..10 * 1024 + 37).map(|i| (i % 251) as u8).collect();
+        store.put(&path, &data).await.unwrap();
+        let reader = store.open(&path).await.unwrap();
+
+        let range = 5..data.len() - 3;
+        let mut assembled = BytesMut::new();
+        let mut chunks = read_range_in_chunks(reader.as_ref(), range.clone(), 1024);
+        while let Some(chunk) = chunks.try_next().await.unwrap() {
+            assembled.extend_from_slice(&chunk);
+        }
+        assert_eq!(assembled.as_ref(), &data[range]);
+    }
+
+    #[tokio::test]
+    async fn test_read_message_larger_than_chunk_size() {
+        // A message body crossing METADATA_READ_CHUNK_SIZE forces read_message
+        // to fetch the remainder as multiple concurrent chunks.
+        let store = ObjectStore::memory();
+        let path = Path::from("/large_message");
+
+        let mut object_writer = ObjectWriter::new(&store, &path).await.unwrap();
+        let payload: Vec<u8> = (0..METADATA_READ_CHUNK_SIZE + 5 * 1024 * 1024)
+            .map(|i| (i % 253) as u8)
+            .collect();
+        let message = BytesWrapper(Bytes::from(payload));
+        let pos = object_writer.write_struct(&message).await.unwrap();
+        object_writer.shutdown().await.unwrap();
+
+        let object_reader =
+            CloudObjectReader::new(store.inner, path, 4096, None, DEFAULT_DOWNLOAD_RETRY_COUNT)
+                .unwrap();
+        let actual: BytesWrapper = read_struct(&object_reader, pos).await.unwrap();
+        assert_eq!(message.0.len(), actual.0.len());
+        assert_eq!(message, actual);
     }
 
     #[tokio::test]

--- a/rust/lance-io/src/utils.rs
+++ b/rust/lance-io/src/utils.rs
@@ -28,7 +28,9 @@ pub const METADATA_READ_CHUNK_SIZE: usize = 16 * 1024 * 1024;
 
 /// Read `range` from `reader` as `chunk_size`-sized concurrent range requests,
 /// yielding the chunks in file order. Concurrency is bounded by
-/// [`Reader::io_parallelism`].
+/// [`Reader::io_parallelism`], clamped to at least 1: a `buffered(0)` window
+/// never polls its input, so an unvalidated reader value (e.g.
+/// `LANCE_URING_IO_PARALLELISM=0`) would hang the read.
 pub fn read_range_in_chunks(
     reader: &dyn Reader,
     range: Range<usize>,
@@ -39,7 +41,7 @@ pub fn read_range_in_chunks(
         .step_by(chunk_size)
         .map(move |start| start..min(start + chunk_size, end));
     futures::stream::iter(chunk_ranges.map(|chunk| reader.get_range(chunk)))
-        .buffered(reader.io_parallelism())
+        .buffered(reader.io_parallelism().max(1))
 }
 
 /// Read a protobuf message at file position 'pos'.
@@ -307,6 +309,32 @@ mod tests {
             assembled.extend_from_slice(&chunk);
         }
         assert_eq!(assembled.as_ref(), &data[range]);
+    }
+
+    #[tokio::test]
+    async fn test_read_range_in_chunks_zero_parallelism_reader() {
+        // A reader advertising io_parallelism 0 (e.g. LANCE_URING_IO_PARALLELISM=0)
+        // must not hang the chunked read: the window is clamped to at least 1.
+        let store = ObjectStore::memory();
+        let path = Path::from("/zero_parallelism");
+        let data: Vec<u8> = (0..4096).map(|i| (i % 249) as u8).collect();
+        store.put(&path, &data).await.unwrap();
+        let reader =
+            CloudObjectReader::new(store.inner, path, 1024, None, DEFAULT_DOWNLOAD_RETRY_COUNT)
+                .unwrap()
+                .with_io_parallelism(0);
+
+        let assembled = tokio::time::timeout(std::time::Duration::from_secs(5), async {
+            let mut buf = BytesMut::new();
+            let mut chunks = read_range_in_chunks(&reader, 0..data.len(), 1024);
+            while let Some(chunk) = chunks.try_next().await.unwrap() {
+                buf.extend_from_slice(&chunk);
+            }
+            buf
+        })
+        .await
+        .expect("chunked read with a zero-parallelism reader must not hang");
+        assert_eq!(assembled.as_ref(), &data[..]);
     }
 
     #[tokio::test]

--- a/rust/lance-io/src/utils.rs
+++ b/rust/lance-io/src/utils.rs
@@ -33,8 +33,7 @@ pub fn read_range_in_chunks(
     reader: &dyn Reader,
     range: Range<usize>,
     chunk_size: usize,
-) -> impl Stream<Item = object_store::Result<Bytes>> + Send + '_ {
-    debug_assert!(chunk_size > 0, "chunk_size must be positive");
+) -> impl Stream<Item = object_store::Result<Bytes>> + '_ {
     let end = range.end;
     let chunk_ranges = range
         .step_by(chunk_size)
@@ -329,7 +328,6 @@ mod tests {
             CloudObjectReader::new(store.inner, path, 4096, None, DEFAULT_DOWNLOAD_RETRY_COUNT)
                 .unwrap();
         let actual: BytesWrapper = read_struct(&object_reader, pos).await.unwrap();
-        assert_eq!(message.0.len(), actual.0.len());
         assert_eq!(message, actual);
     }
 

--- a/rust/lance-table/src/io/manifest.rs
+++ b/rust/lance-table/src/io/manifest.rs
@@ -4,6 +4,7 @@
 use async_trait::async_trait;
 use byteorder::{ByteOrder, LittleEndian};
 use bytes::{Bytes, BytesMut};
+use futures::TryStreamExt;
 use lance_file::{
     version::ConcreteFileVersion,
     versions::v1::{
@@ -21,7 +22,7 @@ use lance_core::{Error, Result, datatypes::Schema};
 use lance_io::{
     object_store::ObjectStore,
     traits::{WriteExt, Writer},
-    utils::read_message,
+    utils::{METADATA_READ_CHUNK_SIZE, read_message, read_range_in_chunks},
 };
 
 use crate::format::{DataStorageFormat, IndexMetadata, MAGIC, Manifest, Transaction, pb};
@@ -75,20 +76,22 @@ pub async fn read_manifest(
         // The prefetch captured the entire manifest. We just need to trim the buffer.
         buf.slice(buf.len() - manifest_len..buf.len())
     } else {
-        // The prefetch only captured part of the manifest. We need to make an
-        // additional range request to read the remainder.
-        let mut buf2: BytesMut = object_store
-            .inner
-            .get_range(
-                path,
-                Range {
-                    start: manifest_pos as u64,
-                    end: file_size - PREFETCH_SIZE,
-                },
-            )
-            .await?
-            .into_iter()
-            .collect();
+        // The prefetch only captured part of the manifest. Fetch the remainder
+        // as concurrent chunked range requests: a single GET is limited to one
+        // connection's throughput, which dominates load time for manifests of
+        // datasets with many fragments.
+        let reader = object_store
+            .open_with_size(path, file_size as usize)
+            .await?;
+        let mut buf2 = BytesMut::with_capacity(manifest_len);
+        let mut chunks = read_range_in_chunks(
+            reader.as_ref(),
+            manifest_pos..(file_size - PREFETCH_SIZE) as usize,
+            METADATA_READ_CHUNK_SIZE,
+        );
+        while let Some(chunk) = chunks.try_next().await? {
+            buf2.extend_from_slice(&chunk);
+        }
         buf2.extend_from_slice(&buf);
         buf2.freeze()
     };
@@ -261,11 +264,8 @@ mod test {
             .collect();
         writer.write_all(&prefix).await.unwrap();
 
-        let long_name: String = rand::rng()
-            .sample_iter(&Alphanumeric)
-            .take(manifest_min_size)
-            .map(char::from)
-            .collect();
+        // A cheap deterministic filler; only the size matters for these tests.
+        let long_name: String = "a".repeat(manifest_min_size);
 
         let arrow_schema =
             ArrowSchema::new(vec![ArrowField::new(long_name, DataType::Int64, false)]);
@@ -301,6 +301,13 @@ mod test {
         test_roundtrip_manifest(0, 100_000).await;
         test_roundtrip_manifest(1000, 100_000).await;
         test_roundtrip_manifest(1000, 1000).await;
+    }
+
+    #[tokio::test]
+    async fn test_read_manifest_larger_than_read_chunk() {
+        // Crosses METADATA_READ_CHUNK_SIZE so the manifest body is fetched as
+        // multiple concurrent chunks and reassembled with the prefetched tail.
+        test_roundtrip_manifest(1000, METADATA_READ_CHUNK_SIZE + 4 * 1024 * 1024).await;
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Problem

`Dataset::open` reads the manifest body with a single object-store `get_range`. The whole
message streams over one HTTP connection, so throughput is capped by the TCP window over the
round-trip time. On a high-latency link to S3 (~300 ms RTT) that is ~16 MB/s. For a table with
17.4B rows, ~20K fragments and stable row ids, the inline row-id sequences push the manifest to
~1 GiB, and opening the dataset spends over a minute in that one GET:

- `Dataset::open`: 68 s, of which 68.5 s is the single body GET (measured 322 s under degraded
  WAN — a single connection is fully at the mercy of current link conditions).
- A single multi-minute GET is also fragile: when the stream slows down it can hit the HTTP
  client timeout (`reqwest Body TimedOut` observed under instrumentation), and the retry then
  re-downloads the entire body.

## Change

- `lance-io`: add `read_range_in_chunks(reader, range, chunk_size)` — splits a range into
  fixed-size chunks fetched as concurrent range requests (window bounded by
  `Reader::io_parallelism()`), yielding chunks in file order — and
  `METADATA_READ_CHUNK_SIZE = 16 MiB`.
- `read_message` (the `Dataset::open` → `load_manifest` path) fetches the message remainder with
  the helper and assembles it into one pre-allocated buffer. This also removes the extra
  full-size copy the old `[buf, remaining_bytes].concat()` made.
- `lance-table`: `read_manifest` (checkout/version paths) fetches the manifest body the same
  way, replacing the per-byte `into_iter().collect::<BytesMut>()` assembly with a pre-allocated
  buffer.

Reads are byte-identical to before; error handling (stale-size retry, short-read check,
corrupt-tail retry) is preserved. Each chunk goes through the existing per-request retry layer,
so a mid-stream failure now retries one 16 MiB chunk instead of the whole gigabyte.

## Numbers

S3 `ap-southeast-2` over a ~300 ms RTT link; manifest 1.04 GiB (19,960 fragments, stable row
ids, delete/compact history); fresh process per measurement:

|                     | before                          | after                                  |
|---------------------|---------------------------------|----------------------------------------|
| `Dataset::open`     | 68.1 s (322.5 s on degraded WAN) | 8.2–13.1 s                            |
| manifest body fetch | 68.5 s (16.3 MB/s, 1 connection) | 3.6–4.8 s (~0.3 GB/s, link ceiling)   |
| peak RSS            | 2.26 GB                         | 2.24 GB                                |

The 16 MiB / `io_parallelism` (64) default comes from a sweep (chunks 4–64 MiB × concurrency
16–256): aggregate throughput plateaus at the link ceiling from 16 MiB × 64 upward; smaller
chunks lose to per-request latency, larger ones under-fill the concurrency window.

A table with a small manifest (22 MiB, 19,047 fragments) opens at parity before/after
(3.8–4.1 s both): its fetch is bound by request latency, and chunk sizes 2–16 MiB measure the
same within noise, so no adaptive chunk sizing.

## Tests

- `lance-io`: `test_read_range_in_chunks_reassembles_in_order` (chunk ordering and boundaries on
  an unaligned range), `test_read_message_larger_than_chunk_size` (message body crossing the
  chunk size, fetched as two concurrent chunks).
- `lance-table`: `test_read_manifest_larger_than_read_chunk` (manifest roundtrip larger than the
  chunk size: multi-chunk assembly plus the prefetched tail).
- The shared `test_roundtrip_manifest` helper now uses a deterministic filler name instead of
  sampling 20M random chars, keeping the new large-manifest case under the 1 s test budget
  (5 s → 0.05 s).

`cargo fmt --all` and `cargo clippy --all --tests --benches -- -D warnings` are clean.