### PR TITLE
fix: preserve complete blob v2 logical schemas

### DIFF
--- a/docs/src/guide/blob.md
+++ b/docs/src/guide/blob.md
@@ -65,6 +65,22 @@ source of truth for which scheme is supported at each `data_storage_version`.
 
 Use `blob_field` and `blob_array` to build blob v2 columns.
 
+### Logical Arrow schema
+
+A blob v2 field is tagged with `ARROW:extension:name = "lance.blob.v2"`. Writers
+accept these logical struct shapes:
+
+| Shape | Children | Use |
+|---|---|---|
+| Minimal | `data: LargeBinary?`, `uri: Utf8?` | Inline bytes or a complete external object |
+| Complete | Minimal fields plus `position: UInt64?`, `size: UInt64?` | An optional byte range within an external object |
+
+For the complete shape, `position` and `size` must either both be set or both be
+null, and a range requires `uri`. Python's `blob_field` and `BlobType` use the
+complete shape. Lance preserves an accepted logical shape, including child
+fields, nullability, and metadata, across create, append, and merge-insert writes;
+descriptor scans still return the compact stored descriptor shape.
+
 ```python
 import lance
 import pyarrow as pa

--- a/docs/src/guide/blob.md
+++ b/docs/src/guide/blob.md
@@ -75,11 +75,14 @@ accept these logical struct shapes:
 | Minimal | `data: LargeBinary?`, `uri: Utf8?` | Inline bytes or a complete external object |
 | Complete | Minimal fields plus `position: UInt64?`, `size: UInt64?` | An optional byte range within an external object |
 
-For the complete shape, `position` and `size` must either both be set or both be
-null, and a range requires `uri`. Python's `blob_field` and `BlobType` use the
+Every non-null row must set exactly one of `data` and `uri`. For the complete
+shape, `position` and `size` must either both be set or both be null, a range
+requires `uri`, and an explicit range must have `size > 0`. Use inline `b""` for
+an empty blob; a URI without range fields still represents the complete external
+object, including an empty object. Python's `blob_field` and `BlobType` use the
 complete shape. Lance preserves an accepted logical shape, including child
-fields, nullability, and metadata, across create, append, and merge-insert writes;
-descriptor scans still return the compact stored descriptor shape.
+fields, nullability, and metadata, across create, append, and merge-insert
+writes; descriptor scans still return the compact stored descriptor shape.
 
 ```python
 import lance

--- a/python/python/lance/blob.py
+++ b/python/python/lance/blob.py
@@ -97,11 +97,12 @@ class BlobType(pa.ExtensionType):
 
     This is the "logical" type users write. Lance will store it in a compact
     descriptor format, and reads will return descriptors by default. Its storage
-    type is ``Struct<data: LargeBinary?, uri: Utf8?, position: UInt64?,
-    size: UInt64?>``. ``position`` and ``size`` select a range within an external
-    ``uri`` and must either both be set or both be null. When set, ``size`` must
-    be greater than zero. Every non-null value must set exactly one of ``data``
-    and ``uri``.
+    type defaults to ``Struct<data: LargeBinary?, uri: Utf8?, position: UInt64?,
+    size: UInt64?>``. Arrow deserialization also preserves the accepted minimal
+    ``Struct<data: LargeBinary?, uri: Utf8?>`` storage type. ``position`` and
+    ``size`` select a range within an external ``uri`` and must either both be set
+    or both be null. When set, ``size`` must be greater than zero. Every non-null
+    value must set exactly one of ``data`` and ``uri``.
     """
 
     def __init__(self) -> None:
@@ -118,11 +119,47 @@ class BlobType(pa.ExtensionType):
     def __arrow_ext_serialize__(self) -> bytes:
         return b""
 
+    @staticmethod
+    def _validate_storage_type(storage_type: pa.DataType) -> None:
+        if not pa.types.is_struct(storage_type):
+            raise TypeError("BlobType storage type must be a struct")
+
+        fields = list(storage_type)
+        if len(fields) not in (2, 4):
+            raise TypeError(
+                "BlobType storage struct must contain either data/uri or "
+                "data/uri/position/size"
+            )
+
+        expected_fields = [
+            ("data", pa.large_binary()),
+            ("uri", pa.utf8()),
+            ("position", pa.uint64()),
+            ("size", pa.uint64()),
+        ]
+        for index, field in enumerate(fields):
+            expected_name, expected_type = expected_fields[index]
+            if field.name != expected_name or field.type != expected_type:
+                raise TypeError(
+                    "BlobType storage field "
+                    f"{index} must be {expected_name}: {expected_type}, got "
+                    f"{field.name}: {field.type}"
+                )
+            if index < 2 and not field.nullable:
+                raise TypeError(f"BlobType storage field {field.name} must be nullable")
+
+    @classmethod
+    def _from_storage_type(cls, storage_type: pa.DataType) -> "BlobType":
+        cls._validate_storage_type(storage_type)
+        instance = cls.__new__(cls)
+        pa.ExtensionType.__init__(instance, storage_type, "lance.blob.v2")
+        return instance
+
     @classmethod
     def __arrow_ext_deserialize__(
         cls, storage_type: pa.DataType, serialized: bytes
     ) -> "BlobType":
-        return BlobType()
+        return cls._from_storage_type(storage_type)
 
     def __arrow_ext_class__(self):
         return BlobArray

--- a/python/python/lance/blob.py
+++ b/python/python/lance/blob.py
@@ -41,8 +41,10 @@ class Blob:
 
     A blob can be represented as:
     - inline bytes
-    - an external URI with position and size, if position and size are not set,
-      use the full uri.
+    - an external URI, optionally with a non-empty range
+
+    Every blob must use exactly one representation. Use ``None`` for a null
+    blob and :meth:`empty` for a valid empty blob.
     """
 
     data: Optional[bytes] = None
@@ -65,6 +67,10 @@ class Blob:
             raise ValueError(
                 "Blob cannot have both inline data and external slice metadata"
             )
+        if self.data is None and self.uri is None:
+            raise ValueError("Blob must set `data` or `uri`; use None for a null blob")
+        if self.size == 0:
+            raise ValueError("External blob range size must be greater than zero")
 
     @staticmethod
     def from_bytes(data: Union[bytes, bytearray, memoryview]) -> "Blob":
@@ -93,7 +99,9 @@ class BlobType(pa.ExtensionType):
     descriptor format, and reads will return descriptors by default. Its storage
     type is ``Struct<data: LargeBinary?, uri: Utf8?, position: UInt64?,
     size: UInt64?>``. ``position`` and ``size`` select a range within an external
-    ``uri`` and must either both be set or both be null.
+    ``uri`` and must either both be set or both be null. When set, ``size`` must
+    be greater than zero. Every non-null value must set exactly one of ``data``
+    and ``uri``.
     """
 
     def __init__(self) -> None:
@@ -244,8 +252,10 @@ def blob_field(
 
     The returned field uses the complete logical blob shape
     ``Struct<data: LargeBinary?, uri: Utf8?, position: UInt64?, size: UInt64?>``.
-    Lance preserves this logical schema across create, append, and merge-insert
-    writes while storing compact descriptors internally.
+    Every non-null value must set exactly one of ``data`` and ``uri``. External
+    ranges must set both ``position`` and a positive ``size``. Lance preserves
+    this logical schema across create, append, and merge-insert writes while
+    storing compact descriptors internally.
 
     Parameters
     ----------

--- a/python/python/lance/blob.py
+++ b/python/python/lance/blob.py
@@ -90,7 +90,10 @@ class BlobType(pa.ExtensionType):
     A PyArrow extension type for Lance blob columns.
 
     This is the "logical" type users write. Lance will store it in a compact
-    descriptor format, and reads will return descriptors by default.
+    descriptor format, and reads will return descriptors by default. Its storage
+    type is ``Struct<data: LargeBinary?, uri: Utf8?, position: UInt64?,
+    size: UInt64?>``. ``position`` and ``size`` select a range within an external
+    ``uri`` and must either both be set or both be null.
     """
 
     def __init__(self) -> None:
