### PR TITLE
feat(java): expose referenced file metadata

### DIFF
--- a/java/lance-jni/src/blocking_dataset.rs
+++ b/java/lance-jni/src/blocking_dataset.rs
@@ -83,6 +83,37 @@ impl FromJObjectWithEnv<BasePath> for JObject<'_> {
     }
 }
 
+impl IntoJava for &BasePath {
+    fn into_java<'a>(self, env: &mut JNIEnv<'a>) -> Result<JObject<'a>> {
+        let id = i32::try_from(self.id).map_err(|_| {
+            Error::runtime_error(format!("Base path id {} exceeds Java int range", self.id))
+        })?;
+        let name = match self.name.as_ref() {
+            Some(name) => env.new_string(name)?.into(),
+            None => JObject::null(),
+        };
+        let name = env
+            .call_static_method(
+                "java/util/Optional",
+                "ofNullable",
+                "(Ljava/lang/Object;)Ljava/util/Optional;",
+                &[JValue::Object(&name)],
+            )?
+            .l()?;
+        let path = env.new_string(&self.path)?;
+        Ok(env.new_object(
+            "org/lance/BasePath",
+            "(ILjava/util/Optional;Ljava/lang/String;Z)V",
+            &[
+                JValue::Int(id),
+                JValue::Object(&name),
+                JValue::Object(&path),
+                JValue::Bool(self.is_dataset_root.into()),
+            ],
+        )?)
+    }
+}
+
 #[derive(Clone)]
 pub struct BlockingDataset {
     pub(crate) inner: Dataset,
@@ -1645,6 +1676,33 @@ fn inner_get_fragments<'local>(
         .map(|f| f.metadata().clone())
         .collect::<Vec<Fragment>>();
     export_vec(env, &fragments)
+}
+
+#[unsafe(no_mangle)]
+pub extern "system" fn Java_org_lance_Dataset_nativeGetBasePaths<'a>(
+    mut env: JNIEnv<'a>,
+    jdataset: JObject,
+) -> JObject<'a> {
+    ok_or_throw!(env, inner_get_base_paths(&mut env, jdataset))
+}
+
+fn inner_get_base_paths<'local>(
+    env: &mut JNIEnv<'local>,
+    jdataset: JObject,
+) -> Result<JObject<'local>> {
+    let mut base_paths = {
+        let dataset =
+            unsafe { env.get_rust_field::<_, _, BlockingDataset>(jdataset, NATIVE_DATASET) }?;
+        dataset
+            .inner
+            .manifest()
+            .base_paths
+            .values()
+            .cloned()
+            .collect::<Vec<_>>()
+    };
+    base_paths.sort_by_key(|base_path| base_path.id);
+    export_vec(env, &base_paths)
 }
 
 #[unsafe(no_mangle)]

--- a/java/lance-jni/src/fragment.rs
+++ b/java/lance-jni/src/fragment.rs
@@ -691,7 +691,7 @@ const DELETE_FILE_CONSTRUCTOR_SIG: &str =
     "(JJLjava/lang/Long;Lorg/lance/fragment/DeletionFileType;Ljava/lang/Integer;)V";
 const DELETE_FILE_TYPE_CLASS: &str = "org/lance/fragment/DeletionFileType";
 const FRAGMENT_METADATA_CLASS: &str = "org/lance/FragmentMetadata";
-const FRAGMENT_METADATA_CONSTRUCTOR_SIG: &str = "(ILjava/util/List;Ljava/lang/Long;Lorg/lance/fragment/DeletionFile;Lorg/lance/fragment/RowIdMeta;Lorg/lance/fragment/VersionMeta;Lorg/lance/fragment/VersionMeta;)V";
+const FRAGMENT_METADATA_CONSTRUCTOR_SIG: &str = "(ILjava/util/List;Ljava/lang/Long;Lorg/lance/fragment/DeletionFile;Lorg/lance/fragment/RowIdMeta;Lorg/lance/fragment/VersionMeta;Lorg/lance/fragment/VersionMeta;Ljava/util/List;)V";
 const ROW_ID_META_CLASS: &str = "org/lance/fragment/RowIdMeta";
 const ROW_ID_META_CONSTRUCTOR_SIG: &str = "(Ljava/lang/String;)V";
 const VERSION_META_CLASS: &str = "org/lance/fragment/VersionMeta";
