### PR TITLE
feat(format): store large row id sequences in a hidden data file column

### DIFF
--- a/docs/src/format/table/index.md
+++ b/docs/src/format/table/index.md
@@ -119,6 +119,13 @@ Field ids might be replaced with `-2`, a tombstone value.
 In this case that column should be ignored. This used, for example, when rewriting a column: 
 The old data file replaces the field id with `-2` to ignore the old data, and a new data file is appended to the fragment.
 
+Negative field ids are reserved for system columns and never appear in the dataset
+schema: `-1` marks a field id that has not been assigned, `-2` is the tombstone
+above, and `-3` is the hidden `_rowid` column that holds a spilled row ID sequence
+(see [Row ID and Lineage](row_id_lineage.md)). The `_rowid` column is reached
+through a fragment's `row_id_sequence`, not through its `files`, so `-3` never
+appears in the file list that column projection walks.
+
 ## Data Files
 
 Data files store column data for a fragment using the Lance file format.

--- a/docs/src/format/table/row_id_lineage.md
+++ b/docs/src/format/table/row_id_lineage.md
@@ -181,11 +181,32 @@ The implementation selects the most compact encoding based on the value range, c
 
 </details>
 
-#### Inline vs External Storage
+#### Inline vs Spilled Storage
 
-Row ID sequences are stored either inline in the fragment metadata or in external files.
-Sequences smaller than ~200KB are stored inline to avoid additional I/O, while larger sequences are written to external files referenced by path and offset.
-This threshold balances manifest size against the overhead of separate file reads.
+Row ID sequences are stored either inline in the fragment metadata or outside it.
+Sequences smaller than ~200KB are stored inline to avoid additional I/O.
+This threshold balances manifest size against the overhead of separate file reads:
+an inline sequence is rewritten into every manifest version, so on a table whose
+sequences do not run-encode well the manifest grows with the total row count.
+
+A larger sequence is written to a **hidden column of a Lance data file**, carrying
+the reserved field id `-3`. The column holds one `uint64` per physical row, in
+offset order, and is located by the same `fields`/`column_indices` pair as a user
+column, so it may share a file with user data or occupy a file of its own. Reading
+it uses the ordinary data file reader and its encodings.
+
+A writer that emits `column_row_ids` MUST set the spilled row ids feature flag
+(bit 9, value 512) in both the reader and writer flag words. A reader without that
+bit sees an unset `row_id_sequence` oneof and would take the fragment to have no
+row IDs at all, on a table whose manifest says every fragment has them.
+
+The `external_row_ids` arm predates this and is a raw byte range holding the same
+encoded form as the inline arm. It is retained for compatibility; new writers use
+`column_row_ids`.
+
+!!! note
+    Spilled row ID sequences are not yet a released feature. A released build
+    treats bit 9 as an unknown feature flag and refuses the dataset.
 
 <details>
 <summary>DataFragment row_id_sequence field</summary>
