### PR TITLE
feat(java): expose aggregate index fragment coverage

### DIFF
--- a/java/lance-jni/src/blocking_dataset.rs
+++ b/java/lance-jni/src/blocking_dataset.rs
@@ -3,6 +3,7 @@
 
 use crate::error::{Error, Result};
 use crate::ffi::JNIEnvExt;
+use crate::index::IndexDescriptionSummary;
 use crate::index_progress::JavaIndexBuildProgress;
 use crate::namespace::{
     BlockingDirectoryNamespace, BlockingRestNamespace, create_java_lance_namespace,
@@ -3713,7 +3714,19 @@ pub extern "system" fn Java_org_lance_Dataset_nativeDescribeIndices<'local>(
 ) -> JObject<'local> {
     ok_or_throw!(
         env,
-        inner_describe_indices(&mut env, java_dataset, criteria_obj)
+        inner_describe_indices(&mut env, java_dataset, criteria_obj, true)
+    )
+}
+
+#[unsafe(no_mangle)]
+pub extern "system" fn Java_org_lance_Dataset_nativeDescribeIndexSummaries<'local>(
+    mut env: JNIEnv<'local>,
+    java_dataset: JObject,
+    criteria_obj: JObject,
+) -> JObject<'local> {
+    ok_or_throw!(
+        env,
+        inner_describe_indices(&mut env, java_dataset, criteria_obj, false)
     )
 }
 
@@ -3721,6 +3734,7 @@ fn inner_describe_indices<'local>(
     env: &mut JNIEnv<'local>,
     java_dataset: JObject,
     java_index_criteria: JObject,
+    include_metadata: bool,
 ) -> Result<JObject<'local>> {
     let mut for_column = None;
     let mut has_name = None;
@@ -3745,7 +3759,15 @@ fn inner_describe_indices<'local>(
         block_on(dataset_guard.inner.describe_indices(index_criteria))?
     };
 
-    export_vec(env, &descriptions)
+    if include_metadata {
+        export_vec(env, &descriptions)
+    } else {
+        let summaries = descriptions
+            .iter()
+            .map(IndexDescriptionSummary)
+            .collect::<Vec<_>>();
+        export_vec(env, &summaries)
+    }
 }
 
 #[unsafe(no_mangle)]

--- a/java/lance-jni/src/index.rs
+++ b/java/lance-jni/src/index.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright The Lance Authors
 
-use crate::error::Result;
+use crate::error::{Error, Result};
 use crate::traits::{IntoJava, export_vec};
 use jni::JNIEnv;
 use jni::objects::{JObject, JValue};
@@ -45,10 +45,35 @@ impl IntoJava for &Arc<dyn IndexDescription> {
         } else {
             JObject::null()
         };
+        let fragment_coverage = if let Some(coverage) = self.fragment_coverage() {
+            let covered_fragment_count =
+                u64_to_jlong(coverage.covered_fragment_count, "covered fragment count")?;
+            let current_fragment_count =
+                u64_to_jlong(coverage.current_fragment_count, "current fragment count")?;
+            let missing_fragment_count =
+                u64_to_jlong(coverage.missing_fragment_count, "missing fragment count")?;
+            let stale_fragment_count =
+                u64_to_jlong(coverage.stale_fragment_count, "stale fragment count")?;
+            let fragment_bitmap_size_bytes =
+                u64_to_jlong(coverage.fragment_bitmap_size_bytes, "fragment bitmap size")?;
+            env.new_object(
+                "org/lance/index/IndexFragmentCoverage",
+                "(JJJJJ)V",
+                &[
+                    JValue::Long(covered_fragment_count),
+                    JValue::Long(current_fragment_count),
+                    JValue::Long(missing_fragment_count),
+                    JValue::Long(stale_fragment_count),
+                    JValue::Long(fragment_bitmap_size_bytes),
+                ],
+            )?
+        } else {
+            JObject::null()
+        };
 
         let j_index_desc = env.new_object(
             "org/lance/index/IndexDescription",
-            "(Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;JLjava/util/List;Ljava/lang/String;Ljava/lang/Long;)V",
+            "(Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;JLjava/util/List;Ljava/lang/String;Ljava/lang/Long;Lorg/lance/index/IndexFragmentCoverage;)V",
             &[
                 JValue::Object(&name),
                 JValue::Object(&field_ids_list),
@@ -58,10 +83,19 @@ impl IntoJava for &Arc<dyn IndexDescription> {
                 JValue::Object(&metadata_list),
                 JValue::Object(&details),
                 JValue::Object(&total_size_bytes),
+                JValue::Object(&fragment_coverage),
             ],
         )?;
         Ok(j_index_desc)
     }
