### PR TITLE
fix(io): prefer goosefs-site.properties HA over dummy URI authority

### DIFF
--- a/docs/src/guide/object_store.md
+++ b/docs/src/guide/object_store.md
@@ -542,7 +542,13 @@ The Master address can be resolved from (in priority order):
 
 1. The `goosefs_master_addr` storage option (supports HA: `"addr1:port,addr2:port"`).
 2. The `GOOSEFS_MASTER_ADDR` environment variable.
-3. The host and port from the URL authority.
+3. `goosefs.master.rpc.addresses` / `goosefs.master.hostname` in `goosefs-site.properties`
+   (discovered via `$GOOSEFS_CONFIG_FILE`, `$GOOSEFS_CONF_DIR`, `$GOOSEFS_HOME/conf`,
+   `~/.goosefs`, or `/etc/goosefs`). When this source is used, a dummy URL
+   authority such as `goosefs://192.0.2.5:9999/...` is **not** dialed.
+4. The host and port from the URL authority (required when none of the above
+   supplies a master — a real leader in the URI with no env and no site file
+   still works).
 
 `storage_options` keys **must be lowercase**. Uppercase or mixed-case spellings
 such as `GOOSEFS_MASTER_ADDR` are rejected with an explicit error — they are
@@ -551,7 +557,7 @@ Environment variables keep the `GOOSEFS_*` form.
 
 | storage_options key | env var | Description |
 |---------------------|---------|-------------|
