### PR TITLE
test(io): deflake AIMD list throttle rate-decrease test

### DIFF
--- a/rust/lance-io/src/object_store/throttle.rs
+++ b/rust/lance-io/src/object_store/throttle.rs
@@ -1189,8 +1189,13 @@ mod tests {
                 .with_window_duration(std::time::Duration::from_millis(1)),
         );
         config.max_retries = 1;
-        config.min_backoff_ms = 0;
-        config.max_backoff_ms = 0;
+        // The AIMD window is only evaluated when an outcome is recorded after the
+        // window has elapsed, so the retry backoff must outlast `window_duration`.
+        // With a zero backoff the two attempts against this in-memory lister can
+        // finish inside the first window (observed on Windows), leaving the rate
+        // untouched.
+        config.min_backoff_ms = 5;
+        config.max_backoff_ms = 5;
         let throttled =
             AimdThrottledStore::new(Arc::new(InMemory::new()) as Arc<dyn ObjectStore>, config)
                 .unwrap();


### PR DESCRIPTION
The AIMD controller only re-evaluates its rate when an outcome is recorded after the current window has elapsed. The test configured a 1ms window but a zero retry backoff, so both list attempts could complete inside the first window and leave the rate at its initial value. The sequence measures ~1.3ms locally, i.e. it passed on only ~0.3ms of slack, and lands under 1ms on Windows CI.

Give the retry backoff 5ms so it comfortably outlasts the window, making the window boundary crossing deterministic instead of timing-dependent.