### PR TITLE
fix: honor nested projections in the mem-wal LSM scanner

### DIFF
--- a/java/lance-jni/src/mem_wal.rs
+++ b/java/lance-jni/src/mem_wal.rs
@@ -775,7 +775,7 @@ fn inner_create_lookup_planner(
     };
     let base_schema = Arc::new(ArrowSchema::from(dataset.schema()));
     let collector = LsmDataSourceCollector::new(dataset, snapshots);
-    let planner = LsmPointLookupPlanner::new(collector, pk_columns.clone(), base_schema.clone());
+    let planner = LsmPointLookupPlanner::new(collector, pk_columns.clone(), base_schema.clone())?;
 
     let blocking = BlockingLsmPointLookupPlanner {
         planner,

--- a/python/src/mem_wal.rs
+++ b/python/src/mem_wal.rs
@@ -727,7 +727,8 @@ impl PyLsmPointLookupPlanner {
         };
         let base_schema = Arc::new(ArrowSchema::from(ds.schema()));
         let collector = LsmDataSourceCollector::new(ds.clone(), snapshots);
-        let planner = LsmPointLookupPlanner::new(collector, pk_cols.clone(), base_schema.clone());
+        let planner = LsmPointLookupPlanner::new(collector, pk_cols.clone(), base_schema.clone())
+            .map_err(|e| PyIOError::new_err(e.to_string()))?;
         Ok(Self {
             planner,
             dataset_schema: base_schema,

--- a/rust/lance/benches/mem_wal/kv/mem_wal_kv_point_lookup.rs
+++ b/rust/lance/benches/mem_wal/kv/mem_wal_kv_point_lookup.rs
@@ -884,6 +884,7 @@ async fn run_lance(
     }
     let planner = Arc::new(
         LsmPointLookupPlanner::new(collector, vec![KEY_COL.to_string()], arrow_schema)
+            .unwrap()
             .with_session(dataset.session())
             .with_sstable_cache(sstable_cache),
     );

--- a/rust/lance/benches/mem_wal/point_lookup/mem_wal_point_lookup_bench.rs
+++ b/rust/lance/benches/mem_wal/point_lookup/mem_wal_point_lookup_bench.rs
@@ -411,7 +411,7 @@ async fn run_lookup(args: &Args) -> Result<serde_json::Value> {
     let collector = LsmDataSourceCollector::new(dataset.clone(), vec![shard_snapshot])
         .with_active_memtable(shard_id, active_ref);
     let pk_columns = vec!["id".to_string()];
-    let planner = LsmPointLookupPlanner::new(collector, pk_columns, arrow_schema);
+    let planner = LsmPointLookupPlanner::new(collector, pk_columns, arrow_schema).unwrap();
 
     // Generate lookup IDs for each category
     let (id_groups, category_names) = generate_lookup_ids(

--- a/rust/lance/src/dataset/mem_wal/memtable/scanner/builder.rs
+++ b/rust/lance/src/dataset/mem_wal/memtable/scanner/builder.rs
@@ -13,6 +13,7 @@ use datafusion::physical_plan::{ExecutionPlan, SendableRecordBatchStream};
 use datafusion::prelude::{Expr, SessionContext};
 use datafusion_physical_expr::PhysicalExprRef;
 use futures::TryStreamExt;
+use lance_core::datatypes::{Schema as LanceSchema, parse_field_path};
 use lance_core::{Error, ROW_ID, Result};
 use lance_datafusion::expr::safe_coerce_scalar;
 use lance_datafusion::planner::Planner;
@@ -929,21 +930,10 @@ impl MemTableScanner {
     ///
     /// If `with_row_id` is true, adds `_rowid` column at the end.
     /// If `with_row_address` is true, adds `_rowaddr` column at the end.
-    pub fn output_schema(&self) -> SchemaRef {
+    pub fn output_schema(&self) -> Result<SchemaRef> {
         use super::exec::ROW_ADDRESS_COLUMN;
 
-        let mut fields: Vec<Field> = if let Some(ref projection) = self.projection {
-            projection
-                .iter()
-                .filter_map(|name| self.schema.field_with_name(name).ok().cloned())
-                .collect()
-        } else {
-            self.schema
-                .fields()
-                .iter()
-                .map(|f| f.as_ref().clone())
-                .collect()
-        };
+        let mut fields: Vec<Field> = self.projected_data_fields()?;
 
         // Add _rowid column if requested
         if self.with_row_id {
@@ -955,25 +945,36 @@ impl MemTableScanner {
             fields.push(Field::new(ROW_ADDRESS_COLUMN, DataType::UInt64, true));
         }
 
-        Arc::new(arrow_schema::Schema::new(fields))
+        Ok(Arc::new(arrow_schema::Schema::new(fields)))
     }
 
     /// Get the base output schema after projection, WITHOUT special columns like _rowid.
     /// This is used by index execs that add their own special columns.
-    fn base_output_schema(&self) -> SchemaRef {
-        let fields: Vec<Field> = if let Some(ref projection) = self.projection {
-            projection
-                .iter()
-                .filter_map(|name| self.schema.field_with_name(name).ok().cloned())
-                .collect()
-        } else {
-            self.schema
+    fn base_output_schema(&self) -> Result<SchemaRef> {
+        Ok(Arc::new(arrow_schema::Schema::new(
+            self.projected_data_fields()?,
+        )))
+    }
+
+    /// Data columns this scan emits, with nested paths narrowed to the leaves
+    /// they select — a projected `meta.a` yields `meta: Struct<a>`.
+    ///
+    /// An unresolvable column is an error here, matching
+    /// [`Self::compute_projection_indices`]; both used to disagree, one
+    /// silently dropping what the other rejected.
+    fn projected_data_fields(&self) -> Result<Vec<Field>> {
+        let Some(ref projection) = self.projection else {
+            return Ok(self
+                .schema
                 .fields()
                 .iter()
                 .map(|f| f.as_ref().clone())
-                .collect()
+                .collect());
         };
-        Arc::new(arrow_schema::Schema::new(fields))
+        let lance_schema = LanceSchema::try_from(self.schema.as_ref())?;
+        let projected = lance_schema.project(projection)?;
+        let arrow = arrow_schema::Schema::from(&projected);
+        Ok(arrow.fields().iter().map(|f| f.as_ref().clone()).collect())
     }
 
     /// Create the execution plan based on the query configuration.
@@ -1025,7 +1026,7 @@ impl MemTableScanner {
             self.batch_store.clone(),
             self.readable_count,
             projection_indices,
-            self.output_schema(),
+            self.output_schema()?,
             self.schema.clone(),
             self.with_row_id,
             self.with_row_address,
@@ -1087,7 +1088,7 @@ impl MemTableScanner {
             self.batch_store.clone(),
             self.readable_count,
             projection_indices,
-            self.output_schema(),
+            self.output_schema()?,
             pk_indices,
             self.with_row_id,
             self.with_row_address,
@@ -1117,7 +1118,7 @@ impl MemTableScanner {
             predicate.clone(),
             max_readable,
             projection_indices,
-            self.output_schema(),
+            self.output_schema()?,
             self.with_row_id,
             self.with_row_address,
         )?;
@@ -1149,7 +1150,7 @@ impl MemTableScanner {
     async fn plan_vector_search(&self, query: &VectorQuery) -> Result<Arc<dyn ExecutionPlan>> {
         let max_readable = self.readable_count;
         let projection_indices = self.compute_projection_indices()?;
-        let base_schema = self.base_output_schema();
+        let base_schema = self.base_output_schema()?;
         let filter_predicate = self.filter_predicate()?;
         if let Some(pk_columns) = &self.pk_columns {
             validate_pk_types(&self.schema, pk_columns)?;
@@ -1227,7 +1228,7 @@ impl MemTableScanner {
             query.clone(),
             max_readable,
             projection_indices,
-            self.base_output_schema(),
+            self.base_output_schema()?,
             self.with_row_id,
         )?
         .with_filter(filter_predicate)
@@ -1242,7 +1243,7 @@ impl MemTableScanner {
         use datafusion::physical_plan::empty::EmptyExec;
 
         let mut fields: Vec<Field> = self
-            .base_output_schema()
+            .base_output_schema()?
             .fields()
             .iter()
             .map(|f| f.as_ref().clone())
@@ -1277,23 +1278,30 @@ impl MemTableScanner {
     }
 
     /// Compute column indices for projection.
+    /// Top-level column indices this scan must materialize.
+    ///
+    /// A nested path contributes its *parent* index — the memtable batch stores
+    /// whole columns, so `meta.a` is served by taking `meta` and narrowing it
+    /// to [`Self::projected_data_fields`] downstream. Sibling leaves of one
+    /// parent therefore collapse to a single index.
     fn compute_projection_indices(&self) -> Result<Option<Vec<usize>>> {
-        if let Some(ref columns) = self.projection {
-            let indices: Result<Vec<usize>> = columns
-                .iter()
-                .map(|name| {
-                    self.schema
-                        .column_with_name(name)
-                        .map(|(idx, _)| idx)
-                        .ok_or_else(|| {
-                            Error::invalid_input(format!("Column '{}' not found in schema", name))
-                        })
-                })
-                .collect();
-            Ok(Some(indices?))
-        } else {
-            Ok(None)
+        let Some(ref columns) = self.projection else {
+            return Ok(None);
+        };
+        let mut indices: Vec<usize> = Vec::with_capacity(columns.len());
+        for name in columns {
+            let top = parse_field_path(name)?
+                .into_iter()
+                .next()
+                .ok_or_else(|| Error::invalid_input(format!("empty projection name: {}", name)))?;
+            let (idx, _) = self.schema.column_with_name(&top).ok_or_else(|| {
+                Error::invalid_input(format!("Column '{}' not found in schema", name))
+            })?;
+            if !indices.contains(&idx) {
+                indices.push(idx);
+            }
         }
+        Ok(Some(indices))
     }
 
     /// Collect `col = lit OR col IN (lit, ..) OR ..` over one column into its
@@ -1607,6 +1615,76 @@ mod tests {
         let result = scanner.try_into_batch().await.unwrap();
         assert_eq!(result.num_columns(), 1);
         assert_eq!(result.schema().field(0).name(), "id");
+    }
+
+    /// `meta: Struct<a, b>` beside a flat column, for nested projection.
+    fn nested_test_schema() -> SchemaRef {
+        use arrow_schema::Fields;
+        Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int32, false),
+            Field::new(
+                "meta",
+                DataType::Struct(Fields::from(vec![
+                    Field::new("a", DataType::Int64, true),
+                    Field::new("b", DataType::Utf8, true),
+                ])),
+                true,
+            ),
+        ]))
+    }
+
+    #[tokio::test]
+    async fn projecting_a_struct_leaf_narrows_the_memtable_output() {
+        use arrow_array::{Int64Array, StructArray};
+        use arrow_schema::Fields;
+
+        let schema = nested_test_schema();
+        let meta_fields = Fields::from(vec![
+            Field::new("a", DataType::Int64, true),
+            Field::new("b", DataType::Utf8, true),
+        ]);
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(Int32Array::from(vec![1, 2])),
+                Arc::new(StructArray::new(
+                    meta_fields,
+                    vec![
+                        Arc::new(Int64Array::from(vec![10, 20])),
+                        Arc::new(StringArray::from(vec!["x", "y"])),
+                    ],
+                    None,
+                )),
+            ],
+        )
+        .unwrap();
+
+        let batch_store = Arc::new(BatchStore::with_capacity(8));
+        batch_store.append(batch.clone()).unwrap();
+        // Publishing through the index store is what makes the batch readable.
+        let index_store = IndexStore::new();
+        index_store
+            .insert_with_batch_position(&batch, 0, Some(0))
+            .unwrap();
+        let indexes = Arc::new(index_store);
+
+        let mut scanner = MemTableScanner::new(batch_store, indexes, schema);
+        scanner.project(&["meta.a"]).unwrap();
+        let result = scanner.try_into_batch().await.unwrap();
+
+        assert_eq!(result.num_rows(), 2);
+        assert_eq!(result.num_columns(), 1);
+        let field = result.schema().field(0).clone();
+        assert_eq!(field.name(), "meta");
+        let DataType::Struct(children) = field.data_type() else {
+            panic!("meta is not a struct: {:?}", field.data_type());
+        };
+        let names: Vec<&str> = children.iter().map(|f| f.name().as_str()).collect();
+        assert_eq!(
+            names,
+            vec!["a"],
+            "sibling `b` must not survive the projection"
+        );
     }
 
     /// The index fast path is chosen from the filter the caller set, which has not
@@ -2339,7 +2417,7 @@ mod tests {
         scanner.with_row_id();
 
         // Verify output schema includes _rowid
-        let output_schema = scanner.output_schema();
+        let output_schema = scanner.output_schema().unwrap();
         assert_eq!(output_schema.fields().len(), 3);
         assert_eq!(output_schema.field(0).name(), "id");
         assert_eq!(output_schema.field(1).name(), "name");
@@ -2375,7 +2453,7 @@ mod tests {
         scanner.project(&["id", "_rowid"]).unwrap();
 
         // Verify output schema
-        let output_schema = scanner.output_schema();
+        let output_schema = scanner.output_schema().unwrap();
         assert_eq!(output_schema.fields().len(), 2);
         assert_eq!(output_schema.field(0).name(), "id");
         assert_eq!(output_schema.field(1).name(), "_rowid");
@@ -2422,13 +2500,13 @@ mod tests {
         let mut scanner = MemTableScanner::new(batch_store, indexes, schema);
 
         // Without with_row_id, schema should not include _rowid
-        let output_schema = scanner.output_schema();
+        let output_schema = scanner.output_schema().unwrap();
         assert_eq!(output_schema.fields().len(), 2);
         assert!(output_schema.field_with_name("_rowid").is_err());
 
         // With with_row_id, schema should include _rowid
         scanner.with_row_id();
-        let output_schema = scanner.output_schema();
+        let output_schema = scanner.output_schema().unwrap();
         assert_eq!(output_schema.fields().len(), 3);
         assert!(output_schema.field_with_name("_rowid").is_ok());
     }
@@ -2451,7 +2529,7 @@ mod tests {
         assert_eq!(scanner.projection, Some(vec!["id".to_string()]));
 
         // Output schema should include _rowid at the end
-        let output_schema = scanner.output_schema();
+        let output_schema = scanner.output_schema().unwrap();
         assert_eq!(output_schema.fields().len(), 2);
         assert_eq!(output_schema.field(0).name(), "id");
         assert_eq!(output_schema.field(1).name(), "_rowid");
@@ -2534,13 +2612,13 @@ mod tests {
         let mut scanner = MemTableScanner::new(batch_store, indexes, schema);
 
         // Without with_row_address, schema should not include _rowaddr
-        let output_schema = scanner.output_schema();
+        let output_schema = scanner.output_schema().unwrap();
         assert_eq!(output_schema.fields().len(), 2);
         assert!(output_schema.field_with_name("_rowaddr").is_err());
 
         // With with_row_address, schema should include _rowaddr
         scanner.with_row_address();
-        let output_schema = scanner.output_schema();
+        let output_schema = scanner.output_schema().unwrap();
         assert_eq!(output_schema.fields().len(), 3);
         assert!(output_schema.field_with_name("_rowaddr").is_ok());
     }
@@ -2556,7 +2634,7 @@ mod tests {
         scanner.with_row_address();
 
         // Verify output schema includes _rowaddr
-        let output_schema = scanner.output_schema();
+        let output_schema = scanner.output_schema().unwrap();
         assert_eq!(output_schema.fields().len(), 3);
         assert_eq!(output_schema.field(0).name(), "id");
         assert_eq!(output_schema.field(1).name(), "name");
@@ -2615,7 +2693,7 @@ mod tests {
         scanner.with_row_address();
 
         // Verify output schema includes both _rowid and _rowaddr
-        let output_schema = scanner.output_schema();
+        let output_schema = scanner.output_schema().unwrap();
         assert_eq!(output_schema.fields().len(), 4);
         assert_eq!(output_schema.field(2).name(), "_rowid");
         assert_eq!(output_schema.field(3).name(), "_rowaddr");

--- a/rust/lance/src/dataset/mem_wal/memtable/scanner/exec.rs
+++ b/rust/lance/src/dataset/mem_wal/memtable/scanner/exec.rs
@@ -11,10 +11,13 @@
 //! - `FtsIndexExec` - Full-text search
 
 use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
 
-use arrow_array::RecordBatch;
+use arrow_array::{ArrayRef, RecordBatch, RecordBatchOptions};
+use arrow_schema::{Fields, Schema};
 use datafusion::common::ScalarValue;
-use datafusion::error::Result as DataFusionResult;
+use datafusion::error::{DataFusionError, Result as DataFusionResult};
+use lance_arrow::RecordBatchExt;
 
 mod brute_force_vector;
 mod btree;
@@ -32,6 +35,47 @@ pub use dedup_scan::MemTableDedupScanExec;
 pub use fts::{FtsIndexExec, SCORE_COLUMN};
 pub use scan::{MemTableScanExec, ROW_ADDRESS_COLUMN};
 pub use vector::VectorIndexExec;
+
+/// Take `indices` out of `source_columns` and trim each to the shape
+/// `output_schema` promises for that column name.
+///
+/// A projected struct leaf (`meta.a`) is served by taking the whole `meta`
+/// column — the memtable stores columns whole — and narrowing it here.
+/// `project_by_schema` recurses through structs, lists and maps and preserves
+/// null buffers. Columns whose type already matches are passed through
+/// untouched, so a projection with no nested paths costs nothing.
+pub(super) fn take_projected_columns(
+    source_columns: &[ArrayRef],
+    source_fields: &Fields,
+    indices: &[usize],
+    output_schema: &Schema,
+    num_rows: usize,
+) -> DataFusionResult<Vec<ArrayRef>> {
+    let mut out = Vec::with_capacity(indices.len());
+    for &i in indices {
+        let field = &source_fields[i];
+        let column = source_columns[i].clone();
+        let Ok(target) = output_schema.field_with_name(field.name()) else {
+            out.push(column);
+            continue;
+        };
+        if target.data_type() == field.data_type() {
+            out.push(column);
+            continue;
+        }
+        let src = RecordBatch::try_new_with_options(
+            Arc::new(Schema::new(vec![field.clone()])),
+            vec![column],
+            &RecordBatchOptions::new().with_row_count(Some(num_rows)),
+        )
+        .map_err(DataFusionError::from)?;
+        let narrowed = src
+            .project_by_schema(&Schema::new(vec![Arc::new(target.clone())]))
+            .map_err(|e| DataFusionError::External(Box::new(e)))?;
+        out.push(narrowed.column(0).clone());
+    }
+    Ok(out)
+}
 
 pub(super) fn newest_pk_positions(
     batch_store: &BatchStore,

--- a/rust/lance/src/dataset/mem_wal/memtable/scanner/exec/brute_force_vector.rs
+++ b/rust/lance/src/dataset/mem_wal/memtable/scanner/exec/brute_force_vector.rs
@@ -34,6 +34,7 @@ use lance_linalg::distance::DistanceType;
 use super::super::builder::VectorQuery;
 use super::newest_pk_positions;
 use super::vector::DISTANCE_COLUMN;
+use crate::dataset::mem_wal::memtable::scanner::exec::take_projected_columns;
 use crate::dataset::mem_wal::write::BatchStore;
 
 /// Distance metric used when [`VectorQuery::distance_type`] is `None`. The
@@ -373,9 +374,15 @@ impl MemTableBruteForceVectorExec {
 
                 columns.push(Arc::new(Float32Array::from(distances)));
 
+                let source_schema = stored.data.schema();
                 let mut final_columns = if let Some(ref proj_indices) = self.projection {
-                    let mut projected: Vec<_> =
-                        proj_indices.iter().map(|&i| columns[i].clone()).collect();
+                    let mut projected: Vec<_> = take_projected_columns(
+                        &columns,
+                        source_schema.fields(),
+                        proj_indices,
+                        self.output_schema.as_ref(),
+                        row_positions.len(),
+                    )?;
                     // Distance was just pushed onto `columns`; keep it last.
                     projected.push(columns.last().unwrap().clone());
                     projected

--- a/rust/lance/src/dataset/mem_wal/memtable/scanner/exec/btree.rs
+++ b/rust/lance/src/dataset/mem_wal/memtable/scanner/exec/btree.rs
@@ -23,6 +23,7 @@ use futures::stream::{self, StreamExt};
 use lance_core::{Error, Result};
 
 use super::super::builder::ScalarPredicate;
+use crate::dataset::mem_wal::memtable::scanner::exec::take_projected_columns;
 use crate::dataset::mem_wal::write::{BatchStore, IndexStore};
 
 /// ExecutionPlan node that queries BTree index with visibility filtering.
@@ -256,9 +257,16 @@ impl BTreeIndexExec {
                 let columns = columns?;
 
                 // Apply projection
+                let source_schema = stored.data.schema();
                 let mut final_columns: Vec<Arc<dyn arrow_array::Array>> =
                     if let Some(ref proj_indices) = self.projection {
-                        proj_indices.iter().map(|&i| columns[i].clone()).collect()
+                        take_projected_columns(
+                            &columns,
+                            source_schema.fields(),
+                            proj_indices,
+                            self.output_schema.as_ref(),
+                            row_positions.len(),
+                        )?
                     } else {
                         columns
                     };

--- a/rust/lance/src/dataset/mem_wal/memtable/scanner/exec/dedup_scan.rs
+++ b/rust/lance/src/dataset/mem_wal/memtable/scanner/exec/dedup_scan.rs
@@ -36,6 +36,7 @@ use datafusion::prelude::Expr;
 use datafusion_physical_expr::{EquivalenceProperties, PhysicalExprRef};
 use futures::stream::{self, StreamExt};
 
+use crate::dataset::mem_wal::memtable::scanner::exec::take_projected_columns;
 use crate::dataset::mem_wal::scanner::exec::compute_pk_hash;
 use crate::dataset::mem_wal::write::BatchStore;
 
@@ -247,8 +248,21 @@ impl ExecutionPlan for MemTableDedupScanExec {
                 vec![]
             };
 
+            let emitted_schema = emitted.schema();
             let mut columns: Vec<Arc<dyn Array>> = if let Some(ref indices) = projection {
-                indices.iter().map(|&i| emitted.column(i).clone()).collect()
+                match take_projected_columns(
+                    emitted.columns(),
+                    emitted_schema.fields(),
+                    indices,
+                    schema.as_ref(),
+                    emitted.num_rows(),
+                ) {
+                    Ok(cols) => cols,
+                    Err(e) => {
+                        out.push(Err(e));
+                        continue;
+                    }
+                }
             } else {
                 emitted.columns().to_vec()
             };

--- a/rust/lance/src/dataset/mem_wal/memtable/scanner/exec/fts.rs
+++ b/rust/lance/src/dataset/mem_wal/memtable/scanner/exec/fts.rs
@@ -28,6 +28,7 @@ use lance_index::scalar::inverted::DOC_INDEX_FIELD;
 use super::super::builder::{FtsQuery, FtsQueryType};
 use super::newest_pk_positions;
 use crate::dataset::mem_wal::index::{FtsQueryExpr, SearchOptions};
+use crate::dataset::mem_wal::memtable::scanner::exec::take_projected_columns;
 use crate::dataset::mem_wal::scanner::exec::resolve_pk_indices;
 use crate::dataset::mem_wal::write::{BatchStore, IndexStore};
 
@@ -471,14 +472,30 @@ impl FtsIndexExec {
         }
 
         // Add score column
+        let n_hits = all_scores.len();
         final_columns.push(Arc::new(Float32Array::from(all_scores)));
 
         // Apply projection if needed
         let mut projected_columns = if let Some(ref proj_indices) = self.projection {
-            let mut projected: Vec<_> = proj_indices
-                .iter()
-                .map(|&i| final_columns[i].clone())
-                .collect();
+            // Source shape comes from the memtable's own batches; `final_columns`
+            // holds one entry per source column, concatenated across hits.
+            let source_fields = self
+                .batch_store
+                .get(0)
+                .map(|stored| stored.data.schema().fields().clone());
+            let mut projected: Vec<_> = match source_fields {
+                Some(fields) => take_projected_columns(
+                    &final_columns,
+                    &fields,
+                    proj_indices,
+                    self.output_schema.as_ref(),
+                    n_hits,
+                )?,
+                None => proj_indices
+                    .iter()
+                    .map(|&i| final_columns[i].clone())
+                    .collect(),
+            };
             if self.with_doc_index {
                 projected.push(final_columns[final_columns.len() - 2].clone());
             }

--- a/rust/lance/src/dataset/mem_wal/memtable/scanner/exec/scan.rs
+++ b/rust/lance/src/dataset/mem_wal/memtable/scanner/exec/scan.rs
@@ -22,6 +22,7 @@ use datafusion::prelude::Expr;
 use datafusion_physical_expr::{EquivalenceProperties, PhysicalExprRef};
 use futures::stream::{self, StreamExt};
 
+use crate::dataset::mem_wal::memtable::scanner::exec::take_projected_columns;
 use crate::dataset::mem_wal::write::BatchStore;
 
 /// Column name for row address (consistent with base table scanner).
@@ -291,13 +292,21 @@ impl ExecutionPlan for MemTableScanExec {
                     return None;
                 }
 
-                // Apply projection
+                // Apply projection. `indices` name whole top-level columns; a
+                // projected struct leaf is narrowed against `schema`.
                 let mut columns: Vec<Arc<dyn arrow_array::Array>> =
                     if let Some(ref indices) = projection {
-                        indices
-                            .iter()
-                            .map(|&i| filtered_batch.column(i).clone())
-                            .collect()
+                        let batch_schema = filtered_batch.schema();
+                        match take_projected_columns(
+                            filtered_batch.columns(),
+                            batch_schema.fields(),
+                            indices,
+                            schema.as_ref(),
+                            filtered_batch.num_rows(),
+                        ) {
+                            Ok(cols) => cols,
+                            Err(e) => return Some(Err(e)),
+                        }
                     } else {
                         filtered_batch.columns().to_vec()
                     };

--- a/rust/lance/src/dataset/mem_wal/memtable/scanner/exec/vector.rs
+++ b/rust/lance/src/dataset/mem_wal/memtable/scanner/exec/vector.rs
@@ -23,6 +23,7 @@ use futures::stream::{self, StreamExt};
 use lance_core::{Error, Result};
 
 use super::super::builder::VectorQuery;
+use crate::dataset::mem_wal::memtable::scanner::exec::take_projected_columns;
 use crate::dataset::mem_wal::write::{BatchStore, IndexStore};
 
 /// Distance column name in output.
@@ -246,9 +247,15 @@ impl VectorIndexExec {
                 columns.push(Arc::new(Float32Array::from(distances)));
 
                 // Apply projection if needed (excluding distance column which is always included)
+                let source_schema = stored.data.schema();
                 let mut final_columns = if let Some(ref proj_indices) = self.projection {
-                    let mut projected: Vec<_> =
-                        proj_indices.iter().map(|&i| columns[i].clone()).collect();
+                    let mut projected: Vec<_> = take_projected_columns(
+                        &columns,
+                        source_schema.fields(),
+                        proj_indices,
+                        self.output_schema.as_ref(),
+                        row_positions.len(),
+                    )?;
                     // Always include distance as last column
                     projected.push(columns.last().unwrap().clone());
                     projected

--- a/rust/lance/src/dataset/mem_wal/scanner/builder.rs
+++ b/rust/lance/src/dataset/mem_wal/scanner/builder.rs
@@ -714,7 +714,7 @@ impl LsmScanner {
                 extract_pk_point_keys(filter, &self.pk_columns[0], pk_field.data_type())
         {
             let mut planner =
-                LsmPointLookupPlanner::new(collector, self.pk_columns.clone(), base_schema);
+                LsmPointLookupPlanner::new(collector, self.pk_columns.clone(), base_schema)?;
             if let Some(session) = &self.session {
                 planner = planner.with_session(session.clone());
             }

--- a/rust/lance/src/dataset/mem_wal/scanner/fts_search.rs
+++ b/rust/lance/src/dataset/mem_wal/scanner/fts_search.rs
@@ -552,7 +552,10 @@ impl LsmFtsSearchPlanner {
             LsmDataSource::BaseTable { dataset } => {
                 let mut scanner = dataset.scan();
                 let cols = self.fts_scanner_projection(projection);
-                scanner.project(&cols.iter().map(|s| s.as_str()).collect::<Vec<_>>())?;
+                // Resolve against the *source* schema so a nested path narrows the
+                // struct rather than flattening it; expressions cannot express a
+                // partial nested projection, only a schema can.
+                scanner.project_with_schema(&dataset.schema().project(&cols)?)?;
                 if let Some(ref filter) = self.filter {
                     // `prefilter(true)` is required: without it the scanner
                     // post-filters the unfiltered BM25 top-k, dropping matching
@@ -580,7 +583,10 @@ impl LsmFtsSearchPlanner {
                 .await?;
                 let mut scanner = dataset.scan();
                 let cols = self.fts_scanner_projection(projection);
-                scanner.project(&cols.iter().map(|s| s.as_str()).collect::<Vec<_>>())?;
+                // Resolve against the *source* schema so a nested path narrows the
+                // struct rather than flattening it; expressions cannot express a
+                // partial nested projection, only a schema can.
+                scanner.project_with_schema(&dataset.schema().project(&cols)?)?;
                 if let Some(ref filter) = self.filter {
                     // See the base arm: `prefilter(true)` makes this a true
                     // prefilter rather than a lossy post-filter on the BM25 top-k.

--- a/rust/lance/src/dataset/mem_wal/scanner/fts_search.rs
+++ b/rust/lance/src/dataset/mem_wal/scanner/fts_search.rs
@@ -35,6 +35,7 @@
 //! base/SSTable Lance datasets, `MemTableScanner` for the active
 //! memtable) and requires no changes to `lance-index`.
 
+use std::collections::HashMap;
 use std::sync::Arc;
 
 use arrow_schema::{DataType, Field, Schema, SchemaRef, SortOptions};
@@ -55,7 +56,9 @@ use super::block_list::compute_source_block_lists;
 use super::collector::LsmDataSourceCollector;
 use super::data_source::LsmDataSource;
 use super::exec::PkBlockFilterExec;
-use super::projection::{project_to_canonical, validate_projection_names};
+use super::projection::{
+    project_to_canonical, resolve_data_fields, top_level_of, validate_projection_names,
+};
 use super::sstable_cache::{DatasetCache, SsTableWarmer, open_sstable};
 use crate::dataset::mem_wal::memtable::scanner::MemTableScanner;
 use crate::index::scalar::inverted::{indexed_fts_document_granularities, resolve_fts_field};
@@ -412,7 +415,7 @@ impl LsmFtsSearchPlanner {
             &[SCORE_COLUMN]
         };
         validate_projection_names(projection, &self.base_schema, allowed_system_columns)?;
-        let target_schema = self.canonical_fts_schema(projection, document_granularity);
+        let target_schema = self.canonical_fts_schema(projection, document_granularity)?;
         let overfetch = super::validate_overfetch_factor(self.overfetch_factor)?;
 
         if sources.is_empty() {
@@ -611,7 +614,7 @@ impl LsmFtsSearchPlanner {
                 let document_granularity = query_document_granularity(query)?;
                 if !active_source_can_execute_fts(source, column, document_granularity) {
                     return self
-                        .empty_plan(&self.canonical_fts_schema(projection, document_granularity));
+                        .empty_plan(&self.canonical_fts_schema(projection, document_granularity)?);
                 }
                 validate_lsm_fts_query(query)?;
                 let mut scanner =
@@ -668,11 +671,19 @@ impl LsmFtsSearchPlanner {
     }
 
     /// Canonical FTS output: user-projected cols + PK + `_score`.
+    ///
+    /// Data columns resolve through [`resolve_data_fields`], the same
+    /// nested-path resolver [`canonical_output_schema`] uses, so `meta.a`
+    /// contributes `meta: Struct<a>` and sibling leaves collapse into one
+    /// field at the parent's first-mentioned position. The FTS-specific
+    /// columns (`_score`, `_doc_index`) are appended around it.
+    ///
+    /// [`canonical_output_schema`]: super::projection::canonical_output_schema
     fn canonical_fts_schema(
         &self,
         user_projection: Option<&[String]>,
         document_granularity: DocumentGranularity,
-    ) -> SchemaRef {
+    ) -> Result<SchemaRef> {
         let mut ordered: Vec<String> = if let Some(p) = user_projection {
             p.to_vec()
         } else {
@@ -693,24 +704,35 @@ impl LsmFtsSearchPlanner {
         if !ordered.iter().any(|c| c == SCORE_COLUMN) {
             ordered.push(SCORE_COLUMN.to_string());
         }
-        let fields: Vec<Arc<Field>> = ordered
+
+        let data_names: Vec<String> = ordered
             .iter()
-            .filter_map(|name| {
-                if name == SCORE_COLUMN {
-                    Some(Arc::new(Field::new(SCORE_COLUMN, DataType::Float32, true)))
-                } else if name == DOC_INDEX_COL {
-                    Some(Arc::new(DOC_INDEX_FIELD.clone()))
-                } else if is_system_column(name) {
-                    Some(Arc::new(Field::new(name.clone(), DataType::UInt64, true)))
-                } else {
-                    self.base_schema
-                        .field_with_name(name)
-                        .ok()
-                        .map(|f| Arc::new(f.clone()))
-                }
+            .filter(|n| {
+                n.as_str() != SCORE_COLUMN && n.as_str() != DOC_INDEX_COL && !is_system_column(n)
             })
+            .cloned()
             .collect();
-        Arc::new(Schema::new(fields))
+        let mut by_name: HashMap<String, Arc<Field>> =
+            resolve_data_fields(&data_names, &self.base_schema)?
+                .into_iter()
+                .map(|f| (f.name().clone(), f))
+                .collect();
+
+        let mut fields: Vec<Arc<Field>> = Vec::with_capacity(ordered.len());
+        for name in &ordered {
+            if name == SCORE_COLUMN {
+                fields.push(Arc::new(Field::new(SCORE_COLUMN, DataType::Float32, true)));
+            } else if name == DOC_INDEX_COL {
+                fields.push(Arc::new(DOC_INDEX_FIELD.clone()));
+            } else if is_system_column(name) {
+                fields.push(Arc::new(Field::new(name.clone(), DataType::UInt64, true)));
+            } else if let Some(field) = by_name.remove(&top_level_of(name)?) {
+                // `remove` is what collapses a second mention of the same
+                // parent (`meta.a` then `meta.c`) into the single merged field.
+                fields.push(field);
+            }
+        }
+        Ok(Arc::new(Schema::new(fields)))
     }
 
     fn empty_plan(&self, schema: &SchemaRef) -> Result<Arc<dyn ExecutionPlan>> {
@@ -726,6 +748,7 @@ mod tests {
     use crate::dataset::mem_wal::write::{BatchStore, IndexStore};
     use crate::dataset::{Dataset, WriteParams};
     use arrow_array::builder::{ListBuilder, StringBuilder};
+    use arrow_array::cast::AsArray;
     use arrow_array::{
         Array, BooleanArray, Int32Array, ListArray, RecordBatch, RecordBatchIterator, StringArray,
         UInt32Array,
@@ -804,6 +827,154 @@ mod tests {
                 .unwrap();
         }
         dataset
+    }
+
+    /// `fts_schema` plus `meta: Struct<a: Int64, b: Utf8>`.
+    fn nested_fts_schema() -> Arc<ArrowSchema> {
+        let mut id_meta = HashMap::new();
+        id_meta.insert(
+            "lance-schema:unenforced-primary-key".to_string(),
+            "true".to_string(),
+        );
+        Arc::new(ArrowSchema::new(vec![
+            Field::new("id", DataType::Int32, false).with_metadata(id_meta),
+            Field::new("text", DataType::Utf8, true),
+            Field::new("meta", DataType::Struct(nested_meta_fields()), true),
+        ]))
+    }
+
+    fn nested_meta_fields() -> arrow_schema::Fields {
+        arrow_schema::Fields::from(vec![
+            Field::new("a", DataType::Int64, true),
+            Field::new("b", DataType::Utf8, true),
+        ])
+    }
+
+    /// The children `meta` carries in `schema`, in order.
+    fn meta_children(schema: &ArrowSchema) -> Vec<String> {
+        let DataType::Struct(fields) = schema
+            .field_with_name("meta")
+            .expect("meta survived canonicalization")
+            .data_type()
+            .clone()
+        else {
+            panic!("meta is not a struct");
+        };
+        fields.iter().map(|f| f.name().clone()).collect()
+    }
+
+    /// The FTS planner builds its own canonical target, so it needs the same
+    /// nested-path resolver as every other arm. A flat `field_with_name`
+    /// lookup misses `meta.a` entirely and `project_to_canonical` then drops
+    /// the column from every source — a silent truncation, since
+    /// `validate_projection_names` accepts the name.
+    #[tokio::test]
+    async fn nested_projection_survives_fts_canonicalization() {
+        let schema = nested_fts_schema();
+        let meta = arrow_array::StructArray::new(
+            nested_meta_fields(),
+            vec![
+                Arc::new(arrow_array::Int64Array::from(vec![10i64, 20])) as Arc<dyn Array>,
+                Arc::new(StringArray::from(vec!["b_1", "b_2"])) as Arc<dyn Array>,
+            ],
+            None,
+        );
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(Int32Array::from(vec![1, 2])),
+                Arc::new(StringArray::from(vec!["lance rocks", "unrelated"])),
+                Arc::new(meta),
+            ],
+        )
+        .unwrap();
+
+        let batch_store = Arc::new(BatchStore::with_capacity(16));
+        let mut indexes = IndexStore::new();
+        indexes.enable_pk_index(&[("id".to_string(), 0)]);
+        indexes.add_fts("text_fts".to_string(), 1, "text".to_string());
+        batch_store.append(batch.clone()).unwrap();
+        indexes
+            .insert_with_batch_position(&batch, 0, Some(0))
+            .unwrap();
+
+        let tmp = tempfile::tempdir().unwrap();
+        let base_uri = format!("{}/base", tmp.path().to_str().unwrap());
+        let collector = LsmDataSourceCollector::without_base_table(base_uri, vec![])
+            .with_in_memory_memtables(
+                uuid::Uuid::new_v4(),
+                InMemoryMemTables {
+                    active: InMemoryMemTableRef {
+                        batch_store,
+                        index_store: Arc::new(indexes),
+                        schema: schema.clone(),
+                        generation: 1,
+                    },
+                    frozen: vec![],
+                },
+            );
+        let planner = LsmFtsSearchPlanner::new(collector, vec!["id".to_string()], schema);
+
+        let projection = vec!["meta.a".to_string()];
+        let plan = planner
+            .plan_search(
+                "text",
+                FullTextSearchQuery::new("lance".to_string()),
+                Some(10),
+                Some(&projection),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(meta_children(&plan.schema()), vec!["a"]);
+
+        let ctx = datafusion::prelude::SessionContext::new();
+        let batches: Vec<RecordBatch> = plan
+            .execute(0, ctx.task_ctx())
+            .unwrap()
+            .try_collect()
+            .await
+            .unwrap();
+        let total: usize = batches.iter().map(|b| b.num_rows()).sum();
+        assert_eq!(total, 1, "only id=1 contains 'lance'");
+        let hit = batches.iter().find(|b| b.num_rows() > 0).unwrap();
+        assert_eq!(meta_children(hit.schema_ref()), vec!["a"]);
+        assert_eq!(
+            hit.column_by_name("meta")
+                .unwrap()
+                .as_struct()
+                .column_by_name("a")
+                .unwrap()
+                .as_any()
+                .downcast_ref::<arrow_array::Int64Array>()
+                .unwrap()
+                .value(0),
+            10
+        );
+    }
+
+    /// The no-source arm builds the same canonical target, so an empty result
+    /// still reports the narrowed struct rather than dropping it.
+    #[tokio::test]
+    async fn empty_fts_plan_preserves_nested_projection() {
+        let schema = nested_fts_schema();
+        let tmp = tempfile::tempdir().unwrap();
+        let base_uri = format!("{}/base", tmp.path().to_str().unwrap());
+        let collector = LsmDataSourceCollector::without_base_table(base_uri, vec![]);
+        let planner = LsmFtsSearchPlanner::new(collector, vec!["id".to_string()], schema);
+
+        let projection = vec!["meta.a".to_string()];
+        let plan = planner
+            .plan_search(
+                "text",
+                FullTextSearchQuery::new("lance".to_string()),
+                Some(1),
+                Some(&projection),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(meta_children(&plan.schema()), vec!["a"]);
     }
 
     #[tokio::test]

--- a/rust/lance/src/dataset/mem_wal/scanner/planner.rs
+++ b/rust/lance/src/dataset/mem_wal/scanner/planner.rs
@@ -245,7 +245,7 @@ impl LsmScanPlanner {
         // `_memtable_gen` unless the caller opted in.
         plan = project_to_canonical(
             plan,
-            &self.canonical_scan_schema(projection, with_memtable_gen, keep_row_address),
+            &self.canonical_scan_schema(projection, with_memtable_gen, keep_row_address)?,
         )?;
 
         // 6. Add limit / offset if specified
@@ -263,13 +263,13 @@ impl LsmScanPlanner {
         projection: Option<&[String]>,
         with_memtable_gen: bool,
         keep_row_address: bool,
-    ) -> SchemaRef {
+    ) -> Result<SchemaRef> {
         let canonical = canonical_output_schema(
             projection,
             &self.base_schema,
             &self.pk_columns,
             false, // no _distance
-        );
+        )?;
         let mut fields: Vec<Arc<Field>> = canonical.fields().iter().cloned().collect();
         if keep_row_address && !fields.iter().any(|f| f.name() == ROW_ADDRESS_COLUMN) {
             fields.push(Arc::new(Field::new(
@@ -285,7 +285,7 @@ impl LsmScanPlanner {
                 false,
             )));
         }
-        Arc::new(Schema::new(fields))
+        Ok(Arc::new(Schema::new(fields)))
     }
 
     /// Build scan plan for a single data source.
@@ -304,7 +304,10 @@ impl LsmScanPlanner {
                 // Project columns + _rowaddr (needed for dedup)
                 let cols =
                     build_scanner_projection(projection, &self.base_schema, &self.pk_columns);
-                scanner.project(&cols.iter().map(|s| s.as_str()).collect::<Vec<_>>())?;
+                // Resolve against the *source* schema so a nested path narrows the
+                // struct rather than flattening it; expressions cannot express a
+                // partial nested projection, only a schema can.
+                scanner.project_with_schema(&dataset.schema().project(&cols)?)?;
                 scanner.with_row_address();
                 // No `with_row_id()`: opting in only for base would mismatch
                 // the union schema against flushed/active. `_rowid` stays NULL
@@ -334,7 +337,10 @@ impl LsmScanPlanner {
 
                 let cols =
                     build_scanner_projection(projection, &self.base_schema, &self.pk_columns);
-                scanner.project(&cols.iter().map(|s| s.as_str()).collect::<Vec<_>>())?;
+                // Resolve against the *source* schema so a nested path narrows the
+                // struct rather than flattening it; expressions cannot express a
+                // partial nested projection, only a schema can.
+                scanner.project_with_schema(&dataset.schema().project(&cols)?)?;
                 scanner.with_row_address();
 
                 // Drop tombstones: fold `NOT _tombstone` into the predicate so
@@ -409,7 +415,7 @@ impl LsmScanPlanner {
     ) -> Result<Arc<dyn ExecutionPlan>> {
         use datafusion::physical_plan::empty::EmptyExec;
 
-        let schema = self.canonical_scan_schema(projection, with_memtable_gen, keep_row_address);
+        let schema = self.canonical_scan_schema(projection, with_memtable_gen, keep_row_address)?;
         Ok(Arc::new(EmptyExec::new(schema)))
     }
 }

--- a/rust/lance/src/dataset/mem_wal/scanner/point_lookup.rs
+++ b/rust/lance/src/dataset/mem_wal/scanner/point_lookup.rs
@@ -122,9 +122,9 @@ impl LsmPointLookupPlanner {
         collector: LsmDataSourceCollector,
         pk_columns: Vec<String>,
         base_schema: SchemaRef,
-    ) -> Self {
-        let none_target = canonical_output_schema(None, &base_schema, &pk_columns, false);
-        Self {
+    ) -> Result<Self> {
+        let none_target = canonical_output_schema(None, &base_schema, &pk_columns, false)?;
+        Ok(Self {
             collector,
             pk_columns,
             base_schema,
@@ -136,7 +136,7 @@ impl LsmPointLookupPlanner {
             none_target,
             task_ctx: SessionContext::new().task_ctx(),
             visibility: MemTableVisibility::Published,
-        }
+        })
     }
 
     /// Read the in-memory memtables at `visibility`. See
@@ -217,8 +217,12 @@ impl LsmPointLookupPlanner {
             // fall through to an older arm — resurrecting the deleted row. Then
             // the carried `_tombstone` column is projected away.
             Some(coalesced) => {
-                let canonical =
-                    canonical_output_schema(projection, &self.base_schema, &self.pk_columns, false);
+                let canonical = canonical_output_schema(
+                    projection,
+                    &self.base_schema,
+                    &self.pk_columns,
+                    false,
+                )?;
                 filter_tombstones_after_coalesce(coalesced, &canonical)
             }
             None => self.empty_plan(projection),
@@ -331,7 +335,7 @@ impl LsmPointLookupPlanner {
         projection: Option<&[String]>,
     ) -> Result<RecordBatch> {
         let canonical =
-            canonical_output_schema(projection, &self.base_schema, &self.pk_columns, false);
+            canonical_output_schema(projection, &self.base_schema, &self.pk_columns, false)?;
         let target = carry_schema(&canonical, &self.pk_columns);
         let mut out: Vec<RecordBatch> = Vec::with_capacity(keys.len());
         for key in keys {
@@ -394,7 +398,7 @@ impl LsmPointLookupPlanner {
                         &self.base_schema,
                         &self.pk_columns,
                         false,
-                    );
+                    )?;
                     &projected
                 }
             };
@@ -473,7 +477,7 @@ impl LsmPointLookupPlanner {
         let target = match projection {
             None => self.none_target.clone(),
             Some(_) => {
-                canonical_output_schema(projection, &self.base_schema, &self.pk_columns, false)
+                canonical_output_schema(projection, &self.base_schema, &self.pk_columns, false)?
             }
         };
         if keys.is_empty() {
@@ -609,7 +613,7 @@ impl LsmPointLookupPlanner {
                     &self.base_schema,
                     &self.pk_columns,
                     false,
-                )),
+                )?),
             }
         } else {
             self.lookup_many(keys, projection).await?
@@ -651,13 +655,16 @@ impl LsmPointLookupPlanner {
     ) -> Result<Arc<dyn ExecutionPlan>> {
         let cols = build_scanner_projection(projection, &self.base_schema, &self.pk_columns);
         let target =
-            canonical_output_schema(projection, &self.base_schema, &self.pk_columns, false);
+            canonical_output_schema(projection, &self.base_schema, &self.pk_columns, false)?;
         let want_row_id = wants_row_id(projection);
         let want_row_addr = wants_row_address(projection);
         let scan: Arc<dyn ExecutionPlan> = match source {
             LsmDataSource::BaseTable { dataset } => {
                 let mut scanner = dataset.scan();
-                scanner.project(&cols.iter().map(|s| s.as_str()).collect::<Vec<_>>())?;
+                // Resolve against the *source* schema so a nested path narrows the
+                // struct rather than flattening it; expressions cannot express a
+                // partial nested projection, only a schema can.
+                scanner.project_with_schema(&dataset.schema().project(&cols)?)?;
                 // Only the base produces row IDs callers can use against the
                 // dataset (e.g. `take_rows`); non-base arms NULL via canonical.
                 if want_row_id {
@@ -687,7 +694,10 @@ impl LsmPointLookupPlanner {
                 // a deleted key (gen written before deletes existed lack it →
                 // `project_to_carry` synthesizes `false`).
                 let cols = cols_with_tombstone(&cols, dataset.schema().field(TOMBSTONE).is_some());
-                scanner.project(&cols.iter().map(|s| s.as_str()).collect::<Vec<_>>())?;
+                // Resolve against the *source* schema so a nested path narrows the
+                // struct rather than flattening it; expressions cannot express a
+                // partial nested projection, only a schema can.
+                scanner.project_with_schema(&dataset.schema().project(&cols)?)?;
                 scanner.filter_expr(filter.clone());
                 Box::pin(scanner.create_plan()).await?
             }
@@ -753,7 +763,7 @@ impl LsmPointLookupPlanner {
         use datafusion::physical_plan::empty::EmptyExec;
 
         let schema =
-            canonical_output_schema(projection, &self.base_schema, &self.pk_columns, false);
+            canonical_output_schema(projection, &self.base_schema, &self.pk_columns, false)?;
         Ok(Arc::new(EmptyExec::new(schema)))
     }
 }
@@ -1112,7 +1122,8 @@ mod tests {
         // Create collector without memtables
         let collector = LsmDataSourceCollector::new(base_dataset, vec![]);
 
-        let planner = LsmPointLookupPlanner::new(collector, vec!["id".to_string()], schema.clone());
+        let planner =
+            LsmPointLookupPlanner::new(collector, vec!["id".to_string()], schema.clone()).unwrap();
 
         let pk_values = vec![ScalarValue::Int32(Some(2))];
         let plan = planner.plan_lookup(&pk_values, None).await.unwrap();
@@ -1152,7 +1163,8 @@ mod tests {
         // Create collector
         let collector = LsmDataSourceCollector::new(base_dataset, vec![shard_snapshot]);
 
-        let planner = LsmPointLookupPlanner::new(collector, vec!["id".to_string()], schema.clone());
+        let planner =
+            LsmPointLookupPlanner::new(collector, vec!["id".to_string()], schema.clone()).unwrap();
 
         let pk_values = vec![ScalarValue::Int32(Some(2))];
         let plan = planner.plan_lookup(&pk_values, None).await.unwrap();
@@ -1187,6 +1199,7 @@ mod tests {
         bf.insert_hash(pk_hash);
 
         let planner = LsmPointLookupPlanner::new(collector, vec!["id".to_string()], schema.clone())
+            .unwrap()
             .with_bloom_filter(1, Arc::new(bf));
 
         let pk_values = vec![ScalarValue::Int32(Some(2))];
@@ -1206,7 +1219,8 @@ mod tests {
 
         let collector = LsmDataSourceCollector::new(base_dataset, vec![]);
 
-        let planner = LsmPointLookupPlanner::new(collector, vec!["id".to_string()], schema);
+        let planner =
+            LsmPointLookupPlanner::new(collector, vec!["id".to_string()], schema).unwrap();
 
         let pk_values = vec![ScalarValue::Int32(Some(42))];
         let expr = planner.build_pk_filter_expr(&pk_values).unwrap();
@@ -1242,7 +1256,8 @@ mod tests {
             .with_sstable(1, "gen_1".to_string());
 
         let collector = LsmDataSourceCollector::without_base_table(base_uri, vec![shard_snapshot]);
-        let planner = LsmPointLookupPlanner::new(collector, vec!["id".to_string()], schema);
+        let planner =
+            LsmPointLookupPlanner::new(collector, vec!["id".to_string()], schema).unwrap();
 
         // id=3 lives in the SSTable
         let pk_values = vec![ScalarValue::Int32(Some(3))];
@@ -1288,7 +1303,8 @@ mod tests {
         let base_dataset = Arc::new(create_dataset(&base_uri, vec![base_batch]).await);
 
         let collector = LsmDataSourceCollector::new(base_dataset, vec![]);
-        let planner = LsmPointLookupPlanner::new(collector, vec!["id".to_string()], schema);
+        let planner =
+            LsmPointLookupPlanner::new(collector, vec!["id".to_string()], schema).unwrap();
 
         // User requests `_rowaddr` between `id` and `name`, plus `_rowoffset` at end.
         let projection = vec![
@@ -1355,7 +1371,8 @@ mod tests {
         let base_uri = format!("{}/base", temp_dir.path().to_str().unwrap());
 
         let collector = LsmDataSourceCollector::without_base_table(base_uri, vec![]);
-        let planner = LsmPointLookupPlanner::new(collector, vec!["id".to_string()], schema);
+        let planner =
+            LsmPointLookupPlanner::new(collector, vec!["id".to_string()], schema).unwrap();
 
         let projection = vec![
             "id".to_string(),
@@ -1394,7 +1411,8 @@ mod tests {
         let base_uri = format!("{}/base", temp_dir.path().to_str().unwrap());
 
         let collector = LsmDataSourceCollector::without_base_table(base_uri, vec![]);
-        let planner = LsmPointLookupPlanner::new(collector, vec!["id".to_string()], schema);
+        let planner =
+            LsmPointLookupPlanner::new(collector, vec!["id".to_string()], schema).unwrap();
 
         let projection = vec!["missing".to_string()];
         let pk_values = vec![ScalarValue::Int32(Some(2))];
@@ -1464,7 +1482,8 @@ mod tests {
                 },
             );
 
-        let planner = LsmPointLookupPlanner::new(collector, vec!["id".to_string()], schema);
+        let planner =
+            LsmPointLookupPlanner::new(collector, vec!["id".to_string()], schema).unwrap();
 
         let plan = planner
             .plan_lookup(&[ScalarValue::Int32(Some(1))], None)
@@ -1535,7 +1554,8 @@ mod tests {
                     frozen: vec![],
                 },
             );
-        let planner = LsmPointLookupPlanner::new(collector, vec!["id".to_string()], schema);
+        let planner =
+            LsmPointLookupPlanner::new(collector, vec!["id".to_string()], schema).unwrap();
 
         // `lookup` takes the fast probe path (single-column PK, no system cols).
         let hit = planner
@@ -1622,7 +1642,8 @@ mod tests {
                     frozen: vec![],
                 },
             );
-        let planner = LsmPointLookupPlanner::new(collector, vec!["id".to_string()], schema);
+        let planner =
+            LsmPointLookupPlanner::new(collector, vec!["id".to_string()], schema).unwrap();
         let key = [ScalarValue::Int32(Some(1))];
 
         assert!(
@@ -1678,7 +1699,8 @@ mod tests {
             .with_sstable(1, "gen_1".to_string());
 
         let collector = LsmDataSourceCollector::without_base_table(base_uri, vec![shard_snapshot]);
-        let planner = LsmPointLookupPlanner::new(collector, vec!["id".to_string()], schema);
+        let planner =
+            LsmPointLookupPlanner::new(collector, vec!["id".to_string()], schema).unwrap();
 
         let plan = planner
             .plan_lookup(&[ScalarValue::Int32(Some(1))], None)
@@ -1764,7 +1786,8 @@ mod tests {
                     frozen: vec![],
                 },
             );
-        let planner = LsmPointLookupPlanner::new(collector, vec!["id".to_string()], schema.clone());
+        let planner =
+            LsmPointLookupPlanner::new(collector, vec!["id".to_string()], schema.clone()).unwrap();
 
         let row = planner
             .lookup(&[ScalarValue::Int32(Some(20))], None)
@@ -1807,7 +1830,8 @@ mod tests {
                     frozen: vec![],
                 },
             );
-        let planner = LsmPointLookupPlanner::new(collector, vec!["id".to_string()], schema);
+        let planner =
+            LsmPointLookupPlanner::new(collector, vec!["id".to_string()], schema).unwrap();
 
         let row = planner
             .lookup(&[ScalarValue::Int32(Some(5))], None)
@@ -1838,7 +1862,8 @@ mod tests {
                 frozen: vec![],
             },
         );
-        let planner = LsmPointLookupPlanner::new(collector, vec!["id".to_string()], schema.clone());
+        let planner =
+            LsmPointLookupPlanner::new(collector, vec!["id".to_string()], schema.clone()).unwrap();
 
         // In active only → fast-path hit.
         let row = planner
@@ -1886,7 +1911,8 @@ mod tests {
                     frozen: vec![],
                 },
             );
-        let planner = LsmPointLookupPlanner::new(collector, vec!["id".to_string()], schema);
+        let planner =
+            LsmPointLookupPlanner::new(collector, vec!["id".to_string()], schema).unwrap();
 
         let row = planner
             .lookup(&[ScalarValue::Int32(Some(20))], Some(&["name".to_string()]))
@@ -1928,7 +1954,8 @@ mod tests {
                     frozen: vec![],
                 },
             );
-        let planner = LsmPointLookupPlanner::new(collector, vec!["id".to_string()], schema);
+        let planner =
+            LsmPointLookupPlanner::new(collector, vec!["id".to_string()], schema).unwrap();
 
         let row = planner
             .lookup(&[ScalarValue::Int64(Some(20))], None)
@@ -1956,7 +1983,8 @@ mod tests {
                     frozen: vec![],
                 },
             );
-        let planner = LsmPointLookupPlanner::new(collector, vec!["id".to_string()], schema);
+        let planner =
+            LsmPointLookupPlanner::new(collector, vec!["id".to_string()], schema).unwrap();
 
         let err = planner.lookup(&[], None).await;
         assert!(err.is_err(), "empty pk_values must error, not panic");
@@ -1988,7 +2016,7 @@ mod tests {
                     frozen: vec![],
                 },
             );
-        LsmPointLookupPlanner::new(collector, vec!["id".to_string()], schema)
+        LsmPointLookupPlanner::new(collector, vec!["id".to_string()], schema).unwrap()
     }
 
     #[tokio::test]
@@ -2126,7 +2154,8 @@ mod tests {
                     frozen: vec![],
                 },
             );
-        let planner = LsmPointLookupPlanner::new(collector, vec!["id".to_string()], schema);
+        let planner =
+            LsmPointLookupPlanner::new(collector, vec!["id".to_string()], schema).unwrap();
 
         let row = planner
             .lookup(&[ScalarValue::Int32(Some(20))], None)
@@ -2204,7 +2233,7 @@ mod tests {
                     frozen: vec![],
                 },
             );
-        LsmPointLookupPlanner::new(collector, vec!["id".to_string()], base_schema)
+        LsmPointLookupPlanner::new(collector, vec!["id".to_string()], base_schema).unwrap()
     }
 
     /// Read the `_tombstone` marker from row 0 of a keep-tombstone result.
@@ -2370,7 +2399,8 @@ mod tests {
                 frozen: vec![],
             },
         );
-        let planner = LsmPointLookupPlanner::new(collector, vec!["id".to_string()], base_schema);
+        let planner =
+            LsmPointLookupPlanner::new(collector, vec!["id".to_string()], base_schema).unwrap();
 
         let proj = vec!["id".to_string(), "_rowid".to_string()];
         assert!(

--- a/rust/lance/src/dataset/mem_wal/scanner/point_lookup.rs
+++ b/rust/lance/src/dataset/mem_wal/scanner/point_lookup.rs
@@ -22,6 +22,7 @@ use datafusion::physical_plan::sorts::sort::SortExec;
 use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
 use datafusion::prelude::{Expr, SessionContext};
 use futures::TryStreamExt;
+use lance_arrow::RecordBatchExt;
 use lance_core::utils::bloomfilter::sbbf::Sbbf;
 use lance_core::{Result, is_system_column};
 use lance_datafusion::exec::OneShotExec;
@@ -989,6 +990,11 @@ fn resolve_position(
 /// Gather `rows` from `batch_store`'s batch `batch_idx` into the `target`
 /// schema. A single row is a zero-copy `slice` (the common point-lookup case);
 /// multiple rows use one vectorized `take` per column.
+///
+/// Columns are stored whole, so a nested projection (`meta.a` -> `meta:
+/// Struct<a>`) leaves the gathered array wider than `target`. Those columns are
+/// narrowed with one `project_by_schema` pass; a projection that selects only
+/// whole columns matches the stored types and skips it.
 fn gather_rows(
     batch_store: &BatchStore,
     batch_idx: usize,
@@ -1003,28 +1009,35 @@ fn gather_rows(
     // shared schema `Arc`, and under concurrency that refcount cache line
     // ping-pongs across cores. `schema_ref()` borrows it.
     let stored_schema = stored.data.schema_ref();
-    let cols: Vec<Arc<dyn Array>> = target
-        .fields()
-        .iter()
-        .map(|f| {
-            let idx = stored_schema.index_of(f.name()).map_err(|_| {
-                lance_core::Error::invalid_input(format!(
-                    "point-lookup projection column '{}' not found in memtable batch",
-                    f.name()
-                ))
-            })?;
-            let col = stored.data.column(idx);
-            // Single row: zero-copy `slice` (the common point-lookup case, and
-            // measurably faster than `take` — copying regressed single-thread
-            // ~30% with no N-thread gain). Multiple rows: one vectorized `take`.
-            match &indices {
-                None => Ok(col.slice(rows[0] as usize, 1)),
-                Some(idxs) => arrow_select::take::take(col.as_ref(), idxs, None)
-                    .map_err(lance_core::Error::from),
-            }
-        })
-        .collect::<Result<Vec<_>>>()?;
-    Ok(RecordBatch::try_new(target.clone(), cols)?)
+    let mut cols: Vec<Arc<dyn Array>> = Vec::with_capacity(target.fields().len());
+    let mut stored_fields: Vec<Arc<Field>> = Vec::with_capacity(target.fields().len());
+    let mut needs_narrowing = false;
+    for f in target.fields() {
+        let idx = stored_schema.index_of(f.name()).map_err(|_| {
+            lance_core::Error::invalid_input(format!(
+                "point-lookup projection column '{}' not found in memtable batch",
+                f.name()
+            ))
+        })?;
+        let stored_field = &stored_schema.fields()[idx];
+        needs_narrowing |= stored_field.data_type() != f.data_type();
+        stored_fields.push(stored_field.clone());
+        let col = stored.data.column(idx);
+        // Single row: zero-copy `slice` (the common point-lookup case, and
+        // measurably faster than `take` — copying regressed single-thread
+        // ~30% with no N-thread gain). Multiple rows: one vectorized `take`.
+        cols.push(match &indices {
+            None => col.slice(rows[0] as usize, 1),
+            Some(idxs) => arrow_select::take::take(col.as_ref(), idxs, None)?,
+        });
+    }
+    if !needs_narrowing {
+        return Ok(RecordBatch::try_new(target.clone(), cols)?);
+    }
+    // `needs_narrowing` implies at least one field, so the row count is
+    // recoverable from the columns.
+    let gathered = RecordBatch::try_new(Arc::new(Schema::new(stored_fields)), cols)?;
+    Ok(gathered.project_by_schema(target)?)
 }
 
 /// Probe one in-memory memtable for a single key and materialize the newest
@@ -1061,6 +1074,7 @@ fn probe_memtable(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use arrow_array::cast::AsArray;
     use arrow_array::{Int32Array, RecordBatch, RecordBatchIterator, StringArray};
     use arrow_schema::{DataType, Field, Schema as ArrowSchema};
     use datafusion::physical_plan::displayable;
@@ -1930,6 +1944,161 @@ mod tests {
         assert_eq!(names, vec!["name", "id"]);
         assert_eq!(name_at(&row), "v_20");
         assert_eq!(id_at(&row), 20);
+    }
+
+    /// `id` (PK) + `meta: Struct<a: Int64, b: Utf8>`, one row per id.
+    fn create_nested_schema() -> Arc<ArrowSchema> {
+        let mut id_metadata = HashMap::new();
+        id_metadata.insert(
+            "lance-schema:unenforced-primary-key".to_string(),
+            "true".to_string(),
+        );
+        Arc::new(ArrowSchema::new(vec![
+            Field::new("id", DataType::Int32, false).with_metadata(id_metadata),
+            Field::new("meta", DataType::Struct(nested_meta_fields()), true),
+        ]))
+    }
+
+    fn nested_meta_fields() -> arrow_schema::Fields {
+        arrow_schema::Fields::from(vec![
+            Field::new("a", DataType::Int64, true),
+            Field::new("b", DataType::Utf8, true),
+        ])
+    }
+
+    fn create_nested_batch(schema: &Arc<ArrowSchema>, ids: &[i32]) -> RecordBatch {
+        let a: Vec<i64> = ids.iter().map(|id| *id as i64 * 10).collect();
+        let b: Vec<String> = ids.iter().map(|id| format!("b_{}", id)).collect();
+        let meta = arrow_array::StructArray::new(
+            nested_meta_fields(),
+            vec![
+                Arc::new(arrow_array::Int64Array::from(a)) as Arc<dyn Array>,
+                Arc::new(StringArray::from(b)) as Arc<dyn Array>,
+            ],
+            None,
+        );
+        RecordBatch::try_new(
+            schema.clone(),
+            vec![Arc::new(Int32Array::from(ids.to_vec())), Arc::new(meta)],
+        )
+        .unwrap()
+    }
+
+    fn nested_planner(schema: &Arc<ArrowSchema>, ids: &[i32]) -> LsmPointLookupPlanner {
+        use crate::dataset::mem_wal::scanner::collector::InMemoryMemTables;
+        let temp = tempfile::tempdir().unwrap();
+        let base_uri = format!("{}/base", temp.path().to_str().unwrap());
+        let active = active_memtable_ref(schema, &[create_nested_batch(schema, ids)], 1);
+        let collector = LsmDataSourceCollector::without_base_table(base_uri, vec![])
+            .with_in_memory_memtables(
+                Uuid::new_v4(),
+                InMemoryMemTables {
+                    active,
+                    frozen: vec![],
+                },
+            );
+        LsmPointLookupPlanner::new(collector, vec!["id".to_string()], schema.clone()).unwrap()
+    }
+
+    /// The children `meta` carries in `batch`, in order.
+    fn meta_children(batch: &RecordBatch) -> Vec<String> {
+        let arrow_schema::DataType::Struct(fields) = batch
+            .schema()
+            .field_with_name("meta")
+            .unwrap()
+            .data_type()
+            .clone()
+        else {
+            panic!("meta is not a struct");
+        };
+        fields.iter().map(|f| f.name().clone()).collect()
+    }
+
+    /// A nested projection narrows the canonical schema to `meta: Struct<a>`,
+    /// but the memtable stores `meta` whole. The fast-path gather has to narrow
+    /// the stored column to match — handing the whole `Struct<a, b>` to
+    /// `RecordBatch::try_new` against a `Struct<a>` schema is a type error.
+    #[tokio::test]
+    async fn test_lookup_nested_projection_narrows_struct() {
+        let schema = create_nested_schema();
+        let planner = nested_planner(&schema, &[1, 2]);
+
+        let row = planner
+            .lookup(
+                &[ScalarValue::Int32(Some(1))],
+                Some(&["meta.a".to_string()]),
+            )
+            .await
+            .unwrap()
+            .unwrap();
+
+        let row_schema = row.schema();
+        let names: Vec<&str> = row_schema
+            .fields()
+            .iter()
+            .map(|f| f.name().as_str())
+            .collect();
+        assert_eq!(names, vec!["meta", "id"]);
+        assert_eq!(meta_children(&row), vec!["a"]);
+        assert_eq!(id_at(&row), 1);
+        let meta = row.column_by_name("meta").unwrap().as_struct();
+        assert_eq!(
+            meta.column_by_name("a")
+                .unwrap()
+                .as_any()
+                .downcast_ref::<arrow_array::Int64Array>()
+                .unwrap()
+                .value(0),
+            10
+        );
+    }
+
+    /// `lookup_many` reaches the same gather through the batched
+    /// group-by-source path, so it narrows identically.
+    #[tokio::test]
+    async fn test_lookup_many_nested_projection_narrows_struct() {
+        let schema = create_nested_schema();
+        let planner = nested_planner(&schema, &[1, 2]);
+
+        let batch = planner
+            .lookup_many(
+                &[ScalarValue::Int32(Some(1)), ScalarValue::Int32(Some(2))],
+                Some(&["meta.a".to_string()]),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(batch.num_rows(), 2);
+        assert_eq!(meta_children(&batch), vec!["a"]);
+        let a = batch
+            .column_by_name("meta")
+            .unwrap()
+            .as_struct()
+            .column_by_name("a")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<arrow_array::Int64Array>()
+            .unwrap()
+            .clone();
+        let mut values: Vec<i64> = (0..batch.num_rows()).map(|i| a.value(i)).collect();
+        values.sort();
+        assert_eq!(values, vec![10, 20]);
+    }
+
+    /// Control for the two tests above: projecting the whole struct leaves the
+    /// stored column untouched, so the narrowing pass must stay skipped.
+    #[tokio::test]
+    async fn test_lookup_whole_struct_projection_passes_through() {
+        let schema = create_nested_schema();
+        let planner = nested_planner(&schema, &[1]);
+
+        let row = planner
+            .lookup(&[ScalarValue::Int32(Some(1))], Some(&["meta".to_string()]))
+            .await
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(meta_children(&row), vec!["a", "b"]);
     }
 
     #[tokio::test]

--- a/rust/lance/src/dataset/mem_wal/scanner/projection.rs
+++ b/rust/lance/src/dataset/mem_wal/scanner/projection.rs
@@ -15,6 +15,7 @@
 //! - [`project_to_canonical`] — wraps a plan to emit `target_schema`,
 //!   NULL-filling system / `_distance` cols missing from the source.
 
+use std::collections::HashMap;
 use std::sync::Arc;
 
 use arrow_schema::{DataType, Field, Schema, SchemaRef};
@@ -23,6 +24,7 @@ use datafusion::physical_expr::expressions::{Column, Literal};
 use datafusion::physical_plan::ExecutionPlan;
 use datafusion::physical_plan::projection::ProjectionExec;
 use datafusion::scalar::ScalarValue;
+use lance_core::datatypes::{Schema as LanceSchema, parse_field_path};
 use lance_core::{ROW_ADDR, ROW_ID, Result, is_system_column};
 
 use super::exec::SchemaRelabelExec;
@@ -47,6 +49,32 @@ pub fn wants_row_address(projection: Option<&[String]>) -> bool {
 /// Auto-managed by the planner; must never reach `scanner.project()`.
 fn is_auto_managed(col: &str) -> bool {
     col == DISTANCE_COLUMN || is_system_column(col)
+}
+
+/// Resolve projection names — dotted paths included — into the narrowed Arrow
+/// fields they select.
+///
+/// [`LanceSchema::project`] does the two things a flat name lookup cannot: it
+/// narrows a struct to the selected leaf (`meta.a` -> `meta: Struct<a>`) and
+/// merges sibling leaves of one parent into a single field (`meta.a` +
+/// `meta.c` -> `meta: Struct<a, c>`). Fields come back in first-mention order
+/// of their top-level column.
+fn resolve_data_fields(data_names: &[String], base_schema: &SchemaRef) -> Result<Vec<Arc<Field>>> {
+    if data_names.is_empty() {
+        return Ok(Vec::new());
+    }
+    let lance_schema = LanceSchema::try_from(base_schema.as_ref())?;
+    let projected = lance_schema.project(data_names)?;
+    let arrow_schema = Schema::from(&projected);
+    Ok(arrow_schema.fields().iter().cloned().collect())
+}
+
+/// Top-level column a (possibly dotted) projection name addresses.
+fn top_level_of(name: &str) -> Result<String> {
+    parse_field_path(name)?
+        .into_iter()
+        .next()
+        .ok_or_else(|| lance_core::Error::invalid_input(format!("empty projection name: {}", name)))
 }
 
 /// Projection to pass to underlying scanners: user cols minus
@@ -84,17 +112,21 @@ pub fn validate_projection_names(
     let Some(user_projection) = user_projection else {
         return Ok(());
     };
+    let lance_schema = LanceSchema::try_from(base_schema.as_ref())?;
     for name in user_projection {
-        if is_system_column(name)
-            || extra_columns.contains(&name.as_str())
-            || base_schema.field_with_name(name).is_ok()
-        {
+        if is_system_column(name) || extra_columns.contains(&name.as_str()) {
             continue;
         }
-        return Err(lance_core::Error::invalid_input(format!(
-            "Column '{}' not found in schema",
-            name
-        )));
+        // `resolve` walks the dotted path and reports whether every segment
+        // exists. `project` is not a substitute: it errors on a missing
+        // top-level column but yields an empty struct for a missing *child*,
+        // so `meta.nope` would slip through.
+        if lance_schema.resolve(name.as_str()).is_none() {
+            return Err(lance_core::Error::invalid_input(format!(
+                "Column '{}' not found in schema",
+                name
+            )));
+        }
     }
     Ok(())
 }
@@ -104,14 +136,16 @@ pub fn validate_projection_names(
 /// System cols → nullable `UInt64` at user position (filled by
 /// `project_to_canonical`). `_distance` (when `include_distance`) →
 /// nullable `Float32` at user position, appended if absent. PKs appended.
-/// Callers should run [`validate_projection_names`] before using this with a
-/// user-supplied projection.
+///
+/// Nested paths resolve to their narrowed struct: `meta.a` contributes
+/// `meta: Struct<a>`, and sibling leaves collapse into one field at the
+/// parent's first-mentioned position.
 pub fn canonical_output_schema(
     user_projection: Option<&[String]>,
     base_schema: &SchemaRef,
     pk_columns: &[String],
     include_distance: bool,
-) -> SchemaRef {
+) -> Result<SchemaRef> {
     let mut ordered: Vec<String> = if let Some(p) = user_projection {
         p.to_vec()
     } else {
@@ -132,24 +166,36 @@ pub fn canonical_output_schema(
         ordered.push(DISTANCE_COLUMN.to_string());
     }
 
-    let fields: Vec<Arc<Field>> = ordered
+    let data_names: Vec<String> = ordered
         .iter()
-        .filter_map(|name| {
-            if name == DISTANCE_COLUMN {
-                include_distance
-                    .then(|| Arc::new(Field::new(DISTANCE_COLUMN, DataType::Float32, true)))
-            } else if is_system_column(name) {
-                Some(Arc::new(Field::new(name.clone(), DataType::UInt64, true)))
-            } else {
-                base_schema
-                    .field_with_name(name)
-                    .ok()
-                    .map(|f| Arc::new(f.clone()))
-            }
-        })
+        .filter(|n| !is_auto_managed(n))
+        .cloned()
+        .collect();
+    let mut by_name: HashMap<String, Arc<Field>> = resolve_data_fields(&data_names, base_schema)?
+        .into_iter()
+        .map(|f| (f.name().clone(), f))
         .collect();
 
-    Arc::new(Schema::new(fields))
+    let mut fields: Vec<Arc<Field>> = Vec::with_capacity(ordered.len());
+    for name in &ordered {
+        if name == DISTANCE_COLUMN {
+            if include_distance {
+                fields.push(Arc::new(Field::new(
+                    DISTANCE_COLUMN,
+                    DataType::Float32,
+                    true,
+                )));
+            }
+        } else if is_system_column(name) {
+            fields.push(Arc::new(Field::new(name.clone(), DataType::UInt64, true)));
+        } else if let Some(field) = by_name.remove(&top_level_of(name)?) {
+            // `remove` is what collapses a second mention of the same parent
+            // (`meta.a` then `meta.c`) into the single merged field.
+            fields.push(field);
+        }
+    }
+
+    Ok(Arc::new(Schema::new(fields)))
 }
 
 /// Wrap `plan` so the named columns become typed NULL literals; all
@@ -303,7 +349,7 @@ mod tests {
         let s = schema();
         let pks = vec!["id".to_string()];
         let user = vec!["_distance".to_string(), "vector".to_string()];
-        let out = canonical_output_schema(Some(&user), &s, &pks, true);
+        let out = canonical_output_schema(Some(&user), &s, &pks, true).unwrap();
         let names: Vec<&str> = out.fields().iter().map(|f| f.name().as_str()).collect();
         assert_eq!(names, vec!["_distance", "vector", "id"]);
         assert_eq!(
@@ -322,7 +368,7 @@ mod tests {
             "_rowaddr".to_string(),
             "_rowoffset".to_string(),
         ];
-        let out = canonical_output_schema(Some(&user), &s, &pks, false);
+        let out = canonical_output_schema(Some(&user), &s, &pks, false).unwrap();
         let names: Vec<&str> = out.fields().iter().map(|f| f.name().as_str()).collect();
         assert_eq!(
             names,
@@ -340,7 +386,7 @@ mod tests {
         let s = schema();
         let pks = vec!["id".to_string()];
         let user = vec!["vector".to_string()];
-        let out = canonical_output_schema(Some(&user), &s, &pks, true);
+        let out = canonical_output_schema(Some(&user), &s, &pks, true).unwrap();
         let names: Vec<&str> = out.fields().iter().map(|f| f.name().as_str()).collect();
         assert_eq!(names, vec!["vector", "id", "_distance"]);
     }
@@ -350,10 +396,84 @@ mod tests {
         let s = schema();
         let pks = vec!["id".to_string()];
         let user = vec!["_distance".to_string(), "vector".to_string()];
-        let out = canonical_output_schema(Some(&user), &s, &pks, false);
+        let out = canonical_output_schema(Some(&user), &s, &pks, false).unwrap();
         let names: Vec<&str> = out.fields().iter().map(|f| f.name().as_str()).collect();
         // _distance dropped because include_distance=false (e.g. point lookup / scan).
         assert_eq!(names, vec!["vector", "id"]);
+    }
+
+    /// `meta: Struct<a, b, c>` alongside flat columns.
+    fn nested_schema() -> SchemaRef {
+        use arrow_schema::Fields;
+        Arc::new(ArrowSchema::new(vec![
+            Field::new("id", DataType::Int32, false),
+            Field::new(
+                "meta",
+                DataType::Struct(Fields::from(vec![
+                    Field::new("a", DataType::Int64, true),
+                    Field::new("b", DataType::Utf8, true),
+                    Field::new("c", DataType::Float64, true),
+                ])),
+                true,
+            ),
+        ]))
+    }
+
+    fn struct_children(schema: &SchemaRef, name: &str) -> Vec<String> {
+        match schema.field_with_name(name).unwrap().data_type() {
+            DataType::Struct(fields) => fields.iter().map(|f| f.name().clone()).collect(),
+            other => panic!("{name} is not a struct: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn canonical_schema_narrows_a_struct_to_the_selected_leaf() {
+        let s = nested_schema();
+        let pks = vec!["id".to_string()];
+        let user = vec!["meta.a".to_string()];
+        let out = canonical_output_schema(Some(&user), &s, &pks, false).unwrap();
+        let names: Vec<&str> = out.fields().iter().map(|f| f.name().as_str()).collect();
+        assert_eq!(names, vec!["meta", "id"]);
+        assert_eq!(struct_children(&out, "meta"), vec!["a".to_string()]);
+    }
+
+    #[test]
+    fn canonical_schema_merges_sibling_leaves_at_the_parents_position() {
+        let s = nested_schema();
+        let pks = vec!["id".to_string()];
+        // Two leaves of one parent must collapse into a single `meta` column,
+        // seated where the parent was first mentioned.
+        let user = vec!["meta.a".to_string(), "id".to_string(), "meta.c".to_string()];
+        let out = canonical_output_schema(Some(&user), &s, &pks, false).unwrap();
+        let names: Vec<&str> = out.fields().iter().map(|f| f.name().as_str()).collect();
+        assert_eq!(names, vec!["meta", "id"]);
+        assert_eq!(
+            struct_children(&out, "meta"),
+            vec!["a".to_string(), "c".to_string()]
+        );
+    }
+
+    #[test]
+    fn canonical_schema_keeps_a_whole_struct_whole() {
+        let s = nested_schema();
+        let pks = vec!["id".to_string()];
+        let user = vec!["meta".to_string()];
+        let out = canonical_output_schema(Some(&user), &s, &pks, false).unwrap();
+        assert_eq!(
+            struct_children(&out, "meta"),
+            vec!["a".to_string(), "b".to_string(), "c".to_string()]
+        );
+    }
+
+    #[test]
+    fn validate_accepts_a_nested_path_and_rejects_a_bogus_child() {
+        let s = nested_schema();
+        validate_projection_names(Some(&["meta.a".to_string()]), &s, &[]).unwrap();
+        let err = validate_projection_names(Some(&["meta.nope".to_string()]), &s, &[]).unwrap_err();
+        assert!(
+            err.to_string().contains("meta.nope"),
+            "error should name the bad column, got: {err}"
+        );
     }
 
     #[test]

--- a/rust/lance/src/dataset/mem_wal/scanner/projection.rs
+++ b/rust/lance/src/dataset/mem_wal/scanner/projection.rs
@@ -59,7 +59,10 @@ fn is_auto_managed(col: &str) -> bool {
 /// merges sibling leaves of one parent into a single field (`meta.a` +
 /// `meta.c` -> `meta: Struct<a, c>`). Fields come back in first-mention order
 /// of their top-level column.
-fn resolve_data_fields(data_names: &[String], base_schema: &SchemaRef) -> Result<Vec<Arc<Field>>> {
+pub(super) fn resolve_data_fields(
+    data_names: &[String],
+    base_schema: &SchemaRef,
+) -> Result<Vec<Arc<Field>>> {
     if data_names.is_empty() {
         return Ok(Vec::new());
     }
@@ -70,7 +73,7 @@ fn resolve_data_fields(data_names: &[String], base_schema: &SchemaRef) -> Result
 }
 
 /// Top-level column a (possibly dotted) projection name addresses.
-fn top_level_of(name: &str) -> Result<String> {
+pub(super) fn top_level_of(name: &str) -> Result<String> {
     parse_field_path(name)?
         .into_iter()
         .next()

--- a/rust/lance/src/dataset/mem_wal/scanner/vector_search.rs
+++ b/rust/lance/src/dataset/mem_wal/scanner/vector_search.rs
@@ -267,7 +267,7 @@ impl LsmVectorSearchPlanner {
             &self.base_schema,
             &self.pk_columns,
             true, // include _distance — KNN always produces it
-        );
+        )?;
 
         // Refine the base table when explicitly requested, or whenever the base
         // is blocked (it then over-fetches its approximate-index candidates, so
@@ -435,7 +435,10 @@ impl LsmVectorSearchPlanner {
                 let mut scanner = dataset.scan();
                 let cols =
                     build_scanner_projection(projection, &self.base_schema, &self.pk_columns);
-                scanner.project(&cols.iter().map(|s| s.as_str()).collect::<Vec<_>>())?;
+                // Resolve against the *source* schema so a nested path narrows the
+                // struct rather than flattening it; expressions cannot express a
+                // partial nested projection, only a schema can.
+                scanner.project_with_schema(&dataset.schema().project(&cols)?)?;
                 if let Some(ref filter) = self.filter {
                     // Native scanner prefilter: the ANN runs over rows matching
                     // the predicate, so the top-k holds only matching rows.
@@ -478,7 +481,10 @@ impl LsmVectorSearchPlanner {
                 let mut scanner = dataset.scan();
                 let cols =
                     build_scanner_projection(projection, &self.base_schema, &self.pk_columns);
-                scanner.project(&cols.iter().map(|s| s.as_str()).collect::<Vec<_>>())?;
+                // Resolve against the *source* schema so a nested path narrows the
+                // struct rather than flattening it; expressions cannot express a
+                // partial nested projection, only a schema can.
+                scanner.project_with_schema(&dataset.schema().project(&cols)?)?;
                 if let Some(ref filter) = self.filter {
                     // See the base arm: `prefilter(true)` makes this a true
                     // prefilter rather than a lossy post-filter on the top-k.
@@ -530,7 +536,8 @@ impl LsmVectorSearchPlanner {
     fn empty_plan(&self, projection: Option<&[String]>) -> Result<Arc<dyn ExecutionPlan>> {
         use datafusion::physical_plan::empty::EmptyExec;
 
-        let schema = canonical_output_schema(projection, &self.base_schema, &self.pk_columns, true);
+        let schema =
+            canonical_output_schema(projection, &self.base_schema, &self.pk_columns, true)?;
         Ok(Arc::new(EmptyExec::new(schema)))
     }
 }

--- a/rust/lance/src/dataset/scanner.rs
+++ b/rust/lance/src/dataset/scanner.rs
@@ -1542,6 +1542,28 @@ impl Scanner {
         Ok(self)
     }
 
+    /// Projection by a (possibly partial) schema.
+    ///
+    /// Unlike [`Self::project`], which routes through expressions, this can
+    /// select *part* of a nested field — `meta` narrowed to just its `a` child.
+    /// Expressions cannot express that, so a nested projection must come
+    /// through here.
+    pub fn project_with_schema(
+        &mut self,
+        projection: &lance_core::datatypes::Schema,
+    ) -> Result<&mut Self> {
+        self.explicit_projection = true;
+        self.projection_plan = ProjectionPlan::from_schema(self.dataset.clone(), projection)?;
+        if self.legacy_with_row_id {
+            self.projection_plan.include_row_id();
+        }
+        if self.legacy_with_row_addr {
+            self.projection_plan.include_row_addr();
+        }
+        self.apply_blob_handling();
+        Ok(self)
+    }
+
     /// Should the filter run before the vector index is applied
     ///
     /// If true then the filter will be applied before the vector index.  This

--- a/rust/lance/src/dataset/scanner.rs
+++ b/rust/lance/src/dataset/scanner.rs
@@ -1548,7 +1548,7 @@ impl Scanner {
     /// select *part* of a nested field — `meta` narrowed to just its `a` child.
     /// Expressions cannot express that, so a nested projection must come
     /// through here.
-    pub fn project_with_schema(
+    pub(crate) fn project_with_schema(
         &mut self,
         projection: &lance_core::datatypes::Schema,
     ) -> Result<&mut Self> {


### PR DESCRIPTION
## Problem

A projection naming a struct leaf is widened back to the whole struct. `SELECT meta.a` on a mem-wal table returns `meta: Struct<a, b>` instead of `meta: Struct<a>`.

Every projection surface in the mem-wal scanner resolved names through flat, top-level lookups — `field_with_name` / `column_with_name` against the Arrow schema — so a dotted path either missed entirely or matched only its parent. `validate_projection_names` rejected `meta.a` outright; `canonical_output_schema` silently dropped it.

## Fix

**Schema.** `canonical_output_schema` and `validate_projection_names` resolve through `lance_core::datatypes::Schema`, which already narrows a struct to the selected leaf and merges sibling leaves of one parent into a single field (`meta.a` + `meta.c` → `meta: Struct<a, c>`, via `do_project`'s `candidate_field.merge()`). `canonical_output_schema` returns `Result` as a consequence.

**Data.** The eight dataset arms (base table + SSTable across the scan, point-lookup, vector and FTS planners) now project *by schema* rather than by expression. That distinction is load-bearing — `ProjectionPlan::from_schema` documents that a partial nested projection "cannot be done easily using expressions", and expressions are what `Scanner::project` builds. `Scanner::project_with_schema` is added for it.

The six memtable execs share a new `take_projected_columns`, which takes whole stored columns and trims them to the projected shape with `RecordBatchExt::project_by_schema` — already recursive through structs, lists and maps, and null-buffer preserving. Columns whose type already matches pass through untouched, so a projection with no nested paths costs nothing.

Both arms therefore emit the same narrowed schema before `UnionExec`, and SSTable reads fetch only the selected sub-columns rather than whole structs.

## Two inconsistencies fixed along the way

- `MemTableScanner::output_schema` silently dropped a column that `compute_projection_indices` rejected outright — the two disagreed on the same input. Both now resolve through one `projected_data_fields` and error alike.
- `validate_projection_names` used `Schema::project`, which errors on a missing *top-level* column but returns an empty struct for a missing *child* — so `meta.nope` passed validation. It now uses `Schema::resolve`, which checks every path segment.

## Tests

- `projection.rs`: four new cases — leaf narrowing, sibling merging at the parent's position, whole-struct passthrough, and nested validation accepting `meta.a` while rejecting `meta.nope`.
- `builder.rs`: `projecting_a_struct_leaf_narrows_the_memtable_output` — end-to-end through `MemTableScanner`, asserting the sibling does not survive.
- Full `mem_wal` suite: **692 passed, 0 failed**.

## Lint status

`cargo fmt --all` clean. `cargo clippy -p lance --lib --tests` clean on every touched file. I have **not** run the full `cargo clippy --all --tests --benches -- -D warnings` that `AGENTS.md` asks for — the machine this was developed on is disk-bound and the full bench build was not viable. Flagging it explicitly rather than implying it passed; CI will cover it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YR3wEnDq7cD2a9v2DdTGsZ
