### PR TITLE
fix(io): carry batch_size_bytes through distributed FilteredReadOptions

### DIFF
--- a/protos/filtered_read.proto
+++ b/protos/filtered_read.proto
@@ -68,6 +68,10 @@ message FilteredReadOptionsProto {
   // bound when no other batch is reserved. If absent, Blob v2 materialization
   // has no independent memory bound.
   optional uint64 materialization_readahead_bytes = 13;
+  // If present, the scanner-level byte budget for output batches. When set,
+  // the file reader uses it as an additional batch boundary alongside the
+  // row-based batch_size. This corresponds to FileReaderOptions.batch_size_bytes.
+  optional uint64 batch_size_bytes = 14;
 }
 
 // Serializable form of FilteredReadPlan (planned/distributed mode).

--- a/rust/lance/src/io/exec/filtered_read_proto.rs
+++ b/rust/lance/src/io/exec/filtered_read_proto.rs
@@ -146,6 +146,10 @@ fn fr_options_to_proto(
         io_buffer_size_bytes: options.io_buffer_size_bytes,
         filter_schema_ipc,
         materialization_readahead_bytes: options.materialization_readahead_bytes,
+        batch_size_bytes: options
+            .file_reader_options
+            .as_ref()
+            .and_then(|o| o.batch_size_bytes),
     })
 }
 
@@ -197,6 +201,14 @@ async fn fr_options_from_proto(
     }
     if let Some(materialization_readahead_bytes) = proto.materialization_readahead_bytes {
         options = options.with_materialization_readahead_bytes(materialization_readahead_bytes);
+    }
+    if let Some(batch_size_bytes) = proto.batch_size_bytes {
+        // Merge the scanner-level byte budget into the dataset's existing
+        // file-reader options so that distributed execution preserves
+        // validation and I/O settings such as read_chunk_size.
+        let mut file_reader_options = dataset.file_reader_options.clone().unwrap_or_default();
+        file_reader_options.batch_size_bytes = Some(batch_size_bytes);
+        options = options.with_file_reader_options(file_reader_options);
     }
     if let Some(mode) = proto.threading_mode {
         options.threading_mode = threading_mode_from_proto(&mode)?;
@@ -498,6 +510,8 @@ mod tests {
     use std::collections::HashSet;
 
     use crate::utils::test::{DatagenExt, FragmentCount, FragmentRowCount};
+    use lance_encoding::decoder::DecoderConfig;
+    use lance_file::reader::FileReaderOptions;
 
     #[test]
     fn test_range_roundtrip() {
@@ -592,9 +606,27 @@ mod tests {
         Arc::new(dataset)
     }
 
+    /// Create a test dataset with non-default file-reader options so that
+    /// round-trip tests can verify that scanner-level overrides preserve the
+    /// dataset-level defaults.
+    async fn make_test_dataset_with_file_reader_options() -> Arc<Dataset> {
+        let mut dataset = make_test_dataset().await;
+        if let Some(ds) = Arc::get_mut(&mut dataset) {
+            ds.file_reader_options = Some(FileReaderOptions {
+                read_chunk_size: 1234,
+                decoder_config: DecoderConfig {
+                    validate_on_decode: true,
+                    ..Default::default()
+                },
+                batch_size_bytes: None,
+            });
+        }
+        dataset
+    }
+
     #[tokio::test]
     async fn test_options_roundtrip_basic() {
-        let dataset = make_test_dataset().await;
+        let dataset = make_test_dataset_with_file_reader_options().await;
         let ctx = SessionContext::new();
         let state = ctx.state();
         let filter_schema = Arc::new(prune_schema_for_substrait(&dataset.schema().into()));
@@ -603,6 +635,10 @@ mod tests {
             .with_scan_range_before_filter(10..90)
             .unwrap()
             .with_batch_size(64)
+            .with_file_reader_options(FileReaderOptions {
+                batch_size_bytes: Some(4096),
+                ..Default::default()
+            })
             .with_fragment_readahead(4)
             .with_io_buffer_size(1024 * 1024)
             .with_materialization_readahead_bytes(8 * 1024 * 1024);
@@ -623,6 +659,20 @@ mod tests {
             options.materialization_readahead_bytes,
             back.materialization_readahead_bytes
         );
+        assert_eq!(
+            options
+                .file_reader_options
+                .as_ref()
+                .and_then(|o| o.batch_size_bytes),
+            back.file_reader_options
+                .as_ref()
+                .and_then(|o| o.batch_size_bytes)
+        );
+        // The scanner-level byte budget must be merged into the dataset's
+        // existing file-reader options, not replace them.
+        let effective = back.file_reader_options.as_ref().unwrap();
+        assert_eq!(effective.read_chunk_size, 1234);
+        assert!(effective.decoder_config.validate_on_decode);
         assert_eq!(options.threading_mode, back.threading_mode);
         assert_eq!(options.with_deleted_rows, back.with_deleted_rows);
         assert_eq!(options.projection.field_ids, back.projection.field_ids);


### PR DESCRIPTION
Serialize the scanner's `batch_size_bytes` budget into `FilteredReadOptionsProto` so remote execution no longer drops the byte cap when `file_reader_options` is reconstructed from the wire.

## Summary

Fixes #8857 (follow-up to #8927): carry `batch_size_bytes` through distributed FilteredReadOptions

This is a follow-up to #8927 ("feat(io): apply byte-sized batch budget to blob materialization"), which applies the scanner's `batch_size_bytes` budget a second time after blob v2 payloads are materialized. The gatekeeper review on #8927 flagged that the budget is silently dropped under distributed execution, because `FilteredReadOptionsProto` does not serialize `file_reader_options`. This PR lands that missing wire field.

## Problem

#8927 forwards the byte budget into the row-stream `FilteredReadExec`, but its distributed codec does not serialize `file_reader_options`; `FilteredReadOptionsProto` has no corresponding field and decode reconstructs `None`. Remote execution therefore silently drops the byte cap.

## Fix

Add an optional `batch_size_bytes` field to `FilteredReadOptionsProto` and round-trip it through the proto codec.

### Changes

- `protos/filtered_read.proto`
  - Add `optional uint64 batch_size_bytes = 14` to `FilteredReadOptionsProto`, documented as the scanner-level byte budget corresponding to `FileReaderOptions.batch_size_bytes`.
- `rust/lance/src/io/exec/filtered_read_proto.rs`
  - `fr_options_to_proto`: serialize `options.file_reader_options.batch_size_bytes` into the new field.
  - `fr_options_from_proto`: reconstruct `file_reader_options` with `batch_size_bytes` when present.
  - Extend `test_options_roundtrip_basic` to set `batch_size_bytes: Some(4096)` and assert it survives the round-trip.

### Tests

- `cargo test -p lance --features substrait --lib filtered_read_proto::tests::test_options_roundtrip_basic` — verifies `batch_size_bytes` round-trips through the proto codec (sender `Some(4096)` → decoded `Some(4096)`).
- `cargo check -p lance --features substrait` — compiles cleanly.

## Relationship to #8927

#8927 implements the core blob byte-budget feature and is still open. This PR is a focused follow-up that addresses one of its three gatekeeper findings (distributed execution dropping the budget). The other two findings — skewed-row chunk sizing in `split_batch_by_bytes` and chunk boundaries being re-merged by `RowStreamRead::read_batch` — are tracked separately and not addressed here.