### PR TITLE
perf(index): accelerate RQ scale search

### DIFF
--- a/rust/lance-index/src/vector/bq/builder.rs
+++ b/rust/lance-index/src/vector/bq/builder.rs
@@ -117,6 +117,38 @@ fn radix_sort_positive_f32_indices(values: &mut [u64]) {
     pass(&scratch, values, 56);
 }
 
+/// Sort RQ threshold events without changing the existing equal-key behavior.
+///
+/// The quantizer updates its floating-point objective after every event, so the
+/// order chosen by the previous unstable comparison sort remains observable when
+/// thresholds tie. Radix sort the common unique-key case, but reconstruct the
+/// original event order and use the previous sort when duplicate keys are found.
+fn sort_ex_thresholds(values: &mut [u64]) {
+    radix_sort_positive_f32_indices(values);
+    let has_duplicate_keys = values
+        .windows(2)
+        .any(|pair| pair[0] >> u32::BITS == pair[1] >> u32::BITS);
+    if !has_duplicate_keys {
+        return;
+    }
+
+    // Events were originally emitted by index, then by increasing threshold.
+    values.sort_unstable_by_key(|value| (*value as u32, (value >> u32::BITS) as u32));
+    let mut comparison_thresholds = values
+        .iter()
+        .map(|value| {
+            (
+                f32::from_bits((value >> u32::BITS) as u32),
+                *value as u32 as usize,
+            )
+        })
+        .collect::<Vec<_>>();
+    comparison_thresholds.sort_unstable_by(|(left, _), (right, _)| left.total_cmp(right));
+    for (value, (threshold, idx)) in values.iter_mut().zip(comparison_thresholds) {
+        *value = ((threshold.to_bits() as u64) << u32::BITS) | idx as u64;
+    }
+}
+
 fn best_ex_rescale_factor(abs_normalized: &[f32], ex_bits: u8) -> f32 {
     let max_value = abs_normalized
         .iter()
@@ -160,7 +192,7 @@ fn best_ex_rescale_factor(abs_normalized: &[f32], ex_bits: u8) -> f32 {
         }
     }
 
-    radix_sort_positive_f32_indices(&mut thresholds);
+    sort_ex_thresholds(&mut thresholds);
 
     let mut best_inner_product = numerator / squared_denominator.sqrt();
     let mut best_t = t_start;
@@ -1023,6 +1055,25 @@ mod tests {
             let actual = best_ex_rescale_factor(&values, ex_bits);
             assert_eq!(actual.to_bits(), expected.to_bits(), "ex_bits={ex_bits}");
         }
+    }
+
+    #[test]
+    fn test_best_ex_rescale_factor_preserves_equal_threshold_order() {
+        let rotated = [0.75, 1.0, 0.0625, 0.5, 2.0 / 3.0, 0.75, 0.5, 2.0 / 3.0];
+        let norm = rotated
+            .iter()
+            .map(|value| value * value)
+            .sum::<f32>()
+            .sqrt();
+        let abs_normalized = rotated
+            .iter()
+            .map(|value| value.abs() / norm)
+            .collect::<Vec<_>>();
+
+        let expected = reference_best_ex_rescale_factor(&abs_normalized, 7);
+        let actual = best_ex_rescale_factor(&abs_normalized, 7);
+
+        assert_eq!(actual.to_bits(), expected.to_bits());
     }
 
     #[rstest]

