### PR TITLE
feat(java): expose merge insert write mode

### DIFF
--- a/java/lance-jni/src/merge_insert.rs
+++ b/java/lance-jni/src/merge_insert.rs
@@ -12,7 +12,8 @@ use jni::objects::{JObject, JString, JValueGen};
 use jni::sys::jlong;
 use lance::dataset::scanner::ExprFilter;
 use lance::dataset::{
-    MergeInsertBuilder, MergeStats, WhenMatched, WhenNotMatched, WhenNotMatchedBySource,
+    MergeInsertBuilder, MergeInsertWriteMode, MergeStats, WhenMatched, WhenNotMatched,
+    WhenNotMatchedBySource,
 };
 use lance_core::datatypes::Schema;
 use lance_index::mem_wal::CompactedSsTable;
@@ -52,6 +53,7 @@ fn inner_merge_insert<'local>(
     let retry_timeout_ms = extract_retry_timeout_ms(env, &jparam)?;
     let skip_auto_cleanup = extract_skip_auto_cleanup(env, &jparam)?;
     let use_index = extract_use_index(env, &jparam)?;
+    let write_mode = extract_write_mode(env, &jparam)?;
     let compacted_sstables = extract_compacted_sstables(env, &jparam)?;
 
     let (new_ds, merge_stats) = unsafe {
@@ -71,6 +73,7 @@ fn inner_merge_insert<'local>(
             .retry_timeout(Duration::from_millis(retry_timeout_ms as u64))
             .skip_auto_cleanup(skip_auto_cleanup)
             .use_index(use_index)
+            .write_mode(write_mode)
             .mark_sstables_as_compacted(compacted_sstables)
             .try_build()?;
 
@@ -239,6 +242,26 @@ fn extract_skip_auto_cleanup<'local>(env: &mut JNIEnv<'local>, jparam: &JObject)
 fn extract_use_index<'local>(env: &mut JNIEnv<'local>, jparam: &JObject) -> Result<bool> {
     let use_index = env.call_method(jparam, "useIndex", "()Z", &[])?.z()?;
     Ok(use_index)
+}
+
+fn extract_write_mode<'local>(
+    env: &mut JNIEnv<'local>,
+    jparam: &JObject,
+) -> Result<MergeInsertWriteMode> {
+    let write_mode: JString = env
+        .call_method(jparam, "writeModeValue", "()Ljava/lang/String;", &[])?
+        .l()?
+        .into();
+    let write_mode = write_mode.extract(env)?;
+
+    match write_mode.as_str() {
+        "Auto" => Ok(MergeInsertWriteMode::Auto),
+        "RewriteRows" => Ok(MergeInsertWriteMode::RewriteRows),
+        "RewriteColumns" => Ok(MergeInsertWriteMode::RewriteColumns),
+        _ => Err(Error::input_error(format!(
+            "Illegal write_mode: {write_mode}",
+        ))),
+    }
 }
 
 fn extract_compacted_sstables<'local>(

