### PR TITLE
feat: budget blob materialization readahead

### DIFF
--- a/.github/labeler-area.yml
+++ b/.github/labeler-area.yml
@@ -29,22 +29,40 @@ A-encoding:
           - "rust/lance-io/**"
           - "rust/lance-file/**"
 
-# On-disk format: the proto definitions and the format spec docs. Format docs
+# On-disk format: persisted proto definitions and the format spec docs. Keep the
+# explicit proto lists here in sync. Execution-plan schemas (ann,
+# filtered_read, and table_identifier) are intentionally excluded. Format docs
 # are excluded from A-docs (see below) so format changes get A-format only.
 A-format:
   - changed-files:
       - any-glob-to-any-file:
-          - "protos/**"
+          - "protos/encodings_v2_0.proto"
+          - "protos/encodings_v2_1.proto"
+          - "protos/file.proto"
+          - "protos/file2.proto"
+          - "protos/index.proto"
+          - "protos/index_old.proto"
+          - "protos/rowids.proto"
+          - "protos/table.proto"
+          - "protos/transaction.proto"
           - "docs/src/format/**"
 
 # Drives the format-spec vote gate (.github/workflows/format-vote-gate.yml):
-# any change to the proto definitions or the spec docs requires a PMC vote.
-# Scoped to *.proto (not e.g. protos/AGENTS.md) since only the IDL and spec are
-# the format. A PMC member waives a trivial edit with the `format-waived` label.
+# any change to persisted proto definitions or the spec docs requires a PMC
+# vote. Execution-only wire schemas such as filtered_read.proto are not format
+# changes. A PMC member waives a trivial edit with the `format-waived` label.
 format-change:
   - changed-files:
       - any-glob-to-any-file:
-          - "protos/**/*.proto"
+          - "protos/encodings_v2_0.proto"
+          - "protos/encodings_v2_1.proto"
+          - "protos/file.proto"
+          - "protos/file2.proto"
+          - "protos/index.proto"
+          - "protos/index_old.proto"
+          - "protos/rowids.proto"
+          - "protos/table.proto"
+          - "protos/transaction.proto"
           - "docs/src/format/**"
 
 # Lockfiles are intentionally not excluded: a pure dependency bump gets both

--- a/.github/workflows/ci-scripts.yml
+++ b/.github/workflows/ci-scripts.yml
@@ -15,6 +15,8 @@ on:
     paths:
       - ci/format_vote_gate.py
       - ci/test_format_vote_gate.py
+      - ci/test_labeler_area.py
+      - .github/labeler-area.yml
       - .github/workflows/format-vote-gate.yml
       - .github/workflows/ci-scripts.yml
 
@@ -32,7 +34,7 @@ jobs:
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.12"
-      - name: Install pytest
-        run: pip install pytest
+      - name: Install test dependencies
+        run: pip install pytest PyYAML
       - name: Run tests
-        run: pytest ci/test_format_vote_gate.py
+        run: pytest ci/test_format_vote_gate.py ci/test_labeler_area.py

--- a/.github/workflows/format-vote-gate.yml
+++ b/.github/workflows/format-vote-gate.yml
@@ -3,12 +3,12 @@ name: Format spec vote gate
 # Structurally enforces the PMC vote required for Lance format-specification
 # changes (see https://lance.org/community/voting/). The path labeler
 # (.github/labeler-area.yml) applies the `format-change` label to PRs that touch
-# the format spec (`protos/**/*.proto`, `docs/src/format/**`); this gate reads
-# that label and blocks merging until the PR has 3 binding +1 votes from PMC
-# members (PR approvals, excluding the author), has no outstanding veto (a PMC
-# "Request changes" review), and the 72-hour voting period has elapsed. That
-# period starts once the PR is labeled and ready for review, and pauses over
-# weekends.
+# the persisted format protos or `docs/src/format/**`; execution-only wire
+# schemas are excluded. This gate reads that label and blocks merging until the
+# PR has 3 binding +1 votes from PMC members (PR approvals, excluding the
+# author), has no outstanding veto (a PMC "Request changes" review), and the
+# 72-hour voting period has elapsed. That period starts once the PR is labeled
+# and ready for review, and pauses over weekends.
 #
 # The gate publishes its verdict as the `format-spec-vote` commit status on the
 # PR head. To make it a merge blocker, an org admin must add `format-spec-vote`

--- a/ci/test_labeler_area.py
+++ b/ci/test_labeler_area.py
@@ -1,0 +1,34 @@
+"""Regression tests for format-spec path classification."""
+
+from pathlib import Path
+
+import yaml
+
+
+ROOT = Path(__file__).parent.parent
+LABELER_CONFIG = ROOT / ".github" / "labeler-area.yml"
+EXECUTION_PROTO_PATHS = {
+    "protos/ann.proto",
+    "protos/filtered_read.proto",
+    "protos/table_identifier.proto",
+}
+
+
+def paths_for(label):
+    config = yaml.safe_load(LABELER_CONFIG.read_text())
+    return set(config[label][0]["changed-files"][0]["any-glob-to-any-file"])
+
+
+def test_format_labels_use_the_same_paths():
+    assert paths_for("A-format") == paths_for("format-change")
+
+
+def test_only_persisted_protos_are_format_changes():
+    detected_proto_paths = {
+        path for path in paths_for("format-change") if path.startswith("protos/")
+    }
+    all_proto_paths = {
+        path.relative_to(ROOT).as_posix() for path in (ROOT / "protos").glob("*.proto")
+    }
+
+    assert detected_proto_paths == all_proto_paths - EXECUTION_PROTO_PATHS

--- a/protos/AGENTS.md
+++ b/protos/AGENTS.md
@@ -4,13 +4,15 @@ Also see [root AGENTS.md](../AGENTS.md) for cross-language standards.
 
 ## Change Process
 
-- Changes to `*.proto` require a PMC vote on the pull request, enforced by the `format-spec-vote` CI gate. See [Lance Format Specification Changes](../docs/src/community/voting.md#lance-format-specification-changes).
-- Keep a proto change in its own PR, together with the matching `docs/src/format/` change and only the library edits needed to compile. Put the implementation in a follow-up PR — voters need to read the contract, not its implementation.
+- Changes to protobuf schemas that define a persisted Lance format require a PMC vote on the pull request, enforced by the `format-spec-vote` CI gate. See [Lance Format Specification Changes](../docs/src/community/voting.md#lance-format-specification-changes).
+- Keep a persisted-format proto change in its own PR, together with the matching `docs/src/format/` change and only the library edits needed to compile. Put the implementation in a follow-up PR — voters need to read the contract, not its implementation.
+- Execution-plan schemas (`ann.proto`, `filtered_read.proto`, and `table_identifier.proto`) are wire contracts, not persisted Lance formats. Changes to them belong with their implementation and do not require a format vote or a `docs/src/format/` change.
 
 ## Compatibility
 
 - Protobuf schemas that are part of a stable file format or any other stable persisted contract must remain backwards compatible. Never reuse or change their existing field numbers.
 - Protobuf schemas used exclusively by an unstable file format follow the root file-format stability contract: do not preserve compatibility with prior unstable revisions. Before making a breaking protobuf change, verify that the schema is not shared with a stable format or another persisted contract.
+- Execution wire schemas may still cross process or version boundaries. Preserve their field-number compatibility unless all producers and consumers are upgraded atomically.
 
 ## Schema Design
 

--- a/protos/filtered_read.proto
+++ b/protos/filtered_read.proto
@@ -62,6 +62,7 @@ message FilteredReadOptionsProto {
   optional uint64 io_buffer_size_bytes = 11;
   // Arrow IPC schema for decoding Substrait filters (may be wider than projection).
   optional bytes filter_schema_ipc = 12;
+  optional uint64 materialization_readahead_bytes = 13;
 }
 
 // Serializable form of FilteredReadPlan (planned/distributed mode).

--- a/protos/filtered_read.proto
+++ b/protos/filtered_read.proto
@@ -62,6 +62,11 @@ message FilteredReadOptionsProto {
   optional uint64 io_buffer_size_bytes = 11;
   // Arrow IPC schema for decoding Substrait filters (may be wider than projection).
   optional bytes filter_schema_ipc = 12;
+  // If present, a nonzero upper bound on bytes reserved by Blob v2
+  // materialization awaiting ordered emission in one scanner execution.
+  // Admission follows output order; one oversized output batch may exceed the
+  // bound when no other batch is reserved. If absent, Blob v2 materialization
+  // has no independent memory bound.
   optional uint64 materialization_readahead_bytes = 13;
 }
 

--- a/rust/lance/src/dataset/blob.rs
+++ b/rust/lance/src/dataset/blob.rs
@@ -2377,7 +2377,7 @@ impl BlobMaterializationBudget {
     }
 }
 
-pub(crate) struct BlobMaterializationAdmission {
+pub struct BlobMaterializationAdmission {
     budget: Option<Arc<BlobMaterializationBudget>>,
     ticket: u64,
     acquired: bool,
@@ -3539,7 +3539,7 @@ pub fn materialize_blob_v2_binary_batch_with_context<'a>(
     )
 }
 
-pub(crate) fn materialize_blob_v2_binary_batch_with_admission<'a>(
+pub fn materialize_blob_v2_binary_batch_with_admission<'a>(
     dataset: &'a Arc<Dataset>,
     output_schema: &'a Schema,
     batch: RecordBatch,
@@ -7594,7 +7594,7 @@ mod tests {
 
         let output_schema = dataset
             .empty_projection()
-            .union_columns(&["blob"], OnMissing::Error)
+            .union_columns(["blob"], OnMissing::Error)
             .unwrap()
             .with_blob_handling(BlobHandling::AllBinary)
             .to_schema();

--- a/rust/lance/src/dataset/blob.rs
+++ b/rust/lance/src/dataset/blob.rs
@@ -15,7 +15,9 @@ use arrow_array::{
     Array, ArrayRef, GenericListArray, OffsetSizeTrait, RecordBatch, builder::LargeBinaryBuilder,
 };
 use arrow_buffer::{ArrowNativeType, OffsetBuffer, ScalarBuffer};
-use arrow_schema::{DataType as ArrowDataType, Field as ArrowField, Schema as ArrowSchema};
+use arrow_schema::{
+    DataType as ArrowDataType, Field as ArrowField, Schema as ArrowSchema, SchemaRef,
+};
 use bytes::Bytes;
 use futures::future::BoxFuture;
 use futures::stream::BoxStream;
@@ -2461,10 +2463,41 @@ impl BlobMaterializationContext {
 /// A materialized batch that retains its byte-budget reservation until yielded.
 pub struct MaterializedBlobBatch {
     batch: RecordBatch,
-    _reservation: Option<BlobMaterializationReservation>,
+    _reservations: Vec<BlobMaterializationReservation>,
 }
 
 impl MaterializedBlobBatch {
+    pub(crate) fn unreserved(batch: RecordBatch) -> Self {
+        Self {
+            batch,
+            _reservations: Vec::new(),
+        }
+    }
+
+    pub(crate) fn batch(&self) -> &RecordBatch {
+        &self.batch
+    }
+
+    pub(crate) fn with_batch(self, batch: RecordBatch) -> Self {
+        Self {
+            batch,
+            _reservations: self._reservations,
+        }
+    }
+
+    pub(crate) fn concat(schema: &SchemaRef, batches: Vec<Self>) -> Result<Self> {
+        let mut record_batches = Vec::with_capacity(batches.len());
+        let mut reservations = Vec::new();
+        for batch in batches {
+            record_batches.push(batch.batch);
+            reservations.extend(batch._reservations);
+        }
+        Ok(Self {
+            batch: arrow::compute::concat_batches(schema, record_batches.iter())?,
+            _reservations: reservations,
+        })
+    }
+
     pub(crate) fn into_batch(self) -> RecordBatch {
         self.batch
     }
@@ -3516,7 +3549,7 @@ pub async fn materialize_blob_v2_binary_batch_with_context(
             )),
             columns,
         )?,
-        _reservation: reservation,
+        _reservations: reservation.into_iter().collect(),
     })
 }
 

