### PR TITLE
feat: specify blob materialization budget

### DIFF
--- a/docs/src/format/.pages
+++ b/docs/src/format/.pages
@@ -1,5 +1,6 @@
 nav:
   - Overview: index.md
+  - Filtered Read Plans: filtered_read.md
   - File Format: file
   - Table Format: table
   - Index Formats: index

--- a/docs/src/format/filtered_read.md
+++ b/docs/src/format/filtered_read.md
@@ -13,11 +13,23 @@ filters for a remote executor.
 
 `materialization_readahead_bytes` controls Blob v2 payload materialization when
 the projection requests binary Blob values. When present, it must be nonzero
-and bounds the aggregate estimated bytes reserved by decoded descriptors and
-materialized payload batches that are awaiting ordered emission in one physical
-scanner execution. A single output batch whose estimate exceeds the bound is
-admitted only when no other materialization is reserved, which guarantees
+and bounds the aggregate bytes reserved by decoded descriptors and materialized
+payload batches that are awaiting ordered emission in one physical scanner
+execution.
+
+Admission tokens are assigned in output order and cannot be bypassed by a later
+batch that becomes ready first. A single complete output batch whose charge
+exceeds the bound is admitted only when no other materialization is reserved.
+Reservations are retained through every ordering buffer and released when the
+batch is emitted, fails, is cancelled, or is dropped. These rules prevent an
+out-of-order batch from holding memory needed by an earlier batch and guarantee
 forward progress.
+
+The charge includes descriptor-array memory, output offsets, and every payload
+byte. Before admission, an external descriptor whose stored size is zero must
+resolve the complete object length from object metadata and charge that resolved
+length. Byte arithmetic saturates at `uint64` maximum, so overflow is treated as
+an oversized batch rather than wrapping or under-accounting.
 
 When `materialization_readahead_bytes` is absent, Blob v2 materialization has no
 independent memory bound. The field has no effect when the projection does not

--- a/docs/src/format/filtered_read.md
+++ b/docs/src/format/filtered_read.md
@@ -1,0 +1,24 @@
+# Filtered Read Plans
+
+Filtered read plans are serialized query-execution contracts. They are not
+stored in Lance datasets. `FilteredReadExecProto` identifies the table, carries
+the read options, and may carry a planner-produced selection of rows and
+filters for a remote executor.
+
+## Read options
+
+```protobuf
+%%% proto.message.FilteredReadOptionsProto %%%
+```
+
+`materialization_readahead_bytes` controls Blob v2 payload materialization when
+the projection requests binary Blob values. When present, it must be nonzero
+and bounds the aggregate estimated bytes reserved by decoded descriptors and
+materialized payload batches that are awaiting ordered emission in one physical
+scanner execution. A single output batch whose estimate exceeds the bound is
+admitted only when no other materialization is reserved, which guarantees
+forward progress.
+
+When `materialization_readahead_bytes` is absent, Blob v2 materialization has no
+independent memory bound. The field has no effect when the projection does not
+materialize Blob v2 values as binary.

--- a/protos/filtered_read.proto
+++ b/protos/filtered_read.proto
@@ -62,10 +62,11 @@ message FilteredReadOptionsProto {
   optional uint64 io_buffer_size_bytes = 11;
   // Arrow IPC schema for decoding Substrait filters (may be wider than projection).
   optional bytes filter_schema_ipc = 12;
-  // If present, a nonzero upper bound on estimated bytes reserved by Blob v2
-  // materialization that is awaiting ordered emission in one scanner execution.
-  // One oversized output batch may exceed the bound when no other batch is reserved.
-  // If absent, Blob v2 materialization has no independent memory bound.
+  // If present, a nonzero upper bound on bytes reserved by Blob v2
+  // materialization awaiting ordered emission in one scanner execution.
+  // Admission follows output order; one oversized output batch may exceed the
+  // bound when no other batch is reserved. If absent, Blob v2 materialization
+  // has no independent memory bound.
   optional uint64 materialization_readahead_bytes = 13;
 }
 

--- a/protos/filtered_read.proto
+++ b/protos/filtered_read.proto
@@ -62,6 +62,11 @@ message FilteredReadOptionsProto {
   optional uint64 io_buffer_size_bytes = 11;
   // Arrow IPC schema for decoding Substrait filters (may be wider than projection).
   optional bytes filter_schema_ipc = 12;
+  // If present, a nonzero upper bound on estimated bytes reserved by Blob v2
+  // materialization that is awaiting ordered emission in one scanner execution.
+  // One oversized output batch may exceed the bound when no other batch is reserved.
+  // If absent, Blob v2 materialization has no independent memory bound.
+  optional uint64 materialization_readahead_bytes = 13;
 }
 
 // Serializable form of FilteredReadPlan (planned/distributed mode).

--- a/rust/lance/src/io/exec/filtered_read_proto.rs
+++ b/rust/lance/src/io/exec/filtered_read_proto.rs
@@ -145,6 +145,7 @@ fn fr_options_to_proto(
         threading_mode: Some(threading_mode_to_proto(&options.threading_mode)),
         io_buffer_size_bytes: options.io_buffer_size_bytes,
         filter_schema_ipc,
+        materialization_readahead_bytes: None,
     })
 }
 


### PR DESCRIPTION
Adds the serialized filtered-read contract for bounding Blob v2 materialization readahead.

Defines present, absent, zero, execution-scope, and oversized-batch semantics in the format documentation. Contains only the protobuf contract and the minimal initializer required to compile; implementation follows separately.