@@ -238,6 +241,11 @@ def blob_field(
 ) -> pa.Field:
     """
     Construct an Arrow field for a Lance blob column.
+
+    The returned field uses the complete logical blob shape
+    ``Struct<data: LargeBinary?, uri: Utf8?, position: UInt64?, size: UInt64?>``.
+    Lance preserves this logical schema across create, append, and merge-insert
+    writes while storing compact descriptors internally.
 
     Parameters
     ----------

--- a/python/python/tests/test_blob.py
+++ b/python/python/tests/test_blob.py
@@ -56,6 +56,26 @@ def _blob_sidecar_path(data_dir, data_file_key, blob_id):
     return data_dir / data_file_key / sidecar_name
 
 
+def _complete_blob_table(ids, values):
+    schema = pa.schema([pa.field("id", pa.int64()), lance.blob_field("blob")])
+    return pa.Table.from_arrays(
+        [pa.array(ids, type=pa.int64()), lance.blob_array(values)],
+        schema=schema,
+    )
+
+
+def _assert_complete_blob_schema(dataset):
+    blob_type = dataset.schema.field("blob").type
+    assert isinstance(blob_type, pa.ExtensionType)
+    assert blob_type.extension_name == "lance.blob.v2"
+    assert [field.name for field in blob_type.storage_type] == [
+        "data",
+        "uri",
+        "position",
+        "size",
+    ]
+
+
 def _add_columns_blob_v2_values(tmp_path):
     external_base = tmp_path / "external_base"
     external_blob = external_base / "external_blob.bin"
@@ -908,65 +928,55 @@ def test_blob_extension_write_inline(tmp_path):
         assert f.read() == b"foo"
 
 
-def test_complete_blob_schema_survives_create_append_and_merge_insert(tmp_path):
-    dataset_path = tmp_path / "complete_blob_schema"
-    external_path = tmp_path / "external.bin"
-    external_path.write_bytes(b"prefix-range-suffix")
-    schema = pa.schema([pa.field("id", pa.int64()), lance.blob_field("blob")])
-
-    def make_table(ids, values):
-        return pa.Table.from_arrays(
-            [pa.array(ids, type=pa.int64()), lance.blob_array(values)],
-            schema=schema,
-        )
-
-    def assert_complete_blob_schema(dataset):
-        blob_type = dataset.schema.field("blob").type
-        assert isinstance(blob_type, pa.ExtensionType)
-        assert blob_type.extension_name == "lance.blob.v2"
-        assert [field.name for field in blob_type.storage_type] == [
-            "data",
-            "uri",
-            "position",
-            "size",
-        ]
-
+def test_complete_blob_schema_survives_create(tmp_path):
+    dataset_path = tmp_path / "complete_blob_create"
     ds = lance.write_dataset(
-        make_table(
-            [0, 1],
-            [
-                Blob.from_uri(external_path.as_uri(), position=7, size=5),
-                b"initial",
-            ],
-        ),
+        _complete_blob_table([0], [b"created"]),
         dataset_path,
         data_storage_version="2.2",
-        external_blob_mode="ingest",
     )
-    external_path.unlink()
-    assert_complete_blob_schema(ds)
+    _assert_complete_blob_schema(ds)
+    assert ds.to_table(blob_handling="all_binary")["blob"].to_pylist() == [b"created"]
 
-    lance.write_dataset(make_table([2], [b"appended"]), dataset_path, mode="append")
+
+def test_complete_blob_schema_survives_append(tmp_path):
+    dataset_path = tmp_path / "complete_blob_append"
+    lance.write_dataset(
+        _complete_blob_table([0], [b"initial"]),
+        dataset_path,
+        data_storage_version="2.2",
+    )
+
+    lance.write_dataset(
+        _complete_blob_table([1], [b"appended"]), dataset_path, mode="append"
+    )
     ds = lance.dataset(dataset_path)
-    assert_complete_blob_schema(ds)
+    _assert_complete_blob_schema(ds)
+    result = ds.to_table(blob_handling="all_binary").sort_by("id")
+    assert result["id"].to_pylist() == [0, 1]
+    assert result["blob"].to_pylist() == [b"initial", b"appended"]
+
+
+def test_complete_blob_schema_survives_merge_insert(tmp_path):
+    dataset_path = tmp_path / "complete_blob_merge_insert"
+    ds = lance.write_dataset(
+        _complete_blob_table([0, 1], [b"zero", b"initial"]),
+        dataset_path,
+        data_storage_version="2.2",
+    )
 
     (
         ds.merge_insert("id")
         .when_matched_update_all()
         .when_not_matched_insert_all()
-        .execute(make_table([1, 3], [b"updated", b"inserted"]))
+        .execute(_complete_blob_table([1, 2], [b"updated", b"inserted"]))
     )
     ds = lance.dataset(dataset_path)
-    assert_complete_blob_schema(ds)
+    _assert_complete_blob_schema(ds)
 
     result = ds.to_table(blob_handling="all_binary").sort_by("id")
-    assert result["id"].to_pylist() == [0, 1, 2, 3]
-    assert result["blob"].to_pylist() == [
-        b"range",
-        b"updated",
-        b"appended",
-        b"inserted",
-    ]
+    assert result["id"].to_pylist() == [0, 1, 2]
+    assert result["blob"].to_pylist() == [b"zero", b"updated", b"inserted"]
 
 
 def test_blob_field_threshold_metadata():

--- a/python/python/tests/test_blob.py
+++ b/python/python/tests/test_blob.py
@@ -65,6 +65,20 @@ def _complete_blob_table(ids, values):
     )
 
 
+def _complete_blob_storage_table(data, uri, position, size):
+    storage = pa.StructArray.from_arrays(
+        [
+            pa.array([data], type=pa.large_binary()),
+            pa.array([uri], type=pa.utf8()),
+            pa.array([position], type=pa.uint64()),
+            pa.array([size], type=pa.uint64()),
+        ],
+        names=["data", "uri", "position", "size"],
+    )
+    blobs = pa.ExtensionArray.from_storage(BlobType(), storage)
+    return pa.Table.from_arrays([blobs], schema=pa.schema([lance.blob_field("blob")]))
+
+
 def _assert_complete_blob_schema(dataset):
     blob_type = dataset.schema.field("blob").type
     assert isinstance(blob_type, pa.ExtensionType)
@@ -1009,6 +1023,84 @@ def test_complete_blob_rows_reject_invalid_ranges(tmp_path, use_uri, position, s
             data_storage_version="2.2",
             allow_external_blob_outside_bases=True,
         )
+
+
+@pytest.mark.parametrize("mode", ["reference", "ingest"])
+def test_complete_blob_rows_reject_zero_size_range(tmp_path, mode):
+    source = tmp_path / "source.bin"
+    source.write_bytes(b"0123456789")
+    table = _complete_blob_storage_table(None, source.as_uri(), 3, 0)
+
+    with pytest.raises(OSError, match="greater than zero"):
+        lance.write_dataset(
+            table,
+            tmp_path / "dataset",
+            data_storage_version="2.2",
+            external_blob_mode=mode,
+            allow_external_blob_outside_bases=mode == "reference",
+        )
+
+
+@pytest.mark.parametrize(
+    ("data", "use_uri"),
+    [
+        pytest.param(b"small", True, id="both-small"),
+        pytest.param(b"x" * 70_000, True, id="both-packed"),
+        pytest.param(None, False, id="neither"),
+    ],
+)
+def test_complete_blob_rows_reject_invalid_representation(tmp_path, data, use_uri):
+    source = tmp_path / "source.bin"
+    source.write_bytes(b"external")
+    table = _complete_blob_storage_table(
+        data, source.as_uri() if use_uri else None, None, None
+    )
+
+    with pytest.raises(OSError, match="data|uri"):
+        lance.write_dataset(
+            table,
+            tmp_path / "dataset",
+            data_storage_version="2.2",
+            allow_external_blob_outside_bases=True,
+        )
+
+
+@pytest.mark.parametrize("mode", ["reference", "ingest"])
+def test_empty_external_object_without_range(tmp_path, mode):
+    source = tmp_path / "empty.bin"
+    source.write_bytes(b"")
+
+    dataset = lance.write_dataset(
+        pa.table({"blob": lance.blob_array([source.as_uri()])}),
+        tmp_path / "dataset",
+        data_storage_version="2.2",
+        external_blob_mode=mode,
+        allow_external_blob_outside_bases=mode == "reference",
+    )
+
+    with dataset.take_blobs("blob", indices=[0])[0] as blob:
+        assert blob.read() == b""
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "message"),
+    [
+        pytest.param({}, "must set `data` or `uri`", id="neither"),
+        pytest.param(
+            {"data": b"data", "uri": "file:///source.bin"},
+            "both data and uri",
+            id="both",
+        ),
+        pytest.param(
+            {"uri": "file:///source.bin", "position": 3, "size": 0},
+            "greater than zero",
+            id="zero-size",
+        ),
+    ],
+)
+def test_blob_rejects_invalid_logical_value(kwargs, message):
+    with pytest.raises(ValueError, match=message):
+        Blob(**kwargs)
 
 
 def test_blob_field_threshold_metadata():

--- a/python/python/tests/test_blob.py
+++ b/python/python/tests/test_blob.py
@@ -91,6 +91,31 @@ def _assert_complete_blob_schema(dataset):
     ]
 
 
+def _assert_blob_storage_type_equal(actual, expected):
+    assert isinstance(actual, pa.StructType)
+    assert isinstance(expected, pa.StructType)
+    assert len(actual) == len(expected)
+    for actual_field, expected_field in zip(actual, expected):
+        assert actual_field.equals(expected_field, check_metadata=True)
+
+
+def _inline_blob_array(storage_type, value):
+    arrays = [
+        pa.array([value], type=pa.large_binary()),
+        pa.array([None], type=pa.utf8()),
+    ]
+    if len(storage_type) == 4:
+        arrays.extend(
+            [
+                pa.array([None], type=pa.uint64()),
+                pa.array([None], type=pa.uint64()),
+            ]
+        )
+    storage = pa.StructArray.from_arrays(arrays, fields=list(storage_type))
+    blob_type = BlobType.__arrow_ext_deserialize__(storage_type, b"")
+    return pa.ExtensionArray.from_storage(blob_type, storage)
+
+
 def _add_columns_blob_v2_values(tmp_path):
     external_base = tmp_path / "external_base"
     external_blob = external_base / "external_blob.bin"
@@ -1101,6 +1126,138 @@ def test_empty_external_object_without_range(tmp_path, mode):
 def test_blob_rejects_invalid_logical_value(kwargs, message):
     with pytest.raises(ValueError, match=message):
         Blob(**kwargs)
+
+
+@pytest.mark.parametrize(
+    "storage_type",
+    [
+        pytest.param(
+            pa.struct(
+                [
+                    pa.field("data", pa.large_binary()),
+                    pa.field("uri", pa.utf8()),
+                ]
+            ),
+            id="minimal",
+        ),
+        pytest.param(BlobType().storage_type, id="complete-nullable-range"),
+        pytest.param(
+            pa.struct(
+                [
+                    pa.field(
+                        "data",
+                        pa.large_binary(),
+                        metadata={b"source": b"preserved"},
+                    ),
+                    pa.field("uri", pa.utf8()),
+                    pa.field("position", pa.uint64(), nullable=False),
+                    pa.field("size", pa.uint64(), nullable=False),
+                ]
+            ),
+            id="complete-required-range-with-metadata",
+        ),
+    ],
+)
+def test_blob_type_preserves_storage_type_through_arrow_ipc(storage_type):
+    blob_type = BlobType.__arrow_ext_deserialize__(storage_type, b"")
+    schema = pa.schema([pa.field("blob", blob_type)])
+    sink = pa.BufferOutputStream()
+    with pa.ipc.new_stream(sink, schema):
+        pass
+
+    restored_type = pa.ipc.open_stream(sink.getvalue()).schema.field("blob").type
+
+    assert isinstance(restored_type, BlobType)
+    _assert_blob_storage_type_equal(restored_type.storage_type, storage_type)
+
+
+@pytest.mark.parametrize(
+    "storage_type",
+    [
+        pytest.param(pa.int32(), id="not-struct"),
+        pytest.param(
+            pa.struct(
+                [
+                    pa.field("data", pa.large_binary()),
+                    pa.field("uri", pa.utf8()),
+                    pa.field("position", pa.uint64()),
+                ]
+            ),
+            id="incomplete-range-shape",
+        ),
+        pytest.param(
+            pa.struct(
+                [
+                    pa.field("data", pa.large_binary(), nullable=False),
+                    pa.field("uri", pa.utf8()),
+                ]
+            ),
+            id="required-data",
+        ),
+        pytest.param(
+            pa.struct(
+                [
+                    pa.field("data", pa.large_binary()),
+                    pa.field("uri", pa.utf8()),
+                    pa.field("position", pa.uint64()),
+                    pa.field("size", pa.int64()),
+                ]
+            ),
+            id="wrong-range-type",
+        ),
+    ],
+)
+def test_blob_type_rejects_invalid_storage_type(storage_type):
+    with pytest.raises(TypeError, match="BlobType storage"):
+        BlobType.__arrow_ext_deserialize__(storage_type, b"")
+
+
+@pytest.mark.parametrize(
+    ("initial_storage_type", "append_storage_type"),
+    [
+        pytest.param(
+            pa.struct(
+                [
+                    pa.field("data", pa.large_binary()),
+                    pa.field("uri", pa.utf8()),
+                ]
+            ),
+            BlobType().storage_type,
+            id="complete-to-minimal",
+        ),
+        pytest.param(
+            BlobType().storage_type,
+            pa.struct(
+                [
+                    pa.field("data", pa.large_binary()),
+                    pa.field("uri", pa.utf8()),
+                ]
+            ),
+            id="minimal-to-complete",
+        ),
+    ],
+)
+def test_blob_v2_append_accepts_mixed_logical_shapes(
+    tmp_path, initial_storage_type, append_storage_type
+):
+    dataset_path = tmp_path / "mixed_blob_shapes"
+    initial = pa.Table.from_arrays(
+        [_inline_blob_array(initial_storage_type, b"initial")], names=["blob"]
+    )
+    append = pa.Table.from_arrays(
+        [_inline_blob_array(append_storage_type, b"appended")], names=["blob"]
+    )
+
+    lance.write_dataset(initial, dataset_path, data_storage_version="2.2")
+    lance.write_dataset(append, dataset_path, mode="append")
+    dataset = lance.dataset(dataset_path)
+
+    _assert_blob_storage_type_equal(
+        dataset.schema.field("blob").type.storage_type,
+        initial_storage_type,
+    )
+    blobs = dataset.take_blobs("blob", indices=[0, 1])
+    assert [blob.readall() for blob in blobs] == [b"initial", b"appended"]
 
 
 def test_blob_field_threshold_metadata():

--- a/python/python/tests/test_blob.py
+++ b/python/python/tests/test_blob.py
@@ -908,6 +908,67 @@ def test_blob_extension_write_inline(tmp_path):
         assert f.read() == b"foo"
 
 
+def test_complete_blob_schema_survives_create_append_and_merge_insert(tmp_path):
+    dataset_path = tmp_path / "complete_blob_schema"
+    external_path = tmp_path / "external.bin"
+    external_path.write_bytes(b"prefix-range-suffix")
+    schema = pa.schema([pa.field("id", pa.int64()), lance.blob_field("blob")])
+
+    def make_table(ids, values):
+        return pa.Table.from_arrays(
+            [pa.array(ids, type=pa.int64()), lance.blob_array(values)],
+            schema=schema,
+        )
+
+    def assert_complete_blob_schema(dataset):
+        blob_type = dataset.schema.field("blob").type
+        assert isinstance(blob_type, pa.ExtensionType)
+        assert blob_type.extension_name == "lance.blob.v2"
+        assert [field.name for field in blob_type.storage_type] == [
+            "data",
+            "uri",
+            "position",
+            "size",
+        ]
+
+    ds = lance.write_dataset(
+        make_table(
+            [0, 1],
+            [
+                Blob.from_uri(external_path.as_uri(), position=7, size=5),
+                b"initial",
+            ],
+        ),
+        dataset_path,
+        data_storage_version="2.2",
+        external_blob_mode="ingest",
+    )
+    external_path.unlink()
+    assert_complete_blob_schema(ds)
+
+    lance.write_dataset(make_table([2], [b"appended"]), dataset_path, mode="append")
+    ds = lance.dataset(dataset_path)
+    assert_complete_blob_schema(ds)
+
+    (
+        ds.merge_insert("id")
+        .when_matched_update_all()
+        .when_not_matched_insert_all()
+        .execute(make_table([1, 3], [b"updated", b"inserted"]))
+    )
+    ds = lance.dataset(dataset_path)
+    assert_complete_blob_schema(ds)
+
+    result = ds.to_table(blob_handling="all_binary").sort_by("id")
+    assert result["id"].to_pylist() == [0, 1, 2, 3]
+    assert result["blob"].to_pylist() == [
+        b"range",
+        b"updated",
+        b"appended",
+        b"inserted",
+    ]
+
+
 def test_blob_field_threshold_metadata():
     field = lance.blob_field(
         "blob",

--- a/python/python/tests/test_blob.py
+++ b/python/python/tests/test_blob.py
@@ -18,6 +18,7 @@ import pandas as pd
 import pyarrow as pa
 import pytest
 from lance import Blob, BlobColumn, BlobFile, DatasetBasePath
+from lance.blob import BlobType
 from lance.file import LanceFileSession
 from lance.fragment import write_fragments
 
@@ -977,6 +978,37 @@ def test_complete_blob_schema_survives_merge_insert(tmp_path):
     result = ds.to_table(blob_handling="all_binary").sort_by("id")
     assert result["id"].to_pylist() == [0, 1, 2]
     assert result["blob"].to_pylist() == [b"zero", b"updated", b"inserted"]
+
+
+@pytest.mark.parametrize(
+    ("use_uri", "position", "size"),
+    [
+        pytest.param(True, 3, None, id="missing-size"),
+        pytest.param(False, 3, 2, id="range-without-uri"),
+    ],
+)
+def test_complete_blob_rows_reject_invalid_ranges(tmp_path, use_uri, position, size):
+    source = tmp_path / "source.bin"
+    source.write_bytes(b"0123456789")
+    storage = pa.StructArray.from_arrays(
+        [
+            pa.array([None], type=pa.large_binary()),
+            pa.array([source.as_uri() if use_uri else None], type=pa.utf8()),
+            pa.array([position], type=pa.uint64()),
+            pa.array([size], type=pa.uint64()),
+        ],
+        names=["data", "uri", "position", "size"],
+    )
+    blobs = pa.ExtensionArray.from_storage(BlobType(), storage)
+    table = pa.Table.from_arrays([blobs], schema=pa.schema([lance.blob_field("blob")]))
+
+    with pytest.raises(OSError, match="position|size|uri"):
+        lance.write_dataset(
+            table,
+            tmp_path / "dataset",
+            data_storage_version="2.2",
+            allow_external_blob_outside_bases=True,
+        )
 
 
 def test_blob_field_threshold_metadata():

--- a/rust/lance-core/src/datatypes.rs
+++ b/rust/lance-core/src/datatypes.rs
@@ -62,8 +62,9 @@ pub static BLOB_V2_LOGICAL_MINIMAL_FIELDS: LazyLock<Fields> = LazyLock::new(|| {
 /// The complete logical blob v2 fields used for writer input and rewrite output.
 ///
 /// `position` and `size` are an optional range within the external object named
-/// by `uri`. They do not describe Lance-managed data, packed, or dedicated
-/// storage.
+/// by `uri`; when present, `size` must be greater than zero. Every non-null row
+/// must set exactly one of `data` and `uri`. These fields do not describe
+/// Lance-managed data, packed, or dedicated storage.
 pub static BLOB_V2_LOGICAL_FIELDS: LazyLock<Fields> = LazyLock::new(|| {
     let mut fields = BLOB_V2_LOGICAL_MINIMAL_FIELDS
         .iter()

--- a/rust/lance-core/src/datatypes/field.rs
+++ b/rust/lance-core/src/datatypes/field.rs
@@ -30,7 +30,7 @@ use super::{
 };
 use crate::{
     Error, Result,
-    datatypes::{BLOB_DESC_LANCE_FIELD, BLOB_V2_DESC_LANCE_FIELD},
+    datatypes::{BLOB_DESC_LANCE_FIELD, BLOB_V2_DESC_LANCE_FIELD, BlobV2Layout},
     utils::parse::str_is_truthy,
 };
 
@@ -368,12 +368,22 @@ impl Field {
                 self_name
             ));
         }
-        let children_differences = explain_fields_difference(
-            &self.children,
-            &expected.children,
-            options,
-            Some(&self_name),
-        );
+        let children_differences =
+            if let Some(shared_child_count) = self.blob_v2_logical_shared_child_count(expected) {
+                explain_fields_difference(
+                    &self.children[..shared_child_count],
+                    &expected.children[..shared_child_count],
+                    options,
+                    Some(&self_name),
+                )
+            } else {
+                explain_fields_difference(
+                    &self.children,
+                    &expected.children,
+                    options,
+                    Some(&self_name),
+                )
+            };
         if !children_differences.is_empty() {
             let children_differences = format!(
                 "`{}` had mismatched children: {}",
@@ -411,10 +421,20 @@ impl Field {
     }
 
     pub fn compare_with_options(&self, expected: &Self, options: &SchemaCompareOptions) -> bool {
+        let children_match = self
+            .blob_v2_logical_shared_child_count(expected)
+            .map(|shared_child_count| {
+                compare_fields(
+                    &self.children[..shared_child_count],
+                    &expected.children[..shared_child_count],
+                    options,
+                )
+            })
+            .unwrap_or_else(|| compare_fields(&self.children, &expected.children, options));
         self.name == expected.name
             && self.logical_type == expected.logical_type
             && Self::compare_nullability(expected.nullable, self.nullable, options)
-            && compare_fields(&self.children, &expected.children, options)
+            && children_match
             && (!options.compare_field_ids || self.id == expected.id)
             && (!options.compare_dictionary || self.dictionary == expected.dictionary)
             && (!options.compare_metadata || self.metadata == expected.metadata)
@@ -544,6 +564,26 @@ impl Field {
             .map(|name| name == BLOB_V2_EXT_NAME)
             .unwrap_or(false)
             || self.is_blob_v2_descriptor()
+    }
+
+    fn blob_v2_layout(&self) -> Option<BlobV2Layout> {
+        if self.extension_name() != Some(BLOB_V2_EXT_NAME) {
+            return None;
+        }
+        let DataType::Struct(fields) = self.data_type() else {
+            return None;
+        };
+        BlobV2Layout::classify(&fields)
+    }
+
+    fn blob_v2_logical_shared_child_count(&self, other: &Self) -> Option<usize> {
+        if self.blob_v2_layout() == Some(BlobV2Layout::Logical)
+            && other.blob_v2_layout() == Some(BlobV2Layout::Logical)
+        {
+            Some(self.children.len().min(other.children.len()))
+        } else {
+            None
+        }
     }
 
     fn is_blob_v2_descriptor(&self) -> bool {
@@ -1275,6 +1315,101 @@ mod tests {
     use arrow_schema::{Fields, TimeUnit};
     use lance_arrow::BLOB_META_KEY;
     use std::collections::HashMap;
+
+    use crate::datatypes::{BLOB_V2_LOGICAL_FIELDS, BLOB_V2_LOGICAL_MINIMAL_FIELDS};
+
+    fn blob_v2_logical_field(children: Fields) -> Field {
+        ArrowField::new("blob", DataType::Struct(children), true)
+            .with_metadata(HashMap::from([(
+                ARROW_EXT_NAME_KEY.to_string(),
+                BLOB_V2_EXT_NAME.to_string(),
+            )]))
+            .try_into()
+            .unwrap()
+    }
+
+    #[test]
+    fn blob_v2_logical_shapes_are_compatible() {
+        let minimal = blob_v2_logical_field(BLOB_V2_LOGICAL_MINIMAL_FIELDS.clone());
+        let complete = blob_v2_logical_field(BLOB_V2_LOGICAL_FIELDS.clone());
+        let complete_required_range = blob_v2_logical_field(Fields::from(
+            BLOB_V2_LOGICAL_FIELDS
+                .iter()
+                .enumerate()
+                .map(|(index, field)| Arc::new(field.as_ref().clone().with_nullable(index < 2)))
+                .collect::<Vec<_>>(),
+        ));
+        let options = SchemaCompareOptions::default();
+
+        for complete_shape in [&complete, &complete_required_range] {
+            assert!(minimal.compare_with_options(complete_shape, &options));
+            assert!(complete_shape.compare_with_options(&minimal, &options));
+            assert_eq!(minimal.explain_difference(complete_shape, &options), None);
+            assert_eq!(complete_shape.explain_difference(&minimal, &options), None);
+        }
+
+        assert!(!complete.compare_with_options(&complete_required_range, &options));
+        let ignore_nullability = SchemaCompareOptions {
+            compare_nullability: NullabilityComparison::Ignore,
+            ..Default::default()
+        };
+        assert!(complete.compare_with_options(&complete_required_range, &ignore_nullability));
+
+        let complete_with_child_metadata = blob_v2_logical_field(Fields::from(
+            BLOB_V2_LOGICAL_FIELDS
+                .iter()
+                .enumerate()
+                .map(|(index, field)| {
+                    let field = if index == 0 {
+                        field.as_ref().clone().with_metadata(HashMap::from([(
+                            "source".to_string(),
+                            "test".to_string(),
+                        )]))
+                    } else {
+                        field.as_ref().clone()
+                    };
+                    Arc::new(field)
+                })
+                .collect::<Vec<_>>(),
+        ));
+        let compare_metadata = SchemaCompareOptions {
+            compare_metadata: true,
+            ..Default::default()
+        };
+        assert!(!complete.compare_with_options(&complete_with_child_metadata, &compare_metadata));
+
+        let nested_minimal: Field = ArrowField::new(
+            "outer",
+            DataType::Struct(Fields::from(vec![ArrowField::from(&minimal)])),
+            true,
+        )
+        .try_into()
+        .unwrap();
+        let nested_complete: Field = ArrowField::new(
+            "outer",
+            DataType::Struct(Fields::from(vec![ArrowField::from(&complete)])),
+            true,
+        )
+        .try_into()
+        .unwrap();
+        assert!(nested_minimal.compare_with_options(&nested_complete, &options));
+        assert!(nested_complete.compare_with_options(&nested_minimal, &options));
+    }
+
+    #[test]
+    fn malformed_blob_v2_logical_shapes_remain_incompatible() {
+        let minimal = blob_v2_logical_field(BLOB_V2_LOGICAL_MINIMAL_FIELDS.clone());
+        let malformed = blob_v2_logical_field(Fields::from(vec![
+            ArrowField::new("data", DataType::LargeBinary, true),
+            ArrowField::new("uri", DataType::LargeUtf8, true),
+        ]));
+        let options = SchemaCompareOptions::default();
+
+        assert!(!minimal.compare_with_options(&malformed, &options));
+        assert!(!malformed.compare_with_options(&minimal, &options));
+        assert!(minimal.explain_difference(&malformed, &options).is_some());
+        assert!(malformed.explain_difference(&minimal, &options).is_some());
+    }
 
     #[test]
     fn arrow_field_to_field_metadata() {

--- a/rust/lance/src/blob.rs
+++ b/rust/lance/src/blob.rs
@@ -1398,6 +1398,43 @@ mod tests {
     }
 
     #[test]
+    fn test_prepared_to_logical_blob_schema_preserves_non_blob_fields() {
+        let mut metadata = HashMap::new();
+        metadata.insert(ARROW_EXT_NAME_KEY.to_string(), BLOB_V2_EXT_NAME.to_string());
+        let prepared_field = prepared_blob_field_with_metadata("blob", true, metadata);
+        let dict_field = Field::new(
+            "dict",
+            DataType::Dictionary(Box::new(DataType::UInt32), Box::new(DataType::Utf8)),
+            true,
+        );
+        let mut schema =
+            LanceSchema::try_from(&ArrowSchema::new(vec![dict_field, prepared_field])).unwrap();
+        schema.fields[0].id = 42;
+        schema.fields[1].id = 7;
+
+        let dictionary_values = Arc::new(StringArray::from(vec!["a", "b"])) as ArrayRef;
+        schema.fields[0].set_dictionary_values(&dictionary_values);
+
+        let normalized = prepared_to_logical_blob_schema(&schema).unwrap();
+
+        assert_eq!(normalized.fields[0].id, 42);
+        assert_eq!(
+            normalized.fields[0]
+                .dictionary
+                .as_ref()
+                .and_then(|dict| dict.values.as_ref())
+                .map(|values| values.len()),
+            Some(2)
+        );
+        assert_eq!(normalized.fields[1].id, 7);
+        assert_eq!(normalized.fields[1].children.len(), 2);
+        assert_eq!(normalized.fields[1].children[0].name, "data");
+        assert_eq!(normalized.fields[1].children[1].name, "uri");
+        assert!(normalized.fields[1].children[0].id >= 0);
+        assert!(normalized.fields[1].children[1].id >= 0);
+    }
+
+    #[test]
     fn test_prepared_blob_schema_normalizes_by_semantic_child_name() {
         let mut metadata = HashMap::new();
         metadata.insert(ARROW_EXT_NAME_KEY.to_string(), BLOB_V2_EXT_NAME.to_string());

--- a/rust/lance/src/blob.rs
+++ b/rust/lance/src/blob.rs
@@ -5,9 +5,9 @@
 //!
 //! Logical blob input uses either `Struct<data: LargeBinary?, uri: Utf8?>` or the complete
 //! `Struct<data: LargeBinary?, uri: Utf8?, position: UInt64?, size: UInt64?>` shape. In the
-//! complete shape, `position` and `size` select a range within an external `uri` and must be
-//! set together. File-level blob preparation produces a kind-aware writer intermediate with
-//! `blob_id` and range fields.
+//! complete shape, `position` and `size` select a non-empty range within an external `uri` and
+//! must be set together. Every non-null row must set exactly one of `data` and `uri`. File-level
+//! blob preparation produces a kind-aware writer intermediate with `blob_id` and range fields.
 
 use std::collections::{HashMap, HashSet};
 use std::num::NonZeroUsize;

--- a/rust/lance/src/blob.rs
+++ b/rust/lance/src/blob.rs
@@ -3,8 +3,11 @@
 
 //! Builders and file-level writer helpers for Lance blob v2 columns.
 //!
-//! Logical blob input uses `Struct<data: LargeBinary?, uri: Utf8?>`. File-level blob
-//! preparation produces a kind-aware writer intermediate with `blob_id` and range fields.
+//! Logical blob input uses either `Struct<data: LargeBinary?, uri: Utf8?>` or the complete
+//! `Struct<data: LargeBinary?, uri: Utf8?, position: UInt64?, size: UInt64?>` shape. In the
+//! complete shape, `position` and `size` select a range within an external `uri` and must be
+//! set together. File-level blob preparation produces a kind-aware writer intermediate with
+//! `blob_id` and range fields.
 
 use std::collections::{HashMap, HashSet};
 use std::num::NonZeroUsize;
@@ -45,8 +48,10 @@ use crate::{Error, Result};
 
 /// Construct the Arrow field for a blob v2 column.
 ///
-/// Blob v2 expects a column shaped as `Struct<data: LargeBinary?, uri: Utf8?>` and
-/// tagged with `ARROW:extension:name = "lance.blob.v2"`.
+/// This helper constructs the minimal logical shape
+/// `Struct<data: LargeBinary?, uri: Utf8?>`, tagged with
+/// `ARROW:extension:name = "lance.blob.v2"`. Writers also accept the complete logical shape
+/// with trailing `position: UInt64?` and `size: UInt64?` fields for external URI ranges.
 pub fn blob_field(name: &str, nullable: bool) -> Field {
     blob_field_with_options(name, nullable, BlobFieldOptions::default())
 }
@@ -79,8 +84,10 @@ impl BlobFieldOptions {
 
 /// Construct the Arrow field for a blob v2 column with storage layout options.
 ///
-/// Blob v2 expects a column shaped as `Struct<data: LargeBinary?, uri: Utf8?>` and
-/// tagged with `ARROW:extension:name = "lance.blob.v2"`.
+/// This helper constructs the minimal logical shape
+/// `Struct<data: LargeBinary?, uri: Utf8?>`, tagged with
+/// `ARROW:extension:name = "lance.blob.v2"`. Writers also accept the complete logical shape
+/// with trailing `position: UInt64?` and `size: UInt64?` fields for external URI ranges.
 ///
 /// ```
 /// # use lance::{BlobFieldOptions, blob_field_with_options};
@@ -171,9 +178,17 @@ fn prepared_to_logical_blob_lance_field(field: &LanceField) -> Result<LanceField
             Some(BlobV2Layout::Prepared) => {
                 let mut normalized = field.clone();
                 let mut logical_children = logical_blob_lance_children()?;
-                for (logical_child, prepared_child) in
-                    logical_children.iter_mut().zip(field.children.iter())
-                {
+                for logical_child in &mut logical_children {
+                    let prepared_child = field
+                        .children
+                        .iter()
+                        .find(|prepared_child| prepared_child.name == logical_child.name)
+                        .ok_or_else(|| {
+                            Error::internal(format!(
+                                "Prepared blob v2 field '{}' is missing logical child '{}'",
+                                field.name, logical_child.name
+                            ))
+                        })?;
                     logical_child.id = prepared_child.id;
                     logical_child.parent_id = field.id;
                 }
@@ -1055,11 +1070,13 @@ mod tests {
     use super::*;
     use arrow_array::cast::AsArray;
     use arrow_array::{Array, StringArray};
-    use arrow_schema::Schema as ArrowSchema;
+    use arrow_schema::{Fields, Schema as ArrowSchema};
     use async_trait::async_trait;
     use futures::task::noop_waker;
+    use lance_core::datatypes::{BLOB_V2_DESC_FIELDS, BLOB_V2_LOGICAL_FIELDS};
     use lance_core::utils::tempfile::TempDir;
     use lance_io::object_writer::WriteResult;
+    use rstest::rstest;
     use tokio::io::AsyncWrite;
 
     #[derive(Clone, Copy)]
@@ -1291,41 +1308,159 @@ mod tests {
         }
     }
 
-    #[test]
-    fn test_prepared_to_logical_blob_schema_preserves_non_blob_fields() {
+    #[derive(Clone, Copy)]
+    enum LogicalBlobShape {
+        Minimal,
+        CompleteNullableRange,
+        CompleteRequiredRange,
+    }
+
+    fn blob_v2_field_with_children(name: &str, children: Fields, nullable: bool) -> Field {
         let mut metadata = HashMap::new();
         metadata.insert(ARROW_EXT_NAME_KEY.to_string(), BLOB_V2_EXT_NAME.to_string());
-        let prepared_field = prepared_blob_field_with_metadata("blob", true, metadata);
+        metadata.insert("blob-root-metadata".to_string(), "preserved".to_string());
+        Field::new(name, DataType::Struct(children), nullable).with_metadata(metadata)
+    }
+
+    fn logical_blob_fields(shape: LogicalBlobShape) -> Fields {
+        let source = match shape {
+            LogicalBlobShape::Minimal => &*BLOB_V2_LOGICAL_MINIMAL_FIELDS,
+            LogicalBlobShape::CompleteNullableRange | LogicalBlobShape::CompleteRequiredRange => {
+                &*BLOB_V2_LOGICAL_FIELDS
+            }
+        };
+        source
+            .iter()
+            .enumerate()
+            .map(|(index, field)| {
+                let nullable = !matches!(shape, LogicalBlobShape::CompleteRequiredRange)
+                    || index < BLOB_V2_LOGICAL_MINIMAL_FIELDS.len();
+                Arc::new(
+                    field
+                        .as_ref()
+                        .clone()
+                        .with_nullable(nullable)
+                        .with_metadata(HashMap::from([(
+                            "blob-child-metadata".to_string(),
+                            field.name().to_string(),
+                        )])),
+                )
+            })
+            .collect::<Vec<_>>()
+            .into()
+    }
+
+    fn lance_schema_with_metadata(fields: Vec<Field>) -> LanceSchema {
+        let arrow_schema = ArrowSchema::new_with_metadata(
+            fields,
+            HashMap::from([("schema-metadata".to_string(), "preserved".to_string())]),
+        );
+        let mut schema = LanceSchema::try_from(&arrow_schema).unwrap();
+        schema.set_field_id(None);
+        schema
+    }
+
+    #[rstest]
+    #[case::minimal(LogicalBlobShape::Minimal)]
+    #[case::complete_nullable_range(LogicalBlobShape::CompleteNullableRange)]
+    #[case::complete_required_range(LogicalBlobShape::CompleteRequiredRange)]
+    fn test_logical_blob_schema_normalization_is_identity(#[case] shape: LogicalBlobShape) {
+        let blob_field = blob_v2_field_with_children("blob", logical_blob_fields(shape), false);
+        let schema = lance_schema_with_metadata(vec![blob_field]);
+
+        let normalized = prepared_to_logical_blob_schema(&schema).unwrap();
+
+        assert_eq!(normalized.fields, schema.fields);
+        assert_eq!(normalized.metadata, schema.metadata);
+    }
+
+    #[test]
+    fn test_nested_logical_blob_schema_normalization_is_identity() {
+        let struct_blob = blob_v2_field_with_children(
+            "struct_blob",
+            logical_blob_fields(LogicalBlobShape::CompleteNullableRange),
+            true,
+        );
+        let list_blob = blob_v2_field_with_children(
+            "item",
+            logical_blob_fields(LogicalBlobShape::CompleteRequiredRange),
+            false,
+        );
+        let schema = lance_schema_with_metadata(vec![
+            Field::new("payload", DataType::Struct(vec![struct_blob].into()), true),
+            Field::new("items", DataType::List(Arc::new(list_blob)), false),
+        ]);
+
+        let normalized = prepared_to_logical_blob_schema(&schema).unwrap();
+
+        assert_eq!(normalized.fields, schema.fields);
+        assert_eq!(normalized.metadata, schema.metadata);
+    }
+
+    #[test]
+    fn test_prepared_blob_schema_normalizes_by_semantic_child_name() {
+        let mut metadata = HashMap::new();
+        metadata.insert(ARROW_EXT_NAME_KEY.to_string(), BLOB_V2_EXT_NAME.to_string());
+        metadata.insert("blob-root-metadata".to_string(), "preserved".to_string());
+        let prepared_field = prepared_blob_field_with_metadata("blob", false, metadata);
         let dict_field = Field::new(
             "dict",
             DataType::Dictionary(Box::new(DataType::UInt32), Box::new(DataType::Utf8)),
             true,
         );
-        let mut schema =
-            LanceSchema::try_from(&ArrowSchema::new(vec![dict_field, prepared_field])).unwrap();
+        let mut schema = lance_schema_with_metadata(vec![dict_field, prepared_field]);
         schema.fields[0].id = 42;
         schema.fields[1].id = 7;
+        for (child, id) in schema.fields[1].children.iter_mut().zip(70..76) {
+            child.id = id;
+            child.parent_id = 7;
+        }
 
         let dictionary_values = Arc::new(StringArray::from(vec!["a", "b"])) as ArrayRef;
         schema.fields[0].set_dictionary_values(&dictionary_values);
 
         let normalized = prepared_to_logical_blob_schema(&schema).unwrap();
 
-        assert_eq!(normalized.fields[0].id, 42);
-        assert_eq!(
-            normalized.fields[0]
-                .dictionary
-                .as_ref()
-                .and_then(|dict| dict.values.as_ref())
-                .map(|values| values.len()),
-            Some(2)
-        );
+        assert_eq!(normalized.metadata, schema.metadata);
+        assert_eq!(normalized.fields[0], schema.fields[0]);
         assert_eq!(normalized.fields[1].id, 7);
+        assert!(!normalized.fields[1].nullable);
+        assert_eq!(normalized.fields[1].metadata, schema.fields[1].metadata);
         assert_eq!(normalized.fields[1].children.len(), 2);
         assert_eq!(normalized.fields[1].children[0].name, "data");
+        assert_eq!(normalized.fields[1].children[0].id, 71);
+        assert_eq!(normalized.fields[1].children[0].parent_id, 7);
         assert_eq!(normalized.fields[1].children[1].name, "uri");
-        assert!(normalized.fields[1].children[0].id >= 0);
-        assert!(normalized.fields[1].children[1].id >= 0);
+        assert_eq!(normalized.fields[1].children[1].id, 72);
+        assert_eq!(normalized.fields[1].children[1].parent_id, 7);
+    }
+
+    #[rstest]
+    #[case::descriptor(BLOB_V2_DESC_FIELDS.clone(), "descriptor layout")]
+    #[case::malformed(
+        vec![
+            Field::new("data", DataType::LargeBinary, true),
+            Field::new("uri", DataType::Utf8, true),
+            Field::new("size", DataType::UInt64, true),
+        ].into(),
+        "unrecognized layout"
+    )]
+    fn test_non_logical_blob_schema_normalization_is_rejected(
+        #[case] fields: Fields,
+        #[case] actual_layout: &str,
+    ) {
+        let field = blob_v2_field_with_children("blob", fields, true);
+        let schema = lance_schema_with_metadata(vec![field]);
+
+        let error = prepared_to_logical_blob_schema(&schema).unwrap_err();
+
+        assert!(matches!(error, Error::InvalidInput { .. }));
+        assert!(error.to_string().contains(actual_layout));
+        assert!(
+            error
+                .to_string()
+                .contains("expected logical or prepared layout")
+        );
     }
 
     #[tokio::test]

--- a/rust/lance/src/dataset/blob.rs
+++ b/rust/lance/src/dataset/blob.rs
@@ -4286,7 +4286,7 @@ mod tests {
         BLOB_V2_EXT_NAME, DataTypeExt,
     };
     use lance_core::{
-        datatypes::{BlobHandling, BlobKind, OnMissing},
+        datatypes::{BLOB_V2_LOGICAL_FIELDS, BlobHandling, BlobKind, OnMissing},
         utils::blob::blob_path,
     };
     use lance_io::object_store::{
@@ -4372,8 +4372,48 @@ mod tests {
         );
     }
 
-    fn nested_blob_v2_batch(blob_array: ArrayRef) -> (Arc<Schema>, RecordBatch) {
-        let blob_field = blob_field("blob", true);
+    fn complete_blob_v2_field(name: &str, nullable: bool) -> Field {
+        Field::new(
+            name,
+            DataType::Struct(BLOB_V2_LOGICAL_FIELDS.clone()),
+            nullable,
+        )
+        .with_metadata(HashMap::from([(
+            ARROW_EXT_NAME_KEY.to_string(),
+            BLOB_V2_EXT_NAME.to_string(),
+        )]))
+    }
+
+    fn complete_blob_v2_array(
+        data: Vec<Option<Vec<u8>>>,
+        uris: Vec<Option<String>>,
+        positions: Vec<Option<u64>>,
+        sizes: Vec<Option<u64>>,
+        validity: Option<NullBuffer>,
+    ) -> ArrayRef {
+        Arc::new(
+            StructArray::try_new(
+                BLOB_V2_LOGICAL_FIELDS.clone(),
+                vec![
+                    Arc::new(LargeBinaryArray::from_iter(
+                        data.iter().map(|value| value.as_deref()),
+                    )) as ArrayRef,
+                    Arc::new(StringArray::from_iter(
+                        uris.iter().map(|value| value.as_deref()),
+                    )) as ArrayRef,
+                    Arc::new(UInt64Array::from(positions)) as ArrayRef,
+                    Arc::new(UInt64Array::from(sizes)) as ArrayRef,
+                ],
+                validity,
+            )
+            .unwrap(),
+        )
+    }
+
+    fn nested_blob_v2_batch_with_field(
+        blob_field: Field,
+        blob_array: ArrayRef,
+    ) -> (Arc<Schema>, RecordBatch) {
         let info_fields = vec![Field::new("name", DataType::Utf8, false), blob_field];
         let info_array: ArrayRef = Arc::new(
             StructArray::try_new(
@@ -4396,6 +4436,10 @@ mod tests {
         )]));
         let batch = RecordBatch::try_new(schema.clone(), vec![info_array]).unwrap();
         (schema, batch)
+    }
+
+    fn nested_blob_v2_batch(blob_array: ArrayRef) -> (Arc<Schema>, RecordBatch) {
+        nested_blob_v2_batch_with_field(blob_field("blob", true), blob_array)
     }
 
     #[cfg(feature = "azure")]
@@ -6037,17 +6081,20 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_write_and_take_nested_blob_v2() {
+    async fn test_write_and_take_nested_complete_blob_v2() {
         let test_dir = TempStrDir::default();
         let packed_payload = vec![0x4A; super::INLINE_MAX + 1024];
 
-        let mut blob_builder = BlobArrayBuilder::new(3);
-        blob_builder.push_bytes(b"hello").unwrap();
-        blob_builder.push_bytes(&packed_payload).unwrap();
-        blob_builder.push_null().unwrap();
-        let blob_array: ArrayRef = blob_builder.finish().unwrap();
+        let blob_array = complete_blob_v2_array(
+            vec![Some(b"hello".to_vec()), Some(packed_payload.clone()), None],
+            vec![None, None, None],
+            vec![None, None, None],
+            vec![None, None, None],
+            Some(NullBuffer::from(vec![true, true, false])),
+        );
 
-        let (schema, batch) = nested_blob_v2_batch(blob_array);
+        let (schema, batch) =
+            nested_blob_v2_batch_with_field(complete_blob_v2_field("blob", true), blob_array);
         let reader = RecordBatchIterator::new(vec![batch].into_iter().map(Ok), schema);
 
         let dataset = Arc::new(
@@ -7718,67 +7765,72 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_blob_v2_external_ingest_inline_slice() {
+    async fn test_complete_blob_v2_create_append_and_external_slice() {
         let dataset_dir = TempDir::default();
         let external_dir = TempDir::default();
         let external_path = external_dir.std_path().join("external.bin");
         std::fs::write(&external_path, b"prefix-inline-suffix").unwrap();
         let external_uri = format!("file://{}", external_path.display());
 
-        let metadata = [(ARROW_EXT_NAME_KEY.to_string(), BLOB_V2_EXT_NAME.to_string())]
-            .into_iter()
-            .collect();
-        let blob_field = Field::new(
-            "blob",
-            DataType::Struct(
-                vec![
-                    Field::new("data", DataType::LargeBinary, true),
-                    Field::new("uri", DataType::Utf8, true),
-                    Field::new("position", DataType::UInt64, true),
-                    Field::new("size", DataType::UInt64, true),
-                ]
-                .into(),
-            ),
-            true,
-        )
-        .with_metadata(metadata);
-        let blob_array: ArrayRef = Arc::new(
-            StructArray::try_new(
-                vec![
-                    Field::new("data", DataType::LargeBinary, true),
-                    Field::new("uri", DataType::Utf8, true),
-                    Field::new("position", DataType::UInt64, true),
-                    Field::new("size", DataType::UInt64, true),
-                ]
-                .into(),
-                vec![
-                    Arc::new(arrow_array::LargeBinaryArray::from(vec![None::<&[u8]>])) as ArrayRef,
-                    Arc::new(StringArray::from(vec![Some(external_uri.as_str())])) as ArrayRef,
-                    Arc::new(UInt64Array::from(vec![Some(7)])) as ArrayRef,
-                    Arc::new(UInt64Array::from(vec![Some(6)])) as ArrayRef,
-                ],
-                None,
-            )
-            .unwrap(),
+        let blob_field = complete_blob_v2_field("blob", true);
+        let blob_array = complete_blob_v2_array(
+            vec![None],
+            vec![Some(external_uri)],
+            vec![Some(7)],
+            vec![Some(6)],
+            None,
         );
         let schema = Arc::new(Schema::new(vec![blob_field]));
         let batch = RecordBatch::try_new(schema.clone(), vec![blob_array]).unwrap();
         let reader = RecordBatchIterator::new(vec![batch].into_iter().map(Ok), schema);
 
-        let dataset = Arc::new(
-            Dataset::write(
-                reader,
-                &dataset_dir.path_str(),
-                Some(WriteParams {
-                    data_storage_version: Some(LanceFileVersion::V2_2),
-                    external_blob_mode: ExternalBlobMode::Ingest,
-                    ..Default::default()
-                }),
+        let mut dataset = Dataset::write(
+            reader,
+            &dataset_dir.path_str(),
+            Some(WriteParams {
+                data_storage_version: Some(LanceFileVersion::V2_2),
+                external_blob_mode: ExternalBlobMode::Ingest,
+                ..Default::default()
+            }),
+        )
+        .await
+        .unwrap();
+
+        let dataset_schema = Schema::from(dataset.schema());
+        let DataType::Struct(fields) = dataset_schema.field_with_name("blob").unwrap().data_type()
+        else {
+            panic!("expected complete logical blob struct");
+        };
+        assert_eq!(fields.as_ref(), BLOB_V2_LOGICAL_FIELDS.as_ref());
+
+        let append_schema = Arc::new(Schema::new(vec![complete_blob_v2_field("blob", true)]));
+        let append_batch = RecordBatch::try_new(
+            append_schema.clone(),
+            vec![complete_blob_v2_array(
+                vec![Some(b"appended".to_vec())],
+                vec![None],
+                vec![None],
+                vec![None],
+                None,
+            )],
+        )
+        .unwrap();
+        dataset
+            .append(
+                RecordBatchIterator::new(vec![Ok(append_batch)], append_schema),
+                None,
             )
             .await
-            .unwrap(),
-        );
+            .unwrap();
 
+        let dataset_schema = Schema::from(dataset.schema());
+        let DataType::Struct(fields) = dataset_schema.field_with_name("blob").unwrap().data_type()
+        else {
+            panic!("expected complete logical blob struct after append");
+        };
+        assert_eq!(fields.as_ref(), BLOB_V2_LOGICAL_FIELDS.as_ref());
+
+        let dataset = Arc::new(dataset);
         let desc = dataset
             .scan()
             .project(&["blob"])
@@ -7797,11 +7849,20 @@ mod tests {
             BlobKind::Inline as u8
         );
 
-        let blobs = dataset.take_blobs_by_indices(&[0], "blob").await.unwrap();
-        assert_eq!(blobs.len(), 1);
-        let blob = blobs[0].as_ref().unwrap();
-        assert_eq!(blob.kind(), BlobKind::Inline);
-        assert_eq!(blob.read().await.unwrap().as_ref(), b"inline");
+        let blobs = dataset
+            .take_blobs_by_indices(&[0, 1], "blob")
+            .await
+            .unwrap();
+        assert_eq!(blobs.len(), 2);
+        assert_eq!(blobs[0].as_ref().unwrap().kind(), BlobKind::Inline);
+        assert_eq!(
+            blobs[0].as_ref().unwrap().read().await.unwrap().as_ref(),
+            b"inline"
+        );
+        assert_eq!(
+            blobs[1].as_ref().unwrap().read().await.unwrap().as_ref(),
+            b"appended"
+        );
     }
 
     #[tokio::test]

--- a/rust/lance/src/dataset/blob.rs
+++ b/rust/lance/src/dataset/blob.rs
@@ -6081,6 +6081,96 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_write_and_take_nested_blob_v2() {
+        let test_dir = TempStrDir::default();
+        let packed_payload = vec![0x4A; super::INLINE_MAX + 1024];
+
+        let mut blob_builder = BlobArrayBuilder::new(3);
+        blob_builder.push_bytes(b"hello").unwrap();
+        blob_builder.push_bytes(&packed_payload).unwrap();
+        blob_builder.push_null().unwrap();
+        let blob_array: ArrayRef = blob_builder.finish().unwrap();
+
+        let (schema, batch) = nested_blob_v2_batch(blob_array);
+        let reader = RecordBatchIterator::new(vec![batch].into_iter().map(Ok), schema);
+
+        let dataset = Arc::new(
+            Dataset::write(
+                reader,
+                &test_dir,
+                Some(WriteParams {
+                    data_storage_version: Some(LanceFileVersion::V2_2),
+                    ..Default::default()
+                }),
+            )
+            .await
+            .unwrap(),
+        );
+
+        let info_batch = dataset
+            .scan()
+            .project(&["info"])
+            .unwrap()
+            .try_into_batch()
+            .await
+            .unwrap();
+        let blob_desc = info_batch
+            .column(0)
+            .as_struct()
+            .column_by_name("blob")
+            .unwrap()
+            .as_struct();
+        assert_eq!(
+            blob_desc
+                .column_by_name("kind")
+                .unwrap()
+                .as_primitive::<UInt8Type>()
+                .value(0),
+            BlobKind::Inline as u8
+        );
+        assert_eq!(
+            blob_desc
+                .column_by_name("kind")
+                .unwrap()
+                .as_primitive::<UInt8Type>()
+                .value(1),
+            BlobKind::Packed as u8
+        );
+
+        let blobs = dataset
+            .take_blobs_by_indices(&[0, 1], "info.blob")
+            .await
+            .unwrap();
+        assert_eq!(blobs.len(), 2);
+        assert_eq!(
+            blobs[0].as_ref().unwrap().read().await.unwrap().as_ref(),
+            b"hello"
+        );
+        assert_eq!(
+            blobs[1].as_ref().unwrap().read().await.unwrap().as_ref(),
+            packed_payload.as_slice()
+        );
+
+        let null_blobs = dataset
+            .take_blobs_by_indices(&[2], "info.blob")
+            .await
+            .unwrap();
+        assert_eq!(null_blobs.len(), 1);
+        assert!(null_blobs[0].is_none());
+
+        let filtered = dataset
+            .scan()
+            .project(&["info"])
+            .unwrap()
+            .filter("info.blob IS NOT NULL")
+            .unwrap()
+            .try_into_batch()
+            .await
+            .unwrap();
+        assert_eq!(filtered.num_rows(), 2);
+    }
+
+    #[tokio::test]
     async fn test_write_and_take_nested_complete_blob_v2() {
         let test_dir = TempStrDir::default();
         let packed_payload = vec![0x4A; super::INLINE_MAX + 1024];
@@ -7765,72 +7855,67 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_complete_blob_v2_create_append_and_external_slice() {
+    async fn test_blob_v2_external_ingest_inline_slice() {
         let dataset_dir = TempDir::default();
         let external_dir = TempDir::default();
         let external_path = external_dir.std_path().join("external.bin");
         std::fs::write(&external_path, b"prefix-inline-suffix").unwrap();
         let external_uri = format!("file://{}", external_path.display());
 
-        let blob_field = complete_blob_v2_field("blob", true);
-        let blob_array = complete_blob_v2_array(
-            vec![None],
-            vec![Some(external_uri)],
-            vec![Some(7)],
-            vec![Some(6)],
-            None,
+        let metadata = [(ARROW_EXT_NAME_KEY.to_string(), BLOB_V2_EXT_NAME.to_string())]
+            .into_iter()
+            .collect();
+        let blob_field = Field::new(
+            "blob",
+            DataType::Struct(
+                vec![
+                    Field::new("data", DataType::LargeBinary, true),
+                    Field::new("uri", DataType::Utf8, true),
+                    Field::new("position", DataType::UInt64, true),
+                    Field::new("size", DataType::UInt64, true),
+                ]
+                .into(),
+            ),
+            true,
+        )
+        .with_metadata(metadata);
+        let blob_array: ArrayRef = Arc::new(
+            StructArray::try_new(
+                vec![
+                    Field::new("data", DataType::LargeBinary, true),
+                    Field::new("uri", DataType::Utf8, true),
+                    Field::new("position", DataType::UInt64, true),
+                    Field::new("size", DataType::UInt64, true),
+                ]
+                .into(),
+                vec![
+                    Arc::new(arrow_array::LargeBinaryArray::from(vec![None::<&[u8]>])) as ArrayRef,
+                    Arc::new(StringArray::from(vec![Some(external_uri.as_str())])) as ArrayRef,
+                    Arc::new(UInt64Array::from(vec![Some(7)])) as ArrayRef,
+                    Arc::new(UInt64Array::from(vec![Some(6)])) as ArrayRef,
+                ],
+                None,
+            )
+            .unwrap(),
         );
         let schema = Arc::new(Schema::new(vec![blob_field]));
         let batch = RecordBatch::try_new(schema.clone(), vec![blob_array]).unwrap();
         let reader = RecordBatchIterator::new(vec![batch].into_iter().map(Ok), schema);
 
-        let mut dataset = Dataset::write(
-            reader,
-            &dataset_dir.path_str(),
-            Some(WriteParams {
-                data_storage_version: Some(LanceFileVersion::V2_2),
-                external_blob_mode: ExternalBlobMode::Ingest,
-                ..Default::default()
-            }),
-        )
-        .await
-        .unwrap();
-
-        let dataset_schema = Schema::from(dataset.schema());
-        let DataType::Struct(fields) = dataset_schema.field_with_name("blob").unwrap().data_type()
-        else {
-            panic!("expected complete logical blob struct");
-        };
-        assert_eq!(fields.as_ref(), BLOB_V2_LOGICAL_FIELDS.as_ref());
-
-        let append_schema = Arc::new(Schema::new(vec![complete_blob_v2_field("blob", true)]));
-        let append_batch = RecordBatch::try_new(
-            append_schema.clone(),
-            vec![complete_blob_v2_array(
-                vec![Some(b"appended".to_vec())],
-                vec![None],
-                vec![None],
-                vec![None],
-                None,
-            )],
-        )
-        .unwrap();
-        dataset
-            .append(
-                RecordBatchIterator::new(vec![Ok(append_batch)], append_schema),
-                None,
+        let dataset = Arc::new(
+            Dataset::write(
+                reader,
+                &dataset_dir.path_str(),
+                Some(WriteParams {
+                    data_storage_version: Some(LanceFileVersion::V2_2),
+                    external_blob_mode: ExternalBlobMode::Ingest,
+                    ..Default::default()
+                }),
             )
             .await
-            .unwrap();
+            .unwrap(),
+        );
 
-        let dataset_schema = Schema::from(dataset.schema());
-        let DataType::Struct(fields) = dataset_schema.field_with_name("blob").unwrap().data_type()
-        else {
-            panic!("expected complete logical blob struct after append");
-        };
-        assert_eq!(fields.as_ref(), BLOB_V2_LOGICAL_FIELDS.as_ref());
-
-        let dataset = Arc::new(dataset);
         let desc = dataset
             .scan()
             .project(&["blob"])
@@ -7849,15 +7934,116 @@ mod tests {
             BlobKind::Inline as u8
         );
 
+        let blobs = dataset.take_blobs_by_indices(&[0], "blob").await.unwrap();
+        assert_eq!(blobs.len(), 1);
+        let blob = blobs[0].as_ref().unwrap();
+        assert_eq!(blob.kind(), BlobKind::Inline);
+        assert_eq!(blob.read().await.unwrap().as_ref(), b"inline");
+    }
+
+    #[tokio::test]
+    async fn test_complete_blob_v2_schema_survives_create() {
+        let dataset_dir = TempDir::default();
+        let schema = Arc::new(Schema::new(vec![complete_blob_v2_field("blob", true)]));
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![complete_blob_v2_array(
+                vec![Some(b"created".to_vec())],
+                vec![None],
+                vec![None],
+                vec![None],
+                None,
+            )],
+        )
+        .unwrap();
+
+        let dataset = Arc::new(
+            Dataset::write(
+                RecordBatchIterator::new(vec![Ok(batch)], schema),
+                &dataset_dir.path_str(),
+                Some(WriteParams {
+                    data_storage_version: Some(LanceFileVersion::V2_2),
+                    ..Default::default()
+                }),
+            )
+            .await
+            .unwrap(),
+        );
+
+        let dataset_schema = Schema::from(dataset.schema());
+        let DataType::Struct(fields) = dataset_schema.field_with_name("blob").unwrap().data_type()
+        else {
+            panic!("expected complete logical blob struct after create");
+        };
+        assert_eq!(fields.as_ref(), BLOB_V2_LOGICAL_FIELDS.as_ref());
+
+        let blobs = dataset.take_blobs_by_indices(&[0], "blob").await.unwrap();
+        assert_eq!(
+            blobs[0].as_ref().unwrap().read().await.unwrap().as_ref(),
+            b"created"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_complete_blob_v2_schema_survives_append() {
+        let dataset_dir = TempDir::default();
+        let schema = Arc::new(Schema::new(vec![complete_blob_v2_field("blob", true)]));
+        let initial_batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![complete_blob_v2_array(
+                vec![Some(b"initial".to_vec())],
+                vec![None],
+                vec![None],
+                vec![None],
+                None,
+            )],
+        )
+        .unwrap();
+        let mut dataset = Dataset::write(
+            RecordBatchIterator::new(vec![Ok(initial_batch)], schema.clone()),
+            &dataset_dir.path_str(),
+            Some(WriteParams {
+                data_storage_version: Some(LanceFileVersion::V2_2),
+                ..Default::default()
+            }),
+        )
+        .await
+        .unwrap();
+
+        let append_batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![complete_blob_v2_array(
+                vec![Some(b"appended".to_vec())],
+                vec![None],
+                vec![None],
+                vec![None],
+                None,
+            )],
+        )
+        .unwrap();
+        dataset
+            .append(
+                RecordBatchIterator::new(vec![Ok(append_batch)], schema),
+                None,
+            )
+            .await
+            .unwrap();
+
+        let dataset = Arc::new(dataset);
+        let dataset_schema = Schema::from(dataset.schema());
+        let DataType::Struct(fields) = dataset_schema.field_with_name("blob").unwrap().data_type()
+        else {
+            panic!("expected complete logical blob struct after append");
+        };
+        assert_eq!(fields.as_ref(), BLOB_V2_LOGICAL_FIELDS.as_ref());
+
         let blobs = dataset
             .take_blobs_by_indices(&[0, 1], "blob")
             .await
             .unwrap();
-        assert_eq!(blobs.len(), 2);
-        assert_eq!(blobs[0].as_ref().unwrap().kind(), BlobKind::Inline);
         assert_eq!(
             blobs[0].as_ref().unwrap().read().await.unwrap().as_ref(),
-            b"inline"
+            b"initial"
         );
         assert_eq!(
             blobs[1].as_ref().unwrap().read().await.unwrap().as_ref(),

--- a/rust/lance/src/dataset/blob.rs
+++ b/rust/lance/src/dataset/blob.rs
@@ -583,6 +583,9 @@ impl ExternalBlobSource {
 
     /// Materialize the slice into memory for the inline blob path.
     async fn read_all(&self) -> Result<bytes::Bytes> {
+        if self.size == 0 {
+            return Ok(bytes::Bytes::new());
+        }
         let range = self.reader_range()?;
         self.reader.get_range(range).await.map_err(Into::into)
     }
@@ -4340,9 +4343,10 @@ mod tests {
     use super::{
         BlobEntry, BlobFile, BlobMaterializationBudget, BlobMaterializationBudgetState,
         BlobRangeRequest, BlobReadRange, BlobSource, ExternalBaseCandidate, ExternalBaseResolver,
-        ReadBlobsExecution, blob_version_from_descriptions, collect_blob_files_v1,
-        data_file_key_from_path, execute_blob_entries, execute_blob_read_batches_stream,
-        execute_blob_read_plan, plan_blob_read_batches, plan_blob_read_plans,
+        ExternalBlobSource, ReadBlobsExecution, blob_version_from_descriptions,
+        collect_blob_files_v1, data_file_key_from_path, execute_blob_entries,
+        execute_blob_read_batches_stream, execute_blob_read_plan, plan_blob_read_batches,
+        plan_blob_read_plans,
     };
     use crate::{
         Dataset,
@@ -6589,6 +6593,19 @@ mod tests {
         let empty_blob = BlobFile::new_packed(store.clone(), path.clone(), 1, 0);
         assert!(empty_blob.read().await.unwrap().is_empty());
         assert!(empty_blob.read_up_to(16).await.unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_external_blob_source_read_all_empty_range_returns_empty_bytes() {
+        let store = reject_empty_range_store();
+        let reader = store.open(&Path::from("blobs/test.bin")).await.unwrap();
+        let source = ExternalBlobSource {
+            reader,
+            start: 0,
+            size: 0,
+        };
+
+        assert!(source.read_all().await.unwrap().is_empty());
     }
 
     #[tokio::test]

--- a/rust/lance/src/dataset/blob.rs
+++ b/rust/lance/src/dataset/blob.rs
@@ -1038,6 +1038,18 @@ impl BlobPreprocessor {
                     field.name()
                 )));
             }
+            if has_data == has_uri {
+                return Err(Error::invalid_input(format!(
+                    "Blob v2 field '{}' row {i} must set exactly one of `data` and `uri`",
+                    field.name()
+                )));
+            }
+            if has_size && size_col.as_ref().is_some_and(|col| col.value(i) == 0) {
+                return Err(Error::invalid_input(format!(
+                    "Blob v2 field '{}' row {i} external range `size` must be greater than zero",
+                    field.name()
+                )));
+            }
 
             let data_len = if has_data { data_col.value(i).len() } else { 0 };
 
@@ -8148,6 +8160,90 @@ mod tests {
 
         assert!(matches!(error, Error::InvalidInput { .. }));
         assert!(error.to_string().contains(expected_message));
+    }
+
+    #[rstest]
+    #[case::reference(ExternalBlobMode::Reference)]
+    #[case::ingest(ExternalBlobMode::Ingest)]
+    #[tokio::test]
+    async fn test_complete_blob_v2_rejects_zero_size_range(
+        #[case] external_blob_mode: ExternalBlobMode,
+    ) {
+        let dataset_dir = TempDir::default();
+        let schema = Arc::new(Schema::new(vec![complete_blob_v2_field("blob", true)]));
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![complete_blob_v2_array(
+                vec![None],
+                vec![Some("file:///source.bin".to_string())],
+                vec![Some(3)],
+                vec![Some(0)],
+                None,
+            )],
+        )
+        .unwrap();
+
+        let error = Dataset::write(
+            RecordBatchIterator::new(vec![Ok(batch)], schema),
+            &dataset_dir.path_str(),
+            Some(WriteParams {
+                data_storage_version: Some(LanceFileVersion::V2_2),
+                allow_external_blob_outside_bases: matches!(
+                    external_blob_mode,
+                    ExternalBlobMode::Reference
+                ),
+                external_blob_mode,
+                ..Default::default()
+            }),
+        )
+        .await
+        .unwrap_err();
+
+        assert!(matches!(error, Error::InvalidInput { .. }));
+        assert!(error.to_string().contains("greater than zero"));
+    }
+
+    #[rstest]
+    #[case::both_small(Some(5), true)]
+    #[case::both_packed(Some(crate::dataset::blob::INLINE_MAX + 1), true)]
+    #[case::neither(None, false)]
+    #[tokio::test]
+    async fn test_complete_blob_v2_rejects_invalid_representation(
+        #[case] data_size: Option<usize>,
+        #[case] has_uri: bool,
+    ) {
+        let dataset_dir = TempDir::default();
+        let schema = Arc::new(Schema::new(vec![complete_blob_v2_field("blob", true)]));
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![complete_blob_v2_array(
+                vec![data_size.map(|size| vec![0x41; size])],
+                vec![has_uri.then(|| "file:///source.bin".to_string())],
+                vec![None],
+                vec![None],
+                None,
+            )],
+        )
+        .unwrap();
+
+        let error = Dataset::write(
+            RecordBatchIterator::new(vec![Ok(batch)], schema),
+            &dataset_dir.path_str(),
+            Some(WriteParams {
+                data_storage_version: Some(LanceFileVersion::V2_2),
+                allow_external_blob_outside_bases: true,
+                ..Default::default()
+            }),
+        )
+        .await
+        .unwrap_err();
+
+        assert!(matches!(error, Error::InvalidInput { .. }));
+        assert!(
+            error
+                .to_string()
+                .contains("must set exactly one of `data` and `uri`")
+        );
     }
 
     #[tokio::test]

--- a/rust/lance/src/dataset/blob.rs
+++ b/rust/lance/src/dataset/blob.rs
@@ -1025,6 +1025,20 @@ impl BlobPreprocessor {
                 .as_ref()
                 .map(|col| !col.is_null(i))
                 .unwrap_or(false);
+
+            if has_position != has_size {
+                return Err(Error::invalid_input(format!(
+                    "Blob v2 field '{}' row {i} must set both `position` and `size`, or neither",
+                    field.name()
+                )));
+            }
+            if has_position && !has_uri {
+                return Err(Error::invalid_input(format!(
+                    "Blob v2 field '{}' row {i} sets `position` and `size` but `uri` is null",
+                    field.name()
+                )));
+            }
+
             let data_len = if has_data { data_col.value(i).len() } else { 0 };
 
             if has_data && data_len > dedicated_threshold {
@@ -8049,6 +8063,91 @@ mod tests {
             blobs[1].as_ref().unwrap().read().await.unwrap().as_ref(),
             b"appended"
         );
+    }
+
+    #[rstest]
+    #[case::reference_missing_size(
+        ExternalBlobMode::Reference,
+        Some("file:///source.bin"),
+        Some(3),
+        None,
+        "both `position` and `size`"
+    )]
+    #[case::reference_missing_position(
+        ExternalBlobMode::Reference,
+        Some("file:///source.bin"),
+        None,
+        Some(2),
+        "both `position` and `size`"
+    )]
+    #[case::reference_range_without_uri(
+        ExternalBlobMode::Reference,
+        None,
+        Some(3),
+        Some(2),
+        "`uri` is null"
+    )]
+    #[case::ingest_missing_size(
+        ExternalBlobMode::Ingest,
+        Some("file:///source.bin"),
+        Some(3),
+        None,
+        "both `position` and `size`"
+    )]
+    #[case::ingest_missing_position(
+        ExternalBlobMode::Ingest,
+        Some("file:///source.bin"),
+        None,
+        Some(2),
+        "both `position` and `size`"
+    )]
+    #[case::ingest_range_without_uri(
+        ExternalBlobMode::Ingest,
+        None,
+        Some(3),
+        Some(2),
+        "`uri` is null"
+    )]
+    #[tokio::test]
+    async fn test_complete_blob_v2_rejects_invalid_ranges(
+        #[case] external_blob_mode: ExternalBlobMode,
+        #[case] uri: Option<&str>,
+        #[case] position: Option<u64>,
+        #[case] size: Option<u64>,
+        #[case] expected_message: &str,
+    ) {
+        let dataset_dir = TempDir::default();
+        let schema = Arc::new(Schema::new(vec![complete_blob_v2_field("blob", true)]));
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![complete_blob_v2_array(
+                vec![None],
+                vec![uri.map(str::to_string)],
+                vec![position],
+                vec![size],
+                None,
+            )],
+        )
+        .unwrap();
+
+        let error = Dataset::write(
+            RecordBatchIterator::new(vec![Ok(batch)], schema),
+            &dataset_dir.path_str(),
+            Some(WriteParams {
+                data_storage_version: Some(LanceFileVersion::V2_2),
+                allow_external_blob_outside_bases: matches!(
+                    external_blob_mode,
+                    ExternalBlobMode::Reference
+                ),
+                external_blob_mode,
+                ..Default::default()
+            }),
+        )
+        .await
+        .unwrap_err();
+
+        assert!(matches!(error, Error::InvalidInput { .. }));
+        assert!(error.to_string().contains(expected_message));
     }
 
     #[tokio::test]

--- a/rust/lance/src/dataset/optimize.rs
+++ b/rust/lance/src/dataset/optimize.rs
@@ -1394,15 +1394,17 @@ async fn descriptor_to_logical_blob_array(
                     let absolute_uri = format!("{}/{}", base.path.trim_end_matches('/'), uri_val);
                     uri_builder.append_value(&absolute_uri);
                 }
-                if descriptor.position_col.is_null(i) {
+                let position =
+                    (!descriptor.position_col.is_null(i)).then(|| descriptor.position_col.value(i));
+                let size = (!descriptor.size_col.is_null(i)).then(|| descriptor.size_col.value(i));
+                if position == Some(0) && size == Some(0) {
+                    // Stable descriptors use (0, 0) for the complete external object.
+                    // Logical input represents the same value by omitting the range.
                     out_position_builder.append_null();
-                } else {
-                    out_position_builder.append_value(descriptor.position_col.value(i));
-                }
-                if descriptor.size_col.is_null(i) {
                     out_size_builder.append_null();
                 } else {
-                    out_size_builder.append_value(descriptor.size_col.value(i));
+                    out_position_builder.append_option(position);
+                    out_size_builder.append_option(size);
                 }
             }
             RowClass::DataBlob => {

--- a/rust/lance/src/dataset/write/merge_insert.rs
+++ b/rust/lance/src/dataset/write/merge_insert.rs
@@ -14738,6 +14738,81 @@ MergeInsert: on=[id], when_matched=DoNothing, when_not_matched=InsertAll, when_n
 
     #[tokio::test]
     async fn test_merge_insert_with_blob_v2_source_provides_blob() {
+        use crate::{BlobArrayBuilder, blob_field};
+        use arrow_schema::Schema as ArrowSchema;
+
+        let test_dir = TempStrDir::default();
+        let schema = Arc::new(ArrowSchema::new(vec![
+            blob_field("blobs", true),
+            Field::new("id", DataType::Int64, true),
+            Field::new("other", DataType::Int64, true),
+        ]));
+        let make_batch = |blob_values: &[&[u8]], ids, others| {
+            let mut blobs = BlobArrayBuilder::new(blob_values.len());
+            for value in blob_values {
+                blobs.push_bytes(value).unwrap();
+            }
+            RecordBatch::try_new(
+                schema.clone(),
+                vec![
+                    blobs.finish().unwrap(),
+                    Arc::new(Int64Array::from(ids)),
+                    Arc::new(Int64Array::from(others)),
+                ],
+            )
+            .unwrap()
+        };
+        let dataset = Arc::new(
+            Dataset::write(
+                RecordBatchIterator::new(
+                    vec![Ok(make_batch(&[b"foo", b"bar"], vec![0, 1], vec![10, 20]))],
+                    schema.clone(),
+                ),
+                &test_dir,
+                Some(WriteParams {
+                    data_storage_version: Some(LanceFileVersion::V2_2),
+                    ..Default::default()
+                }),
+            )
+            .await
+            .unwrap(),
+        );
+        let source = Box::new(RecordBatchIterator::new(
+            vec![Ok(make_batch(
+                &[b"baz", b"qux"],
+                vec![1, 2],
+                vec![200, 300],
+            ))],
+            schema,
+        ));
+
+        let job = MergeInsertBuilder::try_new(dataset, vec!["id".to_string()])
+            .unwrap()
+            .when_matched(WhenMatched::UpdateAll)
+            .when_not_matched(WhenNotMatched::InsertAll)
+            .try_build()
+            .unwrap();
+        let (new_dataset, _) = job.execute_reader(source).await.unwrap();
+        let blobs = new_dataset
+            .take_blobs_by_indices(&[0, 1, 2], "blobs")
+            .await
+            .unwrap();
+        assert_eq!(
+            blobs[0].as_ref().unwrap().read().await.unwrap().as_ref(),
+            b"foo"
+        );
+        assert_eq!(
+            blobs[1].as_ref().unwrap().read().await.unwrap().as_ref(),
+            b"baz"
+        );
+        assert_eq!(
+            blobs[2].as_ref().unwrap().read().await.unwrap().as_ref(),
+            b"qux"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_merge_insert_with_complete_blob_v2_preserves_schema() {
         use arrow_schema::Schema as ArrowSchema;
         use lance_arrow::{ARROW_EXT_NAME_KEY, BLOB_V2_EXT_NAME};
         use lance_core::datatypes::BLOB_V2_LOGICAL_FIELDS;

--- a/rust/lance/src/dataset/write/merge_insert.rs
+++ b/rust/lance/src/dataset/write/merge_insert.rs
@@ -14628,24 +14628,45 @@ MergeInsert: on=[id], when_matched=DoNothing, when_not_matched=InsertAll, when_n
 
     #[tokio::test]
     async fn test_merge_insert_with_blob_v2_source_provides_blob() {
-        use crate::{BlobArrayBuilder, blob_field};
         use arrow_schema::Schema as ArrowSchema;
+        use lance_arrow::{ARROW_EXT_NAME_KEY, BLOB_V2_EXT_NAME};
+        use lance_core::datatypes::BLOB_V2_LOGICAL_FIELDS;
 
         let test_dir = TempStrDir::default();
+        let blob_field = Field::new(
+            "blobs",
+            DataType::Struct(BLOB_V2_LOGICAL_FIELDS.clone()),
+            true,
+        )
+        .with_metadata(HashMap::from([(
+            ARROW_EXT_NAME_KEY.to_string(),
+            BLOB_V2_EXT_NAME.to_string(),
+        )]));
         let schema = Arc::new(ArrowSchema::new(vec![
-            blob_field("blobs", true),
+            blob_field,
             Field::new("id", DataType::Int64, true),
             Field::new("other", DataType::Int64, true),
         ]));
         let make_batch = |blob_values: &[&[u8]], ids, others| {
-            let mut blobs = BlobArrayBuilder::new(blob_values.len());
-            for value in blob_values {
-                blobs.push_bytes(value).unwrap();
-            }
+            let blobs: arrow_array::ArrayRef = Arc::new(
+                StructArray::try_new(
+                    BLOB_V2_LOGICAL_FIELDS.clone(),
+                    vec![
+                        Arc::new(arrow_array::LargeBinaryArray::from_iter(
+                            blob_values.iter().map(|value| Some(*value)),
+                        )),
+                        Arc::new(StringArray::from(vec![None::<&str>; blob_values.len()])),
+                        Arc::new(UInt64Array::from(vec![None::<u64>; blob_values.len()])),
+                        Arc::new(UInt64Array::from(vec![None::<u64>; blob_values.len()])),
+                    ],
+                    None,
+                )
+                .unwrap(),
+            );
             RecordBatch::try_new(
                 schema.clone(),
                 vec![
-                    blobs.finish().unwrap(),
+                    blobs,
                     Arc::new(Int64Array::from(ids)),
                     Arc::new(Int64Array::from(others)),
                 ],
@@ -14683,6 +14704,13 @@ MergeInsert: on=[id], when_matched=DoNothing, when_not_matched=InsertAll, when_n
             .try_build()
             .unwrap();
         let (new_dataset, _) = job.execute_reader(source).await.unwrap();
+        let dataset_schema = ArrowSchema::from(new_dataset.schema());
+        let DataType::Struct(blob_children) =
+            dataset_schema.field_with_name("blobs").unwrap().data_type()
+        else {
+            panic!("expected complete logical blob struct after merge insert");
+        };
+        assert_eq!(blob_children.as_ref(), BLOB_V2_LOGICAL_FIELDS.as_ref());
         let blobs = new_dataset
             .take_blobs_by_indices(&[0, 1, 2], "blobs")
             .await


### PR DESCRIPTION
Blob v2 schema normalization must distinguish logical writer input from the prepared writer intermediate. Rebuilding an already-logical field can collapse the complete `data, uri, position, size` shape to the minimal form and lose schema properties. Prepared child IDs must also follow the semantic `data` and `uri` fields instead of their positions in the prepared layout.

Logical minimal and complete schemas now pass through normalization unchanged, while prepared input alone normalizes to the minimal logical shape with IDs matched by child name. Descriptor and malformed layouts remain explicit errors. The contract is exercised through create, append, merge-insert, external-range, and nested Rust/Python paths and is documented as public behavior.

Blob v2 is beta, so this enforces the complete invariant directly without compatibility handling for intermediate beta schemas.

A mutation check that routes logical input through the prepared normalization branch makes all logical identity matrix cases fail; restoring the intended branch makes the full matrix pass.
