### PR TITLE
fix: list unreferenced data files newer than the retained floor

### DIFF
--- a/docs/src/guide/read_and_write.md
+++ b/docs/src/guide/read_and_write.md
@@ -506,14 +506,16 @@ A file is verified when Lance can see that it was referenced by an older version
 and is no longer referenced by any newer version. However, some orphaned files
 cannot be verified this way — for example, files left behind by aborted or failed
 commits that were never recorded in any version. These files are
-indistinguishable from files being written by an in-progress operation.
+indistinguishable from files being written by an in-progress operation, so their
+**age** is the only evidence that no operation still owns them: by default Lance
+removes an unverifiable file only if it is at least **7 days** old.
 
 Cleanup will never delete the current (active) version. This means passing
 `older_than=timedelta(0)` is safe and will delete all versions except the current
 one.
 
 The `delete_unverified` flag enables a more aggressive strategy that will also
-delete these unverified files:
+delete unverified files regardless of their age:
 
 ```python
 dataset.cleanup_old_versions(
@@ -524,15 +526,14 @@ dataset.cleanup_old_versions(
 
 !!! danger
 
-    Only use `delete_unverified=True` when you are confident that no other
-    concurrent operation has been in-progress for longer than the `older_than`
-    duration. Lance uses the file's age to decide whether an unverified file is
-    safe to remove, so any operation that is still running past the `older_than`
-    window risks having its files deleted out from under it.
+    `delete_unverified=True` removes the 7-day age protection entirely: an
+    unverifiable file is deleted whatever its age. Age is the only thing that
+    distinguishes an abandoned file from one an operation is still writing, so with
+    the flag set there is nothing left to make that distinction.
 
-    In particular, combining `delete_unverified=True` with `older_than=timedelta(0)`
-    is **extremely dangerous** — if any other operation is in-progress at all,
-    its data files may be deleted, leading to dataset corruption.
+    Only use it when you can guarantee that **no other process is operating on the
+    dataset at all**. Any concurrent write may have its files deleted out from under
+    it, leaving the dataset corrupted.
 
 ### Automatic cleanup
 

--- a/rust/lance/src/dataset.rs
+++ b/rust/lance/src/dataset.rs
@@ -1466,11 +1466,12 @@ impl Dataset {
     /// # Arguments
     ///
     /// * `older_than` - Versions older than this will be deleted.
-    /// * `delete_unverified` - If false (the default) then files will only be deleted if they
-    ///                        are listed in at least one manifest.  Otherwise these files will
-    ///                        be kept since they cannot be distinguished from an in-progress
-    ///                        transaction.  Set to true to delete these files if you are sure
-    ///                        there are no other in-progress dataset operations.
+    /// * `delete_unverified` - If false (the default), files that are not referenced by any
+    ///                        manifest will only be deleted if they are more than 7 days old.
+    ///                        Otherwise these files will be kept since they cannot be
+    ///                        distinguished from an in-progress transaction. Set to true to
+    ///                        delete these files if you are sure there are no other
+    ///                        in-progress dataset operations.
     ///
     /// # Returns
     ///

--- a/rust/lance/src/dataset/cleanup.rs
+++ b/rust/lance/src/dataset/cleanup.rs
@@ -317,25 +317,42 @@ struct CleanupInspection {
 }
 
 impl CleanupInspection {
-    /// Cutoff for `read_dir_all(..., unmodified_since)`.
+    /// Cutoff for `read_dir_all(..., unmodified_since)`: it must be late
+    /// enough to list every kind of file cleanup can remove.
     ///
-    /// Listing only files with `last_modified <= earliest_retained` is valid
-    /// when the working set is a time suffix: every retained version is newer
-    /// than every deleted one. A tagged old version (or any other sparse
-    /// retain) pulls that cutoff backwards, so files from newer deleted
-    /// versions are never listed. Their manifests are still removed, which
-    /// permanently orphans the data files ([#8705](https://github.com/lance-format/lance/issues/8705)).
+    /// A file referenced only by manifests being removed needs
+    /// `earliest_retained`. That is valid when the working set is a time
+    /// suffix: every retained version is newer than every deleted one, so
+    /// those files predate the retained floor. A tagged old version (or any
+    /// other sparse retain) pulls the cutoff backwards, leaving files of newer
+    /// deleted versions unlisted while their manifests are removed, which
+    /// orphans them permanently ([#8705](https://github.com/lance-format/lance/issues/8705)).
+    /// In that case drop the cutoff and scan the whole subtree — the same
+    /// approach already used for `_indices/`.
     ///
-    /// When a deleted manifest is newer than the earliest retained one, drop
-    /// the cutoff and scan the whole subtree — the same approach already used
-    /// for `_indices/`.
-    fn listing_unmodified_since(&self) -> Option<DateTime<Utc>> {
+    /// A file referenced by *no* manifest is instead removed on its age, and
+    /// its mtime is unrelated to the retained floor: abandoned
+    /// `write_fragments` output is written whenever the writer ran, possibly
+    /// long after the oldest retained version was committed. Listing it
+    /// requires a cutoff no earlier than `unverified_threshold`, so take the
+    /// later of the two ([#8942](https://github.com/lance-format/lance/issues/8942)).
+    /// With `delete_unverified` such a file is a candidate at any age, which
+    /// admits no cutoff at all.
+    fn listing_unmodified_since(
+        &self,
+        delete_unverified: bool,
+        unverified_threshold: DateTime<Utc>,
+    ) -> Option<DateTime<Utc>> {
+        if delete_unverified {
+            return None;
+        }
         match (
             self.earliest_retained_manifest_time,
             self.latest_deleted_manifest_time,
         ) {
             (Some(retained), Some(deleted)) if deleted > retained => None,
-            (retained, _) => retained,
+            (Some(retained), _) => Some(retained.max(unverified_threshold)),
+            (None, _) => None,
         }
     }
 }
@@ -715,10 +732,12 @@ impl<'a> CleanupTask<'a> {
         };
 
         // Restrict scanning to Lance-managed subtrees for safety and performance.
-        // Drop the retained-manifest cutoff when a sparse retain (e.g. a tag)
-        // would hide files that belong to newer deleted versions. See
+        // The cutoff has to cover every candidate class: files of newer deleted
+        // versions (hidden by a sparse retain such as a tag) and unreferenced
+        // files that have aged past the unverified threshold. See
         // [`CleanupInspection::listing_unmodified_since`].
-        let unmodified_since = inspection.listing_unmodified_since();
+        let unmodified_since = inspection
+            .listing_unmodified_since(self.policy.delete_unverified, verification_threshold);
         let streams = vec![
             build_listing_stream(self.dataset.versions_dir(), unmodified_since),
             build_listing_stream(self.dataset.transactions_dir(), unmodified_since),
@@ -2534,6 +2553,52 @@ mod tests {
         assert_eq!(after_count.num_manifest_files, 2);
         assert_eq!(after_count.num_data_files, 2);
         assert_eq!(after_count.num_tx_files, 2);
+    }
+
+    #[tokio::test]
+    async fn cleanup_deletes_aged_orphan_newer_than_retained_manifests() {
+        // A data file referenced by no manifest (e.g. abandoned
+        // `write_fragments` output) is deleted based on its age, and its mtime
+        // is unrelated to the retained floor.
+        MockClock::set_system_time(std::time::Duration::from_secs(0));
+        let fixture = MockDatasetFixture::try_new().unwrap();
+        fixture.create_some_data().await.unwrap();
+        MockClock::set_system_time(TimeDelta::try_days(1).unwrap().to_std().unwrap());
+        fixture.append_some_data().await.unwrap();
+        MockClock::set_system_time(TimeDelta::try_days(2).unwrap().to_std().unwrap());
+        fixture.append_some_data().await.unwrap();
+
+        // Newer than every manifest, and old enough to be aged out below.
+        MockClock::set_system_time(TimeDelta::try_days(3).unwrap().to_std().unwrap());
+        let dataset = fixture.open().await.unwrap();
+        let orphan = dataset.data_dir().join(format!("{}.lance", Uuid::new_v4()));
+        dataset
+            .object_store
+            .as_ref()
+            .put(&orphan, &[0u8; 1024])
+            .await
+            .unwrap();
+        drop(dataset);
+
+        MockClock::set_system_time(TimeDelta::try_days(20).unwrap().to_std().unwrap());
+
+        let before_count = fixture.count_files().await.unwrap();
+        assert_eq!(before_count.num_data_files, 4);
+        assert_eq!(before_count.num_manifest_files, 3);
+
+        // Suffix-only retention: the two oldest versions go, the latest stays.
+        let removed = fixture
+            .run_cleanup(utc_now() - TimeDelta::try_days(8).unwrap())
+            .await
+            .unwrap();
+
+        assert_eq!(removed.old_versions, 2);
+        assert_eq!(removed.data_files_removed, 1);
+
+        let after_count = fixture.count_files().await.unwrap();
+        assert_eq!(after_count.num_manifest_files, 1);
+        // Appends leave every fragment referenced by the latest version.
+        assert_eq!(after_count.num_data_files, 3);
     }
 
     // Helper function to check that the number of files is correct.

--- a/rust/lance/src/dataset/cleanup.rs
+++ b/rust/lance/src/dataset/cleanup.rs
@@ -317,42 +317,31 @@ struct CleanupInspection {
 }
 
 impl CleanupInspection {
-    /// Cutoff for `read_dir_all(..., unmodified_since)`: it must be late
-    /// enough to list every kind of file cleanup can remove.
+    /// Cutoff for `read_dir_all(..., unmodified_since)`.
     ///
-    /// A file referenced only by manifests being removed needs
-    /// `earliest_retained`. That is valid when the working set is a time
-    /// suffix: every retained version is newer than every deleted one, so
-    /// those files predate the retained floor. A tagged old version (or any
-    /// other sparse retain) pulls the cutoff backwards, leaving files of newer
-    /// deleted versions unlisted while their manifests are removed, which
-    /// orphans them permanently ([#8705](https://github.com/lance-format/lance/issues/8705)).
-    /// In that case drop the cutoff and scan the whole subtree — the same
-    /// approach already used for `_indices/`.
+    /// This bounds files owned by a manifest being removed. Listing only files
+    /// with `last_modified <= earliest_retained` is valid when the working set
+    /// is a time suffix: every retained version is newer than every deleted
+    /// one, so those files predate the retained floor. A tagged old version (or
+    /// any other sparse retain) pulls that cutoff backwards, so files from
+    /// newer deleted versions are never listed. Their manifests are still
+    /// removed, which permanently orphans the data files
+    /// ([#8705](https://github.com/lance-format/lance/issues/8705)).
     ///
-    /// A file referenced by *no* manifest is instead removed on its age, and
-    /// its mtime is unrelated to the retained floor: abandoned
-    /// `write_fragments` output is written whenever the writer ran, possibly
-    /// long after the oldest retained version was committed. Listing it
-    /// requires a cutoff no earlier than `unverified_threshold`, so take the
-    /// later of the two ([#8942](https://github.com/lance-format/lance/issues/8942)).
-    /// With `delete_unverified` such a file is a candidate at any age, which
-    /// admits no cutoff at all.
-    fn listing_unmodified_since(
-        &self,
-        delete_unverified: bool,
-        unverified_threshold: DateTime<Utc>,
-    ) -> Option<DateTime<Utc>> {
-        if delete_unverified {
-            return None;
-        }
+    /// When a deleted manifest is newer than the earliest retained one, drop
+    /// the cutoff and scan the whole subtree — the same approach already used
+    /// for `_indices/`.
+    ///
+    /// A file owned by *no* manifest is bounded by its age instead, not by this
+    /// floor; the `data/` listing widens this accordingly at the call site
+    /// ([#8942](https://github.com/lance-format/lance/issues/8942)).
+    fn listing_unmodified_since(&self) -> Option<DateTime<Utc>> {
         match (
             self.earliest_retained_manifest_time,
             self.latest_deleted_manifest_time,
         ) {
             (Some(retained), Some(deleted)) if deleted > retained => None,
-            (Some(retained), _) => Some(retained.max(unverified_threshold)),
-            (None, _) => None,
+            (retained, _) => retained,
         }
     }
 }
@@ -732,16 +721,25 @@ impl<'a> CleanupTask<'a> {
         };
 
         // Restrict scanning to Lance-managed subtrees for safety and performance.
-        // The cutoff has to cover every candidate class: files of newer deleted
-        // versions (hidden by a sparse retain such as a tag) and unreferenced
-        // files that have aged past the unverified threshold. See
+        // Drop the retained-manifest cutoff when a sparse retain (e.g. a tag)
+        // would hide files that belong to newer deleted versions. See
         // [`CleanupInspection::listing_unmodified_since`].
-        let unmodified_since = inspection
-            .listing_unmodified_since(self.policy.delete_unverified, verification_threshold);
+        let unmodified_since = inspection.listing_unmodified_since();
+        // A data file owned by no manifest is removed on its age, and its mtime is
+        // unrelated to the retained floor: abandoned `write_fragments` output is
+        // written whenever the writer ran, possibly long after the oldest retained
+        // version was committed. List through the moving unverified threshold so it
+        // becomes a candidate once old enough, and drop the cutoff entirely under
+        // `delete_unverified`, where it is a candidate at any age.
+        let data_unmodified_since = if self.policy.delete_unverified {
+            None
+        } else {
+            unmodified_since.map(|cutoff| cutoff.max(verification_threshold))
+        };
         let streams = vec![
             build_listing_stream(self.dataset.versions_dir(), unmodified_since),
             build_listing_stream(self.dataset.transactions_dir(), unmodified_since),
-            build_listing_stream(self.dataset.data_dir(), unmodified_since),
+            build_listing_stream(self.dataset.data_dir(), data_unmodified_since),
             // Index UUIDs from manifests being removed are proof that their files are
             // safe to delete. Scan every index artifact while that proof is available;
             // a retained-manifest cutoff can otherwise skip newer artifacts and lose
@@ -2557,8 +2555,16 @@ mod tests {
         assert_eq!(after_count.num_tx_files, 2);
     }
 
+    #[rstest]
+    // Aged past the unverified threshold, collected by the default policy.
+    #[case::aged(false, 20)]
+    // Fresh, but `delete_unverified` waives the age protection entirely.
+    #[case::delete_unverified(true, 4)]
     #[tokio::test]
-    async fn cleanup_deletes_aged_orphan_newer_than_retained_manifests() {
+    async fn cleanup_deletes_aged_orphan_newer_than_retained_manifests(
+        #[case] delete_unverified: bool,
+        #[case] cleanup_day: i64,
+    ) {
         // A data file referenced by no manifest (e.g. abandoned
         // `write_fragments` output) is deleted based on its age, and its mtime
         // is unrelated to the retained floor.
@@ -2582,7 +2588,7 @@ mod tests {
             .unwrap();
         drop(dataset);
 
-        MockClock::set_system_time(TimeDelta::try_days(20).unwrap().to_std().unwrap());
+        MockClock::set_system_time(TimeDelta::try_days(cleanup_day).unwrap().to_std().unwrap());
 
         let before_count = fixture.count_files().await.unwrap();
         assert_eq!(before_count.num_data_files, 4);
@@ -2590,7 +2596,11 @@ mod tests {
 
         // Suffix-only retention: the two oldest versions go, the latest stays.
         let removed = fixture
-            .run_cleanup(utc_now() - TimeDelta::try_days(8).unwrap())
+            .run_cleanup_with_override(
+                utc_now() - TimeDelta::try_days(2).unwrap(),
+                Some(delete_unverified),
+                None,
+            )
             .await
             .unwrap();
 

--- a/rust/lance/src/dataset/cleanup.rs
+++ b/rust/lance/src/dataset/cleanup.rs
@@ -1490,7 +1490,9 @@ impl CleanupPolicyBuilder {
 /// This function will remove old manifest files, data files, indexes,
 /// delete files, and transaction files.
 ///
-/// It will only remove files that are not referenced by any valid manifest.
+/// Files that are not referenced by any valid manifest are removed if they are more
+/// than 7 days old, unless `delete_unverified` is set, which removes this age
+/// protection.
 ///
 /// The latest manifest is always considered valid and will not be removed
 /// even if it satisfied the cleanup policy.


### PR DESCRIPTION
## Summary

- `cleanup_old_versions` clamped its `data/` listing to `earliest_retained_manifest_time`. That floor is only sound for a file owned by a manifest being removed; a file owned by *no* manifest — abandoned `write_fragments()` output — has an mtime unrelated to it.
- Such a file is documented to be removed on its age, but it was never listed, so its age was never consulted and `delete_unverified=true` had no effect on it.
- When every aged version is retained (e.g. pinned by a tag) no manifest is deleted, so #8708's escape hatch cannot fire and the floor never advances: the orphan is collected by no run at all.
- The `data/` listing now runs through the moving unverified threshold — `earliest_retained.max(verification_threshold)` — and drops the cutoff entirely under `delete_unverified`, where a file is a candidate at any age. `CleanupInspection::listing_unmodified_since` is unchanged, so #8708's sparse-retain case and the other listings behave exactly as before.
- This restores an advancing cutoff, which is what the listing had before #4614 (the caller's `now - older_than`, per #8516). #8516 and #8705 reported the tagged facet of the same clamp and #8708 fixed it; this is the facet left over, reachable with no tag at all.
- Documents the contract the change relies on, which the Rust API and the guide had drifted from: an unverifiable file is removed once it is at least 7 days old, that threshold is fixed and independent of `older_than`, and `delete_unverified` removes the age protection entirely and requires that no other process is operating on the dataset. The Python docstring already said this.
- Adds `cleanup_deletes_aged_orphan_newer_than_retained_manifests`, covering both paths: an aged orphan under the default policy, and a fresh orphan under `delete_unverified`. Both are written after every manifest, under suffix-only retention with no tag anywhere.

`_transactions/` and `_deletions/` are clamped the same way and can strand a file for the same reason. Left for a follow-up so each gets its own regression test rather than widening destructive discovery across four subtrees at once.

Fixes #8942

## Test plan

- [x] `cargo fmt --all --check` — clean
- [x] `cargo check -p lance --tests` — clean
- [x] `cargo clippy -p lance --tests -- -D warnings` — clean
- [x] `cargo test -p lance --lib dataset::cleanup` — 46 passed, 0 failed, including both new cases and #8708's `cleanup_deletes_data_files_newer_than_tagged_version`
- [x] Mutation check: reverting the `data/` cutoff to `unmodified_since` fails `case_1_aged`; removing only the `delete_unverified` arm fails `case_2_delete_unverified`. Each case is gated on the branch it covers, and no other test changes outcome.