@@ -195,6 +216,7 @@ message DataFragment {
   oneof row_id_sequence {
     bytes inline_row_ids = 5;
     ExternalFile external_row_ids = 6;
+    DataFile column_row_ids = 12;
   }
 }
 ```

--- a/protos/table.proto
+++ b/protos/table.proto
@@ -376,6 +376,16 @@ message DataFragment {
     bytes inline_row_ids = 5;
     // Otherwise, stored as part of a file.
     ExternalFile external_row_ids = 6;
+    // The row ids are stored as a hidden column of a Lance data file, at the
+    // reserved field id -3 (`ROW_ID_FIELD_ID`). The `fields`/`column_indices`
+    // pair locates the column the same way it does for a user column, so the
+    // column may share a file with user data or sit in a file of its own.
+    //
+    // A writer MUST set the spilled row ids feature flag (512) when any
+    // fragment uses this arm. A reader that does not understand the flag would
+    // see an unset `row_id_sequence` oneof and treat the fragment as having no
+    // row ids at all.
+    DataFile column_row_ids = 12;
   } // row_id_sequence
 
   oneof last_updated_at_version_sequence {

--- a/python/src/rowids.rs
+++ b/python/src/rowids.rs
@@ -48,8 +48,8 @@ impl PyRowIdSequence {
     fn from_inline_metadata(metadata: PyRef<'_, PyRowIdMeta>) -> PyResult<Self> {
         match &metadata.0 {
             RowIdMeta::Inline(data) => read_row_ids(data).infer_error().map(Self),
-            RowIdMeta::External(_) => Err(PyNotImplementedError::new_err(
-                "Row ids stored in an external file cannot be read into a RowIdSequence",
+            RowIdMeta::External(_) | RowIdMeta::Column(_) => Err(PyNotImplementedError::new_err(
+                "Row ids stored outside the manifest cannot be read into a RowIdSequence",
             )),
         }
     }

--- a/rust/lance-table/src/feature_flags.rs
+++ b/rust/lance-table/src/feature_flags.rs
@@ -55,6 +55,19 @@ pub const FLAG_COVERED_INDEX_METADATA: u64 = 1 << 7;
 pub const FLAG_MIXED_DATA_FILE_VERSIONS: u64 = 1 << 8;
 /// The first bit that is unknown as a feature flag
 pub const FLAG_UNKNOWN: u64 = 1 << 8;
+/// Some fragment stores its row id sequence as a hidden column of a data file
+/// rather than inline in the manifest (`RowIdMeta::Column`).
+///
+/// A reader without this bit sees an unset `row_id_sequence` oneof and would
+/// take the fragment to have no row ids at all, on a table whose manifest says
+/// every fragment has them. Both readers and writers must refuse the table.
+///
+/// Deliberately sits above [`FLAG_UNKNOWN`]: spilled row ids are not a released
+/// feature, so every released build already refuses the dataset without needing
+/// a change of its own. This build understands the bit only in debug builds or
+/// when [`ENABLE_UNSTABLE_SPILLED_ROW_IDS_ENV`] is set, mirroring
+/// [`FLAG_UNSTABLE_DATA_OVERLAY_FILES`].
+pub const FLAG_UNSTABLE_SPILLED_ROW_IDS: u64 = 1 << 9;
 
 // Supported flags stay below the unknown boundary; the mixed-version bit is
 // reserved at the boundary until its storage contract lands.
@@ -69,6 +82,11 @@ pub(crate) const STICKY_PAIRED_FLAGS: u64 = FLAG_MIXED_DATA_FILE_VERSIONS;
 /// Environment variable that opts a release build into reading and writing data
 /// overlay files before the feature is generally released.
 pub const ENABLE_UNSTABLE_DATA_OVERLAY_FILES_ENV: &str = "LANCE_ENABLE_UNSTABLE_DATA_OVERLAY_FILES";
+
+/// Environment variable that opts a release build into reading and writing row
+/// id sequences spilled to a hidden data file column before the feature is
+/// generally released.
+pub const ENABLE_UNSTABLE_SPILLED_ROW_IDS_ENV: &str = "LANCE_ENABLE_UNSTABLE_SPILLED_ROW_IDS";
 
 /// Set the reader and writer feature flags in the manifest based on the contents of the manifest.
 pub fn apply_feature_flags(
@@ -139,6 +157,16 @@ pub fn apply_feature_flags(
         manifest.writer_feature_flags |= FLAG_UNSTABLE_DATA_OVERLAY_FILES;
     }
 
+    let has_spilled_row_ids = manifest.fragments.iter().any(|frag| {
+        frag.row_id_meta
+            .as_ref()
+            .is_some_and(|meta| meta.column_file().is_some())
+    });
+    if has_spilled_row_ids {
+        manifest.reader_feature_flags |= FLAG_UNSTABLE_SPILLED_ROW_IDS;
+        manifest.writer_feature_flags |= FLAG_UNSTABLE_SPILLED_ROW_IDS;
+    }
+
     if disable_transaction_file {
         manifest.writer_feature_flags |= FLAG_DISABLE_TRANSACTION_FILE;
     }
@@ -174,6 +202,12 @@ fn data_overlay_files_enabled() -> bool {
     cfg!(debug_assertions) || std::env::var_os(ENABLE_UNSTABLE_DATA_OVERLAY_FILES_ENV).is_some()
 }
 
+/// Whether this build understands row id sequences spilled to a data file
+/// column. Gated the same way as [`data_overlay_files_enabled`].
+pub fn spilled_row_ids_enabled() -> bool {
+    cfg!(debug_assertions) || std::env::var_os(ENABLE_UNSTABLE_SPILLED_ROW_IDS_ENV).is_some()
+}
+
 /// Clear `flag` from `flags` when its gating feature is not enabled in this
 /// build; leave it set otherwise. One call per unstable flag, so support for
 /// several unstable features chains cleanly.
@@ -186,18 +220,23 @@ fn mark_supported(flags: &mut u64, flag: u64, feature_enabled: bool) {
 /// The feature-flag bits this build understands, given whether overlay support
 /// is enabled. Split out from [`supported_flags`] so the policy is testable
 /// without toggling the build profile or environment.
-fn supported_flags_when(overlay_enabled: bool) -> u64 {
+fn supported_flags_when(overlay_enabled: bool, spilled_row_ids: bool) -> u64 {
     let mut supported = FLAG_UNKNOWN - 1;
     mark_supported(
         &mut supported,
         FLAG_UNSTABLE_DATA_OVERLAY_FILES,
         overlay_enabled,
     );
+    // Added rather than cleared: the bit is above `FLAG_UNKNOWN`, so it is not
+    // in the base set to begin with.
+    if spilled_row_ids {
+        supported |= FLAG_UNSTABLE_SPILLED_ROW_IDS;
+    }
     supported
 }
 
 fn supported_flags() -> u64 {
-    supported_flags_when(data_overlay_files_enabled())
+    supported_flags_when(data_overlay_files_enabled(), spilled_row_ids_enabled())
 }
 
 pub fn can_read_dataset(reader_flags: u64) -> bool {
@@ -323,13 +362,23 @@ mod tests {
     fn test_data_overlay_flag_release_gating() {
         // Release default (overlays disabled): the overlay flag is treated as
         // unknown so the dataset is refused, while other known flags still pass.
-        let supported = supported_flags_when(false);
+        let supported = supported_flags_when(false, false);
         assert_eq!(supported & FLAG_UNSTABLE_DATA_OVERLAY_FILES, 0);
         assert_eq!(FLAG_DELETION_FILES & !supported, 0);
         assert_ne!(FLAG_UNSTABLE_DATA_OVERLAY_FILES & !supported, 0);
         // Enabled (debug or env opt-in): the overlay flag is understood.
-        let supported = supported_flags_when(true);
+        let supported = supported_flags_when(true, false);
         assert_eq!(FLAG_UNSTABLE_DATA_OVERLAY_FILES & !supported, 0);
+    }
+
+    #[test]
+    fn test_spilled_row_ids_flag_release_gating() {
+        // The bit sits above `FLAG_UNKNOWN`, so a build that has not opted in
+        // refuses the dataset without any change of its own.
+        let supported = supported_flags_when(true, false);
+        assert_ne!(FLAG_UNSTABLE_SPILLED_ROW_IDS & !supported, 0);
+        let supported = supported_flags_when(true, true);
+        assert_eq!(FLAG_UNSTABLE_SPILLED_ROW_IDS & !supported, 0);
     }
 
     #[test]

--- a/rust/lance-table/src/format.rs
+++ b/rust/lance-table/src/format.rs
@@ -23,7 +23,7 @@ pub use manifest::{
     SelfDescribingFileReader, WriterVersion, is_detached_version,
     populate_manifest_schema_dictionaries,
 };
-pub use row_ids::{ExternalFile, InlineRowIds, RowIdMeta};
+pub use row_ids::{ExternalFile, InlineRowIds, ROW_ID_FIELD_ID, RowIdMeta};
 pub use transaction::{Transaction, operation_may_change_schema};
 
 use lance_core::{Error, Result};

--- a/rust/lance-table/src/format/fragment.rs
+++ b/rust/lance-table/src/format/fragment.rs
@@ -540,7 +540,7 @@ impl Fragment {
             files,
             overlays,
             deletion_file: _,
-            row_id_meta: _,
+            row_id_meta,
             physical_rows: _,
             last_updated_at_version_meta: _,
             created_at_version_meta: _,
@@ -548,6 +548,7 @@ impl Fragment {
         files
             .iter()
             .chain(overlays.iter().map(|overlay| &overlay.data_file))
+            .chain(row_id_meta.iter().filter_map(RowIdMeta::column_file))
     }
 
     /// Mutable counterpart of [`Self::referenced_lance_files`], for rewriting
@@ -561,7 +562,7 @@ impl Fragment {
             files,
             overlays,
             deletion_file: _,
-            row_id_meta: _,
+            row_id_meta,
             physical_rows: _,
             last_updated_at_version_meta: _,
             created_at_version_meta: _,
@@ -569,6 +570,11 @@ impl Fragment {
         files
             .iter_mut()
             .chain(overlays.iter_mut().map(|overlay| &mut overlay.data_file))
+            .chain(
+                row_id_meta
+                    .iter_mut()
+                    .filter_map(RowIdMeta::column_file_mut),
+            )
     }
 
     pub fn from_json(json: &str) -> Result<Self> {
@@ -741,6 +747,9 @@ impl From<&Fragment> for pb::DataFragment {
                     offset: file.offset,
                     size: file.size,
                 })
+            }
+            RowIdMeta::Column(data_file) => {
+                pb::data_fragment::RowIdSequence::ColumnRowIds(pb::DataFile::from(data_file))
             }
         });
         let last_updated_at_version_sequence =

--- a/rust/lance-table/src/format/row_ids.rs
+++ b/rust/lance-table/src/format/row_ids.rs
@@ -8,7 +8,15 @@ use lance_core::deepsize::{Context, DeepSizeOf};
 use lance_core::{Error, Result};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
+use super::DataFile;
 use super::pb;
+
+/// Field id of the hidden `_rowid` column that a spilled row id sequence lives in.
+///
+/// Field ids are `i32` and negative values are reserved for system columns
+/// (`-1` is the unassigned sentinel, `-2` is
+/// [`TOMBSTONE_FIELD_ID`](crate::format::overlay::TOMBSTONE_FIELD_ID)).
+pub const ROW_ID_FIELD_ID: i32 = -3;
 
 /// A reference to a part of a file.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, DeepSizeOf)]
@@ -124,6 +132,31 @@ impl DeepSizeOf for InlineRowIdsInner {
 pub enum RowIdMeta {
     Inline(InlineRowIds),
     External(ExternalFile),
+    /// The sequence is spilled to a hidden [`ROW_ID_FIELD_ID`] column of a Lance
+    /// data file, one row id per physical row, in offset order.
+    ///
+    /// Unlike [`Self::External`], which is an opaque byte range, this is an
+    /// ordinary column: it carries the file's encodings and page layout, so it
+    /// can be read back a page at a time instead of whole.
+    Column(DataFile),
+}
+
+impl RowIdMeta {
+    /// The data file backing this sequence, if it is spilled to a column.
+    pub fn column_file(&self) -> Option<&DataFile> {
+        match self {
+            Self::Column(data_file) => Some(data_file),
+            Self::Inline(_) | Self::External(_) => None,
+        }
+    }
+
+    /// Mutable counterpart of [`Self::column_file`].
+    pub fn column_file_mut(&mut self) -> Option<&mut DataFile> {
+        match self {
+            Self::Column(data_file) => Some(data_file),
+            Self::Inline(_) | Self::External(_) => None,
+        }
+    }
 }
 
 impl TryFrom<pb::data_fragment::RowIdSequence> for RowIdMeta {
@@ -138,6 +171,9 @@ impl TryFrom<pb::data_fragment::RowIdSequence> for RowIdMeta {
                     offset: file.offset,
                     size: file.size,
                 }))
+            }
+            pb::data_fragment::RowIdSequence::ColumnRowIds(data_file) => {
+                Ok(Self::Column(DataFile::try_from(data_file)?))
             }
         }
     }

--- a/rust/lance-table/src/rowids/version.rs
+++ b/rust/lance-table/src/rowids/version.rs
@@ -502,8 +502,9 @@ pub fn refresh_row_latest_update_meta_for_full_frag_rewrite_cols(
                 let sequence = read_row_ids(data).unwrap();
                 sequence.len()
             }
-            // Follow existing behavior: external sequence not yet supported here
-            crate::format::RowIdMeta::External(_file) => 0,
+            // Follow existing behavior: a sequence that is not inline needs IO
+            // to read, which this synchronous path cannot do.
+            crate::format::RowIdMeta::External(_) | crate::format::RowIdMeta::Column(_) => 0,
         }
     } else {
         0
@@ -539,9 +540,13 @@ pub fn refresh_row_latest_update_meta_for_partial_frag_rewrite_cols(
                 let sequence = read_row_ids(data).unwrap();
                 sequence.len()
             }
-            crate::format::RowIdMeta::External(_file) => {
-                // Preserve original behavior for external sequences
-                todo!("External file loading not yet implemented")
+            // Reading these needs IO, which this synchronous path cannot do.
+            // Reachable only for a fragment that also has no `physical_rows`.
+            crate::format::RowIdMeta::External(_) | crate::format::RowIdMeta::Column(_) => {
+                return Err(Error::not_supported(
+                    "refreshing row update versions for a fragment whose row id \
+                     sequence is stored outside the manifest",
+                ));
             }
         }
     } else {

--- a/rust/lance-table/src/transaction/row_version.rs
+++ b/rust/lance-table/src/transaction/row_version.rs
@@ -134,9 +134,9 @@ pub(super) fn resolve_update_version_metadata(
     for fragment in new_fragments.iter_mut() {
         let row_ids = match &fragment.row_id_meta {
             Some(RowIdMeta::Inline(data)) => read_row_ids(data).ok(),
-            Some(RowIdMeta::External(_)) => {
+            Some(RowIdMeta::External(_) | RowIdMeta::Column(_)) => {
                 log::warn!(
-                    "Fragment {} has external row ID metadata; \
+                    "Fragment {} holds its row ID sequence outside the manifest; \
                      version tracking will use defaults",
                     fragment.id,
                 );

--- a/rust/lance/Cargo.toml
+++ b/rust/lance/Cargo.toml
@@ -320,6 +320,10 @@ name = "manifest_commit"
 harness = false
 
 [[bench]]
+name = "rowid_spill"
+harness = false
+
+[[bench]]
 name = "concurrent_append"
 harness = false
 

--- a/rust/lance/benches/rowid_spill.rs
+++ b/rust/lance/benches/rowid_spill.rs
@@ -4,12 +4,24 @@
 //! What it costs to keep a fragment's stable row id sequence in the manifest,
 //! and what changes when the sequence spills to a hidden data file column.
 //!
-//! The workload is the one that produced the numbers in
-//! <https://github.com/lance-format/lance/issues/8621>: a stable-row-id table
-//! that has had rows deleted and then compacted, so the deletions become holes
-//! in the row id sequences and the sequences stop being plain ranges. From
-//! there the benchmark measures, per arm, both the case for the design and the
-//! costs it adds:
+//! Two workloads, because they sit at opposite ends of what the run encoding
+//! can do with a sequence:
+//!
+//! - `deleted`: rows deleted and then compacted, the workload behind the
+//!   numbers in <https://github.com/lance-format/lance/issues/8621>. The
+//!   deletions become holes, so the sequence encodes as a range plus a bitmap
+//!   and costs a fraction of a byte per row.
+//! - `shuffled`: every row rewritten in random order, which is what a
+//!   reclustering pass leaves behind. Each fragment's rows now come from all
+//!   over the table, so there is no run structure left and the sequence falls
+//!   back to `U64Segment::Array`, at four bytes per row on the wire. This is
+//!   the worst case for keeping sequences inline.
+//!
+//! Each workload runs two arms, and within a workload the arms differ only in
+//! `CompactionOptions::inline_row_ids_max_bytes`: `Some(usize::MAX)` never
+//! spills, which is today's behavior, and `None` takes the format's 200 KiB
+//! inline budget, which is what this change makes the default. Both arms
+//! measure the case for the design and the costs it adds:
 //!
 //! 1. manifest bytes -- the claim is that this stops growing with the table
 //! 2. cold dataset open -- every reader pays the manifest decode
@@ -19,11 +31,6 @@
 //!    an id, and the `take` itself once that index exists -- the read cost the
 //!    design adds
 //! 5. compaction wall time and bytes written -- the write cost it adds
-//!
-//! The two arms differ only in `CompactionOptions::inline_row_ids_max_bytes`:
-//! `Some(usize::MAX)` never spills, which is today's behavior, and `None` takes
-//! the format's 200 KiB inline budget, which is what this change makes the
-//! default.
 //!
 //! ## Running
 //!
@@ -38,26 +45,36 @@
 //!
 //! - `BENCH_FRAGMENTS`: fragments to write (default 8).
 //! - `BENCH_ROWS_PER_FRAGMENT`: rows in each (default 1,000,000).
-//! - `BENCH_DELETE_PERCENT`: percentage of rows deleted before compaction
-//!   (default 30). Deletions are what turn the sequences into something the
-//!   run encoding cannot compress.
+//! - `BENCH_DELETE_PERCENT`: percentage of rows deleted before compaction in
+//!   the `deleted` workload (default 30). Deletions are what turn the sequences
+//!   into something the run encoding cannot compress into a plain range.
 //! - `BENCH_APPENDS`: appends timed for the commit-latency figure (default 5).
+//! - `BENCH_SCENARIOS`: comma-separated subset of `deleted,shuffled` to run
+//!   (default both).
 
 #![allow(clippy::print_stdout)]
 
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
+use arrow_array::cast::AsArray;
+use arrow_array::types::{Int64Type, UInt64Type};
 use arrow_array::{Int64Array, RecordBatch, RecordBatchIterator};
 use arrow_schema::{DataType, Field, Schema as ArrowSchema};
 use criterion::{Criterion, criterion_group, criterion_main};
+use futures::TryStreamExt;
 use lance::dataset::optimize::{CompactionOptions, compact_files};
 use lance::dataset::rowids::{get_row_id_index, load_row_id_sequence};
-use lance::dataset::{Dataset, ProjectionRequest, WriteMode, WriteParams};
+use lance::dataset::{
+    CommitBuilder, Dataset, InsertBuilder, ProjectionRequest, WriteMode, WriteParams,
+};
 use lance::session::Session;
+use lance_core::ROW_ID;
 use lance_io::object_store::ObjectStoreRegistry;
 use lance_table::feature_flags::ENABLE_UNSTABLE_SPILLED_ROW_IDS_ENV;
 use lance_table::format::{RowDatasetVersionMeta, RowIdMeta};
+use lance_table::rowids::{RowIdSequence, write_row_ids};
+use lance_table::transaction::{Operation, RewriteGroup, TransactionBuilder};
 use tokio::runtime::Runtime;
 
 const DEFAULT_FRAGMENTS: usize = 8;
@@ -76,6 +93,29 @@ fn env_usize(name: &str, default: usize) -> usize {
         .ok()
         .and_then(|value| value.parse().ok())
         .unwrap_or(default)
+}
+
+/// How the table is left before compaction, which decides what the row id
+/// sequences look like and so what keeping them inline costs.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum Scenario {
+    /// A slice of every fragment deleted, then compacted. The surviving ids are
+    /// still ascending, so the sequence encodes as a range plus a bitmap of
+    /// holes.
+    Deleted,
+    /// Every row rewritten in a random order. The ids in a fragment are no
+    /// longer ascending or contiguous, so the encoding degrades to a bitpacked
+    /// array of absolute values.
+    Shuffled,
+}
+
+impl Scenario {
+    fn name(self) -> &'static str {
+        match self {
+            Self::Deleted => "deleted",
+            Self::Shuffled => "shuffled",
+        }
+    }
 }
 
 #[derive(Clone, Copy)]
@@ -101,8 +141,10 @@ struct ArmResult {
     compaction: Duration,
     data_bytes: u64,
     manifest_bytes: u64,
+    transaction_bytes: u64,
     inline_row_id_bytes: u64,
     inline_row_version_bytes: u64,
+    rows: u64,
     open: Duration,
     commit: Duration,
     load_sequence: Duration,
@@ -145,9 +187,16 @@ fn schema() -> Arc<ArrowSchema> {
     ]))
 }
 
+/// `value` is a pure function of `id` so that a `take` by row id can be checked
+/// against the id it resolved to, which is what proves a spilled sequence maps
+/// rows to the same places the inline one did.
+fn value_of(id: i64) -> i64 {
+    id * 3
+}
+
 fn batch(schema: Arc<ArrowSchema>, start: i64, len: usize) -> RecordBatch {
     let ids = Int64Array::from_iter_values(start..(start + len as i64));
-    let values = Int64Array::from_iter_values((start..(start + len as i64)).map(|i| i * 3));
+    let values = Int64Array::from_iter_values((start..(start + len as i64)).map(value_of));
     RecordBatch::try_new(schema, vec![Arc::new(ids), Arc::new(values)]).unwrap()
 }
 
@@ -165,9 +214,9 @@ async fn open_cold(uri: &str) -> Dataset {
         .unwrap()
 }
 
-/// Write the table, then delete a slice of every fragment so that compaction
-/// has holes to materialize.
-async fn build_base(uri: &str, config: Config) -> Dataset {
+/// Write the table one fragment per commit, so the fragments come from
+/// different versions the way an incrementally loaded table's would.
+async fn write_table(uri: &str, config: Config) -> Dataset {
     let schema = schema();
     let mut dataset = None;
     for fragment in 0..config.fragments {
@@ -194,16 +243,154 @@ async fn build_base(uri: &str, config: Config) -> Dataset {
             .unwrap(),
         );
     }
+    dataset.unwrap()
+}
 
-    let mut dataset = dataset.unwrap();
-    // Spread the deletions across every fragment rather than truncating a
-    // prefix: a hole every few rows is what stops the sequence from encoding
-    // as a range.
-    dataset
-        .delete(&format!("id % 100 < {}", config.delete_percent))
+/// Every row of the table paired with its stable row id.
+async fn read_rows_with_ids(dataset: &Dataset) -> Vec<(u64, i64)> {
+    let mut scanner = dataset.scan();
+    scanner.with_row_id();
+    scanner.project(&["id"]).unwrap();
+    let mut stream = scanner.try_into_stream().await.unwrap();
+
+    let mut rows = Vec::with_capacity(dataset.count_rows(None).await.unwrap());
+    while let Some(batch) = stream.try_next().await.unwrap() {
+        let row_ids = batch
+            .column_by_name(ROW_ID)
+            .unwrap()
+            .as_primitive::<UInt64Type>();
+        let ids = batch
+            .column_by_name("id")
+            .unwrap()
+            .as_primitive::<Int64Type>();
+        rows.extend(
+            row_ids
+                .values()
+                .iter()
+                .copied()
+                .zip(ids.values().iter().copied()),
+        );
+    }
+    rows
+}
+
+/// Fisher-Yates driven by SplitMix64, so the permutation is the same on every
+/// run and both arms of a scenario shuffle identically. Written out rather than
+/// depending on `rand`, which the `lance` crate does not otherwise use.
+fn shuffle<T>(items: &mut [T]) {
+    let mut state = 0x2545_F491_4F6C_DD1Du64;
+    let mut next = move || {
+        state = state.wrapping_add(0x9E37_79B9_7F4A_7C15);
+        let mut z = state;
+        z = (z ^ (z >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
+        z = (z ^ (z >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
+        z ^ (z >> 31)
+    };
+    for i in (1..items.len()).rev() {
+        items.swap(i, (next() % (i as u64 + 1)) as usize);
+    }
+}
+
+/// Rewrite the whole table in a random row order, keeping every row's stable
+/// row id.
+///
+/// This is the shape a reclustering pass leaves behind, and it goes through the
+/// same `Operation::Rewrite` a compaction commits: the new fragments carry the
+/// permuted sequences, which is how such a pass would have to preserve row ids.
+/// The fragments are written at half the target size so that the compaction
+/// that follows has neighbors to merge, and therefore rechunks -- and in the
+/// spilled arm spills -- every sequence.
+async fn shuffle_rewrite(dataset: Dataset, config: Config) -> Dataset {
+    let mut rows = read_rows_with_ids(&dataset).await;
+    shuffle(&mut rows);
+
+    let rows_per_file = config.rows_per_fragment / 2;
+    let arrow_schema = schema();
+    let shuffled_ids: Vec<u64> = rows.iter().map(|(row_id, _)| *row_id).collect();
+    let batches: Vec<RecordBatch> = rows
+        .chunks(rows_per_file)
+        .map(|chunk| {
+            let ids = Int64Array::from_iter_values(chunk.iter().map(|(_, id)| *id));
+            let values = Int64Array::from_iter_values(chunk.iter().map(|(_, id)| value_of(*id)));
+            RecordBatch::try_new(arrow_schema.clone(), vec![Arc::new(ids), Arc::new(values)])
+                .unwrap()
+        })
+        .collect();
+    drop(rows);
+
+    let dataset = Arc::new(dataset);
+    let reader = RecordBatchIterator::new(batches.into_iter().map(Ok), arrow_schema);
+    let uncommitted = InsertBuilder::new(dataset.clone())
+        .with_params(&WriteParams {
+            mode: WriteMode::Append,
+            enable_stable_row_ids: true,
+            max_rows_per_file: rows_per_file,
+            skip_auto_cleanup: true,
+            ..Default::default()
+        })
+        .execute_uncommitted_stream(reader)
         .await
         .unwrap();
-    dataset
+
+    let mut new_fragments = match uncommitted.operation {
+        Operation::Append { fragments } => fragments,
+        other => panic!("uncommitted write produced {other:?}, expected an append"),
+    };
+
+    // The uncommitted write handed each new fragment a fresh range of row ids.
+    // Replace them with the ids the rows actually carry, sliced in the order
+    // the fragments were written.
+    let mut offset = 0;
+    for fragment in new_fragments.iter_mut() {
+        let rows_in_fragment = fragment.physical_rows.unwrap();
+        let sequence = RowIdSequence::from(&shuffled_ids[offset..offset + rows_in_fragment]);
+        fragment.row_id_meta = Some(RowIdMeta::Inline(write_row_ids(&sequence).into()));
+        offset += rows_in_fragment;
+    }
+    assert_eq!(
+        offset,
+        shuffled_ids.len(),
+        "the new fragments hold {offset} rows but the table has {}",
+        shuffled_ids.len()
+    );
+
+    let transaction = TransactionBuilder::new(
+        dataset.version().version,
+        Operation::Rewrite {
+            groups: vec![RewriteGroup {
+                old_fragments: dataset.manifest.fragments.as_ref().clone(),
+                new_fragments,
+            }],
+            rewritten_indices: Vec::new(),
+            frag_reuse_index: None,
+        },
+    )
+    .build();
+
+    CommitBuilder::new(dataset)
+        .with_skip_auto_cleanup(true)
+        .execute(transaction)
+        .await
+        .unwrap()
+}
+
+/// The table as the scenario leaves it, ready for the compaction that decides
+/// where each sequence lands.
+async fn build_base(uri: &str, config: Config, scenario: Scenario) -> Dataset {
+    let mut dataset = write_table(uri, config).await;
+    match scenario {
+        Scenario::Deleted => {
+            // Spread the deletions across every fragment rather than truncating
+            // a prefix: a hole every few rows is what stops the sequence from
+            // encoding as a range.
+            dataset
+                .delete(&format!("id % 100 < {}", config.delete_percent))
+                .await
+                .unwrap();
+            dataset
+        }
+        Scenario::Shuffled => shuffle_rewrite(dataset, config).await,
+    }
 }
 
 fn dir_bytes(path: &str) -> u64 {
@@ -242,15 +429,28 @@ fn manifest_bytes(dir: &str, version: u64) -> u64 {
         .unwrap_or(0)
 }
 
-async fn run_arm(dir: &str, config: Config, inline_row_ids_max_bytes: Option<usize>) -> ArmResult {
+async fn run_arm(
+    dir: &str,
+    config: Config,
+    scenario: Scenario,
+    inline_row_ids_max_bytes: Option<usize>,
+) -> ArmResult {
     let uri = dir.to_string();
-    let mut dataset = build_base(&uri, config).await;
+    let mut dataset = build_base(&uri, config, scenario).await;
+
+    // A commit writes the whole transaction to its own file under
+    // `_transactions/` as well as putting the fragment list in the manifest, so
+    // the compaction's transaction blob is a write cost the manifest row does
+    // not show.
+    let transactions_before = dir_bytes(&format!("{dir}/_transactions"));
 
     let started = Instant::now();
     compact_files(
         &mut dataset,
         CompactionOptions {
             target_rows_per_fragment: config.rows_per_fragment,
+            // Only bites in the `deleted` scenario; the `shuffled` one has no
+            // deletions and is picked up by the below-target rule instead.
             materialize_deletions: true,
             materialize_deletions_threshold: 0.0,
             inline_row_ids_max_bytes,
@@ -261,6 +461,8 @@ async fn run_arm(dir: &str, config: Config, inline_row_ids_max_bytes: Option<usi
     .await
     .unwrap();
     let compaction = started.elapsed();
+    let transaction_bytes =
+        dir_bytes(&format!("{dir}/_transactions")).saturating_sub(transactions_before);
 
     let total_fragments = dataset.get_fragments().len();
     let spilled_fragments = dataset
@@ -275,6 +477,7 @@ async fn run_arm(dir: &str, config: Config, inline_row_ids_max_bytes: Option<usi
         })
         .count();
 
+    let rows = dataset.count_rows(None).await.unwrap() as u64;
     let manifest_bytes = manifest_bytes(dir, dataset.version().version);
     let (inline_row_id_bytes, inline_row_version_bytes) = inline_sequence_bytes(&dataset);
     // Captured before the appends below, and while the pre-compaction files are
@@ -329,9 +532,23 @@ async fn run_arm(dir: &str, config: Config, inline_row_ids_max_bytes: Option<usi
     let index = get_row_id_index(&warm).await.unwrap();
     let projection = ProjectionRequest::from_columns(["value"], warm.schema());
     let started = Instant::now();
-    warm.take_rows(&[probe_id], projection).await.unwrap();
+    let taken = warm.take_rows(&[probe_id], projection).await.unwrap();
     let take_warm = started.elapsed();
     drop(index);
+
+    // Row ids were handed out in `id` order, so the row a spilled sequence
+    // resolves has to be the one whose `value` matches. Cheap, and it is the
+    // only thing separating a fast answer from a correct one.
+    let value = taken
+        .column_by_name("value")
+        .unwrap()
+        .as_primitive::<Int64Type>()
+        .value(0);
+    assert_eq!(
+        value,
+        value_of(probe_id as i64),
+        "row id {probe_id} resolved to a row holding {value}"
+    );
 
     let schema = schema();
     let mut commit_total = Duration::ZERO;
@@ -357,8 +574,10 @@ async fn run_arm(dir: &str, config: Config, inline_row_ids_max_bytes: Option<usi
         compaction,
         data_bytes,
         manifest_bytes,
+        transaction_bytes,
         inline_row_id_bytes,
         inline_row_version_bytes,
+        rows,
         open,
         commit: commit_total / config.appends as u32,
         load_sequence,
@@ -373,37 +592,24 @@ fn mib(bytes: u64) -> f64 {
     bytes as f64 / (1024.0 * 1024.0)
 }
 
-fn bench_rowid_spill(_c: &mut Criterion) {
-    if std::env::var_os(ENABLE_UNSTABLE_SPILLED_ROW_IDS_ENV).is_none() && !cfg!(debug_assertions) {
-        panic!(
-            "set {ENABLE_UNSTABLE_SPILLED_ROW_IDS_ENV}=1 to run this benchmark: spilled row ids \
-             are an unstable feature and a release build refuses the dataset without it"
-        );
-    }
-
-    let config = Config::from_env();
-    let runtime = Runtime::new().unwrap();
-
-    println!("=== Row id sequence placement ===");
-    println!(
-        "{} fragments x {} rows, {}% deleted then compacted",
-        config.fragments, config.rows_per_fragment, config.delete_percent
-    );
+fn report(scenario: Scenario, config: Config, inline: &ArmResult, spilled: &ArmResult) {
     println!();
-
-    // `usize::MAX` reproduces the behavior on main, where a compacted fragment's
-    // sequence always stays inline however large it grows. `None` takes the
-    // format's documented 200 KiB inline budget, which is what this change makes
-    // the default.
-    let inline_dir = tempfile::tempdir().unwrap();
-    let inline = runtime.block_on(run_arm(
-        &inline_dir.path().to_string_lossy(),
-        config,
-        Some(usize::MAX),
-    ));
-
-    let spill_dir = tempfile::tempdir().unwrap();
-    let spilled = runtime.block_on(run_arm(&spill_dir.path().to_string_lossy(), config, None));
+    match scenario {
+        Scenario::Deleted => println!(
+            "--- {}: {} fragments x {} rows, {}% deleted then compacted ---",
+            scenario.name(),
+            config.fragments,
+            config.rows_per_fragment,
+            config.delete_percent
+        ),
+        Scenario::Shuffled => println!(
+            "--- {}: {} fragments x {} rows, rewritten in random order then compacted ---",
+            scenario.name(),
+            config.fragments,
+            config.rows_per_fragment
+        ),
+    }
+    println!();
 
     println!(
         "{:<28} {:>14} {:>14} {:>10}",
@@ -438,6 +644,12 @@ fn bench_rowid_spill(_c: &mut Criterion) {
         "  of which row versions",
         mib(inline.inline_row_version_bytes),
         mib(spilled.inline_row_version_bytes),
+        "M",
+    );
+    row(
+        "compaction transaction file",
+        mib(inline.transaction_bytes),
+        mib(spilled.transaction_bytes),
         "M",
     );
     row(
@@ -482,17 +694,32 @@ fn bench_rowid_spill(_c: &mut Criterion) {
         mib(spilled.data_bytes),
         "M",
     );
+
     println!();
-    // The commit that creates the fragments writes them into the manifest file
-    // twice: once in the fragment list, once in the inline transaction section
-    // (`Manifest::transaction_section`). So a byte of inline sequence costs two
-    // bytes of manifest at that version, and one byte at every version after.
+    // Bytes per row is what makes the two scenarios comparable: it is the
+    // encoding's cost for one id, and it is what decides whether a sequence
+    // belongs in the manifest at all.
     println!(
-        "manifest holds each sequence twice at the creating commit, so the inline arm's \
-         {:.2}M of row ids accounts for {:.2}M of the {:.2}M manifest delta",
+        "{} rows: {:.2} B/row inline in the manifest, {:.2} B/row in the spilled column",
+        inline.rows,
+        inline.inline_row_id_bytes as f64 / inline.rows as f64,
+        spilled.data_bytes.saturating_sub(inline.data_bytes) as f64 / spilled.rows as f64,
+    );
+    // A commit puts the fragment list in the manifest and writes the whole
+    // transaction to its own file, so an inline sequence is written twice per
+    // commit. It is written a third time when the transaction serializes under
+    // `MAX_INLINE_TRANSACTION_BYTES` (20 MiB), because it is then copied into
+    // the manifest as well (`Manifest::transaction_section`) -- which is why
+    // the small-sequence scenario shows a manifest delta of twice its row ids
+    // and the large one does not.
+    println!(
+        "commit blobs for the compaction: inline {:.2}M manifest + {:.2}M transaction file, \
+         spilled {:.2}M + {:.2}M; row ids inline are {:.2}M",
+        mib(inline.manifest_bytes),
+        mib(inline.transaction_bytes),
+        mib(spilled.manifest_bytes),
+        mib(spilled.transaction_bytes),
         mib(inline.inline_row_id_bytes),
-        mib(2 * inline.inline_row_id_bytes),
-        mib(inline.manifest_bytes.saturating_sub(spilled.manifest_bytes)),
     );
     println!(
         "spilled fragments: inline arm {}/{}, spilled arm {}/{}",
@@ -501,6 +728,64 @@ fn bench_rowid_spill(_c: &mut Criterion) {
         spilled.spilled_fragments,
         spilled.total_fragments
     );
+}
+
+fn scenarios_from_env() -> Vec<Scenario> {
+    let all = [Scenario::Deleted, Scenario::Shuffled];
+    let Ok(requested) = std::env::var("BENCH_SCENARIOS") else {
+        return all.to_vec();
+    };
+    let selected: Vec<Scenario> = all
+        .into_iter()
+        .filter(|scenario| {
+            requested
+                .split(',')
+                .any(|name| name.trim() == scenario.name())
+        })
+        .collect();
+    assert!(
+        !selected.is_empty(),
+        "BENCH_SCENARIOS={requested} selected none of: deleted, shuffled"
+    );
+    selected
+}
+
+fn bench_rowid_spill(_c: &mut Criterion) {
+    if std::env::var_os(ENABLE_UNSTABLE_SPILLED_ROW_IDS_ENV).is_none() && !cfg!(debug_assertions) {
+        panic!(
+            "set {ENABLE_UNSTABLE_SPILLED_ROW_IDS_ENV}=1 to run this benchmark: spilled row ids \
+             are an unstable feature and a release build refuses the dataset without it"
+        );
+    }
+
+    let config = Config::from_env();
+    let runtime = Runtime::new().unwrap();
+
+    println!("=== Row id sequence placement ===");
+
+    for scenario in scenarios_from_env() {
+        // `usize::MAX` reproduces the behavior on main, where a compacted
+        // fragment's sequence always stays inline however large it grows.
+        // `None` takes the format's documented 200 KiB inline budget, which is
+        // what this change makes the default.
+        let inline_dir = tempfile::tempdir().unwrap();
+        let inline = runtime.block_on(run_arm(
+            &inline_dir.path().to_string_lossy(),
+            config,
+            scenario,
+            Some(usize::MAX),
+        ));
+
+        let spill_dir = tempfile::tempdir().unwrap();
+        let spilled = runtime.block_on(run_arm(
+            &spill_dir.path().to_string_lossy(),
+            config,
+            scenario,
+            None,
+        ));
+
+        report(scenario, config, &inline, &spilled);
+    }
 }
 
 criterion_group!(benches, bench_rowid_spill);

--- a/rust/lance/benches/rowid_spill.rs
+++ b/rust/lance/benches/rowid_spill.rs
@@ -1,0 +1,507 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+//! What it costs to keep a fragment's stable row id sequence in the manifest,
+//! and what changes when the sequence spills to a hidden data file column.
+//!
+//! The workload is the one that produced the numbers in
+//! <https://github.com/lance-format/lance/issues/8621>: a stable-row-id table
+//! that has had rows deleted and then compacted, so the deletions become holes
+//! in the row id sequences and the sequences stop being plain ranges. From
+//! there the benchmark measures, per arm, both the case for the design and the
+//! costs it adds:
+//!
+//! 1. manifest bytes -- the claim is that this stops growing with the table
+//! 2. cold dataset open -- every reader pays the manifest decode
+//! 3. commit latency for one small append -- every writer rewrites the manifest
+//! 4. reading a sequence back, split into loading one fragment's sequence, the
+//!    dataset-wide row id index build that a query pays before it can resolve
+//!    an id, and the `take` itself once that index exists -- the read cost the
+//!    design adds
+//! 5. compaction wall time and bytes written -- the write cost it adds
+//!
+//! The two arms differ only in `CompactionOptions::inline_row_ids_max_bytes`:
+//! `Some(usize::MAX)` never spills, which is today's behavior, and `None` takes
+//! the format's 200 KiB inline budget, which is what this change makes the
+//! default.
+//!
+//! ## Running
+//!
+//! Spilled row ids are an unstable feature, so a release build -- which is what
+//! `cargo bench` produces -- has to opt in:
+//!
+//! ```bash
+//! LANCE_ENABLE_UNSTABLE_SPILLED_ROW_IDS=1 cargo bench --bench rowid_spill
+//! ```
+//!
+//! ## Configuration
+//!
+//! - `BENCH_FRAGMENTS`: fragments to write (default 8).
+//! - `BENCH_ROWS_PER_FRAGMENT`: rows in each (default 1,000,000).
+//! - `BENCH_DELETE_PERCENT`: percentage of rows deleted before compaction
+//!   (default 30). Deletions are what turn the sequences into something the
+//!   run encoding cannot compress.
+//! - `BENCH_APPENDS`: appends timed for the commit-latency figure (default 5).
+
+#![allow(clippy::print_stdout)]
+
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use arrow_array::{Int64Array, RecordBatch, RecordBatchIterator};
+use arrow_schema::{DataType, Field, Schema as ArrowSchema};
+use criterion::{Criterion, criterion_group, criterion_main};
+use lance::dataset::optimize::{CompactionOptions, compact_files};
+use lance::dataset::rowids::{get_row_id_index, load_row_id_sequence};
+use lance::dataset::{Dataset, ProjectionRequest, WriteMode, WriteParams};
+use lance::session::Session;
+use lance_io::object_store::ObjectStoreRegistry;
+use lance_table::feature_flags::ENABLE_UNSTABLE_SPILLED_ROW_IDS_ENV;
+use lance_table::format::{RowDatasetVersionMeta, RowIdMeta};
+use tokio::runtime::Runtime;
+
+const DEFAULT_FRAGMENTS: usize = 8;
+const DEFAULT_ROWS_PER_FRAGMENT: usize = 1_000_000;
+const DEFAULT_DELETE_PERCENT: usize = 30;
+const DEFAULT_APPENDS: usize = 5;
+
+/// Repeats for the cold-open figure, which is sub-millisecond on local disk.
+const OPEN_SAMPLES: usize = 10;
+
+/// Repeats for the two cold sequence-read figures.
+const READ_SAMPLES: usize = 3;
+
+fn env_usize(name: &str, default: usize) -> usize {
+    std::env::var(name)
+        .ok()
+        .and_then(|value| value.parse().ok())
+        .unwrap_or(default)
+}
+
+#[derive(Clone, Copy)]
+struct Config {
+    fragments: usize,
+    rows_per_fragment: usize,
+    delete_percent: usize,
+    appends: usize,
+}
+
+impl Config {
+    fn from_env() -> Self {
+        Self {
+            fragments: env_usize("BENCH_FRAGMENTS", DEFAULT_FRAGMENTS),
+            rows_per_fragment: env_usize("BENCH_ROWS_PER_FRAGMENT", DEFAULT_ROWS_PER_FRAGMENT),
+            delete_percent: env_usize("BENCH_DELETE_PERCENT", DEFAULT_DELETE_PERCENT),
+            appends: env_usize("BENCH_APPENDS", DEFAULT_APPENDS),
+        }
+    }
+}
+
+struct ArmResult {
+    compaction: Duration,
+    data_bytes: u64,
+    manifest_bytes: u64,
+    inline_row_id_bytes: u64,
+    inline_row_version_bytes: u64,
+    open: Duration,
+    commit: Duration,
+    load_sequence: Duration,
+    index_build: Duration,
+    take_warm: Duration,
+    spilled_fragments: usize,
+    total_fragments: usize,
+}
+
+/// Encoded bytes each fragment keeps inline in the manifest, split by which of
+/// the three per-row sequence families they belong to. The row version families
+/// are the other two columns section 5.3 moves; this change only moves row ids,
+/// so the split says how much of the manifest is left behind.
+fn inline_sequence_bytes(dataset: &Dataset) -> (u64, u64) {
+    let mut row_ids = 0;
+    let mut versions = 0;
+    for fragment in dataset.manifest.fragments.iter() {
+        if let Some(RowIdMeta::Inline(data)) = &fragment.row_id_meta {
+            row_ids += data.len() as u64;
+        }
+        for meta in [
+            &fragment.created_at_version_meta,
+            &fragment.last_updated_at_version_meta,
+        ]
+        .into_iter()
+        .flatten()
+        {
+            if let RowDatasetVersionMeta::Inline(data) = meta {
+                versions += data.len() as u64;
+            }
+        }
+    }
+    (row_ids, versions)
+}
+
+fn schema() -> Arc<ArrowSchema> {
+    Arc::new(ArrowSchema::new(vec![
+        Field::new("id", DataType::Int64, false),
+        Field::new("value", DataType::Int64, false),
+    ]))
+}
+
+fn batch(schema: Arc<ArrowSchema>, start: i64, len: usize) -> RecordBatch {
+    let ids = Int64Array::from_iter_values(start..(start + len as i64));
+    let values = Int64Array::from_iter_values((start..(start + len as i64)).map(|i| i * 3));
+    RecordBatch::try_new(schema, vec![Arc::new(ids), Arc::new(values)]).unwrap()
+}
+
+/// A fresh session with no caches, so each measurement pays the real decode
+/// rather than reading back what the previous one memoized.
+fn cold_session() -> Arc<Session> {
+    Arc::new(Session::new(0, 0, Arc::new(ObjectStoreRegistry::default())))
+}
+
+async fn open_cold(uri: &str) -> Dataset {
+    lance::dataset::builder::DatasetBuilder::from_uri(uri)
+        .with_session(cold_session())
+        .load()
+        .await
+        .unwrap()
+}
+
+/// Write the table, then delete a slice of every fragment so that compaction
+/// has holes to materialize.
+async fn build_base(uri: &str, config: Config) -> Dataset {
+    let schema = schema();
+    let mut dataset = None;
+    for fragment in 0..config.fragments {
+        let start = (fragment * config.rows_per_fragment) as i64;
+        let data = batch(schema.clone(), start, config.rows_per_fragment);
+        let reader = RecordBatchIterator::new(vec![Ok(data)], schema.clone());
+        dataset = Some(
+            Dataset::write(
+                reader,
+                uri,
+                Some(WriteParams {
+                    enable_stable_row_ids: true,
+                    max_rows_per_file: config.rows_per_fragment,
+                    mode: if fragment == 0 {
+                        WriteMode::Create
+                    } else {
+                        WriteMode::Append
+                    },
+                    skip_auto_cleanup: true,
+                    ..Default::default()
+                }),
+            )
+            .await
+            .unwrap(),
+        );
+    }
+
+    let mut dataset = dataset.unwrap();
+    // Spread the deletions across every fragment rather than truncating a
+    // prefix: a hole every few rows is what stops the sequence from encoding
+    // as a range.
+    dataset
+        .delete(&format!("id % 100 < {}", config.delete_percent))
+        .await
+        .unwrap();
+    dataset
+}
+
+fn dir_bytes(path: &str) -> u64 {
+    let mut total = 0;
+    let Ok(entries) = std::fs::read_dir(path) else {
+        return 0;
+    };
+    for entry in entries.flatten() {
+        let Ok(metadata) = entry.metadata() else {
+            continue;
+        };
+        if metadata.is_dir() {
+            total += dir_bytes(&entry.path().to_string_lossy());
+        } else {
+            total += metadata.len();
+        }
+    }
+    total
+}
+
+/// Size of the manifest for exactly `version`, which is the blob a commit at
+/// that version rewrote and every reader of it downloads.
+///
+/// Both manifest naming schemes live under `_versions/`: V1 names the file after
+/// the version, V2 after `u64::MAX - version`, zero padded.
+fn manifest_bytes(dir: &str, version: u64) -> u64 {
+    let versions = format!("{dir}/_versions");
+    let candidates = [
+        format!("{versions}/{version}.manifest"),
+        format!("{versions}/{:020}.manifest", u64::MAX - version),
+    ];
+    candidates
+        .iter()
+        .find_map(|path| std::fs::metadata(path).ok())
+        .map(|metadata| metadata.len())
+        .unwrap_or(0)
+}
+
+async fn run_arm(dir: &str, config: Config, inline_row_ids_max_bytes: Option<usize>) -> ArmResult {
+    let uri = dir.to_string();
+    let mut dataset = build_base(&uri, config).await;
+
+    let started = Instant::now();
+    compact_files(
+        &mut dataset,
+        CompactionOptions {
+            target_rows_per_fragment: config.rows_per_fragment,
+            materialize_deletions: true,
+            materialize_deletions_threshold: 0.0,
+            inline_row_ids_max_bytes,
+            ..Default::default()
+        },
+        None,
+    )
+    .await
+    .unwrap();
+    let compaction = started.elapsed();
+
+    let total_fragments = dataset.get_fragments().len();
+    let spilled_fragments = dataset
+        .get_fragments()
+        .iter()
+        .filter(|fragment| {
+            fragment
+                .metadata()
+                .row_id_meta
+                .as_ref()
+                .is_some_and(|meta| meta.column_file().is_some())
+        })
+        .count();
+
+    let manifest_bytes = manifest_bytes(dir, dataset.version().version);
+    let (inline_row_id_bytes, inline_row_version_bytes) = inline_sequence_bytes(&dataset);
+    // Captured before the appends below, and while the pre-compaction files are
+    // still on disk in both arms. Both arms wrote identical user data, so the
+    // difference between them is exactly what the spilled columns cost.
+    let data_bytes = dir_bytes(&format!("{dir}/data"));
+
+    // A cold open is sub-millisecond on a local filesystem, so a single sample
+    // is mostly noise. Averaged, since this is one of the figures the design is
+    // argued on.
+    let started = Instant::now();
+    for _ in 0..OPEN_SAMPLES {
+        let _ = open_cold(&uri).await;
+    }
+    let open = started.elapsed() / OPEN_SAMPLES as u32;
+
+    // One fragment's sequence, read cold. This is the work the design moves out
+    // of the manifest decode and into a data file read, so it is measured on its
+    // own rather than only through the query that depends on it. The last
+    // fragment, so resolving its ids cannot short-circuit on the first one.
+    let mut probe_id = 0;
+    let mut load_total = Duration::ZERO;
+    for _ in 0..READ_SAMPLES {
+        // Opened outside the timed region: this row is the sequence read, not
+        // the manifest decode that `open` already reports.
+        let cold = open_cold(&uri).await;
+        let last = cold.get_fragments().pop().unwrap();
+        let started = Instant::now();
+        let sequence = load_row_id_sequence(&cold, last.metadata()).await.unwrap();
+        load_total += started.elapsed();
+        probe_id = sequence.iter().next_back().unwrap();
+    }
+    let load_sequence = load_total / READ_SAMPLES as u32;
+
+    // The dataset-wide row id index, which is what any query that resolves a row
+    // id pays for before it can touch data.
+    let mut index_total = Duration::ZERO;
+    for _ in 0..READ_SAMPLES {
+        let cold = open_cold(&uri).await;
+        let started = Instant::now();
+        let _ = get_row_id_index(&cold).await.unwrap();
+        index_total += started.elapsed();
+    }
+    let index_build = index_total / READ_SAMPLES as u32;
+
+    // Once the index exists the two arms follow the same path, so this row is a
+    // control: it should not move. It needs a session that actually caches --
+    // `open_cold` gives the caches zero capacity, so on that dataset `take_rows`
+    // would rebuild the index and re-measure `index_build`. Holding `index`
+    // alive across the take keeps it from being evicted.
+    let warm = Dataset::open(&uri).await.unwrap();
+    let index = get_row_id_index(&warm).await.unwrap();
+    let projection = ProjectionRequest::from_columns(["value"], warm.schema());
+    let started = Instant::now();
+    warm.take_rows(&[probe_id], projection).await.unwrap();
+    let take_warm = started.elapsed();
+    drop(index);
+
+    let schema = schema();
+    let mut commit_total = Duration::ZERO;
+    for append in 0..config.appends {
+        let data = batch(schema.clone(), 1_000_000_000 + append as i64 * 10, 10);
+        let reader = RecordBatchIterator::new(vec![Ok(data)], schema.clone());
+        let started = Instant::now();
+        Dataset::write(
+            reader,
+            &uri,
+            Some(WriteParams {
+                mode: WriteMode::Append,
+                skip_auto_cleanup: true,
+                ..Default::default()
+            }),
+        )
+        .await
+        .unwrap();
+        commit_total += started.elapsed();
+    }
+
+    ArmResult {
+        compaction,
+        data_bytes,
+        manifest_bytes,
+        inline_row_id_bytes,
+        inline_row_version_bytes,
+        open,
+        commit: commit_total / config.appends as u32,
+        load_sequence,
+        index_build,
+        take_warm,
+        spilled_fragments,
+        total_fragments,
+    }
+}
+
+fn mib(bytes: u64) -> f64 {
+    bytes as f64 / (1024.0 * 1024.0)
+}
+
+fn bench_rowid_spill(_c: &mut Criterion) {
+    if std::env::var_os(ENABLE_UNSTABLE_SPILLED_ROW_IDS_ENV).is_none() && !cfg!(debug_assertions) {
+        panic!(
+            "set {ENABLE_UNSTABLE_SPILLED_ROW_IDS_ENV}=1 to run this benchmark: spilled row ids \
+             are an unstable feature and a release build refuses the dataset without it"
+        );
+    }
+
+    let config = Config::from_env();
+    let runtime = Runtime::new().unwrap();
+
+    println!("=== Row id sequence placement ===");
+    println!(
+        "{} fragments x {} rows, {}% deleted then compacted",
+        config.fragments, config.rows_per_fragment, config.delete_percent
+    );
+    println!();
+
+    // `usize::MAX` reproduces the behavior on main, where a compacted fragment's
+    // sequence always stays inline however large it grows. `None` takes the
+    // format's documented 200 KiB inline budget, which is what this change makes
+    // the default.
+    let inline_dir = tempfile::tempdir().unwrap();
+    let inline = runtime.block_on(run_arm(
+        &inline_dir.path().to_string_lossy(),
+        config,
+        Some(usize::MAX),
+    ));
+
+    let spill_dir = tempfile::tempdir().unwrap();
+    let spilled = runtime.block_on(run_arm(&spill_dir.path().to_string_lossy(), config, None));
+
+    println!(
+        "{:<28} {:>14} {:>14} {:>10}",
+        "metric", "inline", "spilled", "ratio"
+    );
+    let row = |name: &str, inline: f64, spilled: f64, unit: &str| {
+        println!(
+            "{:<28} {:>12.2}{unit:<2} {:>12.2}{unit:<2} {:>9.2}x",
+            name,
+            inline,
+            spilled,
+            if spilled == 0.0 {
+                f64::INFINITY
+            } else {
+                inline / spilled
+            }
+        );
+    };
+    row(
+        "manifest size",
+        mib(inline.manifest_bytes),
+        mib(spilled.manifest_bytes),
+        "M",
+    );
+    row(
+        "  of which row ids",
+        mib(inline.inline_row_id_bytes),
+        mib(spilled.inline_row_id_bytes),
+        "M",
+    );
+    row(
+        "  of which row versions",
+        mib(inline.inline_row_version_bytes),
+        mib(spilled.inline_row_version_bytes),
+        "M",
+    );
+    row(
+        "cold dataset open",
+        inline.open.as_secs_f64() * 1e3,
+        spilled.open.as_secs_f64() * 1e3,
+        "ms",
+    );
+    row(
+        "append commit (mean)",
+        inline.commit.as_secs_f64() * 1e3,
+        spilled.commit.as_secs_f64() * 1e3,
+        "ms",
+    );
+    row(
+        "load one sequence (cold)",
+        inline.load_sequence.as_secs_f64() * 1e3,
+        spilled.load_sequence.as_secs_f64() * 1e3,
+        "ms",
+    );
+    row(
+        "row id index build (cold)",
+        inline.index_build.as_secs_f64() * 1e3,
+        spilled.index_build.as_secs_f64() * 1e3,
+        "ms",
+    );
+    row(
+        "take by row id (index built)",
+        inline.take_warm.as_secs_f64() * 1e3,
+        spilled.take_warm.as_secs_f64() * 1e3,
+        "ms",
+    );
+    row(
+        "compaction",
+        inline.compaction.as_secs_f64() * 1e3,
+        spilled.compaction.as_secs_f64() * 1e3,
+        "ms",
+    );
+    row(
+        "data files on disk",
+        mib(inline.data_bytes),
+        mib(spilled.data_bytes),
+        "M",
+    );
+    println!();
+    // The commit that creates the fragments writes them into the manifest file
+    // twice: once in the fragment list, once in the inline transaction section
+    // (`Manifest::transaction_section`). So a byte of inline sequence costs two
+    // bytes of manifest at that version, and one byte at every version after.
+    println!(
+        "manifest holds each sequence twice at the creating commit, so the inline arm's \
+         {:.2}M of row ids accounts for {:.2}M of the {:.2}M manifest delta",
+        mib(inline.inline_row_id_bytes),
+        mib(2 * inline.inline_row_id_bytes),
+        mib(inline.manifest_bytes.saturating_sub(spilled.manifest_bytes)),
+    );
+    println!(
+        "spilled fragments: inline arm {}/{}, spilled arm {}/{}",
+        inline.spilled_fragments,
+        inline.total_fragments,
+        spilled.spilled_fragments,
+        spilled.total_fragments
+    );
+}
+
+criterion_group!(benches, bench_rowid_spill);
+criterion_main!(benches);

