### PR TITLE
feat(io): apply byte-sized batch budget to blob materialization

### DIFF
--- a/rust/lance/src/dataset/blob.rs
+++ b/rust/lance/src/dataset/blob.rs
@@ -2533,6 +2533,18 @@ impl MaterializedBlobBatch {
         })
     }
 
+    /// Split the batch into chunks of at most `max_bytes` array memory.
+    ///
+    /// Reservations are not carried over to the chunks; the byte budget itself
+    /// bounds the output size.
+    pub(crate) fn split_by_bytes(self, max_bytes: usize) -> Result<Vec<Self>> {
+        let chunks = split_batch_by_bytes(self.batch, max_bytes)?
+            .into_iter()
+            .map(Self::unreserved)
+            .collect::<Vec<_>>();
+        Ok(chunks)
+    }
+
     pub(crate) fn into_batch(self) -> RecordBatch {
         self.batch
     }
@@ -3521,6 +3533,50 @@ pub async fn materialize_blob_v2_binary_batch(
             .await?
             .into_batch(),
     )
+}
+
+/// Split `batch` into row-aligned chunks whose total array memory size is at
+/// most `max_bytes`.
+///
+/// The split estimates chunk boundaries from average bytes per row and then
+/// recursively re-checks each deep-copied slice. Because `RecordBatch::slice`
+/// shares backing buffers, each slice is deep-copied so that
+/// `get_array_memory_size` reflects the true chunk size. Splitting stops when
+/// a chunk is within budget or contains a single indivisible row.
+pub fn split_batch_by_bytes(batch: RecordBatch, max_bytes: usize) -> Result<Vec<RecordBatch>> {
+    split_batch_by_bytes_recursive(batch, max_bytes)
+}
+
+fn split_batch_by_bytes_recursive(
+    batch: RecordBatch,
+    max_bytes: usize,
+) -> Result<Vec<RecordBatch>> {
+    if batch.num_rows() == 0 {
+        return Ok(Vec::new());
+    }
+    let total_bytes = batch.get_array_memory_size();
+    let num_rows = batch.num_rows();
+    if total_bytes <= max_bytes || num_rows == 1 {
+        return Ok(vec![batch]);
+    }
+    let bytes_per_row = total_bytes / num_rows;
+    let rows_per_chunk = (max_bytes / bytes_per_row.max(1)).max(1);
+    // Make sure we make progress: never take all rows in one slice.
+    let rows_per_chunk = rows_per_chunk.min(num_rows - 1).max(1);
+
+    let mut chunks = Vec::new();
+    let mut offset = 0;
+    while offset < num_rows {
+        let rows = (offset + rows_per_chunk).min(num_rows) - offset;
+        let sliced = batch.slice(offset, rows);
+        // Deep-copy so that `get_array_memory_size()` reports the slice's own
+        // size rather than the parent buffer's size, allowing recursion to
+        // catch skewed rows that still exceed the budget.
+        let copied = lance_arrow::deepcopy::deep_copy_batch_sliced(&sliced)?;
+        chunks.extend(split_batch_by_bytes_recursive(copied, max_bytes)?);
+        offset += rows;
+    }
+    Ok(chunks)
 }
 
 pub fn materialize_blob_v2_binary_batch_with_context<'a>(
@@ -8675,5 +8731,77 @@ mod tests {
             3,
             "write-param override should force one pack file per blob: {blob_ids:?}"
         );
