### PR TITLE
fix(encoding): accept 1-bit booleans in the single-row full-zip fallback

### DIFF
--- a/rust/lance-encoding/src/encodings/logical/list.rs
+++ b/rust/lance-encoding/src/encodings/logical/list.rs
@@ -240,8 +240,8 @@ mod tests {
         STRUCTURAL_ENCODING_FULLZIP, STRUCTURAL_ENCODING_META_KEY, STRUCTURAL_ENCODING_MINIBLOCK,
     };
     use arrow_array::{
-        Array, ArrayRef, BooleanArray, DictionaryArray, LargeStringArray, ListArray, StructArray,
-        UInt8Array, UInt64Array,
+        Array, ArrayRef, BooleanArray, DictionaryArray, LargeStringArray, ListArray, StringArray,
+        StructArray, UInt8Array, UInt64Array,
         builder::{
             Int32Builder, Int64Builder, LargeListBuilder, ListBuilder, StringBuilder, UInt32Builder,
         },
@@ -1493,74 +1493,37 @@ mod tests {
         check_round_trip_encoding_of_data(vec![list_array], &test_cases, HashMap::new()).await;
     }
 
-    #[test_log::test(tokio::test)]
-    async fn test_nested_sparse_boolean_list_fails_without_panic() {
-        let empty_inner_lists = 70_000usize;
-        let booleans_per_list = 8usize;
-
+    fn unsplittable_nested_list(items: ArrayRef, empty_inner_lists: usize) -> ArrayRef {
         let mut inner_offsets = vec![0i32; empty_inner_lists + 1];
-        let values = (0..booleans_per_list)
-            .map(|idx| idx % 2 == 0)
-            .collect::<Vec<_>>();
-        inner_offsets.push(values.len() as i32);
-
-        let inner_items = BooleanArray::from(values);
+        inner_offsets.push(items.len() as i32);
         let inner_list = ListArray::new(
-            Arc::new(Field::new("item", DataType::Boolean, true)),
+            Arc::new(Field::new("item", items.data_type().clone(), true)),
             OffsetBuffer::new(ScalarBuffer::from(inner_offsets)),
-            Arc::new(inner_items),
+            items,
             None,
         );
-        let outer_list = ListArray::new(
+        Arc::new(ListArray::new(
             Arc::new(Field::new("item", inner_list.data_type().clone(), true)),
             OffsetBuffer::new(ScalarBuffer::from(vec![0i32, empty_inner_lists as i32 + 1])),
             Arc::new(inner_list),
             None,
-        );
-
-        let err = try_encode_v22_pages(Arc::new(outer_list))
-            .await
-            .unwrap_err();
-        assert!(
-            err.to_string().contains("Mini-block cannot encode"),
-            "unexpected error: {err}"
-        );
+        ))
     }
 
+    #[rstest]
+    #[case::boolean(Arc::new(BooleanArray::from(vec![true, false, true, false, true, false, true, false])))]
+    #[case::string(Arc::new(StringArray::from(vec!["value", "other"])))]
     #[test_log::test(tokio::test)]
-    async fn test_nested_sparse_string_single_row_falls_back_to_fullzip() {
-        let empty_inner_lists = 70_000usize;
-
-        let mut inner_offsets = vec![0i32; empty_inner_lists + 1];
-        inner_offsets.push(1);
-        inner_offsets.push(2);
-
-        let mut strings = StringBuilder::new();
-        strings.append_value("value");
-        strings.append_value("other");
-        let inner_items = strings.finish();
-        let inner_list = ListArray::new(
-            Arc::new(Field::new("item", DataType::Utf8, true)),
-            OffsetBuffer::new(ScalarBuffer::from(inner_offsets)),
-            Arc::new(inner_items),
-            None,
-        );
-        let outer_list = ListArray::new(
-            Arc::new(Field::new("item", inner_list.data_type().clone(), true)),
-            OffsetBuffer::new(ScalarBuffer::from(vec![0i32, empty_inner_lists as i32 + 2])),
-            Arc::new(inner_list),
-            None,
-        );
-
-        let outer_list = Arc::new(outer_list) as ArrayRef;
-        let pages = encode_v22_pages(outer_list.clone()).await;
+    async fn test_nested_sparse_single_row_falls_back_to_fullzip(#[case] items: ArrayRef) {
+        let list = unsplittable_nested_list(items, 70_000);
+        let pages = encode_v22_pages(list.clone()).await;
         assert_has_fullzip_layout(&pages);
 
         let test_cases = TestCases::default()
             .with_range(0..1)
             .with_indices(vec![0])
             .with_dense_encodings();
-        check_round_trip_encoding_of_data(vec![outer_list], &test_cases, HashMap::new()).await;
+        check_round_trip_encoding_of_data(vec![list], &test_cases, HashMap::new()).await;
     }
 
     /// Builds the HNSW-flush repro shape: a dense prefix where every row has

--- a/rust/lance-encoding/src/encodings/logical/primitive.rs
+++ b/rust/lance-encoding/src/encodings/logical/primitive.rs
@@ -6480,7 +6480,10 @@ impl PrimitiveStructuralEncoder {
                 .get(STRUCTURAL_ENCODING_META_KEY)
                 .map(|requested| requested.to_lowercase());
             let fullzip_error = match &data_block {
-                DataBlock::FixedWidth(fixed) if !fixed.bits_per_value.is_multiple_of(8) => {
+                // 1-bit booleans are widened to bytes inside `encode_full_zip`.
+                DataBlock::FixedWidth(fixed)
+                    if fixed.bits_per_value != 1 && !fixed.bits_per_value.is_multiple_of(8) =>
+                {
                     Some(format!(
                         "Full-zip fixed-width values must be byte aligned, got {} bits per value",
                         fixed.bits_per_value


### PR DESCRIPTION
When a single top-level row carries more rep/def levels than one mini-block chunk can hold, the primitive encoder falls back to full-zip after a pre-check that the value block is something full-zip can serialize. That pre-check rejected 1-bit booleans as non-byte-aligned, although `encode_full_zip` widens them to bytes before compressing (#6723).

A sparse `List<List<Boolean>>` row therefore failed with "Mini-block cannot encode N rep/def levels in one top-level row" even though it encodes fine, and even when the user explicitly requested `structural_encoding=fullzip`. Before #6787 the same row was written through full-zip.

The pre-check now lets 1-bit fixed-width blocks through, matching what `encode_full_zip` accepts. The boolean test that asserted the error now asserts a full-zip round trip alongside the existing string case.