--- a/rust/lance/src/dataset/optimize.rs
+++ b/rust/lance/src/dataset/optimize.rs
@@ -89,7 +89,7 @@ use std::sync::Arc;
 
 use super::fragment::FileFragment;
 use super::index::{DatasetIndexRemapperOptions, load_indices_for_remapping};
-use super::rowids::load_row_id_sequences;
+use super::rowids::{build_row_id_meta, load_row_id_sequences};
 use super::transaction::{
     Operation, RewriteGroup, RewrittenIndex, Transaction, TransactionBuilder,
 };
@@ -249,6 +249,14 @@ pub struct CompactionOptions {
     /// not be remapped during this compaction operation. Instead, the fragment reuse index
     /// is updated and will be used to perform remapping later.
     pub defer_index_remap: bool,
+    /// Largest encoded row id sequence, in bytes, that a compacted fragment may
+    /// keep inline in the manifest. Anything larger is spilled to a hidden
+    /// column of a data file. Defaults to
+    /// [`DEFAULT_INLINE_ROW_IDS_MAX_BYTES`](crate::dataset::rowids::DEFAULT_INLINE_ROW_IDS_MAX_BYTES).
+    ///
+    /// Only has an effect on datasets that use stable row ids.
+    #[serde(default)]
+    pub inline_row_ids_max_bytes: Option<usize>,
     /// How the old-to-new row-address mapping used to remap indices is built.
     /// Defaults to [`IndexRemapMode::Direct`].
     #[serde(default)]
@@ -329,6 +337,7 @@ impl Default for CompactionOptions {
             batch_size: None,
             io_buffer_size: None,
             defer_index_remap: false,
+            inline_row_ids_max_bytes: None,
             index_remap_mode: IndexRemapMode::Direct,
             compaction_mode: None,
             enable_binary_copy: false,
@@ -2540,7 +2549,13 @@ async fn rewrite_files(
         } else {
             if dataset.manifest.uses_stable_row_ids() {
                 log::info!("Compaction task {}: rechunking stable row ids", task_id);
-                rechunk_stable_row_ids(dataset.as_ref(), &mut new_fragments, &fragments).await?;
+                rechunk_stable_row_ids(
+                    dataset.as_ref(),
+                    &mut new_fragments,
+                    &fragments,
+                    options.inline_row_ids_max_bytes,
+                )
+                .await?;
                 recalc_versions_for_rewritten_fragments(
                     dataset.as_ref(),
                     &mut new_fragments,
@@ -2589,6 +2604,7 @@ async fn rechunk_stable_row_ids(
     dataset: &Dataset,
     new_fragments: &mut [Fragment],
     old_fragments: &[Fragment],
+    inline_max_bytes: Option<usize>,
 ) -> Result<()> {
     let mut old_sequences = load_row_id_sequences(dataset, old_fragments)
         .try_collect::<Vec<_>>()
@@ -2639,9 +2655,7 @@ async fn rechunk_stable_row_ids(
     )?;
 
     for (fragment, sequence) in new_fragments.iter_mut().zip(new_sequences) {
-        // TODO: if large enough, serialize to separate file
-        let serialized = lance_table::rowids::write_row_ids(&sequence);
-        fragment.row_id_meta = Some(RowIdMeta::Inline(serialized.into()));
+        fragment.row_id_meta = Some(build_row_id_meta(dataset, &sequence, inline_max_bytes).await?);
     }
 
     Ok(())
@@ -2664,7 +2678,9 @@ async fn recalc_versions_for_rewritten_fragments(
         let row_count = if let Some(row_id_meta) = &frag.row_id_meta {
             match row_id_meta {
                 RowIdMeta::Inline(data) => lance_table::rowids::read_row_ids(data)?.len(),
-                RowIdMeta::External(_file) => frag.physical_rows.unwrap_or(0) as u64,
+                RowIdMeta::External(_) | RowIdMeta::Column(_) => {
+                    frag.physical_rows.unwrap_or(0) as u64
+                }
             }
         } else {
             frag.physical_rows.unwrap_or(0) as u64

--- a/rust/lance/src/dataset/rowids.rs
+++ b/rust/lance/src/dataset/rowids.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright The Lance Authors
 
+mod spill;
 mod validate;
 
 use super::Dataset;
@@ -15,6 +16,8 @@ use lance_table::{
 };
 use std::sync::Arc;
 
+pub use spill::DEFAULT_INLINE_ROW_IDS_MAX_BYTES;
+pub(crate) use spill::build_row_id_meta;
 pub(super) use validate::validate_stable_row_ids;
 
 /// Load a row id sequence from the given dataset and fragment.
@@ -55,6 +58,20 @@ pub async fn load_row_id_sequence(
                         .get_range(range)
                         .await?;
                     read_row_ids(&data)
+                })
+                .await
+        }
+        Some(row_id_meta @ RowIdMeta::Column(data_file)) => {
+            let data_file = data_file.clone();
+            let dataset_clone = dataset.clone();
+            let key = RowIdSequenceKey {
+                fragment_id: fragment.id,
+                row_id_meta,
+            };
+            dataset
+                .metadata_cache
+                .get_or_insert_with_key(key, || async move {
+                    spill::read_spilled_row_id_sequence(&dataset_clone, &data_file).await
                 })
                 .await
         }

--- a/rust/lance/src/dataset/rowids/spill.rs
+++ b/rust/lance/src/dataset/rowids/spill.rs
@@ -1,0 +1,417 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+//! Spilling a fragment's row id sequence out of the manifest and into a hidden
+//! column of a Lance data file.
+//!
+//! A row id sequence is run-encoded, so an appended fragment costs about 20
+//! bytes of manifest and never needs to leave it. A fragment whose rows came
+//! from many places -- the output of compacting a shuffled table, for instance
+//! -- has no runs to exploit and falls back to 8 bytes per row. Inline, that
+//! cost is paid again in every manifest version, so the manifest grows with the
+//! table and every commit rewrites all of it.
+//!
+//! Spilled, the sequence is an ordinary `UInt64` column carrying field id
+//! [`ROW_ID_FIELD_ID`], written with the same encodings and read with the same
+//! reader as user data. The manifest keeps only the [`DataFile`] that locates
+//! it.
+
+use std::sync::Arc;
+
+use arrow_array::{RecordBatch, UInt64Array};
+use arrow_schema::{DataType, Field as ArrowField, Schema as ArrowSchema};
+use futures::TryStreamExt;
+use lance_core::datatypes::Schema;
+use lance_encoding::decoder::{DecoderPlugins, FilterExpression};
+use lance_file::reader::FileReader;
+use lance_file::versions;
+use lance_file::writer::FileWriterOptions;
+use lance_io::ReadBatchParams;
+use lance_io::scheduler::{ScanScheduler, SchedulerConfig};
+use lance_table::format::{DataFile, ROW_ID_FIELD_ID, RowIdMeta};
+use lance_table::rowids::{RowIdSequence, write_row_ids};
+use object_store::path::Path;
+
+use super::super::Dataset;
+use crate::dataset::fragment::write::generate_random_filename;
+use crate::{Error, Result};
+
+/// Name of the hidden column holding a spilled row id sequence. Only the field
+/// id is load-bearing; the name is for humans reading a file dump.
+const ROW_ID_COLUMN_NAME: &str = "_rowid";
+
+/// Rows per batch handed to the file writer.
+const SPILL_BATCH_ROWS: usize = 64 * 1024;
+
+/// Encoded sequences at or below this size stay in the manifest.
+///
+/// Matches the inline limit the format has always documented for the
+/// `row_id_sequence` oneof. A `Range` sequence -- every appended fragment --
+/// encodes to a few dozen bytes and is nowhere near it.
+pub const DEFAULT_INLINE_ROW_IDS_MAX_BYTES: usize = 200 * 1024;
+
+/// Place `sequence` either inline in the manifest or in a data file column,
+/// whichever its encoded size calls for. `inline_max_bytes` defaults to
+/// [`DEFAULT_INLINE_ROW_IDS_MAX_BYTES`].
+pub async fn build_row_id_meta(
+    dataset: &Dataset,
+    sequence: &RowIdSequence,
+    inline_max_bytes: Option<usize>,
+) -> Result<RowIdMeta> {
+    let encoded = write_row_ids(sequence);
+    let limit = inline_max_bytes.unwrap_or(DEFAULT_INLINE_ROW_IDS_MAX_BYTES);
+    if encoded.len() <= limit || !lance_table::feature_flags::spilled_row_ids_enabled() {
+        return Ok(RowIdMeta::Inline(encoded.into()));
+    }
+    Ok(RowIdMeta::Column(
+        spill_row_id_sequence(dataset, sequence).await?,
+    ))
+}
+
+/// Write `sequence` as a hidden column and return the data file that holds it.
+async fn spill_row_id_sequence(dataset: &Dataset, sequence: &RowIdSequence) -> Result<DataFile> {
+    let file_version = dataset.manifest.data_storage_format.version;
+    let filename = format!("{}.lance", generate_random_filename());
+    let full_path = dataset.data_dir().join(filename.as_str());
+
+    let arrow_schema = Arc::new(ArrowSchema::new(vec![ArrowField::new(
+        ROW_ID_COLUMN_NAME,
+        DataType::UInt64,
+        false,
+    )]));
+    let schema = Schema::try_from(arrow_schema.as_ref())?;
+    let object_writer = dataset.object_store.create(&full_path).await?;
+    let mut writer = versions::create_writer(
+        file_version,
+        object_writer,
+        schema,
+        FileWriterOptions::default(),
+    )?;
+
+    // Materialized up front rather than streamed from `sequence.iter()`: that
+    // returns a boxed `dyn DoubleEndedIterator`, which is not `Send`, so holding
+    // it across the write below would make this future non-`Send` and every
+    // caller of `compact_files` along with it -- including the Python bindings,
+    // which spawn that future. The batches are zero-copy slices of it.
+    let ids = UInt64Array::from(sequence.iter().collect::<Vec<u64>>());
+    for offset in (0..ids.len()).step_by(SPILL_BATCH_ROWS) {
+        let len = SPILL_BATCH_ROWS.min(ids.len() - offset);
+        let batch =
+            RecordBatch::try_new(arrow_schema.clone(), vec![Arc::new(ids.slice(offset, len))])?;
+        writer.write_batch(&batch).await?;
+    }
+    let summary = writer.finish().await?;
+
+    Ok(DataFile::new(
+        filename,
+        vec![ROW_ID_FIELD_ID],
+        vec![0],
+        file_version,
+        std::num::NonZero::new(summary.size_bytes),
+        None,
+    ))
+}
+
+/// Read back a sequence spilled by [`spill_row_id_sequence`].
+pub async fn read_spilled_row_id_sequence(
+    dataset: &Dataset,
+    data_file: &DataFile,
+) -> Result<RowIdSequence> {
+    let column_index = data_file
+        .fields
+        .iter()
+        .position(|field| *field == ROW_ID_FIELD_ID)
+        .and_then(|position| data_file.column_indices.get(position))
+        .ok_or_else(|| {
+            Error::corrupt_file_named(
+                &data_file.path,
+                format!("spilled row id file does not carry field id {ROW_ID_FIELD_ID}"),
+            )
+        })?;
+    if *column_index != 0 {
+        return Err(Error::not_supported(format!(
+            "spilled row ids at column index {column_index}; only a dedicated file is supported"
+        )));
+    }
+
+    // Resolved through `data_file_dir` rather than `data_dir` so a shallow
+    // clone, which rewrites `base_id` on every referenced file, still finds it.
+    let path: Path = dataset
+        .data_file_dir(data_file)?
+        .join(data_file.path.as_str());
+    let object_store = dataset.object_store_for_data_file(data_file).await?;
+    let scheduler = ScanScheduler::new(
+        object_store.clone(),
+        SchedulerConfig::max_bandwidth(&object_store),
+    );
+    let file = scheduler
+        .open_file(&path, &data_file.file_size_bytes)
+        .await?;
+    let reader = FileReader::try_open(
+        file,
+        None,
+        Arc::<DecoderPlugins>::default(),
+        &dataset.metadata_cache.file_metadata_cache(&path),
+        dataset.file_reader_options.clone().unwrap_or_default(),
+    )
+    .await?;
+
+    let mut ids: Vec<u64> = Vec::with_capacity(reader.num_rows() as usize);
+    let mut stream = reader
+        .read_stream(
+            ReadBatchParams::RangeFull,
+            SPILL_BATCH_ROWS as u32,
+            8,
+            FilterExpression::no_filter(),
+        )
+        .await?;
+    while let Some(batch) = stream.try_next().await? {
+        let column = batch
+            .column(0)
+            .as_any()
+            .downcast_ref::<UInt64Array>()
+            .ok_or_else(|| {
+                Error::corrupt_file_named(
+                    &data_file.path,
+                    "spilled row id column is not UInt64".to_string(),
+                )
+            })?;
+        ids.extend_from_slice(column.values());
+    }
+
+    Ok(RowIdSequence::from(ids.as_slice()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::dataset::cleanup::{CleanupPolicyBuilder, cleanup_old_versions};
+    use crate::dataset::optimize::{CompactionOptions, compact_files};
+    use crate::dataset::{WriteMode, WriteParams};
+    use arrow_array::{Int32Array, RecordBatchIterator};
+    use arrow_schema::Field;
+    use chrono::Utc;
+    use lance_core::utils::tempfile::TempStrDir;
+    use lance_table::feature_flags::FLAG_UNSTABLE_SPILLED_ROW_IDS;
+
+    /// A sequence with no runs to exploit, which is what a globally shuffled
+    /// table produces and what forces the spill path.
+    fn scattered_sequence(len: u64) -> RowIdSequence {
+        // A stride coprime with `len` visits every id exactly once in an order
+        // with no ascending run longer than one.
+        let ids: Vec<u64> = (0..len).map(|i| (i * 7919) % len).collect();
+        RowIdSequence::from(ids.as_slice())
+    }
+
+    fn test_schema() -> Arc<ArrowSchema> {
+        Arc::new(ArrowSchema::new(vec![Field::new(
+            "i",
+            DataType::Int32,
+            false,
+        )]))
+    }
+
+    async fn tiny_dataset(uri: &str) -> Dataset {
+        let schema = test_schema();
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![Arc::new(Int32Array::from(vec![1, 2, 3, 4]))],
+        )
+        .unwrap();
+        let reader = RecordBatchIterator::new(vec![Ok(batch)], schema);
+        Dataset::write(
+            reader,
+            uri,
+            Some(WriteParams {
+                enable_stable_row_ids: true,
+                ..Default::default()
+            }),
+        )
+        .await
+        .unwrap()
+    }
+
+    #[tokio::test]
+    async fn spilled_sequence_round_trips() {
+        let dir = TempStrDir::default();
+        let dataset = tiny_dataset(dir.as_str()).await;
+
+        let sequence = scattered_sequence(20_000);
+        let meta = build_row_id_meta(&dataset, &sequence, Some(0))
+            .await
+            .unwrap();
+        let RowIdMeta::Column(data_file) = &meta else {
+            panic!("expected the sequence to spill, got {meta:?}");
+        };
+        assert_eq!(data_file.fields.as_ref(), [ROW_ID_FIELD_ID]);
+
+        let restored = read_spilled_row_id_sequence(&dataset, data_file)
+            .await
+            .unwrap();
+        assert_eq!(
+            restored.iter().collect::<Vec<_>>(),
+            sequence.iter().collect::<Vec<_>>()
+        );
+    }
+
+    #[tokio::test]
+    async fn sequence_under_the_limit_stays_inline() {
+        let dir = TempStrDir::default();
+        let dataset = tiny_dataset(dir.as_str()).await;
+
+        // An appended fragment's sequence is a single `Range`, so it encodes to
+        // a few dozen bytes and must never leave the manifest.
+        let meta = build_row_id_meta(&dataset, &RowIdSequence::from(0..1_000_000), None)
+            .await
+            .unwrap();
+        assert!(
+            matches!(meta, RowIdMeta::Inline(_)),
+            "a range sequence must stay inline, got {meta:?}"
+        );
+    }
+
+    /// A stable-row-id dataset built from `chunks` separate appends, so
+    /// compacting it has several sequences to concatenate.
+    async fn appended_dataset(uri: &str, chunks: i32, rows_per_chunk: i32) -> Dataset {
+        let schema = test_schema();
+        let mut dataset: Option<Dataset> = None;
+        for chunk in 0..chunks {
+            let batch = RecordBatch::try_new(
+                schema.clone(),
+                vec![Arc::new(Int32Array::from_iter_values(
+                    (chunk * rows_per_chunk)..((chunk + 1) * rows_per_chunk),
+                ))],
+            )
+            .unwrap();
+            let reader = RecordBatchIterator::new(vec![Ok(batch)], schema.clone());
+            dataset = Some(
+                Dataset::write(
+                    reader,
+                    uri,
+                    Some(WriteParams {
+                        enable_stable_row_ids: true,
+                        mode: if chunk == 0 {
+                            WriteMode::Create
+                        } else {
+                            WriteMode::Append
+                        },
+                        ..Default::default()
+                    }),
+                )
+                .await
+                .unwrap(),
+            );
+        }
+        dataset.unwrap()
+    }
+
+    /// Force the spill path regardless of size: reaching the natural 200 KiB
+    /// threshold needs ~25k scattered rows, more than these tests need to prove.
+    fn spill_everything() -> CompactionOptions {
+        CompactionOptions {
+            target_rows_per_fragment: 1_000,
+            inline_row_ids_max_bytes: Some(0),
+            ..Default::default()
+        }
+    }
+
+    #[tokio::test]
+    async fn compaction_spills_and_reads_back_row_ids() {
+        let dir = TempStrDir::default();
+        let uri = dir.as_str();
+        let mut dataset = appended_dataset(uri, 4, 250).await;
+        let before = collect_row_ids(&dataset).await;
+
+        compact_files(&mut dataset, spill_everything(), None)
+            .await
+            .unwrap();
+
+        let fragments = dataset.get_fragments();
+        assert_eq!(fragments.len(), 1);
+        assert!(
+            matches!(
+                fragments[0].metadata().row_id_meta,
+                Some(RowIdMeta::Column(_))
+            ),
+            "compaction must spill under a zero inline budget, got {:?}",
+            fragments[0].metadata().row_id_meta
+        );
+        assert_ne!(
+            dataset.manifest.reader_feature_flags & FLAG_UNSTABLE_SPILLED_ROW_IDS,
+            0,
+            "a spilled sequence must set the reader feature flag"
+        );
+
+        // The ids survive the rewrite and are still readable through the
+        // ordinary scan path, now served from the data file column.
+        assert_eq!(collect_row_ids(&dataset).await, before);
+        // `validate_stable_row_ids` reads every fragment's sequence back and
+        // checks it against the fragment length, so this covers the read path
+        // for a spilled sequence independently of the scan.
+        dataset.validate().await.unwrap();
+    }
+
+    /// Cleanup decides what to delete by walking
+    /// [`Fragment::referenced_lance_files`], so a spilled sequence has to be
+    /// reachable from there. If it were not, an ordinary cleanup would delete a
+    /// live file and leave the fragment claiming row ids it can no longer read.
+    #[tokio::test]
+    async fn cleanup_keeps_a_live_spilled_file() {
+        let dir = TempStrDir::default();
+        let uri = dir.as_str();
+        let mut dataset = appended_dataset(uri, 4, 250).await;
+        let before = collect_row_ids(&dataset).await;
+
+        compact_files(&mut dataset, spill_everything(), None)
+            .await
+            .unwrap();
+
+        let spilled = dataset.get_fragments()[0]
+            .metadata()
+            .row_id_meta
+            .as_ref()
+            .and_then(RowIdMeta::column_file)
+            .expect("compaction must spill under a zero inline budget")
+            .path
+            .clone();
+        let on_disk = std::path::Path::new(uri).join("data").join(&spilled);
+        assert!(on_disk.exists(), "no spilled file written at {on_disk:?}");
+
+        // Everything written so far is older than this instant, so the
+        // pre-compaction versions and their data files are all candidates.
+        let removed = cleanup_old_versions(
+            &dataset,
+            CleanupPolicyBuilder::default()
+                .before_timestamp(Utc::now())
+                .delete_unverified(true)
+                .build(),
+        )
+        .await
+        .unwrap();
+        assert!(
+            removed.old_versions > 0,
+            "expected the pre-compaction versions to be cleaned up"
+        );
+        assert!(
+            on_disk.exists(),
+            "cleanup deleted the live spilled row id file at {on_disk:?}"
+        );
+
+        let reopened = Dataset::open(uri).await.unwrap();
+        assert_eq!(collect_row_ids(&reopened).await, before);
+    }
+
+    async fn collect_row_ids(dataset: &Dataset) -> Vec<u64> {
+        let mut scanner = dataset.scan();
+        scanner.with_row_id().project::<&str>(&[]).unwrap();
+        let batch = scanner.try_into_batch().await.unwrap();
+        batch
+            .column_by_name("_rowid")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<UInt64Array>()
+            .unwrap()
+            .values()
+            .to_vec()
+    }
+}

--- a/rust/lance/src/dataset/tests/dataset_schema_evolution.rs
+++ b/rust/lance/src/dataset/tests/dataset_schema_evolution.rs
@@ -71,7 +71,7 @@ async fn test_add_sub_column_to_struct_col_unsupported(
     )]
     version: LanceFileVersion,
 ) {
-    let mut dataset = prepare_initial_dataset_with_struct_col(version, 3).await;
+    let mut dataset = Box::pin(prepare_initial_dataset_with_struct_col(version, 3)).await;
 
     // add 2 sub-column of animal
     let batch = prepare_sub_column_batch(3).await;
@@ -99,7 +99,7 @@ async fn test_add_sub_column_to_struct_col_unsupported(
 async fn test_add_sub_column_to_struct_col(
     #[values(LanceFileVersion::V2_2)] version: LanceFileVersion,
 ) {
-    let mut dataset = prepare_initial_dataset_with_struct_col(version, 3).await;
+    let mut dataset = Box::pin(prepare_initial_dataset_with_struct_col(version, 3)).await;
 
     // add 2 sub-columns of animal
     let batch = prepare_sub_column_batch(3).await;

--- a/rust/lance/src/session/caches.rs
+++ b/rust/lance/src/session/caches.rs
@@ -270,6 +270,12 @@ impl CacheKey for RowIdSequenceKey<'_> {
                 builder.write_u64(file.offset);
                 builder.write_u64(file.size);
             }
+            // The path is a fresh random name per spilled sequence, so it
+            // identifies the contents the way the inline digest does.
+            RowIdMeta::Column(data_file) => {
+                builder.write_variant(2);
+                builder.write_str(&data_file.path);
+            }
         }
     }
 }


### PR DESCRIPTION
Draft prototype of §5.3 of the Stable Row IDs design, "Row-ID sequences as a hidden column".

A fragment's row id sequence is run-encoded, so an appended fragment costs about 20 bytes of manifest and never needs to leave it. A fragment assembled from many places has no runs to exploit and falls back toward a byte per row per id. Inline, that cost is rewritten into every manifest version, so the manifest grows with the table and every commit rewrites all of it.

This adds a third arm to the `row_id_sequence` oneof:

```proto
DataFile column_row_ids = 12;
```

a hidden `uint64` column at the reserved field id `-3`, one row id per physical row in offset order. It is located by the same `fields`/`column_indices` pair as a user column and read back with the ordinary data file reader, so it inherits the file format's encodings and page layout rather than introducing a new file type. The pre-existing `external_row_ids` arm — an opaque byte range, never written by any release — is left untouched for compatibility.

## Scope

Compaction is the only write path. `assign_row_ids` runs in `lance-table` with no object store, so it cannot spill, and an appended fragment's sequence is a `Range` that is nowhere near the threshold. `CompactionOptions::inline_row_ids_max_bytes` sets the budget, defaulting to the 200 KiB inline limit the format has always documented.

The spilled file is reached through `Fragment::referenced_lance_files`, which is what cleanup, transaction validation, file listing, and shallow-clone `base_id` rewriting all already walk — so those paths pick it up without changes of their own. `cleanup_keeps_a_live_spilled_file` covers the failure mode with teeth: if the file were not reachable from there, an ordinary cleanup would delete a live file and leave the fragment claiming row ids it can no longer read.

## Gating

`FLAG_UNSTABLE_SPILLED_ROW_IDS` is bit 9 (value 512), deliberately *above* `FLAG_UNKNOWN`. Every released build therefore already refuses such a dataset with no change of its own, and this build understands the bit only in debug builds or with `LANCE_ENABLE_UNSTABLE_SPILLED_ROW_IDS=1`.

## Benchmarks

`LANCE_ENABLE_UNSTABLE_SPILLED_ROW_IDS=1 cargo bench --bench rowid_spill` — 8 fragments × 1,000,000 rows, in two workloads that bracket what the run encoding can do with a sequence. Within each workload the two arms differ only in `inline_row_ids_max_bytes`: the inline arm never spills (today's behaviour), the spilled arm takes the 200 KiB default.

**`deleted`** — 30% of rows deleted, then compacted. The deletions become holes but the surviving ids are still ascending, so each sequence encodes as a range plus a bitmap: **0.18 B/row**.

```
metric                               inline        spilled      ratio
manifest size                        5.73M          3.82M       1.50x
  of which row ids                   0.95M          0.00M        infx
  of which row versions              1.91M          1.91M       1.00x
compaction transaction file          2.86M          1.91M       1.50x
cold dataset open                    0.82ms         0.78ms      1.05x
append commit (mean)                 5.26ms         4.06ms      1.30x
load one sequence (cold)             0.07ms         5.11ms      0.01x
row id index build (cold)            0.39ms        26.47ms      0.01x
take by row id (index built)         0.78ms         0.59ms      1.32x
compaction                         204.45ms       234.45ms      0.87x
data files on disk                  74.36M         89.12M       0.83x
```

**`shuffled`** — every row rewritten in random order, then compacted. No run structure survives, so the encoding degrades to `U64Segment::Array`, a bitpacked array of absolute values: **4.00 B/row**, 22x the deleted case. This is the worst case for inline sequences, and the shape a reclustering pass would leave behind.

```
metric                               inline        spilled      ratio
manifest size                       30.52M          0.00M   16285.82x
  of which row ids                  30.52M          0.00M        infx
  of which row versions              0.00M          0.00M       1.00x
compaction transaction file         61.04M         30.52M       2.00x
cold dataset open                   17.17ms         0.16ms    105.11x
append commit (mean)                59.52ms         2.94ms     20.23x
load one sequence (cold)             1.61ms         2.85ms      0.56x
row id index build (cold)          180.57ms       197.59ms      0.91x
take by row id (index built)         1.18ms         0.88ms      1.34x
compaction                         299.54ms       268.08ms      1.12x
data files on disk                 135.93M        158.01M       0.86x
```

The shuffle is not a synthetic manifest edit: the benchmark reads every row with its stable row id, permutes them, writes the data back out, and commits an `Operation::Rewrite` carrying the permuted sequences on the new fragments — which is how a reclustering pass would have to preserve row ids. Both arms then compact that state. A `take` by row id is checked against the value the row should hold, so a spilled sequence that resolved to the wrong row would fail the benchmark rather than just look fast.

Local NVMe. The byte rows are deterministic and reproduced exactly across runs. The latency rows move between runs, so a difference under about 2x should be read as noise; every conclusion below either rests on a byte count or on a gap far wider than that.

### What the two cases have in common

**Inline sequences are written two or three times per commit, not once.** A commit puts the fragment list in the manifest *and* writes the whole transaction to its own file under `_transactions/`. When that transaction serializes under `MAX_INLINE_TRANSACTION_BYTES` (20 MiB) it is *also* copied into the manifest. That is visible in both tables: in `deleted` the manifest delta is 1.91M for 0.95M of row ids, exactly 2x, because the 2.86M transaction fits under the cap; in `shuffled` the 61.04M transaction does not fit, so the manifest holds the sequences once and the transaction file holds them again.

**The read cost, once the row id index exists, is not a per-query tax.** `take by row id (index built)` is the control row and never favours either arm consistently (0.78 vs 0.59 ms, 1.18 vs 0.88 ms). What spilling adds is a one-time index build per dataset open.

### `deleted`: a modest manifest win, paid for on the read side

The manifest shrinks by a third (5.73M → 3.82M) and the transaction file by the same 0.95M. But the bitmap encoding is extremely good here — 0.18 B/row against 2.76 B/row for the general-purpose column encoding — so **spilling costs ~15 MiB on disk to save ~1 MiB of manifest**, and the dataset-wide **row id index build goes from 0.39 ms to 26.47 ms**, roughly 70x. Compaction is ~13% slower. Cold open and commit latency are inside the noise band at this size, and a 5.73 MiB manifest decodes in well under a millisecond on a local filesystem either way.

On this workload the design is a bad trade on raw bytes, and pays off only because the manifest is rewritten on every commit while the data file is written once.

### `shuffled`: the case the design is actually for

Every cost above either inverts or disappears once the inline encoding has nothing to exploit:

- **The manifest stops carrying row ids at all**: 30.52M → effectively zero, and the transaction file halves.
- **Cold open drops from 17.17 ms to 0.16 ms**, a 105x gap — two orders of magnitude, far outside the noise band, and the same effect the `deleted` case was too small to show.
- **A small append commits 20x faster**, 59.52 ms → 2.94 ms, because the writer no longer rewrites 30 MiB of row ids to add ten rows.
- **The index-build objection evaporates**: 180.57 ms against 197.59 ms, a 9% difference. Decoding 30 MiB of protobuf arrays costs about what reading the same ids out of a column does, so the 70x penalty in `deleted` is an artifact of the bitmap encoding being nearly free, not a property of spilling.
- **Compaction is 12% *faster* spilled**, because writing 30 MiB into the manifest and transaction file costs more than writing the column.
- **Bytes on disk favour the column**: 2.89 B/row spilled against 4.00 B/row inline. The trade reverses — the same file-format encoding that lost by 15x on sorted-with-holes ids wins on shuffled ones.

Two caveats on the `shuffled` table. Its row-version rows are zero in both arms because the benchmark's rewrite leaves version metadata unset and the compaction has none to carry forward, so that manifest is row-ids-only; with version tracking active the spilled arm's manifest would not be empty. And the 30.52M transaction file in the spilled arm is the *old* fragments' inline sequences, which the setup rewrite created — the new fragments contribute only file references.

## Known gaps

- **The row version sequences are untouched.** §5.3 also covers `_row_created_at_version` (-4) and `_row_last_updated_at_version` (-5). In the `deleted` case those are 1.91 MiB, *larger* than the 0.95 MiB of row ids this change moves, so on that workload spilling row ids alone removes only part of the manifest bloat.
- **`inline_row_ids_max_bytes` is on `CompactionOptions`.** It belongs in table config at GA; a per-call compaction option is the smallest thing that let the two arms be measured.
- **Row version tracking degrades on a spilled fragment.** Three synchronous paths in `lance-table` need the sequence and cannot do IO to get it: `refresh_row_latest_update_meta_for_partial_frag_rewrite_cols` had a `todo!()` there and now returns `Error::NotSupported` rather than panicking; `resolve_update_version_metadata` logs a warning and uses default versions; `refresh_row_latest_update_meta_for_full_frag_rewrite_cols` treats the fragment as empty and writes no metadata at all. Only the last is silent, and all three want the read to become async.
- **The whole sequence is materialized on read.** The column is written and read a page at a time, but building a `RowIdSequence` needs every id, so the read path allocates one `u64` per row.
- **A dedicated file per spilled sequence.** Co-locating `_rowid` in the fragment's main data file would remove one file open per fragment from the read path.
- **A delta-aware encoding for the `_rowid` column is not attempted.** It would narrow the 2.76 B/row the column costs on sorted-with-holes sequences, which is what makes the `deleted` case a loss on disk.
- Adding a field to `CompactionOptions` pushed a future in `dataset_schema_evolution.rs` past the workspace's `large_futures` deny, so two call sites there are now `Box::pin`-ed. Included because it is a direct consequence, not a drive-by.

Refs #8931