--- a/rust/lance/src/dataset/blob.rs
+++ b/rust/lance/src/dataset/blob.rs
@@ -28,7 +28,7 @@ use lance_arrow::{
 use lance_io::object_store::{ObjectStore, ObjectStoreParams, ObjectStoreRegistry};
 use lance_io::scheduler::{FileScheduler, ScanScheduler, SchedulerConfig};
 use object_store::path::Path;
-use tokio::sync::{Mutex, OnceCell, oneshot};
+use tokio::sync::{Mutex, Notify, OnceCell, oneshot};
 use url::Url;
 
 use super::take::{MissingRowPolicy, TakeBuilder};
@@ -2329,6 +2329,147 @@ struct ReadBlobsExecution {
     schedulers: std::sync::Mutex<HashMap<String, Arc<ScanScheduler>>>,
 }
 
+#[derive(Debug)]
+struct BlobMaterializationBudget {
+    limit: u64,
+    state: std::sync::Mutex<BlobMaterializationBudgetState>,
+    notify: Notify,
+}
+
+#[derive(Debug, Default)]
+struct BlobMaterializationBudgetState {
+    reserved: u64,
+    next_ticket: u64,
+    serving_ticket: u64,
+    cancelled_tickets: HashSet<u64>,
+}
+
+impl BlobMaterializationBudgetState {
+    fn skip_cancelled(&mut self) {
+        while self.cancelled_tickets.remove(&self.serving_ticket) {
+            self.serving_ticket = self.serving_ticket.wrapping_add(1);
+        }
+    }
+}
+
+impl BlobMaterializationBudget {
+    async fn reserve(self: &Arc<Self>, bytes: u64) -> BlobMaterializationReservation {
+        let ticket = {
+            let mut state = self.state.lock().unwrap();
+            let ticket = state.next_ticket;
+            state.next_ticket = state.next_ticket.wrapping_add(1);
+            ticket
+        };
+        let mut waiter = BlobMaterializationWaiter {
+            budget: self.clone(),
+            ticket,
+            acquired: false,
+        };
+        loop {
+            let notified = self.notify.notified();
+            {
+                let mut state = self.state.lock().unwrap();
+                let fits = bytes <= self.limit.saturating_sub(state.reserved);
+                let oversized_and_idle = state.reserved == 0 && bytes > self.limit;
+                if ticket == state.serving_ticket && (fits || oversized_and_idle) {
+                    state.reserved = state.reserved.saturating_add(bytes);
+                    state.serving_ticket = state.serving_ticket.wrapping_add(1);
+                    state.skip_cancelled();
+                    waiter.acquired = true;
+                    let reservation = BlobMaterializationReservation {
+                        budget: self.clone(),
+                        bytes,
+                    };
+                    drop(state);
+                    self.notify.notify_waiters();
+                    return reservation;
+                }
+            }
+            notified.await;
+        }
+    }
+}
+
+struct BlobMaterializationWaiter {
+    budget: Arc<BlobMaterializationBudget>,
+    ticket: u64,
+    acquired: bool,
+}
+
+impl Drop for BlobMaterializationWaiter {
+    fn drop(&mut self) {
+        if self.acquired {
+            return;
+        }
+        let mut state = self.budget.state.lock().unwrap();
+        if self.ticket >= state.serving_ticket {
+            state.cancelled_tickets.insert(self.ticket);
+            state.skip_cancelled();
+        }
+        drop(state);
+        self.budget.notify.notify_waiters();
+    }
+}
+
+#[derive(Debug)]
+struct BlobMaterializationReservation {
+    budget: Arc<BlobMaterializationBudget>,
+    bytes: u64,
+}
+
+impl Drop for BlobMaterializationReservation {
+    fn drop(&mut self) {
+        let mut state = self.budget.state.lock().unwrap();
+        state.reserved = state.reserved.saturating_sub(self.bytes);
+        drop(state);
+        self.budget.notify.notify_waiters();
+    }
+}
+
+/// Shared state for asynchronously materializing blob v2 descriptor batches.
+#[derive(Debug)]
+pub(crate) struct BlobMaterializationContext {
+    execution: Arc<ReadBlobsExecution>,
+    budget: Option<Arc<BlobMaterializationBudget>>,
+}
+
+impl BlobMaterializationContext {
+    pub(crate) fn new(
+        io_buffer_size_bytes: Option<u64>,
+        materialization_readahead_bytes: Option<u64>,
+    ) -> Arc<Self> {
+        Arc::new(Self {
+            execution: Arc::new(ReadBlobsExecution::new(io_buffer_size_bytes)),
+            budget: materialization_readahead_bytes.map(|limit| {
+                Arc::new(BlobMaterializationBudget {
+                    limit,
+                    state: std::sync::Mutex::new(BlobMaterializationBudgetState::default()),
+                    notify: Notify::new(),
+                })
+            }),
+        })
+    }
+
+    async fn reserve(&self, bytes: u64) -> Option<BlobMaterializationReservation> {
+        match &self.budget {
+            Some(budget) => Some(budget.reserve(bytes).await),
+            None => None,
+        }
+    }
+}
+
+/// A materialized batch that retains its byte-budget reservation until yielded.
+pub(crate) struct MaterializedBlobBatch {
+    batch: RecordBatch,
+    _reservation: Option<BlobMaterializationReservation>,
+}
+
+impl MaterializedBlobBatch {
+    pub(crate) fn into_batch(self) -> RecordBatch {
+        self.batch
+    }
+}
+
 impl ReadBlobsExecution {
     fn new(io_buffer_size_bytes: Option<u64>) -> Self {
         Self {
@@ -2824,12 +2965,24 @@ async fn execute_blob_entries(
     io_parallelism: usize,
     io_buffer_size_bytes: Option<u64>,
 ) -> Result<Vec<IndexedReadBlob>> {
+    execute_blob_entries_with_execution(
+        entries,
+        io_parallelism,
+        Arc::new(ReadBlobsExecution::new(io_buffer_size_bytes)),
+    )
+    .await
+}
+
+async fn execute_blob_entries_with_execution(
+    entries: Vec<BlobEntry>,
+    io_parallelism: usize,
+    execution: Arc<ReadBlobsExecution>,
+) -> Result<Vec<IndexedReadBlob>> {
     let plans = plan_blob_read_plans(entries)?;
     if plans.is_empty() {
         return Ok(Vec::new());
     }
 
-    let execution = Arc::new(ReadBlobsExecution::new(io_buffer_size_bytes));
     let batches = stream::iter(plans.into_iter().map(move |plan| {
         let execution = execution.clone();
         execute_blob_read_plan(plan, execution)
@@ -3293,6 +3446,22 @@ pub async fn materialize_blob_v2_binary_batch(
     output_schema: &Schema,
     batch: RecordBatch,
 ) -> Result<RecordBatch> {
+    let context = BlobMaterializationContext::new(None, None);
+    Ok(
+        materialize_blob_v2_binary_batch_with_context(dataset, output_schema, batch, &context)
+            .await?
+            .into_batch(),
+    )
+}
+
+pub(crate) async fn materialize_blob_v2_binary_batch_with_context(
+    dataset: &Arc<Dataset>,
+    output_schema: &Schema,
+    batch: RecordBatch,
+    context: &Arc<BlobMaterializationContext>,
+) -> Result<MaterializedBlobBatch> {
+    let materialized_bytes = estimate_blob_v2_materialized_batch_bytes(output_schema, &batch)?;
+    let reservation = context.reserve(materialized_bytes).await;
     let row_addr_idx = batch
         .schema()
         .column_with_name(ROW_ADDR)
@@ -3331,19 +3500,99 @@ pub async fn materialize_blob_v2_binary_batch(
             })?
             .clone();
         let materialized =
-            materialize_blob_v2_binary_array(dataset, field, input, row_addrs.clone()).await?;
+            materialize_blob_v2_binary_array(dataset, field, input, row_addrs.clone(), context)
+                .await?;
         columns.push(materialized);
         let output_field = public_blob_v2_binary_output_field(field.clone());
         fields.push(ArrowField::from(&output_field));
     }
 
-    Ok(RecordBatch::try_new(
-        Arc::new(ArrowSchema::new_with_metadata(
-            fields,
-            batch.schema().metadata().clone(),
-        )),
-        columns,
-    )?)
+    Ok(MaterializedBlobBatch {
+        batch: RecordBatch::try_new(
+            Arc::new(ArrowSchema::new_with_metadata(
+                fields,
+                batch.schema().metadata().clone(),
+            )),
+            columns,
+        )?,
+        _reservation: reservation,
+    })
+}
+
+fn estimate_blob_v2_materialized_batch_bytes(
+    output_schema: &Schema,
+    batch: &RecordBatch,
+) -> Result<u64> {
+    let mut bytes = u64::try_from(batch.get_array_memory_size()).unwrap_or(u64::MAX);
+    for field in &output_schema.fields {
+        let input = batch.column_by_name(&field.name).ok_or_else(|| {
+            Error::internal(format!(
+                "blob v2 binary scan batch missing projected column '{}'",
+                field.name
+            ))
+        })?;
+        bytes = bytes.saturating_add(estimate_blob_v2_materialized_array_bytes(field, input)?);
+    }
+    Ok(bytes)
+}
+
+fn estimate_blob_v2_materialized_array_bytes(field: &LanceField, array: &ArrayRef) -> Result<u64> {
+    if is_blob_v2_binary_view(field) {
+        let descriptions = array.as_struct();
+        match blob_version_from_descriptions(descriptions)? {
+            BlobVersion::V1 => {
+                return Err(Error::not_supported(
+                    "Blob v2 binary materialization received a legacy blob descriptor".to_string(),
+                ));
+            }
+            BlobVersion::V2 => {}
+        }
+        let columns = BlobV2DescriptorColumns::new(descriptions);
+        let payload_bytes = (0..descriptions.len())
+            .filter(|idx| !columns.is_null_blob(*idx))
+            .fold(0_u64, |total, idx| {
+                total.saturating_add(columns.sizes.value(idx))
+            });
+        let offsets_bytes =
+            u64::try_from((descriptions.len() + 1).saturating_mul(std::mem::size_of::<i64>()))
+                .unwrap_or(u64::MAX);
+        return Ok(payload_bytes.saturating_add(offsets_bytes));
+    }
+
+    match field.data_type() {
+        ArrowDataType::Struct(_) => {
+            let array = array.as_struct();
+            field
+                .children
+                .iter()
+                .zip(array.columns())
+                .try_fold(0_u64, |total, (child, array)| {
+                    Ok(total
+                        .saturating_add(estimate_blob_v2_materialized_array_bytes(child, array)?))
+                })
+        }
+        ArrowDataType::List(_) => {
+            let array = array.as_list::<i32>();
+            let child = field.children.first().ok_or_else(|| {
+                Error::internal(format!(
+                    "List field '{}' missing child while estimating blob v2 materialization",
+                    field.name
+                ))
+            })?;
+            estimate_blob_v2_materialized_array_bytes(child, array.values())
+        }
+        ArrowDataType::LargeList(_) => {
+            let array = array.as_list::<i64>();
+            let child = field.children.first().ok_or_else(|| {
+                Error::internal(format!(
+                    "List field '{}' missing child while estimating blob v2 materialization",
+                    field.name
+                ))
+            })?;
+            estimate_blob_v2_materialized_array_bytes(child, array.values())
+        }
+        _ => Ok(0),
+    }
 }
 
 fn materialize_blob_v2_binary_array<'a>(
@@ -3351,6 +3600,7 @@ fn materialize_blob_v2_binary_array<'a>(
     field: &'a LanceField,
     array: ArrayRef,
     row_addrs: Arc<[u64]>,
+    context: &'a Arc<BlobMaterializationContext>,
 ) -> BoxFuture<'a, Result<ArrayRef>> {
     async move {
         if is_blob_v2_binary_view(field) {
@@ -3360,6 +3610,7 @@ fn materialize_blob_v2_binary_array<'a>(
                 field.id as u32,
                 descriptions,
                 row_addrs.as_ref(),
+                context,
             )
             .await;
         }
@@ -3377,6 +3628,7 @@ fn materialize_blob_v2_binary_array<'a>(
                             child_field,
                             child_array.clone(),
                             row_addrs.clone(),
+                            context,
                         )
                         .await?,
                     );
@@ -3393,11 +3645,17 @@ fn materialize_blob_v2_binary_array<'a>(
             }
             ArrowDataType::List(_) => {
                 let list_array = array.as_list::<i32>();
-                materialize_blob_v2_list_array::<i32>(dataset, field, list_array, row_addrs).await
+                materialize_blob_v2_list_array::<i32>(
+                    dataset, field, list_array, row_addrs, context,
+                )
+                .await
             }
             ArrowDataType::LargeList(_) => {
                 let list_array = array.as_list::<i64>();
-                materialize_blob_v2_list_array::<i64>(dataset, field, list_array, row_addrs).await
+                materialize_blob_v2_list_array::<i64>(
+                    dataset, field, list_array, row_addrs, context,
+                )
+                .await
             }
             _ => Ok(array),
         }
@@ -3410,6 +3668,7 @@ async fn materialize_blob_v2_list_array<O: OffsetSizeTrait>(
     field: &LanceField,
     list_array: &GenericListArray<O>,
     row_addrs: Arc<[u64]>,
+    context: &Arc<BlobMaterializationContext>,
 ) -> Result<ArrayRef> {
     let offsets = list_array.value_offsets();
     let values_start = offsets[0].as_usize();
@@ -3455,7 +3714,8 @@ async fn materialize_blob_v2_list_array<O: OffsetSizeTrait>(
         ))
     })?;
     let values = list_array.values().slice(values_start, values_len);
