### PR TITLE
fix(python): correct the asof and reader input annotations

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -119,6 +119,7 @@ include = [
     "python/lance/arrow.py",
     "python/tests/test_arrow.py",
     "python/tests/test_fragment_typing.py",
+    "python/tests/test_optional_types_typing.py",
     "python/tests/test_udf.py",
 ]
 # Dependencies like pyarrow make this difficult to enforce strictly.

--- a/python/python/lance/__init__.py
+++ b/python/python/lance/__init__.py
@@ -72,13 +72,10 @@ from .schema import json_to_schema, schema_to_json
 from .util import sanitize_ts
 
 if TYPE_CHECKING:
-    from datetime import datetime
     from pathlib import Path
 
     from lance.commit import CommitLock
-    from lance.dependencies import pandas as pd
-
-    ts_types = Union[datetime, pd.Timestamp, str]
+    from lance.util import ts_types
 
 
 __all__ = [

--- a/python/python/lance/dataset.py
+++ b/python/python/lance/dataset.py
@@ -7766,7 +7766,11 @@ def write_dataset(
     ----------
     data_obj: Reader-like
         The data to be written. Acceptable types are:
-        - Pandas DataFrame, Pyarrow Table, Dataset, Scanner, or RecordBatchReader
+        - Pandas DataFrame, Polars DataFrame
+        - Pyarrow Table, RecordBatch, Dataset, Scanner, or RecordBatchReader
+        - An iterable of Pyarrow RecordBatch (requires ``schema``)
+        - A dict of columns, or a list of row dicts
+        - A list of Pydantic model instances
         - Huggingface dataset
     uri: str, Path, LanceDataset, or None
         Where to write the dataset to (directory). If a LanceDataset is passed,

--- a/python/python/lance/dependencies.py
+++ b/python/python/lance/dependencies.py
@@ -162,6 +162,7 @@ if TYPE_CHECKING:
     import numpy
     import pandas
     import polars
+    import pydantic
     import torch  # type: ignore[reportMissingImports]
 else:
     # heavy/optional third party libs
@@ -170,7 +171,7 @@ else:
     polars, _POLARS_AVAILABLE = _lazy_import("polars")
     torch, _TORCH_AVAILABLE = _lazy_import("torch")
     datasets, _HUGGING_FACE_AVAILABLE = _lazy_import("datasets")
-    _, _PYDANTIC_AVAILABLE = _lazy_import("pydantic")
+    pydantic, _PYDANTIC_AVAILABLE = _lazy_import("pydantic")
 
 
 @lru_cache(maxsize=None)
@@ -266,6 +267,7 @@ __all__ = [
     "numpy",
     "pandas",
     "polars",
+    "pydantic",
     "torch",
     # lazy utilities
     "_check_for_hugging_face",

--- a/python/python/lance/types.py
+++ b/python/python/lance/types.py
@@ -3,30 +3,47 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Iterable, Optional, Union
+from typing import TYPE_CHECKING, Any, Iterable, Mapping, Optional, Sequence, Union
 
 import pyarrow as pa
 from pyarrow import RecordBatch
+from pyarrow.dataset import Dataset as ArrowDataset
+from pyarrow.dataset import Scanner as ArrowScanner
 
-from . import dataset
 from .dependencies import (
     _check_for_hugging_face,
     _check_for_pandas,
+    _check_for_polars,
     _is_pydantic_base_model,
     _validate_pydantic_list,
     model_to_dict,
 )
 from .dependencies import pandas as pd
+from .dependencies import polars as pl
 
 if TYPE_CHECKING:
+    from .dependencies import datasets, pydantic
+
+    # Keep in step with the branches of ``_coerce_reader``: every input coerced
+    # there needs a member here, and every member here needs a branch there.
+    # The container members are the covariant spellings so that, say, a
+    # ``list[MyModel]`` is accepted; ``_coerce_reader`` narrows them to ``dict``
+    # and ``list`` and reports anything else it cannot read.
     ReaderLike = Union[
-        pd.Timestamp,
+        pd.DataFrame,
+        pl.DataFrame,
         pa.Table,
-        pa.dataset.Dataset,
-        pa.dataset.Scanner,
         pa.RecordBatch,
-        Iterable[RecordBatch],
         pa.RecordBatchReader,
+        # ``LanceDataset`` is an ``ArrowDataset`` subclass.
+        ArrowDataset,
+        ArrowScanner,
+        datasets.Dataset,
+        datasets.IterableDataset,
+        Mapping[str, Any],
+        Sequence[Mapping[str, Any]],
+        Sequence[pydantic.BaseModel],
+        Iterable[RecordBatch],
     ]
 
 
@@ -70,10 +87,7 @@ def _is_materialized(data_obj: ReaderLike) -> bool:
         return True
     if isinstance(data_obj, (pa.Table, pa.RecordBatch)):
         return True
-    if (
-        type(data_obj).__module__.startswith("polars")
-        and data_obj.__class__.__name__ == "DataFrame"
-    ):
+    if _check_for_polars(data_obj) and isinstance(data_obj, pl.DataFrame):
         return True
     if isinstance(data_obj, dict):
         return True
@@ -89,24 +103,25 @@ def _is_materialized(data_obj: ReaderLike) -> bool:
 def _coerce_reader(
     data_obj: ReaderLike, schema: Optional[pa.Schema] = None
 ) -> pa.RecordBatchReader:
+    # Imported here because ``lance.dataset`` imports this module, and because
+    # the ``lance.dataset`` name is also bound to a function in ``lance``.
+    from .dataset import LanceDataset
+
     if _check_for_pandas(data_obj) and isinstance(data_obj, pd.DataFrame):
         return pa.Table.from_pandas(data_obj, schema=schema).to_reader()
     elif isinstance(data_obj, pa.Table):
         return data_obj.to_reader()
     elif isinstance(data_obj, pa.RecordBatch):
         return pa.Table.from_batches([data_obj]).to_reader()
-    elif isinstance(data_obj, dataset.LanceDataset):
+    elif isinstance(data_obj, LanceDataset):
         return data_obj.scanner().to_reader()
-    elif isinstance(data_obj, pa.dataset.Dataset):
-        return pa.dataset.Scanner.from_dataset(data_obj).to_reader()
-    elif isinstance(data_obj, pa.dataset.Scanner):
+    elif isinstance(data_obj, ArrowDataset):
+        return ArrowScanner.from_dataset(data_obj).to_reader()
+    elif isinstance(data_obj, ArrowScanner):
         return data_obj.to_reader()
     elif isinstance(data_obj, pa.RecordBatchReader):
         return data_obj
-    elif (
-        type(data_obj).__module__.startswith("polars")
-        and data_obj.__class__.__name__ == "DataFrame"
-    ):
+    elif _check_for_polars(data_obj) and isinstance(data_obj, pl.DataFrame):
         return data_obj.to_arrow().to_reader()
     elif _check_for_hugging_face(data_obj):
         from .dependencies import datasets as hf_datasets

--- a/python/python/lance/util.py
+++ b/python/python/lance/util.py
@@ -18,13 +18,20 @@ from typing import (
 
 import pyarrow as pa
 
-from .dependencies import _check_for_numpy, _check_for_pandas
+from .dependencies import _PANDAS_AVAILABLE, _check_for_numpy, _check_for_pandas
 from .dependencies import numpy as np
 from .dependencies import pandas as pd
 from .lance import _Hnsw, _KMeans
 
 if TYPE_CHECKING:
-    ts_types = Union[datetime, pd.Timestamp, str]
+    from pandas.api.typing import NaTType
+
+    # ``pandas.Timestamp`` is a ``datetime`` subclass, so it needs no member of
+    # its own. ``NaTType`` does: the stubs bundled with pandas declare
+    # ``Timestamp.__new__`` as returning ``Self | NaTType``, so every caller
+    # writing ``asof=pd.Timestamp(...)`` hands us that union. We accept it here
+    # and reject the ``NaT`` half in ``sanitize_ts``.
+    ts_types = Union[datetime, NaTType, str]
 
 MetricType = Literal["l2", "euclidean", "dot", "cosine"]
 
@@ -40,20 +47,26 @@ def _normalize_metric_type(metric_type: str) -> MetricType:
 
 def sanitize_ts(ts: ts_types) -> datetime:
     """Returns a python datetime object from various timestamp input types."""
-    if _check_for_pandas(ts) and isinstance(ts, str):
-        ts = pd.to_datetime(ts).to_pydatetime()
-    elif isinstance(ts, str):
-        try:
-            ts = datetime.strptime(ts, "%Y-%m-%d %H:%M:%S")
-        except ValueError:
-            raise ValueError(
-                f"Failed to parse timestamp string {ts}. Try installing Pandas."
-            )
-    elif _check_for_pandas(ts) and isinstance(ts, pd.Timestamp):
-        ts = ts.to_pydatetime()
-    elif not isinstance(ts, datetime):
-        raise TypeError(f"Unrecognized version timestamp {ts} of type {type(ts)}")
-    return ts
+    if isinstance(ts, str):
+        if not _PANDAS_AVAILABLE:
+            try:
+                return datetime.strptime(ts, "%Y-%m-%d %H:%M:%S")
+            except ValueError:
+                raise ValueError(
+                    f"Failed to parse timestamp string {ts}. Try installing Pandas."
+                ) from None
+        ts = pd.to_datetime(ts)
+    if _check_for_pandas(ts):
+        # pandas spells a missing timestamp ``NaT``, which subclasses ``datetime``
+        # and compares false against every version timestamp, so it would
+        # otherwise be reported as being older than the first version.
+        if ts is pd.NaT:
+            raise ValueError("NaT is not a valid version timestamp")
+        if isinstance(ts, pd.Timestamp):
+            return ts.to_pydatetime()
+    if isinstance(ts, datetime):
+        return ts
+    raise TypeError(f"Unrecognized version timestamp {ts} of type {type(ts)}")
 
 
 def td_to_micros(td: timedelta) -> int:

--- a/python/python/tests/test_dataset.py
+++ b/python/python/tests/test_dataset.py
@@ -33,7 +33,7 @@ from lance.dataset import LANCE_COMMIT_MESSAGE_KEY, AutoCleanupConfig
 from lance.debug import format_fragment
 from lance.file import LanceFileWriter, stable_version
 from lance.schema import LanceSchema
-from lance.util import validate_vector_index
+from lance.util import sanitize_ts, validate_vector_index
 
 BaseModel = pytest.importorskip("pydantic").BaseModel
 
@@ -556,6 +556,32 @@ def test_asof_checkout(tmp_path: Path):
     ds = lance.dataset(base_dir, asof=ts_3)
     assert ds.version == 3
     assert len(ds.to_table()) == 9
+
+
+def test_sanitize_ts_parses_strings_with_pandas():
+    # pandas accepts timestamp strings that the pandas-free fallback format
+    # rejects, so a date without a time of day has to work here.
+    assert sanitize_ts("2026-01-01") == datetime(2026, 1, 1)
+
+
+def test_sanitize_ts_rejects_nat():
+    # `NaT` is a `datetime` subclass, so it would otherwise pass through and
+    # compare false against every version timestamp.
+    with pytest.raises(ValueError, match="NaT is not a valid version timestamp"):
+        sanitize_ts(pd.NaT)
+
+
+def test_sanitize_ts_rejects_unknown_type():
+    with pytest.raises(TypeError, match="Unrecognized version timestamp"):
+        sanitize_ts(object())
+
+
+def test_sanitize_ts_without_pandas(monkeypatch):
+    monkeypatch.setattr("lance.util._PANDAS_AVAILABLE", False)
+
+    assert sanitize_ts("2026-01-01 00:00:00") == datetime(2026, 1, 1)
+    with pytest.raises(ValueError, match="Try installing Pandas"):
+        sanitize_ts("2026-01-01")
 
 
 def test_enable_stable_row_ids(tmp_path: Path):

--- a/python/python/tests/test_dataset.py
+++ b/python/python/tests/test_dataset.py
@@ -70,6 +70,8 @@ input_data = [
     ),
     # Pydantic model instances are auto-converted
     (None, [_InputModel(a=1.0, b=20), _InputModel(a=2.0, b=30)]),
+    (None, {"a": [1.0, 2.0], "b": [20, 30]}),
+    (None, [{"a": 1.0, "b": 20}, {"a": 2.0, "b": 30}]),
 ]
 
 

--- a/python/python/tests/test_optional_types_typing.py
+++ b/python/python/tests/test_optional_types_typing.py
@@ -1,0 +1,60 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright The Lance Authors
+
+"""Type-checking regression tests for optional dependency input types.
+
+This module is part of the pyright target configured in ``pyproject.toml``, so
+a regression in the annotations below fails the repository type check and not
+only the runtime suite.
+
+The rejected cases are pinned with ``pyright: ignore`` comments and
+``reportUnnecessaryTypeIgnoreComment``, so the file also fails if an annotation
+becomes *too* permissive and one of them stops being an error. They sit in a
+``TYPE_CHECKING`` block because they are invalid at runtime; the matching
+runtime assertions live in ``test_dataset.py``.
+
+Like ``test_fragment_typing.py``, this module does not import ``pytest``: the
+lint workflow installs pyright without the test dependencies.
+"""
+
+# pyright: reportUnnecessaryTypeIgnoreComment=true
+
+from datetime import datetime
+from typing import TYPE_CHECKING
+
+import pandas as pd
+from lance.util import sanitize_ts
+
+if TYPE_CHECKING:
+    import lance
+
+    def _check_accepted_asof_types() -> None:
+        # ``sanitize_ts`` is exercised at runtime below; this pins the public
+        # entry point that forwards to it.
+        lance.dataset("memory://unused", asof=pd.Timestamp("2026-01-01"))
+        lance.dataset("memory://unused", asof=pd.NaT)
+        lance.dataset("memory://unused", asof=datetime(2026, 1, 1))
+        lance.dataset("memory://unused", asof="2026-01-01")
+
+    def _check_rejected_asof_types() -> None:
+        # `DatetimeIndex` has a `to_pydatetime` method, so it satisfies a
+        # structural timestamp annotation without being a valid instant.
+        index = pd.DatetimeIndex(["2026-01-01"])
+        lance.dataset(
+            "memory://unused",
+            asof=index,  # pyright: ignore[reportArgumentType]
+        )
+        sanitize_ts(object())  # pyright: ignore[reportArgumentType]
+
+
+def test_sanitize_ts_accepts_pandas_timestamp() -> None:
+    # The stubs bundled with pandas type this constructor as
+    # ``Timestamp | NaTType``, so both halves have to satisfy ``ts_types``.
+    result: datetime = sanitize_ts(pd.Timestamp("2026-01-01"))
+
+    assert result == datetime(2026, 1, 1)
+
+
+def test_sanitize_ts_accepts_datetime_and_str() -> None:
+    assert sanitize_ts(datetime(2026, 1, 1)) == datetime(2026, 1, 1)
+    assert sanitize_ts("2026-01-01 00:00:00") == datetime(2026, 1, 1)

--- a/python/python/tests/test_optional_types_typing.py
+++ b/python/python/tests/test_optional_types_typing.py
@@ -27,6 +27,44 @@ from lance.util import sanitize_ts
 
 if TYPE_CHECKING:
     import lance
+    import polars as pl
+    import pyarrow as pa
+    from lance.types import ReaderLike
+    from pyarrow.dataset import Dataset as ArrowDataset
+    from pyarrow.dataset import Scanner as ArrowScanner
+    from pydantic import BaseModel
+
+    def _accept_reader(reader: ReaderLike) -> None:
+        pass
+
+    def _check_reader_types(
+        pandas_dataframe: pd.DataFrame,
+        polars_dataframe: pl.DataFrame,
+        arrow_dataset: ArrowDataset,
+        arrow_scanner: ArrowScanner,
+        lance_dataset: lance.LanceDataset,
+        table: pa.Table,
+        batch: pa.RecordBatch,
+        reader: pa.RecordBatchReader,
+        batches: list[pa.RecordBatch],
+        models: list[BaseModel],
+    ) -> None:
+        # One case per branch of `lance.types._coerce_reader`.
+        _accept_reader(pandas_dataframe)
+        _accept_reader(polars_dataframe)
+        _accept_reader(arrow_dataset)
+        _accept_reader(arrow_scanner)
+        _accept_reader(lance_dataset)
+        _accept_reader(table)
+        _accept_reader(batch)
+        _accept_reader(reader)
+        _accept_reader(batches)
+        _accept_reader(models)
+        _accept_reader({"a": [1.0, 2.0]})
+        _accept_reader([{"a": 1.0}, {"a": 2.0}])
+        # No rejected case here: `ReaderLike` names pyarrow types, which are
+        # unresolved without `pyarrow-stubs`, and a union with an unresolved
+        # member accepts anything. The `asof` pins below have no such member.
 
     def _check_accepted_asof_types() -> None:
         # ``sanitize_ts`` is exercised at runtime below; this pins the public


### PR DESCRIPTION
Fixes two wrong type annotations for optional-dependency inputs, each of which hid a runtime bug.

## `asof`

- `ts_types` was `Union[datetime, pd.Timestamp, str]`, defined twice. pandas types `pd.Timestamp(...)` as `Timestamp | NaTType`, so `lance.dataset(uri, asof=pd.Timestamp(...))` failed strict type checking. It is now `Union[datetime, NaTType, str]`, defined once in `lance.util`.
- `pd.NaT` subclasses `datetime`, so `sanitize_ts` passed it through and it compared false against every version. It is now rejected with `ValueError`.
- The pandas branch for timestamp strings was guarded by `_check_for_pandas(ts)`, which is always false for a `str`. So `asof="2026-01-01"` asked you to install pandas even when it was installed. It is now guarded by `_PANDAS_AVAILABLE`.

## `ReaderLike`

- It listed `pd.Timestamp` where a DataFrame belongs and referenced `pa.dataset.*`, which type checkers can't resolve. It now lists every input `_coerce_reader` accepts, with the Arrow classes imported directly.
- Polars frames are detected with `_check_for_polars` + `isinstance` instead of matching `__module__`.
- The `write_dataset` docstring now lists the accepted inputs, and `test_input_data` gains dict and row-dict cases.

`test_optional_types_typing.py` pins the accepted and rejected `asof` types under Pyright. `ReaderLike` can't be checked in CI until pyarrow stubs are added: without them the union accepts anything.