+    }
+
+    #[test]
+    fn test_split_batch_by_bytes_skewed_rows() {
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "data",
+            DataType::LargeBinary,
+            false,
+        )]));
+        let small = vec![0u8; 1];
+        let large = vec![0u8; 10_000];
+        let values: Vec<Option<&[u8]>> = (0..100)
+            .map(|_| Some(small.as_slice()))
+            .chain(std::iter::once(Some(large.as_slice())))
+            .collect();
+        let array = Arc::new(LargeBinaryArray::from_iter(values)) as ArrayRef;
+        let batch = RecordBatch::try_new(schema, vec![array]).unwrap();
+
+        let max_bytes = 200;
+        let chunks = super::split_batch_by_bytes(batch.clone(), max_bytes).unwrap();
+        let total_rows: usize = chunks.iter().map(|c| c.num_rows()).sum();
+        assert_eq!(total_rows, batch.num_rows());
+
+        for chunk in &chunks {
+            if chunk.num_rows() > 1 {
+                assert!(
+                    chunk.get_array_memory_size() <= max_bytes,
+                    "chunk with {} rows has {} bytes, max is {}",
+                    chunk.num_rows(),
+                    chunk.get_array_memory_size(),
+                    max_bytes
+                );
+            }
+        }
+    }
+
+    // Regression: multiple medium rows that individually fit the budget can
+    // still be grouped into a chunk above it by the average-based split; the
+    // recursive re-check must split them apart (bot reproducer: 10 rows × 900 B
+    // plus 90 rows × 1 B, budget 1024 B).
+    #[test]
+    fn test_split_batch_by_bytes_grouped_oversized_rows() {
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "data",
+            DataType::LargeBinary,
+            false,
+        )]));
+        let small = vec![0u8; 1];
+        let medium = vec![0u8; 900];
+        let values: Vec<Option<&[u8]>> = (0..10)
+            .map(|_| Some(medium.as_slice()))
+            .chain((0..90).map(|_| Some(small.as_slice())))
+            .collect();
+        let array = Arc::new(LargeBinaryArray::from_iter(values)) as ArrayRef;
+        let batch = RecordBatch::try_new(schema, vec![array]).unwrap();
+
+        let max_bytes = 1024;
+        let chunks = super::split_batch_by_bytes(batch.clone(), max_bytes).unwrap();
+        let total_rows: usize = chunks.iter().map(|c| c.num_rows()).sum();
+        assert_eq!(total_rows, batch.num_rows());
+
+        for chunk in &chunks {
+            if chunk.num_rows() > 1 {
+                assert!(
+                    chunk.get_array_memory_size() <= max_bytes,
+                    "chunk with {} rows has {} bytes, max is {}",
+                    chunk.num_rows(),
+                    chunk.get_array_memory_size(),
+                    max_bytes
+                );
+            }
+        }
     }
 }

--- a/rust/lance/src/dataset/blob.rs
+++ b/rust/lance/src/dataset/blob.rs
@@ -2498,7 +2498,10 @@ impl BlobMaterializationContext {
 /// A materialized batch that retains its byte-budget reservation until yielded.
 pub struct MaterializedBlobBatch {
     batch: RecordBatch,
-    _reservations: Vec<BlobMaterializationReservation>,
+    /// Reservations are reference-counted so that splitting a batch into
+    /// multiple chunks keeps the original memory reservation alive until the
+    /// last chunk is dropped.
+    _reservations: Vec<Arc<BlobMaterializationReservation>>,
 }
 
 impl MaterializedBlobBatch {
@@ -2506,6 +2509,17 @@ impl MaterializedBlobBatch {
         Self {
             batch,
             _reservations: Vec::new(),
+        }
+    }
+
+    #[cfg(test)]
+    fn with_reservations(
+        batch: RecordBatch,
+        reservations: Vec<Arc<BlobMaterializationReservation>>,
+    ) -> Self {
+        Self {
+            batch,
+            _reservations: reservations,
         }
     }
 
@@ -2535,14 +2549,23 @@ impl MaterializedBlobBatch {
 
     /// Split the batch into chunks of at most `max_bytes` array memory.
     ///
-    /// Reservations are not carried over to the chunks; the byte budget itself
-    /// bounds the output size.
+    /// The original materialization reservation is shared across all chunks so
+    /// that the memory remains accounted for until every chunk has been
+    /// dropped, preserving the `materialization_readahead_bytes` bound while
+    /// the split chunks are queued.
     pub(crate) fn split_by_bytes(self, max_bytes: usize) -> Result<Vec<Self>> {
-        let chunks = split_batch_by_bytes(self.batch, max_bytes)?
+        let Self {
+            batch,
+            _reservations,
+        } = self;
+        let chunks = split_batch_by_bytes(batch, max_bytes)?;
+        Ok(chunks
             .into_iter()
-            .map(Self::unreserved)
-            .collect::<Vec<_>>();
-        Ok(chunks)
+            .map(|batch| Self {
+                batch,
+                _reservations: _reservations.clone(),
+            })
+            .collect())
     }
 
     pub(crate) fn into_batch(self) -> RecordBatch {
@@ -3659,7 +3682,7 @@ pub fn materialize_blob_v2_binary_batch_with_admission<'a>(
                 )),
                 columns,
             )?,
-            _reservations: reservation.into_iter().collect(),
+            _reservations: reservation.into_iter().map(Arc::new).collect(),
         })
     }
     .boxed()