+}
+
+fn u64_to_jlong(value: u64, description: &str) -> Result<i64> {
+    i64::try_from(value).map_err(|_| {
+        Error::runtime_error(format!(
+            "Index {description} {value} exceeds Java long range"
+        ))
+    })
 }
 
 impl IntoJava for &IndexMetadata {

--- a/java/lance-jni/src/index.rs
+++ b/java/lance-jni/src/index.rs
@@ -30,63 +30,91 @@ fn int_list<'a>(env: &mut JNIEnv<'a>, ids: impl IntoIterator<Item = i32>) -> Res
     Ok(array_list)
 }
 
+fn index_description_into_java<'a>(
+    description: &Arc<dyn IndexDescription>,
+    env: &mut JNIEnv<'a>,
+    include_metadata: bool,
+) -> Result<JObject<'a>> {
+    let field_ids_list = int_list(env, description.field_ids().iter().map(|id| *id as i32))?;
+    let name = env.new_string(description.name())?;
+    let type_url = env.new_string(description.type_url())?;
+    let index_type = env.new_string(description.index_type())?;
+    let rows_indexed = description.rows_indexed() as i64;
+    let metadata_list = if include_metadata {
+        export_vec(env, description.metadata())?
+    } else {
+        env.call_static_method(
+            "java/util/Collections",
+            "emptyList",
+            "()Ljava/util/List;",
+            &[],
+        )?
+        .l()?
+    };
+    let details_json = description.details()?;
+    let details = env.new_string(details_json)?;
+    let total_size_bytes = if let Some(size) = description.total_size_bytes() {
+        env.new_object("java/lang/Long", "(J)V", &[JValue::Long(size as i64)])?
+    } else {
+        JObject::null()
+    };
+    let fragment_coverage = if let Some(coverage) = description.fragment_coverage() {
+        let covered_fragment_count =
+            u64_to_jlong(coverage.covered_fragment_count, "covered fragment count")?;
+        let current_fragment_count =
+            u64_to_jlong(coverage.current_fragment_count, "current fragment count")?;
+        let missing_fragment_count =
+            u64_to_jlong(coverage.missing_fragment_count, "missing fragment count")?;
+        let stale_fragment_count =
+            u64_to_jlong(coverage.stale_fragment_count, "stale fragment count")?;
+        let fragment_bitmap_size_bytes =
+            u64_to_jlong(coverage.fragment_bitmap_size_bytes, "fragment bitmap size")?;
+        env.new_object(
+            "org/lance/index/IndexFragmentCoverage",
+            "(JJJJJ)V",
+            &[
+                JValue::Long(covered_fragment_count),
+                JValue::Long(current_fragment_count),
+                JValue::Long(missing_fragment_count),
+                JValue::Long(stale_fragment_count),
+                JValue::Long(fragment_bitmap_size_bytes),
+            ],
+        )?
+    } else {
+        JObject::null()
+    };
+
+    let j_index_desc = env.new_object(
+        "org/lance/index/IndexDescription",
+        "(Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;JLjava/util/List;Ljava/lang/String;Ljava/lang/Long;Lorg/lance/index/IndexFragmentCoverage;)V",
+        &[
+            JValue::Object(&name),
+            JValue::Object(&field_ids_list),
+            JValue::Object(&type_url),
+            JValue::Object(&index_type),
+            JValue::Long(rows_indexed),
+            JValue::Object(&metadata_list),
+            JValue::Object(&details),
+            JValue::Object(&total_size_bytes),
+            JValue::Object(&fragment_coverage),
+        ],
+    )?;
+    Ok(j_index_desc)
+}
+
 impl IntoJava for &Arc<dyn IndexDescription> {
     fn into_java<'a>(self, env: &mut JNIEnv<'a>) -> Result<JObject<'a>> {