--- a/java/src/main/java/org/lance/merge/MergeInsertParams.java
+++ b/java/src/main/java/org/lance/merge/MergeInsertParams.java
@@ -39,6 +39,7 @@ public class MergeInsertParams {
   private long retryTimeoutMs = 30 * 1000;
   private boolean skipAutoCleanup = false;
   private boolean useIndex = true;
+  private MergeWriteMode writeMode = MergeWriteMode.Auto;
   private List<CompactedSsTable> compactedSstables = Collections.emptyList();
 
   public MergeInsertParams(List<String> on) {
@@ -245,6 +246,26 @@ public class MergeInsertParams {
   }
 
   /**
+   * Selects how the merged rows are written.
+   *
+   * <p>Only has an effect on a partial-schema update (the source omits some dataset columns), where
+   * {@link MergeWriteMode#RewriteColumns} writes fewer bytes than {@link
+   * MergeWriteMode#RewriteRows} once the fraction of rows matched exceeds roughly the fraction of
+   * each row's bytes the source columns occupy: nearly always for a KB-scale update of a MB-per-row
+   * table, possibly never for a table of narrow columns.
+   *
+   * <p>Default is {@link MergeWriteMode#Auto}, which rewrites whole rows.
+   *
+   * @param writeMode How the merged rows are written.
+   * @return This MergeInsertParams instance
+   */
+  public MergeInsertParams withWriteMode(MergeWriteMode writeMode) {
+    Preconditions.checkNotNull(writeMode, "writeMode must not be null");
+    this.writeMode = writeMode;
+    return this;
+  }
+
+  /**
    * Mark MemWAL SSTables as compacted into the base table.
    *
    * <p>Use this when merge insert compacts MemWAL SSTables. It updates MemWAL compaction progress
@@ -325,6 +346,14 @@ public class MergeInsertParams {
     return useIndex;
   }
 
+  public MergeWriteMode writeMode() {
+    return writeMode;
+  }
+
+  public String writeModeValue() {
+    return writeMode.name();
+  }
+
   @Override
   public String toString() {
     return MoreObjects.toStringHelper(this)
@@ -343,7 +372,44 @@ public class MergeInsertParams {
         .add("retryTimeoutMs", retryTimeoutMs)
         .add("skipAutoCleanup", skipAutoCleanup)
         .add("useIndex", useIndex)
+        .add("writeMode", writeMode)
         .toString();
+  }
+
+  /**
+   * How a merge insert writes the merged rows.
+   *
+   * <p>The caller chooses rather than the engine because which mode writes fewer bytes depends on
+   * the fraction of each fragment's rows the source matches, which is only known once the join has
+   * run.
+   */
+  public enum MergeWriteMode {
+    /**
+     * Let the engine choose: whole rows, except that a partial-schema update whose join key carries
+     * a scalar index patches columns, on the indexed path that predates this enum.
+     */
+    Auto,
+
+    /**
+     * Delete the matched rows and write whole rows into new fragments. Cost scales with the number
+     * of matched rows.
+     *
+     * <p>For a partial-schema update this gives up the scalar-index probe on the join key, because
+     * the indexed path only ever patches columns.
+     */
+    RewriteRows,
+
+    /**
+     * Attach new data files holding the source columns to the fragments that already hold the
+     * matched rows, and tombstone the old versions of those columns. The omitted columns are
+     * neither read nor written, but the replacement column file covers every row of each fragment
+     * it touches, so the bytes written barely fall as fewer rows match.
+     *
+     * <p>Errors if the merge cannot be expressed this way: it must update matched rows only (no
+     * inserts, no matched deletes, no delete-by-source) with a source that omits at least one
+     * dataset column, carries at least one column besides the join key, and carries no blob column.
+     */
+    RewriteColumns,
   }
 
   public enum WhenMatched {

--- a/java/src/main/java/org/lance/merge/MergeInsertParams.java
+++ b/java/src/main/java/org/lance/merge/MergeInsertParams.java
@@ -254,7 +254,8 @@ public class MergeInsertParams {
    * each row's bytes the source columns occupy: nearly always for a KB-scale update of a MB-per-row
    * table, possibly never for a table of narrow columns.
    *
-   * <p>Default is {@link MergeWriteMode#Auto}, which rewrites whole rows.
+   * <p>Default is {@link MergeWriteMode#Auto}: the write mode is chosen by the engine, typically
+   * rewriting whole rows.
    *
    * @param writeMode How the merged rows are written.
    * @return This MergeInsertParams instance
@@ -385,8 +386,8 @@ public class MergeInsertParams {
    */
   public enum MergeWriteMode {
     /**
-     * Let the engine choose: whole rows, except that a partial-schema update whose join key carries
-     * a scalar index patches columns, on the indexed path that predates this enum.
+     * Let the engine choose, typically rewriting whole rows. A partial-schema update whose join key
+     * carries a scalar index may instead patch columns on the indexed path that predates this enum.
      */
     Auto,
 

--- a/java/src/test/java/org/lance/MergeInsertTest.java
+++ b/java/src/test/java/org/lance/MergeInsertTest.java
@@ -13,6 +13,10 @@
  */
 package org.lance;
 
+import org.lance.index.IndexOptions;
+import org.lance.index.IndexParams;
+import org.lance.index.IndexType;
+import org.lance.index.scalar.ScalarIndexParams;
 import org.lance.merge.MergeInsertParams;
 import org.lance.merge.MergeInsertResult;
 
@@ -25,12 +29,16 @@ import org.apache.arrow.vector.VectorSchemaRoot;
 import org.apache.arrow.vector.ipc.ArrowReader;
 import org.apache.arrow.vector.ipc.ArrowStreamReader;
 import org.apache.arrow.vector.ipc.ArrowStreamWriter;
+import org.apache.arrow.vector.types.pojo.ArrowType;
+import org.apache.arrow.vector.types.pojo.Field;
 import org.apache.arrow.vector.types.pojo.Schema;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -40,10 +48,29 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.TreeMap;
 import java.util.UUID;
 
 public class MergeInsertTest {
+  private static final Schema WIDE_SCHEMA =
+      new Schema(
+          Arrays.asList(
+              Field.nullable("id", new ArrowType.Int(32, true)),
+              Field.nullable("name", new ArrowType.Utf8()),
+              Field.nullable("score", new ArrowType.Int(32, true))));
+
+  /** {@link #WIDE_SCHEMA} minus "score", so a source over it is a partial-schema update. */
+  private static final Schema PARTIAL_SOURCE_SCHEMA =
+      new Schema(
+          Arrays.asList(
+              Field.nullable("id", new ArrowType.Int(32, true)),
+              Field.nullable("name", new ArrowType.Utf8())));
+
+  /** {@link #createWideDataset()} after the rows with id 1 and 4 are renamed. */
+  private static final String WIDE_AFTER_UPDATE =
+      "{0=Person 0/0, 1=Updated 1/10, 2=Person 2/20, 3=Person 3/30, 4=Updated 4/40, 5=Person 5/50}";
+
   @TempDir private Path tempDir;
   private RootAllocator allocator;
   private TestUtils.SimpleTestDataset testDataset;
@@ -296,6 +323,148 @@ public class MergeInsertTest {
             "merge insert with useIndex=false should produce correct upsert results");
       }
     }
+  }
+
+  @ParameterizedTest
+  @CsvSource({"Auto, 2", "RewriteRows, 3"})
+  public void testWriteModeOnIndexedPartialUpdate(
+      MergeInsertParams.MergeWriteMode writeMode, int expectedFragments) throws Exception {
+    try (Dataset wideDataset = createWideDataset()) {
+      createIdIndex(wideDataset);
+
+      try (VectorSchemaRoot source = buildPartialSource(1, 4);
+          ArrowArrayStream sourceStream = convertToStream(source, allocator)) {
+        MergeInsertResult result =
+            wideDataset.mergeInsert(
+                new MergeInsertParams(Collections.singletonList("id"))
+                    .withMatchedUpdateAll()
+                    .withNotMatched(MergeInsertParams.WhenNotMatched.DoNothing)
+                    .withWriteMode(writeMode),
+                sourceStream);
+
+        Assertions.assertEquals(2, result.stats().numUpdatedRows());
+        try (Dataset merged = result.dataset()) {
+          Assertions.assertEquals(expectedFragments, merged.getFragments().size());
+          Assertions.assertEquals(WIDE_AFTER_UPDATE, readWide(merged).toString());
+        }
+      }
+    }
+  }
+
+  @Test
+  public void testWriteModeRewriteColumns() throws Exception {
+    try (Dataset wideDataset = createWideDataset()) {
+      try (VectorSchemaRoot source = buildPartialSource(1, 4);
+          ArrowArrayStream sourceStream = convertToStream(source, allocator)) {
+        MergeInsertResult result =
+            wideDataset.mergeInsert(
+                new MergeInsertParams(Collections.singletonList("id"))
+                    .withMatchedUpdateAll()
+                    .withNotMatched(MergeInsertParams.WhenNotMatched.DoNothing)
+                    .withWriteMode(MergeInsertParams.MergeWriteMode.RewriteColumns),
+                sourceStream);
+
+        Assertions.assertEquals(2, result.stats().numUpdatedRows());
+        try (Dataset merged = result.dataset()) {
+          Assertions.assertEquals(2, merged.getFragments().size());
+          // "score", which the source omits, is carried through untouched.
+          Assertions.assertEquals(WIDE_AFTER_UPDATE, readWide(merged).toString());
+        }
+      }
+    }
+  }
+
+  @Test
+  public void testWriteModeRewriteColumnsRejectsInserts() throws Exception {
+
+    try (Dataset wideDataset = createWideDataset()) {
+      try (VectorSchemaRoot source = buildPartialSource(100);
+          ArrowArrayStream sourceStream = convertToStream(source, allocator)) {
+        Exception e =
+            Assertions.assertThrows(
+                Exception.class,
+                () ->
+                    wideDataset.mergeInsert(
+                        // WhenNotMatched defaults to InsertAll.
+                        new MergeInsertParams(Collections.singletonList("id"))
+                            .withMatchedUpdateAll()
+                            .withWriteMode(MergeInsertParams.MergeWriteMode.RewriteColumns)
+                            .withConflictRetries(0),
+                        sourceStream));
+        Assertions.assertTrue(
+            e.getMessage().contains("RewriteColumns cannot express"),
+            "expected the RewriteColumns rejection, got: " + e.getMessage());
+      }
+    }
+  }
+
+  /** A dataset of 6 rows over 2 fragments, whose "score" column no partial source carries. */
+  private Dataset createWideDataset() {
+    String path = tempDir.resolve(UUID.randomUUID().toString()).toString();
+    Dataset.create(allocator, path, WIDE_SCHEMA, new WriteParams.Builder().build()).close();
+
+    List<FragmentMetadata> fragments;
+    try (VectorSchemaRoot root = VectorSchemaRoot.create(WIDE_SCHEMA, allocator)) {
+      root.allocateNew();
+      IntVector idVector = (IntVector) root.getVector("id");
+      VarCharVector nameVector = (VarCharVector) root.getVector("name");
+      IntVector scoreVector = (IntVector) root.getVector("score");
+      for (int i = 0; i < 6; i++) {
+        idVector.setSafe(i, i);
+        nameVector.setSafe(i, ("Person " + i).getBytes(StandardCharsets.UTF_8));
+        scoreVector.setSafe(i, i * 10);
+      }
+      root.setRowCount(6);
+      fragments =
+          Fragment.create(
+              path, allocator, root, new WriteParams.Builder().withMaxRowsPerFile(3).build());
+    }
+
+    Dataset wideDataset =
+        Dataset.commit(allocator, path, new FragmentOperation.Append(fragments), Optional.of(1L));
+    Assertions.assertEquals(2, wideDataset.getFragments().size());
+    return wideDataset;
+  }
+
+  private void createIdIndex(Dataset dataset) {
+    IndexParams indexParams =
+        IndexParams.builder().setScalarIndexParams(ScalarIndexParams.create("btree", "{}")).build();
+    dataset.createIndex(
+        IndexOptions.builder(Collections.singletonList("id"), IndexType.BTREE, indexParams)
+            .withIndexName("id_btree")
+            .replace(true)
+            .build());
+  }
+
+  /** A source over {@link #WIDE_SCHEMA} minus "score", renaming the rows it names. */
+  private VectorSchemaRoot buildPartialSource(int... ids) {
+    VectorSchemaRoot source = VectorSchemaRoot.create(PARTIAL_SOURCE_SCHEMA, allocator);
+    source.allocateNew();
+    IntVector idVector = (IntVector) source.getVector("id");
+    VarCharVector nameVector = (VarCharVector) source.getVector("name");
+    for (int i = 0; i < ids.length; i++) {
+      idVector.setSafe(i, ids[i]);
+      nameVector.setSafe(i, ("Updated " + ids[i]).getBytes(StandardCharsets.UTF_8));
+    }
+    source.setRowCount(ids.length);
+    return source;
+  }
+
+  /** Reads a {@link #WIDE_SCHEMA} dataset as id -&gt; "name/score". */
+  private TreeMap<Integer, String> readWide(Dataset dataset) throws Exception {
+    TreeMap<Integer, String> rows = new TreeMap<>();
+    try (ArrowReader reader = dataset.newScan().scanBatches()) {
+      while (reader.loadNextBatch()) {
+        VectorSchemaRoot batch = reader.getVectorSchemaRoot();
+        IntVector ids = (IntVector) batch.getVector("id");
+        VarCharVector names = (VarCharVector) batch.getVector("name");
+        IntVector scores = (IntVector) batch.getVector("score");
+        for (int i = 0; i < batch.getRowCount(); i++) {
+          rows.put(ids.get(i), new String(names.get(i)) + "/" + scores.get(i));
+        }
+      }
+    }
+    return rows;
   }
 
   private TreeMap<Integer, String> readAll(Dataset dataset) throws Exception {


### PR DESCRIPTION
Adds `MergeInsertParams.withWriteMode` so Java callers can pick how a merge insert writes the merged rows, matching the Rust `MergeInsertBuilder::write_mode` and the Python `write_mode` bindings.

`MergeWriteMode.RewriteColumns` patches the source columns into the fragments that already hold the matched rows, which is the cheaper mode for a narrow update of a wide table; `RewriteRows` rewrites whole rows and scales with the matched row count. The default stays `Auto`, so existing callers are unaffected.

The enum is named `MergeWriteMode` rather than `WriteMode` to avoid colliding with `WriteParams.WriteMode`.