@@ -8803,5 +8826,43 @@ mod tests {
                 );
             }
         }
+    }
+
+    #[tokio::test]
+    async fn test_split_materialized_batch_retains_reservation_until_chunks_drop() {
+        let budget = Arc::new(super::BlobMaterializationBudget {
+            limit: 1024,
+            state: std::sync::Mutex::new(super::BlobMaterializationBudgetState::default()),
+            notify: Notify::new(),
+        });
+        let reservation = budget.reserve(800).await;
+        assert_eq!(budget.state.lock().unwrap().reserved, 800);
+
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "data",
+            DataType::LargeBinary,
+            false,
+        )]));
+        let value = [0u8; 100];
+        let values: Vec<Option<&[u8]>> = (0..10).map(|_| Some(value.as_slice())).collect();
+        let array = Arc::new(LargeBinaryArray::from_iter(values)) as ArrayRef;
+        let batch = RecordBatch::try_new(schema, vec![array]).unwrap();
+
+        let materialized =
+            super::MaterializedBlobBatch::with_reservations(batch, vec![Arc::new(reservation)]);
+        let chunks = materialized.split_by_bytes(200).unwrap();
+        assert!(!chunks.is_empty());
+        assert_eq!(
+            budget.state.lock().unwrap().reserved,
+            800,
+            "reservation should be held while chunks are alive"
+        );
+
+        drop(chunks);
+        assert_eq!(
+            budget.state.lock().unwrap().reserved,
+            0,
+            "reservation should be released after chunks drop"
+        );
     }
 }

--- a/rust/lance/src/dataset/scanner.rs
+++ b/rust/lance/src/dataset/scanner.rs
@@ -6924,9 +6924,13 @@ impl Scanner {
             input.clone(),
             self.get_batch_size(),
         ));