--- a/rust/lance-index/src/vector/bq/builder.rs
+++ b/rust/lance-index/src/vector/bq/builder.rs
@@ -81,6 +81,42 @@ fn pack_sign_bits(codes: &mut [u8], rotated: &[f32]) {
 const EX_QUANTIZATION_EPSILON: f32 = 1.0e-5;
 const EX_TIGHT_START: [f32; 9] = [0.0, 0.15, 0.20, 0.52, 0.59, 0.71, 0.75, 0.77, 0.81];
 
+/// Sort packed `(positive_f32_bits, index)` values by their floating-point key.
+///
+/// All thresholds emitted by [`best_ex_rescale_factor`] are positive and finite,
+/// so their IEEE-754 bit patterns have the same order as the represented values.
+/// Four stable byte-wise passes avoid the comparison-heavy tuple sort on every
+/// vector while preserving the exact threshold order.
+fn radix_sort_positive_f32_indices(values: &mut [u64]) {
+    if values.len() < 2 {
+        return;
+    }
+
+    fn pass(source: &[u64], destination: &mut [u64], shift: u32) {
+        let mut offsets = [0usize; 256];
+        for &value in source {
+            offsets[((value >> shift) & 0xff) as usize] += 1;
+        }
+        let mut next_offset = 0;
+        for offset in &mut offsets {
+            let count = *offset;
+            *offset = next_offset;
+            next_offset += count;
+        }
+        for &value in source {
+            let bucket = ((value >> shift) & 0xff) as usize;
+            destination[offsets[bucket]] = value;
+            offsets[bucket] += 1;
+        }
+    }
+
+    let mut scratch = vec![0u64; values.len()];
+    pass(values, &mut scratch, 32);
+    pass(&scratch, values, 40);
+    pass(values, &mut scratch, 48);
+    pass(&scratch, values, 56);
+}
+
 fn best_ex_rescale_factor(abs_normalized: &[f32], ex_bits: u8) -> f32 {
     let max_value = abs_normalized
         .iter()
@@ -117,17 +153,20 @@ fn best_ex_rescale_factor(abs_normalized: &[f32], ex_bits: u8) -> f32 {
         while next <= max_code {
             let threshold = next as f32 / value;
             if threshold < t_end {
-                thresholds.push((threshold, idx));
+                debug_assert!(u32::try_from(idx).is_ok());
+                thresholds.push(((threshold.to_bits() as u64) << u32::BITS) | idx as u64);
             }
             next += 1;
         }
     }
 
-    thresholds.sort_unstable_by(|(left, _), (right, _)| left.total_cmp(right));
+    radix_sort_positive_f32_indices(&mut thresholds);
 
     let mut best_inner_product = numerator / squared_denominator.sqrt();
     let mut best_t = t_start;
-    for (threshold, idx) in thresholds {
+    for packed_threshold in thresholds {
+        let threshold = f32::from_bits((packed_threshold >> u32::BITS) as u32);
+        let idx = packed_threshold as u32 as usize;
         current_codes[idx] += 1;
         let updated = current_codes[idx];
         squared_denominator += (2 * updated) as f32;
@@ -891,6 +930,100 @@ mod tests {
     use rstest::rstest;
 
     use crate::vector::bq::storage::RABIT_BLOCKED_EX_CODE_COLUMN;
+
+    fn reference_best_ex_rescale_factor(abs_normalized: &[f32], ex_bits: u8) -> f32 {
+        let max_value = abs_normalized
+            .iter()
+            .copied()
+            .filter(|value| value.is_finite())
+            .fold(0.0f32, f32::max);
+        if max_value <= 0.0 {
+            return 0.0;
+        }
+
+        let max_code = (1usize << ex_bits) - 1;
+        let t_end = ((max_code + 10) as f32) / max_value;
+        let t_start = t_end * EX_TIGHT_START[ex_bits as usize];
+        let mut current_codes = Vec::with_capacity(abs_normalized.len());
+        let mut squared_denominator = abs_normalized.len() as f32 * 0.25;
+        let mut numerator = 0.0f32;
+        let mut thresholds = Vec::with_capacity(abs_normalized.len() * max_code);
+
+        for (idx, &value) in abs_normalized.iter().enumerate() {
+            if value <= 0.0 || !value.is_finite() {
+                current_codes.push(0usize);
+                continue;
+            }
+            let current = ((t_start * value) + EX_QUANTIZATION_EPSILON)
+                .floor()
+                .clamp(0.0, max_code as f32) as usize;
+            current_codes.push(current);
+            squared_denominator += (current * current + current) as f32;
+            numerator += (current as f32 + 0.5) * value;
+
+            for next in (current + 1)..=max_code {
+                let threshold = next as f32 / value;
+                if threshold < t_end {
+                    thresholds.push((threshold, idx));
+                }
+            }
+        }
+
+        thresholds.sort_unstable_by(|(left, _), (right, _)| left.total_cmp(right));
+        let mut best_inner_product = numerator / squared_denominator.sqrt();
+        let mut best_t = t_start;
+        for (threshold, idx) in thresholds {
+            current_codes[idx] += 1;
+            let updated = current_codes[idx];
+            squared_denominator += (2 * updated) as f32;
+            numerator += abs_normalized[idx];
+            let current_inner_product = numerator / squared_denominator.sqrt();
+            if current_inner_product > best_inner_product {
+                best_inner_product = current_inner_product;
+                best_t = threshold;
+            }
+        }
+        best_t
+    }
+
+    #[test]
+    fn test_radix_sort_positive_f32_indices_matches_float_order() {
+        let mut values = (0..4096u32)
+            .map(|idx| {
+                let key = ((idx.wrapping_mul(2654435761) % 997) + 1) as f32 / 37.0;
+                ((key.to_bits() as u64) << u32::BITS) | idx as u64
+            })
+            .collect::<Vec<_>>();
+        let mut expected = values.clone();
+        expected.sort_by_key(|value| *value >> u32::BITS);
+
+        radix_sort_positive_f32_indices(&mut values);
+
+        assert_eq!(values, expected);
+    }
+
+    #[test]
+    fn test_best_ex_rescale_factor_matches_comparison_sort() {
+        let mut values = (0..1536u32)
+            .map(|idx| {
+                let mixed = idx
+                    .wrapping_mul(747796405)
+                    .wrapping_add(2891336453)
+                    .rotate_right((idx % 31) + 1);
+                (mixed as f32 / u32::MAX as f32) * 0.1
+            })
+            .collect::<Vec<_>>();
+        values[0] = 0.0;
+        values[1] = f32::NAN;
+        values[2] = f32::INFINITY;
+        values[3] = values[4];
+
+        for ex_bits in 1..=8 {
+            let expected = reference_best_ex_rescale_factor(&values, ex_bits);
+            let actual = best_ex_rescale_factor(&values, ex_bits);
+            assert_eq!(actual.to_bits(), expected.to_bits(), "ex_bits={ex_bits}");
+        }
+    }
 
     #[rstest]
     #[case(8)]


### PR DESCRIPTION
## What is the performance issue?

RQ scale search generates several quantization thresholds per vector dimension and sorts them before selecting the best rescale factor. For RQ8 on 1,536-dimensional vectors, comparison-based tuple sorting was the dominant sampled cost in this part of index training.

## How does this PR improve performance?

This PR packs each `(positive finite f32 threshold, dimension index)` pair into a `u64` and sorts the threshold bits with four stable byte-wise radix passes. Positive finite IEEE-754 values have the same ordering as their bit patterns, so this removes comparison-heavy tuple sorting for the common unique-key case. Equal thresholds retain the previous quantizer behavior by falling back to the original comparison sort because their event order can affect the incrementally evaluated floating-point objective.

The implementation is isolated from the shuffle reader and scheduling changes in #8894.

## Benchmark

The following supporting A/B measurement isolated this implementation on the #8894 benchmark context. Both variants ran on the same AWS `m7i.4xlarge` VM (16 vCPU, 64 GiB RAM, gp3 storage) against the same S3 dataset: 1,000,000 rows, 1,536 `float32` dimensions, 10,000 supplied IVF centroids, and RQ8. Each value is from one fresh process.

| Scenario / metric | Comparison sort (`c7508ad49`) | Radix sort (`174663d0a`) | Benefit |
| --- | ---: | ---: | ---: |
| Shuffle elapsed (lower is better) | 70.219 s | 51.470 s | 1.36x speedup |
| Full index build elapsed (lower is better) | 76.831 s | 58.346 s | 1.32x speedup |
| Shuffle CPU time (lower is better) | 1,012.95 core-s | 718.29 core-s | 1.41x less CPU time |
| S3 read throughput during shuffle (higher is better) | 84.16 MB/s | 117.61 MB/s | 1.40x higher |

The two measured commits differed only by the initial RQ radix implementation, but they were on the stacked #8894 context and predate the equal-threshold comparison-sort fallback in this standalone latest-`main` PR. The standalone head has not been remeasured, so the table is supporting implementation evidence rather than a current-head benchmark claim.

## Testing

- `cargo test -p lance-index vector::bq::builder::tests --lib --no-fail-fast` (13 passed)
- `cargo fmt --all -- --check`
- `cargo clippy --all --tests --benches -- -D warnings`

The added regression tests verify that radix sorting matches floating-point threshold ordering and that the selected rescale factor is bit-for-bit identical to the comparison-sort reference for RQ1 through RQ8, including zero, duplicate, NaN, and infinite inputs. A targeted equal-threshold regression also verifies the exact rescale factor from the previous comparison-sort behavior.
