### PR TITLE
fix(io): parse GooseFS chunk/block size suffixes like 4MB

### DIFF
--- a/docs/src/guide/object_store.md
+++ b/docs/src/guide/object_store.md
@@ -553,8 +553,8 @@ Environment variables keep the `GOOSEFS_*` form.
 |---------------------|---------|-------------|
 | `goosefs_master_addr` | `GOOSEFS_MASTER_ADDR` | GooseFS Master address. Supports a single address (`host:port`) or comma-separated HA addresses (`addr1:port,addr2:port`). Optional if the address is provided in the URL. |
 | `goosefs_write_type` | `GOOSEFS_WRITE_TYPE` | Write type, e.g. `MUST_CACHE`, `CACHE_THROUGH`, `THROUGH`, `ASYNC_THROUGH`. Optional. |
-| `goosefs_block_size` | `GOOSEFS_BLOCK_SIZE` | GooseFS block size in bytes (this is the GooseFS-side block size, not Lance's I/O block size). Optional. |
-| `goosefs_chunk_size` | `GOOSEFS_CHUNK_SIZE` | Chunk size in bytes used when reading or writing files. Optional. |
+| `goosefs_block_size` | `GOOSEFS_BLOCK_SIZE` | GooseFS block size (this is the GooseFS-side block size, not Lance's I/O block size). Accepts a raw byte count or GooseFS suffixes such as `64MB` (binary units: `1KB = 1024`). Optional. |
+| `goosefs_chunk_size` | `GOOSEFS_CHUNK_SIZE` | Chunk size used when reading or writing files. Accepts a raw byte count or GooseFS suffixes such as `4MB` (binary units: `1KB = 1024`). Optional. |
 | `goosefs_auth_type` | `GOOSEFS_AUTH_TYPE` | Authentication type. Either `nosasl` or `simple` (case-insensitive; the value is passed through to OpenDAL). Optional. |
 | `goosefs_auth_username` | `GOOSEFS_AUTH_USERNAME` | Username used in `simple` authentication mode. Optional. |
 

--- a/rust/lance-io/src/object_store/providers/goosefs.rs
+++ b/rust/lance-io/src/object_store/providers/goosefs.rs
@@ -73,6 +73,31 @@ const STORAGE_OPTION_KEYS: &[&str] = &[
 #[derive(Default, Debug)]
 pub struct GooseFsStoreProvider;
 
+/// Parse the exponent of a scientific coefficient (`e10`, `E-3`, `e+02`).
+///
+/// Magnitudes that do not fit in `i32` saturate to `i32::MAX` / `i32::MIN`
+/// so a zero significand such as `0e9999999999` still evaluates to 0, while
+/// a non-zero significand overflows later in checked arithmetic.
+fn parse_decimal_exponent(s: &str) -> Option<i32> {
+    if s.is_empty() {
+        return None;
+    }
+    let (negative, digits) = if let Some(rest) = s.strip_prefix('+') {
+        (false, rest)
+    } else if let Some(rest) = s.strip_prefix('-') {
+        (true, rest)
+    } else {
+        (false, s)
+    };
+    if digits.is_empty() || !digits.chars().all(|c| c.is_ascii_digit()) {
+        return None;
+    }
+    match digits.parse::<i32>() {
+        Ok(n) => Some(if negative { -n } else { n }),
+        Err(_) => Some(if negative { i32::MIN } else { i32::MAX }),
+    }
+}
+
 impl GooseFsStoreProvider {
     /// Reject GooseFS `storage_options` keys that match a canonical key
     /// case-insensitively but are not lowercase.
@@ -172,7 +197,9 @@ impl GooseFsStoreProvider {
     ///
     /// Accepted suffixes (case-insensitive): `b`, `k`/`kb`, `m`/`mb`,
     /// `g`/`gb`, `t`/`tb`, `p`/`pb`. A missing suffix means bytes. Fractional
-    /// coefficients such as `1.5MB` are accepted.
+    /// and scientific coefficients such as `1.5MB` or `1e3KB` are accepted
+    /// and converted with exact decimal arithmetic (truncated toward zero,
+    /// matching GooseFS `parseSpaceSize` without the `double` rounding fudge).
     fn parse_space_size(option_key: &str, value: &str) -> Result<u64> {
         let trimmed = value.trim();
         if trimmed.is_empty() {
@@ -216,8 +243,7 @@ impl GooseFsStoreProvider {
         };
 
         // Exact integer path. Digit-only coefficients that fail `u64` parsing
-        // have overflowed; do not retry them via `f64` (which cannot represent
-        // every integer above 2^53 and would saturate on `as u64`).
+        // have overflowed; do not retry them as decimals.
         if let Ok(n) = number.parse::<u64>() {
             return n.checked_mul(multiplier).ok_or_else(overflow);
         }
@@ -225,26 +251,122 @@ impl GooseFsStoreProvider {
             return Err(overflow());
         }
 
-        let coeff: f64 = number.parse().map_err(|_| {
+        Self::parse_decimal_times_unit(option_key, value, number, multiplier)
+    }
+
+    /// Parse a decimal or scientific coefficient and return `floor(coeff * multiplier)`.
+    ///
+    /// GooseFS `FormatUtils.parseSpaceSize` truncates toward zero after
+    /// `coeff * unit` in IEEE-754 `double`. That silently changes integers
+    /// above `2^53` (e.g. `9007199254740993.0` becomes `9007199254740992`).
+    /// This path keeps the same truncation semantics with checked decimal
+    /// arithmetic so every accepted configuration preserves its value.
+    fn parse_decimal_times_unit(
+        option_key: &str,
+        value: &str,
+        number: &str,
+        multiplier: u64,
+    ) -> Result<u64> {
+        let invalid_number = || {
             Error::invalid_input(format!(
                 "invalid {option_key} `{value}`: `{number}` is not a valid number"
             ))
-        })?;
-        if !coeff.is_finite() || coeff < 0.0 {
-            return Err(Error::invalid_input(format!(
-                "invalid {option_key} `{value}`: size must be a non-negative finite number"
-            )));
+        };
+        let overflow = || {
+            Error::invalid_input(format!(
+                "invalid {option_key} `{value}`: size overflows u64"
+            ))
+        };
+        let negative = || {
+            Error::invalid_input(format!(
+                "invalid {option_key} `{value}`: size must be a non-negative number"
+            ))
+        };
+
+        if number.starts_with('-') {
+            return Err(negative());
+        }
+        let s = number.strip_prefix('+').unwrap_or(number);
+        if s.is_empty() {
+            return Err(invalid_number());
         }
 
-        // Match GooseFS FormatUtils.parseSpaceSize: truncate (coeff * unit + 0.0001).
-        let bytes = coeff.mul_add(multiplier as f64, 0.0001);
-        // `u64::MAX` is not representable as `f64` and rounds up to `2^64`,
-        // which *is* exact. Reject anything that is not strictly below that
-        // boundary so the `as u64` conversion cannot saturate.
-        if !(bytes >= 0.0 && bytes < u64::MAX as f64) {
-            return Err(overflow());
+        let (mantissa, exp) = if let Some(e_idx) = s.find(['e', 'E']) {
+            let mantissa = &s[..e_idx];
+            let exp_str = &s[e_idx + 1..];
+            if mantissa.is_empty() {
+                return Err(invalid_number());
+            }
+            let exp = parse_decimal_exponent(exp_str).ok_or_else(invalid_number)?;
+            (mantissa, exp)
+        } else {
+            (s, 0i32)
+        };
+
+        let mut parts = mantissa.split('.');
+        let int_str = parts.next().unwrap_or("");
+        let frac_raw = parts.next();
+        if parts.next().is_some() {
+            return Err(invalid_number());
         }
-        Ok(bytes as u64)
+        if !int_str.chars().all(|c| c.is_ascii_digit()) {
+            return Err(invalid_number());
+        }
+        let frac_raw = match frac_raw {
+            Some(frac) if frac.chars().all(|c| c.is_ascii_digit()) => frac,
+            Some(_) => return Err(invalid_number()),
+            None => "",
+        };
+        if int_str.is_empty() && frac_raw.is_empty() {
+            return Err(invalid_number());
+        }
+        let frac_str = frac_raw.trim_end_matches('0');
+
+        let int_part: u128 = if int_str.is_empty() {
+            0
+        } else {
+            int_str.parse().map_err(|_| overflow())?
+        };
+        let frac_digits = u32::try_from(frac_str.len()).map_err(|_| overflow())?;
+        let frac_part: u128 = if frac_str.is_empty() {
+            0
+        } else {
+            frac_str.parse().map_err(|_| overflow())?
+        };
+
+        let significand = if frac_digits == 0 {
+            int_part
+        } else {
+            let pow10 = 10u128.checked_pow(frac_digits).ok_or_else(overflow)?;
+            int_part
+                .checked_mul(pow10)
+                .and_then(|v| v.checked_add(frac_part))
+                .ok_or_else(overflow)?
+        };
+        if significand == 0 {
+            return Ok(0);
+        }
+
+        // floor(significand * multiplier * 10^exp / 10^frac_digits)
+        let mut num = significand
+            .checked_mul(u128::from(multiplier))
+            .ok_or_else(overflow)?;
+        let scale = i64::from(frac_digits) - i64::from(exp);
+        if scale > 0 {
+            match u32::try_from(scale)
+                .ok()
+                .and_then(|s| 10u128.checked_pow(s))
+            {
+                Some(den) => num /= den,
+                None => num = 0,
+            }
+        } else if scale < 0 {
+            let raise = u32::try_from(scale.unsigned_abs()).map_err(|_| overflow())?;
+            let factor = 10u128.checked_pow(raise).ok_or_else(overflow)?;
+            num = num.checked_mul(factor).ok_or_else(overflow)?;
+        }
+
+        u64::try_from(num).map_err(|_| overflow())
     }
 
     fn resolve_space_size(
@@ -586,6 +708,10 @@ mod tests {
     #[case::suffix_mb("4MB", 4 * 1024 * 1024)]
     #[case::suffix_gb("1GB", 1024 * 1024 * 1024)]
     #[case::fractional_mb("1.5MB", 1_572_864)]
+    #[case::fractional_kb("2.5KB", 2560)]
+    #[case::scientific_kb("1e3KB", 1000 * 1024)]
+    #[case::leading_dot(".5KB", 512)]
+    #[case::truncate_toward_zero("1.9", 1)]
     #[case::trimmed("  4MB  ", 4 * 1024 * 1024)]
     fn test_parse_space_size_accepts_goosefs_suffixes(#[case] input: &str, #[case] expected: u64) {
         assert_eq!(
@@ -601,6 +727,7 @@ mod tests {
     #[case::unknown_suffix("4MiB")]
     #[case::si_mismatch_not_mib("4XB")]
     #[case::negative("-4MB")]
+    #[case::two_dots("1.2.3")]
     fn test_parse_space_size_rejects_invalid(#[case] input: &str) {
         let err = GooseFsStoreProvider::parse_space_size("goosefs_chunk_size", input).unwrap_err();
         let msg = err.to_string();
@@ -620,6 +747,7 @@ mod tests {
     #[case::integer_mul_overflow("16384PB")]
     #[case::fractional_mul_overflow("16384.0PB")]
     #[case::scientific_overflow("1e20")]
+    #[case::scientific_u64_max_plus_one("1.8446744073709551616e19")]
     fn test_parse_space_size_rejects_overflow(#[case] input: &str) {
         let err = GooseFsStoreProvider::parse_space_size("goosefs_chunk_size", input).unwrap_err();
         assert!(
@@ -643,6 +771,30 @@ mod tests {
             GooseFsStoreProvider::parse_space_size("goosefs_chunk_size", "18446744073709551615")
                 .unwrap(),
             u64::MAX
+        );
+        assert_eq!(
+            GooseFsStoreProvider::parse_space_size(
+                "goosefs_chunk_size",
+                "1.8446744073709551615e19"
+            )
+            .unwrap(),
+            u64::MAX
+        );
+    }
+
+    #[test]
+    fn test_parse_space_size_preserves_values_beyond_f64_precision() {
+        // 2^53+1 is not representable as f64. The previous `double` path
+        // silently converted `9007199254740993.0` to `9007199254740992`.
+        assert_eq!(
+            GooseFsStoreProvider::parse_space_size("goosefs_chunk_size", "9007199254740993.0")
+                .unwrap(),
+            9007199254740993
+        );
+        assert_eq!(
+            GooseFsStoreProvider::parse_space_size("goosefs_chunk_size", "9007199254740993.0b")
+                .unwrap(),
+            9007199254740993
         );
     }
 

--- a/rust/lance-io/src/object_store/providers/goosefs.rs
+++ b/rust/lance-io/src/object_store/providers/goosefs.rs
@@ -209,12 +209,20 @@ impl GooseFsStoreProvider {
             }
         };
 
+        let overflow = || {
+            Error::invalid_input(format!(
+                "invalid {option_key} `{value}`: size overflows u64"
+            ))
+        };
+
+        // Exact integer path. Digit-only coefficients that fail `u64` parsing
+        // have overflowed; do not retry them via `f64` (which cannot represent
+        // every integer above 2^53 and would saturate on `as u64`).
         if let Ok(n) = number.parse::<u64>() {
-            return n.checked_mul(multiplier).ok_or_else(|| {
-                Error::invalid_input(format!(
-                    "invalid {option_key} `{value}`: size overflows u64"
-                ))
-            });
+            return n.checked_mul(multiplier).ok_or_else(overflow);
+        }
+        if number.chars().all(|c| c.is_ascii_digit()) {
+            return Err(overflow());
         }
 
         let coeff: f64 = number.parse().map_err(|_| {
@@ -230,10 +238,11 @@ impl GooseFsStoreProvider {
 
         // Match GooseFS FormatUtils.parseSpaceSize: truncate (coeff * unit + 0.0001).
         let bytes = coeff.mul_add(multiplier as f64, 0.0001);
-        if bytes > u64::MAX as f64 {
-            return Err(Error::invalid_input(format!(
-                "invalid {option_key} `{value}`: size overflows u64"
-            )));
+        // `u64::MAX` is not representable as `f64` and rounds up to `2^64`,
+        // which *is* exact. Reject anything that is not strictly below that
+        // boundary so the `as u64` conversion cannot saturate.
+        if !(bytes >= 0.0 && bytes < u64::MAX as f64) {
+            return Err(overflow());
         }
         Ok(bytes as u64)
     }
@@ -602,6 +611,38 @@ mod tests {
         assert!(
             msg.contains(input.trim()) || input.trim().is_empty(),
             "error should include the input, got: {msg}"
+        );
+    }
+
+    #[rstest]
+    #[case::u64_max_plus_one("18446744073709551616")]
+    #[case::u64_max_plus_one_bytes("18446744073709551616b")]
+    #[case::integer_mul_overflow("16384PB")]
+    #[case::fractional_mul_overflow("16384.0PB")]
+    #[case::scientific_overflow("1e20")]
+    fn test_parse_space_size_rejects_overflow(#[case] input: &str) {
+        let err = GooseFsStoreProvider::parse_space_size("goosefs_chunk_size", input).unwrap_err();
+        assert!(
+            matches!(err, Error::InvalidInput { .. }),
+            "expected InvalidInput, got: {err:?}"
+        );
+        let msg = err.to_string();
+        assert!(
+            msg.contains("overflows u64"),
+            "overflowing size should be rejected, got: {msg}"
+        );
+        assert!(
+            msg.contains(input),
+            "error should include the input, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn test_parse_space_size_accepts_u64_max_integer() {
+        assert_eq!(
+            GooseFsStoreProvider::parse_space_size("goosefs_chunk_size", "18446744073709551615")
+                .unwrap(),
+            u64::MAX
         );
     }
 

--- a/rust/lance-io/src/object_store/providers/goosefs.rs
+++ b/rust/lance-io/src/object_store/providers/goosefs.rs
@@ -61,8 +61,8 @@ const STORAGE_OPTION_KEYS: &[&str] = &[
 /// | `goosefs_master_addr`     | `GOOSEFS_MASTER_ADDR`   | Master gRPC address, e.g. `host:9200`. Supports HA: `addr1:port,addr2:port`.                  |
 /// | `goosefs_root`            | `GOOSEFS_ROOT`          | Cluster-wide OpenDAL root shared by all datasets under the same master. Defaults to `/`.      |
 /// | `goosefs_write_type`      | `GOOSEFS_WRITE_TYPE`    | GooseFS write type (e.g. `MUST_CACHE`, `CACHE_THROUGH`, `THROUGH`, `ASYNC_THROUGH`).          |
-/// | `goosefs_block_size`      | `GOOSEFS_BLOCK_SIZE`    | GooseFS block size (bytes). Distinct from Lance's own `block_size`.                           |
-/// | `goosefs_chunk_size`      | `GOOSEFS_CHUNK_SIZE`    | GooseFS chunk size (bytes) used by the client.                                                |
+/// | `goosefs_block_size`      | `GOOSEFS_BLOCK_SIZE`    | GooseFS block size. Bytes or suffixes like `4MB` (binary: 1KB=1024). Distinct from Lance I/O `block_size`. |
+/// | `goosefs_chunk_size`      | `GOOSEFS_CHUNK_SIZE`    | GooseFS client chunk size. Bytes or suffixes like `4MB` (binary: 1KB=1024).                   |
 /// | `goosefs_auth_type`       | `GOOSEFS_AUTH_TYPE`     | Authentication mode: `nosasl` or `simple`.                                                    |
 /// | `goosefs_auth_username`   | `GOOSEFS_AUTH_USERNAME` | Username for `simple` auth mode.                                                              |
 ///
@@ -160,6 +160,94 @@ impl GooseFsStoreProvider {
         Self::resolve_option(storage_options, "goosefs_root", "GOOSEFS_ROOT")
             .unwrap_or_else(|| "/".to_string())
     }
+
+    /// Parse a GooseFS space-size string into bytes.
+    ///
+    /// OpenDAL's GooseFS config deserializes `chunk_size` / `block_size` as
+    /// `u64`, so a value like `4MB` fails with `ParseIntError`. GooseFS itself
+    /// accepts Hadoop-style suffixes via `FormatUtils.parseSpaceSize`, where
+    /// units are **binary** (`1KB = 1024`, so `4MB` is `4194304`), not SI
+    /// (`10^6`). Generic crates such as `parse-size` / `bytesize` default to
+    /// SI for `MB`, so this parser matches GooseFS instead of adding a dep.
+    ///
+    /// Accepted suffixes (case-insensitive): `b`, `k`/`kb`, `m`/`mb`,
+    /// `g`/`gb`, `t`/`tb`, `p`/`pb`. A missing suffix means bytes. Fractional
+    /// coefficients such as `1.5MB` are accepted.
+    fn parse_space_size(option_key: &str, value: &str) -> Result<u64> {
+        let trimmed = value.trim();
+        if trimmed.is_empty() {
+            return Err(Error::invalid_input(format!(
+                "{option_key} must be a size such as `4MB` or `4194304`, got `{value}`"
+            )));
+        }
+
+        let suffix_start = trimmed
+            .char_indices()
+            .rev()
+            .find(|(_, c)| c.is_ascii_digit())
+            .map(|(i, c)| i + c.len_utf8())
+            .unwrap_or(0);
+        let (number, suffix) = trimmed.split_at(suffix_start);
+        if number.is_empty() {
+            return Err(Error::invalid_input(format!(
+                "invalid {option_key} `{value}`: missing numeric coefficient"
+            )));
+        }
+
+        let multiplier = match suffix.to_ascii_lowercase().as_str() {
+            "" | "b" => 1u64,
+            "k" | "kb" => 1024,
+            "m" | "mb" => 1024 * 1024,
+            "g" | "gb" => 1024 * 1024 * 1024,
+            "t" | "tb" => 1024u64.pow(4),
+            "p" | "pb" => 1024u64.pow(5),
+            other => {
+                return Err(Error::invalid_input(format!(
+                    "invalid {option_key} `{value}`: unrecognized size suffix `{other}` \
+                     (supported: b, k/kb, m/mb, g/gb, t/tb, p/pb; units are binary, 1KB=1024)"
+                )));
+            }
+        };
+
+        if let Ok(n) = number.parse::<u64>() {
+            return n.checked_mul(multiplier).ok_or_else(|| {
+                Error::invalid_input(format!(
+                    "invalid {option_key} `{value}`: size overflows u64"
+                ))
+            });
+        }
+
+        let coeff: f64 = number.parse().map_err(|_| {
+            Error::invalid_input(format!(
+                "invalid {option_key} `{value}`: `{number}` is not a valid number"
+            ))
+        })?;
+        if !coeff.is_finite() || coeff < 0.0 {
+            return Err(Error::invalid_input(format!(
+                "invalid {option_key} `{value}`: size must be a non-negative finite number"
+            )));
+        }
+
+        // Match GooseFS FormatUtils.parseSpaceSize: truncate (coeff * unit + 0.0001).
+        let bytes = coeff.mul_add(multiplier as f64, 0.0001);
+        if bytes > u64::MAX as f64 {
+            return Err(Error::invalid_input(format!(
+                "invalid {option_key} `{value}`: size overflows u64"
+            )));
+        }
+        Ok(bytes as u64)
+    }
+
+    fn resolve_space_size(
+        storage_options: &StorageOptions,
+        option_key: &str,
+        env_key: &str,
+    ) -> Result<Option<u64>> {
+        let Some(raw) = Self::resolve_option(storage_options, option_key, env_key) else {
+            return Ok(None);
+        };
+        Self::parse_space_size(option_key, &raw).map(Some)
+    }
 }
 
 #[async_trait::async_trait]
@@ -190,18 +278,19 @@ impl ObjectStoreProvider for GooseFsStoreProvider {
             config_map.insert("write_type".to_string(), wt);
         }
 
-        // Optional: block_size (for GooseFS, not Lance block_size)
+        // Optional: block_size (for GooseFS, not Lance block_size).
+        // Normalize suffixes like `64MB` to a raw byte count; OpenDAL expects u64.
         if let Some(bs) =
-            Self::resolve_option(&storage_options, "goosefs_block_size", "GOOSEFS_BLOCK_SIZE")
+            Self::resolve_space_size(&storage_options, "goosefs_block_size", "GOOSEFS_BLOCK_SIZE")?
         {
-            config_map.insert("block_size".to_string(), bs);
+            config_map.insert("block_size".to_string(), bs.to_string());
         }
 
         // Optional: chunk_size
         if let Some(cs) =
-            Self::resolve_option(&storage_options, "goosefs_chunk_size", "GOOSEFS_CHUNK_SIZE")
+            Self::resolve_space_size(&storage_options, "goosefs_chunk_size", "GOOSEFS_CHUNK_SIZE")?
         {
-            config_map.insert("chunk_size".to_string(), cs);
+            config_map.insert("chunk_size".to_string(), cs.to_string());
         }
 
         // Optional: auth_type (nosasl / simple)
@@ -279,6 +368,7 @@ impl ObjectStoreProvider for GooseFsStoreProvider {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use rstest::rstest;
 
     #[test]
     fn test_goosefs_extract_path_basic() {
@@ -476,5 +566,64 @@ mod tests {
         assert!(msg.contains("must be lowercase"), "got: {msg}");
         assert!(msg.contains("goosefs_master_addr"), "got: {msg}");
         assert!(msg.contains("goosefs_auth_type"), "got: {msg}");
+    }
+
+    #[rstest]
+    #[case::bare_bytes("4096", 4096)]
+    #[case::suffix_b("4096b", 4096)]
+    #[case::suffix_k("4k", 4096)]
+    #[case::suffix_kb("4KB", 4096)]
+    #[case::suffix_m("4m", 4 * 1024 * 1024)]
+    #[case::suffix_mb("4MB", 4 * 1024 * 1024)]
+    #[case::suffix_gb("1GB", 1024 * 1024 * 1024)]
+    #[case::fractional_mb("1.5MB", 1_572_864)]
+    #[case::trimmed("  4MB  ", 4 * 1024 * 1024)]
+    fn test_parse_space_size_accepts_goosefs_suffixes(#[case] input: &str, #[case] expected: u64) {
+        assert_eq!(
+            GooseFsStoreProvider::parse_space_size("goosefs_chunk_size", input).unwrap(),
+            expected
+        );
+    }
+
+    #[rstest]
+    #[case::empty("")]
+    #[case::whitespace("   ")]
+    #[case::missing_number("MB")]
+    #[case::unknown_suffix("4MiB")]
+    #[case::si_mismatch_not_mib("4XB")]
+    #[case::negative("-4MB")]
+    fn test_parse_space_size_rejects_invalid(#[case] input: &str) {
+        let err = GooseFsStoreProvider::parse_space_size("goosefs_chunk_size", input).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("goosefs_chunk_size"),
+            "error should name the option, got: {msg}"
+        );
+        assert!(
+            msg.contains(input.trim()) || input.trim().is_empty(),
+            "error should include the input, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn test_parse_space_size_four_mb_is_binary_not_si() {
+        let bytes = GooseFsStoreProvider::parse_space_size("goosefs_chunk_size", "4MB").unwrap();
+        assert_eq!(bytes, 4_194_304, "GooseFS MB is 1024^2, not 10^6");
+        assert_ne!(bytes, 4_000_000);
+    }
+
+    #[test]
+    fn test_resolve_space_size_from_storage_options() {
+        let opts = StorageOptions(HashMap::from([(
+            "goosefs_chunk_size".to_string(),
+            "4MB".to_string(),
+        )]));
+        let bytes = GooseFsStoreProvider::resolve_space_size(
+            &opts,
+            "goosefs_chunk_size",
+            "GOOSEFS_CHUNK_SIZE",
+        )
+        .unwrap();
+        assert_eq!(bytes, Some(4 * 1024 * 1024));
     }
 }


### PR DESCRIPTION
## Summary
- Parse `goosefs_chunk_size` / `goosefs_block_size` values such as `4MB` before passing them to OpenDAL, which expects `u64` and otherwise fails with `ParseIntError`.
- Match GooseFS `FormatUtils.parseSpaceSize`: binary units (`1KB = 1024`, so `4MB = 4194304`), not SI `10^6`.
- Document the accepted suffixes in the object store guide.

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p lance-io --all-targets --features goosefs -- -D warnings`
- [x] `cargo test -p lance-io --features goosefs --lib object_store::providers::goosefs`