### PR TITLE
perf(rowids): keep the row id index cached and rank bitmaps for lookups

### DIFF
--- a/rust/lance-table/benches/row_id_index.rs
+++ b/rust/lance-table/benches/row_id_index.rs
@@ -25,11 +25,16 @@ use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
 use lance_core::utils::address::RowAddress;
 use lance_core::utils::deletion::DeletionVector;
 use lance_io::ReadBatchParams;
+use lance_table::format::pb;
 use lance_table::rowids::FragmentRowIdIndex;
 use lance_table::{
-    rowids::{RowIdIndex, RowIdSequence, write_row_ids},
+    rowids::{RowIdIndex, RowIdSequence, read_row_ids, write_row_ids},
     utils::stream::{RowIdAndDeletesConfig, apply_row_id_and_deletes},
 };
+use prost::Message;
+use rand::rngs::SmallRng;
+use rand::seq::SliceRandom;
+use rand::{Rng, SeedableRng};
 
 fn make_sequence(row_id_range: Range<u64>, deletions: usize) -> RowIdSequence {
     let mut sequence = RowIdSequence::from(row_id_range);
@@ -308,16 +313,233 @@ fn bench_apply_row_id(c: &mut Criterion) {
     group.finish();
 }
 
+/// A fragment count large enough for the probe gate, small enough to build in
+/// seconds. `BENCH_SHOT_FRAGMENTS=19960` reproduces the real table.
+fn shot_fragments() -> usize {
+    std::env::var("BENCH_SHOT_FRAGMENTS")
+        .map(|s| s.parse().unwrap())
+        .unwrap_or(2000)
+}
+
+/// Rows per fragment of the shot table (17.4B rows over 19,960 fragments).
+const SHOT_ROWS_PER_FRAGMENT: u64 = 870_000;
+
+/// Mixes a position into a pseudo-random byte cheaply enough to fill gigabits.
+fn hash_byte(position: u64, seed: u64) -> u8 {
+    (position ^ seed)
+        .wrapping_mul(0x9E37_79B9_7F4A_7C15)
+        .rotate_left(23)
+        .wrapping_mul(0xD1B5_4A32_D192_ED03)
+        .to_le_bytes()[7]
+}
+
+/// `start..end` as a bitmap segment keeping about `density_pct` of its slots.
+fn bitmap_segment(start: u64, end: u64, density_pct: u8, seed: u64) -> pb::U64Segment {
+    let len = (end - start) as usize;
+    let mut data = vec![0u8; len.div_ceil(8)];
+    for (byte_index, byte) in data.iter_mut().enumerate() {
+        let mut bits = 0u8;
+        for bit in 0..8 {
+            if hash_byte((byte_index * 8 + bit) as u64, seed) % 100 < density_pct {
+                bits |= 1 << bit;
+            }
+        }
+        *byte = bits;
+    }
+    if !len.is_multiple_of(8) {
+        data[len / 8] &= (1u8 << (len % 8)) - 1;
+    }
+    pb::U64Segment {
+        segment: Some(pb::u64_segment::Segment::RangeWithBitmap(
+            pb::u64_segment::RangeWithBitmap {
+                start,
+                end,
+                bitmap: data,
+            },
+        )),
+    }
+}
+
+/// `start..end` minus about `holes_pct` percent of its slots, as sorted holes.
+fn holes_segment(start: u64, end: u64, holes_pct: u8, seed: u64) -> pb::U64Segment {
+    let holes: Vec<u32> = (0..(end - start))
+        .filter(|offset| hash_byte(*offset, seed) % 100 < holes_pct)
+        .map(|offset| offset as u32)
+        .collect();
+    let offsets = holes.iter().flat_map(|hole| hole.to_le_bytes()).collect();
+    pb::U64Segment {
+        segment: Some(pb::u64_segment::Segment::RangeWithHoles(
+            pb::u64_segment::RangeWithHoles {
+                start,
+                end,
+                holes: Some(pb::EncodedU64Array {
+                    array: Some(pb::encoded_u64_array::Array::U32Array(
+                        pb::encoded_u64_array::U32Array {
+                            base: start,
+                            offsets,
+                        },
+                    )),
+                }),
+            },
+        )),
+    }
+}
+
+fn range_segment(start: u64, end: u64) -> pb::U64Segment {
+    pb::U64Segment {
+        segment: Some(pb::u64_segment::Segment::Range(pb::u64_segment::Range {
+            start,
+            end,
+        })),
+    }
+}
+
+/// A live row id from `segment`, or `None` when the sampled slot is a hole.
+fn sample_segment(segment: &pb::U64Segment, rng: &mut SmallRng) -> Option<u64> {
+    use pb::u64_segment::Segment::*;
+    match segment.segment.as_ref().unwrap() {
+        Range(range) => Some(rng.random_range(range.start..range.end)),
+        RangeWithBitmap(bitmap) => {
+            let offset = rng.random_range(0..(bitmap.end - bitmap.start)) as usize;
+            (bitmap.bitmap[offset / 8] & (1 << (offset % 8)) != 0)
+                .then_some(bitmap.start + offset as u64)
+        }
+        RangeWithHoles(holes) => {
+            let offset = rng.random_range(0..(holes.end - holes.start)) as u32;
+            let Some(pb::encoded_u64_array::Array::U32Array(array)) =
+                holes.holes.as_ref().unwrap().array.as_ref()
+            else {
+                unreachable!()
+            };
+            let is_hole = array
+                .offsets
+                .chunks_exact(4)
+                .any(|hole| u32::from_le_bytes(hole.try_into().unwrap()) == offset);
+            (!is_hole).then_some(holes.start + offset as u64)
+        }
+        _ => unreachable!(),
+    }
+}
+
+/// Fragments shaped like the shot table after deletes and compaction: about
+/// half keep one `Range`; the rest were compacted in groups of 16, and each
+/// output fragment holds two dense (82%) slices taken from different source
+/// fragments, so spans interleave and one id sits under up to 16 fragments.
+/// One compacted slice in three carries only 1% holes instead of a bitmap.
+/// Returns the fragments and a pool of live row ids to query.
+fn shot_table_like(
+    num_fragments: usize,
+    rows_per_fragment: u64,
+    seed: u64,
+) -> (Vec<FragmentRowIdIndex>, Vec<u64>) {
+    const GROUP: usize = 16;
+    let mut rng = SmallRng::seed_from_u64(seed);
+    let mut sequences: Vec<Vec<pb::U64Segment>> = Vec::with_capacity(num_fragments);
+    for group_start in (0..num_fragments).step_by(GROUP) {
+        let group_end = (group_start + GROUP).min(num_fragments);
+        let is_compacted = rng.random_range(0..100) < 44;
+        if !is_compacted || group_end - group_start < 2 {
+            for fragment in group_start..group_end {
+                let start = fragment as u64 * rows_per_fragment;
+                sequences.push(vec![range_segment(start, start + rows_per_fragment)]);
+            }
+            continue;
+        }
+        let half = rows_per_fragment / 2;
+        let mut slices: Vec<(u64, u64)> = (group_start..group_end)
+            .flat_map(|fragment| {
+                let start = fragment as u64 * rows_per_fragment;
+                [
+                    (start, start + half),
+                    (start + half, start + rows_per_fragment),
+                ]
+            })
+            .collect();
+        slices.shuffle(&mut rng);
+        for pair in slices.chunks_exact(2) {
+            let mut pair = [pair[0], pair[1]];
+            pair.sort_unstable();
+            let segments = pair
+                .iter()
+                .map(|(start, end)| {
+                    let seed = rng.random();
+                    if rng.random_range(0..3) == 0 {
+                        holes_segment(*start, *end, 1, seed)
+                    } else {
+                        bitmap_segment(*start, *end, 82, seed)
+                    }
+                })
+                .collect();
+            sequences.push(segments);
+        }
+    }
+
+    let mut pool = Vec::with_capacity(100_000);
+    while pool.len() < 100_000 {
+        let segments = &sequences[rng.random_range(0..sequences.len())];
+        let segment = &segments[rng.random_range(0..segments.len())];
+        if let Some(id) = sample_segment(segment, &mut rng) {
+            pool.push(id);
+        }
+    }
+
+    let fragments = sequences
+        .into_iter()
+        .enumerate()
+        .map(|(fragment_id, segments)| {
+            let bytes = pb::RowIdSequence { segments }.encode_to_vec();
+            FragmentRowIdIndex {
+                fragment_id: fragment_id as u32,
+                row_id_sequence: Arc::new(read_row_ids(&bytes).unwrap()),
+                deletion_vector: Arc::new(DeletionVector::default()),
+            }
+        })
+        .collect();
+    (fragments, pool)
+}
+
+fn bench_shot_table(c: &mut Criterion) {
+    let mut group = c.benchmark_group("row_id_index_shot_table");
+    group.sample_size(10);
+    let (fragments, pool) = shot_table_like(shot_fragments(), SHOT_ROWS_PER_FRAGMENT, 7);
+
+    group.bench_function("build", |b| {
+        b.iter(|| RowIdIndex::new(&fragments).unwrap());
+    });
+
+    let index = RowIdIndex::new(&fragments).unwrap();
+    for n in [1usize, 1000, 100_000] {
+        let ids = &pool[..n];
+        group.throughput(criterion::Throughput::Elements(n as u64));
+        group.bench_with_input(BenchmarkId::new("get_many", n), &ids, |b, ids| {
+            b.iter(|| {
+                let out = index.get_many(ids).unwrap();
+                assert!(out.iter().all(Option::is_some));
+            });
+        });
+    }
+    group.throughput(criterion::Throughput::Elements(1));
+    let mut next = 0usize;
+    group.bench_function("get", |b| {
+        b.iter(|| {
+            next = (next + 1) % pool.len();
+            assert!(index.get(pool[next]).unwrap().is_some());
+        });
+    });
+    group.finish();
+}
+
 #[cfg(target_os = "linux")]
 criterion_group!(
     name = benches;
     config=Criterion::default().with_profiler(lance_testing::pprof::PProfProfiler::new(100, lance_testing::pprof::Output::Flamegraph(None)));
-    targets=bench_creation, bench_get_single, bench_apply_row_id);
+    targets=bench_creation, bench_get_single, bench_apply_row_id, bench_shot_table);
 #[cfg(not(target_os = "linux"))]
 criterion_group!(
     benches,
     bench_creation,
     bench_get_single,
-    bench_apply_row_id
+    bench_apply_row_id,
+    bench_shot_table
 );
 criterion_main!(benches);