-| `goosefs_master_addr` | `GOOSEFS_MASTER_ADDR` | GooseFS Master address. Supports a single address (`host:port`) or comma-separated HA addresses (`addr1:port,addr2:port`). Optional if the address is provided in the URL. |
+| `goosefs_master_addr` | `GOOSEFS_MASTER_ADDR` | GooseFS Master address. Supports a single address (`host:port`) or comma-separated HA addresses (`addr1:port,addr2:port`). Optional if the address is in the URL or in `goosefs-site.properties`. |
 | `goosefs_write_type` | `GOOSEFS_WRITE_TYPE` | Write type, e.g. `MUST_CACHE`, `CACHE_THROUGH`, `THROUGH`, `ASYNC_THROUGH`. Optional. |
 | `goosefs_block_size` | `GOOSEFS_BLOCK_SIZE` | GooseFS block size (this is the GooseFS-side block size, not Lance's I/O block size). Accepts a raw byte count or GooseFS suffixes such as `64MB` (binary units: `1KB = 1024`). Optional. |
 | `goosefs_chunk_size` | `GOOSEFS_CHUNK_SIZE` | Chunk size used when reading or writing files. Accepts a raw byte count or GooseFS suffixes such as `4MB` (binary units: `1KB = 1024`). Optional. |

--- a/rust/lance-io/src/object_store/providers/goosefs.rs
+++ b/rust/lance-io/src/object_store/providers/goosefs.rs
@@ -89,6 +89,19 @@ fn site_file_has_master_addresses(path: &Path) -> bool {
     parse_properties_has_master(&content)
 }
 
+/// Parse `goosefs-site.properties` the same way goosefs-sdk 0.1.8 does, and
+/// report whether that parse would set a master from the file.
+///
+/// Syntax (SDK `PropertiesMap::parse`):
+/// - `#` / `!` comments and blank lines are skipped
+/// - separator is the first `=` if the line contains one, otherwise the first `:`
+/// - empty keys are skipped; empty values are kept so a later line can override
+/// - duplicate keys last-win
+///
+/// Master selection (SDK `into_goosefs_config`):
+/// - a non-empty `goosefs.master.rpc.addresses` list wins
+/// - otherwise `goosefs.master.hostname` if that key was present
+/// - an empty addresses value does *not* fall through to hostname
 fn parse_properties_has_master(content: &str) -> bool {
     let mut hostname: Option<&str> = None;
     let mut addresses: Option<&str> = None;
@@ -97,12 +110,15 @@ fn parse_properties_has_master(content: &str) -> bool {
         if line.is_empty() || line.starts_with('#') || line.starts_with('!') {
             continue;
         }
-        let Some((key, value)) = line.split_once('=') else {
+        // Prefer `=` when present, else `:`. Matching `find('=').or_else(find(':'))`
+        // rather than "first of either" keeps colon-form HA (`host:port` in the
+        // value) aligned with the pinned SDK parser.
+        let Some(sep_pos) = line.find('=').or_else(|| line.find(':')) else {
             continue;
         };
-        let key = key.trim();
-        let value = value.trim();
-        if value.is_empty() {
+        let key = line[..sep_pos].trim();
+        let value = line[sep_pos + 1..].trim();
+        if key.is_empty() {
             continue;
         }
         match key {
@@ -820,6 +836,24 @@ mod tests {
         );
     }
 
+    /// Colon-form HA is valid in goosefs-sdk 0.1.8 (`=` or `:`). Missing it
+    /// here would overlay the dummy URI and wipe the SDK-loaded HA list.
+    #[test]
+    #[serial(GOOSEFS_SITE_CONF)]
+    fn test_resolve_master_addr_site_ha_colon_form_suppresses_dummy_uri() {
+        with_site_properties(
+            "goosefs.master.rpc.addresses:172.31.5.10:9200,172.31.5.2:9200,172.31.5.11:9200\n",
+            || {
+                let addr = resolve(
+                    "goosefs://192.0.2.5:9999/lance-cosn/lance_qta/xxx.lance",
+                    StorageOptions(HashMap::new()),
+                )
+                .unwrap();
+                assert_eq!(addr, None);
+            },
+        );
+    }
+
     #[test]
     #[serial(GOOSEFS_SITE_CONF)]
     fn test_resolve_master_addr_site_ha_allows_uri_without_host() {
@@ -837,6 +871,19 @@ mod tests {
     #[serial(GOOSEFS_SITE_CONF)]
     fn test_resolve_master_addr_site_hostname_suppresses_uri() {
         with_site_properties("goosefs.master.hostname=goosefs-master\n", || {
+            let addr = resolve(
+                "goosefs://192.0.2.5:9999/data",
+                StorageOptions(HashMap::new()),
+            )
+            .unwrap();
+            assert_eq!(addr, None);
+        });
+    }
+
+    #[test]
+    #[serial(GOOSEFS_SITE_CONF)]
+    fn test_resolve_master_addr_site_hostname_colon_form_suppresses_uri() {
+        with_site_properties("goosefs.master.hostname:goosefs-master\n", || {
             let addr = resolve(
                 "goosefs://192.0.2.5:9999/data",
                 StorageOptions(HashMap::new()),
@@ -918,6 +965,26 @@ mod tests {
         ));
         assert!(parse_properties_has_master(
             "  goosefs.master.hostname = master.local  \n"
+        ));
+        // SDK accepts `:` as well as `=`; colon-form HA must not be missed.
+        assert!(parse_properties_has_master(
+            "goosefs.master.rpc.addresses:10.0.0.1:9200,10.0.0.2:9200\n"
+        ));
+        assert!(parse_properties_has_master(
+            "goosefs.master.hostname:goosefs-master\n"
+        ));
+        // Last-wins, including an empty later line clearing a colon-form HA list.
+        assert!(parse_properties_has_master(
+            "goosefs.master.rpc.addresses=10.0.0.9:9200\n\
+             goosefs.master.rpc.addresses:10.0.0.1:9200,10.0.0.2:9200\n"
+        ));
+        assert!(!parse_properties_has_master(
+            "goosefs.master.rpc.addresses:10.0.0.1:9200,10.0.0.2:9200\n\
+             goosefs.master.rpc.addresses=\n"
+        ));
+        // Empty addresses does not fall through to hostname (SDK if/else-if).
+        assert!(!parse_properties_has_master(
+            "goosefs.master.rpc.addresses=\ngoosefs.master.hostname=master.local\n"
         ));
     }
 

--- a/rust/lance-io/src/object_store/providers/goosefs.rs
+++ b/rust/lance-io/src/object_store/providers/goosefs.rs
@@ -2,6 +2,7 @@
 // SPDX-FileCopyrightText: Copyright The Lance Authors
 
 use std::collections::HashMap;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use opendal::{Operator, services::GooseFs};
@@ -31,6 +32,95 @@ const STORAGE_OPTION_KEYS: &[&str] = &[
     "goosefs_auth_username",
 ];
 
+/// Filename searched under `GOOSEFS_CONF_DIR` / `GOOSEFS_HOME/conf` / `~/.goosefs` / `/etc/goosefs`.
+const SITE_PROPERTIES_FILENAME: &str = "goosefs-site.properties";
+
+/// Discover `goosefs-site.properties` using the same search order as goosefs-sdk.
+///
+/// 1. `$GOOSEFS_CONFIG_FILE`
+/// 2. `$GOOSEFS_CONF_DIR/goosefs-site.properties`
+/// 3. `$GOOSEFS_HOME/conf/goosefs-site.properties`
+/// 4. `~/.goosefs/goosefs-site.properties`
+/// 5. `/etc/goosefs/goosefs-site.properties`
+fn discover_site_properties_file() -> Option<PathBuf> {
+    if let Ok(p) = std::env::var("GOOSEFS_CONFIG_FILE") {
+        let pb = PathBuf::from(p);
+        if pb.is_file() {
+            return Some(pb);
+        }
+    }
+    if let Ok(dir) = std::env::var("GOOSEFS_CONF_DIR") {
+        let p = PathBuf::from(dir).join(SITE_PROPERTIES_FILENAME);
+        if p.is_file() {
+            return Some(p);
+        }
+    }
+    if let Ok(home) = std::env::var("GOOSEFS_HOME") {
+        let p = PathBuf::from(home)
+            .join("conf")
+            .join(SITE_PROPERTIES_FILENAME);
+        if p.is_file() {
+            return Some(p);
+        }
+    }
+    if let Some(home) = std::env::var_os("HOME").or_else(|| std::env::var_os("USERPROFILE")) {
+        let p = PathBuf::from(home)
+            .join(".goosefs")
+            .join(SITE_PROPERTIES_FILENAME);
+        if p.is_file() {
+            return Some(p);
+        }
+    }
+    let system = PathBuf::from("/etc/goosefs").join(SITE_PROPERTIES_FILENAME);
+    if system.is_file() {
+        return Some(system);
+    }
+    None
+}
+
+/// True when the properties file names a master via HA list or hostname.
+///
+/// A file that exists but has neither key must *not* suppress the URI
+/// fallback, otherwise `from_properties_auto()` would dial `127.0.0.1:9200`.
+fn site_file_has_master_addresses(path: &Path) -> bool {
+    let Ok(content) = std::fs::read_to_string(path) else {
+        return false;
+    };
+    parse_properties_has_master(&content)
+}
+
+fn parse_properties_has_master(content: &str) -> bool {
+    let mut hostname: Option<&str> = None;
+    let mut addresses: Option<&str> = None;
+    for raw in content.lines() {
+        let line = raw.trim();
+        if line.is_empty() || line.starts_with('#') || line.starts_with('!') {
+            continue;
+        }
+        let Some((key, value)) = line.split_once('=') else {
+            continue;
+        };
+        let key = key.trim();
+        let value = value.trim();
+        if value.is_empty() {
+            continue;
+        }
+        match key {
+            "goosefs.master.rpc.addresses" => addresses = Some(value),
+            "goosefs.master.hostname" => hostname = Some(value),
+            _ => {}
+        }
+    }
+    if let Some(addrs) = addresses {
+        return addrs.split(',').any(|s| !s.trim().is_empty());
+    }
+    hostname.is_some()
+}
+
+fn site_properties_have_master_addresses() -> bool {
+    discover_site_properties_file().is_some_and(|path| site_file_has_master_addresses(&path))
+}
+
 /// GooseFS object store provider.
 ///
 /// Uses OpenDAL's GooseFs service to access GooseFS via gRPC.
@@ -52,7 +142,8 @@ const STORAGE_OPTION_KEYS: &[&str] = &[
 ///   yields key `k`.
 ///
 /// Supported configuration keys (via `storage_options` or environment variables,
-/// resolved with priority: `storage_options` > env var > URL authority > default).
+/// resolved with priority: `storage_options` > `GOOSEFS_MASTER_ADDR` >
+/// `goosefs.master.rpc.addresses` in `goosefs-site.properties` > URL authority).
 /// `storage_options` keys must be lowercase; uppercase/mixed-case spellings are
 /// rejected rather than silently ignored.
 ///
@@ -131,38 +222,56 @@ impl GooseFsStoreProvider {
         )))
     }
 
-    /// Resolve the GooseFS Master address from storage_options, environment, or URL.
+    /// Resolve the GooseFS Master address to pass to OpenDAL.
+    ///
+    /// Returns `Ok(Some(addr))` when Lance should set OpenDAL `master_addr`
+    /// (this *overrides* anything `from_properties_auto()` loaded from
+    /// `goosefs-site.properties`). Returns `Ok(None)` when the site file
+    /// already names masters and neither `storage_options` nor
+    /// `GOOSEFS_MASTER_ADDR` was set — OpenDAL then uses the file as-is,
+    /// so a dummy URI authority is not dialed.
     ///
     /// Priority:
     /// 1. `storage_options["goosefs_master_addr"]` (supports HA: "addr1:port,addr2:port")
     /// 2. `GOOSEFS_MASTER_ADDR` environment variable
-    /// 3. URL authority (host:port from the URL)
-    fn resolve_master_addr(url: &Url, storage_options: &StorageOptions) -> Result<String> {
+    /// 3. `goosefs.master.rpc.addresses` / `goosefs.master.hostname` in the
+    ///    discovered `goosefs-site.properties` (`Ok(None)` — do not overlay)
+    /// 4. URL authority (host:port from the URL)
+    fn resolve_master_addr(url: &Url, storage_options: &StorageOptions) -> Result<Option<String>> {
         // 1. storage_options
         if let Some(addr) = storage_options
             .0
             .get("goosefs_master_addr")
             .filter(|v| !v.is_empty())
         {
-            return Ok(addr.clone());
+            return Ok(Some(addr.clone()));
         }
 
         // 2. Environment variable
         if let Ok(addr) = std::env::var("GOOSEFS_MASTER_ADDR")
             && !addr.is_empty()
         {
-            return Ok(addr);
+            return Ok(Some(addr));
         }
 
-        // 3. URL authority
+        // 3. Site properties already name a master. Leave OpenDAL's
+        // `from_properties_auto()` overlay empty so HA from the file wins
+        // over a dummy `goosefs://192.0.2.5:9999/...` URI.
+        if site_properties_have_master_addresses() {
+            return Ok(None);
+        }
+
+        // 4. URL authority — required when nothing else supplied a master.
         let host = url.host_str().ok_or_else(|| {
             Error::invalid_input(
-                "GooseFS URL must contain a master address (host), e.g. goosefs://host:port/path",
+                "GooseFS URL must contain a master address (host), e.g. goosefs://host:port/path, \
+                 or set goosefs_master_addr / GOOSEFS_MASTER_ADDR / \
+                 goosefs.master.rpc.addresses in goosefs-site.properties",
             )
         })?;
 
         let port = url.port().unwrap_or(DEFAULT_GOOSEFS_PORT);
-        Ok(format!("{}:{}", host, port))
+        Ok(Some(format!("{}:{}", host, port)))
     }
 
     /// Resolve a storage option from storage_options or environment variable.
@@ -389,17 +498,18 @@ impl ObjectStoreProvider for GooseFsStoreProvider {
 
         Self::validate_storage_option_keys(&storage_options)?;
 
-        // Resolve master address
-        let master_addr = Self::resolve_master_addr(&base_path, &storage_options)?;
-
         // Resolve a stable cluster-wide root. The URL path is *not* used here
         // because it varies per dataset; per-request keys are supplied by
         // `extract_path` instead.
         let root = Self::resolve_root(&storage_options);
 
-        // Build OpenDAL config map
+        // Build OpenDAL config map. `master_addr` is omitted when site
+        // properties already name masters so OpenDAL `from_properties_auto()`
+        // keeps HA instead of dialing a dummy URI authority.
         let mut config_map: HashMap<String, String> = HashMap::new();
-        config_map.insert("master_addr".to_string(), master_addr);
+        if let Some(master_addr) = Self::resolve_master_addr(&base_path, &storage_options)? {
+            config_map.insert("master_addr".to_string(), master_addr);
+        }
         config_map.insert("root".to_string(), root);
 
         // Optional: write_type
@@ -500,6 +610,29 @@ impl ObjectStoreProvider for GooseFsStoreProvider {
 mod tests {
     use super::*;
     use rstest::rstest;
+    use serial_test::serial;
+
+    /// Point `GOOSEFS_CONFIG_FILE` at a temp properties file so discovery
+    /// does not pick up `~/.goosefs` / `/etc/goosefs` from the host.
+    fn with_site_properties(contents: &str, f: impl FnOnce()) {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join(SITE_PROPERTIES_FILENAME);
+        std::fs::write(&path, contents).unwrap();
+        unsafe {
+            std::env::set_var("GOOSEFS_CONFIG_FILE", &path);
+            std::env::remove_var("GOOSEFS_MASTER_ADDR");
+            std::env::remove_var("GOOSEFS_CONF_DIR");
+            std::env::remove_var("GOOSEFS_HOME");
+        }
+        f();
+        unsafe {
+            std::env::remove_var("GOOSEFS_CONFIG_FILE");
+        }
+    }
+
+    fn resolve(url: &str, opts: StorageOptions) -> Result<Option<String>> {
+        GooseFsStoreProvider::resolve_master_addr(&Url::parse(url).unwrap(), &opts)
+    }
 
     #[test]
     fn test_goosefs_extract_path_basic() {
@@ -610,30 +743,182 @@ mod tests {
     }
 
     #[test]
+    #[serial(GOOSEFS_SITE_CONF)]
     fn test_resolve_master_addr_from_url() {
-        let url = Url::parse("goosefs://10.0.0.1:9200/data").unwrap();
-        let storage_options = StorageOptions(HashMap::new());
-        let addr = GooseFsStoreProvider::resolve_master_addr(&url, &storage_options).unwrap();
-        assert_eq!(addr, "10.0.0.1:9200");
+        with_site_properties("", || {
+            let addr = resolve(
+                "goosefs://10.0.0.1:9200/data",
+                StorageOptions(HashMap::new()),
+            )
+            .unwrap();
+            assert_eq!(addr.as_deref(), Some("10.0.0.1:9200"));
+        });
     }
 
     #[test]
+    #[serial(GOOSEFS_SITE_CONF)]
     fn test_resolve_master_addr_default_port() {
-        let url = Url::parse("goosefs://10.0.0.1/data").unwrap();
-        let storage_options = StorageOptions(HashMap::new());
-        let addr = GooseFsStoreProvider::resolve_master_addr(&url, &storage_options).unwrap();
-        assert_eq!(addr, "10.0.0.1:9200");
+        with_site_properties("", || {
+            let addr = resolve("goosefs://10.0.0.1/data", StorageOptions(HashMap::new())).unwrap();
+            assert_eq!(addr.as_deref(), Some("10.0.0.1:9200"));
+        });
     }
 
     #[test]
+    #[serial(GOOSEFS_SITE_CONF)]
     fn test_resolve_master_addr_from_storage_options() {
-        let url = Url::parse("goosefs://10.0.0.1:9200/data").unwrap();
-        let storage_options = StorageOptions(HashMap::from([(
-            "goosefs_master_addr".to_string(),
-            "10.0.0.2:9200,10.0.0.3:9200".to_string(),
-        )]));
-        let addr = GooseFsStoreProvider::resolve_master_addr(&url, &storage_options).unwrap();
-        assert_eq!(addr, "10.0.0.2:9200,10.0.0.3:9200");
+        with_site_properties(
+            "goosefs.master.rpc.addresses=10.0.0.9:9200,10.0.0.8:9200\n",
+            || {
+                let storage_options = StorageOptions(HashMap::from([(
+                    "goosefs_master_addr".to_string(),
+                    "10.0.0.2:9200,10.0.0.3:9200".to_string(),
+                )]));
+                let addr = resolve("goosefs://10.0.0.1:9200/data", storage_options).unwrap();
+                assert_eq!(addr.as_deref(), Some("10.0.0.2:9200,10.0.0.3:9200"));
+            },
+        );
+    }
+
+    #[test]
+    #[serial(GOOSEFS_SITE_CONF)]
+    fn test_resolve_master_addr_env_beats_uri_and_site() {
+        with_site_properties(
+            "goosefs.master.rpc.addresses=10.0.0.9:9200,10.0.0.8:9200\n",
+            || {
+                unsafe {
+                    std::env::set_var("GOOSEFS_MASTER_ADDR", "10.0.0.7:9200,10.0.0.6:9200");
+                }
+                let addr = resolve(
+                    "goosefs://192.0.2.5:9999/data",
+                    StorageOptions(HashMap::new()),
+                )
+                .unwrap();
+                unsafe {
+                    std::env::remove_var("GOOSEFS_MASTER_ADDR");
+                }
+                assert_eq!(addr.as_deref(), Some("10.0.0.7:9200,10.0.0.6:9200"));
+            },
+        );
+    }
+
+    /// Ticket: dummy URI + empty storage_options + site HA must not overlay
+    /// OpenDAL `master_addr` (OpenDAL then keeps `from_properties_auto()`).
+    #[test]
+    #[serial(GOOSEFS_SITE_CONF)]
+    fn test_resolve_master_addr_site_ha_suppresses_dummy_uri() {
+        with_site_properties(
+            "goosefs.master.rpc.addresses=172.31.5.10:9200,172.31.5.2:9200,172.31.5.11:9200\n",
+            || {
+                let addr = resolve(
+                    "goosefs://192.0.2.5:9999/lance-cosn/lance_qta/xxx.lance",
+                    StorageOptions(HashMap::new()),
+                )
+                .unwrap();
+                assert_eq!(addr, None);
+            },
+        );
+    }
+
+    #[test]
+    #[serial(GOOSEFS_SITE_CONF)]
+    fn test_resolve_master_addr_site_ha_allows_uri_without_host() {
+        with_site_properties(
+            "goosefs.master.rpc.addresses=10.0.0.1:9200,10.0.0.2:9200\n",
+            || {
+                let addr =
+                    resolve("goosefs:///data/ds.lance", StorageOptions(HashMap::new())).unwrap();
+                assert_eq!(addr, None);
+            },
+        );
+    }
+
+    #[test]
+    #[serial(GOOSEFS_SITE_CONF)]
+    fn test_resolve_master_addr_site_hostname_suppresses_uri() {
+        with_site_properties("goosefs.master.hostname=goosefs-master\n", || {
+            let addr = resolve(
+                "goosefs://192.0.2.5:9999/data",
+                StorageOptions(HashMap::new()),
+            )
+            .unwrap();
+            assert_eq!(addr, None);
+        });
+    }
+
+    #[test]
+    #[serial(GOOSEFS_SITE_CONF)]
+    fn test_resolve_master_addr_empty_site_file_keeps_real_uri() {
+        with_site_properties(
+            "# no master keys\ngoosefs.user.block.size.bytes.default=4MB\n",
+            || {
+                let addr = resolve(
+                    "goosefs://10.0.0.1:9200/data",
+                    StorageOptions(HashMap::new()),
+                )
+                .unwrap();
+                assert_eq!(addr.as_deref(), Some("10.0.0.1:9200"));
+            },
+        );
+    }
+
+    #[test]
+    #[serial(GOOSEFS_SITE_CONF)]
+    fn test_resolve_master_addr_no_host_without_site_errors() {
+        with_site_properties("", || {
+            let err =
+                resolve("goosefs:///data/ds.lance", StorageOptions(HashMap::new())).unwrap_err();
+            let msg = err.to_string();
+            assert!(msg.contains("must contain a master address"), "got: {msg}");
+        });
+    }
+
+    #[test]
+    #[serial(GOOSEFS_SITE_CONF)]
+    fn test_discover_site_properties_via_conf_dir() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join(SITE_PROPERTIES_FILENAME);
+        std::fs::write(
+            &path,
+            "goosefs.master.rpc.addresses=10.0.0.1:9200,10.0.0.2:9200\n",
+        )
+        .unwrap();
+        unsafe {
+            std::env::remove_var("GOOSEFS_CONFIG_FILE");
+            std::env::remove_var("GOOSEFS_MASTER_ADDR");
+            std::env::remove_var("GOOSEFS_HOME");
+            std::env::set_var("GOOSEFS_CONF_DIR", dir.path());
+        }
+
+        let addr = resolve(
+            "goosefs://192.0.2.5:9999/data",
+            StorageOptions(HashMap::new()),
+        )
+        .unwrap();
+        unsafe {
+            std::env::remove_var("GOOSEFS_CONF_DIR");
+        }
+        assert_eq!(addr, None);
+    }
+
+    #[test]
+    fn test_parse_properties_has_master_ignores_comments_and_empty() {
+        assert!(!parse_properties_has_master(""));
+        assert!(!parse_properties_has_master(
+            "# goosefs.master.rpc.addresses=a:9200\n"
+        ));
+        assert!(!parse_properties_has_master(
+            "goosefs.master.rpc.addresses=\n"
+        ));
+        assert!(!parse_properties_has_master(
+            "goosefs.master.rpc.addresses=   ,  \n"
+        ));
+        assert!(parse_properties_has_master(
+            "goosefs.master.rpc.addresses=10.0.0.1:9200,10.0.0.2:9200\n"
+        ));
+        assert!(parse_properties_has_master(
+            "  goosefs.master.hostname = master.local  \n"
+        ));
     }
 
     #[test]


### PR DESCRIPTION
Do not overlay OpenDAL `master_addr` from the URL when site properties already name masters, so dummy `goosefs://` URIs still use the HA list. Keep URI fallback when no env, `storage_options`, or site master is set.

## Problem

`GooseFsStoreProvider` always copied the URI authority into OpenDAL `master_addr` (`Operator::from_iter`). OpenDAL then overwrote whatever `from_properties_auto()` loaded from `goosefs-site.properties`.

Ticket repro (`storage_options={}`, `GOOSEFS_MASTER_ADDR` unset):

- `GOOSEFS_CONFIG_FILE` has `goosefs.master.rpc.addresses=172.31.5.10:9200,...`
- URI `goosefs://192.0.2.5:9999/lance-cosn/...`
- Client dialed `192.0.2.5:9999` instead of the HA list.

A real leader in the URI with **no** site file and **no** env must keep working (`goosefs://leader:9200/path`). Dropping URI unconditionally would fall through to OpenDAL's default `127.0.0.1:9200`.

## Resolution order (after)

1. `storage_options["goosefs_master_addr"]`
2. `GOOSEFS_MASTER_ADDR`
3. `goosefs.master.rpc.addresses` / `goosefs.master.hostname` in discovered `goosefs-site.properties` (`GOOSEFS_CONFIG_FILE` → `GOOSEFS_CONF_DIR` → `GOOSEFS_HOME/conf` → `~/.goosefs` → `/etc/goosefs`) — **do not set** OpenDAL `master_addr`
4. URI authority

A site file that exists but has **no** master keys does not suppress URI fallback.

```mermaid
flowchart TD
    start([resolve_master_addr]) --> so{"storage_options goosefs_master_addr set?"}
    so -->|yes| overlay[return Some addr — OpenDAL overlay]
    so -->|no| env{"GOOSEFS_MASTER_ADDR set?"}
    env -->|yes| overlay
    env -->|no| site{"site.properties has rpc.addresses or hostname?"}
    site -->|yes| none["return None — OpenDAL keeps from_properties_auto HA"]
    site -->|no| uri{"URI has host?"}
    uri -->|yes| overlayUri[return Some host:port]
    uri -->|no| err[error: need host, env, or site master]
```

## Matrix (`storage_options` empty)

**No site.properties / no master keys in the file**

| URI | `GOOSEFS_MASTER_ADDR` | Must connect to | Before | After |
|-----|----------------------|-----------------|--------|-------|
| Real leader | unset | URI | URI, OK | URI, OK |
| Real leader | set | env | env, OK | env, OK |
| dummy `192.0.2.5:9999` | unset | nowhere | dummy, fail | dummy, fail |
| dummy | set | env | env, OK | env, OK |
| no host `goosefs:///path` | set | env | env, OK | env, OK |
| no host | unset | nowhere | require host | require host |

**Site file has `goosefs.master.rpc.addresses` (or hostname)**

| URI | `GOOSEFS_MASTER_ADDR` | Must connect to | Before | After |
|-----|----------------------|-----------------|--------|-------|
| dummy | unset | site HA | dialed dummy **(ticket)** | site HA |
| dummy | set | env | env, OK | env, OK |
| real leader | unset | site HA (inquire) | URI only | site HA |
| real leader | set | env | env, OK | env, OK |
| no host | unset | site HA | required host **(same class)** | site HA |
| no host | set | env | env, OK | env, OK |

## Test plan

- [x] `cargo fmt -p lance-io -- --check`
- [x] `cargo check -p lance-io --features goosefs --all-targets`
- [x] `cargo test -p lance-io --features goosefs --lib providers::goosefs` (55 passed)

Includes ticket dummy URI + site HA, real URI with empty site file, env over site, `GOOSEFS_CONF_DIR`, and host-less URI with/without site masters.