-        if let Some(take_plan) =
-            TakeExec::try_new(self.dataset.clone(), coalesced, output_projection)?
-        {
+        if let Some(take_plan) = TakeExec::try_new_with_batch_size(
+            self.dataset.clone(),
+            coalesced,
+            output_projection,
+            self.resolved_file_reader_options()
+                .and_then(|o| o.batch_size_bytes),
+        )? {
             Ok(Arc::new(take_plan))
         } else {
             // No new columns needed
@@ -8370,6 +8374,113 @@ mod test {
                 .contains("strict_batch_size=true cannot be combined with batch_size_bytes=8192"),
             "unexpected error: {error}"
         );
+    }
+
+    #[tokio::test]
+    async fn test_batch_size_bytes_blob_v2_late_materialization() {
+        use lance_core::datatypes::BlobHandling;
+        use lance_table::io::commit::RenameCommitHandler;
+
+        let blob_meta = HashMap::from([("lance-encoding:blob".to_string(), "true".to_string())]);
+        let blobs = array::rand_fixedbin(ByteCount::from(8 * 1024), true).with_metadata(blob_meta);
+        let data = gen_batch()
+            .col("filterme", array::step::<Int32Type>())
+            .col("blobs", blobs)
+            .into_reader_rows(RowCount::from(500), BatchCount::from(8));
+
+        let dataset = Dataset::write(
+            data,
+            "memory://test",
+            Some(WriteParams {
+                commit_handler: Some(Arc::new(RenameCommitHandler)),
+                data_storage_version: Some(LanceFileVersion::Stable),
+                ..Default::default()
+            }),
+        )
+        .await
+        .unwrap();
+
+        let target_bytes = 8 * 1024;
+        let mut scan = dataset.scan();
+        scan.project(&["blobs"])
+            .unwrap()
+            .blob_handling(BlobHandling::AllBinary)
+            .filter("filterme < 100")
+            .unwrap()
+            .batch_size_bytes(target_bytes);
+        let batches = scan
+            .try_into_stream()
+            .await
+            .unwrap()
+            .try_collect::<Vec<_>>()
+            .await
+            .unwrap();
+
+        assert_eq!(batches.iter().map(|b| b.num_rows()).sum::<usize>(), 100);
+        for batch in &batches {
+            assert!(
+                batch.get_array_memory_size() <= (target_bytes * 2) as usize,
+                "batch has {} bytes, limit is {}",
+                batch.get_array_memory_size(),
+                target_bytes * 2
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn test_batch_size_bytes_blob_v2_vector_search() {
+        use lance_core::datatypes::BlobHandling;
+        use lance_table::io::commit::RenameCommitHandler;
+
+        let blob_meta = HashMap::from([("lance-encoding:blob".to_string(), "true".to_string())]);
+        let blobs = array::rand_fixedbin(ByteCount::from(8 * 1024), true).with_metadata(blob_meta);
+        let vectors = array::rand_vec::<Float32Type>(Dimension::from(32));
+        let data = gen_batch()
+            .col("i", array::step::<Int32Type>())
+            .col("vec", vectors)
+            .col("blobs", blobs)
+            .into_reader_rows(RowCount::from(500), BatchCount::from(8));
+
+        let dataset = Dataset::write(
+            data,
+            "memory://test",
+            Some(WriteParams {
+                commit_handler: Some(Arc::new(RenameCommitHandler)),
+                data_storage_version: Some(LanceFileVersion::Stable),
+                ..Default::default()
+            }),
+        )
+        .await
+        .unwrap();
+
+        let query = Float32Array::from_iter_values((0..32).map(|v| v as f32));
+        let target_bytes = 8 * 1024;
+        let k = 20;
+        let mut scan = dataset.scan();
+        scan.nearest("vec", &query, k)
+            .unwrap()
+            .use_index(false)
+            .project(&["blobs"])
+            .unwrap()
+            .blob_handling(BlobHandling::AllBinary)
+            .batch_size_bytes(target_bytes);
+        let batches = scan
+            .try_into_stream()
+            .await
+            .unwrap()
+            .try_collect::<Vec<_>>()
+            .await
+            .unwrap();
+
+        assert_eq!(batches.iter().map(|b| b.num_rows()).sum::<usize>(), k);
+        for batch in &batches {
+            assert!(
+                batch.get_array_memory_size() <= (target_bytes * 2) as usize,
+                "batch has {} bytes, limit is {}",
+                batch.get_array_memory_size(),
+                target_bytes * 2
+            );
+        }
     }
 
     #[tokio::test]

--- a/rust/lance/src/io/exec/filtered_read.rs
+++ b/rust/lance/src/io/exec/filtered_read.rs
@@ -71,6 +71,8 @@ use crate::dataset::versions;
 use super::utils::IoMetrics;
 
 type MaterializedReadBatchFut = futures::future::BoxFuture<'static, Result<MaterializedBlobBatch>>;
+type MaterializedReadBatchesFut =
+    futures::future::BoxFuture<'static, Result<Vec<MaterializedBlobBatch>>>;
 
 fn public_blob_v2_binary_projection_schema(projection: &Projection) -> SchemaRef {
     let schema = projection.to_schema();
@@ -438,7 +440,7 @@ struct FilteredReadStream {
     /// The stream of filtered rows, expressed as a stream of tasks (batch futures)
     ///
     /// This stream can be shared by multiple partitions
-    task_stream: Arc<AsyncMutex<BoxStream<'static, Result<MaterializedReadBatchFut>>>>,
+    task_stream: Arc<AsyncMutex<BoxStream<'static, Result<MaterializedReadBatchesFut>>>>,
     /// The scan scheduler for the scan
     scan_scheduler: Arc<ScanScheduler>,
     /// The global metrics for the scan
@@ -546,7 +548,7 @@ pub fn coalesce_batches(
                 return Ok(Some((this.emit()?, this)));
             }
             if this.exhausted {
-                return Ok(None);
+                return Ok::<_, DataFusionError>(None);
             }
             match this.input.try_next().await? {
                 Some(batch) if batch.num_rows() >= this.target && !this.buffered.is_empty() => {
@@ -696,7 +698,7 @@ impl FilteredReadStream {
         let mut task_stream = self.task_stream.lock().await;
         (&mut *task_stream)
             .try_buffered(decode_parallelism)
-            .try_collect()
+            .try_concat()
             .await
     }
 
@@ -1329,6 +1331,8 @@ impl FilteredReadStream {
                 let partition_metrics_clone = partition_metrics.clone();
                 let base_batch_stream = futures_stream
                     .try_buffered(num_threads)
+                    .map_ok(|batches| futures::stream::iter(batches.into_iter().map(Ok)))
+                    .try_flatten()
                     .map_ok(MaterializedBlobBatch::into_batch)
                     .try_filter_map(move |batch| {
                         std::future::ready(Ok(if batch.num_rows() == 0 {
@@ -1392,14 +1396,16 @@ impl FilteredReadStream {
                             };
                             if let Some(task) = maybe_task {
                                 let task = task?;
-                                let batch = task.await?.into_batch();
-                                partition_metrics
-                                    .baseline_metrics
-                                    .record_output(batch.num_rows());
+                                let batches = task.await?;
+                                let batch_rows = batches
+                                    .iter()
+                                    .map(|batch| batch.batch().num_rows())
+                                    .sum::<usize>();
+                                partition_metrics.baseline_metrics.record_output(batch_rows);
 
                                 global_metrics.io_metrics.record(&scan_scheduler);
 
-                                Ok(Some((batch, task_stream)))
+                                Ok::<_, lance_core::Error>(Some((batches, task_stream)))
                             } else {
                                 partition_metrics.baseline_metrics.done();
                                 Ok(None)
@@ -1408,6 +1414,9 @@ impl FilteredReadStream {
                         .instrument(tracing::debug_span!("filtered_read_task"))
                     }
                 })
+                .map_ok(|batches| futures::stream::iter(batches.into_iter().map(Ok)))
+                .try_flatten()
+                .map_ok(MaterializedBlobBatch::into_batch)
                 .try_filter_map(move |batch| {
                     std::future::ready(Ok(if batch.num_rows() == 0 {
                         None
@@ -1430,7 +1439,11 @@ impl FilteredReadStream {
         fragment_soft_limit: Option<u64>,
         materialization_context: Arc<BlobMaterializationContext>,
         materialize_blob_v2_binary: bool,
-    ) -> Result<BoxStream<'static, Result<MaterializedReadBatchFut>>> {
+    ) -> Result<BoxStream<'static, Result<MaterializedReadBatchesFut>>> {
+        let batch_size_bytes = fragment_read_task
+            .file_reader_options
+            .as_ref()
+            .and_then(|o| o.batch_size_bytes);
         let output_schema = if materialize_blob_v2_binary {
             public_blob_v2_binary_projection_schema(fragment_read_task.projection.as_ref())
         } else {
@@ -1553,7 +1566,19 @@ impl FilteredReadStream {
                 physical_filter.clone(),
                 output_schema.clone(),
             )))
-            .map(|(batch_fut, args)| Self::wrap_with_filter(batch_fut, args.0, args.1));
+            .map(|(batch_fut, args)| Self::wrap_with_filter(batch_fut, args.0, args.1))
+            .map(move |batch_fut_result| {
+                let batch_fut = batch_fut_result?;
+                Ok(batch_fut
+                    .and_then(move |batch| {
+                        futures::future::ready(if let Some(budget) = batch_size_bytes {
+                            batch.split_by_bytes((budget * 2) as usize)
+                        } else {
+                            Ok(vec![batch])
+                        })
+                    })
+                    .boxed())
+            });
 
         let result = if let Some(limit) = fragment_soft_limit {
             Self::apply_soft_limit(fragment_stream, limit).boxed()
@@ -1591,9 +1616,9 @@ impl FilteredReadStream {
     fn apply_soft_limit<S>(
         stream: S,
         limit: u64,
-    ) -> impl Stream<Item = Result<MaterializedReadBatchFut>>
+    ) -> impl Stream<Item = Result<MaterializedReadBatchesFut>>
     where
-        S: Stream<Item = Result<MaterializedReadBatchFut>>,
+        S: Stream<Item = Result<MaterializedReadBatchesFut>>,
     {
         let rows_read = Arc::new(AtomicUsize::new(0));
 
@@ -1607,8 +1632,9 @@ impl FilteredReadStream {
                 batch_fut_result.map(move |batch_fut| {
                     batch_fut
                         .map(move |batch_result| {
-                            batch_result.inspect(|batch| {
-                                let batch_rows = batch.batch().num_rows();
+                            batch_result.inspect(|batches| {
+                                let batch_rows =
+                                    batches.iter().map(|b| b.batch().num_rows()).sum::<usize>();
                                 rows_read.fetch_add(batch_rows, Ordering::Relaxed);
                             })
                         })
@@ -2970,29 +2996,38 @@ impl RowStreamRead {
         batch: RecordBatch,
         batch_index: u32,
         admission: crate::dataset::blob::BlobMaterializationAdmission,
-    ) -> DataFusionResult<MaterializedBlobBatch> {
+    ) -> DataFusionResult<Vec<MaterializedBlobBatch>> {
         if batch.num_rows() == 0 {
-            return Ok(MaterializedBlobBatch::unreserved(RecordBatch::new_empty(
-                self.output_schema.clone(),
-            )));
+            return Ok(vec![MaterializedBlobBatch::unreserved(
+                RecordBatch::new_empty(self.output_schema.clone()),
+            )]);
         }
         let internal_plan = self.plan_batch(self.key_array(&batch, "input")?).await?;
         let read_data = self.read_batch(internal_plan, batch_index).await?;
         let attached = self.attach_columns(batch, read_data)?;
-        if let Some(output_schema) = &self.source.materialization_output_schema {
-            Ok(
-                crate::dataset::blob::materialize_blob_v2_binary_batch_with_admission(
-                    &self.dataset,
-                    output_schema,
-                    attached.into_batch(),
-                    &self.materialization_context,
-                    admission,
-                )
-                .await?,
+        let batch_size_bytes = self
+            .source
+            .read_options
+            .file_reader_options
+            .as_ref()
+            .and_then(|o| o.batch_size_bytes);
+        let result = if let Some(output_schema) = &self.source.materialization_output_schema {
+            crate::dataset::blob::materialize_blob_v2_binary_batch_with_admission(
+                &self.dataset,
+                output_schema,
+                attached.into_batch(),
+                &self.materialization_context,
+                admission,
             )
+            .await?
         } else {
             drop(admission);
-            Ok(attached)
+            attached
+        };
+        if let Some(budget) = batch_size_bytes {
+            Ok(result.split_by_bytes((budget * 2) as usize)?)
+        } else {
+            Ok(vec![result])
         }
     }
 
@@ -3029,6 +3064,8 @@ impl RowStreamRead {
             })
             .boxed()
             .try_buffered(ROW_STREAM_CONCURRENT_BATCHES)
+            .map_ok(|batches| futures::stream::iter(batches.into_iter().map(Ok)))
+            .try_flatten()
             .map_ok(MaterializedBlobBatch::into_batch)
             .map(move |result| {
                 on_result

--- a/rust/lance/src/io/exec/pushdown_scan.rs
+++ b/rust/lance/src/io/exec/pushdown_scan.rs
@@ -327,6 +327,11 @@ impl FragmentScanner {
         let batch_readahead = self.config.batch_readahead;
         let simplified_predicates = self.simplified_predicates()?;
         let ordered_output = self.config.ordered_output;
+        let batch_size_bytes = self
+            .config
+            .file_reader_options
+            .as_ref()
+            .and_then(|o| o.batch_size_bytes);
 
         let scanner = Arc::new(self);
 
@@ -362,6 +367,21 @@ impl FragmentScanner {
                 .buffer_unordered(batch_readahead)
                 .try_filter_map(|res| futures::future::ready(Ok(res)))
                 .boxed()
+        };
+
+        let stream = if let Some(budget) = batch_size_bytes {
+            stream
+                .and_then(move |batch| {
+                    futures::future::ready(
+                        crate::dataset::blob::split_batch_by_bytes(batch, (budget * 2) as usize)
+                            .map_err(DataFusionError::from),
+                    )
+                })
+                .map_ok(|batches| futures::stream::iter(batches.into_iter().map(Ok)))
+                .try_flatten()
+                .boxed()
+        } else {
+            stream
         };
 
         Ok(stream)

--- a/rust/lance/src/io/exec/scan.rs
+++ b/rust/lance/src/io/exec/scan.rs
@@ -378,6 +378,10 @@ impl LanceStream {
             )
             .stream_in_current_span()
             .boxed();
+        let batch_size_bytes = config
+            .file_reader_options
+            .as_ref()
+            .and_then(|o| o.batch_size_bytes);
         let inner_stream = if materialize_blob_v2_binary {
             inner_stream
                 .map_ok(move |batch| {
@@ -399,6 +403,16 @@ impl LanceStream {
                 })
                 .try_buffered(config.batch_readahead)
                 .map_ok(|batch| batch.into_batch())
+                .and_then(move |batch| {
+                    futures::future::ready(if let Some(budget) = batch_size_bytes {
+                        crate::dataset::blob::split_batch_by_bytes(batch, (budget * 2) as usize)
+                            .map_err(DataFusionError::from)
+                    } else {
+                        Ok(vec![batch])
+                    })
+                })
+                .map_ok(|batches| futures::stream::iter(batches.into_iter().map(Ok)))
+                .try_flatten()
                 .boxed()
         } else {
             inner_stream

--- a/rust/lance/src/io/exec/take.rs
+++ b/rust/lance/src/io/exec/take.rs
@@ -75,6 +75,9 @@ struct TakeStream {
     /// must be materialized after take.
     read_fields: Arc<Schema>,
     materialize_blob_v2_binary: bool,
+    /// Scanner-level byte budget for output batches. Applied after blob v2
+    /// payloads are materialized so that the final batch size is capped.
+    batch_size_bytes: Option<u64>,
     /// The output schema, needed for us to merge the new columns
     /// into the input data in the correct order
     output_schema: SchemaRef,
@@ -96,6 +99,7 @@ impl TakeStream {
         scan_scheduler: Arc<ScanScheduler>,
         metrics: &ExecutionPlanMetricsSet,
         partition: usize,
+        batch_size_bytes: Option<u64>,
     ) -> Self {
         let materialize_blob_v2_binary =
             crate::dataset::blob::schema_has_blob_v2_binary_view(fields_to_take.as_ref());
@@ -111,6 +115,7 @@ impl TakeStream {
             fields_to_take,
             read_fields,
             materialize_blob_v2_binary,
+            batch_size_bytes,
             output_schema,
             readers_cache: Arc::new(Mutex::new(HashMap::new())),
             scan_scheduler,
@@ -239,7 +244,7 @@ impl TakeStream {
         self: Arc<Self>,
         batch: RecordBatch,
         batch_number: u32,
-    ) -> DataFusionResult<RecordBatch> {
+    ) -> DataFusionResult<Vec<RecordBatch>> {
         let compute_timer = self.metrics.baseline_metrics.elapsed_compute().timer();
         let (row_addrs_arr, validity_mask) = self.get_row_addrs(&batch).await?;
 
@@ -354,7 +359,7 @@ impl TakeStream {
         let batches = futures.try_collect::<Vec<_>>().await?;
 
         if batches.is_empty() {
-            return Ok(RecordBatch::new_empty(self.output_schema.clone()));
+            return Ok(vec![RecordBatch::new_empty(self.output_schema.clone())]);
         }
 
         let _compute_timer = self.metrics.baseline_metrics.elapsed_compute().timer();
@@ -399,7 +404,15 @@ impl TakeStream {
             .await?;
         }
 
-        Ok(batch.merge_with_schema(&new_data, self.output_schema.as_ref())?)
+        let merged = batch.merge_with_schema(&new_data, self.output_schema.as_ref())?;
+        if let Some(budget) = self.batch_size_bytes {
+            Ok(crate::dataset::blob::split_batch_by_bytes(
+                merged,
+                (budget * 2) as usize,
+            )?)
+        } else {
+            Ok(vec![merged])
+        }
     }
 
     fn apply<S: Stream<Item = Result<RecordBatch>> + Send + 'static>(
@@ -423,6 +436,8 @@ impl TakeStream {
             .boxed();
         batches
             .try_buffered(get_num_compute_intensive_cpus())
+            .map_ok(|batches| futures::stream::iter(batches.into_iter().map(Ok)))
+            .try_flatten()
             .map(move |result| {
                 if result.is_ok() {
                     result_metrics.batches_processed.add(1);
@@ -459,6 +474,8 @@ pub struct TakeExec {
     input: Arc<dyn ExecutionPlan>,
     properties: Arc<PlanProperties>,
     metrics: ExecutionPlanMetricsSet,
+    /// Scanner-level byte budget for output batches.
+    batch_size_bytes: Option<u64>,
 }
 
 impl DisplayAs for TakeExec {
@@ -507,6 +524,16 @@ impl TakeExec {
         input: Arc<dyn ExecutionPlan>,
         projection: Projection,
     ) -> Result<Option<Self>> {
+        Self::try_new_with_batch_size(dataset, input, projection, None)
+    }
+
+    /// Create a [`TakeExec`] node with an explicit byte budget for output batches.
+    pub fn try_new_with_batch_size(
+        dataset: Arc<Dataset>,
+        input: Arc<dyn ExecutionPlan>,
+        projection: Projection,
+        batch_size_bytes: Option<u64>,
+    ) -> Result<Option<Self>> {
         let original_projection = projection.clone();
         let projection =
             projection.subtract_arrow_schema(input.schema().as_ref(), OnMissing::Ignore)?;
@@ -553,6 +580,7 @@ impl TakeExec {
             output_schema: output_arrow,
             properties,
             metrics: ExecutionPlanMetricsSet::new(),
+            batch_size_bytes,
         }))
     }
 
@@ -649,7 +677,12 @@ impl ExecutionPlan for TakeExec {
 
         let projection = self.output_projection.clone();
 
-        let plan = Self::try_new(self.dataset.clone(), children[0].clone(), projection)?;
+        let plan = Self::try_new_with_batch_size(
+            self.dataset.clone(),
+            children[0].clone(),
+            projection,
+            self.batch_size_bytes,
+        )?;
 
         if let Some(plan) = plan {
             Ok(Arc::new(plan))
@@ -669,6 +702,7 @@ impl ExecutionPlan for TakeExec {
         let schema_to_take = self.schema_to_take.clone();
         let output_schema = self.output_schema.clone();
         let metrics = self.metrics.clone();
+        let batch_size_bytes = self.batch_size_bytes;
 
         // ScanScheduler::new launches the I/O scheduler in the background.
         // We aren't allowed to do work in `execute` and so we defer creation of the
@@ -686,6 +720,7 @@ impl ExecutionPlan for TakeExec {
                 scan_scheduler,
                 &metrics,
                 partition,
+                batch_size_bytes,
             ));
             take_stream.apply(input_stream)
         });


### PR DESCRIPTION
close #8857

Apply the scanner's `batch_size_bytes` budget a second time after blob v2 payloads are materialized, splitting the merged batch by bytes so blob reads are capped at 2x oversubscription relative to the inline/descriptor budget.