### PR TITLE
feat(index): default ivf_rq to 5-bit quantization

### DIFF
--- a/docs/src/guide/performance.md
+++ b/docs/src/guide/performance.md
@@ -480,14 +480,26 @@ exact size depends on the quantizer:
 100M * (768 + 8) = ~72.3 GiB
 ```
 
-**RQ (RaBitQ):** Vectors are currently quantized to 1-bit binary codes. Each row also stores per-row
-scale and offset factors (4 bytes each) used for distance correction. Each row requires
-`dimension / 8 + 16` bytes (8 bytes for the row ID plus 8 bytes for the factors). For example, 100M
-rows with 768 dimensions and 1 bit per dimension:
+**RQ (RaBitQ):** New indexes default to 5 bits per dimension. Every bit width stores a 1-bit sign
+code plus three 4-byte correction factors. Multi-bit indexes also store the remaining bits in
+64-dimension-padded blocks and two additional 4-byte correction factors. Including the 8-byte row
+ID, the approximate size per row is:
+
+- 1-bit: `dimension / 8 + 20` bytes
+- Multi-bit: `dimension / 8 + round_up(dimension, 64) * (num_bits - 1) / 8 + 28` bytes
+
+For example, the default 5-bit index for 100M rows with 768 dimensions requires:
 
 ```
-100M * (768 / 8 + 16) = ~10.8 GiB
+100M * (768 / 8 + 768 * 4 / 8 + 28) = ~47.3 GiB
 ```
+
+The 5-bit default retains more information for the higher-fidelity distance estimates used by
+`Normal` and `Accurate` search modes, at the cost of more quantization work and index I/O during
+the build and a larger index. `Fast` search mode uses only the 1-bit sign code even when the index
+stores additional bits. Set `num_bits=1` explicitly to minimize index size and build I/O; the same
+100M-row example uses about 10.8 GiB, but searches cannot use the multi-bit distance estimate and
+may have lower recall.
 
 #### AMX Acceleration
 

--- a/java/src/main/java/org/lance/index/vector/RQBuildParams.java
+++ b/java/src/main/java/org/lance/index/vector/RQBuildParams.java
@@ -15,7 +15,7 @@ package org.lance.index.vector;
 
 import com.google.common.base.MoreObjects;
 
-/** Parameters for building a Rabit Quantizer (RQ) index stage. */
+/** Parameters for building a Rabit Quantizer (RQ) index stage. Defaults to 5 bits per dimension. */
 public class RQBuildParams {
   private final byte numBits;
 
@@ -24,7 +24,7 @@ public class RQBuildParams {
   }
 
   public static class Builder {
-    private byte numBits = 1;
+    private byte numBits = 5;
 
     public Builder() {}
 

--- a/java/src/test/java/org/lance/JNITest.java
+++ b/java/src/test/java/org/lance/JNITest.java
@@ -18,6 +18,7 @@ import org.lance.index.IndexParams;
 import org.lance.index.vector.HnswBuildParams;
 import org.lance.index.vector.IvfBuildParams;
 import org.lance.index.vector.PQBuildParams;
+import org.lance.index.vector.RQBuildParams;
 import org.lance.index.vector.SQBuildParams;
 import org.lance.index.vector.VectorIndexParams;
 import org.lance.ipc.ApproxMode;
@@ -76,6 +77,11 @@ public class JNITest {
         IndexParams.builder()
             .setVectorIndexParams(VectorIndexParams.ivfFlat(10, DistanceType.L2))
             .build());
+  }
+
+  @Test
+  public void testRqBuildParamsDefaultNumBits() {
+    assertEquals((byte) 5, new RQBuildParams.Builder().build().getNumBits());
   }
 
   @Test

--- a/python/python/lance/dataset.py
+++ b/python/python/lance/dataset.py
@@ -4306,7 +4306,7 @@ class LanceDataset(pa.dataset.Dataset):
         Optional parameters for `IVF_RQ`:
 
             - num_bits
-                The number of bits for RQ (Rabit Quantization). Default is 1.
+                The number of bits for RQ (Rabit Quantization). Default is 5.
 
         Optional parameters for `IVF_HNSW_*`:
             max_level

--- a/python/python/lance/lance/indices/__init__.pyi
+++ b/python/python/lance/lance/indices/__init__.pyi
@@ -69,7 +69,7 @@ def transform_vectors(
 ): ...
 def build_rq_model(
     dimension: int,
-    num_bits: int = 1,
+    num_bits: int = 5,
     dtype: str = "float32",
 ) -> str: ...
 

--- a/python/python/tests/test_vector_index.py
+++ b/python/python/tests/test_vector_index.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright The Lance Authors
 
+import json
 import logging
 import os
 import platform
@@ -1191,10 +1192,10 @@ def test_create_ivf_rq_index():
         "vector",
         index_type="IVF_RQ",
         num_partitions=4,
-        num_bits=1,
     )
     assert ds.describe_indices()[0].field_names == ["vector"]
     stats = ds.stats.index_stats("vector_idx")
+    assert stats["indices"][0]["sub_index"]["num_bits"] == 5
     assert stats["indices"][0]["sub_index"]["packed"] is True
 
     with pytest.raises(
@@ -1232,6 +1233,13 @@ def test_create_ivf_rq_index():
     assert res.num_rows == 10
     assert res["_distance"].to_numpy().min() == 0.0
     assert res["_distance"].to_numpy().max() == 0.0
+
+
+def test_build_rq_model_default_num_bits():
+    from lance.lance import indices
+
+    model = json.loads(indices.build_rq_model(dimension=8))
+    assert model["num_bits"] == 5
 
 
 def test_create_ivf_rq_skip_transpose():

--- a/python/src/indices.rs
+++ b/python/src/indices.rs
@@ -319,7 +319,7 @@ fn train_pq_model<'py>(
 /// from lance.lance import indices
 ///
 /// # Mint one model and broadcast `model` to every worker.
-/// model = indices.build_rq_model(dimension=128, num_bits=1)
+/// model = indices.build_rq_model(dimension=128, num_bits=5)
 /// seg = ds.create_index_uncommitted(
 ///     column="vector",
 ///     index_type="IVF_RQ",
@@ -330,7 +330,7 @@ fn train_pq_model<'py>(
 /// )
 /// ```
 #[pyfunction]