@@ -829,6 +829,11 @@ impl IntoJava for &Fragment {
     fn into_java<'local>(self, env: &mut JNIEnv<'local>) -> Result<JObject<'local>> {
         let files = self.files.clone();
         let files = export_vec::<DataFile>(env, &files)?;
+        let referenced_data_files = self
+            .referenced_lance_files()
+            .cloned()
+            .collect::<Vec<DataFile>>();
+        let referenced_data_files = export_vec::<DataFile>(env, &referenced_data_files)?;
         let deletion_file = match &self.deletion_file {
             Some(f) => f.into_java(env)?,
             None => JObject::null(),
@@ -858,6 +863,7 @@ impl IntoJava for &Fragment {
                 JValueGen::Object(&row_id_meta),
                 JValueGen::Object(&created_at),
                 JValueGen::Object(&last_updated_at),
+                JValueGen::Object(&referenced_data_files),
             ],
         )
         .map_err(|e| {

--- a/java/src/main/java/org/lance/Dataset.java
+++ b/java/src/main/java/org/lance/Dataset.java
@@ -1416,6 +1416,21 @@ public class Dataset implements Closeable {
   private native List<FragmentMetadata> getFragmentsNative();
 
   /**
+   * Returns the storage bases registered by the current manifest.
+   *
+   * <p>Files without a base id resolve against this dataset's own URI. Files with a base id resolve
+   * against the matching entry in this list.
+   */
+  public List<BasePath> getBasePaths() {
+    try (LockManager.ReadLock readLock = lockManager.acquireReadLock()) {
+      Preconditions.checkArgument(nativeDatasetHandle != 0, "Dataset is closed");
+      return nativeGetBasePaths();
+    }
+  }
+
+  private native List<BasePath> nativeGetBasePaths();
+
+  /**
    * Get per-fragment statistics for all fragments in this dataset version.
    *
    * <p>Unlike {@link #getFragments()}, this is a metadata-only bulk operation: no per-fragment Java

--- a/java/src/main/java/org/lance/FragmentMetadata.java
+++ b/java/src/main/java/org/lance/FragmentMetadata.java
@@ -29,6 +29,7 @@ public class FragmentMetadata implements Serializable {
   private static final long serialVersionUID = -5886811251944130460L;
   private final int id;
   private final List<DataFile> files;
+  private final List<DataFile> referencedLanceFiles;
   private final long physicalRows;
   private final DeletionFile deletionFile;
   private final RowIdMeta rowIdMeta;
@@ -41,7 +42,7 @@ public class FragmentMetadata implements Serializable {
       Long physicalRows,
       DeletionFile deletionFile,
       RowIdMeta rowIdMeta) {
-    this(id, files, physicalRows, deletionFile, rowIdMeta, null, null);
+    this(id, files, physicalRows, deletionFile, rowIdMeta, null, null, files);
   }
 
   public FragmentMetadata(
@@ -52,8 +53,29 @@ public class FragmentMetadata implements Serializable {
       RowIdMeta rowIdMeta,
       VersionMeta createdAtVersionMeta,
       VersionMeta lastUpdatedAtVersionMeta) {
+    this(
+        id,
+        files,
+        physicalRows,
+        deletionFile,
+        rowIdMeta,
+        createdAtVersionMeta,
+        lastUpdatedAtVersionMeta,
+        files);
+  }
+
+  public FragmentMetadata(
+      int id,
+      List<DataFile> files,
+      Long physicalRows,
+      DeletionFile deletionFile,
+      RowIdMeta rowIdMeta,
+      VersionMeta createdAtVersionMeta,
+      VersionMeta lastUpdatedAtVersionMeta,
+      List<DataFile> referencedLanceFiles) {
     this.id = id;
     this.files = files;
+    this.referencedLanceFiles = referencedLanceFiles;
     this.physicalRows = physicalRows;
     this.deletionFile = deletionFile;
     this.rowIdMeta = rowIdMeta;
@@ -67,6 +89,16 @@ public class FragmentMetadata implements Serializable {
 
   public List<DataFile> getFiles() {
     return files;
+  }
+
+  /**
+   * Returns every Lance data file referenced by this fragment.
+   *
+   * <p>This includes both the base data files returned by {@link #getFiles()} and data overlay
+   * files. Prefer this method when accounting for storage or copying a fragment.
+   */
+  public List<DataFile> getReferencedLanceFiles() {
+    return referencedLanceFiles;
   }
 
   public long getPhysicalRows() {
@@ -116,6 +148,7 @@ public class FragmentMetadata implements Serializable {
     return id == that.id
         && physicalRows == that.physicalRows
         && Objects.equals(this.files, that.files)
+        && Objects.equals(referencedLanceFiles, that.referencedLanceFiles)
         && Objects.equals(deletionFile, that.deletionFile)
         && Objects.equals(rowIdMeta, that.rowIdMeta)
         && Objects.equals(createdAtVersionMeta, that.createdAtVersionMeta)
@@ -128,6 +161,7 @@ public class FragmentMetadata implements Serializable {
         id,
         physicalRows,
         files,
+        referencedLanceFiles,
         deletionFile,
         rowIdMeta,
         createdAtVersionMeta,
@@ -140,6 +174,7 @@ public class FragmentMetadata implements Serializable {
         .add("id", id)
         .add("physicalRows", physicalRows)
         .add("files", files)
+        .add("referencedLanceFiles", referencedLanceFiles)
         .add("deletionFile", deletionFile)
         .add("rowIdMeta", rowIdMeta)
         .add("createdAtVersionMeta", createdAtVersionMeta)

--- a/java/src/main/java/org/lance/fragment/DeletionFile.java
+++ b/java/src/main/java/org/lance/fragment/DeletionFile.java
@@ -77,7 +77,14 @@ public class DeletionFile implements Serializable {
       default:
         throw new IllegalStateException("Unsupported deletion file type: " + fileType);
     }
-    return "_deletions/" + fragmentId + "-" + readVersion + "-" + id + "." + suffix;
+    return "_deletions/"
+        + fragmentId
+        + "-"
+        + readVersion
+        + "-"
+        + Long.toUnsignedString(id)
+        + "."
+        + suffix;
   }
 
   @Override

--- a/java/src/main/java/org/lance/fragment/DeletionFile.java
+++ b/java/src/main/java/org/lance/fragment/DeletionFile.java
@@ -57,6 +57,29 @@ public class DeletionFile implements Serializable {
     return Optional.ofNullable(baseId);
   }
 
+  /**
+   * Returns the deletion file path relative to its dataset-root base.
+   *
+   * @param fragmentId fragment that owns this deletion file
+   */
+  public String getRelativePath(long fragmentId) {
+    if (fragmentId < 0) {
+      throw new IllegalArgumentException("fragmentId must be non-negative");
+    }
+    String suffix;
+    switch (fileType) {
+      case ARRAY:
+        suffix = "arrow";
+        break;
+      case BITMAP:
+        suffix = "bin";
+        break;
+      default:
+        throw new IllegalStateException("Unsupported deletion file type: " + fileType);
+    }
+    return "_deletions/" + fragmentId + "-" + readVersion + "-" + id + "." + suffix;
+  }
+
   @Override
   public boolean equals(Object o) {
     if (this == o) return true;

--- a/java/src/test/java/org/lance/FragmentTest.java
+++ b/java/src/test/java/org/lance/FragmentTest.java
@@ -13,6 +13,8 @@
  */
 package org.lance;
 
+import org.lance.fragment.DeletionFile;
+import org.lance.fragment.DeletionFileType;
 import org.lance.fragment.FragmentMergeResult;
 import org.lance.ipc.LanceScanner;
 import org.lance.ipc.ScanOptions;
@@ -55,6 +57,16 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class FragmentTest {
   @Test
+  void testDeletionFileRelativePath() {
+    DeletionFile bitmap = new DeletionFile(7, 11, 2L, DeletionFileType.BITMAP, null);
+    DeletionFile array = new DeletionFile(7, 11, 2L, DeletionFileType.ARRAY, null);
+
+    assertEquals("_deletions/5-11-7.bin", bitmap.getRelativePath(5));
+    assertEquals("_deletions/5-11-7.arrow", array.getRelativePath(5));
+    assertThrows(IllegalArgumentException.class, () -> bitmap.getRelativePath(-1));
+  }
+
+  @Test
   void testFragmentCreateFfiArray(@TempDir Path tempDir) {
     String datasetPath = tempDir.resolve("new_fragment_array").toString();
     try (RootAllocator allocator = new RootAllocator(Long.MAX_VALUE)) {
@@ -74,6 +86,7 @@ public class FragmentTest {
       testDataset.createEmptyDataset().close();
       int rowCount = 21;
       FragmentMetadata fragmentMeta = testDataset.createNewFragment(rowCount);
+      assertEquals(fragmentMeta.getFiles(), fragmentMeta.getReferencedLanceFiles());
 
       // Commit fragment
       FragmentOperation.Append appendOp = new FragmentOperation.Append(Arrays.asList(fragmentMeta));

--- a/java/src/test/java/org/lance/FragmentTest.java
+++ b/java/src/test/java/org/lance/FragmentTest.java
@@ -60,9 +60,11 @@ public class FragmentTest {
   void testDeletionFileRelativePath() {
     DeletionFile bitmap = new DeletionFile(7, 11, 2L, DeletionFileType.BITMAP, null);
     DeletionFile array = new DeletionFile(7, 11, 2L, DeletionFileType.ARRAY, null);
+    DeletionFile highBitId = new DeletionFile(-1L, 11, 2L, DeletionFileType.BITMAP, null);
 
     assertEquals("_deletions/5-11-7.bin", bitmap.getRelativePath(5));
     assertEquals("_deletions/5-11-7.arrow", array.getRelativePath(5));
+    assertEquals("_deletions/5-11-18446744073709551615.bin", highBitId.getRelativePath(5));
     assertThrows(IllegalArgumentException.class, () -> bitmap.getRelativePath(-1));
   }
 

--- a/java/src/test/java/org/lance/MultiBaseTest.java
+++ b/java/src/test/java/org/lance/MultiBaseTest.java
@@ -175,6 +175,13 @@ public class MultiBaseTest {
     assertNotNull(ds);
     assertEquals(primary, ds.uri());
     assertEquals(500, ds.countRows());
+    assertEquals(2, ds.getBasePaths().size());
+    assertEquals(
+        Arrays.asList("base1", "base2"),
+        ds.getBasePaths().stream()
+            .map(base -> base.getName().orElseThrow(AssertionError::new))
+            .sorted()
+            .collect(Collectors.toList()));
   }
 
   @Test

--- a/java/src/test/java/org/lance/operation/DataReplacementTest.java
+++ b/java/src/test/java/org/lance/operation/DataReplacementTest.java
@@ -134,6 +134,13 @@ public class DataReplacementTest extends OperationTestBase {
                     new CommitBuilder(initDataset).execute(replaceTxn)) {
                   assertEquals(4, datasetWithAddress.version());
                   assertEquals(rowCount, datasetWithAddress.countRows());
+                  FragmentMetadata fragmentWithOverlay =
+                      datasetWithAddress.getFragments().get(0).metadata();
+                  List<DataFile> referencedFiles = fragmentWithOverlay.getReferencedLanceFiles();
+                  assertEquals(2, referencedFiles.size());
+                  assertEquals(fragmentMetas.get(0).getFiles().get(0), referencedFiles.get(0));
+                  assertEquals(datafile.getPath(), referencedFiles.get(1).getPath());
+                  assertEquals(datafile.getBaseId(), referencedFiles.get(1).getBaseId());
 
                   try (LanceScanner scanner = datasetWithAddress.newScan()) {
                     try (ArrowReader resultReader = scanner.scanBatches()) {


### PR DESCRIPTION
## Summary

- expose every Lance data file referenced by a fragment, including data-overlay files
- expose manifest base paths so Java callers can resolve base-relative physical URIs
- expose the canonical deletion-file relative path for exact metadata/accounting lookups

## Motivation

Java storage-accounting and maintenance clients currently see only FragmentMetadata.getFiles(), which omits data-overlay files. They also cannot resolve non-default base IDs or construct deletion-file paths without duplicating Lance naming rules. Together, these gaps prevent complete physical-file enumeration without falling back to object-store prefix listing.

This PR exposes the existing Rust manifest metadata through Java/JNI. Existing FragmentMetadata constructors remain source compatible.

## Validation

- cargo fmt --all -- --check
- cargo clippy --all --tests --benches -- -D warnings
- cd java && ./mvnw test -Dtest=FragmentTest#testFragmentCreate+testDeletionFileRelativePath,MultiBaseTest#testCreateMode
- Java: 3 passed; JNI: 18 passed