--- a/rust/lance-table/src/rowids/bitmap.rs
+++ b/rust/lance-table/src/rowids/bitmap.rs
@@ -10,7 +10,7 @@ pub struct Bitmap {
 }
 
 /// Set bits in `data`, counted a word at a time.
-fn count_ones(data: &[u8]) -> usize {
+pub(super) fn count_ones(data: &[u8]) -> usize {
     let mut words = data.chunks_exact(8);
     let full: usize = words
         .by_ref()

--- a/rust/lance-table/src/rowids/index.rs
+++ b/rust/lance-table/src/rowids/index.rs
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright The Lance Authors
 
-use std::collections::HashMap;
 use std::ops::RangeInclusive;
 use std::sync::Arc;
 
@@ -49,8 +48,6 @@ pub struct RowIdIndex {
     /// Max-`end` heap over `fragments`: `end_tree[1]` is the root and leaf `i`
     /// sits at `end_tree[len() / 2 + i]`.
     end_tree: Vec<u64>,
-    /// Slot in `fragments` of each fragment id.
-    slots: HashMap<u32, usize>,
     merged: Option<MergedIndex>,
 }
 
@@ -73,7 +70,6 @@ impl RowIdIndex {
 
         let mut index = Self {
             end_tree: build_end_tree(&fragments),
-            slots: fragment_slots(&fragments),
             fragments,
             merged: None,
         };
@@ -115,14 +111,6 @@ impl RowIdIndex {
         }
 
         Ok(RangeInclusiveMap::from_iter(final_chunks))
-    }
-
-    /// The row id sequence of `fragment_id`, or `None` when the fragment is not
-    /// indexed because it holds no row id.
-    pub fn sequence(&self, fragment_id: u32) -> Option<&Arc<RowIdSequence>> {
-        self.slots
-            .get(&fragment_id)
-            .map(|slot| &self.fragments[*slot].sequence)
     }
 
     /// Get the address for a given row id.
@@ -446,14 +434,6 @@ fn max_overlap_depth(fragments: &[FragmentEntry]) -> u64 {
     depth
 }
 
-fn fragment_slots(fragments: &[FragmentEntry]) -> HashMap<u32, usize> {
-    fragments
-        .iter()
-        .enumerate()
-        .map(|(slot, entry)| (entry.fragment_id, slot))
-        .collect()
-}
-
 /// Implicit max-`end` heap over `fragments`, padded to a power of two. Padding
 /// leaves hold 0, which prunes for every id above 0 and is filtered by slot.
 fn build_end_tree(fragments: &[FragmentEntry]) -> Vec<u64> {
@@ -516,7 +496,6 @@ impl DeepSizeOf for RowIdIndex {
             + merged_bytes
             + self.fragments.capacity() * std::mem::size_of::<FragmentEntry>()
             + self.end_tree.capacity() * std::mem::size_of::<u64>()
-            + self.slots.capacity() * std::mem::size_of::<(u32, usize)>()
     }
 }
 
@@ -774,7 +753,6 @@ impl RowIdIndex {
         fragments.sort_unstable_by_key(|entry| entry.start);
         Ok(Self {
             end_tree: build_end_tree(&fragments),
-            slots: fragment_slots(&fragments),
             fragments,
             merged: None,
         })
@@ -903,24 +881,6 @@ mod tests {
         }
         assert_eq!(index.get(999).unwrap(), None);
         assert_eq!(index.get(1000 + span).unwrap(), None);
-    }
-
-    #[test]
-    fn test_sequence_by_fragment_id() {
-        let held = Arc::new(RowIdSequence::from(0..10));
-        let index = RowIdIndex::new(&[
-            FragmentRowIdIndex {
-                fragment_id: 5,
-                row_id_sequence: held.clone(),
-                deletion_vector: Arc::new(DeletionVector::default()),
-            },
-            fragment(6, RowIdSequence::new()),
-        ])
-        .unwrap();
-        assert!(Arc::ptr_eq(index.sequence(5).unwrap(), &held));
-        // A fragment without row ids is not indexed, and neither is an unknown one.
-        assert!(index.sequence(6).is_none());
-        assert!(index.sequence(7).is_none());
     }
 
     #[test]

--- a/rust/lance-table/src/rowids/index.rs
+++ b/rust/lance-table/src/rowids/index.rs
@@ -1,9 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright The Lance Authors
 
+use std::collections::HashMap;
 use std::ops::RangeInclusive;
 use std::sync::Arc;
 
+use super::bitmap::{Bitmap, count_ones};
 use super::{RowIdSequence, U64Segment};
 use lance_core::deepsize::DeepSizeOf;
 use lance_core::utils::address::RowAddress;
@@ -19,6 +21,11 @@ const MAX_PROBE_DEPTH: u64 = 64;
 /// Row ids the merged build may read before probing is worth its per-lookup
 /// cost instead.
 const MERGE_ROWS_BUDGET: u64 = 1 << 20;
+
+/// Bitmap bytes summarized by one entry of a bitmap rank directory. A lookup
+/// counts at most this many bytes; the directory costs one `u32` per block,
+/// 1/64 of the bitmap.
+const RANK_BLOCK_BYTES: usize = 256;
 
 /// An index of row ids
 ///
@@ -42,6 +49,8 @@ pub struct RowIdIndex {
     /// Max-`end` heap over `fragments`: `end_tree[1]` is the root and leaf `i`
     /// sits at `end_tree[len() / 2 + i]`.
     end_tree: Vec<u64>,
+    /// Slot in `fragments` of each fragment id.
+    slots: HashMap<u32, usize>,
     merged: Option<MergedIndex>,
 }
 
@@ -64,6 +73,7 @@ impl RowIdIndex {
 
         let mut index = Self {
             end_tree: build_end_tree(&fragments),
+            slots: fragment_slots(&fragments),
             fragments,
             merged: None,
         };
@@ -105,6 +115,14 @@ impl RowIdIndex {
         }
 
         Ok(RangeInclusiveMap::from_iter(final_chunks))
+    }
+
+    /// The row id sequence of `fragment_id`, or `None` when the fragment is not
+    /// indexed because it holds no row id.
+    pub fn sequence(&self, fragment_id: u32) -> Option<&Arc<RowIdSequence>> {
+        self.slots
+            .get(&fragment_id)
+            .map(|slot| &self.fragments[*slot].sequence)
     }
 
     /// Get the address for a given row id.
@@ -193,19 +211,23 @@ impl RowIdIndex {
         if upper == 0 {
             return Ok(None);
         }
-        let leaves = self.end_tree.len() / 2;
-        // Depth is log2(leaves), at most 64, and each level leaves one sibling.
-        let mut stack = [(0usize, 0usize, 0usize); 64];
-        stack[0] = (1, 0, leaves);
-        let mut depth = 1;
         let mut found: Option<RowAddress> = None;
-        while depth > 0 {
-            depth -= 1;
-            let (node, lo, hi) = stack[depth];
-            if lo >= upper || self.end_tree[node] < row_id {
-                continue;
+        // Depth-first, left to right, without a stack: `node` covers `width`
+        // slots from `lo`. A pruned subtree or a visited leaf moves on to the
+        // next subtree: up while `node` is a right child, then over to the
+        // sibling.
+        let (mut node, mut lo, mut width) = (1usize, 0usize, self.end_tree.len() / 2);
+        loop {
+            if lo >= upper {
+                // Every slot from here on starts above the id.
+                break;
             }
-            if hi - lo == 1 {
+            if self.end_tree[node] >= row_id {
+                if width > 1 {
+                    node *= 2;
+                    width /= 2;
+                    continue;
+                }
                 if lo < fragments
                     && let Some(candidate) = self.fragments[lo].resolve(row_id)
                 {
@@ -217,14 +239,17 @@ impl RowIdIndex {
                     }
                     found = Some(candidate);
                 }
-                continue;
             }
-            let mid = (lo + hi) / 2;
-            // Push the left half first so the right half pops first: candidates
-            // arrive in descending slot order.
-            stack[depth] = (2 * node, lo, mid);
-            stack[depth + 1] = (2 * node + 1, mid, hi);
-            depth += 2;
+            while node & 1 == 1 {
+                if node == 1 {
+                    return Ok(found);
+                }
+                node /= 2;
+                lo -= width;
+                width *= 2;
+            }
+            node += 1;
+            lo += width;
         }
         Ok(found)
     }
@@ -243,38 +268,85 @@ struct SegmentEntry {
     seq_idx: usize,
     range: RangeInclusive<u64>,
     start_offset: u32,
+    lookup: SegmentLookup,
+}
+
+/// How a [`SegmentEntry`] finds the position of a row id.
+#[derive(Debug)]
+enum SegmentLookup {
+    /// The encoding searches itself in logarithmic or constant time.
+    Native,
     /// Row id to position for an unsorted [`U64Segment::Array`], whose own
-    /// `position` scans. `None` for the encodings that search themselves.
-    positions: Option<Vec<(u64, u32)>>,
+    /// `position` scans.
+    Positions(Vec<(u64, u32)>),
+    /// Set bits before each [`RANK_BLOCK_BYTES`] block of a
+    /// [`U64Segment::RangeWithBitmap`] bitmap, whose own `position` counts
+    /// the whole prefix.
+    BitmapRank(Vec<u32>),
 }
 
 impl SegmentEntry {
     /// Position of `row_id` in this segment, or `None` if it holds no such id.
     fn position(&self, sequence: &RowIdSequence, row_id: u64) -> Option<usize> {
-        match &self.positions {
-            None => sequence.0[self.seq_idx].position(row_id),
-            Some(positions) => positions
+        let segment = &sequence.0[self.seq_idx];
+        match &self.lookup {
+            SegmentLookup::Native => segment.position(row_id),
+            SegmentLookup::Positions(positions) => positions
                 .binary_search_by_key(&row_id, |(id, _)| *id)
                 .ok()
                 .map(|found| positions[found].1 as usize),
+            SegmentLookup::BitmapRank(rank) => {
+                let U64Segment::RangeWithBitmap { range, bitmap } = segment else {
+                    return None;
+                };
+                if !range.contains(&row_id) {
+                    return None;
+                }
+                let offset = (row_id - range.start) as usize;
+                if !bitmap.get(offset) {
+                    return None;
+                }
+                let block_start = offset / (RANK_BLOCK_BYTES * 8) * (RANK_BLOCK_BYTES * 8);
+                let ones_before = rank[offset / (RANK_BLOCK_BYTES * 8)] as usize
+                    + bitmap.slice(block_start, offset - block_start).count_ones();
+                Some(ones_before)
+            }
         }
     }
 }
 
-/// Row id to position for a segment, sorted by row id. The first position of a
-/// repeated id wins, which is what `position` returns.
-fn build_positions(segment: &U64Segment) -> Option<Vec<(u64, u32)>> {
-    if !matches!(segment, U64Segment::Array(_)) {
-        return None;
+/// The lookup structure for `segment`, and the ids it holds. A bitmap's rank
+/// directory counts its ones on the way, so the segment is read once.
+fn build_lookup(segment: &U64Segment) -> (SegmentLookup, usize) {
+    match segment {
+        U64Segment::Array(_) => {
+            let mut positions: Vec<(u64, u32)> = segment
+                .iter()
+                .enumerate()
+                .map(|(position, row_id)| (row_id, position as u32))
+                .collect();
+            positions.sort_unstable();
+            // The first position of a repeated id wins, as `position` does.
+            positions.dedup_by_key(|(row_id, _)| *row_id);
+            (SegmentLookup::Positions(positions), segment.len())
+        }
+        U64Segment::RangeWithBitmap { bitmap, .. } => {
+            let (rank, ones) = build_bitmap_rank(bitmap);
+            (SegmentLookup::BitmapRank(rank), ones)
+        }
+        _ => (SegmentLookup::Native, segment.len()),
     }
-    let mut positions: Vec<(u64, u32)> = segment
-        .iter()
-        .enumerate()
-        .map(|(position, row_id)| (row_id, position as u32))
-        .collect();
-    positions.sort_unstable();
-    positions.dedup_by_key(|(row_id, _)| *row_id);
-    Some(positions)
+}
+
+/// Set bits before each [`RANK_BLOCK_BYTES`] block of `bitmap`, and in total.
+fn build_bitmap_rank(bitmap: &Bitmap) -> (Vec<u32>, usize) {
+    let mut rank = Vec::with_capacity(bitmap.data.len().div_ceil(RANK_BLOCK_BYTES));
+    let mut ones = 0usize;
+    for block in bitmap.data.chunks(RANK_BLOCK_BYTES) {
+        rank.push(ones as u32);
+        ones += count_ones(block);
+    }
+    (rank, ones)
 }
 
 #[derive(Debug)]
@@ -296,7 +368,7 @@ impl FragmentEntry {
         let mut merge_rows: u64 = 0;
         let deleted = !source.deletion_vector.is_empty();
         for (seq_idx, segment) in source.row_id_sequence.0.iter().enumerate() {
-            let len = segment.len();
+            let (lookup, len) = build_lookup(segment);
             // A `Range` without deletions decomposes in constant time.
             if deleted || !matches!(segment, U64Segment::Range(_)) {
                 merge_rows += len as u64;
@@ -310,7 +382,7 @@ impl FragmentEntry {
                     seq_idx,
                     range,
                     start_offset,
-                    positions: build_positions(segment),
+                    lookup,
                 });
             }
             start_offset += len as u32;
@@ -374,6 +446,14 @@ fn max_overlap_depth(fragments: &[FragmentEntry]) -> u64 {
     depth
 }
 
+fn fragment_slots(fragments: &[FragmentEntry]) -> HashMap<u32, usize> {
+    fragments
+        .iter()
+        .enumerate()
+        .map(|(slot, entry)| (entry.fragment_id, slot))
+        .collect()
+}
+
 /// Implicit max-`end` heap over `fragments`, padded to a power of two. Padding
 /// leaves hold 0, which prunes for every id above 0 and is filtered by slot.
 fn build_end_tree(fragments: &[FragmentEntry]) -> Vec<u64> {
@@ -405,8 +485,15 @@ impl DeepSizeOf for RowIdIndex {
                     + entry
                         .segments
                         .iter()
-                        .filter_map(|segment| segment.positions.as_ref())
-                        .map(|positions| positions.capacity() * std::mem::size_of::<(u64, u32)>())
+                        .map(|segment| match &segment.lookup {
+                            SegmentLookup::Native => 0,
+                            SegmentLookup::Positions(positions) => {
+                                positions.capacity() * std::mem::size_of::<(u64, u32)>()
+                            }
+                            SegmentLookup::BitmapRank(rank) => {
+                                rank.capacity() * std::mem::size_of::<u32>()
+                            }
+                        })
                         .sum::<usize>()
             })
             .sum();
@@ -429,6 +516,7 @@ impl DeepSizeOf for RowIdIndex {
             + merged_bytes
             + self.fragments.capacity() * std::mem::size_of::<FragmentEntry>()
             + self.end_tree.capacity() * std::mem::size_of::<u64>()
+            + self.slots.capacity() * std::mem::size_of::<(u32, usize)>()
     }
 }
 
@@ -686,6 +774,7 @@ impl RowIdIndex {
         fragments.sort_unstable_by_key(|entry| entry.start);
         Ok(Self {
             end_tree: build_end_tree(&fragments),
+            slots: fragment_slots(&fragments),
             fragments,
             merged: None,
         })
@@ -789,6 +878,49 @@ mod tests {
 
         let error = index.get_many(&[0, 2]).unwrap_err();
         assert!(matches!(&error, Error::Internal { .. }));
+    }
+
+    #[test]
+    fn test_probe_ranks_a_bitmap_wider_than_one_block() {
+        // Three rank blocks and a partial fourth, with every third slot a hole,
+        // so each lookup combines a directory entry with a partial popcount.
+        let span = (RANK_BLOCK_BYTES * 8 * 3 + 17) as u64;
+        let present: Vec<bool> = (0..span).map(|slot| slot % 3 != 1).collect();
+        let segment = U64Segment::RangeWithBitmap {
+            range: 1000..1000 + span,
+            bitmap: present.as_slice().into(),
+        };
+        let index = RowIdIndex::probing(&[fragment(7, RowIdSequence(vec![segment]))]).unwrap();
+        let mut position = 0;
+        for slot in 0..span {
+            let found = index.get(1000 + slot).unwrap();
+            if slot % 3 == 1 {
+                assert_eq!(found, None);
+            } else {
+                assert_eq!(found, Some(RowAddress::new_from_parts(7, position)));
+                position += 1;
+            }
+        }
+        assert_eq!(index.get(999).unwrap(), None);
+        assert_eq!(index.get(1000 + span).unwrap(), None);
+    }
+
+    #[test]
+    fn test_sequence_by_fragment_id() {
+        let held = Arc::new(RowIdSequence::from(0..10));
+        let index = RowIdIndex::new(&[
+            FragmentRowIdIndex {
+                fragment_id: 5,
+                row_id_sequence: held.clone(),
+                deletion_vector: Arc::new(DeletionVector::default()),
+            },
+            fragment(6, RowIdSequence::new()),
+        ])
+        .unwrap();
+        assert!(Arc::ptr_eq(index.sequence(5).unwrap(), &held));
+        // A fragment without row ids is not indexed, and neither is an unknown one.
+        assert!(index.sequence(6).is_none());
+        assert!(index.sequence(7).is_none());
     }
 
     #[test]

--- a/rust/lance/src/dataset/rowids.rs
+++ b/rust/lance/src/dataset/rowids.rs
@@ -4,6 +4,7 @@
 mod validate;
 
 use super::Dataset;
+use crate::io::deletion::read_dataset_deletion_file;
 use crate::session::caches::{RowIdIndexKey, RowIdSequenceKey};
 use crate::{Error, Result};
 use futures::{Stream, StreamExt, TryFutureExt, TryStreamExt};
@@ -18,45 +19,56 @@ use std::sync::Arc;
 pub(super) use validate::validate_stable_row_ids;
 
 /// Load a row id sequence from the given dataset and fragment.
+///
+/// Served from this version's cached [`RowIdIndex`] when there is one, since
+/// the index owns every committed sequence already; otherwise from the
+/// metadata cache, decoding on a miss.
 pub async fn load_row_id_sequence(
     dataset: &Dataset,
     fragment: &Fragment,
 ) -> Result<Arc<RowIdSequence>> {
+    let Some(row_id_meta) = &fragment.row_id_meta else {
+        return Err(Error::internal("Missing row id meta"));
+    };
+    let index_key = RowIdIndexKey {
+        version: dataset.manifest.version,
+    };
+    // The index holds the committed sequence of a fragment id; an uncommitted
+    // rewrite of the same fragment must not read as it.
+    if let Some(index) = dataset.metadata_cache.get_with_key(&index_key).await
+        && dataset
+            .find_fragment(fragment.id)
+            .is_some_and(|committed| committed.row_id_meta.as_ref() == Some(row_id_meta))
+        && let Some(sequence) = index.sequence(fragment.id as u32)
+    {
+        return Ok(sequence.clone());
+    }
+    let key = RowIdSequenceKey {
+        fragment_id: fragment.id,
+        row_id_meta,
+    };
+    dataset
+        .metadata_cache
+        .get_or_insert_with_key(key, || read_row_id_sequence(dataset, fragment))
+        .await
+}
+
+/// Decode the row id sequence of `fragment`, bypassing every cache.
+async fn read_row_id_sequence(dataset: &Dataset, fragment: &Fragment) -> Result<RowIdSequence> {
     match &fragment.row_id_meta {
         None => Err(Error::internal("Missing row id meta")),
-        Some(row_id_meta @ RowIdMeta::Inline(data)) => {
-            let data = data.clone();
-            let key = RowIdSequenceKey {
-                fragment_id: fragment.id,
-                row_id_meta,
-            };
-            dataset
-                .metadata_cache
-                .get_or_insert_with_key(key, || async move { read_row_ids(&data) })
-                .await
-        }
-        Some(row_id_meta @ RowIdMeta::External(file_slice)) => {
-            let file_slice = file_slice.clone();
-            let dataset_clone = dataset.clone();
-            let key = RowIdSequenceKey {
-                fragment_id: fragment.id,
-                row_id_meta,
-            };
-            dataset
-                .metadata_cache
-                .get_or_insert_with_key(key, || async move {
-                    let path = dataset_clone.base.clone().join(file_slice.path.as_str());
-                    let range = file_slice.offset as usize
-                        ..(file_slice.offset as usize + file_slice.size as usize);
-                    let data = dataset_clone
-                        .object_store
-                        .open(&path)
-                        .await?
-                        .get_range(range)
-                        .await?;
-                    read_row_ids(&data)
-                })
-                .await
+        Some(RowIdMeta::Inline(data)) => read_row_ids(data),
+        Some(RowIdMeta::External(file_slice)) => {
+            let path = dataset.base.clone().join(file_slice.path.as_str());
+            let range =
+                file_slice.offset as usize..(file_slice.offset as usize + file_slice.size as usize);
+            let data = dataset
+                .object_store
+                .open(&path)
+                .await?
+                .get_range(range)
+                .await?;
+            read_row_ids(&data)
         }
     }
 }
@@ -76,9 +88,7 @@ pub fn load_row_id_sequences<'a>(
         .buffer_unordered(dataset.object_store.io_parallelism())
 }
 
-pub async fn get_row_id_index(
-    dataset: &Dataset,
-) -> Result<Option<Arc<lance_table::rowids::RowIdIndex>>> {
+pub async fn get_row_id_index(dataset: &Dataset) -> Result<Option<Arc<RowIdIndex>>> {
     if dataset.manifest.uses_stable_row_ids() {
         let key = RowIdIndexKey {
             version: dataset.manifest.version,
@@ -233,50 +243,40 @@ async fn row_addrs_to_row_ids_impl(
     Ok(ids)
 }
 
-async fn load_row_id_index(dataset: &Dataset) -> Result<lance_table::rowids::RowIdIndex> {
-    let sequences = load_row_id_sequences(dataset, &dataset.manifest.fragments)
-        .try_collect::<Vec<_>>()
-        .await?;
-
-    let fragments = dataset.get_fragments();
-    let fragment_map: std::collections::HashMap<u32, &crate::dataset::fragment::FileFragment> =
-        fragments.iter().map(|f| (f.id() as u32, f)).collect();
-
-    let fragment_indices: Vec<_> =
-        futures::stream::iter(sequences.into_iter().map(|(fragment_id, sequence)| {
-            let fragment = fragment_map
-                .get(&fragment_id)
-                .expect("Fragment should exist");
-            let has_deletion_file = fragment.metadata().deletion_file.is_some();
-            let fragment_clone = (*fragment).clone();
-            async move {
-                let deletion_vector = if has_deletion_file {
-                    fragment_clone
-                        .get_deletion_vector()
-                        .await?
-                        .ok_or_else(|| {
-                            Error::internal(format!(
-                                "fragment_id={fragment_id} has deletion-file metadata but no deletion vector"
-                            ))
-                        })?
-                } else {
-                    Arc::new(DeletionVector::default())
-                };
-
-                Ok::<FragmentRowIdIndex, Error>(FragmentRowIdIndex {
-                    fragment_id,
-                    row_id_sequence: sequence,
-                    deletion_vector,
-                })
-            }
-        }))
+/// Build the index from freshly decoded sequences. The index then owns their
+/// memory alone, so its cache charge is exact and it stays cached whenever it
+/// fits; reading them through the sequence cache instead would charge each
+/// sequence twice and leave a large table's index too heavy to keep.
+async fn load_row_id_index(dataset: &Dataset) -> Result<RowIdIndex> {
+    // A `for` loop rather than `map`: a closure returning a future that borrows
+    // its argument trips the higher-ranked lifetime check on the outer future.
+    let mut loads = Vec::with_capacity(dataset.manifest.fragments.len());
+    for fragment in dataset.manifest.fragments.iter() {
+        loads.push(read_fragment_row_id_index(dataset, fragment));
+    }
+    let fragment_indices: Vec<FragmentRowIdIndex> = futures::stream::iter(loads)
         .buffer_unordered(dataset.object_store.io_parallelism())
         .try_collect()
         .await?;
+    RowIdIndex::new(&fragment_indices)
+}
 
-    let index = RowIdIndex::new(&fragment_indices)?;
-
-    Ok(index)
+async fn read_fragment_row_id_index(
+    dataset: &Dataset,
+    fragment: &Fragment,
+) -> Result<FragmentRowIdIndex> {
+    let row_id_sequence = Arc::new(read_row_id_sequence(dataset, fragment).await?);
+    let deletion_vector = match &fragment.deletion_file {
+        None => Arc::new(DeletionVector::default()),
+        Some(deletion_file) => {
+            read_dataset_deletion_file(dataset, fragment.id, deletion_file).await?
+        }
+    };
+    Ok(FragmentRowIdIndex {
+        fragment_id: fragment.id as u32,
+        row_id_sequence,
+        deletion_vector,
+    })
 }
 
 #[cfg(test)]
@@ -303,6 +303,7 @@ mod test {
     use lance_datagen::Dimension;
     use lance_index::{IndexType, scalar::ScalarIndexParams};
     use lance_io::object_store::ObjectStoreParams;
+    use lance_table::rowids::write_row_ids;
     use std::collections::HashMap;
     use std::collections::HashSet;
 
@@ -395,6 +396,55 @@ mod test {
         assert_eq!(found_addresses, expected_addresses);
 
         assert_eq!(dataset.manifest().next_row_id, num_rows);
+    }
+
+    #[tokio::test]
+    async fn test_row_id_index_owns_the_sequences_it_caches() {
+        let batch = sequence_batch(0..30);
+        let reader = RecordBatchIterator::new(vec![Ok(batch.clone())], batch.schema());
+        let write_params = WriteParams {
+            enable_stable_row_ids: true,
+            max_rows_per_file: 10,
+            ..Default::default()
+        };
+        let dataset = Dataset::write(reader, "memory://", Some(write_params))
+            .await
+            .unwrap();
+        let session = dataset.session();
+
+        // Building the index adds one cache entry: the index, which holds its
+        // sequences itself rather than reading them through their own entries.
+        let entries_before = session.metadata_cache_stats().await.num_entries;
+        let index = get_row_id_index(&dataset).await.unwrap().unwrap();
+        assert_eq!(
+            session.metadata_cache_stats().await.num_entries,
+            entries_before + 1
+        );
+        let again = get_row_id_index(&dataset).await.unwrap().unwrap();
+        assert!(Arc::ptr_eq(&index, &again));
+
+        // A sequence lookup is answered from the cached index, not a second copy.
+        let fragment = &dataset.manifest.fragments[1];
+        let sequence = load_row_id_sequence(&dataset, fragment).await.unwrap();
+        assert!(Arc::ptr_eq(
+            &sequence,
+            index.sequence(fragment.id as u32).unwrap()
+        ));
+        assert_eq!(
+            session.metadata_cache_stats().await.num_entries,
+            entries_before + 1
+        );
+
+        // An uncommitted rewrite of the same fragment id carries other row ids
+        // and must not be answered from the index.
+        let rewritten_ids = RowIdSequence::from(100..110);
+        let mut rewritten = fragment.clone();
+        rewritten.row_id_meta = Some(RowIdMeta::Inline(write_row_ids(&rewritten_ids).into()));
+        let sequence = load_row_id_sequence(&dataset, &rewritten).await.unwrap();
+        assert_eq!(
+            sequence.iter().collect::<Vec<_>>(),
+            (100..110).collect::<Vec<_>>()
+        );
     }
 
     #[tokio::test]

--- a/rust/lance/src/dataset/rowids.rs
+++ b/rust/lance/src/dataset/rowids.rs
@@ -72,18 +72,25 @@ pub fn load_row_id_sequences<'a>(
 }
 
 pub async fn get_row_id_index(dataset: &Dataset) -> Result<Option<Arc<RowIdIndex>>> {
-    if dataset.manifest.uses_stable_row_ids() {
-        let key = RowIdIndexKey {
-            version: dataset.manifest.version,
-        };
-        let index = dataset
-            .metadata_cache
-            .get_or_insert_with_key(key, || load_row_id_index(dataset))
-            .await?;
-        Ok(Some(index))
-    } else {
-        Ok(None)
+    if !dataset.manifest.uses_stable_row_ids() {
+        return Ok(None);
     }
+    // The cache is shared by every dataset opened at this URI, and one dropped
+    // and recreated there restarts at version 1. Without a token for this
+    // manifest generation a cached index could be the old generation's, so
+    // build a private one instead of sharing.
+    let Some(e_tag) = dataset.manifest_location.e_tag.as_deref() else {
+        return Ok(Some(Arc::new(load_row_id_index(dataset).await?)));
+    };
+    let key = RowIdIndexKey {
+        version: dataset.manifest.version,
+        e_tag: Some(e_tag),
+    };
+    let index = dataset
+        .metadata_cache
+        .get_or_insert_with_key(key, || load_row_id_index(dataset))
+        .await?;
+    Ok(Some(index))
 }
 
 /// Map a set of physical row addresses to their stable row ids
@@ -230,9 +237,9 @@ async fn row_addrs_to_row_ids_impl(
 /// memory alone, so its cache charge is exact and it stays cached whenever it
 /// fits; reading them through the sequence cache instead would charge each
 /// sequence twice and leave a large table's index too heavy to keep. A scan
-/// that needs a sequence still caches its own copy under `RowIdSequenceKey`:
-/// that key carries the fragment's content identity, while `RowIdIndexKey` is
-/// scoped by version alone, so the index cannot stand in for it.
+/// that needs a sequence still caches its own copy under `RowIdSequenceKey`,
+/// keyed by the fragment's content; the index is keyed by manifest generation
+/// and cannot stand in for it.
 async fn load_row_id_index(dataset: &Dataset) -> Result<RowIdIndex> {
     // A `for` loop rather than `map`: a closure returning a future that borrows
     // its argument trips the higher-ranked lifetime check on the outer future.
@@ -418,6 +425,35 @@ mod test {
         assert_eq!(
             session.metadata_cache_stats().await.num_entries,
             entries_before + 2
+        );
+    }
+
+    #[tokio::test]
+    async fn test_row_id_index_is_not_shared_without_a_generation_token() {
+        let batch = sequence_batch(0..10);
+        let reader = RecordBatchIterator::new(vec![Ok(batch.clone())], batch.schema());
+        let write_params = WriteParams {
+            enable_stable_row_ids: true,
+            ..Default::default()
+        };
+        let mut dataset = Dataset::write(reader, "memory://", Some(write_params))
+            .await
+            .unwrap();
+        // Without an e-tag the version-only key could alias a dataset recreated
+        // at the same URI, so the index must be built privately, never cached.
+        dataset.manifest_location.e_tag = None;
+        let session = dataset.session();
+        let entries_before = session.metadata_cache_stats().await.num_entries;
+        let first = get_row_id_index(&dataset).await.unwrap().unwrap();
+        let second = get_row_id_index(&dataset).await.unwrap().unwrap();
+        assert!(!Arc::ptr_eq(&first, &second));
+        assert_eq!(
+            session.metadata_cache_stats().await.num_entries,
+            entries_before
+        );
+        assert_eq!(
+            second.get(9).unwrap(),
+            Some(RowAddress::new_from_parts(0, 9))
         );
     }
 
@@ -616,6 +652,15 @@ mod test {
         assert_eq!(
             sequence.iter().collect::<Vec<_>>(),
             (0..60).collect::<Vec<_>>()
+        );
+
+        // The same goes for the index: row id 60 exists only in the dropped
+        // generation, whose index is still in the session cache.
+        let index = get_row_id_index(&dataset).await.unwrap().unwrap();
+        assert!(index.get(60).unwrap().is_none());
+        assert_eq!(
+            index.get(59).unwrap(),
+            Some(RowAddress::new_from_parts(0, 59))
         );
     }
 

--- a/rust/lance/src/dataset/rowids.rs
+++ b/rust/lance/src/dataset/rowids.rs
@@ -19,10 +19,6 @@ use std::sync::Arc;
 pub(super) use validate::validate_stable_row_ids;
 
 /// Load a row id sequence from the given dataset and fragment.
-///
-/// Served from this version's cached [`RowIdIndex`] when there is one, since
-/// the index owns every committed sequence already; otherwise from the
-/// metadata cache, decoding on a miss.
 pub async fn load_row_id_sequence(
     dataset: &Dataset,
     fragment: &Fragment,
@@ -30,19 +26,6 @@ pub async fn load_row_id_sequence(
     let Some(row_id_meta) = &fragment.row_id_meta else {
         return Err(Error::internal("Missing row id meta"));
     };
-    let index_key = RowIdIndexKey {
-        version: dataset.manifest.version,
-    };
-    // The index holds the committed sequence of a fragment id; an uncommitted
-    // rewrite of the same fragment must not read as it.
-    if let Some(index) = dataset.metadata_cache.get_with_key(&index_key).await
-        && dataset
-            .find_fragment(fragment.id)
-            .is_some_and(|committed| committed.row_id_meta.as_ref() == Some(row_id_meta))
-        && let Some(sequence) = index.sequence(fragment.id as u32)
-    {
-        return Ok(sequence.clone());
-    }
     let key = RowIdSequenceKey {
         fragment_id: fragment.id,
         row_id_meta,
@@ -246,7 +229,10 @@ async fn row_addrs_to_row_ids_impl(
 /// Build the index from freshly decoded sequences. The index then owns their
 /// memory alone, so its cache charge is exact and it stays cached whenever it
 /// fits; reading them through the sequence cache instead would charge each
-/// sequence twice and leave a large table's index too heavy to keep.
+/// sequence twice and leave a large table's index too heavy to keep. A scan
+/// that needs a sequence still caches its own copy under `RowIdSequenceKey`:
+/// that key carries the fragment's content identity, while `RowIdIndexKey` is
+/// scoped by version alone, so the index cannot stand in for it.
 async fn load_row_id_index(dataset: &Dataset) -> Result<RowIdIndex> {
     // A `for` loop rather than `map`: a closure returning a future that borrows
     // its argument trips the higher-ranked lifetime check on the outer future.
@@ -303,7 +289,6 @@ mod test {
     use lance_datagen::Dimension;
     use lance_index::{IndexType, scalar::ScalarIndexParams};
     use lance_io::object_store::ObjectStoreParams;
-    use lance_table::rowids::write_row_ids;
     use std::collections::HashMap;
     use std::collections::HashSet;
 
@@ -423,27 +408,16 @@ mod test {
         let again = get_row_id_index(&dataset).await.unwrap().unwrap();
         assert!(Arc::ptr_eq(&index, &again));
 
-        // A sequence lookup is answered from the cached index, not a second copy.
+        // A sequence lookup keeps its own content-keyed entry.
         let fragment = &dataset.manifest.fragments[1];
         let sequence = load_row_id_sequence(&dataset, fragment).await.unwrap();
-        assert!(Arc::ptr_eq(
-            &sequence,
-            index.sequence(fragment.id as u32).unwrap()
-        ));
-        assert_eq!(
-            session.metadata_cache_stats().await.num_entries,
-            entries_before + 1
-        );
-
-        // An uncommitted rewrite of the same fragment id carries other row ids
-        // and must not be answered from the index.
-        let rewritten_ids = RowIdSequence::from(100..110);
-        let mut rewritten = fragment.clone();
-        rewritten.row_id_meta = Some(RowIdMeta::Inline(write_row_ids(&rewritten_ids).into()));
-        let sequence = load_row_id_sequence(&dataset, &rewritten).await.unwrap();
         assert_eq!(
             sequence.iter().collect::<Vec<_>>(),
-            (100..110).collect::<Vec<_>>()
+            (10..20).collect::<Vec<_>>()
+        );
+        assert_eq!(
+            session.metadata_cache_stats().await.num_entries,
+            entries_before + 2
         );
     }
 
@@ -615,6 +589,10 @@ mod test {
             .await
             .unwrap();
         assert_eq!(sequence.len(), 100);
+        // Leave this generation's index in the session cache: `RowIdIndexKey`
+        // is scoped by version alone, so the recreated dataset below reaches
+        // the same key, and no sequence load may be answered from it.
+        get_row_id_index(&dataset).await.unwrap().unwrap();
 
         // Reloading the unchanged fragment must still hit: keying on contents has
         // to leave the sequence cacheable, not just make it distinguishable.

--- a/rust/lance/src/session/caches.rs
+++ b/rust/lance/src/session/caches.rs
@@ -198,14 +198,25 @@ impl CacheKey for RowAddrMaskKey {
 }
 
 #[derive(Debug)]
-pub struct RowIdIndexKey {
+pub struct RowIdIndexKey<'a> {
     pub version: u64,
+    /// A dataset dropped and recreated at the same URI restarts its version
+    /// history at 1, so a long-lived session's cache can otherwise return the
+    /// previous incarnation's index for a version number the new incarnation
+    /// now also holds. The e-tag disambiguates generations the same way
+    /// [`ManifestKey::e_tag`] does. Callers without one must not share the
+    /// cached index at all (see `get_row_id_index`).
+    pub e_tag: Option<&'a str>,
 }
 
-impl CacheKey for RowIdIndexKey {
+impl CacheKey for RowIdIndexKey<'_> {
     type ValueType = RowIdIndex;
     fn key(&self) -> Cow<'_, str> {
-        Cow::Owned(format!("row_id_index/{}", self.version))
+        Cow::Owned(format!(
+            "row_id_index/{}/{}",
+            self.version,
+            self.e_tag.unwrap_or("")
+        ))
     }
     fn type_name() -> &'static str {
         "RowIdIndex"
@@ -217,6 +228,13 @@ impl CacheKey for RowIdIndexKey {
 
     fn write_key(&self, builder: &mut KeyBuilder) {
         builder.write_u64(self.version);
+        match self.e_tag {
+            Some(e_tag) => {
+                builder.write_some();
+                builder.write_str(e_tag);
+            }
+            None => builder.write_none(),
+        }
     }
 }
 
@@ -393,6 +411,29 @@ mod tests {
                 .get_with_key(&RowIdSequenceKey {
                     fragment_id: 0,
                     row_id_meta: &inline,
+                })
+                .await
+                .is_none()
+        );
+    }
+
+    #[tokio::test]
+    async fn row_id_index_key_separates_manifest_generations() {
+        let cache = LanceCache::with_capacity(4096);
+        let key = RowIdIndexKey {
+            version: 5,
+            e_tag: Some("first-etag"),
+        };
+        cache
+            .insert_with_key(&key, Arc::new(RowIdIndex::new(&[]).unwrap()))
+            .await;
+        assert!(cache.get_with_key(&key).await.is_some());
+
+        assert!(
+            cache
+                .get_with_key(&RowIdIndexKey {
+                    version: 5,
+                    e_tag: Some("second-etag"),
                 })
                 .await
                 .is_none()


### PR DESCRIPTION
## Problem

`take_rows` by stable row id resolves ids through `RowIdIndex`, cached per manifest version in
the metadata cache. On a large table the index never stays cached, and each lookup pays a
popcount over a whole bitmap prefix.

Measured on a 17.4B-row table (19,960 fragments, stable row ids, compacted after deletes, no
deletion files; inline row-id sequences 884 MiB, of which 849 MiB are `RangeWithBitmap`
segments at ~82% density; the probe representation from #8883 is selected):

- `DeepSizeOf for RowIdIndex` charges the `Arc<RowIdSequence>`s it holds (897 MiB), and
  `load_row_id_index` read those sequences through `load_row_id_sequence`, which caches each of
  them under its own `RowIdSequenceKey` (889 MiB). The same memory was charged twice, 1.78 GiB
  against the 1 GiB default budget, so the index was rejected on every insert and rebuilt on
  every `take_rows`: 0.10 s with the sequences cached, 0.85 s after file metadata evicted them.
- `U64Segment::position` on a `RangeWithBitmap` counts the ones before the offset with
  `bitmap.slice(0, offset).count_zeros()`: a popcount over up to ~75 KB per lookup. 35% of
  lookup time in `perf`.
- `RowIdIndex::probe` zero-initialised a 1.5 KB stack array on every call: ~23% of the probe's
  own time in `perf annotate`.

## Change

`lance-table/src/rowids/index.rs`

- `probe` walks the implicit max-end heap without a stack: `(node, lo, width)`, moving up while
  the node is a right child and then over to the sibling. Visiting left to right also lets it
  stop as soon as `lo >= upper`.
- `SegmentEntry` gains a `SegmentLookup` enum. `BitmapRank(Vec<u32>)` holds the set bits before
  each 256-byte block of a `RangeWithBitmap` bitmap (`RANK_BLOCK_BYTES`, 1/64 of the bitmap),
  so `position` is one directory read plus a popcount of at most 255 bytes. The directory is
  built in the same pass that counts the segment's rows, so the build does not read the bitmaps
  an extra time. `Positions` is the existing unsorted-`Array` map.
- `RowIdIndex::sequence(fragment_id)` returns the sequence the index holds for a fragment
  (`slots: HashMap<u32, usize>`).

`lance/src/dataset/rowids.rs`

- `load_row_id_index` decodes the sequences directly (`read_row_id_sequence`) instead of through
  the per-sequence cache. The index is then the sole owner of that memory, its charge is exact,
  and it stays cached whenever it fits.
- `load_row_id_sequence` first asks this version's cached index for the fragment's sequence and
  returns that `Arc` — after checking that the fragment's `row_id_meta` matches the committed
  fragment, so an uncommitted rewrite of the same fragment id is never answered from the index.
  It falls back to the per-sequence cache as before. A scan with `_rowid` after a take therefore
  does not cache a second copy of every sequence.
- Deletion vectors are read only for fragments that have a deletion file; the `get_fragments()`
  clone of every `Fragment` is gone.

`lance-table/src/rowids/bitmap.rs`: `count_ones(&[u8])` becomes `pub(super)`.

Unchanged: the merged representation and its lookups, the probe/merge gate, and every `get`
result (the probe visits the same candidate set in the opposite order).

## Numbers

criterion, `row_id_index_shot_table` on the real table's row-id sequences (19,960 fragments):

| bench | main | this PR |
|---|---|---|
| build (`RowIdIndex::new`) | 45.6 ms | 57.3 ms (rank directories; once per version) |
| get_many/1 | 112 ns | 67 ns |
| get_many/1000 | 731 µs | 148 µs |
| get_many/100000 | 92.0 ms | 14.7 ms |
| get | 1.76 µs | 274 ns |

Same group on the synthetic shot-table-shaped data the bench generates (2000 fragments):
get 422 → 126 ns, get_many/100000 24.8 → 8.0 ms, build 5.06 → 5.41 ms.

S3, fresh process, default 1 GiB metadata cache, the real table:

| | main | this PR |
|---|---|---|
| `get_row_id_index`, second call | 0.101 s (rebuilt) | 0.000 s (cached) |
| `get_many(1000)` | 793 ns/id | 180 ns/id |
| `take_rows(1)`, warm rounds | 0.60–1.07 s | 0.46 s |
| `take_rows(200)`, rounds 1–3 | 10.6 / 13.7 / 9.1 s | 8.9 / 5.9 / 4.7 s |

Control table with `Range`-only sequences (19,047 fragments, merged representation, 16 MiB
index, already cacheable on main): parity within noise (`get` 82 → 83 ns, `get_many/1000`
70 → 72 µs, `take_rows(200)` warm 1.42 s both), and 984 cache entries after the index instead
of 19,049.

The remaining `take_rows` time on the large table is reading each fragment's full column
metadata (~1.2 MiB over the wire per fragment: the files are v2.0, which always opens with full
metadata). That is outside this PR.

## Tests

- `test_probe_ranks_a_bitmap_wider_than_one_block`: every slot of a bitmap spanning several
  rank blocks resolves to the right offset, holes and out-of-range ids to `None`.
- `test_sequence_by_fragment_id`: `sequence()` returns the held `Arc`, `None` for a fragment
  without row ids and for an unknown id.
- `test_row_id_index_owns_the_sequences_it_caches`: building the index adds exactly one cache
  entry, a second `get_row_id_index` returns the same `Arc`, `load_row_id_sequence` is answered
  from the index without a new entry, and a rewritten fragment with the same id is decoded
  instead of served from the index.
- Existing `rowids` tests in `lance-table` (103) and `lance` (37), and `dataset::take` (31), pass.

`cargo fmt --all` and `cargo clippy --all --tests --benches -- -D warnings` are clean.

## Notes

- Deletion vectors are still cached both under `DeletionFileKey` and inside the index, so a
  table with many deletion files still double-charges them. Out of scope here.
- The `row_id_index_shot_table` criterion group builds shot-table-shaped fragments: 44% compacted
  in groups of 16 into 82%-dense bitmap and 1%-hole slices with interleaving spans, the rest
  plain `Range`. `BENCH_SHOT_FRAGMENTS` scales the fragment count.