-    let values = materialize_blob_v2_binary_array(dataset, child, values, child_row_addrs).await?;
+    let values =
+        materialize_blob_v2_binary_array(dataset, child, values, child_row_addrs, context).await?;
     let child_field = public_blob_v2_binary_output_field(child.clone());
     let list_array = GenericListArray::<O>::try_new(
         Arc::new(ArrowField::from(&child_field)),
@@ -3471,6 +3731,7 @@ async fn materialize_blob_v2_descriptors(
     blob_field_id: u32,
     descriptions: &StructArray,
     row_addrs: &[u64],
+    context: &Arc<BlobMaterializationContext>,
 ) -> Result<ArrayRef> {
     if descriptions.len() != row_addrs.len() {
         return Err(Error::internal(format!(
@@ -3523,7 +3784,12 @@ async fn materialize_blob_v2_descriptors(
         });
     }
 
-    let blobs = execute_blob_entries(entries, dataset.object_store.io_parallelism(), None).await?;
+    let blobs = execute_blob_entries_with_execution(
+        entries,
+        dataset.object_store.io_parallelism(),
+        context.execution.clone(),
+    )
+    .await?;
     for blob in blobs {
         let payload = payloads.get_mut(blob.selection_index).ok_or_else(|| {
             Error::internal(format!(
@@ -3875,11 +4141,11 @@ mod tests {
     use uuid::Uuid;
 
     use super::{
-        BlobEntry, BlobFile, BlobRangeRequest, BlobReadRange, BlobSource, ExternalBaseCandidate,
-        ExternalBaseResolver, ReadBlobsExecution, blob_version_from_descriptions,
-        collect_blob_files_v1, data_file_key_from_path, execute_blob_entries,
-        execute_blob_read_batches_stream, execute_blob_read_plan, plan_blob_read_batches,
-        plan_blob_read_plans,
+        BlobEntry, BlobFile, BlobMaterializationBudget, BlobMaterializationBudgetState,
+        BlobRangeRequest, BlobReadRange, BlobSource, ExternalBaseCandidate, ExternalBaseResolver,
+        ReadBlobsExecution, blob_version_from_descriptions, collect_blob_files_v1,
+        data_file_key_from_path, execute_blob_entries, execute_blob_read_batches_stream,
+        execute_blob_read_plan, plan_blob_read_batches, plan_blob_read_plans,
     };
     use crate::{
         Dataset,
@@ -6148,6 +6414,39 @@ mod tests {
         assert_eq!(blobs[1].row_address, 11);
         assert_eq!(blobs[1].data.as_ref(), b"bcd");
         assert_eq!(inner.requested_blob_ranges(), vec![1..7]);
+    }
+
+    #[tokio::test]
+    async fn test_blob_materialization_budget_blocks_and_admits_oversized_batch() {
+        let budget = Arc::new(BlobMaterializationBudget {
+            limit: 10,
+            state: std::sync::Mutex::new(BlobMaterializationBudgetState::default()),
+            notify: Notify::new(),
+        });
+        let first = budget.reserve(8).await;
+        let waiting_budget = budget.clone();
+        let waiting = tokio::spawn(async move { waiting_budget.reserve(4).await });
+        assert!(
+            tokio::time::timeout(Duration::from_millis(20), waiting_budget_wait(&waiting))
+                .await
+                .is_err()
+        );
+        drop(first);
+        let second = waiting.await.unwrap();
+        drop(second);
+
+        let oversized = budget.reserve(11).await;
+        assert_eq!(budget.state.lock().unwrap().reserved, 11);
+        drop(oversized);
+        assert_eq!(budget.state.lock().unwrap().reserved, 0);
+    }
+
+    async fn waiting_budget_wait(
+        task: &tokio::task::JoinHandle<super::BlobMaterializationReservation>,
+    ) {
+        while !task.is_finished() {
+            tokio::task::yield_now().await;
+        }
     }
 
     #[test]

--- a/rust/lance/src/dataset/blob.rs
+++ b/rust/lance/src/dataset/blob.rs
@@ -2428,7 +2428,7 @@ impl Drop for BlobMaterializationReservation {
 
 /// Shared state for asynchronously materializing blob v2 descriptor batches.
 #[derive(Debug)]
-pub(crate) struct BlobMaterializationContext {
+pub struct BlobMaterializationContext {
     execution: Arc<ReadBlobsExecution>,
     budget: Option<Arc<BlobMaterializationBudget>>,
 }
@@ -2459,7 +2459,7 @@ impl BlobMaterializationContext {
 }
 
 /// A materialized batch that retains its byte-budget reservation until yielded.
-pub(crate) struct MaterializedBlobBatch {
+pub struct MaterializedBlobBatch {
     batch: RecordBatch,
     _reservation: Option<BlobMaterializationReservation>,
 }
@@ -2960,6 +2960,7 @@ fn execute_blob_read_plans_stream(
         .boxed()
 }
 
+#[cfg(test)]
 async fn execute_blob_entries(
     entries: Vec<BlobEntry>,
     io_parallelism: usize,
@@ -3454,7 +3455,7 @@ pub async fn materialize_blob_v2_binary_batch(
     )
 }
 
-pub(crate) async fn materialize_blob_v2_binary_batch_with_context(
+pub async fn materialize_blob_v2_binary_batch_with_context(
     dataset: &Arc<Dataset>,
     output_schema: &Schema,
     batch: RecordBatch,

--- a/rust/lance/src/dataset/blob.rs
+++ b/rust/lance/src/dataset/blob.rs
@@ -2355,36 +2355,56 @@ impl BlobMaterializationBudgetState {
 }
 
 impl BlobMaterializationBudget {
-    async fn reserve(self: &Arc<Self>, bytes: u64) -> BlobMaterializationReservation {
+    fn admission(self: &Arc<Self>) -> BlobMaterializationAdmission {
         let ticket = {
             let mut state = self.state.lock().unwrap();
             let ticket = state.next_ticket;
             state.next_ticket = state.next_ticket.wrapping_add(1);
             ticket
         };
-        let mut waiter = BlobMaterializationWaiter {
-            budget: self.clone(),
+        BlobMaterializationAdmission {
+            budget: Some(self.clone()),
             ticket,
             acquired: false,
+        }
+    }
+
+    #[cfg(test)]
+    async fn reserve(self: &Arc<Self>, bytes: u64) -> BlobMaterializationReservation {
+        self.admission().reserve(bytes).await.unwrap()
+    }
+}
+
+pub(crate) struct BlobMaterializationAdmission {
+    budget: Option<Arc<BlobMaterializationBudget>>,
+    ticket: u64,
+    acquired: bool,
+}
+
+impl BlobMaterializationAdmission {
+    async fn reserve(mut self, bytes: u64) -> Option<BlobMaterializationReservation> {
+        let Some(budget) = self.budget.clone() else {
+            self.acquired = true;
+            return None;
         };
         loop {
-            let notified = self.notify.notified();
+            let notified = budget.notify.notified();
             {
-                let mut state = self.state.lock().unwrap();
-                let fits = bytes <= self.limit.saturating_sub(state.reserved);
-                let oversized_and_idle = state.reserved == 0 && bytes > self.limit;
-                if ticket == state.serving_ticket && (fits || oversized_and_idle) {
+                let mut state = budget.state.lock().unwrap();
+                let fits = bytes <= budget.limit.saturating_sub(state.reserved);
+                let oversized_and_idle = state.reserved == 0 && bytes > budget.limit;
+                if self.ticket == state.serving_ticket && (fits || oversized_and_idle) {
                     state.reserved = state.reserved.saturating_add(bytes);
                     state.serving_ticket = state.serving_ticket.wrapping_add(1);
                     state.skip_cancelled();
-                    waiter.acquired = true;
+                    self.acquired = true;
                     let reservation = BlobMaterializationReservation {
-                        budget: self.clone(),
+                        budget: budget.clone(),
                         bytes,
                     };
                     drop(state);
-                    self.notify.notify_waiters();
-                    return reservation;
+                    budget.notify.notify_waiters();
+                    return Some(reservation);
                 }
             }
             notified.await;
@@ -2392,24 +2412,21 @@ impl BlobMaterializationBudget {
     }
 }
 
-struct BlobMaterializationWaiter {
-    budget: Arc<BlobMaterializationBudget>,
-    ticket: u64,
-    acquired: bool,
-}
-
-impl Drop for BlobMaterializationWaiter {
+impl Drop for BlobMaterializationAdmission {
     fn drop(&mut self) {
+        let Some(budget) = &self.budget else {
+            return;
+        };
         if self.acquired {
             return;
         }
-        let mut state = self.budget.state.lock().unwrap();
+        let mut state = budget.state.lock().unwrap();
         if self.ticket >= state.serving_ticket {
             state.cancelled_tickets.insert(self.ticket);
             state.skip_cancelled();
         }
         drop(state);
-        self.budget.notify.notify_waiters();
+        budget.notify.notify_waiters();
     }
 }
 
@@ -2452,10 +2469,14 @@ impl BlobMaterializationContext {
         })
     }
 
-    async fn reserve(&self, bytes: u64) -> Option<BlobMaterializationReservation> {
+    pub(crate) fn admission(&self) -> BlobMaterializationAdmission {
         match &self.budget {
-            Some(budget) => Some(budget.reserve(bytes).await),
-            None => None,
+            Some(budget) => budget.admission(),
+            None => BlobMaterializationAdmission {
+                budget: None,
+                ticket: 0,
+                acquired: false,
+            },
         }
     }
 }
@@ -3488,76 +3509,107 @@ pub async fn materialize_blob_v2_binary_batch(
     )
 }
 
-pub async fn materialize_blob_v2_binary_batch_with_context(
-    dataset: &Arc<Dataset>,
-    output_schema: &Schema,
+pub fn materialize_blob_v2_binary_batch_with_context<'a>(
+    dataset: &'a Arc<Dataset>,
+    output_schema: &'a Schema,
     batch: RecordBatch,
-    context: &Arc<BlobMaterializationContext>,
-) -> Result<MaterializedBlobBatch> {
-    let materialized_bytes = estimate_blob_v2_materialized_batch_bytes(output_schema, &batch)?;
-    let reservation = context.reserve(materialized_bytes).await;
-    let row_addr_idx = batch
-        .schema()
-        .column_with_name(ROW_ADDR)
-        .ok_or_else(|| {
-            Error::internal(format!(
-                "_rowaddr column missing from blob v2 binary scan batch, columns: {:?}",
-                batch
-                    .schema()
-                    .fields()
-                    .iter()
-                    .map(|field| field.name())
-                    .collect::<Vec<_>>()
-            ))
-        })?
-        .0;
-    let row_addrs = batch
-        .column(row_addr_idx)
-        .as_primitive::<UInt64Type>()
-        .values()
-        .iter()
-        .copied()
-        .collect::<Vec<_>>();
-    let row_addrs: Arc<[u64]> = row_addrs.into();
-
-    let mut columns = Vec::with_capacity(output_schema.fields.len());
-    let mut fields = Vec::with_capacity(output_schema.fields.len());
-
-    for field in &output_schema.fields {
-        let input = batch
-            .column_by_name(&field.name)
-            .ok_or_else(|| {
-                Error::internal(format!(
-                    "blob v2 binary scan batch missing projected column '{}'",
-                    field.name
-                ))
-            })?
-            .clone();
-        let materialized =
-            materialize_blob_v2_binary_array(dataset, field, input, row_addrs.clone(), context)
-                .await?;
-        columns.push(materialized);
-        let output_field = public_blob_v2_binary_output_field(field.clone());
-        fields.push(ArrowField::from(&output_field));
-    }
-
-    Ok(MaterializedBlobBatch {
-        batch: RecordBatch::try_new(
-            Arc::new(ArrowSchema::new_with_metadata(
-                fields,
-                batch.schema().metadata().clone(),
-            )),
-            columns,
-        )?,
-        _reservations: reservation.into_iter().collect(),
-    })
+    context: &'a Arc<BlobMaterializationContext>,
+) -> BoxFuture<'a, Result<MaterializedBlobBatch>> {
+    let admission = context.admission();
+    materialize_blob_v2_binary_batch_with_admission(
+        dataset,
+        output_schema,
+        batch,
+        context,
+        admission,
+    )
 }
 
-fn estimate_blob_v2_materialized_batch_bytes(
+pub(crate) fn materialize_blob_v2_binary_batch_with_admission<'a>(
+    dataset: &'a Arc<Dataset>,
+    output_schema: &'a Schema,
+    batch: RecordBatch,
+    context: &'a Arc<BlobMaterializationContext>,
+    admission: BlobMaterializationAdmission,
+) -> BoxFuture<'a, Result<MaterializedBlobBatch>> {
+    async move {
+        let materialized_bytes =
+            estimate_blob_v2_materialized_batch_bytes(dataset, output_schema, &batch).await?;
+        let reservation = admission.reserve(materialized_bytes).await;
+        let row_addr_idx = batch
+            .schema()
+            .column_with_name(ROW_ADDR)
+            .ok_or_else(|| {
+                Error::internal(format!(
+                    "_rowaddr column missing from blob v2 binary scan batch, columns: {:?}",
+                    batch
+                        .schema()
+                        .fields()
+                        .iter()
+                        .map(|field| field.name())
+                        .collect::<Vec<_>>()
+                ))
+            })?
+            .0;
+        let row_addrs = batch
+            .column(row_addr_idx)
+            .as_primitive::<UInt64Type>()
+            .values()
+            .iter()
+            .copied()
+            .collect::<Vec<_>>();
+        let row_addrs: Arc<[u64]> = row_addrs.into();
+
+        let mut columns = Vec::with_capacity(output_schema.fields.len());
+        let mut fields = Vec::with_capacity(output_schema.fields.len());
+
+        for field in &output_schema.fields {
+            let input = batch
+                .column_by_name(&field.name)
+                .ok_or_else(|| {
+                    Error::internal(format!(
+                        "blob v2 binary scan batch missing projected column '{}'",
+                        field.name
+                    ))
+                })?
+                .clone();
+            let materialized =
+                materialize_blob_v2_binary_array(dataset, field, input, row_addrs.clone(), context)
+                    .await?;
+            columns.push(materialized);
+            let output_field = public_blob_v2_binary_output_field(field.clone());
+            fields.push(ArrowField::from(&output_field));
+        }
+
+        Ok(MaterializedBlobBatch {
+            batch: RecordBatch::try_new(
+                Arc::new(ArrowSchema::new_with_metadata(
+                    fields,
+                    batch.schema().metadata().clone(),
+                )),
+                columns,
+            )?,
+            _reservations: reservation.into_iter().collect(),
+        })
+    }
+    .boxed()
+}
+
+async fn estimate_blob_v2_materialized_batch_bytes(
+    dataset: &Arc<Dataset>,
     output_schema: &Schema,
     batch: &RecordBatch,
 ) -> Result<u64> {
     let mut bytes = u64::try_from(batch.get_array_memory_size()).unwrap_or(u64::MAX);
+    let row_addr_idx = batch
+        .schema()
+        .column_with_name(ROW_ADDR)
+        .ok_or_else(|| Error::internal("_rowaddr missing while estimating blob materialization"))?
+        .0;
+    let row_addrs = batch
+        .column(row_addr_idx)
+        .as_primitive::<UInt64Type>()
+        .values();
     for field in &output_schema.fields {
         let input = batch.column_by_name(&field.name).ok_or_else(|| {
             Error::internal(format!(
@@ -3565,68 +3617,139 @@ fn estimate_blob_v2_materialized_batch_bytes(
                 field.name
             ))
         })?;
-        bytes = bytes.saturating_add(estimate_blob_v2_materialized_array_bytes(field, input)?);
+        bytes = bytes.saturating_add(
+            estimate_blob_v2_materialized_array_bytes(dataset, field, input, row_addrs.as_ref())
+                .await?,
+        );
     }
     Ok(bytes)
 }
 
-fn estimate_blob_v2_materialized_array_bytes(field: &LanceField, array: &ArrayRef) -> Result<u64> {
-    if is_blob_v2_binary_view(field) {
-        let descriptions = array.as_struct();
-        match blob_version_from_descriptions(descriptions)? {
-            BlobVersion::V1 => {
-                return Err(Error::not_supported(
-                    "Blob v2 binary materialization received a legacy blob descriptor".to_string(),
-                ));
+fn estimate_blob_v2_materialized_array_bytes<'a>(
+    dataset: &'a Arc<Dataset>,
+    field: &'a LanceField,
+    array: &'a ArrayRef,
+    row_addrs: &'a [u64],
+) -> BoxFuture<'a, Result<u64>> {
+    async move {
+        if is_blob_v2_binary_view(field) {
+            let descriptions = array.as_struct();
+            match blob_version_from_descriptions(descriptions)? {
+                BlobVersion::V1 => {
+                    return Err(Error::not_supported(
+                        "Blob v2 binary materialization received a legacy blob descriptor"
+                            .to_string(),
+                    ));
+                }
+                BlobVersion::V2 => {}
             }
-            BlobVersion::V2 => {}
+            if descriptions.len() != row_addrs.len() {
+                return Err(Error::internal(format!(
+                    "blob v2 descriptor count {} did not match row address count {}",
+                    descriptions.len(),
+                    row_addrs.len()
+                )));
+            }
+            let columns = BlobV2DescriptorColumns::new(descriptions);
+            let mut read_context = BlobV2ReadContext::new(dataset, field.id as u32);
+            let mut payload_bytes = 0_u64;
+            for (idx, row_addr) in row_addrs.iter().copied().enumerate() {
+                if columns.is_null_blob(idx) {
+                    continue;
+                }
+                let kind = BlobKind::try_from(columns.kinds.value(idx))?;
+                if matches!(kind, BlobKind::Inline)
+                    && columns.positions.value(idx) == 0
+                    && columns.sizes.value(idx) == 0
+                {
+                    continue;
+                }
+                let file = read_context
+                    .collect_file(&columns, idx, row_addr)
+                    .await?
+                    .ok_or_else(|| {
+                        Error::internal(format!(
+                            "blob v2 descriptor at index {idx} unexpectedly resolved to null"
+                        ))
+                    })?;
+                payload_bytes = payload_bytes.saturating_add(file.size);
+            }
+            let offsets_bytes =
+                u64::try_from((descriptions.len() + 1).saturating_mul(std::mem::size_of::<i64>()))
+                    .unwrap_or(u64::MAX);
+            return Ok(payload_bytes.saturating_add(offsets_bytes));
         }
-        let columns = BlobV2DescriptorColumns::new(descriptions);
-        let payload_bytes = (0..descriptions.len())
-            .filter(|idx| !columns.is_null_blob(*idx))
-            .fold(0_u64, |total, idx| {
-                total.saturating_add(columns.sizes.value(idx))
-            });
-        let offsets_bytes =
-            u64::try_from((descriptions.len() + 1).saturating_mul(std::mem::size_of::<i64>()))
-                .unwrap_or(u64::MAX);
-        return Ok(payload_bytes.saturating_add(offsets_bytes));
-    }
 
-    match field.data_type() {
-        ArrowDataType::Struct(_) => {
-            let array = array.as_struct();
-            field
-                .children
-                .iter()
-                .zip(array.columns())
-                .try_fold(0_u64, |total, (child, array)| {
-                    Ok(total
-                        .saturating_add(estimate_blob_v2_materialized_array_bytes(child, array)?))
-                })
+        match field.data_type() {
+            ArrowDataType::Struct(_) => {
+                let array = array.as_struct();
+                let mut total = 0_u64;
+                for (child, array) in field.children.iter().zip(array.columns()) {
+                    total = total.saturating_add(
+                        estimate_blob_v2_materialized_array_bytes(dataset, child, array, row_addrs)
+                            .await?,
+                    );
+                }
+                Ok(total)
+            }
+            ArrowDataType::List(_) => {
+                let array = array.as_list::<i32>();
+                let child = field.children.first().ok_or_else(|| {
+                    Error::internal(format!(
+                        "List field '{}' missing child while estimating blob v2 materialization",
+                        field.name
+                    ))
+                })?;
+                let (values_start, child_row_addrs) =
+                    list_child_row_addrs(array.value_offsets(), row_addrs)?;
+                let values = array.values().slice(values_start, child_row_addrs.len());
+                estimate_blob_v2_materialized_array_bytes(dataset, child, &values, &child_row_addrs)
+                    .await
+            }
+            ArrowDataType::LargeList(_) => {
+                let array = array.as_list::<i64>();
+                let child = field.children.first().ok_or_else(|| {
+                    Error::internal(format!(
+                        "List field '{}' missing child while estimating blob v2 materialization",
+                        field.name
+                    ))
+                })?;
+                let (values_start, child_row_addrs) =
+                    list_child_row_addrs(array.value_offsets(), row_addrs)?;
+                let values = array.values().slice(values_start, child_row_addrs.len());
+                estimate_blob_v2_materialized_array_bytes(dataset, child, &values, &child_row_addrs)
+                    .await
+            }
+            _ => Ok(0),
         }
-        ArrowDataType::List(_) => {
-            let array = array.as_list::<i32>();
-            let child = field.children.first().ok_or_else(|| {
-                Error::internal(format!(
-                    "List field '{}' missing child while estimating blob v2 materialization",
-                    field.name
-                ))
-            })?;
-            estimate_blob_v2_materialized_array_bytes(child, array.values())
-        }
-        ArrowDataType::LargeList(_) => {
-            let array = array.as_list::<i64>();
-            let child = field.children.first().ok_or_else(|| {
-                Error::internal(format!(
-                    "List field '{}' missing child while estimating blob v2 materialization",
-                    field.name
-                ))
-            })?;
-            estimate_blob_v2_materialized_array_bytes(child, array.values())
-        }
-        _ => Ok(0),
     }
+    .boxed()
+}
+
+fn list_child_row_addrs<O: OffsetSizeTrait>(
+    offsets: &[O],
+    row_addrs: &[u64],
+) -> Result<(usize, Vec<u64>)> {
+    if offsets.len() != row_addrs.len() + 1 {
+        return Err(Error::internal(
+            "list offsets did not match row addresses while estimating blob materialization"
+                .to_string(),
+        ));
+    }
+    let values_start = offsets[0].as_usize();
+    let values_end = offsets[row_addrs.len()].as_usize();
+    let mut child_row_addrs = Vec::with_capacity(values_end.saturating_sub(values_start));
+    for (row_idx, row_addr) in row_addrs.iter().copied().enumerate() {
+        let start = offsets[row_idx].as_usize();
+        let end = offsets[row_idx + 1].as_usize();
+        if end < start {
+            return Err(Error::internal(
+                "list offsets decreased while estimating blob materialization".to_string(),
+            ));
+        }
+        child_row_addrs.extend(std::iter::repeat_n(row_addr, end - start));
+    }
+    Ok((values_start, child_row_addrs))
 }
 
 fn materialize_blob_v2_binary_array<'a>(
@@ -4149,7 +4272,7 @@ mod tests {
         BLOB_V2_EXT_NAME, DataTypeExt,
     };
     use lance_core::{
-        datatypes::{BlobHandling, BlobKind},
+        datatypes::{BlobHandling, BlobKind, OnMissing},
         utils::blob::blob_path,
     };
     use lance_io::object_store::{
@@ -6475,6 +6598,32 @@ mod tests {
         assert_eq!(budget.state.lock().unwrap().reserved, 0);
     }
 
+    #[tokio::test]
+    async fn test_blob_materialization_admission_cannot_invert_output_order() {
+        let budget = Arc::new(BlobMaterializationBudget {
+            limit: 100,
+            state: std::sync::Mutex::new(BlobMaterializationBudgetState::default()),
+            notify: Notify::new(),
+        });
+        let first = budget.admission();
+        let second = budget.admission();
+        let later = tokio::spawn(async move { second.reserve(60).await.unwrap() });
+        assert!(
+            tokio::time::timeout(Duration::from_millis(20), waiting_budget_wait(&later))
+                .await
+                .is_err()
+        );
+        assert_eq!(budget.state.lock().unwrap().reserved, 0);
+
+        let earlier = first.reserve(80).await.unwrap();
+        assert_eq!(budget.state.lock().unwrap().reserved, 80);
+        drop(earlier);
+        let later = later.await.unwrap();
+        assert_eq!(budget.state.lock().unwrap().reserved, 60);
+        drop(later);
+        assert_eq!(budget.state.lock().unwrap().reserved, 0);
+    }
+
     async fn waiting_budget_wait(
         task: &tokio::task::JoinHandle<super::BlobMaterializationReservation>,
     ) {
@@ -7409,23 +7558,76 @@ mod tests {
             .unwrap(),
         );
 
-        let desc = dataset
+        let descriptor_batch = dataset
             .scan()
             .project(&["blob"])
             .unwrap()
+            .with_row_address()
             .try_into_batch()
             .await
+            .unwrap();
+        {
+            let desc = descriptor_batch.column_by_name("blob").unwrap().as_struct();
+            assert_eq!(
+                desc.column(0).as_primitive::<UInt8Type>().value(0),
+                BlobKind::External as u8
+            );
+            assert_eq!(desc.column(2).as_primitive::<UInt64Type>().value(0), 0);
+            assert_eq!(desc.column(3).as_primitive::<UInt32Type>().value(0), 0);
+            let expected_uri = super::normalize_external_absolute_uri(&external_uri).unwrap();
+            assert_eq!(desc.column(4).as_string::<i32>().value(0), expected_uri);
+        }
+
+        let output_schema = dataset
+            .empty_projection()
+            .union_columns(&["blob"], OnMissing::Error)
             .unwrap()
-            .column(0)
-            .as_struct()
-            .to_owned();
+            .with_blob_handling(BlobHandling::AllBinary)
+            .to_schema();
+        let descriptor_bytes =
+            u64::try_from(descriptor_batch.get_array_memory_size()).unwrap_or(u64::MAX);
+        let context = super::BlobMaterializationContext::new(None, Some(1));
+        let materialized = super::materialize_blob_v2_binary_batch_with_context(
+            &dataset,
+            &output_schema,
+            descriptor_batch,
+            &context,
+        )
+        .await
+        .unwrap();
+        let reserved = context
+            .budget
+            .as_ref()
+            .unwrap()
+            .state
+            .lock()
+            .unwrap()
+            .reserved;
         assert_eq!(
-            desc.column(0).as_primitive::<UInt8Type>().value(0),
-            BlobKind::External as u8
+            reserved,
+            descriptor_bytes + b"outside".len() as u64 + 2 * std::mem::size_of::<i64>() as u64
         );
-        assert_eq!(desc.column(3).as_primitive::<UInt32Type>().value(0), 0);
-        let expected_uri = super::normalize_external_absolute_uri(&external_uri).unwrap();
-        assert_eq!(desc.column(4).as_string::<i32>().value(0), expected_uri);
+        assert_eq!(
+            materialized
+                .batch()
+                .column_by_name("blob")
+                .unwrap()
+                .as_binary::<i64>()
+                .value(0),
+            b"outside"
+        );
+        drop(materialized);
+        assert_eq!(
+            context
+                .budget
+                .as_ref()
+                .unwrap()
+                .state
+                .lock()
+                .unwrap()
+                .reserved,
+            0
+        );
 
         let blobs = dataset.take_blobs_by_indices(&[0], "blob").await.unwrap();
         assert_eq!(blobs.len(), 1);

--- a/rust/lance/src/dataset/blob.rs
+++ b/rust/lance/src/dataset/blob.rs
@@ -2344,6 +2344,8 @@ struct BlobMaterializationBudgetState {
     next_ticket: u64,
     serving_ticket: u64,
     cancelled_tickets: HashSet<u64>,
+    #[cfg(test)]
+    peak_reserved: u64,
 }
 
 impl BlobMaterializationBudgetState {
@@ -2395,6 +2397,10 @@ impl BlobMaterializationAdmission {
                 let oversized_and_idle = state.reserved == 0 && bytes > budget.limit;
                 if self.ticket == state.serving_ticket && (fits || oversized_and_idle) {
                     state.reserved = state.reserved.saturating_add(bytes);
+                    #[cfg(test)]
+                    {
+                        state.peak_reserved = state.peak_reserved.max(state.reserved);
+                    }
                     state.serving_ticket = state.serving_ticket.wrapping_add(1);
                     state.skip_cancelled();
                     self.acquired = true;
@@ -2478,6 +2484,14 @@ impl BlobMaterializationContext {
                 acquired: false,
             },
         }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn peak_reserved_bytes(&self) -> u64 {
+        self.budget
+            .as_ref()
+            .map(|budget| budget.state.lock().unwrap().peak_reserved)
+            .unwrap_or(0)
     }
 }
 

--- a/rust/lance/src/dataset/scanner.rs
+++ b/rust/lance/src/dataset/scanner.rs
@@ -1117,6 +1117,9 @@ pub struct Scanner {
     /// Number of bytes to allow to queue up in the I/O buffer
     io_buffer_size: Option<u64>,
 
+    /// Total bytes reserved by asynchronously materialized blob v2 batches
+    materialization_readahead_bytes: Option<u64>,
+
     limit: Option<i64>,
     offset: Option<i64>,
 
@@ -1399,6 +1402,7 @@ impl Scanner {
             batch_readahead: get_num_compute_intensive_cpus(),
             fragment_readahead: None,
             io_buffer_size: None,
+            materialization_readahead_bytes: None,
             limit: None,
             offset: None,
             ordering: None,
@@ -1764,6 +1768,22 @@ impl Scanner {
     ///
     pub fn io_buffer_size(&mut self, size: u64) -> &mut Self {
         self.io_buffer_size = Some(size);
+        self
+    }
+
+    /// Set the memory budget for asynchronous blob v2 materialization.
+    ///
+    /// Blob descriptors are decoded before their payloads are fetched. When this
+    /// budget is set, payload materialization may run ahead while the aggregate
+    /// descriptor and payload memory stays within `size`. A single oversized
+    /// batch is admitted when no other materialization is reserved, which
+    /// guarantees forward progress.
+    ///
+    /// This budget is separate from [`Self::io_buffer_size`], which controls the
+    /// storage I/O scheduler, and [`Self::batch_size_bytes`], which targets the
+    /// size of individual decoded batches.
+    pub fn materialization_readahead_bytes(&mut self, size: u64) -> &mut Self {
+        self.materialization_readahead_bytes = Some(size);
         self
     }
 
@@ -2846,6 +2866,12 @@ impl Scanner {
             ));
         }
 
+        if self.materialization_readahead_bytes == Some(0) {
+            return Err(Error::invalid_input_source(
+                "materialization_readahead_bytes must be greater than 0, got 0".into(),
+            ));
+        }
+
         if let Some(batch_size) = self.batch_size {
             validate_batch_size(batch_size)?;
         }
@@ -3464,6 +3490,11 @@ impl Scanner {
 
         if let Some(io_buffer_size_bytes) = self.io_buffer_size {
             read_options = read_options.with_io_buffer_size(io_buffer_size_bytes);
+        }
+
+        if let Some(materialization_readahead_bytes) = self.materialization_readahead_bytes {
+            read_options =
+                read_options.with_materialization_readahead_bytes(materialization_readahead_bytes);
         }
 
         if self.fast_search && filter_plan.has_index_query() {
@@ -6196,6 +6227,7 @@ impl Scanner {
             batch_readahead: self.batch_readahead,
             fragment_readahead: self.fragment_readahead,
             io_buffer_size: self.get_io_buffer_size(),
+            materialization_readahead_bytes: self.materialization_readahead_bytes,
             with_row_id,
             with_row_address,
             with_row_last_updated_at_version,
@@ -6850,6 +6882,22 @@ impl Scanner {
             }
             if let Some(fragments) = &self.fragments {
                 read_options = read_options.with_fragments(Arc::new(fragments.clone()));
+            }
+            read_options = read_options.with_threading_mode(
+                FilteredReadThreadingMode::OnePartitionMultipleThreads(self.batch_readahead),
+            );
+            if let Some(file_reader_options) = self.resolved_file_reader_options() {
+                read_options = read_options.with_file_reader_options(file_reader_options);
+            }
+            if let Some(fragment_readahead) = self.fragment_readahead {
+                read_options = read_options.with_fragment_readahead(fragment_readahead);
+            }
+            if let Some(io_buffer_size_bytes) = self.io_buffer_size {
+                read_options = read_options.with_io_buffer_size(io_buffer_size_bytes);
+            }
+            if let Some(materialization_readahead_bytes) = self.materialization_readahead_bytes {
+                read_options = read_options
+                    .with_materialization_readahead_bytes(materialization_readahead_bytes);
             }
             return Ok(Arc::new(FilteredReadExec::try_new(
                 self.dataset.clone(),
@@ -16001,6 +16049,43 @@ full_filter=name LIKE Utf8(\"test%2\"), refine_filter=name LIKE Utf8(\"test%2\")
         let filtered = find_filtered_read(plan.as_ref())
             .expect("expected a FilteredReadExec in the scan plan");
         assert_eq!(filtered.options().io_buffer_size_bytes, Some(7777));
+    }
+
+    #[tokio::test]
+    async fn test_materialization_readahead_bytes_propagated() {
+        let data = lance_datagen::gen_batch()
+            .col("x", lance_datagen::array::step::<Int32Type>())
+            .into_reader_rows(RowCount::from(8), BatchCount::from(1));
+        let dataset = Dataset::write(data, "memory://test_materialization_readahead_bytes", None)
+            .await
+            .unwrap();
+
+        let mut scanner = dataset.scan();
+        scanner.materialization_readahead_bytes(7777);
+        let plan = scanner.create_plan().await.unwrap();
+        let filtered = find_filtered_read(plan.as_ref())
+            .expect("expected a FilteredReadExec in the scan plan");
+        assert_eq!(
+            filtered.options().materialization_readahead_bytes,
+            Some(7777)
+        );
+    }
+
+    #[tokio::test]
+    async fn test_zero_materialization_readahead_bytes_rejected() {
+        let data = lance_datagen::gen_batch()
+            .col("x", lance_datagen::array::step::<Int32Type>())
+            .into_reader_rows(RowCount::from(8), BatchCount::from(1));
+        let dataset = Dataset::write(data, "memory://test_zero_materialization_budget", None)
+            .await
+            .unwrap();
+        let mut scanner = dataset.scan();
+        scanner.materialization_readahead_bytes(0);
+        let err = scanner.create_plan().await.unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("materialization_readahead_bytes must be greater than 0")
+        );
     }
 
     #[tokio::test]

--- a/rust/lance/src/dataset/scanner.rs
+++ b/rust/lance/src/dataset/scanner.rs
@@ -1775,13 +1775,18 @@ impl Scanner {
     ///
     /// Blob descriptors are decoded before their payloads are fetched. When this
     /// budget is set, payload materialization may run ahead while the aggregate
-    /// descriptor and payload memory stays within `size`. A single oversized
+    /// descriptor arrays, output offsets, and payload bytes awaiting ordered
+    /// emission stay within `size`. Admission follows output order, and each
+    /// reservation is retained until its batch is emitted. A single oversized
     /// batch is admitted when no other materialization is reserved, which
-    /// guarantees forward progress.
+    /// guarantees forward progress. External descriptors without a stored size
+    /// resolve the complete object length before admission.
     ///
     /// This budget is separate from [`Self::io_buffer_size`], which controls the
     /// storage I/O scheduler, and [`Self::batch_size_bytes`], which targets the
-    /// size of individual decoded batches.
+    /// size of individual decoded batches. If this setting is not provided,
+    /// Blob v2 materialization has no independent memory bound. A size of zero
+    /// is rejected when the scan plan is built.
     pub fn materialization_readahead_bytes(&mut self, size: u64) -> &mut Self {
         self.materialization_readahead_bytes = Some(size);
         self

--- a/rust/lance/src/io/exec/filtered_read.rs
+++ b/rust/lance/src/io/exec/filtered_read.rs
@@ -59,6 +59,7 @@ use tokio::sync::{Mutex as AsyncMutex, OnceCell};
 use tracing::{Instrument, instrument};
 
 use crate::Dataset;
+use crate::dataset::blob::{BlobMaterializationContext, MaterializedBlobBatch};
 use crate::dataset::fragment::{FileFragment, FragReadConfig};
 use crate::dataset::rowids::load_row_id_sequence;
 use crate::dataset::scanner::{
@@ -68,6 +69,8 @@ use crate::dataset::scanner::{
 use crate::dataset::versions;
 
 use super::utils::IoMetrics;
+
+type MaterializedReadBatchFut = futures::future::BoxFuture<'static, Result<MaterializedBlobBatch>>;
 
 fn public_blob_v2_binary_projection_schema(projection: &Projection) -> SchemaRef {
     let schema = projection.to_schema();
@@ -435,7 +438,7 @@ struct FilteredReadStream {
     /// The stream of filtered rows, expressed as a stream of tasks (batch futures)
     ///
     /// This stream can be shared by multiple partitions
-    task_stream: Arc<AsyncMutex<BoxStream<'static, Result<ReadBatchFut>>>>,
+    task_stream: Arc<AsyncMutex<BoxStream<'static, Result<MaterializedReadBatchFut>>>>,
     /// The scan scheduler for the scan
     scan_scheduler: Arc<ScanScheduler>,
     /// The global metrics for the scan
@@ -581,6 +584,7 @@ impl FilteredReadStream {
         plan: FilteredReadInternalPlan,
         scan_scheduler: Option<Arc<ScanScheduler>>,
         priority_offset: Option<u32>,
+        materialization_context: Arc<BlobMaterializationContext>,
     ) -> Self {
         let scan_scheduler =
             scan_scheduler.unwrap_or_else(|| Self::make_scan_scheduler(&dataset, &options));
@@ -605,11 +609,6 @@ impl FilteredReadStream {
         );
 
         let output_schema = public_blob_v2_binary_projection_schema(&options.projection);
-        let materialization_context = crate::dataset::blob::BlobMaterializationContext::new(
-            options.io_buffer_size_bytes,
-            options.materialization_readahead_bytes,
-        );
-
         // Get scan_range_after_filter from the plan
         let scan_range_after_filter = plan.scan_range_after_filter.clone();
 
@@ -684,7 +683,7 @@ impl FilteredReadStream {
 
     /// Drain the entire read into batches (used by the row-stream path,
     /// which is the stream's only consumer and records metrics per batch)
-    async fn collect_all(&self, decode_parallelism: usize) -> Result<Vec<RecordBatch>> {
+    async fn collect_all(&self, decode_parallelism: usize) -> Result<Vec<MaterializedBlobBatch>> {
         let mut task_stream = self.task_stream.lock().await;
         (&mut *task_stream)
             .try_buffered(decode_parallelism)
@@ -1319,16 +1318,16 @@ impl FilteredReadStream {
                     }
                 });
                 let partition_metrics_clone = partition_metrics.clone();
-                let base_batch_stream =
-                    futures_stream
-                        .try_buffered(num_threads)
-                        .try_filter_map(move |batch| {
-                            std::future::ready(Ok(if batch.num_rows() == 0 {
-                                None
-                            } else {
-                                Some(batch)
-                            }))
-                        });
+                let base_batch_stream = futures_stream
+                    .try_buffered(num_threads)
+                    .map_ok(MaterializedBlobBatch::into_batch)
+                    .try_filter_map(move |batch| {
+                        std::future::ready(Ok(if batch.num_rows() == 0 {
+                            None
+                        } else {
+                            Some(batch)
+                        }))
+                    });
 
                 let batch_stream = if let Some(ref range) = self.scan_range_after_filter {
                     Self::apply_hard_range(base_batch_stream, range.clone()).boxed()
@@ -1384,7 +1383,7 @@ impl FilteredReadStream {
                             };
                             if let Some(task) = maybe_task {
                                 let task = task?;
-                                let batch = task.await?;
+                                let batch = task.await?.into_batch();
                                 partition_metrics
                                     .baseline_metrics
                                     .record_output(batch.num_rows());
@@ -1420,8 +1419,8 @@ impl FilteredReadStream {
         mut fragment_read_task: ScopedFragmentRead,
         global_metrics: Arc<FilteredReadGlobalMetrics>,
         fragment_soft_limit: Option<u64>,
-        materialization_context: Arc<crate::dataset::blob::BlobMaterializationContext>,
-    ) -> Result<BoxStream<'static, Result<ReadBatchFut>>> {
+        materialization_context: Arc<BlobMaterializationContext>,
+    ) -> Result<BoxStream<'static, Result<MaterializedReadBatchFut>>> {
         let output_schema =
             public_blob_v2_binary_projection_schema(fragment_read_task.projection.as_ref());
 
@@ -1524,11 +1523,10 @@ impl FilteredReadStream {
                                 &materialization_context,
                             )
                             .await
-                            .map(|batch| batch.into_batch())
                         })
                         .boxed()
                 } else {
-                    batch_fut
+                    batch_fut.map_ok(MaterializedBlobBatch::unreserved).boxed()
                 }
             })
             .zip(futures::stream::repeat((
@@ -1546,22 +1544,23 @@ impl FilteredReadStream {
     }
 
     fn wrap_with_filter(
-        batch_fut: ReadBatchFut,
+        batch_fut: MaterializedReadBatchFut,
         filter: Option<Arc<dyn PhysicalExpr>>,
         output_schema: SchemaRef,
-    ) -> Result<ReadBatchFut> {
+    ) -> Result<MaterializedReadBatchFut> {
         if let Some(filter) = filter {
             Ok(batch_fut
                 .map(move |batch| {
                     let batch = batch?;
-                    let batch = datafusion_physical_plan::filter::batch_filter(&batch, &filter)
-                        .map_err(|e| {
-                            Error::execution(format!(
-                                "Error applying filter expression to batch: {e}"
-                            ))
-                        })?;
+                    let filtered =
+                        datafusion_physical_plan::filter::batch_filter(batch.batch(), &filter)
+                            .map_err(|e| {
+                                Error::execution(format!(
+                                    "Error applying filter expression to batch: {e}"
+                                ))
+                            })?;
                     // Drop any fields loaded purely for the purpose of applying the filter
-                    Ok(batch.project_by_schema(output_schema.as_ref())?)
+                    Ok(batch.with_batch(filtered.project_by_schema(output_schema.as_ref())?))
                 })
                 .boxed())
         } else {
@@ -1569,9 +1568,12 @@ impl FilteredReadStream {
         }
     }
 
-    fn apply_soft_limit<S>(stream: S, limit: u64) -> impl Stream<Item = Result<ReadBatchFut>>
+    fn apply_soft_limit<S>(
+        stream: S,
+        limit: u64,
+    ) -> impl Stream<Item = Result<MaterializedReadBatchFut>>
     where
-        S: Stream<Item = Result<ReadBatchFut>>,
+        S: Stream<Item = Result<MaterializedReadBatchFut>>,
     {
         let rows_read = Arc::new(AtomicUsize::new(0));
 
@@ -1586,7 +1588,7 @@ impl FilteredReadStream {
                     batch_fut
                         .map(move |batch_result| {
                             batch_result.inspect(|batch| {
-                                let batch_rows = batch.num_rows();
+                                let batch_rows = batch.batch().num_rows();
                                 rows_read.fetch_add(batch_rows, Ordering::Relaxed);
                             })
                         })
@@ -1955,6 +1957,7 @@ impl FilteredReadOptions {
 pub struct FilteredReadExec {
     dataset: Arc<Dataset>,
     options: FilteredReadOptions,
+    materialization_context: Arc<BlobMaterializationContext>,
     properties: Arc<PlanProperties>,
     metrics: ExecutionPlanMetricsSet,
     input: RowSelector,
@@ -2195,6 +2198,10 @@ impl FilteredReadExec {
         };
 
         Ok(Self {
+            materialization_context: BlobMaterializationContext::new(
+                options.io_buffer_size_bytes,
+                options.materialization_readahead_bytes,
+            ),
             dataset,
             options,
             properties,
@@ -2284,6 +2291,10 @@ impl FilteredReadExec {
         let metrics = ExecutionPlanMetricsSet::new();
 
         Ok(Self {
+            materialization_context: BlobMaterializationContext::new(
+                options.io_buffer_size_bytes,
+                options.materialization_readahead_bytes,
+            ),
             dataset,
             options,
             properties,
@@ -2490,6 +2501,7 @@ impl FilteredReadExec {
         let metrics = self.metrics.clone();
         let index_input = self.input.row_set_plan().cloned();
         let plan_cell = self.plan.clone();
+        let materialization_context = self.materialization_context.clone();
 
         let stream = futures::stream::once(async move {
             let mut running_stream = running_stream_lock.lock().await;
@@ -2513,6 +2525,7 @@ impl FilteredReadExec {
                     plan.clone(),
                     None,
                     None,
+                    materialization_context,
                 );
                 let first_stream = new_running_stream.get_stream(&metrics, partition);
                 *running_stream = Some(new_running_stream);
@@ -2599,6 +2612,7 @@ impl FilteredReadExec {
             Self::carried_schema(source.plan.schema().as_ref(), &self.options.projection);
         let output_schema = self.schema();
         let metrics = self.metrics.clone();
+        let materialization_context = self.materialization_context.clone();
 
         let lazy_stream = futures::stream::once(async move {
             let row_stream_read = Arc::new(RowStreamRead::new(
@@ -2608,6 +2622,7 @@ impl FilteredReadExec {
                 output_schema,
                 &metrics,
                 partition,
+                materialization_context,
             ));
             row_stream_read.apply(input_stream)
         })
@@ -2652,6 +2667,7 @@ struct RowStreamRead {
     carried_schema: SchemaRef,
     output_schema: SchemaRef,
     scan_scheduler: Arc<ScanScheduler>,
+    materialization_context: Arc<BlobMaterializationContext>,
     loaded_fragments: OnceCell<StreamFragments>,
     global_metrics: Arc<FilteredReadGlobalMetrics>,
     baseline_metrics: BaselineMetrics,
@@ -2665,6 +2681,7 @@ impl RowStreamRead {
         output_schema: SchemaRef,
         metrics: &ExecutionPlanMetricsSet,
         partition: usize,
+        materialization_context: Arc<BlobMaterializationContext>,
     ) -> Self {
         let scan_scheduler =
             FilteredReadStream::make_scan_scheduler(&dataset, &source.read_options);
@@ -2674,6 +2691,7 @@ impl RowStreamRead {
             carried_schema,
             output_schema,
             scan_scheduler,
+            materialization_context,
             loaded_fragments: OnceCell::new(),
             global_metrics: Arc::new(FilteredReadGlobalMetrics::new(metrics)),
             baseline_metrics: BaselineMetrics::new(metrics, partition),
@@ -2834,7 +2852,7 @@ impl RowStreamRead {
         &self,
         internal_plan: FilteredReadInternalPlan,
         batch_index: u32,
-    ) -> DataFusionResult<RecordBatch> {
+    ) -> DataFusionResult<MaterializedBlobBatch> {
         let fragment_count = self.load_fragments().await?.fragments.len();
         // I/O priority: earlier batches strictly first (output emits in batch
         // order), fragments keep dataset order within a batch
@@ -2846,15 +2864,16 @@ impl RowStreamRead {
             internal_plan,
             Some(self.scan_scheduler.clone()),
             Some(priority_offset),
+            self.materialization_context.clone(),
         );
         let decode_parallelism = match self.source.read_options.threading_mode {
             FilteredReadThreadingMode::OnePartitionMultipleThreads(n) => n,
             FilteredReadThreadingMode::MultiplePartitions(n) => n,
         };
         let read_batches = read.collect_all(decode_parallelism.max(1)).await?;
-        Ok(arrow::compute::concat_batches(
+        Ok(MaterializedBlobBatch::concat(
             &read.output_schema,
-            read_batches.iter(),
+            read_batches,
         )?)
     }
 
@@ -2863,29 +2882,32 @@ impl RowStreamRead {
     fn attach_columns(
         &self,
         batch: RecordBatch,
-        read_data: RecordBatch,
-    ) -> DataFusionResult<RecordBatch> {
+        read_data: MaterializedBlobBatch,
+    ) -> DataFusionResult<MaterializedBlobBatch> {
         let _compute_timer = self.baseline_metrics.elapsed_compute().timer();
         let keys = self.key_array(&batch, "input")?;
-        let read_keys = self.key_array(&read_data, "read")?;
-        attach_read_columns(
+        let read_keys = self.key_array(read_data.batch(), "read")?;
+        let output = attach_read_columns(
             &batch,
             keys,
-            &read_data,
+            read_data.batch(),
             read_keys,
             self.carried_schema.as_ref(),
             self.source.new_fields_schema.as_ref(),
             &self.output_schema,
-        )
+        )?;
+        Ok(read_data.with_batch(output))
     }
 
     async fn execute_batch(
         self: Arc<Self>,
         batch: RecordBatch,
         batch_index: u32,
-    ) -> DataFusionResult<RecordBatch> {
+    ) -> DataFusionResult<MaterializedBlobBatch> {
         if batch.num_rows() == 0 {
-            return Ok(RecordBatch::new_empty(self.output_schema.clone()));
+            return Ok(MaterializedBlobBatch::unreserved(RecordBatch::new_empty(
+                self.output_schema.clone(),
+            )));
         }
         let internal_plan = self.plan_batch(self.key_array(&batch, "input")?).await?;
         let read_data = self.read_batch(internal_plan, batch_index).await?;
@@ -2924,6 +2946,7 @@ impl RowStreamRead {
             })
             .boxed()
             .try_buffered(ROW_STREAM_CONCURRENT_BATCHES)
+            .map_ok(MaterializedBlobBatch::into_batch)
             .map(move |result| {
                 on_result
                     .global_metrics

--- a/rust/lance/src/io/exec/filtered_read.rs
+++ b/rust/lance/src/io/exec/filtered_read.rs
@@ -6111,6 +6111,10 @@ mod tests {
             .await
             .expect("row-stream blob materialization must make progress");
             let output = concat_batches(&plan.schema(), &batches).unwrap();
+            assert!(
+                plan.materialization_context.peak_reserved_bytes()
+                    >= (101 * first_payload.len()) as u64
+            );
             let blobs = output
                 .column_by_name("blob")
                 .unwrap()

--- a/rust/lance/src/io/exec/filtered_read.rs
+++ b/rust/lance/src/io/exec/filtered_read.rs
@@ -614,9 +614,7 @@ impl FilteredReadStream {
             public_blob_v2_binary_projection_schema(&options.projection)
         } else {
             Arc::new(ArrowSchema::from(
-                &crate::dataset::blob::blob_v2_descriptor_schema(
-                    &options.projection.to_bare_schema(),
-                ),
+                &crate::dataset::blob::blob_v2_descriptor_schema(&options.projection.to_schema()),
             ))
         };
         // Get scan_range_after_filter from the plan
@@ -1433,8 +1431,15 @@ impl FilteredReadStream {
         materialization_context: Arc<BlobMaterializationContext>,
         materialize_blob_v2_binary: bool,
     ) -> Result<BoxStream<'static, Result<MaterializedReadBatchFut>>> {
-        let output_schema =
-            public_blob_v2_binary_projection_schema(fragment_read_task.projection.as_ref());
+        let output_schema = if materialize_blob_v2_binary {
+            public_blob_v2_binary_projection_schema(fragment_read_task.projection.as_ref())
+        } else {
+            Arc::new(ArrowSchema::from(
+                &crate::dataset::blob::blob_v2_descriptor_schema(
+                    &fragment_read_task.projection.to_schema(),
+                ),
+            ))
+        };
 
         if let Some(filter) = &fragment_read_task.filter {
             let filter_cols = Planner::column_names_in_expr(filter);

--- a/rust/lance/src/io/exec/filtered_read.rs
+++ b/rust/lance/src/io/exec/filtered_read.rs
@@ -605,6 +605,10 @@ impl FilteredReadStream {
         );
 
         let output_schema = public_blob_v2_binary_projection_schema(&options.projection);
+        let materialization_context = crate::dataset::blob::BlobMaterializationContext::new(
+            options.io_buffer_size_bytes,
+            options.materialization_readahead_bytes,
+        );
 
         // Get scan_range_after_filter from the plan
         let scan_range_after_filter = plan.scan_range_after_filter.clone();
@@ -632,9 +636,16 @@ impl FilteredReadStream {
                     let metrics = global_metrics_clone.clone();
                     let limit = scan_range_after_filter.as_ref().map(|r| r.end);
                     let dataset = dataset.clone();
+                    let materialization_context = materialization_context.clone();
                     SpawnedTask::spawn(
-                        Self::read_fragment(dataset, scoped_fragment, metrics, limit)
-                            .in_current_span(),
+                        Self::read_fragment(
+                            dataset,
+                            scoped_fragment,
+                            metrics,
+                            limit,
+                            materialization_context,
+                        )
+                        .in_current_span(),
                     )
                     .map(|thread_result| thread_result.unwrap())
                 }
@@ -1409,6 +1420,7 @@ impl FilteredReadStream {
         mut fragment_read_task: ScopedFragmentRead,
         global_metrics: Arc<FilteredReadGlobalMetrics>,
         fragment_soft_limit: Option<u64>,
+        materialization_context: Arc<crate::dataset::blob::BlobMaterializationContext>,
     ) -> Result<BoxStream<'static, Result<ReadBatchFut>>> {
         let output_schema =
             public_blob_v2_binary_projection_schema(fragment_read_task.projection.as_ref());
@@ -1502,14 +1514,17 @@ impl FilteredReadStream {
                 if materialize_blob_v2_binary {
                     let dataset = dataset.clone();
                     let output_read_schema = output_read_schema.clone();
+                    let materialization_context = materialization_context.clone();
                     batch_fut
                         .and_then(move |batch| async move {
-                            crate::dataset::blob::materialize_blob_v2_binary_batch(
+                            crate::dataset::blob::materialize_blob_v2_binary_batch_with_context(
                                 &dataset,
                                 output_read_schema.as_ref(),
                                 batch,
+                                &materialization_context,
                             )
                             .await
+                            .map(|batch| batch.into_batch())
                         })
                         .boxed()
                 } else {
@@ -1656,6 +1671,8 @@ pub struct FilteredReadOptions {
     pub threading_mode: FilteredReadThreadingMode,
     /// The size of the I/O buffer to use for the scan
     pub io_buffer_size_bytes: Option<u64>,
+    /// Total memory budget for asynchronously materialized blob v2 batches
+    pub materialization_readahead_bytes: Option<u64>,
     /// If true, skip fragments that are not covered by the scalar index result.
     pub only_indexed_fragments: bool,
     /// Row addresses whose index entries may be stale because an overlay committed after the
@@ -1693,6 +1710,7 @@ impl FilteredReadOptions {
             full_filter: None,
             physical_filters: Vec::new(),
             io_buffer_size_bytes: None,
+            materialization_readahead_bytes: None,
             only_indexed_fragments: false,
             overlay_block: None,
             threading_mode: FilteredReadThreadingMode::OnePartitionMultipleThreads(
@@ -1893,6 +1911,12 @@ impl FilteredReadOptions {
         self
     }
 
+    /// Specify the memory budget for asynchronous blob v2 materialization.
+    pub fn with_materialization_readahead_bytes(mut self, size: u64) -> Self {
+        self.materialization_readahead_bytes = Some(size);
+        self
+    }
+
     /// Only read fragments covered by a scalar index result.
     pub fn with_only_indexed_fragments(mut self) -> Self {
         self.only_indexed_fragments = true;
@@ -2036,6 +2060,11 @@ impl FilteredReadExec {
         options: FilteredReadOptions,
         input: Option<Arc<dyn ExecutionPlan>>,
     ) -> Result<Self> {
+        if options.materialization_readahead_bytes == Some(0) {
+            return Err(Error::invalid_input_source(
+                "materialization_readahead_bytes must be greater than 0, got 0".into(),
+            ));
+        }
         match input {
             Some(input) if Self::is_index_query_schema(input.schema().as_ref()) => {
                 Self::try_new_scan(dataset, options, Some(input))

--- a/rust/lance/src/io/exec/filtered_read.rs
+++ b/rust/lance/src/io/exec/filtered_read.rs
@@ -5773,10 +5773,10 @@ mod tests {
         use lance_datafusion::exec::OneShotExec;
         use rstest::rstest;
 
-        use crate::blob::BlobArrayBuilder;
+        use crate::blob::{BlobArrayBuilder, blob_field};
         use crate::dataset::{Dataset, WriteParams};
         use crate::utils::test::NoContextTestFixture;
-        use lance_core::datatypes::{BlobHandling, blob_field};
+        use lance_core::datatypes::BlobHandling;
 
         struct TakeFixture {
             dataset: Arc<Dataset>,

--- a/rust/lance/src/io/exec/filtered_read.rs
+++ b/rust/lance/src/io/exec/filtered_read.rs
@@ -6061,9 +6061,7 @@ mod tests {
             let mut blobs = BlobArrayBuilder::new(2);
             blobs.push_bytes(&first_payload).unwrap();
             blobs.push_bytes(&second_payload).unwrap();
-            let schema = Arc::new(ArrowSchema::new(vec![ArrowField::from(&blob_field(
-                "blob", false,
-            ))]));
+            let schema = Arc::new(ArrowSchema::new(vec![blob_field("blob", false)]));
             let batch =
                 RecordBatch::try_new(schema.clone(), vec![blobs.finish().unwrap()]).unwrap();
             let dataset = Arc::new(

--- a/rust/lance/src/io/exec/filtered_read.rs
+++ b/rust/lance/src/io/exec/filtered_read.rs
@@ -32,7 +32,7 @@ use datafusion_physical_plan::metrics::{BaselineMetrics, Count, MetricsSet, Time
 use futures::stream::BoxStream;
 use futures::{FutureExt, Stream, StreamExt, TryFutureExt, TryStreamExt, future};
 use lance_arrow::RecordBatchExt;
-use lance_core::datatypes::OnMissing;
+use lance_core::datatypes::{OnMissing, Schema as LanceSchema};
 use lance_core::utils::deletion::DeletionVector;
 use lance_core::utils::futures::FinallyStreamExt;
 use lance_core::utils::tokio::get_num_compute_intensive_cpus;
@@ -585,6 +585,7 @@ impl FilteredReadStream {
         scan_scheduler: Option<Arc<ScanScheduler>>,
         priority_offset: Option<u32>,
         materialization_context: Arc<BlobMaterializationContext>,
+        materialize_blob_v2_binary: bool,
     ) -> Self {
         let scan_scheduler =
             scan_scheduler.unwrap_or_else(|| Self::make_scan_scheduler(&dataset, &options));
@@ -608,7 +609,15 @@ impl FilteredReadStream {
             io_parallelism
         );
 
-        let output_schema = public_blob_v2_binary_projection_schema(&options.projection);
+        let output_schema = if materialize_blob_v2_binary {
+            public_blob_v2_binary_projection_schema(&options.projection)
+        } else {
+            Arc::new(ArrowSchema::from(
+                &crate::dataset::blob::blob_v2_descriptor_schema(
+                    &options.projection.to_bare_schema(),
+                ),
+            ))
+        };
         // Get scan_range_after_filter from the plan
         let scan_range_after_filter = plan.scan_range_after_filter.clone();
 
@@ -643,6 +652,7 @@ impl FilteredReadStream {
                             metrics,
                             limit,
                             materialization_context,
+                            materialize_blob_v2_binary,
                         )
                         .in_current_span(),
                     )
@@ -1420,6 +1430,7 @@ impl FilteredReadStream {
         global_metrics: Arc<FilteredReadGlobalMetrics>,
         fragment_soft_limit: Option<u64>,
         materialization_context: Arc<BlobMaterializationContext>,
+        materialize_blob_v2_binary: bool,
     ) -> Result<BoxStream<'static, Result<MaterializedReadBatchFut>>> {
         let output_schema =
             public_blob_v2_binary_projection_schema(fragment_read_task.projection.as_ref());
@@ -1439,15 +1450,16 @@ impl FilteredReadStream {
 
         let output_read_schema = Arc::new(fragment_read_task.projection.to_schema());
         let bare_read_schema = fragment_read_task.projection.to_bare_schema();
-        let materialize_blob_v2_binary =
+        let has_blob_v2_binary =
             crate::dataset::blob::schema_has_blob_v2_binary_view(&bare_read_schema);
-        let read_schema = if materialize_blob_v2_binary {
+        let materialize_blob_v2_binary = materialize_blob_v2_binary && has_blob_v2_binary;
+        let read_schema = if has_blob_v2_binary {
             crate::dataset::blob::blob_v2_descriptor_schema(&bare_read_schema)
         } else {
             bare_read_schema
         };
         let mut frag_read_config = fragment_read_task.frag_read_config();
-        if materialize_blob_v2_binary {
+        if has_blob_v2_binary {
             frag_read_config = frag_read_config.with_row_address(true);
         }
         let mut fragment_reader = fragment_read_task
@@ -1514,13 +1526,15 @@ impl FilteredReadStream {
                     let dataset = dataset.clone();
                     let output_read_schema = output_read_schema.clone();
                     let materialization_context = materialization_context.clone();
+                    let admission = materialization_context.admission();
                     batch_fut
                         .and_then(move |batch| async move {
-                            crate::dataset::blob::materialize_blob_v2_binary_batch_with_context(
+                            crate::dataset::blob::materialize_blob_v2_binary_batch_with_admission(
                                 &dataset,
                                 output_read_schema.as_ref(),
                                 batch,
                                 &materialization_context,
+                                admission,
                             )
                             .await
                         })
@@ -2009,6 +2023,10 @@ struct RowStreamSource {
     read_options: FilteredReadOptions,
     /// The schema for newly read columns
     new_fields_schema: SchemaRef,
+    /// Descriptor-bearing output before Blob v2 payload materialization
+    intermediate_output_schema: SchemaRef,
+    /// Final schema used to materialize one complete row-stream output batch
+    materialization_output_schema: Option<Arc<LanceSchema>>,
 }
 
 /// Public plan for distributed execution - uses bitmap for flexibility
@@ -2162,11 +2180,14 @@ impl FilteredReadExec {
         let carried_schema = Self::carried_schema(input_schema.as_ref(), &options.projection);
 
         // Output = carried columns ⊕ fetched fields ⊕ synthesized identity
+        let materialization_output_schema = super::TakeExec::calculate_output_schema(
+            dataset.schema(),
+            carried_schema.as_ref(),
+            &fields_to_read,
+        );
         let output_schema = Arc::new(arrow_schema::Schema::from(
-            &super::TakeExec::calculate_output_schema(
-                dataset.schema(),
-                carried_schema.as_ref(),
-                &fields_to_read,
+            &crate::dataset::blob::public_blob_v2_binary_output_schema(
+                &materialization_output_schema,
             ),
         ));
 
@@ -2176,18 +2197,50 @@ impl FilteredReadExec {
                 .properties()
                 .as_ref()
                 .clone()
-                .with_eq_properties(EquivalenceProperties::new(output_schema)),
+                .with_eq_properties(EquivalenceProperties::new(output_schema.clone())),
         );
 
-        let bare_schema = arrow_schema::Schema::from(&fields_to_read.to_bare_schema());
+        let bare_lance_schema = fields_to_read.to_bare_schema();
+        let materialize_blob_v2_binary =
+            crate::dataset::blob::schema_has_blob_v2_binary_view(&bare_lance_schema);
+        let read_lance_schema = if materialize_blob_v2_binary {
+            crate::dataset::blob::blob_v2_descriptor_schema(&bare_lance_schema)
+        } else {
+            bare_lance_schema.clone()
+        };
+        let bare_schema = arrow_schema::Schema::from(&read_lance_schema);
         let mut new_fields = bare_schema.fields().iter().cloned().collect::<Vec<_>>();
         if synthesize_row_id {
             new_fields.push(Arc::new(ROW_ID_FIELD.clone()));
         }
-        if synthesize_row_addr {
+        if (synthesize_row_addr || materialize_blob_v2_binary)
+            && !new_fields.iter().any(|field| field.name() == ROW_ADDR)
+        {
             new_fields.push(Arc::new(ROW_ADDR_FIELD.clone()));
         }
         let new_fields_schema = Arc::new(arrow_schema::Schema::new(new_fields));
+
+        let intermediate_lance_schema = if materialize_blob_v2_binary {
+            crate::dataset::blob::blob_v2_descriptor_schema(&materialization_output_schema)
+        } else {
+            materialization_output_schema.clone()
+        };
+        let mut intermediate_fields = arrow_schema::Schema::from(&intermediate_lance_schema)
+            .fields()
+            .iter()
+            .cloned()
+            .collect::<Vec<_>>();
+        if materialize_blob_v2_binary
+            && !intermediate_fields
+                .iter()
+                .any(|field| field.name() == ROW_ADDR)
+        {
+            intermediate_fields.push(Arc::new(ROW_ADDR_FIELD.clone()));
+        }
+        let intermediate_output_schema = Arc::new(arrow_schema::Schema::new(intermediate_fields));
+
+        let materialization_output_schema =
+            materialize_blob_v2_binary.then(|| Arc::new(materialization_output_schema));
 
         // fields_to_read keeps the synthesis flags; add the key column on top
         let mut read_options = options.clone();
@@ -2196,6 +2249,9 @@ impl FilteredReadExec {
         } else {
             fields_to_read.with_row_addr()
         };
+        if materialize_blob_v2_binary {
+            read_options.projection = read_options.projection.with_row_addr();
+        }
 
         Ok(Self {
             materialization_context: BlobMaterializationContext::new(
@@ -2211,6 +2267,8 @@ impl FilteredReadExec {
                 key_column,
                 read_options,
                 new_fields_schema,
+                intermediate_output_schema,
+                materialization_output_schema,
             })),
             plan: Arc::new(OnceCell::new()),
             running_stream: Arc::new(AsyncMutex::new(None)),
@@ -2526,6 +2584,7 @@ impl FilteredReadExec {
                     None,
                     None,
                     materialization_context,
+                    true,
                 );
                 let first_stream = new_running_stream.get_stream(&metrics, partition);
                 *running_stream = Some(new_running_stream);
@@ -2865,6 +2924,7 @@ impl RowStreamRead {
             Some(self.scan_scheduler.clone()),
             Some(priority_offset),
             self.materialization_context.clone(),
+            false,
         );
         let decode_parallelism = match self.source.read_options.threading_mode {
             FilteredReadThreadingMode::OnePartitionMultipleThreads(n) => n,
@@ -2894,7 +2954,7 @@ impl RowStreamRead {
             read_keys,
             self.carried_schema.as_ref(),
             self.source.new_fields_schema.as_ref(),
-            &self.output_schema,
+            &self.source.intermediate_output_schema,
         )?;
         Ok(read_data.with_batch(output))
     }
@@ -2903,6 +2963,7 @@ impl RowStreamRead {
         self: Arc<Self>,
         batch: RecordBatch,
         batch_index: u32,
+        admission: crate::dataset::blob::BlobMaterializationAdmission,
     ) -> DataFusionResult<MaterializedBlobBatch> {
         if batch.num_rows() == 0 {
             return Ok(MaterializedBlobBatch::unreserved(RecordBatch::new_empty(
@@ -2911,7 +2972,22 @@ impl RowStreamRead {
         }
         let internal_plan = self.plan_batch(self.key_array(&batch, "input")?).await?;
         let read_data = self.read_batch(internal_plan, batch_index).await?;
-        self.attach_columns(batch, read_data)
+        let attached = self.attach_columns(batch, read_data)?;
+        if let Some(output_schema) = &self.source.materialization_output_schema {
+            Ok(
+                crate::dataset::blob::materialize_blob_v2_binary_batch_with_admission(
+                    &self.dataset,
+                    output_schema,
+                    attached.into_batch(),
+                    &self.materialization_context,
+                    admission,
+                )
+                .await?,
+            )
+        } else {
+            drop(admission);
+            Ok(attached)
+        }
     }
 
     fn apply(
@@ -2931,11 +3007,12 @@ impl RowStreamRead {
             .map(move |(batch_index, batch)| {
                 let batch = batch?;
                 let this = self.clone();
+                let admission = this.materialization_context.admission();
                 DataFusionResult::Ok(
                     // SpawnedTask aborts on drop: cancelling the query
                     // cancels in-flight batches
                     SpawnedTask::spawn(
-                        this.execute_batch(batch, batch_index as u32)
+                        this.execute_batch(batch, batch_index as u32, admission)
                             .in_current_span(),
                     )
                     .map(|res| match res {
@@ -5690,14 +5767,16 @@ mod tests {
 
     mod row_stream {
         use super::*;
-        use arrow_array::{Float32Array, StringArray, UInt64Array};
+        use arrow_array::{Float32Array, LargeBinaryArray, StringArray, UInt64Array};
         use arrow_schema::{DataType, Field as ArrowField, Fields, Schema as ArrowSchema};
         use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
         use lance_datafusion::exec::OneShotExec;
         use rstest::rstest;
 
+        use crate::blob::BlobArrayBuilder;
         use crate::dataset::{Dataset, WriteParams};
         use crate::utils::test::NoContextTestFixture;
+        use lance_core::datatypes::{BlobHandling, blob_field};
 
         struct TakeFixture {
             dataset: Arc<Dataset>,
@@ -5972,6 +6051,80 @@ mod tests {
                 .unwrap()
                 .as_primitive::<Float32Type>();
             assert_eq!(payload_col.values(), &payload[..]);
+        }
+
+        #[tokio::test]
+        async fn blob_take_reserves_one_complete_duplicate_expanded_output() {
+            let tmp_dir = TempStrDir::default();
+            let first_payload = vec![0x11; 1024];
+            let second_payload = vec![0x22; 1024];
+            let mut blobs = BlobArrayBuilder::new(2);
+            blobs.push_bytes(&first_payload).unwrap();
+            blobs.push_bytes(&second_payload).unwrap();
+            let schema = Arc::new(ArrowSchema::new(vec![ArrowField::from(&blob_field(
+                "blob", false,
+            ))]));
+            let batch =
+                RecordBatch::try_new(schema.clone(), vec![blobs.finish().unwrap()]).unwrap();
+            let dataset = Arc::new(
+                Dataset::write(
+                    RecordBatchIterator::new(vec![Ok(batch)], schema),
+                    tmp_dir.as_str(),
+                    Some(WriteParams {
+                        data_storage_version: Some(lance_file::version::LanceFileVersion::V2_2),
+                        max_rows_per_file: 1,
+                        ..Default::default()
+                    }),
+                )
+                .await
+                .unwrap(),
+            );
+
+            let first = 0_u64;
+            let second = 1_u64 << 32;
+            let mut keys = vec![first; 100];
+            keys.push(second);
+            let input_schema = Arc::new(ArrowSchema::new(vec![ArrowField::new(
+                ROW_ADDR,
+                DataType::UInt64,
+                false,
+            )]));
+            let input = RecordBatch::try_new(input_schema, vec![Arc::new(UInt64Array::from(keys))])
+                .unwrap();
+            let projection = dataset
+                .empty_projection()
+                .union_columns(&["blob"], OnMissing::Error)
+                .unwrap()
+                .with_blob_handling(BlobHandling::AllBinary);
+            let plan = FilteredReadExec::try_new(
+                dataset,
+                FilteredReadOptions::new(projection)
+                    .with_batch_size(101)
+                    .with_materialization_readahead_bytes(512),
+                Some(rows_input(vec![input])),
+            )
+            .unwrap();
+
+            let batches = tokio::time::timeout(std::time::Duration::from_secs(10), async {
+                run(&plan).await
+            })
+            .await
+            .expect("row-stream blob materialization must make progress");
+            let output = concat_batches(&plan.schema(), &batches).unwrap();
+            let blobs = output
+                .column_by_name("blob")
+                .unwrap()
+                .as_any()
+                .downcast_ref::<LargeBinaryArray>()
+                .unwrap();
+            assert_eq!(blobs.len(), 101);
+            assert!(
+                blobs
+                    .iter()
+                    .take(100)
+                    .all(|value| value == Some(first_payload.as_slice()))
+            );
+            assert_eq!(blobs.value(100), second_payload.as_slice());
         }
 
         /// Tiny input batches merge up to the target and oversized ones pass

--- a/rust/lance/src/io/exec/filtered_read.rs
+++ b/rust/lance/src/io/exec/filtered_read.rs
@@ -577,6 +577,7 @@ impl FilteredReadStream {
     /// scheduler is created here; the row-stream path injects its per-query
     /// shared one and a per-batch priority offset.
     #[instrument(name = "init_filtered_read_stream", skip_all)]
+    #[allow(clippy::too_many_arguments)]
     fn try_new(
         dataset: Arc<Dataset>,
         options: FilteredReadOptions,
@@ -2197,7 +2198,7 @@ impl FilteredReadExec {
                 .properties()
                 .as_ref()
                 .clone()
-                .with_eq_properties(EquivalenceProperties::new(output_schema.clone())),
+                .with_eq_properties(EquivalenceProperties::new(output_schema)),
         );
 
         let bare_lance_schema = fields_to_read.to_bare_schema();
@@ -2206,7 +2207,7 @@ impl FilteredReadExec {
         let read_lance_schema = if materialize_blob_v2_binary {
             crate::dataset::blob::blob_v2_descriptor_schema(&bare_lance_schema)
         } else {
-            bare_lance_schema.clone()
+            bare_lance_schema
         };
         let bare_schema = arrow_schema::Schema::from(&read_lance_schema);
         let mut new_fields = bare_schema.fields().iter().cloned().collect::<Vec<_>>();
@@ -6091,7 +6092,7 @@ mod tests {
                 .unwrap();
             let projection = dataset
                 .empty_projection()
-                .union_columns(&["blob"], OnMissing::Error)
+                .union_columns(["blob"], OnMissing::Error)
                 .unwrap()
                 .with_blob_handling(BlobHandling::AllBinary);
             let plan = FilteredReadExec::try_new(

--- a/rust/lance/src/io/exec/filtered_read_proto.rs
+++ b/rust/lance/src/io/exec/filtered_read_proto.rs
@@ -145,6 +145,7 @@ fn fr_options_to_proto(
         threading_mode: Some(threading_mode_to_proto(&options.threading_mode)),
         io_buffer_size_bytes: options.io_buffer_size_bytes,
         filter_schema_ipc,
+        materialization_readahead_bytes: options.materialization_readahead_bytes,
     })
 }
 
@@ -193,6 +194,9 @@ async fn fr_options_from_proto(
     }
     if let Some(io_buffer) = proto.io_buffer_size_bytes {
         options = options.with_io_buffer_size(io_buffer);
+    }
+    if let Some(materialization_readahead_bytes) = proto.materialization_readahead_bytes {
+        options = options.with_materialization_readahead_bytes(materialization_readahead_bytes);
     }
     if let Some(mode) = proto.threading_mode {
         options.threading_mode = threading_mode_from_proto(&mode)?;
@@ -600,7 +604,8 @@ mod tests {
             .unwrap()
             .with_batch_size(64)
             .with_fragment_readahead(4)
-            .with_io_buffer_size(1024 * 1024);
+            .with_io_buffer_size(1024 * 1024)
+            .with_materialization_readahead_bytes(8 * 1024 * 1024);
 
         let proto = fr_options_to_proto(&options, &filter_schema, &state).unwrap();
         let back = fr_options_from_proto(proto, &dataset, &state)
@@ -614,6 +619,10 @@ mod tests {
         assert_eq!(options.batch_size, back.batch_size);
         assert_eq!(options.fragment_readahead, back.fragment_readahead);
         assert_eq!(options.io_buffer_size_bytes, back.io_buffer_size_bytes);
+        assert_eq!(
+            options.materialization_readahead_bytes,
+            back.materialization_readahead_bytes
+        );
         assert_eq!(options.threading_mode, back.threading_mode);
         assert_eq!(options.with_deleted_rows, back.with_deleted_rows);
         assert_eq!(options.projection.field_ids, back.projection.field_ids);

--- a/rust/lance/src/io/exec/scan.rs
+++ b/rust/lance/src/io/exec/scan.rs
@@ -299,6 +299,10 @@ impl LanceStream {
         let scan_scheduler_clone = scan_scheduler.clone();
 
         let materialize_dataset = dataset;
+        let materialization_context = crate::dataset::blob::BlobMaterializationContext::new(
+            Some(config.io_buffer_size),
+            config.materialization_readahead_bytes,
+        );
         let config_for_stream = config.clone();
         let batches = stream::iter(file_fragments.into_iter().enumerate())
             .map(move |(priority, file_fragment)| {
@@ -376,19 +380,23 @@ impl LanceStream {
             .boxed();
         let inner_stream = if materialize_blob_v2_binary {
             inner_stream
-                .and_then(move |batch| {
+                .map_ok(move |batch| {
                     let dataset = materialize_dataset.clone();
                     let output_projection = output_projection.clone();
+                    let materialization_context = materialization_context.clone();
                     async move {
-                        crate::dataset::blob::materialize_blob_v2_binary_batch(
+                        crate::dataset::blob::materialize_blob_v2_binary_batch_with_context(
                             &dataset,
                             output_projection.as_ref(),
                             batch,
+                            &materialization_context,
                         )
                         .await
                         .map_err(DataFusionError::from)
                     }
                 })
+                .try_buffered(config.batch_readahead)
+                .map_ok(|batch| batch.into_batch())
                 .boxed()
         } else {
             inner_stream
@@ -560,6 +568,7 @@ pub struct LanceScanConfig {
     pub batch_readahead: usize,
     pub fragment_readahead: Option<usize>,
     pub io_buffer_size: u64,
+    pub materialization_readahead_bytes: Option<u64>,
     pub with_row_id: bool,
     pub with_row_address: bool,
     pub with_row_last_updated_at_version: bool,
@@ -581,6 +590,7 @@ impl Default for LanceScanConfig {
             batch_readahead: get_num_compute_intensive_cpus(),
             fragment_readahead: None,
             io_buffer_size: *DEFAULT_IO_BUFFER_SIZE,
+            materialization_readahead_bytes: None,
             with_row_id: false,
             with_row_address: false,
             with_row_last_updated_at_version: false,

--- a/rust/lance/src/io/exec/scan.rs
+++ b/rust/lance/src/io/exec/scan.rs
@@ -384,12 +384,14 @@ impl LanceStream {
                     let dataset = materialize_dataset.clone();
                     let output_projection = output_projection.clone();
                     let materialization_context = materialization_context.clone();
+                    let admission = materialization_context.admission();
                     async move {
-                        crate::dataset::blob::materialize_blob_v2_binary_batch_with_context(
+                        crate::dataset::blob::materialize_blob_v2_binary_batch_with_admission(
                             &dataset,
                             output_projection.as_ref(),
                             batch,
                             &materialization_context,
+                            admission,
                         )
                         .await
                         .map_err(DataFusionError::from)


### PR DESCRIPTION
Adds a scanner-level byte budget for asynchronous Blob v2 descriptor materialization. Shares one materialization context across the physical execution, retains reservations through ordered emission, preserves output order, admits a single oversized batch for forward progress, and propagates the setting through local, filtered, and distributed reads.

The filtered-read protobuf is an execution wire contract rather than a persisted Lance format. This PR also fixes the format-path detector and protobuf guidance so execution-plan schema changes ship with their implementation and do not require a format-spec vote.