### PR TITLE
fix(fts): align v1 merge reads with writer batches

### DIFF
--- a/rust/lance-index/src/scalar/inverted/builder.rs
+++ b/rust/lance-index/src/scalar/inverted/builder.rs
@@ -73,6 +73,12 @@ static LANCE_FTS_POSTING_BATCH_ROWS: LazyLock<usize> = LazyLock::new(|| {
         .parse()
         .expect("failed to parse LANCE_FTS_POSTING_BATCH_ROWS")
 });
+
+/// Configured posting rows per writer batch, shared with merge read planning.
+pub(crate) fn posting_batch_rows() -> usize {
+    (*LANCE_FTS_POSTING_BATCH_ROWS).max(1)
+}
+
 const MAX_RETAINED_TOKEN_IDS: usize = 8 * 1024;
 
 fn default_num_workers() -> usize {
@@ -1157,7 +1163,7 @@ impl InnerBuilder {
         );
         let docs_for_batches = docs.clone();
         let schema_for_batches = schema.clone();
-        let batch_rows = *LANCE_FTS_POSTING_BATCH_ROWS;
+        let batch_rows = posting_batch_rows();
         let (tx, rx) = async_channel::bounded(*LANCE_FTS_WRITE_QUEUE_SIZE);
         // The producer builds posting-list batches on the CPU pool and hands them
         // to the writer through a bounded channel. Each batch is built inside its

--- a/rust/lance-index/src/scalar/inverted/builder.rs
+++ b/rust/lance-index/src/scalar/inverted/builder.rs
@@ -73,12 +73,6 @@ static LANCE_FTS_POSTING_BATCH_ROWS: LazyLock<usize> = LazyLock::new(|| {
         .parse()
         .expect("failed to parse LANCE_FTS_POSTING_BATCH_ROWS")
 });
-
-/// Configured posting rows per writer batch, shared with merge read planning.
-pub(crate) fn posting_batch_rows() -> usize {
-    (*LANCE_FTS_POSTING_BATCH_ROWS).max(1)
-}
-
 const MAX_RETAINED_TOKEN_IDS: usize = 8 * 1024;
 
 fn default_num_workers() -> usize {
@@ -1163,7 +1157,7 @@ impl InnerBuilder {
         );
         let docs_for_batches = docs.clone();
         let schema_for_batches = schema.clone();
-        let batch_rows = posting_batch_rows();
+        let batch_rows = *LANCE_FTS_POSTING_BATCH_ROWS;
         let (tx, rx) = async_channel::bounded(*LANCE_FTS_WRITE_QUEUE_SIZE);
         // The producer builds posting-list batches on the CPU pool and hands them
         // to the writer through a bounded channel. Each batch is built inside its

--- a/rust/lance-index/src/scalar/inverted/index.rs
+++ b/rust/lance-index/src/scalar/inverted/index.rs
@@ -57,7 +57,7 @@ use tokio::{
     sync::{Mutex, OnceCell},
     task::spawn_blocking,
 };
-use tracing::{info, instrument, warn};
+use tracing::{debug, info, instrument, warn};
 
 use super::documents::{
     DocId, DocLengths, DocVisibility, PartitionDocumentStore, PartitionDocuments,
@@ -70,8 +70,8 @@ use super::{DocumentGranularity, InvertedIndexBuilder, InvertedIndexParams, wand
 use super::{
     builder::{
         BLOCK_SIZE, ScoredDoc, doc_file_path,
-        inverted_list_schema_for_version_with_block_size_and_impacts, posting_batch_rows,
-        posting_file_path, token_file_path,
+        inverted_list_schema_for_version_with_block_size_and_impacts, posting_file_path,
+        token_file_path,
     },
     iter::PlainPostingListIterator,
     query::*,

--- a/rust/lance-index/src/scalar/inverted/index.rs
+++ b/rust/lance-index/src/scalar/inverted/index.rs
@@ -57,7 +57,7 @@ use tokio::{
     sync::{Mutex, OnceCell},
     task::spawn_blocking,
 };
-use tracing::{debug, info, instrument, warn};
+use tracing::{info, instrument, warn};
 
 use super::documents::{
     DocId, DocLengths, DocVisibility, PartitionDocumentStore, PartitionDocuments,
@@ -70,8 +70,8 @@ use super::{DocumentGranularity, InvertedIndexBuilder, InvertedIndexParams, wand
 use super::{
     builder::{
         BLOCK_SIZE, ScoredDoc, doc_file_path,
-        inverted_list_schema_for_version_with_block_size_and_impacts, posting_file_path,
-        token_file_path,
+        inverted_list_schema_for_version_with_block_size_and_impacts, posting_batch_rows,
+        posting_file_path, token_file_path,
     },
     iter::PlainPostingListIterator,
     query::*,

--- a/rust/lance-index/src/scalar/inverted/index.rs
+++ b/rust/lance-index/src/scalar/inverted/index.rs
@@ -57,7 +57,7 @@ use tokio::{
     sync::{Mutex, OnceCell},
     task::spawn_blocking,
 };
-use tracing::{info, instrument, warn};
+use tracing::{debug, info, instrument, warn};
 
 use super::documents::{
     DocId, DocLengths, DocVisibility, PartitionDocumentStore, PartitionDocuments,

--- a/rust/lance-index/src/scalar/inverted/index/partition.rs
+++ b/rust/lance-index/src/scalar/inverted/index/partition.rs
@@ -1495,6 +1495,15 @@ impl InvertedPartition {
         chunk_tokens_override: Option<usize>,
         max_list_children_override: Option<u64>,
     ) -> Result<(InnerBuilder, usize)> {
+        // Legacy per-document positions require singleton reads to protect Arrow's
+        // List<i32> offsets. Cap overlap so remote latency is hidden without
+        // multiplying retained decoded posting buffers by the store's full limit.
+        const MAX_LEGACY_POSITION_MERGE_CONCURRENCY: usize = 8;
+
+        let legacy_position_concurrency = self
+            .store
+            .io_parallelism()
+            .clamp(1, MAX_LEGACY_POSITION_MERGE_CONCURRENCY);
         let mut builder = InnerBuilder::new_with_posting_tail_codec_and_block_size(
             self.id,
             self.inverted_list.has_positions(),
@@ -1514,6 +1523,7 @@ impl InvertedPartition {
                 self.inverted_list.has_positions(),
                 chunk_tokens_override,
                 max_list_children_override,
+                legacy_position_concurrency,
                 |posting_list| {
                     builder
                         .posting_lists

--- a/rust/lance-index/src/scalar/inverted/index/partition.rs
+++ b/rust/lance-index/src/scalar/inverted/index/partition.rs
@@ -1495,6 +1495,15 @@ impl InvertedPartition {
         chunk_tokens_override: Option<usize>,
         max_list_children_override: Option<u64>,
     ) -> Result<(InnerBuilder, usize)> {
+        // Legacy per-document positions require singleton reads to protect Arrow's
+        // List<i32> offsets. Cap overlap so remote latency is hidden without
+        // multiplying retained decoded posting buffers by the store's full limit.
+        const MAX_LEGACY_POSITION_MERGE_CONCURRENCY: usize = 8;
+
+        let legacy_position_concurrency = self
+            .store
+            .io_parallelism()
+            .clamp(1, MAX_LEGACY_POSITION_MERGE_CONCURRENCY);
         let mut builder = InnerBuilder::new_with_posting_tail_codec_and_block_size(
             self.id,
             self.inverted_list.has_positions(),
@@ -1514,7 +1523,7 @@ impl InvertedPartition {
                 self.inverted_list.has_positions(),
                 chunk_tokens_override,
                 max_list_children_override,
-                posting_batch_rows(),
+                legacy_position_concurrency,
                 |posting_list| {
                     builder
                         .posting_lists

--- a/rust/lance-index/src/scalar/inverted/index/partition.rs
+++ b/rust/lance-index/src/scalar/inverted/index/partition.rs
@@ -1495,15 +1495,6 @@ impl InvertedPartition {
         chunk_tokens_override: Option<usize>,
         max_list_children_override: Option<u64>,
     ) -> Result<(InnerBuilder, usize)> {
-        // Legacy per-document positions require singleton reads to protect Arrow's
-        // List<i32> offsets. Cap overlap so remote latency is hidden without
-        // multiplying retained decoded posting buffers by the store's full limit.
-        const MAX_LEGACY_POSITION_MERGE_CONCURRENCY: usize = 8;
-
-        let legacy_position_concurrency = self
-            .store
-            .io_parallelism()
-            .clamp(1, MAX_LEGACY_POSITION_MERGE_CONCURRENCY);
         let mut builder = InnerBuilder::new_with_posting_tail_codec_and_block_size(
             self.id,
             self.inverted_list.has_positions(),
@@ -1523,7 +1514,7 @@ impl InvertedPartition {
                 self.inverted_list.has_positions(),
                 chunk_tokens_override,
                 max_list_children_override,
-                legacy_position_concurrency,
+                posting_batch_rows(),
                 |posting_list| {
                     builder
                         .posting_lists

--- a/rust/lance-index/src/scalar/inverted/index/posting_prewarm.rs
+++ b/rust/lance-index/src/scalar/inverted/index/posting_prewarm.rs
@@ -91,8 +91,9 @@ impl PostingListReader {
                 // Cached posting lists outlive the read chunk and should not
                 // retain unrelated token rows through shared Arrow buffers.
                 ChunkPostingMode::Prewarm => row_batch.shrink_to_fit()?,
-                // Merge consumes every posting before advancing to the next
-                // chunk, so retaining the chunk temporarily avoids a deep copy.
+                // Merge consumes chunks in order, so retaining each chunk until
+                // its turn avoids a deep copy. Legacy-position reads hold only
+                // the caller's bounded concurrent window.
                 ChunkPostingMode::Merge => row_batch,
             };
             let posting_list = Self::posting_list_from_batch_parts(
@@ -269,8 +270,8 @@ impl PostingListReader {
     }
 
     /// Read one token-row chunk and build its posting lists off the runtime thread.
-    /// Shared buffers are retained only by that chunk's returned posting lists,
-    /// bounding resident memory to one chunk.
+    /// Shared buffers are retained only by that chunk's returned posting lists;
+    /// callers bound the number of concurrently retained chunks.
     async fn build_chunk_postings(
         &self,
         tok_start: usize,
@@ -517,7 +518,7 @@ impl PostingListReader {
         with_position: bool,
         chunk_tokens_override: Option<usize>,
         max_list_children_override: Option<u64>,
-        posting_batch_rows: usize,
+        legacy_position_concurrency: usize,
         mut visit: F,
     ) -> Result<usize>
     where
@@ -533,14 +534,49 @@ impl PostingListReader {
         let max_list_children = max_list_children_override
             .unwrap_or(POSTING_READ_MAX_LIST_CHILDREN)
             .max(1);
-        let chunk_ranges = self.posting_read_chunk_ranges(
-            chunk_tokens,
-            max_list_children,
-            with_position,
-            posting_batch_rows,
-        )?;
+        let chunk_ranges =
+            self.posting_read_chunk_ranges(chunk_tokens, max_list_children, with_position)?;
         let chunk_count = chunk_ranges.len();
         let state = self.chunk_build_state();
+
+        if with_position
+            && matches!(&self.metadata, PostingMetadata::V2 { .. })
+            && matches!(self.positions_layout, PositionsLayout::LegacyPerDoc)
+        {
+            let legacy_position_concurrency = legacy_position_concurrency.max(1);
+            let read_build_start = Instant::now();
+            debug!(
+                token_count,
+                chunk_count,
+                legacy_position_concurrency,
+                "legacy per-document posting merge reads started"
+            );
+            let mut posting_chunks = stream::iter(chunk_ranges)
+                .map(|(tok_start, tok_end)| {
+                    self.build_chunk_postings(
+                        tok_start,
+                        tok_end,
+                        with_position,
+                        &state,
+                        ChunkPostingMode::Merge,
+                    )
+                })
+                // Keep token order while allowing singleton remote reads to overlap.
+                .buffered(legacy_position_concurrency);
+            while let Some(posting_lists) = posting_chunks.try_next().await? {
+                for (_, posting_list) in posting_lists {
+                    visit(posting_list)?;
+                }
+            }
+            debug!(
+                token_count,
+                chunk_count,
+                legacy_position_concurrency,
+                read_build_ms = read_build_start.elapsed().as_secs_f64() * 1000.0,
+                "legacy per-document posting merge reads finished"
+            );
+            return Ok(chunk_count);
+        }
 
         for (tok_start, tok_end) in chunk_ranges {
             let posting_lists = self
@@ -578,11 +614,7 @@ impl PostingListReader {
     /// widest projected `List<i32>` column. V2/V3 posting lengths determine
     /// posting blocks, position-block offsets, and impact entries exactly.
     /// Compressed V1 positions use nested per-document lists whose child count
-    /// is not available in metadata. For that layout, ranges reconstruct the
-    /// configured writer batch boundaries exactly and bypass the generic size
-    /// heuristics below. Historical files do not persist their writer batch size,
-    /// so this is only a heuristic when the current setting differs from the one
-    /// used to build the file; it is not a universal historical offset-safety proof.
+    /// is not available in metadata, so those reads stay at one token per batch.
     /// For row-based legacy indexes, persisted posting row offsets provide the
     /// best available bound.
     fn posting_read_chunk_ranges(
@@ -590,21 +622,13 @@ impl PostingListReader {
         max_tokens: usize,
         max_list_children: u64,
         with_position: bool,
-        posting_batch_rows: usize,
     ) -> Result<Vec<(usize, usize)>> {
         if with_position
             && matches!(&self.metadata, PostingMetadata::V2 { .. })
             && matches!(self.positions_layout, PositionsLayout::LegacyPerDoc)
         {
-            let posting_batch_rows = posting_batch_rows.max(1);
             return Ok((0..self.len())
-                .step_by(posting_batch_rows)
-                .map(|start| {
-                    (
-                        start,
-                        start.saturating_add(posting_batch_rows).min(self.len()),
-                    )
-                })
+                .map(|token_id| (token_id, token_id + 1))
                 .collect());
         }
 
@@ -635,23 +659,6 @@ impl PostingListReader {
             tok_start = tok_end;
         }
         Ok(ranges)
-    }
-
-    #[cfg(test)]
-    pub(super) async fn posting_read_chunk_ranges_for_test(
-        &self,
-        max_tokens: usize,
-        max_list_children: u64,
-        with_position: bool,
-        posting_batch_rows: usize,
-    ) -> Result<Vec<(usize, usize)>> {
-        self.ensure_metadata_loaded().await?;
-        self.posting_read_chunk_ranges(
-            max_tokens,
-            max_list_children,
-            with_position,
-            posting_batch_rows,
-        )
     }
 
     fn max_list_children_for_token(&self, token_id: usize, with_position: bool) -> u64 {
@@ -821,7 +828,8 @@ impl PostingListReader {
 pub(super) enum ChunkPostingMode {
     /// Build independently-owned posting lists for the index cache.
     Prewarm,
-    /// Share the current read chunk while merge immediately consumes its lists.
+    /// Share each read chunk until ordered merge consumption; compressed legacy
+    /// positions may retain a bounded concurrent window of singleton chunks.
     Merge,
 }
 

--- a/rust/lance-index/src/scalar/inverted/index/posting_prewarm.rs
+++ b/rust/lance-index/src/scalar/inverted/index/posting_prewarm.rs
@@ -91,9 +91,8 @@ impl PostingListReader {
                 // Cached posting lists outlive the read chunk and should not
                 // retain unrelated token rows through shared Arrow buffers.
                 ChunkPostingMode::Prewarm => row_batch.shrink_to_fit()?,
-                // Merge consumes chunks in order, so retaining each chunk until
-                // its turn avoids a deep copy. Legacy-position reads hold only
-                // the caller's bounded concurrent window.
+                // Merge consumes every posting before advancing to the next
+                // chunk, so retaining the chunk temporarily avoids a deep copy.
                 ChunkPostingMode::Merge => row_batch,
             };
             let posting_list = Self::posting_list_from_batch_parts(
@@ -270,8 +269,8 @@ impl PostingListReader {
     }
 
     /// Read one token-row chunk and build its posting lists off the runtime thread.
-    /// Shared buffers are retained only by that chunk's returned posting lists;
-    /// callers bound the number of concurrently retained chunks.
+    /// Shared buffers are retained only by that chunk's returned posting lists,
+    /// bounding resident memory to one chunk.
     async fn build_chunk_postings(
         &self,
         tok_start: usize,
@@ -518,7 +517,7 @@ impl PostingListReader {
         with_position: bool,
         chunk_tokens_override: Option<usize>,
         max_list_children_override: Option<u64>,
-        legacy_position_concurrency: usize,
+        posting_batch_rows: usize,
         mut visit: F,
     ) -> Result<usize>
     where
@@ -534,49 +533,14 @@ impl PostingListReader {
         let max_list_children = max_list_children_override
             .unwrap_or(POSTING_READ_MAX_LIST_CHILDREN)
             .max(1);
-        let chunk_ranges =
-            self.posting_read_chunk_ranges(chunk_tokens, max_list_children, with_position)?;
+        let chunk_ranges = self.posting_read_chunk_ranges(
+            chunk_tokens,
+            max_list_children,
+            with_position,
+            posting_batch_rows,
+        )?;
         let chunk_count = chunk_ranges.len();
         let state = self.chunk_build_state();
-
-        if with_position
-            && matches!(&self.metadata, PostingMetadata::V2 { .. })
-            && matches!(self.positions_layout, PositionsLayout::LegacyPerDoc)
-        {
-            let legacy_position_concurrency = legacy_position_concurrency.max(1);
-            let read_build_start = Instant::now();
-            debug!(
-                token_count,
-                chunk_count,
-                legacy_position_concurrency,
-                "legacy per-document posting merge reads started"
-            );
-            let mut posting_chunks = stream::iter(chunk_ranges)
-                .map(|(tok_start, tok_end)| {
-                    self.build_chunk_postings(
-                        tok_start,
-                        tok_end,
-                        with_position,
-                        &state,
-                        ChunkPostingMode::Merge,
-                    )
-                })
-                // Keep token order while allowing singleton remote reads to overlap.
-                .buffered(legacy_position_concurrency);
-            while let Some(posting_lists) = posting_chunks.try_next().await? {
-                for (_, posting_list) in posting_lists {
-                    visit(posting_list)?;
-                }
-            }
-            debug!(
-                token_count,
-                chunk_count,
-                legacy_position_concurrency,
-                read_build_ms = read_build_start.elapsed().as_secs_f64() * 1000.0,
-                "legacy per-document posting merge reads finished"
-            );
-            return Ok(chunk_count);
-        }
 
         for (tok_start, tok_end) in chunk_ranges {
             let posting_lists = self
@@ -614,7 +578,11 @@ impl PostingListReader {
     /// widest projected `List<i32>` column. V2/V3 posting lengths determine
     /// posting blocks, position-block offsets, and impact entries exactly.
     /// Compressed V1 positions use nested per-document lists whose child count
-    /// is not available in metadata, so those reads stay at one token per batch.
+    /// is not available in metadata, so their token ranges are capped by the
+    /// configured writer batch-row limit. Historical files do not persist their
+    /// writer batch size, so this only reconstructs known-safe write boundaries
+    /// when the reader setting and batching semantics match those used to build
+    /// the file. Otherwise this is a heuristic, not a complete offset-safety proof.
     /// For row-based legacy indexes, persisted posting row offsets provide the
     /// best available bound.
     fn posting_read_chunk_ranges(
@@ -622,15 +590,16 @@ impl PostingListReader {
         max_tokens: usize,
         max_list_children: u64,
         with_position: bool,
+        posting_batch_rows: usize,
     ) -> Result<Vec<(usize, usize)>> {
-        if with_position
+        let max_tokens = if with_position
             && matches!(&self.metadata, PostingMetadata::V2 { .. })
             && matches!(self.positions_layout, PositionsLayout::LegacyPerDoc)
         {
-            return Ok((0..self.len())
-                .map(|token_id| (token_id, token_id + 1))
-                .collect());
-        }
+            max_tokens.min(posting_batch_rows.max(1))
+        } else {
+            max_tokens
+        };
 
         let mut ranges = Vec::new();
         let mut tok_start = 0usize;
@@ -659,6 +628,23 @@ impl PostingListReader {
             tok_start = tok_end;
         }
         Ok(ranges)
+    }
+
+    #[cfg(test)]
+    pub(super) async fn posting_read_chunk_ranges_for_test(
+        &self,
+        max_tokens: usize,
+        max_list_children: u64,
+        with_position: bool,
+        posting_batch_rows: usize,
+    ) -> Result<Vec<(usize, usize)>> {
+        self.ensure_metadata_loaded().await?;
+        self.posting_read_chunk_ranges(
+            max_tokens,
+            max_list_children,
+            with_position,
+            posting_batch_rows,
+        )
     }
 
     fn max_list_children_for_token(&self, token_id: usize, with_position: bool) -> u64 {
@@ -828,8 +814,7 @@ impl PostingListReader {
 pub(super) enum ChunkPostingMode {
     /// Build independently-owned posting lists for the index cache.
     Prewarm,
-    /// Share each read chunk until ordered merge consumption; compressed legacy
-    /// positions may retain a bounded concurrent window of singleton chunks.
+    /// Share the current read chunk while merge immediately consumes its lists.
     Merge,
 }
 

--- a/rust/lance-index/src/scalar/inverted/index/posting_prewarm.rs
+++ b/rust/lance-index/src/scalar/inverted/index/posting_prewarm.rs
@@ -91,8 +91,9 @@ impl PostingListReader {
                 // Cached posting lists outlive the read chunk and should not
                 // retain unrelated token rows through shared Arrow buffers.
                 ChunkPostingMode::Prewarm => row_batch.shrink_to_fit()?,
-                // Merge consumes every posting before advancing to the next
-                // chunk, so retaining the chunk temporarily avoids a deep copy.
+                // Merge consumes chunks in order, so retaining each chunk until
+                // its turn avoids a deep copy. Legacy-position reads hold only
+                // the caller's bounded concurrent window.
                 ChunkPostingMode::Merge => row_batch,
             };
             let posting_list = Self::posting_list_from_batch_parts(
@@ -269,8 +270,8 @@ impl PostingListReader {
     }
 
     /// Read one token-row chunk and build its posting lists off the runtime thread.
-    /// Shared buffers are retained only by that chunk's returned posting lists,
-    /// bounding resident memory to one chunk.
+    /// Shared buffers are retained only by that chunk's returned posting lists;
+    /// callers bound the number of concurrently retained chunks.
     async fn build_chunk_postings(
         &self,
         tok_start: usize,
@@ -517,6 +518,7 @@ impl PostingListReader {
         with_position: bool,
         chunk_tokens_override: Option<usize>,
         max_list_children_override: Option<u64>,
+        legacy_position_concurrency: usize,
         mut visit: F,
     ) -> Result<usize>
     where
@@ -536,6 +538,45 @@ impl PostingListReader {
             self.posting_read_chunk_ranges(chunk_tokens, max_list_children, with_position)?;
         let chunk_count = chunk_ranges.len();
         let state = self.chunk_build_state();
+
+        if with_position
+            && matches!(&self.metadata, PostingMetadata::V2 { .. })
+            && matches!(self.positions_layout, PositionsLayout::LegacyPerDoc)
+        {
+            let legacy_position_concurrency = legacy_position_concurrency.max(1);
+            let read_build_start = Instant::now();
+            debug!(
+                token_count,
+                chunk_count,
+                legacy_position_concurrency,
+                "legacy per-document posting merge reads started"
+            );
+            let mut posting_chunks = stream::iter(chunk_ranges)
+                .map(|(tok_start, tok_end)| {
+                    self.build_chunk_postings(
+                        tok_start,
+                        tok_end,
+                        with_position,
+                        &state,
+                        ChunkPostingMode::Merge,
+                    )
+                })
+                // Keep token order while allowing singleton remote reads to overlap.
+                .buffered(legacy_position_concurrency);
+            while let Some(posting_lists) = posting_chunks.try_next().await? {
+                for (_, posting_list) in posting_lists {
+                    visit(posting_list)?;
+                }
+            }
+            debug!(
+                token_count,
+                chunk_count,
+                legacy_position_concurrency,
+                read_build_ms = read_build_start.elapsed().as_secs_f64() * 1000.0,
+                "legacy per-document posting merge reads finished"
+            );
+            return Ok(chunk_count);
+        }
 
         for (tok_start, tok_end) in chunk_ranges {
             let posting_lists = self
@@ -787,7 +828,8 @@ impl PostingListReader {
 pub(super) enum ChunkPostingMode {
     /// Build independently-owned posting lists for the index cache.
     Prewarm,
-    /// Share the current read chunk while merge immediately consumes its lists.
+    /// Share each read chunk until ordered merge consumption; compressed legacy
+    /// positions may retain a bounded concurrent window of singleton chunks.
     Merge,
 }
 

--- a/rust/lance-index/src/scalar/inverted/index/posting_prewarm.rs
+++ b/rust/lance-index/src/scalar/inverted/index/posting_prewarm.rs
@@ -578,11 +578,11 @@ impl PostingListReader {
     /// widest projected `List<i32>` column. V2/V3 posting lengths determine
     /// posting blocks, position-block offsets, and impact entries exactly.
     /// Compressed V1 positions use nested per-document lists whose child count
-    /// is not available in metadata, so their token ranges are capped by the
-    /// configured writer batch-row limit. Historical files do not persist their
-    /// writer batch size, so this only reconstructs known-safe write boundaries
-    /// when the reader setting and batching semantics match those used to build
-    /// the file. Otherwise this is a heuristic, not a complete offset-safety proof.
+    /// is not available in metadata. For that layout, ranges reconstruct the
+    /// configured writer batch boundaries exactly and bypass the generic size
+    /// heuristics below. Historical files do not persist their writer batch size,
+    /// so this is only a heuristic when the current setting differs from the one
+    /// used to build the file; it is not a universal historical offset-safety proof.
     /// For row-based legacy indexes, persisted posting row offsets provide the
     /// best available bound.
     fn posting_read_chunk_ranges(
@@ -592,14 +592,21 @@ impl PostingListReader {
         with_position: bool,
         posting_batch_rows: usize,
     ) -> Result<Vec<(usize, usize)>> {
-        let max_tokens = if with_position
+        if with_position
             && matches!(&self.metadata, PostingMetadata::V2 { .. })
             && matches!(self.positions_layout, PositionsLayout::LegacyPerDoc)
         {
-            max_tokens.min(posting_batch_rows.max(1))
-        } else {
-            max_tokens
-        };
+            let posting_batch_rows = posting_batch_rows.max(1);
+            return Ok((0..self.len())
+                .step_by(posting_batch_rows)
+                .map(|start| {
+                    (
+                        start,
+                        start.saturating_add(posting_batch_rows).min(self.len()),
+                    )
+                })
+                .collect());
+        }
 
         let mut ranges = Vec::new();
         let mut tok_start = 0usize;

--- a/rust/lance-index/src/scalar/inverted/index/tests/format_and_builder.rs
+++ b/rust/lance-index/src/scalar/inverted/index/tests/format_and_builder.rs
@@ -4,6 +4,242 @@
 use super::super::posting_prewarm::ChunkPostingMode;
 use super::*;
 
+#[derive(Debug)]
+struct ControlledPostingReads {
+    started: std::sync::atomic::AtomicUsize,
+    active: std::sync::atomic::AtomicUsize,
+    max_active: std::sync::atomic::AtomicUsize,
+    gates: Vec<tokio::sync::Semaphore>,
+    completed: std::sync::Mutex<Vec<usize>>,
+    changed: tokio::sync::Notify,
+}
+
+impl ControlledPostingReads {
+    fn new(token_count: usize) -> Self {
+        Self {
+            started: std::sync::atomic::AtomicUsize::new(0),
+            active: std::sync::atomic::AtomicUsize::new(0),
+            max_active: std::sync::atomic::AtomicUsize::new(0),
+            gates: (0..token_count)
+                .map(|_| tokio::sync::Semaphore::new(0))
+                .collect(),
+            completed: std::sync::Mutex::new(Vec::with_capacity(token_count)),
+            changed: tokio::sync::Notify::new(),
+        }
+    }
+
+    async fn wait_for_started(&self, expected: usize) {
+        tokio::time::timeout(std::time::Duration::from_secs(5), async {
+            loop {
+                let changed = self.changed.notified();
+                if self.started.load(std::sync::atomic::Ordering::SeqCst) >= expected {
+                    return;
+                }
+                changed.await;
+            }
+        })
+        .await
+        .expect("timed out waiting for controlled posting reads to start");
+    }
+
+    async fn release_and_wait(&self, token_id: usize, expected_completed: usize) {
+        self.gates[token_id].add_permits(1);
+        tokio::time::timeout(std::time::Duration::from_secs(5), async {
+            loop {
+                let changed = self.changed.notified();
+                if self
+                    .completed
+                    .lock()
+                    .expect("controlled posting completion lock poisoned")
+                    .len()
+                    >= expected_completed
+                {
+                    return;
+                }
+                changed.await;
+            }
+        })
+        .await
+        .expect("timed out waiting for controlled posting read to complete");
+    }
+}
+
+struct ControlledPostingReader {
+    inner: Arc<dyn IndexReader>,
+    control: Arc<ControlledPostingReads>,
+    fail_token: Option<usize>,
+}
+
+#[async_trait]
+impl IndexReader for ControlledPostingReader {
+    async fn read_record_batch(&self, n: u64, batch_size: u64) -> Result<RecordBatch> {
+        self.inner.read_record_batch(n, batch_size).await
+    }
+
+    async fn read_global_buffer(&self, index: u32) -> Result<bytes::Bytes> {
+        self.inner.read_global_buffer(index).await
+    }
+
+    async fn read_range(
+        &self,
+        range: std::ops::Range<usize>,
+        projection: Option<&[&str]>,
+    ) -> Result<RecordBatch> {
+        let is_singleton_position_read = range.end == range.start + 1
+            && projection.is_some_and(|columns| {
+                columns.contains(&POSTING_COL) && columns.contains(&POSITION_COL)
+            });
+        if !is_singleton_position_read {
+            return self.inner.read_range(range, projection).await;
+        }
+
+        let token_id = range.start;
+        self.control
+            .started
+            .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        let active = self
+            .control
+            .active
+            .fetch_add(1, std::sync::atomic::Ordering::SeqCst)
+            + 1;
+        self.control
+            .max_active
+            .fetch_max(active, std::sync::atomic::Ordering::SeqCst);
+        self.control.changed.notify_waiters();
+
+        let permit = self.control.gates[token_id]
+            .acquire()
+            .await
+            .map_err(|err| Error::internal(format!("controlled posting gate closed: {err}")))?;
+        permit.forget();
+        let result = if self.fail_token == Some(token_id) {
+            Err(Error::io(format!(
+                "injected singleton posting read failure for token {token_id}"
+            )))
+        } else {
+            self.inner.read_range(range, projection).await
+        };
+
+        self.control
+            .active
+            .fetch_sub(1, std::sync::atomic::Ordering::SeqCst);
+        self.control
+            .completed
+            .lock()
+            .expect("controlled posting completion lock poisoned")
+            .push(token_id);
+        self.control.changed.notify_waiters();
+        result
+    }
+
+    async fn num_batches(&self, batch_size: u64) -> u32 {
+        self.inner.num_batches(batch_size).await
+    }
+
+    fn num_rows(&self) -> usize {
+        self.inner.num_rows()
+    }
+
+    fn schema(&self) -> &lance_core::datatypes::Schema {
+        self.inner.schema()
+    }
+
+    fn file_size_bytes(&self) -> Option<u64> {
+        self.inner.file_size_bytes()
+    }
+}
+
+#[derive(Debug)]
+struct ControlledMergeStore {
+    inner: Arc<dyn IndexStore>,
+    posting_file: String,
+    io_parallelism: usize,
+    control: Arc<ControlledPostingReads>,
+    fail_token: Option<usize>,
+}
+
+impl DeepSizeOf for ControlledMergeStore {
+    fn deep_size_of_children(&self, context: &mut lance_core::deepsize::Context) -> usize {
+        self.inner.deep_size_of_children(context)
+    }
+}
+
+#[async_trait]
+impl IndexStore for ControlledMergeStore {
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+
+    fn clone_arc(&self) -> Arc<dyn IndexStore> {
+        Arc::new(Self {
+            inner: self.inner.clone(),
+            posting_file: self.posting_file.clone(),
+            io_parallelism: self.io_parallelism,
+            control: self.control.clone(),
+            fail_token: self.fail_token,
+        })
+    }
+
+    fn io_parallelism(&self) -> usize {
+        self.io_parallelism
+    }
+
+    async fn new_index_file(
+        &self,
+        name: &str,
+        schema: Arc<Schema>,
+    ) -> Result<Box<dyn crate::scalar::IndexWriter>> {
+        self.inner.new_index_file(name, schema).await
+    }
+
+    async fn open_index_file(&self, name: &str) -> Result<Arc<dyn IndexReader>> {
+        let reader = self.inner.open_index_file(name).await?;
+        if name == self.posting_file {
+            Ok(Arc::new(ControlledPostingReader {
+                inner: reader,
+                control: self.control.clone(),
+                fail_token: self.fail_token,
+            }))
+        } else {
+            Ok(reader)
+        }
+    }
+
+    fn with_io_priority(&self, io_priority: u64) -> Arc<dyn IndexStore> {
+        Arc::new(Self {
+            inner: self.inner.with_io_priority(io_priority),
+            posting_file: self.posting_file.clone(),
+            io_parallelism: self.io_parallelism,
+            control: self.control.clone(),
+            fail_token: self.fail_token,
+        })
+    }
+
+    async fn copy_index_file(
+        &self,
+        name: &str,
+        dest_store: &dyn IndexStore,
+    ) -> Result<crate::scalar::IndexFile> {
+        self.inner.copy_index_file(name, dest_store).await
+    }
+
+    async fn rename_index_file(
+        &self,
+        name: &str,
+        new_name: &str,
+    ) -> Result<crate::scalar::IndexFile> {
+        self.inner.rename_index_file(name, new_name).await
+    }
+
+    async fn delete_index_file(&self, name: &str) -> Result<()> {
+        self.inner.delete_index_file(name).await
+    }
+
+    async fn list_files_with_sizes(&self) -> Result<Vec<crate::scalar::IndexFile>> {
+        self.inner.list_files_with_sizes().await
+    }
+}
+
 #[test]
 fn address_read_concurrency_respects_payload_budget() {
     assert_eq!(address_read_concurrency(64, 0), 64);
@@ -349,20 +585,21 @@ async fn test_build_search_uses_configured_posting_block_size() {
 }
 
 #[rstest::rstest]
-#[case::v1(InvertedListFormatVersion::V1, LEGACY_BLOCK_SIZE, 514, None)]
-#[case::v2(InvertedListFormatVersion::V2, LEGACY_BLOCK_SIZE, 8, Some(4))]
-#[case::v3(InvertedListFormatVersion::V3, 256, 6, Some(4))]
+#[case::v1(InvertedListFormatVersion::V1, LEGACY_BLOCK_SIZE, 514, 7)]
+#[case::v2(InvertedListFormatVersion::V2, LEGACY_BLOCK_SIZE, 8, 4)]
+#[case::v3(InvertedListFormatVersion::V3, 256, 6, 4)]
 #[tokio::test]
 async fn test_into_builder_chunks_postings_by_list_children(
     #[case] format_version: InvertedListFormatVersion,
     #[case] block_size: usize,
     #[case] max_list_children: u64,
-    #[case] expected_chunk_count: Option<usize>,
+    #[case] expected_chunk_count: usize,
 ) {
     const NUM_TOKENS: usize = 7;
     const NUM_DOCS: usize = 257;
-    // V1 uses the configured writer batch-row boundary and ignores the generic
-    // child bound. V2/V3 retain metadata-derived child planning.
+    // V1's nested per-document position block count is not stored in metadata,
+    // so each token gets its own read. V3's exact metadata-derived bound admits
+    // two token rows per read.
 
     let source_dir = TempObjDir::default();
     let source_store = Arc::new(LanceIndexStore::new(
@@ -412,11 +649,9 @@ async fn test_into_builder_chunks_postings_by_list_children(
         .into_builder_with_chunk_limits(NUM_TOKENS, max_list_children)
         .await
         .unwrap();
-    let expected_chunk_count =
-        expected_chunk_count.unwrap_or_else(|| NUM_TOKENS.div_ceil(posting_batch_rows()));
     assert_eq!(
         chunk_count, expected_chunk_count,
-        "posting read planner produced an unexpected chunk count"
+        "list-child limit must split merge reads"
     );
     assert_eq!(merged.posting_lists.len(), NUM_TOKENS);
     assert!(
@@ -466,21 +701,14 @@ async fn test_into_builder_chunks_postings_by_list_children(
     assert_eq!(actual[NUM_DOCS - 1], (256, 2, vec![0, 10]));
 }
 
-#[rstest::rstest]
-#[case::v1(InvertedListFormatVersion::V1, LEGACY_BLOCK_SIZE, true)]
-#[case::v2(InvertedListFormatVersion::V2, LEGACY_BLOCK_SIZE, false)]
-#[case::v3(InvertedListFormatVersion::V3, MAX_POSTING_BLOCK_SIZE, false)]
 #[tokio::test]
-async fn test_position_read_ranges_respect_v1_posting_batch_rows(
-    #[case] format_version: InvertedListFormatVersion,
-    #[case] block_size: usize,
-    #[case] is_v1: bool,
-) {
-    const NUM_TOKENS: usize = 7;
-    const NUM_DOCS: usize = 257;
+async fn test_v1_position_merge_reads_are_bounded_and_ordered() {
+    const NUM_TOKENS: usize = 10;
+    const NUM_DOCS: usize = 3;
+    const EXPECTED_CONCURRENCY: usize = 8;
 
     let source_dir = TempObjDir::default();
-    let source_store = Arc::new(LanceIndexStore::new(
+    let source_store: Arc<dyn IndexStore> = Arc::new(LanceIndexStore::new(
         ObjectStore::local().into(),
         source_dir.clone(),
         Arc::new(LanceCache::no_cache()),
@@ -489,20 +717,20 @@ async fn test_position_read_ranges_respect_v1_posting_batch_rows(
         0,
         true,
         TokenSetFormat::default(),
-        format_version,
-        block_size,
+        InvertedListFormatVersion::V1,
+        LEGACY_BLOCK_SIZE,
     );
     for token_id in 0..NUM_TOKENS {
         source.tokens.add(format!("token_{token_id}"));
         let mut posting = PostingListBuilder::new_with_posting_tail_codec_and_block_size(
             true,
-            format_version.posting_tail_codec(),
-            block_size,
+            InvertedListFormatVersion::V1.posting_tail_codec(),
+            LEGACY_BLOCK_SIZE,
         );
         for doc_id in 0..NUM_DOCS {
             posting.add(
                 doc_id as u32,
-                PositionRecorder::Position(vec![token_id as u32, token_id as u32 + 10].into()),
+                PositionRecorder::Position(vec![token_id as u32, token_id as u32 + 100].into()),
             );
         }
         source.posting_lists.push(posting);
@@ -514,8 +742,16 @@ async fn test_position_read_ranges_respect_v1_posting_batch_rows(
     }
     source.write(source_store.as_ref()).await.unwrap();
 
-    let partition = InvertedPartition::load(
-        source_store,
+    let control = Arc::new(ControlledPostingReads::new(NUM_TOKENS));
+    let controlled_store: Arc<dyn IndexStore> = Arc::new(ControlledMergeStore {
+        inner: source_store.clone(),
+        posting_file: posting_file_path(0),
+        io_parallelism: 64,
+        control: control.clone(),
+        fail_token: None,
+    });
+    let source_partition = InvertedPartition::load(
+        controlled_store,
         0,
         None,
         &LanceCache::no_cache(),
@@ -523,47 +759,113 @@ async fn test_position_read_ranges_respect_v1_posting_batch_rows(
     )
     .await
     .unwrap();
-    let batch_capped = partition
-        .inverted_list
-        .posting_read_chunk_ranges_for_test(NUM_TOKENS, u64::MAX, true, 3)
-        .await
-        .unwrap();
-    let without_positions = partition
-        .inverted_list
-        .posting_read_chunk_ranges_for_test(NUM_TOKENS, u64::MAX, false, 1)
-        .await
-        .unwrap();
 
-    assert_eq!(without_positions, vec![(0, NUM_TOKENS)]);
-    if is_v1 {
-        assert_eq!(batch_capped, vec![(0, 3), (3, 6), (6, 7)]);
-        assert_eq!(
-            partition
-                .inverted_list
-                .posting_read_chunk_ranges_for_test(1, 1, true, 3)
-                .await
-                .unwrap(),
-            vec![(0, 3), (3, 6), (6, 7)],
-            "V1 writer-aligned ranges must ignore generic token and child limits"
-        );
-        assert_eq!(
-            partition
-                .inverted_list
-                .posting_read_chunk_ranges_for_test(NUM_TOKENS, u64::MAX, true, 1)
-                .await
-                .unwrap(),
-            (0..NUM_TOKENS)
-                .map(|token_id| (token_id, token_id + 1))
-                .collect::<Vec<_>>(),
-            "a configured cap of one must retain singleton reads"
-        );
-    } else {
-        assert_eq!(
-            batch_capped,
-            vec![(0, NUM_TOKENS)],
-            "V2/V3 positions must ignore the V1 posting batch-row cap"
-        );
+    let merge_task = tokio::spawn(async move {
+        source_partition
+            .into_builder_with_chunk_limits(NUM_TOKENS, u64::MAX)
+            .await
+    });
+    control.wait_for_started(EXPECTED_CONCURRENCY).await;
+    assert_eq!(
+        control.active.load(std::sync::atomic::Ordering::SeqCst),
+        EXPECTED_CONCURRENCY
+    );
+    assert_eq!(
+        control.max_active.load(std::sync::atomic::Ordering::SeqCst),
+        EXPECTED_CONCURRENCY,
+        "store I/O parallelism must be capped"
+    );
+
+    let mut completed_count = 0;
+    for token_id in (1..EXPECTED_CONCURRENCY).rev() {
+        completed_count += 1;
+        control.release_and_wait(token_id, completed_count).await;
     }
+    assert_eq!(
+        control.started.load(std::sync::atomic::Ordering::SeqCst),
+        EXPECTED_CONCURRENCY,
+        "completed chunks behind token 0 must remain inside the bounded ordered window"
+    );
+    completed_count += 1;
+    control.release_and_wait(0, completed_count).await;
+    control.wait_for_started(NUM_TOKENS).await;
+    for token_id in (EXPECTED_CONCURRENCY..NUM_TOKENS).rev() {
+        completed_count += 1;
+        control.release_and_wait(token_id, completed_count).await;
+    }
+
+    let (merged, chunk_count) = tokio::time::timeout(std::time::Duration::from_secs(5), merge_task)
+        .await
+        .expect("timed out waiting for controlled V1 position merge")
+        .unwrap()
+        .unwrap();
+    assert_eq!(chunk_count, NUM_TOKENS);
+    assert!(
+        control.max_active.load(std::sync::atomic::Ordering::SeqCst) <= EXPECTED_CONCURRENCY,
+        "singleton posting reads exceeded the bounded concurrency cap"
+    );
+    assert_eq!(
+        *control
+            .completed
+            .lock()
+            .expect("controlled posting completion lock poisoned"),
+        vec![7, 6, 5, 4, 3, 2, 1, 0, 9, 8],
+        "test reads must complete out of token order"
+    );
+    assert_eq!(merged.posting_lists.len(), NUM_TOKENS);
+    for (token_id, posting) in merged.posting_lists.iter().enumerate() {
+        let entries = posting.iter().collect::<Vec<_>>();
+        assert_eq!(entries.len(), NUM_DOCS);
+        for (expected_doc_id, (doc_id, frequency, positions)) in entries.into_iter().enumerate() {
+            assert_eq!(frequency, 2);
+            assert_eq!(doc_id as usize, expected_doc_id);
+            assert_eq!(
+                positions.unwrap(),
+                vec![token_id as u32, token_id as u32 + 100],
+                "posting positions must remain aligned with token order"
+            );
+        }
+    }
+
+    let error_control = Arc::new(ControlledPostingReads::new(NUM_TOKENS));
+    let error_store: Arc<dyn IndexStore> = Arc::new(ControlledMergeStore {
+        inner: source_store,
+        posting_file: posting_file_path(0),
+        io_parallelism: 64,
+        control: error_control.clone(),
+        fail_token: Some(1),
+    });
+    let error_partition = InvertedPartition::load(
+        error_store,
+        0,
+        None,
+        &LanceCache::no_cache(),
+        TokenSetFormat::default(),
+    )
+    .await
+    .unwrap();
+    let error_task = tokio::spawn(async move {
+        error_partition
+            .into_builder_with_chunk_limits(NUM_TOKENS, u64::MAX)
+            .await
+    });
+    error_control.wait_for_started(EXPECTED_CONCURRENCY).await;
+    for (completed_count, token_id) in (0..EXPECTED_CONCURRENCY).rev().enumerate() {
+        error_control
+            .release_and_wait(token_id, completed_count + 1)
+            .await;
+    }
+    let error = tokio::time::timeout(std::time::Duration::from_secs(5), error_task)
+        .await
+        .expect("timed out waiting for injected V1 position merge failure")
+        .unwrap()
+        .unwrap_err();
+    assert!(matches!(error, Error::IO { .. }));
+    assert!(
+        error
+            .to_string()
+            .contains("injected singleton posting read failure for token 1")
+    );
 }
 
 #[tokio::test]

--- a/rust/lance-index/src/scalar/inverted/index/tests/format_and_builder.rs
+++ b/rust/lance-index/src/scalar/inverted/index/tests/format_and_builder.rs
@@ -349,20 +349,20 @@ async fn test_build_search_uses_configured_posting_block_size() {
 }
 
 #[rstest::rstest]
-#[case::v1(InvertedListFormatVersion::V1, LEGACY_BLOCK_SIZE, 514, 4)]
-#[case::v2(InvertedListFormatVersion::V2, LEGACY_BLOCK_SIZE, 8, 4)]
-#[case::v3(InvertedListFormatVersion::V3, 256, 6, 4)]
+#[case::v1(InvertedListFormatVersion::V1, LEGACY_BLOCK_SIZE, 514, None)]
+#[case::v2(InvertedListFormatVersion::V2, LEGACY_BLOCK_SIZE, 8, Some(4))]
+#[case::v3(InvertedListFormatVersion::V3, 256, 6, Some(4))]
 #[tokio::test]
 async fn test_into_builder_chunks_postings_by_list_children(
     #[case] format_version: InvertedListFormatVersion,
     #[case] block_size: usize,
     #[case] max_list_children: u64,
-    #[case] expected_chunk_count: usize,
+    #[case] expected_chunk_count: Option<usize>,
 ) {
     const NUM_TOKENS: usize = 7;
     const NUM_DOCS: usize = 257;
-    // V1 and V3 both retain the generic metadata-derived child bound, which
-    // admits two token rows per read for these inputs.
+    // V1 uses the configured writer batch-row boundary and ignores the generic
+    // child bound. V2/V3 retain metadata-derived child planning.
 
     let source_dir = TempObjDir::default();
     let source_store = Arc::new(LanceIndexStore::new(
@@ -412,9 +412,11 @@ async fn test_into_builder_chunks_postings_by_list_children(
         .into_builder_with_chunk_limits(NUM_TOKENS, max_list_children)
         .await
         .unwrap();
+    let expected_chunk_count =
+        expected_chunk_count.unwrap_or_else(|| NUM_TOKENS.div_ceil(posting_batch_rows()));
     assert_eq!(
         chunk_count, expected_chunk_count,
-        "list-child limit must split merge reads"
+        "posting read planner produced an unexpected chunk count"
     );
     assert_eq!(merged.posting_lists.len(), NUM_TOKENS);
     assert!(
@@ -538,11 +540,11 @@ async fn test_position_read_ranges_respect_v1_posting_batch_rows(
         assert_eq!(
             partition
                 .inverted_list
-                .posting_read_chunk_ranges_for_test(NUM_TOKENS, 514, true, 3)
+                .posting_read_chunk_ranges_for_test(1, 1, true, 3)
                 .await
                 .unwrap(),
-            vec![(0, 2), (2, 4), (4, 6), (6, 7)],
-            "known child counts must split below the posting batch-row cap"
+            vec![(0, 3), (3, 6), (6, 7)],
+            "V1 writer-aligned ranges must ignore generic token and child limits"
         );
         assert_eq!(
             partition

--- a/rust/lance-index/src/scalar/inverted/index/tests/format_and_builder.rs
+++ b/rust/lance-index/src/scalar/inverted/index/tests/format_and_builder.rs
@@ -4,242 +4,6 @@
 use super::super::posting_prewarm::ChunkPostingMode;
 use super::*;
 
-#[derive(Debug)]
-struct ControlledPostingReads {
-    started: std::sync::atomic::AtomicUsize,
-    active: std::sync::atomic::AtomicUsize,
-    max_active: std::sync::atomic::AtomicUsize,
-    gates: Vec<tokio::sync::Semaphore>,
-    completed: std::sync::Mutex<Vec<usize>>,
-    changed: tokio::sync::Notify,
-}
-
-impl ControlledPostingReads {
-    fn new(token_count: usize) -> Self {
-        Self {
-            started: std::sync::atomic::AtomicUsize::new(0),
-            active: std::sync::atomic::AtomicUsize::new(0),
-            max_active: std::sync::atomic::AtomicUsize::new(0),
-            gates: (0..token_count)
-                .map(|_| tokio::sync::Semaphore::new(0))
-                .collect(),
-            completed: std::sync::Mutex::new(Vec::with_capacity(token_count)),
-            changed: tokio::sync::Notify::new(),
-        }
-    }
-
-    async fn wait_for_started(&self, expected: usize) {
-        tokio::time::timeout(std::time::Duration::from_secs(5), async {
-            loop {
-                let changed = self.changed.notified();
-                if self.started.load(std::sync::atomic::Ordering::SeqCst) >= expected {
-                    return;
-                }
-                changed.await;
-            }
-        })
-        .await
-        .expect("timed out waiting for controlled posting reads to start");
-    }
-
-    async fn release_and_wait(&self, token_id: usize, expected_completed: usize) {
-        self.gates[token_id].add_permits(1);
-        tokio::time::timeout(std::time::Duration::from_secs(5), async {
-            loop {
-                let changed = self.changed.notified();
-                if self
-                    .completed
-                    .lock()
-                    .expect("controlled posting completion lock poisoned")
-                    .len()
-                    >= expected_completed
-                {
-                    return;
-                }
-                changed.await;
-            }
-        })
-        .await
-        .expect("timed out waiting for controlled posting read to complete");
-    }
-}
-
-struct ControlledPostingReader {
-    inner: Arc<dyn IndexReader>,
-    control: Arc<ControlledPostingReads>,
-    fail_token: Option<usize>,
-}
-
-#[async_trait]
-impl IndexReader for ControlledPostingReader {
-    async fn read_record_batch(&self, n: u64, batch_size: u64) -> Result<RecordBatch> {
-        self.inner.read_record_batch(n, batch_size).await
-    }
-
-    async fn read_global_buffer(&self, index: u32) -> Result<bytes::Bytes> {
-        self.inner.read_global_buffer(index).await
-    }
-
-    async fn read_range(
-        &self,
-        range: std::ops::Range<usize>,
-        projection: Option<&[&str]>,
-    ) -> Result<RecordBatch> {
-        let is_singleton_position_read = range.end == range.start + 1
-            && projection.is_some_and(|columns| {
-                columns.contains(&POSTING_COL) && columns.contains(&POSITION_COL)
-            });
-        if !is_singleton_position_read {
-            return self.inner.read_range(range, projection).await;
-        }
-
-        let token_id = range.start;
-        self.control
-            .started
-            .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-        let active = self
-            .control
-            .active
-            .fetch_add(1, std::sync::atomic::Ordering::SeqCst)
-            + 1;
-        self.control
-            .max_active
-            .fetch_max(active, std::sync::atomic::Ordering::SeqCst);
-        self.control.changed.notify_waiters();
-
-        let permit = self.control.gates[token_id]
-            .acquire()
-            .await
-            .map_err(|err| Error::internal(format!("controlled posting gate closed: {err}")))?;
-        permit.forget();
-        let result = if self.fail_token == Some(token_id) {
-            Err(Error::io(format!(
-                "injected singleton posting read failure for token {token_id}"
-            )))
-        } else {
-            self.inner.read_range(range, projection).await
-        };
-
-        self.control
-            .active
-            .fetch_sub(1, std::sync::atomic::Ordering::SeqCst);
-        self.control
-            .completed
-            .lock()
-            .expect("controlled posting completion lock poisoned")
-            .push(token_id);
-        self.control.changed.notify_waiters();
-        result
-    }
-
-    async fn num_batches(&self, batch_size: u64) -> u32 {
-        self.inner.num_batches(batch_size).await
-    }
-
-    fn num_rows(&self) -> usize {
-        self.inner.num_rows()
-    }
-
-    fn schema(&self) -> &lance_core::datatypes::Schema {
-        self.inner.schema()
-    }
-
-    fn file_size_bytes(&self) -> Option<u64> {
-        self.inner.file_size_bytes()
-    }
-}
-
-#[derive(Debug)]
-struct ControlledMergeStore {
-    inner: Arc<dyn IndexStore>,
-    posting_file: String,
-    io_parallelism: usize,
-    control: Arc<ControlledPostingReads>,
-    fail_token: Option<usize>,
-}
-
-impl DeepSizeOf for ControlledMergeStore {
-    fn deep_size_of_children(&self, context: &mut lance_core::deepsize::Context) -> usize {
-        self.inner.deep_size_of_children(context)
-    }
-}
-
-#[async_trait]
-impl IndexStore for ControlledMergeStore {
-    fn as_any(&self) -> &dyn std::any::Any {
-        self
-    }
-
-    fn clone_arc(&self) -> Arc<dyn IndexStore> {
-        Arc::new(Self {
-            inner: self.inner.clone(),
-            posting_file: self.posting_file.clone(),
-            io_parallelism: self.io_parallelism,
-            control: self.control.clone(),
-            fail_token: self.fail_token,
-        })
-    }
-
-    fn io_parallelism(&self) -> usize {
-        self.io_parallelism
-    }
-
-    async fn new_index_file(
-        &self,
-        name: &str,
-        schema: Arc<Schema>,
-    ) -> Result<Box<dyn crate::scalar::IndexWriter>> {
-        self.inner.new_index_file(name, schema).await
-    }
-
-    async fn open_index_file(&self, name: &str) -> Result<Arc<dyn IndexReader>> {
-        let reader = self.inner.open_index_file(name).await?;
-        if name == self.posting_file {
-            Ok(Arc::new(ControlledPostingReader {
-                inner: reader,
-                control: self.control.clone(),
-                fail_token: self.fail_token,
-            }))
-        } else {
-            Ok(reader)
-        }
-    }
-
-    fn with_io_priority(&self, io_priority: u64) -> Arc<dyn IndexStore> {
-        Arc::new(Self {
-            inner: self.inner.with_io_priority(io_priority),
-            posting_file: self.posting_file.clone(),
-            io_parallelism: self.io_parallelism,
-            control: self.control.clone(),
-            fail_token: self.fail_token,
-        })
-    }
-
-    async fn copy_index_file(
-        &self,
-        name: &str,
-        dest_store: &dyn IndexStore,
-    ) -> Result<crate::scalar::IndexFile> {
-        self.inner.copy_index_file(name, dest_store).await
-    }
-
-    async fn rename_index_file(
-        &self,
-        name: &str,
-        new_name: &str,
-    ) -> Result<crate::scalar::IndexFile> {
-        self.inner.rename_index_file(name, new_name).await
-    }
-
-    async fn delete_index_file(&self, name: &str) -> Result<()> {
-        self.inner.delete_index_file(name).await
-    }
-
-    async fn list_files_with_sizes(&self) -> Result<Vec<crate::scalar::IndexFile>> {
-        self.inner.list_files_with_sizes().await
-    }
-}
-
 #[test]
 fn address_read_concurrency_respects_payload_budget() {
     assert_eq!(address_read_concurrency(64, 0), 64);
@@ -585,7 +349,7 @@ async fn test_build_search_uses_configured_posting_block_size() {
 }
 
 #[rstest::rstest]
-#[case::v1(InvertedListFormatVersion::V1, LEGACY_BLOCK_SIZE, 514, 7)]
+#[case::v1(InvertedListFormatVersion::V1, LEGACY_BLOCK_SIZE, 514, 4)]
 #[case::v2(InvertedListFormatVersion::V2, LEGACY_BLOCK_SIZE, 8, 4)]
 #[case::v3(InvertedListFormatVersion::V3, 256, 6, 4)]
 #[tokio::test]
@@ -597,9 +361,8 @@ async fn test_into_builder_chunks_postings_by_list_children(
 ) {
     const NUM_TOKENS: usize = 7;
     const NUM_DOCS: usize = 257;
-    // V1's nested per-document position block count is not stored in metadata,
-    // so each token gets its own read. V3's exact metadata-derived bound admits
-    // two token rows per read.
+    // V1 and V3 both retain the generic metadata-derived child bound, which
+    // admits two token rows per read for these inputs.
 
     let source_dir = TempObjDir::default();
     let source_store = Arc::new(LanceIndexStore::new(
@@ -701,14 +464,21 @@ async fn test_into_builder_chunks_postings_by_list_children(
     assert_eq!(actual[NUM_DOCS - 1], (256, 2, vec![0, 10]));
 }
 
+#[rstest::rstest]
+#[case::v1(InvertedListFormatVersion::V1, LEGACY_BLOCK_SIZE, true)]
+#[case::v2(InvertedListFormatVersion::V2, LEGACY_BLOCK_SIZE, false)]
+#[case::v3(InvertedListFormatVersion::V3, MAX_POSTING_BLOCK_SIZE, false)]
 #[tokio::test]
-async fn test_v1_position_merge_reads_are_bounded_and_ordered() {
-    const NUM_TOKENS: usize = 10;
-    const NUM_DOCS: usize = 3;
-    const EXPECTED_CONCURRENCY: usize = 8;
+async fn test_position_read_ranges_respect_v1_posting_batch_rows(
+    #[case] format_version: InvertedListFormatVersion,
+    #[case] block_size: usize,
+    #[case] is_v1: bool,
+) {
+    const NUM_TOKENS: usize = 7;
+    const NUM_DOCS: usize = 257;
 
     let source_dir = TempObjDir::default();
-    let source_store: Arc<dyn IndexStore> = Arc::new(LanceIndexStore::new(
+    let source_store = Arc::new(LanceIndexStore::new(
         ObjectStore::local().into(),
         source_dir.clone(),
         Arc::new(LanceCache::no_cache()),
@@ -717,20 +487,20 @@ async fn test_v1_position_merge_reads_are_bounded_and_ordered() {
         0,
         true,
         TokenSetFormat::default(),
-        InvertedListFormatVersion::V1,
-        LEGACY_BLOCK_SIZE,
+        format_version,
+        block_size,
     );
     for token_id in 0..NUM_TOKENS {
         source.tokens.add(format!("token_{token_id}"));
         let mut posting = PostingListBuilder::new_with_posting_tail_codec_and_block_size(
             true,
-            InvertedListFormatVersion::V1.posting_tail_codec(),
-            LEGACY_BLOCK_SIZE,
+            format_version.posting_tail_codec(),
+            block_size,
         );
         for doc_id in 0..NUM_DOCS {
             posting.add(
                 doc_id as u32,
-                PositionRecorder::Position(vec![token_id as u32, token_id as u32 + 100].into()),
+                PositionRecorder::Position(vec![token_id as u32, token_id as u32 + 10].into()),
             );
         }
         source.posting_lists.push(posting);
@@ -742,16 +512,8 @@ async fn test_v1_position_merge_reads_are_bounded_and_ordered() {
     }
     source.write(source_store.as_ref()).await.unwrap();
 
-    let control = Arc::new(ControlledPostingReads::new(NUM_TOKENS));
-    let controlled_store: Arc<dyn IndexStore> = Arc::new(ControlledMergeStore {
-        inner: source_store.clone(),
-        posting_file: posting_file_path(0),
-        io_parallelism: 64,
-        control: control.clone(),
-        fail_token: None,
-    });
-    let source_partition = InvertedPartition::load(
-        controlled_store,
+    let partition = InvertedPartition::load(
+        source_store,
         0,
         None,
         &LanceCache::no_cache(),
@@ -759,113 +521,47 @@ async fn test_v1_position_merge_reads_are_bounded_and_ordered() {
     )
     .await
     .unwrap();
-
-    let merge_task = tokio::spawn(async move {
-        source_partition
-            .into_builder_with_chunk_limits(NUM_TOKENS, u64::MAX)
-            .await
-    });
-    control.wait_for_started(EXPECTED_CONCURRENCY).await;
-    assert_eq!(
-        control.active.load(std::sync::atomic::Ordering::SeqCst),
-        EXPECTED_CONCURRENCY
-    );
-    assert_eq!(
-        control.max_active.load(std::sync::atomic::Ordering::SeqCst),
-        EXPECTED_CONCURRENCY,
-        "store I/O parallelism must be capped"
-    );
-
-    let mut completed_count = 0;
-    for token_id in (1..EXPECTED_CONCURRENCY).rev() {
-        completed_count += 1;
-        control.release_and_wait(token_id, completed_count).await;
-    }
-    assert_eq!(
-        control.started.load(std::sync::atomic::Ordering::SeqCst),
-        EXPECTED_CONCURRENCY,
-        "completed chunks behind token 0 must remain inside the bounded ordered window"
-    );
-    completed_count += 1;
-    control.release_and_wait(0, completed_count).await;
-    control.wait_for_started(NUM_TOKENS).await;
-    for token_id in (EXPECTED_CONCURRENCY..NUM_TOKENS).rev() {
-        completed_count += 1;
-        control.release_and_wait(token_id, completed_count).await;
-    }
-
-    let (merged, chunk_count) = tokio::time::timeout(std::time::Duration::from_secs(5), merge_task)
+    let batch_capped = partition
+        .inverted_list
+        .posting_read_chunk_ranges_for_test(NUM_TOKENS, u64::MAX, true, 3)
         .await
-        .expect("timed out waiting for controlled V1 position merge")
-        .unwrap()
         .unwrap();
-    assert_eq!(chunk_count, NUM_TOKENS);
-    assert!(
-        control.max_active.load(std::sync::atomic::Ordering::SeqCst) <= EXPECTED_CONCURRENCY,
-        "singleton posting reads exceeded the bounded concurrency cap"
-    );
-    assert_eq!(
-        *control
-            .completed
-            .lock()
-            .expect("controlled posting completion lock poisoned"),
-        vec![7, 6, 5, 4, 3, 2, 1, 0, 9, 8],
-        "test reads must complete out of token order"
-    );
-    assert_eq!(merged.posting_lists.len(), NUM_TOKENS);
-    for (token_id, posting) in merged.posting_lists.iter().enumerate() {
-        let entries = posting.iter().collect::<Vec<_>>();
-        assert_eq!(entries.len(), NUM_DOCS);
-        for (expected_doc_id, (doc_id, frequency, positions)) in entries.into_iter().enumerate() {
-            assert_eq!(frequency, 2);
-            assert_eq!(doc_id as usize, expected_doc_id);
-            assert_eq!(
-                positions.unwrap(),
-                vec![token_id as u32, token_id as u32 + 100],
-                "posting positions must remain aligned with token order"
-            );
-        }
-    }
-
-    let error_control = Arc::new(ControlledPostingReads::new(NUM_TOKENS));
-    let error_store: Arc<dyn IndexStore> = Arc::new(ControlledMergeStore {
-        inner: source_store,
-        posting_file: posting_file_path(0),
-        io_parallelism: 64,
-        control: error_control.clone(),
-        fail_token: Some(1),
-    });
-    let error_partition = InvertedPartition::load(
-        error_store,
-        0,
-        None,
-        &LanceCache::no_cache(),
-        TokenSetFormat::default(),
-    )
-    .await
-    .unwrap();
-    let error_task = tokio::spawn(async move {
-        error_partition
-            .into_builder_with_chunk_limits(NUM_TOKENS, u64::MAX)
-            .await
-    });
-    error_control.wait_for_started(EXPECTED_CONCURRENCY).await;
-    for (completed_count, token_id) in (0..EXPECTED_CONCURRENCY).rev().enumerate() {
-        error_control
-            .release_and_wait(token_id, completed_count + 1)
-            .await;
-    }
-    let error = tokio::time::timeout(std::time::Duration::from_secs(5), error_task)
+    let without_positions = partition
+        .inverted_list
+        .posting_read_chunk_ranges_for_test(NUM_TOKENS, u64::MAX, false, 1)
         .await
-        .expect("timed out waiting for injected V1 position merge failure")
-        .unwrap()
-        .unwrap_err();
-    assert!(matches!(error, Error::IO { .. }));
-    assert!(
-        error
-            .to_string()
-            .contains("injected singleton posting read failure for token 1")
-    );
+        .unwrap();
+
+    assert_eq!(without_positions, vec![(0, NUM_TOKENS)]);
+    if is_v1 {
+        assert_eq!(batch_capped, vec![(0, 3), (3, 6), (6, 7)]);
+        assert_eq!(
+            partition
+                .inverted_list
+                .posting_read_chunk_ranges_for_test(NUM_TOKENS, 514, true, 3)
+                .await
+                .unwrap(),
+            vec![(0, 2), (2, 4), (4, 6), (6, 7)],
+            "known child counts must split below the posting batch-row cap"
+        );
+        assert_eq!(
+            partition
+                .inverted_list
+                .posting_read_chunk_ranges_for_test(NUM_TOKENS, u64::MAX, true, 1)
+                .await
+                .unwrap(),
+            (0..NUM_TOKENS)
+                .map(|token_id| (token_id, token_id + 1))
+                .collect::<Vec<_>>(),
+            "a configured cap of one must retain singleton reads"
+        );
+    } else {
+        assert_eq!(
+            batch_capped,
+            vec![(0, NUM_TOKENS)],
+            "V2/V3 positions must ignore the V1 posting batch-row cap"
+        );
+    }
 }
 
 #[tokio::test]

--- a/rust/lance-index/src/scalar/inverted/index/tests/format_and_builder.rs
+++ b/rust/lance-index/src/scalar/inverted/index/tests/format_and_builder.rs
@@ -4,6 +4,242 @@
 use super::super::posting_prewarm::ChunkPostingMode;
 use super::*;
 
+#[derive(Debug)]
+struct ControlledPostingReads {
+    started: std::sync::atomic::AtomicUsize,
+    active: std::sync::atomic::AtomicUsize,
+    max_active: std::sync::atomic::AtomicUsize,
+    gates: Vec<tokio::sync::Semaphore>,
+    completed: std::sync::Mutex<Vec<usize>>,
+    changed: tokio::sync::Notify,
+}
+
+impl ControlledPostingReads {
+    fn new(token_count: usize) -> Self {
+        Self {
+            started: std::sync::atomic::AtomicUsize::new(0),
+            active: std::sync::atomic::AtomicUsize::new(0),
+            max_active: std::sync::atomic::AtomicUsize::new(0),
+            gates: (0..token_count)
+                .map(|_| tokio::sync::Semaphore::new(0))
+                .collect(),
+            completed: std::sync::Mutex::new(Vec::with_capacity(token_count)),
+            changed: tokio::sync::Notify::new(),
+        }
+    }
+
+    async fn wait_for_started(&self, expected: usize) {
+        tokio::time::timeout(std::time::Duration::from_secs(5), async {
+            loop {
+                let changed = self.changed.notified();
+                if self.started.load(std::sync::atomic::Ordering::SeqCst) >= expected {
+                    return;
+                }
+                changed.await;
+            }
+        })
+        .await
+        .expect("timed out waiting for controlled posting reads to start");
+    }
+
+    async fn release_and_wait(&self, token_id: usize, expected_completed: usize) {
+        self.gates[token_id].add_permits(1);
+        tokio::time::timeout(std::time::Duration::from_secs(5), async {
+            loop {
+                let changed = self.changed.notified();
+                if self
+                    .completed
+                    .lock()
+                    .expect("controlled posting completion lock poisoned")
+                    .len()
+                    >= expected_completed
+                {
+                    return;
+                }
+                changed.await;
+            }
+        })
+        .await
+        .expect("timed out waiting for controlled posting read to complete");
+    }
+}
+
+struct ControlledPostingReader {
+    inner: Arc<dyn IndexReader>,
+    control: Arc<ControlledPostingReads>,
+    fail_token: Option<usize>,
+}
+
+#[async_trait]
+impl IndexReader for ControlledPostingReader {
+    async fn read_record_batch(&self, n: u64, batch_size: u64) -> Result<RecordBatch> {
+        self.inner.read_record_batch(n, batch_size).await
+    }
+
+    async fn read_global_buffer(&self, index: u32) -> Result<bytes::Bytes> {
+        self.inner.read_global_buffer(index).await
+    }
+
+    async fn read_range(
+        &self,
+        range: std::ops::Range<usize>,
+        projection: Option<&[&str]>,
+    ) -> Result<RecordBatch> {
+        let is_singleton_position_read = range.end == range.start + 1
+            && projection.is_some_and(|columns| {
+                columns.contains(&POSTING_COL) && columns.contains(&POSITION_COL)
+            });
+        if !is_singleton_position_read {
+            return self.inner.read_range(range, projection).await;
+        }
+
+        let token_id = range.start;
+        self.control
+            .started
+            .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        let active = self
+            .control
+            .active
+            .fetch_add(1, std::sync::atomic::Ordering::SeqCst)
+            + 1;
+        self.control
+            .max_active
+            .fetch_max(active, std::sync::atomic::Ordering::SeqCst);
+        self.control.changed.notify_waiters();
+
+        let permit = self.control.gates[token_id]
+            .acquire()
+            .await
+            .map_err(|err| Error::internal(format!("controlled posting gate closed: {err}")))?;
+        permit.forget();
+        let result = if self.fail_token == Some(token_id) {
+            Err(Error::io(format!(
+                "injected singleton posting read failure for token {token_id}"
+            )))
+        } else {
+            self.inner.read_range(range, projection).await
+        };
+
+        self.control
+            .active
+            .fetch_sub(1, std::sync::atomic::Ordering::SeqCst);
+        self.control
+            .completed
+            .lock()
+            .expect("controlled posting completion lock poisoned")
+            .push(token_id);
+        self.control.changed.notify_waiters();
+        result
+    }
+
+    async fn num_batches(&self, batch_size: u64) -> u32 {
+        self.inner.num_batches(batch_size).await
+    }
+
+    fn num_rows(&self) -> usize {
+        self.inner.num_rows()
+    }
+
+    fn schema(&self) -> &lance_core::datatypes::Schema {
+        self.inner.schema()
+    }
+
+    fn file_size_bytes(&self) -> Option<u64> {
+        self.inner.file_size_bytes()
+    }
+}
+
+#[derive(Debug)]
+struct ControlledMergeStore {
+    inner: Arc<dyn IndexStore>,
+    posting_file: String,
+    io_parallelism: usize,
+    control: Arc<ControlledPostingReads>,
+    fail_token: Option<usize>,
+}
+
+impl DeepSizeOf for ControlledMergeStore {
+    fn deep_size_of_children(&self, context: &mut lance_core::deepsize::Context) -> usize {
+        self.inner.deep_size_of_children(context)
+    }
+}
+
+#[async_trait]
+impl IndexStore for ControlledMergeStore {
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+
+    fn clone_arc(&self) -> Arc<dyn IndexStore> {
+        Arc::new(Self {
+            inner: self.inner.clone(),
+            posting_file: self.posting_file.clone(),
+            io_parallelism: self.io_parallelism,
+            control: self.control.clone(),
+            fail_token: self.fail_token,
+        })
+    }
+
+    fn io_parallelism(&self) -> usize {
+        self.io_parallelism
+    }
+
+    async fn new_index_file(
+        &self,
+        name: &str,
+        schema: Arc<Schema>,
+    ) -> Result<Box<dyn crate::scalar::IndexWriter>> {
+        self.inner.new_index_file(name, schema).await
+    }
+
+    async fn open_index_file(&self, name: &str) -> Result<Arc<dyn IndexReader>> {
+        let reader = self.inner.open_index_file(name).await?;
+        if name == self.posting_file {
+            Ok(Arc::new(ControlledPostingReader {
+                inner: reader,
+                control: self.control.clone(),
+                fail_token: self.fail_token,
+            }))
+        } else {
+            Ok(reader)
+        }
+    }
+
+    fn with_io_priority(&self, io_priority: u64) -> Arc<dyn IndexStore> {
+        Arc::new(Self {
+            inner: self.inner.with_io_priority(io_priority),
+            posting_file: self.posting_file.clone(),
+            io_parallelism: self.io_parallelism,
+            control: self.control.clone(),
+            fail_token: self.fail_token,
+        })
+    }
+
+    async fn copy_index_file(
+        &self,
+        name: &str,
+        dest_store: &dyn IndexStore,
+    ) -> Result<crate::scalar::IndexFile> {
+        self.inner.copy_index_file(name, dest_store).await
+    }
+
+    async fn rename_index_file(
+        &self,
+        name: &str,
+        new_name: &str,
+    ) -> Result<crate::scalar::IndexFile> {
+        self.inner.rename_index_file(name, new_name).await
+    }
+
+    async fn delete_index_file(&self, name: &str) -> Result<()> {
+        self.inner.delete_index_file(name).await
+    }
+
+    async fn list_files_with_sizes(&self) -> Result<Vec<crate::scalar::IndexFile>> {
+        self.inner.list_files_with_sizes().await
+    }
+}
+
 #[test]
 fn address_read_concurrency_respects_payload_budget() {
     assert_eq!(address_read_concurrency(64, 0), 64);
@@ -350,6 +586,7 @@ async fn test_build_search_uses_configured_posting_block_size() {
 
 #[rstest::rstest]
 #[case::v1(InvertedListFormatVersion::V1, LEGACY_BLOCK_SIZE, 514, 7)]
+#[case::v2(InvertedListFormatVersion::V2, LEGACY_BLOCK_SIZE, 8, 4)]
 #[case::v3(InvertedListFormatVersion::V3, 256, 6, 4)]
 #[tokio::test]
 async fn test_into_builder_chunks_postings_by_list_children(
@@ -424,7 +661,7 @@ async fn test_into_builder_chunks_postings_by_list_children(
             .all(|posting| posting.len() == NUM_DOCS && posting.has_positions())
     );
 
-    // Rewriting the chunk-built builder verifies that V3 positions survived
+    // Rewriting the chunk-built builder verifies that positions survived
     // conversion and that impact data can be regenerated from every posting.
     let dest_dir = TempObjDir::default();
     let dest_store = Arc::new(LanceIndexStore::new(
@@ -462,6 +699,173 @@ async fn test_into_builder_chunks_postings_by_list_children(
     assert_eq!(actual.len(), NUM_DOCS);
     assert_eq!(actual[0], (0, 2, vec![0, 10]));
     assert_eq!(actual[NUM_DOCS - 1], (256, 2, vec![0, 10]));
+}
+
+#[tokio::test]
+async fn test_v1_position_merge_reads_are_bounded_and_ordered() {
+    const NUM_TOKENS: usize = 10;
+    const NUM_DOCS: usize = 3;
+    const EXPECTED_CONCURRENCY: usize = 8;
+
+    let source_dir = TempObjDir::default();
+    let source_store: Arc<dyn IndexStore> = Arc::new(LanceIndexStore::new(
+        ObjectStore::local().into(),
+        source_dir.clone(),
+        Arc::new(LanceCache::no_cache()),
+    ));
+    let mut source = InnerBuilder::new_with_format_version_and_block_size(
+        0,
+        true,
+        TokenSetFormat::default(),
+        InvertedListFormatVersion::V1,
+        LEGACY_BLOCK_SIZE,
+    );
+    for token_id in 0..NUM_TOKENS {
+        source.tokens.add(format!("token_{token_id}"));
+        let mut posting = PostingListBuilder::new_with_posting_tail_codec_and_block_size(
+            true,
+            InvertedListFormatVersion::V1.posting_tail_codec(),
+            LEGACY_BLOCK_SIZE,
+        );
+        for doc_id in 0..NUM_DOCS {
+            posting.add(
+                doc_id as u32,
+                PositionRecorder::Position(vec![token_id as u32, token_id as u32 + 100].into()),
+            );
+        }
+        source.posting_lists.push(posting);
+    }
+    for doc_id in 0..NUM_DOCS {
+        source
+            .docs
+            .append(1_000 + doc_id as u64, (NUM_TOKENS * 2) as u32);
+    }
+    source.write(source_store.as_ref()).await.unwrap();
+
+    let control = Arc::new(ControlledPostingReads::new(NUM_TOKENS));
+    let controlled_store: Arc<dyn IndexStore> = Arc::new(ControlledMergeStore {
+        inner: source_store.clone(),
+        posting_file: posting_file_path(0),
+        io_parallelism: 64,
+        control: control.clone(),
+        fail_token: None,
+    });
+    let source_partition = InvertedPartition::load(
+        controlled_store,
+        0,
+        None,
+        &LanceCache::no_cache(),
+        TokenSetFormat::default(),
+    )
+    .await
+    .unwrap();
+
+    let merge_task = tokio::spawn(async move {
+        source_partition
+            .into_builder_with_chunk_limits(NUM_TOKENS, u64::MAX)
+            .await
+    });
+    control.wait_for_started(EXPECTED_CONCURRENCY).await;
+    assert_eq!(
+        control.active.load(std::sync::atomic::Ordering::SeqCst),
+        EXPECTED_CONCURRENCY
+    );
+    assert_eq!(
+        control.max_active.load(std::sync::atomic::Ordering::SeqCst),
+        EXPECTED_CONCURRENCY,
+        "store I/O parallelism must be capped"
+    );
+
+    let mut completed_count = 0;
+    for token_id in (1..EXPECTED_CONCURRENCY).rev() {
+        completed_count += 1;
+        control.release_and_wait(token_id, completed_count).await;
+    }
+    assert_eq!(
+        control.started.load(std::sync::atomic::Ordering::SeqCst),
+        EXPECTED_CONCURRENCY,
+        "completed chunks behind token 0 must remain inside the bounded ordered window"
+    );
+    completed_count += 1;
+    control.release_and_wait(0, completed_count).await;
+    control.wait_for_started(NUM_TOKENS).await;
+    for token_id in (EXPECTED_CONCURRENCY..NUM_TOKENS).rev() {
+        completed_count += 1;
+        control.release_and_wait(token_id, completed_count).await;
+    }
+
+    let (merged, chunk_count) = tokio::time::timeout(std::time::Duration::from_secs(5), merge_task)
+        .await
+        .expect("timed out waiting for controlled V1 position merge")
+        .unwrap()
+        .unwrap();
+    assert_eq!(chunk_count, NUM_TOKENS);
+    assert!(
+        control.max_active.load(std::sync::atomic::Ordering::SeqCst) <= EXPECTED_CONCURRENCY,
+        "singleton posting reads exceeded the bounded concurrency cap"
+    );
+    assert_eq!(
+        *control
+            .completed
+            .lock()
+            .expect("controlled posting completion lock poisoned"),
+        vec![7, 6, 5, 4, 3, 2, 1, 0, 9, 8],
+        "test reads must complete out of token order"
+    );
+    assert_eq!(merged.posting_lists.len(), NUM_TOKENS);
+    for (token_id, posting) in merged.posting_lists.iter().enumerate() {
+        let entries = posting.iter().collect::<Vec<_>>();
+        assert_eq!(entries.len(), NUM_DOCS);
+        for (expected_doc_id, (doc_id, frequency, positions)) in entries.into_iter().enumerate() {
+            assert_eq!(frequency, 2);
+            assert_eq!(doc_id as usize, expected_doc_id);
+            assert_eq!(
+                positions.unwrap(),
+                vec![token_id as u32, token_id as u32 + 100],
+                "posting positions must remain aligned with token order"
+            );
+        }
+    }
+
+    let error_control = Arc::new(ControlledPostingReads::new(NUM_TOKENS));
+    let error_store: Arc<dyn IndexStore> = Arc::new(ControlledMergeStore {
+        inner: source_store,
+        posting_file: posting_file_path(0),
+        io_parallelism: 64,
+        control: error_control.clone(),
+        fail_token: Some(1),
+    });
+    let error_partition = InvertedPartition::load(
+        error_store,
+        0,
+        None,
+        &LanceCache::no_cache(),
+        TokenSetFormat::default(),
+    )
+    .await
+    .unwrap();
+    let error_task = tokio::spawn(async move {
+        error_partition
+            .into_builder_with_chunk_limits(NUM_TOKENS, u64::MAX)
+            .await
+    });
+    error_control.wait_for_started(EXPECTED_CONCURRENCY).await;
+    for (completed_count, token_id) in (0..EXPECTED_CONCURRENCY).rev().enumerate() {
+        error_control
+            .release_and_wait(token_id, completed_count + 1)
+            .await;
+    }
+    let error = tokio::time::timeout(std::time::Duration::from_secs(5), error_task)
+        .await
+        .expect("timed out waiting for injected V1 position merge failure")
+        .unwrap()
+        .unwrap_err();
+    assert!(matches!(error, Error::IO { .. }));
+    assert!(
+        error
+            .to_string()
+            .contains("injected singleton posting read failure for token 1")
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
## What is the bug?

[#8668](https://github.com/lance-format/lance/pull/8668) prevents Arrow `List<i32>` child-offset overflow during FTS segment merge by reading compressed V1 per-document positions one token at a time. That fallback turns a large-vocabulary merge into a very large number of serialized object-store reads.

Internal issue: [ENT-2418](https://linear.app/lancedb/issue/ENT-2418/fts-index-rebuild-stalls-indefinitely-in-final-merge).

## What issues or incorrect behavior does the bug cause?

On remote object stores, the one-token fallback can make the final merge appear stalled while the job remains alive.

## How does this PR fix the problem?

- use the same `LANCE_FTS_POSTING_BATCH_ROWS` setting for writer batching and compressed V1 legacy-position merge reads
- read exact aligned token ranges `[0, B)`, `[B, 2B)`, ... where `B = max(1, LANCE_FTS_POSTING_BATCH_ROWS)`
- bypass the generic file-size and known-child splitters for this V1 special path
- consume the resulting batches sequentially
- leave V2, V3, no-position, and pre-compression legacy paths unchanged

This does not change public APIs or the on-disk format.

## Compatibility and safety limitation

Historical V1 files do not persist their writer batch-row setting or original input-batch boundaries. Therefore the current environment value only reconstructs the original grouping when it matches the value and batching semantics used to build the file. For mismatched historical files, this is a heuristic and cannot provide the universal nested-list offset-safety proof of singleton reads. Setting `LANCE_FTS_POSTING_BATCH_ROWS=1` retains singleton behavior.

This compatibility tradeoff is intentional for this tactical change. Persisted writer boundaries, authoritative nested-child metadata, or a posting-first planner could remove the assumption in a future change.

## Tests

- `cargo fmt --all -- --check`
- `cargo clippy --all --tests --benches -- -D warnings`
- `cargo test -p lance-index` — 1,186 passed, 3 ignored; 9 doctests passed
- focused coverage verifies:
  - V1 position ranges exactly follow the configured posting batch rows
  - generic token and child limits do not alter those V1 ranges
  - a configured value of 1 retains singleton ranges
  - V2/V3 and no-position planning remain on the generic path
  - V1/V2/V3 positions survive chunked builder conversion and rewrite

## Performance validation

| Scenario / metric | Baseline | This PR | Benefit |
| --- | ---: | ---: | ---: |
| V1 positions merge wall time on a comparable remote-object-store dataset | Not measured | Not measured | Not yet verified |
| Peak RSS on the same workload | Not measured | Not measured | Not yet verified |

A safe comparable Azure repro environment was not available from this worktree. This PR does not claim a measured speedup.