-#[pyo3(signature = (dimension, num_bits=1, dtype="float32"))]
+#[pyo3(signature = (dimension, num_bits=5, dtype="float32"))]
 pub fn build_rq_model(dimension: usize, num_bits: u8, dtype: &str) -> PyResult<String> {
     use arrow::datatypes::{Float16Type, Float32Type, Float64Type};
     use lance_index::vector::bq::RQRotationType;

--- a/rust/lance-index/src/vector/bq.rs
+++ b/rust/lance-index/src/vector/bq.rs
@@ -28,6 +28,8 @@ pub mod transform;
 pub const RABIT_MIN_NUM_BITS: u8 = 1;
 pub const RABIT_MAX_NUM_BITS: u8 = 9;
 pub const RABIT_BINARY_NUM_BITS: u8 = 1;
+/// Default number of bits per dimension for IVF_RQ indexes.
+pub(crate) const RABIT_DEFAULT_NUM_BITS: u8 = 5;
 
 #[derive(Clone, Default)]
 pub struct BinaryQuantization {}
@@ -110,6 +112,7 @@ impl FromStr for RQRotationType {
 
 #[derive(Clone, Debug)]
 pub struct RQBuildParams {
+    /// Number of bits per dimension. Defaults to 5.
     pub num_bits: u8,
     pub rotation_type: RQRotationType,
     /// Optional pre-built rotation to reuse instead of generating a fresh random one.
@@ -193,7 +196,7 @@ impl QuantizerBuildParams for RQBuildParams {
 impl Default for RQBuildParams {
     fn default() -> Self {
         Self {
-            num_bits: 1,
+            num_bits: RABIT_DEFAULT_NUM_BITS,
             rotation_type: RQRotationType::default(),
             rotation: None,
         }
@@ -235,6 +238,11 @@ mod tests {
             RQRotationType::Matrix
         );
         assert!("invalid".parse::<RQRotationType>().is_err());
+    }
+
+    #[test]
+    fn test_rq_build_params_default_num_bits() {
+        assert_eq!(RQBuildParams::default().num_bits, 5);
     }
 
     #[test]

--- a/rust/lance-index/src/vector/bq/builder.rs
+++ b/rust/lance-index/src/vector/bq/builder.rs
@@ -25,7 +25,7 @@ use crate::vector::bq::transform::{
     SCALE_FACTORS_FIELD,
 };
 use crate::vector::bq::{
-    RQBuildParams, RQRotationType, rabit_binary_code_bytes, rabit_ex_bits,
+    RABIT_DEFAULT_NUM_BITS, RQBuildParams, RQRotationType, rabit_binary_code_bytes, rabit_ex_bits,
     rotation::{apply_fast_rotation, fast_rotation_signs_len, random_fast_rotation_signs},
     validate_rq_num_bits,
 };
@@ -33,7 +33,7 @@ use crate::vector::quantizer::{Quantization, Quantizer, QuantizerBuildParams};
 
 /// Build parameters for RabitQuantizer.
 ///
-/// num_bits: the number of bits per dimension.
+/// num_bits: the number of bits per dimension. Defaults to 5.
 pub struct RabitBuildParams {
     pub num_bits: u8,
     pub rotation_type: RQRotationType,
@@ -42,7 +42,7 @@ pub struct RabitBuildParams {
 impl Default for RabitBuildParams {
     fn default() -> Self {
         Self {
-            num_bits: 1,
+            num_bits: RABIT_DEFAULT_NUM_BITS,
             rotation_type: RQRotationType::default(),
         }
     }
@@ -962,6 +962,11 @@ mod tests {
     use rstest::rstest;
 
     use crate::vector::bq::storage::RABIT_BLOCKED_EX_CODE_COLUMN;
+
+    #[test]
+    fn test_rabit_build_params_default_num_bits() {
+        assert_eq!(RabitBuildParams::default().num_bits, 5);
+    }
 
     fn reference_best_ex_rescale_factor(abs_normalized: &[f32], ex_bits: u8) -> f32 {
         let max_value = abs_normalized

--- a/rust/lance-namespace-impls/src/dir.rs
+++ b/rust/lance-namespace-impls/src/dir.rs
@@ -30,7 +30,10 @@ use lance_index::scalar::{
     BuiltinIndexType, FullTextSearchQuery, InvertedIndexParams, ScalarIndexParams,
 };
 use lance_index::vector::{
-    bq::RQBuildParams, hnsw::builder::HnswBuildParams, ivf::IvfBuildParams, pq::PQBuildParams,
+    bq::{RABIT_MAX_NUM_BITS, RABIT_MIN_NUM_BITS, RQBuildParams, validate_supported_rq_num_bits},
+    hnsw::builder::HnswBuildParams,
+    ivf::IvfBuildParams,
+    pq::PQBuildParams,
     sq::builder::SQBuildParams,
 };
 use lance_index::{IndexType, is_system_index};
@@ -2454,14 +2457,30 @@ impl DirectoryNamespace {
                     SQBuildParams::default(),
                 ),
             },
-            IndexType::IvfRq => DirectoryIndexParams::Vector {
-                index_type,
-                params: VectorIndexParams::with_ivf_rq_params(
-                    Self::parse_metric_type(request.distance_type.as_deref())?,
-                    IvfBuildParams::default(),
-                    RQBuildParams::default(),
-                ),
-            },
+            IndexType::IvfRq => {
+                let rq_params = if let Some(requested_num_bits) = request.num_bits {
+                    let invalid_num_bits = || NamespaceError::InvalidInput {
+                        message: format!(
+                            "IVF_RQ num_bits must be in {}..={}, got {}",
+                            RABIT_MIN_NUM_BITS, RABIT_MAX_NUM_BITS, requested_num_bits
+                        ),
+                    };
+                    let num_bits =
+                        u8::try_from(requested_num_bits).map_err(|_| invalid_num_bits())?;
+                    validate_supported_rq_num_bits(num_bits).map_err(|_| invalid_num_bits())?;
+                    RQBuildParams::new(num_bits)
+                } else {
+                    RQBuildParams::default()
+                };
+                DirectoryIndexParams::Vector {
+                    index_type,
+                    params: VectorIndexParams::with_ivf_rq_params(
+                        Self::parse_metric_type(request.distance_type.as_deref())?,
+                        IvfBuildParams::default(),
+                        rq_params,
+                    ),
+                }
+            }
             IndexType::IvfHnswFlat => DirectoryIndexParams::Vector {
                 index_type,
                 params: VectorIndexParams::ivf_hnsw(
@@ -6105,6 +6124,55 @@ fn build_engine_match_query(
 mod tests {
     use super::*;
     use arrow_ipc::reader::{FileReader, StreamReader};
+    use lance::index::vector::StageParams;
+    use rstest::rstest;
+
+    fn build_ivf_rq_num_bits(num_bits: Option<i32>) -> Result<u8> {
+        let mut request = CreateTableIndexRequest::new("vector".to_string(), "IVF_RQ".to_string());
+        request.num_bits = num_bits;
+
+        let DirectoryIndexParams::Vector {
+            index_type: IndexType::IvfRq,
+            params,
+        } = DirectoryNamespace::build_index_params(&request)?
+        else {
+            panic!("expected IVF_RQ vector index params");
+        };
+        match params.stages.as_slice() {
+            [StageParams::Ivf(_), StageParams::RQ(rq)] => Ok(rq.num_bits),
+            stages => panic!("expected IVF and RQ stages, got {stages:?}"),
+        }
+    }
+
+    #[rstest]
+    #[case::omitted(None, 5)]
+    #[case::explicit_one(Some(1), 1)]
+    #[case::explicit_max(Some(9), 9)]
+    fn test_build_index_params_ivf_rq_num_bits(
+        #[case] requested: Option<i32>,
+        #[case] expected: u8,
+    ) {
+        assert_eq!(build_ivf_rq_num_bits(requested).unwrap(), expected);
+    }
+
+    #[rstest]
+    #[case::negative(-1)]
+    #[case::zero(0)]
+    #[case::above_max(10)]
+    #[case::conversion_overflow(i32::MAX)]
+    fn test_build_index_params_rejects_invalid_ivf_rq_num_bits(#[case] requested: i32) {
+        let error = build_ivf_rq_num_bits(Some(requested))
+            .expect_err("invalid IVF_RQ num_bits should fail");
+        let message = error.to_string();
+
+        assert_eq!(mutation_error_code(error), ErrorCode::InvalidInput);
+        assert!(
+            message.contains(&format!(
+                "IVF_RQ num_bits must be in 1..=9, got {requested}"
+            )),
+            "unexpected error message: {message}"
+        );
+    }
 
     #[test]
     fn test_build_engine_fts_query_match() {


### PR DESCRIPTION
## What changed

- Change the Rust IVF_RQ build defaults from 1 bit to 5 bits.
- Preserve explicit namespace `num_bits` values with checked conversion and 1..=9 validation while keeping omitted values at the 5-bit default.
- Keep the Python model helper, type stub, documentation, and Java builder aligned with the Rust default.
- Update operational sizing guidance for the 5-bit layout and document the 1-bit storage and search trade-off.
- Add regression coverage for Rust, Python, Java, and namespace default handling while preserving explicit 1-bit coverage.

## Why

Implicit IVF_RQ index creation should consistently use `num_bits=5` across supported language surfaces, while explicit `num_bits` values must remain unchanged. Capacity guidance must also reflect the larger multi-bit layout so users can choose the 1-bit opt-out when appropriate.

## Validation

Static checks and formatting completed locally:

- `cargo fmt --all -- --check`
- `cargo clippy -p lance-index --tests -- -D warnings`
- `cargo clippy -p lance-namespace-impls --tests -- -D warnings`
- pre-commit `ruff`, `ruff-format`, `fmt`, and `typos`

The complete test suite is delegated to CI. Java validation was not run locally because this host does not have a JDK.