-        let field_ids_list = int_list(env, self.field_ids().iter().map(|id| *id as i32))?;
-        let name = env.new_string(self.name())?;
-        let type_url = env.new_string(self.type_url())?;
-        let index_type = env.new_string(self.index_type())?;
-        let rows_indexed = self.rows_indexed() as i64;
-        let metadata_list = export_vec(env, self.metadata())?;
-        let details_json = self.details()?;
-        let details = env.new_string(details_json)?;
-        let total_size_bytes = if let Some(size) = self.total_size_bytes() {
-            env.new_object("java/lang/Long", "(J)V", &[JValue::Long(size as i64)])?
-        } else {
-            JObject::null()
-        };
-        let fragment_coverage = if let Some(coverage) = self.fragment_coverage() {
-            let covered_fragment_count =
-                u64_to_jlong(coverage.covered_fragment_count, "covered fragment count")?;
-            let current_fragment_count =
-                u64_to_jlong(coverage.current_fragment_count, "current fragment count")?;
-            let missing_fragment_count =
-                u64_to_jlong(coverage.missing_fragment_count, "missing fragment count")?;
-            let stale_fragment_count =
-                u64_to_jlong(coverage.stale_fragment_count, "stale fragment count")?;
-            let fragment_bitmap_size_bytes =
-                u64_to_jlong(coverage.fragment_bitmap_size_bytes, "fragment bitmap size")?;
-            env.new_object(
-                "org/lance/index/IndexFragmentCoverage",
-                "(JJJJJ)V",
-                &[
-                    JValue::Long(covered_fragment_count),
-                    JValue::Long(current_fragment_count),
-                    JValue::Long(missing_fragment_count),
-                    JValue::Long(stale_fragment_count),
-                    JValue::Long(fragment_bitmap_size_bytes),
-                ],
-            )?
-        } else {
-            JObject::null()
-        };
+        index_description_into_java(self, env, true)
+    }
+}
 
-        let j_index_desc = env.new_object(
-            "org/lance/index/IndexDescription",
-            "(Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;JLjava/util/List;Ljava/lang/String;Ljava/lang/Long;Lorg/lance/index/IndexFragmentCoverage;)V",
-            &[
-                JValue::Object(&name),
-                JValue::Object(&field_ids_list),
-                JValue::Object(&type_url),
-                JValue::Object(&index_type),
-                JValue::Long(rows_indexed),
-                JValue::Object(&metadata_list),
-                JValue::Object(&details),
-                JValue::Object(&total_size_bytes),
-                JValue::Object(&fragment_coverage),
-            ],
-        )?;
-        Ok(j_index_desc)
+/// JNI conversion for the summary-only API, which deliberately omits segment
+/// metadata so fragment bitmaps are never expanded into Java collections.
+pub(crate) struct IndexDescriptionSummary<'a>(pub &'a Arc<dyn IndexDescription>);
+
+impl IntoJava for &IndexDescriptionSummary<'_> {
+    fn into_java<'a>(self, env: &mut JNIEnv<'a>) -> Result<JObject<'a>> {
+        index_description_into_java(self.0, env, false)
     }
 }
 

--- a/java/src/main/java/org/lance/Dataset.java
+++ b/java/src/main/java/org/lance/Dataset.java
@@ -1569,6 +1569,42 @@ public class Dataset implements Closeable {
   private native List<IndexDescription> nativeDescribeIndices(Optional<IndexCriteria> criteria);
 
   /**
+   * Describe indices on this dataset without materializing per-segment metadata.
+   *
+   * <p>The returned descriptions contain the same logical index properties and aggregate fragment
+   * coverage as {@link #describeIndices(IndexCriteria)}, but their segment lists are empty. Use
+   * this method when only summary information is needed, especially for indices covering many
+   * fragments.
+   *
+   * @param criteria filter options such as column, name or index capabilities
+   * @return list of index descriptions with empty segment lists
+   */
+  public List<IndexDescription> describeIndexSummaries(IndexCriteria criteria) {
+    Preconditions.checkNotNull(criteria, "criteria cannot be null");
+    try (LockManager.ReadLock readLock = lockManager.acquireReadLock()) {
+      Preconditions.checkArgument(nativeDatasetHandle != 0, "Dataset is closed");
+      return nativeDescribeIndexSummaries(Optional.of(criteria));
+    }
+  }
+
+  /**
+   * Describe all indices on this dataset without materializing per-segment metadata.
+   *
+   * <p>The returned descriptions contain aggregate fragment coverage and have empty segment lists.
+   *
+   * @return list of index descriptions with empty segment lists
+   */
+  public List<IndexDescription> describeIndexSummaries() {
+    try (LockManager.ReadLock readLock = lockManager.acquireReadLock()) {
+      Preconditions.checkArgument(nativeDatasetHandle != 0, "Dataset is closed");
+      return nativeDescribeIndexSummaries(Optional.empty());
+    }
+  }
+
+  private native List<IndexDescription> nativeDescribeIndexSummaries(
+      Optional<IndexCriteria> criteria);
+
+  /**
    * Read zonemap statistics for a column.
    *
    * <p>Returns per-zone min/max/null_count statistics for the given column, if a zonemap index

--- a/java/src/main/java/org/lance/index/IndexDescription.java
+++ b/java/src/main/java/org/lance/index/IndexDescription.java
@@ -33,6 +33,7 @@ public final class IndexDescription {
   private final List<Index> metadata;
   private final String detailsJson;
   private final Long totalSizeBytes;
+  private final IndexFragmentCoverage fragmentCoverage;
 
   public IndexDescription(
       String name,
@@ -42,7 +43,7 @@ public final class IndexDescription {
       long rowsIndexed,
       List<Index> metadata,
       String detailsJson) {
-    this(name, fieldIds, typeUrl, indexType, rowsIndexed, metadata, detailsJson, null);
+    this(name, fieldIds, typeUrl, indexType, rowsIndexed, metadata, detailsJson, null, null);
   }
 
   public IndexDescription(
@@ -54,6 +55,28 @@ public final class IndexDescription {
       List<Index> metadata,
       String detailsJson,
       Long totalSizeBytes) {
+    this(
+        name,
+        fieldIds,
+        typeUrl,
+        indexType,
+        rowsIndexed,
+        metadata,
+        detailsJson,
+        totalSizeBytes,
+        null);
+  }
+
+  public IndexDescription(
+      String name,
+      List<Integer> fieldIds,
+      String typeUrl,
+      String indexType,
+      long rowsIndexed,
+      List<Index> metadata,
+      String detailsJson,
+      Long totalSizeBytes,
+      IndexFragmentCoverage fragmentCoverage) {
     this.name = Objects.requireNonNull(name, "name must not be null");
     this.fieldIds = Objects.requireNonNull(fieldIds, "fieldIds must not be null");
     this.typeUrl = Objects.requireNonNull(typeUrl, "typeUrl must not be null");
@@ -62,6 +85,7 @@ public final class IndexDescription {
     this.metadata = Objects.requireNonNull(metadata, "metadata must not be null");
     this.detailsJson = detailsJson;
     this.totalSizeBytes = totalSizeBytes;
+    this.fragmentCoverage = fragmentCoverage;
   }
 
   /** The logical name of the index. */
@@ -125,5 +149,14 @@ public final class IndexDescription {
    */
   public Optional<Long> getTotalSizeBytes() {
     return Optional.ofNullable(totalSizeBytes);
+  }
+
+  /**
+   * Aggregate fragment coverage for this logical index.
+   *
+   * @return coverage counts and bitmap size, or empty when fragment coverage is unknown
+   */
+  public Optional<IndexFragmentCoverage> getFragmentCoverage() {
+    return Optional.ofNullable(fragmentCoverage);
   }
 }

--- a/java/src/main/java/org/lance/index/IndexDescription.java
+++ b/java/src/main/java/org/lance/index/IndexDescription.java
@@ -155,7 +155,8 @@ public final class IndexDescription {
   /**
    * Aggregate fragment coverage for this logical index.
    *
-   * @return coverage counts and bitmap size, or empty when fragment coverage is unknown
+   * @return coverage counts and bitmap size, or empty when fragment coverage is unknown or not
+   *     applicable, including for system indexes
    */
   public Optional<IndexFragmentCoverage> getFragmentCoverage() {
     return Optional.ofNullable(fragmentCoverage);

--- a/java/src/main/java/org/lance/index/IndexDescription.java
+++ b/java/src/main/java/org/lance/index/IndexDescription.java
@@ -116,7 +116,8 @@ public final class IndexDescription {
   /**
    * Per-segment metadata objects for this index.
    *
-   * <p>Each entry corresponds to a single {@link Index} segment in the manifest.
+   * <p>Each entry corresponds to a single {@link Index} segment in the manifest. The list is empty
+   * for descriptions returned by {@code Dataset.describeIndexSummaries}.
    */
   public List<Index> getMetadata() {
     return metadata;

--- a/java/src/main/java/org/lance/index/IndexFragmentCoverage.java
+++ b/java/src/main/java/org/lance/index/IndexFragmentCoverage.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.lance.index;
+
+import java.util.OptionalDouble;
+
+/** Fragment coverage summary for a logical index across all of its physical segments. */
+public final class IndexFragmentCoverage {
+
+  private final long coveredFragmentCount;
+  private final long currentFragmentCount;
+  private final long missingFragmentCount;
+  private final long staleFragmentCount;
+  private final long fragmentBitmapSizeBytes;
+
+  public IndexFragmentCoverage(
+      long coveredFragmentCount,
+      long currentFragmentCount,
+      long missingFragmentCount,
+      long staleFragmentCount,
+      long fragmentBitmapSizeBytes) {
+    this.coveredFragmentCount = coveredFragmentCount;
+    this.currentFragmentCount = currentFragmentCount;
+    this.missingFragmentCount = missingFragmentCount;
+    this.staleFragmentCount = staleFragmentCount;
+    this.fragmentBitmapSizeBytes = fragmentBitmapSizeBytes;
+  }
+
+  /** Number of current dataset fragments covered by the index. */
+  public long getCoveredFragmentCount() {
+    return coveredFragmentCount;
+  }
+
+  /** Number of fragments in the current dataset. */
+  public long getCurrentFragmentCount() {
+    return currentFragmentCount;
+  }
+
+  /** Number of current dataset fragments not covered by the index. */
+  public long getMissingFragmentCount() {
+    return missingFragmentCount;
+  }
+
+  /** Number of indexed fragments that are no longer in the current dataset. */
+  public long getStaleFragmentCount() {
+    return staleFragmentCount;
+  }
+
+  /** Serialized size of all physical segment fragment bitmaps in bytes. */
+  public long getFragmentBitmapSizeBytes() {
+    return fragmentBitmapSizeBytes;
+  }
+
+  /**
+   * Ratio of covered current fragments to all current fragments.
+   *
+   * @return empty when the current dataset has no fragments
+   */
+  public OptionalDouble getCoverageRatio() {
+    if (currentFragmentCount == 0) {
+      return OptionalDouble.empty();
+    }
+    return OptionalDouble.of((double) coveredFragmentCount / currentFragmentCount);
+  }
+}

--- a/java/src/test/java/org/lance/DatasetTest.java
+++ b/java/src/test/java/org/lance/DatasetTest.java
@@ -17,6 +17,7 @@ import org.lance.compaction.CompactionOptions;
 import org.lance.index.Index;
 import org.lance.index.IndexCriteria;
 import org.lance.index.IndexDescription;
+import org.lance.index.IndexFragmentCoverage;
 import org.lance.index.IndexOptions;
 import org.lance.index.IndexParams;
 import org.lance.index.IndexType;
@@ -2282,6 +2283,14 @@ public class DatasetTest {
             desc.getSegments().get(0).getSizeBytes(),
             desc.getTotalSizeBytes(),
             "single-segment size should equal the logical index size");
+        IndexFragmentCoverage coverage =
+            desc.getFragmentCoverage().orElseThrow(AssertionError::new);
+        assertTrue(coverage.getCurrentFragmentCount() > 0);
+        assertEquals(coverage.getCurrentFragmentCount(), coverage.getCoveredFragmentCount());
+        assertEquals(0, coverage.getMissingFragmentCount());
+        assertEquals(0, coverage.getStaleFragmentCount());
+        assertTrue(coverage.getFragmentBitmapSizeBytes() > 0);
+        assertEquals(1.0, coverage.getCoverageRatio().orElseThrow(AssertionError::new));
 
         descriptions = dataset.describeIndices();
         assertEquals(2, descriptions.size(), "Expected exactly one matching index");

--- a/java/src/test/java/org/lance/DatasetTest.java
+++ b/java/src/test/java/org/lance/DatasetTest.java
@@ -2292,6 +2292,22 @@ public class DatasetTest {
         assertTrue(coverage.getFragmentBitmapSizeBytes() > 0);
         assertEquals(1.0, coverage.getCoverageRatio().orElseThrow(AssertionError::new));
 
+        List<IndexDescription> summaries = dataset.describeIndexSummaries(criteria);
+        assertEquals(1, summaries.size());
+        IndexDescription summary = summaries.get(0);
+        assertEquals(desc.getName(), summary.getName());
+        assertEquals(desc.getRowsIndexed(), summary.getRowsIndexed());
+        assertEquals(desc.getTotalSizeBytes(), summary.getTotalSizeBytes());
+        assertTrue(summary.getSegments().isEmpty());
+        IndexFragmentCoverage summaryCoverage =
+            summary.getFragmentCoverage().orElseThrow(AssertionError::new);
+        assertEquals(coverage.getCoveredFragmentCount(), summaryCoverage.getCoveredFragmentCount());
+        assertEquals(coverage.getCurrentFragmentCount(), summaryCoverage.getCurrentFragmentCount());
+        assertEquals(coverage.getMissingFragmentCount(), summaryCoverage.getMissingFragmentCount());
+        assertEquals(coverage.getStaleFragmentCount(), summaryCoverage.getStaleFragmentCount());
+        assertEquals(
+            coverage.getFragmentBitmapSizeBytes(), summaryCoverage.getFragmentBitmapSizeBytes());
+
         descriptions = dataset.describeIndices();
         assertEquals(2, descriptions.size(), "Expected exactly one matching index");
         for (IndexDescription indexDesc : descriptions) {

--- a/rust/lance-index/src/traits.rs
+++ b/rust/lance-index/src/traits.rs
@@ -297,6 +297,25 @@ pub enum PrewarmOptions {
     Fts(FtsPrewarmOptions),
 }
 
+/// Fragment coverage summary for a logical index.
+///
+/// A logical index can contain multiple physical segments. This summary unions
+/// their fragment bitmaps before comparing them with the dataset's current
+/// fragments, so fragment counts are not inflated by duplicate segment entries.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct IndexFragmentCoverage {
+    /// Number of current dataset fragments covered by the index.
+    pub covered_fragment_count: u64,
+    /// Number of fragments in the current dataset.
+    pub current_fragment_count: u64,
+    /// Number of current dataset fragments not covered by the index.
+    pub missing_fragment_count: u64,
+    /// Number of indexed fragments that are no longer in the current dataset.
+    pub stale_fragment_count: u64,
+    /// Serialized size of all physical segment fragment bitmaps in bytes.
+    pub fragment_bitmap_size_bytes: u64,
+}
+
 /// Additional information about an index
 ///
 /// Note that a single index might consist of multiple segments.  Each segment has its own
@@ -367,4 +386,12 @@ pub trait IndexDescription: Send + Sync {
     /// Returns `None` if file size information is not available for any segment
     /// (for backward compatibility with indices created before file tracking was added).
     fn total_size_bytes(&self) -> Option<u64>;
+
+    /// Returns aggregate fragment coverage for this logical index.
+    ///
+    /// Returns `None` when any segment has no fragment bitmap, which is expected
+    /// for system indices and legacy index metadata with unknown coverage.
+    fn fragment_coverage(&self) -> Option<&IndexFragmentCoverage> {
+        None
+    }
 }

--- a/rust/lance-index/src/traits.rs
+++ b/rust/lance-index/src/traits.rs
@@ -389,8 +389,9 @@ pub trait IndexDescription: Send + Sync {
 
     /// Returns aggregate fragment coverage for this logical index.
     ///
-    /// Returns `None` when any segment has no fragment bitmap, which is expected
-    /// for system indices and legacy index metadata with unknown coverage.
+    /// Returns `None` for system indices, whose bitmaps have index-specific
+    /// semantics, or when any segment has no fragment bitmap and coverage is
+    /// unknown.
     fn fragment_coverage(&self) -> Option<&IndexFragmentCoverage> {
         None
     }

--- a/rust/lance-table/src/format/index.rs
+++ b/rust/lance-table/src/format/index.rs
@@ -94,6 +94,17 @@ pub struct IndexMetadata {
 }
 
 impl IndexMetadata {
+    /// Returns the size of the fragment bitmap in its manifest serialization.
+    ///
+    /// Fragment bitmaps are run-optimized before they are persisted. This method
+    /// applies the same optimization so callers can report the stored metadata
+    /// size without serializing or exporting the bitmap itself.
+    pub fn fragment_bitmap_serialized_size(&self) -> Option<usize> {
+        let mut bitmap = self.fragment_bitmap.clone()?;
+        bitmap.optimize();
+        Some(bitmap.serialized_size())
+    }
+
     pub fn effective_fragment_bitmap(
         &self,
         existing_fragments: &RoaringBitmap,
@@ -460,6 +471,10 @@ mod tests {
         };
 
         let proto = pb::IndexMetadata::from(&metadata);
+        assert_eq!(
+            metadata.fragment_bitmap_serialized_size(),
+            Some(proto.fragment_bitmap.len())
+        );
         assert!(
             proto.fragment_bitmap.len() < unoptimized_size / 100,
             "expected run-optimized bitmap ({} bytes) to be <1% of the \

--- a/rust/lance/src/dataset/index.rs
+++ b/rust/lance/src/dataset/index.rs
@@ -233,7 +233,7 @@ mod tests {
             FragReuseIndexDetails {
                 versions: Vec::new(),
             },
-            Default::default(),
+            std::iter::once(0_u32).collect(),
         )
         .await
         .unwrap();
@@ -253,6 +253,19 @@ mod tests {
         let indices = dataset.load_indices().await.unwrap();
         assert_eq!(indices.len(), 1);
         assert_eq!(indices[0].name, FRAG_REUSE_INDEX_NAME);
+        assert_eq!(
+            indices[0].fragment_bitmap.as_ref().unwrap().len(),
+            1,
+            "the regression requires a bitmap-bearing system index"
+        );
+
+        let descriptions = dataset.describe_indices(None).await.unwrap();
+        assert_eq!(descriptions.len(), 1);
+        assert_eq!(descriptions[0].name(), FRAG_REUSE_INDEX_NAME);
+        assert!(
+            descriptions[0].fragment_coverage().is_none(),
+            "fragment-reuse metadata does not represent data-index coverage"
+        );
         assert!(options.create_remapper(&dataset).await.unwrap().is_none());
     }
 

--- a/rust/lance/src/index.rs
+++ b/rust/lance/src/index.rs
@@ -1495,7 +1495,9 @@ impl IndexDescriptionImpl {
         let mut missing_fragment_refs = 0u64;
         let mut indexed_fragments = RoaringBitmap::new();
         let mut fragment_bitmap_size_bytes = 0u64;
-        let mut has_fragment_coverage = true;
+        // System-index bitmaps have index-specific meanings (for example,
+        // fragment-reuse participation), not data-index coverage.
+        let reports_fragment_coverage = !is_system_index(example_metadata);
 
         for shard in &segments {
             let Some(fragment_bitmap) = shard.fragment_bitmap.as_ref() else {
@@ -1503,7 +1505,6 @@ impl IndexDescriptionImpl {
                 // missing bitmap means zero indexed rows. For a data index it
                 // means unknown coverage — reject rather than fabricate a count.
                 if is_system_index(shard) {
-                    has_fragment_coverage = false;
                     continue;
                 }
                 return Err(Error::index("Fragment bitmap is required for index description.  This index must be retrained to support this method.".to_string()));
@@ -1538,7 +1539,7 @@ impl IndexDescriptionImpl {
             "described index row coverage from fragment metadata"
         );
 
-        let fragment_coverage = if has_fragment_coverage {
+        let fragment_coverage = if reports_fragment_coverage {
             let current_fragments = fragment_rows.keys().copied().collect::<RoaringBitmap>();
             Some(IndexFragmentCoverage {
                 covered_fragment_count: indexed_fragments.intersection_len(&current_fragments),

--- a/rust/lance/src/index.rs
+++ b/rust/lance/src/index.rs
@@ -46,7 +46,8 @@ use lance_index::vector::sq::ScalarQuantizer;
 use lance_index::vector::v3::subindex::IvfSubIndex;
 use lance_index::{
     FtsPrewarmDiagnostics, FtsPrewarmOptions, FtsPrewarmResult, FtsPrewarmSegmentStatus,
-    INDEX_FILE_NAME, Index, IndexType, PrewarmOptions, pb, vector::VectorIndex,
+    INDEX_FILE_NAME, Index, IndexFragmentCoverage, IndexType, PrewarmOptions, pb,
+    vector::VectorIndex,
 };
 use lance_index::{
     IndexCriteria, is_system_index,
@@ -1398,6 +1399,7 @@ struct IndexDescriptionImpl {
     /// best-effort basis rather than rejected.
     details: Option<IndexDetails>,
     rows_indexed: u64,
+    fragment_coverage: Option<IndexFragmentCoverage>,
 }
 
 impl IndexDescriptionImpl {
@@ -1491,6 +1493,9 @@ impl IndexDescriptionImpl {
         let mut rows_indexed = 0;
         let mut indexed_fragment_refs = 0u64;
         let mut missing_fragment_refs = 0u64;
+        let mut indexed_fragments = RoaringBitmap::new();
+        let mut fragment_bitmap_size_bytes = 0u64;
+        let mut has_fragment_coverage = true;
 
         for shard in &segments {
             let Some(fragment_bitmap) = shard.fragment_bitmap.as_ref() else {
@@ -1498,11 +1503,21 @@ impl IndexDescriptionImpl {
                 // missing bitmap means zero indexed rows. For a data index it
                 // means unknown coverage — reject rather than fabricate a count.
                 if is_system_index(shard) {
+                    has_fragment_coverage = false;
                     continue;
                 }
                 return Err(Error::index("Fragment bitmap is required for index description.  This index must be retrained to support this method.".to_string()));
             };
 
+            indexed_fragments |= fragment_bitmap;
+            let serialized_size = shard.fragment_bitmap_serialized_size().ok_or_else(|| {
+                Error::index("Fragment bitmap disappeared while describing index".to_string())
+            })?;
+            let serialized_size = u64::try_from(serialized_size)
+                .map_err(|_| Error::index("Fragment bitmap size overflow".to_string()))?;
+            fragment_bitmap_size_bytes = fragment_bitmap_size_bytes
+                .checked_add(serialized_size)
+                .ok_or_else(|| Error::index("Fragment bitmap size overflow".to_string()))?;
             indexed_fragment_refs += fragment_bitmap.len();
             for fragment_id in fragment_bitmap.iter() {
                 if let Some(fragment_rows) = fragment_rows.get(&fragment_id) {
@@ -1523,6 +1538,19 @@ impl IndexDescriptionImpl {
             "described index row coverage from fragment metadata"
         );
 
+        let fragment_coverage = if has_fragment_coverage {
+            let current_fragments = fragment_rows.keys().copied().collect::<RoaringBitmap>();
+            Some(IndexFragmentCoverage {
+                covered_fragment_count: indexed_fragments.intersection_len(&current_fragments),
+                current_fragment_count: current_fragments.len(),
+                missing_fragment_count: current_fragments.difference_len(&indexed_fragments),
+                stale_fragment_count: indexed_fragments.difference_len(&current_fragments),
+                fragment_bitmap_size_bytes,
+            })
+        } else {
+            None
+        };
+
         Ok(Self {
             name,
             field_ids: field_ids_vec,
@@ -1530,6 +1558,7 @@ impl IndexDescriptionImpl {
             segments,
             details,
             rows_indexed,
+            fragment_coverage,
         })
     }
 }
@@ -1593,6 +1622,10 @@ impl IndexDescription for IndexDescriptionImpl {
             }
         }
         Some(total)
+    }
+
+    fn fragment_coverage(&self) -> Option<&IndexFragmentCoverage> {
+        self.fragment_coverage.as_ref()
     }
 }
 
@@ -10342,6 +10375,19 @@ mod tests {
             descriptions[0].rows_indexed(),
             20,
             "stale bitmap entries for missing fragments should be skipped without failing"
+        );
+        assert_eq!(
+            descriptions[0].fragment_coverage(),
+            Some(&IndexFragmentCoverage {
+                covered_fragment_count: 2,
+                current_fragment_count: 2,
+                missing_fragment_count: 0,
+                stale_fragment_count: 1,
+                fragment_bitmap_size_bytes: u64::try_from(
+                    stale_segment.fragment_bitmap_serialized_size().unwrap(),
+                )
+                .unwrap(),
+            })
         );
     }
 

--- a/rust/lance/src/index/mem_wal.rs
+++ b/rust/lance/src/index/mem_wal.rs
@@ -1031,6 +1031,10 @@ mod tests {
             0,
             "a bitmap-less system index indexes zero rows"
         );
+        assert!(
+            mem_wal_desc.fragment_coverage().is_none(),
+            "system index fragment metadata does not represent data-index coverage"
+        );
         assert_eq!(
             descriptions.len(),
             2,


### PR DESCRIPTION
## Why

Java callers can inspect each segment fragment list today, but must materialize every fragment id in the JVM to calculate logical index coverage. This is expensive for large datasets and does not expose the serialized bitmap size.

## What

- add an aggregate IndexFragmentCoverage result to Rust IndexDescription and Java IndexDescription
- union all physical segment bitmaps before calculating covered, current, missing, and stale fragment counts
- report the exact run-optimized manifest serialization size of all segment bitmaps
- expose a Java coverage ratio without copying the raw bitmap
- preserve compatibility for external Rust IndexDescription implementations and existing Java constructors

## Tests

- cargo test -p lance-table test_fragment_bitmap_serialized_run_optimized
- cargo test -p lance test_describe_indices_rows_indexed_stale_bitmap_fragment
- cd java && ./mvnw test -Dtest=DatasetTest#testDescribeIndicesByName
- cargo clippy --all --tests --benches -- -D warnings