### PR TITLE
feat(core,index): fragment reuse row map for reordered rewrites

### DIFF
--- a/rust/lance-core/src/utils.rs
+++ b/rust/lance-core/src/utils.rs
@@ -16,6 +16,7 @@ pub mod io_stats;
 pub mod parse;
 pub mod path;
 pub mod row_addr_remap;
+pub mod stable_partition;
 pub mod tempfile;
 pub mod testing;
 pub mod tokio;

--- a/rust/lance-core/src/utils/stable_partition.rs
+++ b/rust/lance-core/src/utils/stable_partition.rs
@@ -37,7 +37,7 @@
 //!   cumulative per-label row count through the end of that block, as a
 //!   dense `num_blocks * m` grid. A block is the unit of storage, IO and
 //!   caching for the label column. The grid size is exact and data
-//!   independent (~600 KB for 50M rows across 500 destinations, ~61 MB at a
+//!   independent (~1.5 MB for 50M rows across 500 destinations, ~61 MB at a
 //!   1B-row rewrite across 1000); the encoded header names the
 //!   representation so sparser encodings can be added later without breaking
 //!   readers.

--- a/rust/lance-core/src/utils/stable_partition.rs
+++ b/rust/lance-core/src/utils/stable_partition.rs
@@ -13,20 +13,40 @@
 //!   the index of its destination in the rewrite's ordered destination list.
 //! * A deleted source row is labeled NULL: it moved nowhere.
 //!
+//! Ordering:
+//!
+//! The labels do not carry destination offsets; offsets are reconstructed by
+//! counting, which is only correct when the rewrite obeys all of:
+//!
+//! * Labels are recorded in source physical-row order: fragments in scan
+//!   order, offsets ascending within each fragment.
+//! * Each destination receives its rows in that same source order, and rows
+//!   are never re-sorted within a destination afterwards.
+//! * The ordered destination list is fixed for the whole rewrite.
+//!
+//! A rewrite that routes rows through parallel writers must merge each
+//! destination's output back into source order before recording this
+//! mapping; otherwise the derived offsets address the wrong rows.
+//!
 //! Because each destination is filled in source scan order, the destination
 //! row offset of a live row equals the number of earlier source rows with the
 //! same label. This module provides that arithmetic without materializing an
 //! O(rows) address map:
 //!
 //! * [`CountsMatrix`] — for every fixed-size block of source rows, the
-//!   cumulative per-label row count through the end of that block. A block is
-//!   the unit of storage, IO and caching for the label column.
+//!   cumulative per-label row count through the end of that block, as a
+//!   dense `num_blocks * m` grid. A block is the unit of storage, IO and
+//!   caching for the label column. The grid size is exact and data
+//!   independent (~600 KB for 50M rows across 500 destinations, ~61 MB at a
+//!   1B-row rewrite across 1000); the encoded header names the
+//!   representation so sparser encodings can be added later without breaking
+//!   readers.
 //! * [`translate_in_block`] — point lookup: destination offset = cumulative
-//!   count before the row's block + the label's rank within the block prefix.
-//!   Touches one block of labels.
+//!   count before the row's block (one array read) + the label's rank within
+//!   the block prefix. Touches one block of labels.
 //! * [`SweepTranslator`] — sequential translation: per-label counters seeded
-//!   from a block boundary, then `offset = counter[label]++` per row. O(1) per
-//!   row, used for bulk remapping and whole-unit decodes.
+//!   from a block boundary, then `offset = counter[label]++` per row. O(1)
+//!   per row, used for bulk remapping and whole-unit decodes.
 //!
 //! Label storage and file IO live in `lance-index`; this module is pure
 //! arithmetic over decoded label blocks and the counts matrix.
@@ -45,11 +65,21 @@ pub const MAX_DESTINATIONS: u32 = u16::MAX as u32 + 1;
 
 const COUNTS_MAGIC: &[u8; 4] = b"LSPC";
 const COUNTS_VERSION: u32 = 1;
-const COUNTS_HEADER_BYTES: usize = 4 + 4 + 4 + 4 + 8;
+/// magic + version + repr + num_destinations + block_rows + total_rows
+const COUNTS_HEADER_BYTES: usize = 4 + 4 + 4 + 4 + 4 + 8;
+/// Representation tag in the encoded header. Only the dense grid is written
+/// today; other tag values are reserved for future representations (e.g.
+/// per-destination sparse postings) and rejected with a clear error by
+/// current readers.
+const REPR_DENSE: u32 = 0;
+
+fn corrupt(message: impl Into<String>) -> Error {
+    Error::corrupt_file_named("stable_partition_counts", message)
+}
 
 /// Cumulative per-destination row counts at every block boundary.
 ///
-/// Row `b` of the matrix holds, for each destination label `d`, the number of
+/// Row `b` of the grid holds, for each destination label `d`, the number of
 /// source rows labeled `d` in blocks `0..=b`. The final row therefore holds
 /// the total row count of every destination. Deleted (NULL-labeled) rows are
 /// not counted; the deleted count of a block is implied by
@@ -152,28 +182,27 @@ impl CountsMatrix {
 
     /// Check internal consistency: per-label counts must be non-decreasing
     /// across blocks and each block's live rows must fit its row range.
-    /// O(num_blocks * num_destinations); intended for commit validation and
-    /// tests, not the read path.
+    /// O(num_blocks * num_destinations), no label IO. Called when a row map
+    /// is opened, so a corrupt counts buffer fails loudly instead of
+    /// translating rows to wrong addresses.
     pub fn validate(&self) -> Result<()> {
         let mut prev_live = 0u64;
         for block in 0..self.num_blocks() {
             if block > 0 {
                 let (prev, cur) = (self.block_row(block - 1), self.block_row(block));
                 if prev.iter().zip(cur).any(|(p, c)| c < p) {
-                    return Err(Error::corrupt_file_named(
-                        "stable_partition_counts",
-                        format!("stable-partition counts decrease at block {block}"),
-                    ));
+                    return Err(corrupt(format!(
+                        "cumulative counts decrease at block {block}"
+                    )));
                 }
             }
             let live_through: u64 = self.block_row(block).iter().map(|&c| u64::from(c)).sum();
             let range = self.block_range(block);
             let block_len = range.end - range.start;
             if live_through - prev_live > block_len {
-                return Err(Error::corrupt_file_named(
-                    "stable_partition_counts",
-                    format!("stable-partition counts at block {block} exceed its {block_len} rows"),
-                ));
+                return Err(corrupt(format!(
+                    "block {block} accounts for more live rows than its {block_len} rows"
+                )));
             }
             prev_live = live_through;
         }
@@ -181,12 +210,13 @@ impl CountsMatrix {
     }
 
     /// Serialize to the on-disk form stored in the row map file's global
-    /// buffer: a fixed header followed by the cumulative counts as
-    /// little-endian u32.
+    /// buffer: a fixed header naming the representation, then the cumulative
+    /// counts as little-endian u32.
     pub fn encode(&self) -> Vec<u8> {
         let mut buf = Vec::with_capacity(COUNTS_HEADER_BYTES + self.cumulative.len() * 4);
         buf.extend_from_slice(COUNTS_MAGIC);
         buf.extend_from_slice(&COUNTS_VERSION.to_le_bytes());
+        buf.extend_from_slice(&REPR_DENSE.to_le_bytes());
         buf.extend_from_slice(&self.num_destinations.to_le_bytes());
         buf.extend_from_slice(&self.block_rows.to_le_bytes());
         buf.extend_from_slice(&self.total_rows.to_le_bytes());
@@ -196,51 +226,50 @@ impl CountsMatrix {
         buf
     }
 
-    /// Decode the on-disk form. Checks structure (magic, version, lengths)
-    /// only; see [`Self::validate`] for content invariants.
+    /// Decode the on-disk form, checking structure exactly: magic, version, a
+    /// supported representation, shape legality and precise payload length.
+    /// Content invariants (monotone counts, per-block row budgets) are
+    /// checked by [`Self::validate`].
     pub fn decode(buf: &[u8]) -> Result<Self> {
         let header: &[u8; COUNTS_HEADER_BYTES] = buf
             .get(..COUNTS_HEADER_BYTES)
-            .and_then(|h| h.try_into().ok())
+            .and_then(|header| header.try_into().ok())
             .ok_or_else(|| {
-                Error::corrupt_file_named(
-                    "stable_partition_counts",
-                    format!(
-                    "stable-partition counts buffer is {} bytes, shorter than the {COUNTS_HEADER_BYTES}-byte header",
+                corrupt(format!(
+                    "counts buffer is {} bytes, shorter than the {COUNTS_HEADER_BYTES}-byte header",
                     buf.len()
                 ))
             })?;
         if &header[0..4] != COUNTS_MAGIC {
-            return Err(Error::corrupt_file_named(
-                "stable_partition_counts",
-                "stable-partition counts buffer has a bad magic number",
-            ));
+            return Err(corrupt("counts buffer has a bad magic number"));
         }
         let version = u32::from_le_bytes(header[4..8].try_into().unwrap());
         if version != COUNTS_VERSION {
-            return Err(Error::corrupt_file_named(
-                "stable_partition_counts",
-                format!("unsupported stable-partition counts version {version}"),
-            ));
+            return Err(corrupt(format!("unsupported counts version {version}")));
         }
-        let num_destinations = u32::from_le_bytes(header[8..12].try_into().unwrap());
-        let block_rows = u32::from_le_bytes(header[12..16].try_into().unwrap());
-        let total_rows = u64::from_le_bytes(header[16..24].try_into().unwrap());
+        let repr = u32::from_le_bytes(header[8..12].try_into().unwrap());
+        if repr != REPR_DENSE {
+            return Err(corrupt(format!(
+                "unsupported counts representation {repr}; this reader only supports the dense grid ({REPR_DENSE})"
+            )));
+        }
+        let num_destinations = u32::from_le_bytes(header[12..16].try_into().unwrap());
+        let block_rows = u32::from_le_bytes(header[16..20].try_into().unwrap());
+        let total_rows = u64::from_le_bytes(header[20..28].try_into().unwrap());
         Self::check_shape(num_destinations, block_rows)?;
         let num_blocks = total_rows.div_ceil(u64::from(block_rows));
-        let expected = num_blocks
+        num_blocks
             .checked_mul(u64::from(num_destinations))
-            .and_then(|counts| counts.checked_mul(4))
+            .and_then(|cells| cells.checked_mul(4))
             .filter(|&bytes| bytes == (buf.len() - COUNTS_HEADER_BYTES) as u64)
             .ok_or_else(|| {
-                Error::corrupt_file_named(
-                    "stable_partition_counts",
-                    format!(
-                    "stable-partition counts buffer of {} bytes does not match {num_blocks} blocks of {num_destinations} destinations",
+                corrupt(format!(
+                    "counts buffer of {} bytes does not match {num_blocks} blocks of {num_destinations} destinations",
                     buf.len()
                 ))
             })?;
-        let mut cumulative = Vec::with_capacity((expected / 4) as usize);
+        let mut cumulative =
+            Vec::with_capacity((num_blocks * u64::from(num_destinations)) as usize);
         for chunk in buf[COUNTS_HEADER_BYTES..].chunks_exact(4) {
             cumulative.push(u32::from_le_bytes(chunk.try_into().unwrap()));
         }
@@ -447,28 +476,20 @@ impl SweepTranslator {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use rand::rngs::StdRng;
+    use rand::{Rng, SeedableRng};
 
-    /// Deterministic labels without a rand dependency: a simple LCG.
-    struct Lcg(u64);
-
-    impl Lcg {
-        fn next(&mut self) -> u64 {
-            self.0 = self
-                .0
-                .wrapping_mul(6364136223846793005)
-                .wrapping_add(1442695040888963407);
-            self.0 >> 33
-        }
-
-        /// ~1/8 deleted rows, labels uniform over `m`.
-        fn label(&mut self, m: u32) -> Option<u16> {
-            let raw = self.next();
-            if raw.is_multiple_of(8) {
-                None
-            } else {
-                Some((raw % u64::from(m)) as u16)
-            }
-        }
+    /// ~1/8 deleted rows, labels uniform over `m`.
+    fn random_labels(rng: &mut StdRng, rows: usize, m: u32) -> Vec<Option<u16>> {
+        (0..rows)
+            .map(|_| {
+                if rng.random_ratio(1, 8) {
+                    None
+                } else {
+                    Some(rng.random_range(0..m) as u16)
+                }
+            })
+            .collect()
     }
 
     fn build(labels: &[Option<u16>], m: u32, block_rows: u32) -> CountsMatrix {
@@ -516,7 +537,8 @@ mod tests {
 
     #[test]
     fn test_counts_matrix_hand_example() {
-        // 10 rows, block_rows=4 -> blocks of 4, 4, 2. m=3.
+        // 10 rows, block_rows=4 -> blocks of 4, 4, 2. m=3, and destination 1
+        // receives nothing in blocks 0 and 2.
         let labels = [
             Some(0),
             Some(2),
@@ -538,6 +560,10 @@ mod tests {
         assert_eq!(counts.count_before(0, 2), 0);
         assert_eq!(counts.count_before(1, 2), 2);
         assert_eq!(counts.count_before(2, 0), 2);
+        // Destination 1 received nothing in blocks 0 and 2: lookups around
+        // the gap see the count of its last change (or 0).
+        assert_eq!(counts.count_before(1, 1), 0);
+        assert_eq!(counts.count_before(3, 1), 2);
         assert_eq!(
             (counts.total(0), counts.total(1), counts.total(2)),
             (3, 2, 3)
@@ -561,16 +587,18 @@ mod tests {
 
     #[test]
     fn test_encode_decode_round_trip() {
-        let mut lcg = Lcg(7);
-        let labels: Vec<_> = (0..1000).map(|_| lcg.label(5)).collect();
+        let mut rng = StdRng::seed_from_u64(7);
+        let labels = random_labels(&mut rng, 1000, 5);
         let counts = build(&labels, 5, 64);
         let decoded = CountsMatrix::decode(&counts.encode()).unwrap();
         assert_eq!(decoded, counts);
+        decoded.validate().unwrap();
 
         let empty = build(&[], 5, 64);
         assert_eq!(CountsMatrix::decode(&empty.encode()).unwrap(), empty);
 
-        // Structural corruption is caught at decode.
+        // Structural corruption is caught at decode: too short, bad magic,
+        // truncated payload, unknown representation tag.
         assert!(CountsMatrix::decode(&[]).is_err());
         let mut bad_magic = counts.encode();
         bad_magic[0] = b'X';
@@ -578,6 +606,9 @@ mod tests {
         let mut truncated = counts.encode();
         truncated.pop();
         assert!(CountsMatrix::decode(&truncated).is_err());
+        let mut bad_repr = counts.encode();
+        bad_repr[8] = 9;
+        assert!(CountsMatrix::decode(&bad_repr).is_err());
 
         // Content corruption is caught by validate: shrink a later block's
         // cumulative count below an earlier one.
@@ -605,8 +636,8 @@ mod tests {
     #[test]
     fn test_point_and_sweep_match_reference() {
         let m = 5u32;
-        let mut lcg = Lcg(42);
-        let labels: Vec<_> = (0..1000).map(|_| lcg.label(m)).collect();
+        let mut rng = StdRng::seed_from_u64(42);
+        let labels = random_labels(&mut rng, 1000, m);
         let counts = build(&labels, m, 64);
         counts.validate().unwrap();
         let expected = reference(&labels);

--- a/rust/lance-core/src/utils/stable_partition.rs
+++ b/rust/lance-core/src/utils/stable_partition.rs
@@ -1,0 +1,658 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+//! Stable-partition row mapping for reordered rewrites.
+//!
+//! A reordered rewrite (e.g. reclustering) reads `n` source fragments in scan
+//! order and distributes their live rows across `m` destination fragments,
+//! preserving relative row order within each destination (a stable partition).
+//! Unlike compaction, the destination of a row cannot be derived from row
+//! order alone, so the rewrite records one label per physical source row:
+//!
+//! * The label of the `i`-th physical source row (concatenated scan order) is
+//!   the index of its destination in the rewrite's ordered destination list.
+//! * A deleted source row is labeled NULL: it moved nowhere.
+//!
+//! Because each destination is filled in source scan order, the destination
+//! row offset of a live row equals the number of earlier source rows with the
+//! same label. This module provides that arithmetic without materializing an
+//! O(rows) address map:
+//!
+//! * [`CountsMatrix`] — for every fixed-size block of source rows, the
+//!   cumulative per-label row count through the end of that block. A block is
+//!   the unit of storage, IO and caching for the label column.
+//! * [`translate_in_block`] — point lookup: destination offset = cumulative
+//!   count before the row's block + the label's rank within the block prefix.
+//!   Touches one block of labels.
+//! * [`SweepTranslator`] — sequential translation: per-label counters seeded
+//!   from a block boundary, then `offset = counter[label]++` per row. O(1) per
+//!   row, used for bulk remapping and whole-unit decodes.
+//!
+//! Label storage and file IO live in `lance-index`; this module is pure
+//! arithmetic over decoded label blocks and the counts matrix.
+
+use crate::deepsize::{Context, DeepSizeOf};
+use crate::{Error, Result};
+use arrow_buffer::NullBuffer;
+
+/// Default number of source rows per block: the counts granularity and the
+/// unit of label IO.
+pub const DEFAULT_BLOCK_ROWS: u32 = 64 * 1024;
+
+/// Labels are u16 destination indices, so one rewrite addresses at most
+/// 65536 destinations.
+pub const MAX_DESTINATIONS: u32 = u16::MAX as u32 + 1;
+
+const COUNTS_MAGIC: &[u8; 4] = b"LSPC";
+const COUNTS_VERSION: u32 = 1;
+const COUNTS_HEADER_BYTES: usize = 4 + 4 + 4 + 4 + 8;
+
+/// Cumulative per-destination row counts at every block boundary.
+///
+/// Row `b` of the matrix holds, for each destination label `d`, the number of
+/// source rows labeled `d` in blocks `0..=b`. The final row therefore holds
+/// the total row count of every destination. Deleted (NULL-labeled) rows are
+/// not counted; the deleted count of a block is implied by
+/// `block length - sum of per-label deltas`.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct CountsMatrix {
+    /// Number of destinations `m`; labels are `0..m`.
+    num_destinations: u32,
+    /// Source rows per block. Only the final block may be shorter.
+    block_rows: u32,
+    /// Total physical source rows, including deleted rows.
+    total_rows: u64,
+    /// `num_blocks * num_destinations` cumulative counts, row-major by block.
+    cumulative: Vec<u32>,
+}
+
+impl CountsMatrix {
+    pub fn num_destinations(&self) -> u32 {
+        self.num_destinations
+    }
+
+    pub fn block_rows(&self) -> u32 {
+        self.block_rows
+    }
+
+    pub fn total_rows(&self) -> u64 {
+        self.total_rows
+    }
+
+    pub fn num_blocks(&self) -> usize {
+        self.cumulative.len() / self.num_destinations as usize
+    }
+
+    /// The block containing physical source row `row`.
+    pub fn block_of(&self, row: u64) -> usize {
+        (row / u64::from(self.block_rows)) as usize
+    }
+
+    /// The physical source row range covered by `block`.
+    pub fn block_range(&self, block: usize) -> std::ops::Range<u64> {
+        let start = block as u64 * u64::from(self.block_rows);
+        let end = (start + u64::from(self.block_rows)).min(self.total_rows);
+        start..end
+    }
+
+    fn block_row(&self, block: usize) -> &[u32] {
+        let m = self.num_destinations as usize;
+        &self.cumulative[block * m..(block + 1) * m]
+    }
+
+    /// Rows labeled `label` in blocks before `block`: the destination offset
+    /// of the first `label`-row inside `block`.
+    pub fn count_before(&self, block: usize, label: u16) -> u32 {
+        if block == 0 {
+            0
+        } else {
+            self.block_row(block - 1)[label as usize]
+        }
+    }
+
+    /// Per-label counters at the start of `block`, seeding a
+    /// [`SweepTranslator`].
+    pub fn counters_at_block(&self, block: usize) -> Vec<u32> {
+        if block == 0 {
+            vec![0; self.num_destinations as usize]
+        } else {
+            self.block_row(block - 1).to_vec()
+        }
+    }
+
+    /// Total rows of destination `label`; the final cumulative row.
+    pub fn total(&self, label: u16) -> u32 {
+        let blocks = self.num_blocks();
+        if blocks == 0 {
+            0
+        } else {
+            self.block_row(blocks - 1)[label as usize]
+        }
+    }
+
+    /// Total live (labeled) rows across all destinations.
+    pub fn total_live_rows(&self) -> u64 {
+        let blocks = self.num_blocks();
+        if blocks == 0 {
+            0
+        } else {
+            self.block_row(blocks - 1)
+                .iter()
+                .map(|&c| u64::from(c))
+                .sum()
+        }
+    }
+
+    /// Deleted (NULL-labeled) rows in blocks `0..=block`.
+    pub fn deleted_through(&self, block: usize) -> u64 {
+        let rows_through = self.block_range(block).end;
+        let live_through: u64 = self.block_row(block).iter().map(|&c| u64::from(c)).sum();
+        rows_through - live_through
+    }
+
+    /// Check internal consistency: per-label counts must be non-decreasing
+    /// across blocks and each block's live rows must fit its row range.
+    /// O(num_blocks * num_destinations); intended for commit validation and
+    /// tests, not the read path.
+    pub fn validate(&self) -> Result<()> {
+        let mut prev_live = 0u64;
+        for block in 0..self.num_blocks() {
+            if block > 0 {
+                let (prev, cur) = (self.block_row(block - 1), self.block_row(block));
+                if prev.iter().zip(cur).any(|(p, c)| c < p) {
+                    return Err(Error::corrupt_file_named(
+                        "stable_partition_counts",
+                        format!("stable-partition counts decrease at block {block}"),
+                    ));
+                }
+            }
+            let live_through: u64 = self.block_row(block).iter().map(|&c| u64::from(c)).sum();
+            let range = self.block_range(block);
+            let block_len = range.end - range.start;
+            if live_through - prev_live > block_len {
+                return Err(Error::corrupt_file_named(
+                    "stable_partition_counts",
+                    format!("stable-partition counts at block {block} exceed its {block_len} rows"),
+                ));
+            }
+            prev_live = live_through;
+        }
+        Ok(())
+    }
+
+    /// Serialize to the on-disk form stored in the row map file's global
+    /// buffer: a fixed header followed by the cumulative counts as
+    /// little-endian u32.
+    pub fn encode(&self) -> Vec<u8> {
+        let mut buf = Vec::with_capacity(COUNTS_HEADER_BYTES + self.cumulative.len() * 4);
+        buf.extend_from_slice(COUNTS_MAGIC);
+        buf.extend_from_slice(&COUNTS_VERSION.to_le_bytes());
+        buf.extend_from_slice(&self.num_destinations.to_le_bytes());
+        buf.extend_from_slice(&self.block_rows.to_le_bytes());
+        buf.extend_from_slice(&self.total_rows.to_le_bytes());
+        for count in &self.cumulative {
+            buf.extend_from_slice(&count.to_le_bytes());
+        }
+        buf
+    }
+
+    /// Decode the on-disk form. Checks structure (magic, version, lengths)
+    /// only; see [`Self::validate`] for content invariants.
+    pub fn decode(buf: &[u8]) -> Result<Self> {
+        let header: &[u8; COUNTS_HEADER_BYTES] = buf
+            .get(..COUNTS_HEADER_BYTES)
+            .and_then(|h| h.try_into().ok())
+            .ok_or_else(|| {
+                Error::corrupt_file_named(
+                    "stable_partition_counts",
+                    format!(
+                    "stable-partition counts buffer is {} bytes, shorter than the {COUNTS_HEADER_BYTES}-byte header",
+                    buf.len()
+                ))
+            })?;
+        if &header[0..4] != COUNTS_MAGIC {
+            return Err(Error::corrupt_file_named(
+                "stable_partition_counts",
+                "stable-partition counts buffer has a bad magic number",
+            ));
+        }
+        let version = u32::from_le_bytes(header[4..8].try_into().unwrap());
+        if version != COUNTS_VERSION {
+            return Err(Error::corrupt_file_named(
+                "stable_partition_counts",
+                format!("unsupported stable-partition counts version {version}"),
+            ));
+        }
+        let num_destinations = u32::from_le_bytes(header[8..12].try_into().unwrap());
+        let block_rows = u32::from_le_bytes(header[12..16].try_into().unwrap());
+        let total_rows = u64::from_le_bytes(header[16..24].try_into().unwrap());
+        Self::check_shape(num_destinations, block_rows)?;
+        let num_blocks = total_rows.div_ceil(u64::from(block_rows));
+        let expected = num_blocks
+            .checked_mul(u64::from(num_destinations))
+            .and_then(|counts| counts.checked_mul(4))
+            .filter(|&bytes| bytes == (buf.len() - COUNTS_HEADER_BYTES) as u64)
+            .ok_or_else(|| {
+                Error::corrupt_file_named(
+                    "stable_partition_counts",
+                    format!(
+                    "stable-partition counts buffer of {} bytes does not match {num_blocks} blocks of {num_destinations} destinations",
+                    buf.len()
+                ))
+            })?;
+        let mut cumulative = Vec::with_capacity((expected / 4) as usize);
+        for chunk in buf[COUNTS_HEADER_BYTES..].chunks_exact(4) {
+            cumulative.push(u32::from_le_bytes(chunk.try_into().unwrap()));
+        }
+        Ok(Self {
+            num_destinations,
+            block_rows,
+            total_rows,
+            cumulative,
+        })
+    }
+
+    fn check_shape(num_destinations: u32, block_rows: u32) -> Result<()> {
+        if num_destinations == 0 || num_destinations > MAX_DESTINATIONS {
+            return Err(Error::invalid_input(format!(
+                "stable partition needs 1..={MAX_DESTINATIONS} destinations, got {num_destinations}"
+            )));
+        }
+        if block_rows == 0 {
+            return Err(Error::invalid_input(
+                "stable partition block_rows must be positive",
+            ));
+        }
+        Ok(())
+    }
+
+    fn check_label(&self, label: u16) -> Result<()> {
+        if u32::from(label) >= self.num_destinations {
+            return Err(Error::invalid_input(format!(
+                "label {label} is outside the {} destinations of this stable partition",
+                self.num_destinations
+            )));
+        }
+        Ok(())
+    }
+}
+
+impl DeepSizeOf for CountsMatrix {
+    fn deep_size_of_children(&self, context: &mut Context) -> usize {
+        self.cumulative.deep_size_of_children(context)
+    }
+}
+
+/// Streaming builder for a [`CountsMatrix`]: feed one label per physical
+/// source row in scan order.
+#[derive(Debug)]
+pub struct CountsMatrixBuilder {
+    num_destinations: u32,
+    block_rows: u32,
+    running: Vec<u32>,
+    cumulative: Vec<u32>,
+    total_rows: u64,
+    rows_in_block: u32,
+}
+
+impl CountsMatrixBuilder {
+    pub fn try_new(num_destinations: u32, block_rows: u32) -> Result<Self> {
+        CountsMatrix::check_shape(num_destinations, block_rows)?;
+        Ok(Self {
+            num_destinations,
+            block_rows,
+            running: vec![0; num_destinations as usize],
+            cumulative: Vec::new(),
+            total_rows: 0,
+            rows_in_block: 0,
+        })
+    }
+
+    /// Record the label of the next physical source row; `None` marks a
+    /// deleted row.
+    pub fn push(&mut self, label: Option<u16>) -> Result<()> {
+        if let Some(label) = label {
+            if u32::from(label) >= self.num_destinations {
+                return Err(Error::invalid_input(format!(
+                    "label {label} is outside the {} destinations of this stable partition",
+                    self.num_destinations
+                )));
+            }
+            let counter = &mut self.running[label as usize];
+            *counter = counter.checked_add(1).ok_or_else(|| {
+                Error::invalid_input(format!(
+                    "destination {label} exceeds the u32 row-offset range"
+                ))
+            })?;
+        }
+        self.total_rows += 1;
+        self.rows_in_block += 1;
+        if self.rows_in_block == self.block_rows {
+            self.cumulative.extend_from_slice(&self.running);
+            self.rows_in_block = 0;
+        }
+        Ok(())
+    }
+
+    pub fn finish(mut self) -> CountsMatrix {
+        if self.rows_in_block > 0 {
+            self.cumulative.extend_from_slice(&self.running);
+        }
+        CountsMatrix {
+            num_destinations: self.num_destinations,
+            block_rows: self.block_rows,
+            total_rows: self.total_rows,
+            cumulative: self.cumulative,
+        }
+    }
+}
+
+/// Rank of `label` among the first `upto` labels of a block: the number of
+/// valid entries equal to `label` in `values[..upto]`.
+pub fn rank_label_prefix(
+    values: &[u16],
+    validity: Option<&NullBuffer>,
+    upto: usize,
+    label: u16,
+) -> u32 {
+    match validity {
+        // NULL slots hold arbitrary values after an encoding round trip, so
+        // they must be masked out of the count.
+        Some(validity) if validity.null_count() > 0 => values[..upto]
+            .iter()
+            .enumerate()
+            .filter(|&(i, &value)| value == label && validity.is_valid(i))
+            .count() as u32,
+        _ => values[..upto]
+            .iter()
+            .filter(|&&value| value == label)
+            .count() as u32,
+    }
+}
+
+/// Translate one physical source row using its decoded label block.
+///
+/// `values`/`validity` are the labels of `block` (exactly the rows of
+/// [`CountsMatrix::block_range`]); `pos_in_block` addresses the row within
+/// them. Returns `None` when the row was deleted at the source, otherwise
+/// `(destination index, destination row offset)`.
+pub fn translate_in_block(
+    counts: &CountsMatrix,
+    block: usize,
+    values: &[u16],
+    validity: Option<&NullBuffer>,
+    pos_in_block: usize,
+) -> Result<Option<(u16, u32)>> {
+    let block_range = counts.block_range(block);
+    let block_len = (block_range.end - block_range.start) as usize;
+    if values.len() != block_len {
+        return Err(Error::invalid_input(format!(
+            "block {block} holds {block_len} labels but {} were supplied",
+            values.len()
+        )));
+    }
+    if pos_in_block >= block_len {
+        return Err(Error::invalid_input(format!(
+            "row {pos_in_block} is outside block {block} of {block_len} rows"
+        )));
+    }
+    if validity.is_some_and(|validity| !validity.is_valid(pos_in_block)) {
+        return Ok(None);
+    }
+    let label = values[pos_in_block];
+    counts.check_label(label)?;
+    let offset = counts.count_before(block, label)
+        + rank_label_prefix(values, validity, pos_in_block, label);
+    Ok(Some((label, offset)))
+}
+
+/// Sequential translator: seed per-label counters from a block boundary, then
+/// feed every physical source row's label in order.
+#[derive(Debug)]
+pub struct SweepTranslator {
+    counters: Vec<u32>,
+}
+
+impl SweepTranslator {
+    /// Counters positioned at the first row of `start_block`.
+    pub fn new(counts: &CountsMatrix, start_block: usize) -> Result<Self> {
+        if start_block >= counts.num_blocks().max(1) {
+            return Err(Error::invalid_input(format!(
+                "start block {start_block} is outside the {} blocks of this stable partition",
+                counts.num_blocks()
+            )));
+        }
+        Ok(Self {
+            counters: counts.counters_at_block(start_block),
+        })
+    }
+
+    /// Translate the next row. `None` in, `None` out for deleted rows.
+    #[inline]
+    pub fn advance(&mut self, label: Option<u16>) -> Result<Option<(u16, u32)>> {
+        let Some(label) = label else {
+            return Ok(None);
+        };
+        let counter = self.counters.get_mut(label as usize).ok_or_else(|| {
+            Error::invalid_input(format!(
+                "label {label} is outside the destinations of this stable partition"
+            ))
+        })?;
+        let offset = *counter;
+        *counter += 1;
+        Ok(Some((label, offset)))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Deterministic labels without a rand dependency: a simple LCG.
+    struct Lcg(u64);
+
+    impl Lcg {
+        fn next(&mut self) -> u64 {
+            self.0 = self
+                .0
+                .wrapping_mul(6364136223846793005)
+                .wrapping_add(1442695040888963407);
+            self.0 >> 33
+        }
+
+        /// ~1/8 deleted rows, labels uniform over `m`.
+        fn label(&mut self, m: u32) -> Option<u16> {
+            let raw = self.next();
+            if raw.is_multiple_of(8) {
+                None
+            } else {
+                Some((raw % u64::from(m)) as u16)
+            }
+        }
+    }
+
+    fn build(labels: &[Option<u16>], m: u32, block_rows: u32) -> CountsMatrix {
+        let mut builder = CountsMatrixBuilder::try_new(m, block_rows).unwrap();
+        for &label in labels {
+            builder.push(label).unwrap();
+        }
+        builder.finish()
+    }
+
+    /// Reference translation: scan all labels with per-destination counters.
+    fn reference(labels: &[Option<u16>]) -> Vec<Option<(u16, u32)>> {
+        let mut counters = std::collections::HashMap::new();
+        labels
+            .iter()
+            .map(|label| {
+                label.map(|label| {
+                    let counter = counters.entry(label).or_insert(0u32);
+                    let offset = *counter;
+                    *counter += 1;
+                    (label, offset)
+                })
+            })
+            .collect()
+    }
+
+    fn block_slices(
+        labels: &[Option<u16>],
+        counts: &CountsMatrix,
+        block: usize,
+    ) -> (Vec<u16>, Option<NullBuffer>) {
+        let range = counts.block_range(block);
+        let block_labels = &labels[range.start as usize..range.end as usize];
+        // NULL slots get a garbage value on purpose: after an encoding round
+        // trip their contents are undefined and must not affect ranks.
+        let values = block_labels
+            .iter()
+            .map(|label| label.unwrap_or(0xBEEF_u64 as u16))
+            .collect();
+        let has_nulls = block_labels.iter().any(Option::is_none);
+        let validity =
+            has_nulls.then(|| NullBuffer::from_iter(block_labels.iter().map(Option::is_some)));
+        (values, validity)
+    }
+
+    #[test]
+    fn test_counts_matrix_hand_example() {
+        // 10 rows, block_rows=4 -> blocks of 4, 4, 2. m=3.
+        let labels = [
+            Some(0),
+            Some(2),
+            None,
+            Some(2), // block 0: d0=1, d2=2, 1 deleted
+            Some(1),
+            Some(1),
+            Some(0),
+            Some(2), // block 1: cum d0=2, d1=2, d2=3
+            None,
+            Some(0), // block 2: cum d0=3, d1=2, d2=3, 2 deleted total
+        ];
+        let counts = build(&labels, 3, 4);
+        counts.validate().unwrap();
+        assert_eq!(counts.num_blocks(), 3);
+        assert_eq!(counts.total_rows(), 10);
+        assert_eq!(counts.block_range(2), 8..10);
+
+        assert_eq!(counts.count_before(0, 2), 0);
+        assert_eq!(counts.count_before(1, 2), 2);
+        assert_eq!(counts.count_before(2, 0), 2);
+        assert_eq!(
+            (counts.total(0), counts.total(1), counts.total(2)),
+            (3, 2, 3)
+        );
+        assert_eq!(counts.total_live_rows(), 8);
+        assert_eq!(counts.deleted_through(0), 1);
+        assert_eq!(counts.deleted_through(2), 2);
+        assert_eq!(counts.counters_at_block(1), vec![1, 0, 2]);
+
+        // Exact multiple of block_rows: no partial block.
+        let exact = build(&labels[..8], 3, 4);
+        assert_eq!(exact.num_blocks(), 2);
+        assert_eq!(exact.total_rows(), 8);
+
+        let empty = build(&[], 3, 4);
+        assert_eq!(empty.num_blocks(), 0);
+        assert_eq!(empty.total(1), 0);
+        assert_eq!(empty.total_live_rows(), 0);
+        empty.validate().unwrap();
+    }
+
+    #[test]
+    fn test_encode_decode_round_trip() {
+        let mut lcg = Lcg(7);
+        let labels: Vec<_> = (0..1000).map(|_| lcg.label(5)).collect();
+        let counts = build(&labels, 5, 64);
+        let decoded = CountsMatrix::decode(&counts.encode()).unwrap();
+        assert_eq!(decoded, counts);
+
+        let empty = build(&[], 5, 64);
+        assert_eq!(CountsMatrix::decode(&empty.encode()).unwrap(), empty);
+
+        // Structural corruption is caught at decode.
+        assert!(CountsMatrix::decode(&[]).is_err());
+        let mut bad_magic = counts.encode();
+        bad_magic[0] = b'X';
+        assert!(CountsMatrix::decode(&bad_magic).is_err());
+        let mut truncated = counts.encode();
+        truncated.pop();
+        assert!(CountsMatrix::decode(&truncated).is_err());
+
+        // Content corruption is caught by validate: shrink a later block's
+        // cumulative count below an earlier one.
+        let mut decreasing = counts;
+        let m = decreasing.num_destinations as usize;
+        decreasing.cumulative[m] = 0;
+        assert!(
+            CountsMatrix::decode(&decreasing.encode())
+                .unwrap()
+                .validate()
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn test_builder_rejects_bad_shapes_and_labels() {
+        assert!(CountsMatrixBuilder::try_new(0, 64).is_err());
+        assert!(CountsMatrixBuilder::try_new(MAX_DESTINATIONS + 1, 64).is_err());
+        assert!(CountsMatrixBuilder::try_new(1, 0).is_err());
+        let mut builder = CountsMatrixBuilder::try_new(3, 4).unwrap();
+        assert!(builder.push(Some(3)).is_err());
+        assert!(builder.push(Some(2)).is_ok());
+    }
+
+    #[test]
+    fn test_point_and_sweep_match_reference() {
+        let m = 5u32;
+        let mut lcg = Lcg(42);
+        let labels: Vec<_> = (0..1000).map(|_| lcg.label(m)).collect();
+        let counts = build(&labels, m, 64);
+        counts.validate().unwrap();
+        let expected = reference(&labels);
+
+        // Point lookups, block by block, against the reference map.
+        for block in 0..counts.num_blocks() {
+            let (values, validity) = block_slices(&labels, &counts, block);
+            let range = counts.block_range(block);
+            for pos in 0..(range.end - range.start) as usize {
+                let translated =
+                    translate_in_block(&counts, block, &values, validity.as_ref(), pos).unwrap();
+                assert_eq!(
+                    translated,
+                    expected[range.start as usize + pos],
+                    "row {}",
+                    range.start as usize + pos
+                );
+            }
+        }
+
+        // A sweep from the start and one from every block boundary.
+        for start_block in 0..counts.num_blocks() {
+            let mut sweep = SweepTranslator::new(&counts, start_block).unwrap();
+            let start_row = counts.block_range(start_block).start as usize;
+            for (row, &label) in labels.iter().enumerate().skip(start_row) {
+                assert_eq!(
+                    sweep.advance(label).unwrap(),
+                    expected[row],
+                    "row {row} from block {start_block}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn test_translate_in_block_input_checks() {
+        let labels = [Some(0), Some(1), None, Some(0)];
+        let counts = build(&labels, 2, 4);
+        let (values, validity) = block_slices(&labels, &counts, 0);
+        // Wrong slice length and out-of-range row are rejected.
+        assert!(translate_in_block(&counts, 0, &values[..3], None, 0).is_err());
+        assert!(translate_in_block(&counts, 0, &values, validity.as_ref(), 4).is_err());
+        // A label outside the destination list is data corruption.
+        assert!(translate_in_block(&counts, 0, &[0, 9, 0, 0], None, 1).is_err());
+        assert!(SweepTranslator::new(&counts, 1).is_err());
+        let mut sweep = SweepTranslator::new(&counts, 0).unwrap();
+        assert!(sweep.advance(Some(9)).is_err());
+    }
+}

--- a/rust/lance-core/src/utils/stable_partition.rs
+++ b/rust/lance-core/src/utils/stable_partition.rs
@@ -28,6 +28,14 @@
 //! destination's output back into source order before recording this
 //! mapping; otherwise the derived offsets address the wrong rows.
 //!
+//! This contract is deliberate scope, not an oversight: the format
+//! represents stable partitions only. A rewrite that sorts rows *within* a
+//! destination is not representable here — with source rows `[a, b]`
+//! written to one destination as `[b, a]`, both labels are equal, and
+//! counting would assign the offsets backwards. Such a rewrite needs a
+//! per-row final-offset (permutation) encoding, which would be a separate
+//! format rather than a relaxation of this one.
+//!
 //! Because each destination is filled in source scan order, the destination
 //! row offset of a live row equals the number of earlier source rows with the
 //! same label. This module provides that arithmetic without materializing an

--- a/rust/lance-index/Cargo.toml
+++ b/rust/lance-index/Cargo.toml
@@ -162,6 +162,10 @@ name = "bitmap"
 harness = false
 
 [[bench]]
+name = "stable_partition_row_map"
+harness = false
+
+[[bench]]
 name = "geo"
 harness = false
 required-features = ["geo"]

--- a/rust/lance-index/benches/stable_partition_row_map.rs
+++ b/rust/lance-index/benches/stable_partition_row_map.rs
@@ -20,6 +20,8 @@ use lance_index::frag_reuse::row_map::{RowMapReader, RowMapWriter, SourceRows};
 use lance_index::scalar::IndexStore;
 use lance_index::scalar::lance_format::LanceIndexStore;
 use lance_io::object_store::ObjectStore;
+use rand::rngs::StdRng;
+use rand::{Rng, SeedableRng};
 use roaring::RoaringBitmap;
 
 const TOTAL_ROWS: u64 = 2_000_000;
@@ -32,18 +34,6 @@ struct Fixture {
 }
 
 static FIXTURE: OnceLock<Fixture> = OnceLock::new();
-
-struct Lcg(u64);
-
-impl Lcg {
-    fn next(&mut self) -> u64 {
-        self.0 = self
-            .0
-            .wrapping_mul(6364136223846793005)
-            .wrapping_add(1442695040888963407);
-        self.0 >> 33
-    }
-}
 
 fn fixture() -> &'static Fixture {
     FIXTURE.get_or_init(|| {
@@ -66,10 +56,10 @@ fn fixture() -> &'static Fixture {
             lance_file::version::ConcreteFileVersion::V2_1,
         ));
 
-        let mut lcg = Lcg(97);
+        let mut rng = StdRng::seed_from_u64(97);
         let mut deleted = RoaringBitmap::new();
         for offset in 0..TOTAL_ROWS {
-            if lcg.next().is_multiple_of(8) {
+            if rng.random_ratio(1, 8) {
                 deleted.insert(offset as u32);
             }
         }
@@ -87,7 +77,7 @@ fn fixture() -> &'static Fixture {
             let mut writer = RowMapWriter::try_new(writer, sources, NUM_DESTINATIONS).unwrap();
             let mut pending = Vec::with_capacity(64 * 1024);
             for _ in 0..live_rows {
-                pending.push((lcg.next() % u64::from(NUM_DESTINATIONS)) as u16);
+                pending.push(rng.random_range(0..NUM_DESTINATIONS) as u16);
                 if pending.len() == pending.capacity() {
                     writer.append_labels(&pending).await.unwrap();
                     pending.clear();
@@ -125,7 +115,9 @@ fn fixture() -> &'static Fixture {
             let mut pending = Vec::with_capacity(64 * 1024);
             for row in 0..local_rows {
                 let window = (row / (64 * 1024)) * 16 % u64::from(NUM_DESTINATIONS);
-                pending.push(((window + lcg.next() % 16) % u64::from(NUM_DESTINATIONS)) as u16);
+                pending.push(
+                    ((window + rng.random_range(0..16)) % u64::from(NUM_DESTINATIONS)) as u16,
+                );
                 if pending.len() == pending.capacity() {
                     writer.append_labels(&pending).await.unwrap();
                     pending.clear();
@@ -136,7 +128,7 @@ fn fixture() -> &'static Fixture {
             let local_counts_bytes = local_counts.encode().len();
             println!(
                 "row map (16-destination block locality): {local_rows} rows -> \
-                 {} bytes file ({:.2} bits/row)",
+                 {} bytes file ({:.2} bits/row), {local_counts_bytes} bytes counts",
                 local_file.size_bytes,
                 (local_file
                     .size_bytes
@@ -160,10 +152,10 @@ fn fixture() -> &'static Fixture {
 
 fn bench_point_translate(c: &mut Criterion) {
     let fixture = fixture();
-    let mut lcg = Lcg(3);
+    let mut rng = StdRng::seed_from_u64(3);
     c.bench_function("row_map/translate_point", |b| {
         b.iter(|| {
-            let row = lcg.next() % TOTAL_ROWS;
+            let row = rng.random_range(0..TOTAL_ROWS);
             black_box(
                 fixture
                     .runtime
@@ -176,8 +168,8 @@ fn bench_point_translate(c: &mut Criterion) {
 
 fn bench_translate_many(c: &mut Criterion) {
     let fixture = fixture();
-    let mut lcg = Lcg(5);
-    let rows: Vec<u64> = (0..1024).map(|_| lcg.next() % TOTAL_ROWS).collect();
+    let mut rng = StdRng::seed_from_u64(5);
+    let rows: Vec<u64> = (0..1024).map(|_| rng.random_range(0..TOTAL_ROWS)).collect();
     c.bench_function("row_map/translate_many_1k", |b| {
         b.iter(|| {
             black_box(
@@ -214,9 +206,9 @@ fn bench_sweep(c: &mut Criterion) {
 fn bench_rank_in_block(c: &mut Criterion) {
     // The in-memory cost of one worst-case point lookup: ranking a label over
     // a full 64K block.
-    let mut lcg = Lcg(11);
+    let mut rng = StdRng::seed_from_u64(11);
     let values: Vec<u16> = (0..64 * 1024)
-        .map(|_| (lcg.next() % u64::from(NUM_DESTINATIONS)) as u16)
+        .map(|_| rng.random_range(0..NUM_DESTINATIONS) as u16)
         .collect();
     c.bench_function("row_map/rank_label_prefix_64k", |b| {
         b.iter(|| black_box(rank_label_prefix(&values, None, values.len(), 500)))

--- a/rust/lance-index/benches/stable_partition_row_map.rs
+++ b/rust/lance-index/benches/stable_partition_row_map.rs
@@ -9,6 +9,10 @@
 //! low-cardinality u16 column, so the Lance page dictionary path should land
 //! well under the nominal 10 bits (ceil(log2 1000)) per row.
 
+// The size probes report to the human running the bench; log targets nothing
+// useful here.
+#![allow(clippy::print_stdout)]
+
 use std::hint::black_box;
 use std::sync::{Arc, OnceLock};
 

--- a/rust/lance-index/benches/stable_partition_row_map.rs
+++ b/rust/lance-index/benches/stable_partition_row_map.rs
@@ -1,0 +1,233 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+//! Benchmarks of the stable-partition row map: file size (label encoding),
+//! point translation, batch translation and sweep throughput.
+//!
+//! The setup writes a 2M-row map with 1000 destinations and ~1/8 deleted
+//! rows, then prints the achieved bits per row: the label column is a
+//! low-cardinality u16 column, so the Lance page dictionary path should land
+//! well under the nominal 10 bits (ceil(log2 1000)) per row.
+
+use std::hint::black_box;
+use std::sync::{Arc, OnceLock};
+
+use criterion::{Criterion, criterion_group, criterion_main};
+use lance_core::cache::LanceCache;
+use lance_core::utils::stable_partition::rank_label_prefix;
+use lance_core::utils::tempfile::TempDir;
+use lance_index::frag_reuse::row_map::{RowMapReader, RowMapWriter, SourceRows};
+use lance_index::scalar::IndexStore;
+use lance_index::scalar::lance_format::LanceIndexStore;
+use lance_io::object_store::ObjectStore;
+use roaring::RoaringBitmap;
+
+const TOTAL_ROWS: u64 = 2_000_000;
+const NUM_DESTINATIONS: u32 = 1000;
+
+struct Fixture {
+    _tempdir: TempDir,
+    reader: RowMapReader,
+    runtime: tokio::runtime::Runtime,
+}
+
+static FIXTURE: OnceLock<Fixture> = OnceLock::new();
+
+struct Lcg(u64);
+
+impl Lcg {
+    fn next(&mut self) -> u64 {
+        self.0 = self
+            .0
+            .wrapping_mul(6364136223846793005)
+            .wrapping_add(1442695040888963407);
+        self.0 >> 33
+    }
+}
+
+fn fixture() -> &'static Fixture {
+    FIXTURE.get_or_init(|| {
+        let runtime = tokio::runtime::Builder::new_multi_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let tempdir = TempDir::default();
+        // The store's IO scheduler spawns onto the ambient tokio runtime.
+        let _guard = runtime.enter();
+        let (object_store, path) = runtime
+            .block_on(ObjectStore::from_uri(tempdir.obj_path().as_ref()))
+            .unwrap();
+        // 2.1+ has the miniblock dictionary path; 2.0 stores the labels as
+        // plain u16 and roughly triples the file.
+        let store: Arc<dyn IndexStore> = Arc::new(LanceIndexStore::with_format_version(
+            object_store,
+            path,
+            Arc::new(LanceCache::with_capacity(128 * 1024 * 1024)),
+            lance_file::version::ConcreteFileVersion::V2_1,
+        ));
+
+        let mut lcg = Lcg(97);
+        let mut deleted = RoaringBitmap::new();
+        for offset in 0..TOTAL_ROWS {
+            if lcg.next().is_multiple_of(8) {
+                deleted.insert(offset as u32);
+            }
+        }
+        let live_rows = TOTAL_ROWS - deleted.len();
+        let sources = vec![SourceRows {
+            physical_rows: TOTAL_ROWS,
+            deleted: Some(deleted),
+        }];
+
+        let reader = runtime.block_on(async {
+            let writer = store
+                .new_index_file("row_map.lance", RowMapWriter::schema())
+                .await
+                .unwrap();
+            let mut writer = RowMapWriter::try_new(writer, sources, NUM_DESTINATIONS).unwrap();
+            let mut pending = Vec::with_capacity(64 * 1024);
+            for _ in 0..live_rows {
+                pending.push((lcg.next() % u64::from(NUM_DESTINATIONS)) as u16);
+                if pending.len() == pending.capacity() {
+                    writer.append_labels(&pending).await.unwrap();
+                    pending.clear();
+                }
+            }
+            writer.append_labels(&pending).await.unwrap();
+            let (file, counts) = writer.finish().await.unwrap();
+            let counts_bytes = counts.encode().len();
+            println!(
+                "row map: {TOTAL_ROWS} rows, {NUM_DESTINATIONS} destinations -> \
+                 {} bytes file ({:.2} bits/row, nominal 10), {counts_bytes} bytes counts",
+                file.size_bytes,
+                (file.size_bytes.saturating_sub(counts_bytes as u64)) as f64 * 8.0
+                    / TOTAL_ROWS as f64,
+            );
+            // Size probe with destination locality: each 64K block draws its
+            // labels from a small window of destinations, the realistic shape
+            // when source scan order correlates with the clustering key. The
+            // uniform-random file above is the worst case (every block sees
+            // all destinations, dictionary indices need the nominal width).
+            let local_rows = 512u64 * 1024;
+            let writer = store
+                .new_index_file("row_map_local.lance", RowMapWriter::schema())
+                .await
+                .unwrap();
+            let mut writer = RowMapWriter::try_new(
+                writer,
+                vec![SourceRows {
+                    physical_rows: local_rows,
+                    deleted: None,
+                }],
+                NUM_DESTINATIONS,
+            )
+            .unwrap();
+            let mut pending = Vec::with_capacity(64 * 1024);
+            for row in 0..local_rows {
+                let window = (row / (64 * 1024)) * 16 % u64::from(NUM_DESTINATIONS);
+                pending.push(((window + lcg.next() % 16) % u64::from(NUM_DESTINATIONS)) as u16);
+                if pending.len() == pending.capacity() {
+                    writer.append_labels(&pending).await.unwrap();
+                    pending.clear();
+                }
+            }
+            writer.append_labels(&pending).await.unwrap();
+            let (local_file, local_counts) = writer.finish().await.unwrap();
+            let local_counts_bytes = local_counts.encode().len();
+            println!(
+                "row map (16-destination block locality): {local_rows} rows -> \
+                 {} bytes file ({:.2} bits/row)",
+                local_file.size_bytes,
+                (local_file
+                    .size_bytes
+                    .saturating_sub(local_counts_bytes as u64)) as f64
+                    * 8.0
+                    / local_rows as f64,
+            );
+
+            RowMapReader::open(store.open_index_file("row_map.lance").await.unwrap())
+                .await
+                .unwrap()
+        });
+
+        Fixture {
+            _tempdir: tempdir,
+            reader,
+            runtime,
+        }
+    })
+}
+
+fn bench_point_translate(c: &mut Criterion) {
+    let fixture = fixture();
+    let mut lcg = Lcg(3);
+    c.bench_function("row_map/translate_point", |b| {
+        b.iter(|| {
+            let row = lcg.next() % TOTAL_ROWS;
+            black_box(
+                fixture
+                    .runtime
+                    .block_on(fixture.reader.translate(row))
+                    .unwrap(),
+            )
+        })
+    });
+}
+
+fn bench_translate_many(c: &mut Criterion) {
+    let fixture = fixture();
+    let mut lcg = Lcg(5);
+    let rows: Vec<u64> = (0..1024).map(|_| lcg.next() % TOTAL_ROWS).collect();
+    c.bench_function("row_map/translate_many_1k", |b| {
+        b.iter(|| {
+            black_box(
+                fixture
+                    .runtime
+                    .block_on(fixture.reader.translate_many(&rows))
+                    .unwrap(),
+            )
+        })
+    });
+}
+
+fn bench_sweep(c: &mut Criterion) {
+    let fixture = fixture();
+    let mut group = c.benchmark_group("row_map");
+    group.sample_size(10);
+    group.throughput(criterion::Throughput::Elements(TOTAL_ROWS));
+    group.bench_function("sweep_full", |b| {
+        b.iter(|| {
+            let mut live = 0u64;
+            fixture
+                .runtime
+                .block_on(fixture.reader.sweep(0..TOTAL_ROWS, |_, translated| {
+                    live += u64::from(translated.is_some());
+                    Ok(())
+                }))
+                .unwrap();
+            black_box(live)
+        })
+    });
+    group.finish();
+}
+
+fn bench_rank_in_block(c: &mut Criterion) {
+    // The in-memory cost of one worst-case point lookup: ranking a label over
+    // a full 64K block.
+    let mut lcg = Lcg(11);
+    let values: Vec<u16> = (0..64 * 1024)
+        .map(|_| (lcg.next() % u64::from(NUM_DESTINATIONS)) as u16)
+        .collect();
+    c.bench_function("row_map/rank_label_prefix_64k", |b| {
+        b.iter(|| black_box(rank_label_prefix(&values, None, values.len(), 500)))
+    });
+}
+
+criterion_group!(
+    benches,
+    bench_point_translate,
+    bench_translate_many,
+    bench_sweep,
+    bench_rank_in_block
+);
+criterion_main!(benches);

--- a/rust/lance-index/src/frag_reuse.rs
+++ b/rust/lance-index/src/frag_reuse.rs
@@ -21,6 +21,8 @@ use serde::Serialize;
 
 pub use lance_table::system_index::frag_reuse::*;
 
+pub mod row_map;
+
 use crate::scalar::RowIdRemapper;
 use crate::{Index, IndexType};
 

--- a/rust/lance-index/src/frag_reuse/row_map.rs
+++ b/rust/lance-index/src/frag_reuse/row_map.rs
@@ -12,22 +12,15 @@
 //! * NULL — the row was deleted at the source; the rewrite moved it nowhere.
 //!
 //! The per-block cumulative counts
-//! ([`CountsMatrix`](lance_core::utils::stable_partition::CountsMatrix)) are
+//! ([`CountsMatrix`]) are
 //! serialized into a global buffer of the same file, so opening costs one tail
-//! read and no label IO. Point translations read one block of labels; sweeps
+//! read plus an in-memory consistency check of the counts; no label IO. Point translations read one block of labels; sweeps
 //! stream blocks in order. The translation arithmetic itself lives in
 //! [`lance_core::utils::stable_partition`].
 //!
 //! The writer is fed labels of *live* rows only, in source scan order, and
 //! interleaves the NULL rows itself from the source deletion vectors: the
 //! rewrite job scans with deletions applied, so it never sees a deleted row.
-//!
-//! Correctness rests on the stable-partition ordering contract spelled out
-//! in [`lance_core::utils::stable_partition`]: labels arrive in source
-//! physical-row order, each destination is written in that same order and
-//! never re-sorted, and the destination list is fixed for the rewrite. A
-//! job that routes rows through parallel writers must restore that order
-//! per destination before feeding this writer.
 //!
 //! Correctness rests on the stable-partition ordering contract spelled out
 //! in [`lance_core::utils::stable_partition`]: labels arrive in source
@@ -113,6 +106,9 @@ impl RowMapWriter {
         label_schema()
     }
 
+    /// Create a writer over `sources` (the rewrite's source fragments in
+    /// scan order) targeting `num_destinations` ordered destinations, with
+    /// the default 64K-row block size.
     pub fn try_new(
         writer: Box<dyn IndexWriter>,
         sources: Vec<SourceRows>,
@@ -121,6 +117,8 @@ impl RowMapWriter {
         Self::try_new_with_block_rows(writer, sources, num_destinations, DEFAULT_BLOCK_ROWS)
     }
 
+    /// [`Self::try_new`] with an explicit block size, the counts granularity
+    /// and label IO unit; tests use small blocks to exercise boundaries.
     pub fn try_new_with_block_rows(
         writer: Box<dyn IndexWriter>,
         sources: Vec<SourceRows>,
@@ -267,17 +265,23 @@ impl RowMapReader {
     /// must fail here rather than translate rows to wrong addresses.
     pub async fn open(reader: Arc<dyn IndexReader>) -> Result<Self> {
         let schema = reader.schema();
-        let label_field = schema
-            .fields
-            .first()
-            .ok_or_else(|| Error::corrupt_file_named("row_map", "row map file has no columns"))?;
+        let [label_field] = schema.fields.as_slice() else {
+            return Err(Error::corrupt_file_named(
+                "row_map",
+                format!(
+                    "row map file must hold exactly one column, found {}",
+                    schema.fields.len()
+                ),
+            ));
+        };
         if label_field.name != LABEL_COLUMN
             || label_field.data_type() != arrow_schema::DataType::UInt16
+            || !label_field.nullable
         {
             return Err(Error::corrupt_file_named(
                 "row_map",
                 format!(
-                    "row map file must hold a single u16 {LABEL_COLUMN} column, found {} of type {}",
+                    "row map file must hold a single nullable u16 {LABEL_COLUMN} column, found {} of type {}",
                     label_field.name,
                     label_field.data_type()
                 ),
@@ -308,6 +312,8 @@ impl RowMapReader {
         Ok(Self { reader, counts })
     }
 
+    /// The validated counts matrix decoded at open: per-destination totals
+    /// and per-block counter bases without any label IO.
     pub fn counts(&self) -> &CountsMatrix {
         &self.counts
     }
@@ -401,6 +407,10 @@ impl RowMapReader {
         self.check_row(rows.end - 1)?;
         let start_block = self.counts.block_of(rows.start);
         let end_block = self.counts.block_of(rows.end - 1);
+        // Blocks are read one at a time on purpose: a sweep is bulk work and
+        // bounded memory matters more than per-block latency. Overlapping the
+        // next block's read with translation belongs to the read-integration
+        // follow-up.
         // The sweep counters start at a block boundary; rows before
         // `rows.start` in the first block are translated and discarded.
         let mut translator = SweepTranslator::new(&self.counts, start_block)?;
@@ -690,5 +700,59 @@ mod tests {
         writer.finish().await.unwrap();
         let reader = store.open_index_file("not_a_row_map.lance").await.unwrap();
         assert!(RowMapReader::open(reader).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_null_edge_cases() {
+        // Deterministic NULL/empty shapes: a fully-deleted source, a
+        // zero-physical-row source, and a deleted tail that only finish()
+        // drains. 7 physical rows, 2 live.
+        let sources = vec![
+            SourceRows {
+                physical_rows: 4,
+                deleted: Some(RoaringBitmap::from_iter(0u32..4)),
+            },
+            SourceRows {
+                physical_rows: 0,
+                deleted: None,
+            },
+            SourceRows {
+                physical_rows: 3,
+                deleted: Some(RoaringBitmap::from_iter([2u32])),
+            },
+        ];
+        let tempdir = TempDir::default();
+        let store = test_store(&tempdir);
+        let writer = store
+            .new_index_file("row_map.lance", RowMapWriter::schema())
+            .await
+            .unwrap();
+        let mut writer = RowMapWriter::try_new_with_block_rows(writer, sources, 2, 4).unwrap();
+        writer.append_labels(&[1, 0]).await.unwrap();
+        let (_, counts) = writer.finish().await.unwrap();
+        assert_eq!(counts.total_rows(), 7);
+        assert_eq!((counts.total(0), counts.total(1)), (1, 1));
+
+        let reader = RowMapReader::open(store.open_index_file("row_map.lance").await.unwrap())
+            .await
+            .unwrap();
+        let expected = [
+            None,
+            None,
+            None,
+            None,            // source 1: fully deleted
+            Some((1u16, 0)), // source 3 row 0
+            Some((0u16, 0)), // source 3 row 1
+            None,            // source 3 row 2: the deleted tail
+        ];
+        for (row, &expected) in expected.iter().enumerate() {
+            assert_eq!(reader.translate(row as u64).await.unwrap(), expected);
+        }
+        // Empty inputs are empty outputs.
+        assert!(reader.translate_many(&[]).await.unwrap().is_empty());
+        reader
+            .sweep(3..3, |_, _| panic!("empty sweep must visit nothing"))
+            .await
+            .unwrap();
     }
 }

--- a/rust/lance-index/src/frag_reuse/row_map.rs
+++ b/rust/lance-index/src/frag_reuse/row_map.rs
@@ -21,6 +21,20 @@
 //! The writer is fed labels of *live* rows only, in source scan order, and
 //! interleaves the NULL rows itself from the source deletion vectors: the
 //! rewrite job scans with deletions applied, so it never sees a deleted row.
+//!
+//! Correctness rests on the stable-partition ordering contract spelled out
+//! in [`lance_core::utils::stable_partition`]: labels arrive in source
+//! physical-row order, each destination is written in that same order and
+//! never re-sorted, and the destination list is fixed for the rewrite. A
+//! job that routes rows through parallel writers must restore that order
+//! per destination before feeding this writer.
+//!
+//! Correctness rests on the stable-partition ordering contract spelled out
+//! in [`lance_core::utils::stable_partition`]: labels arrive in source
+//! physical-row order, each destination is written in that same order and
+//! never re-sorted, and the destination list is fixed for the rewrite. A
+//! job that routes rows through parallel writers must restore that order
+//! per destination before feeding this writer.
 
 use std::ops::Range;
 use std::sync::Arc;
@@ -52,6 +66,19 @@ fn label_schema() -> Arc<ArrowSchema> {
         DataType::UInt16,
         true,
     )]))
+}
+
+fn label_column(batch: &RecordBatch) -> Result<&UInt16Array> {
+    batch
+        .columns()
+        .first()
+        .and_then(|column| column.as_primitive_opt::<UInt16Type>())
+        .ok_or_else(|| {
+            Error::corrupt_file_named(
+                "row_map",
+                "row map read returned a batch without a u16 label column",
+            )
+        })
 }
 
 /// The physical layout of one source fragment, in scan order.
@@ -235,11 +262,28 @@ impl std::fmt::Debug for RowMapReader {
 }
 
 impl RowMapReader {
-    /// Open a row map file: decodes the counts matrix from its global buffer
-    /// without touching any label data.
+    /// Open a row map file: decodes and validates the counts matrix from its
+    /// global buffer without touching any label data. A corrupt counts buffer
+    /// must fail here rather than translate rows to wrong addresses.
     pub async fn open(reader: Arc<dyn IndexReader>) -> Result<Self> {
-        let buffer_index = reader
-            .schema()
+        let schema = reader.schema();
+        let label_field = schema
+            .fields
+            .first()
+            .ok_or_else(|| Error::corrupt_file_named("row_map", "row map file has no columns"))?;
+        if label_field.name != LABEL_COLUMN
+            || label_field.data_type() != arrow_schema::DataType::UInt16
+        {
+            return Err(Error::corrupt_file_named(
+                "row_map",
+                format!(
+                    "row map file must hold a single u16 {LABEL_COLUMN} column, found {} of type {}",
+                    label_field.name,
+                    label_field.data_type()
+                ),
+            ));
+        }
+        let buffer_index = schema
             .metadata
             .get(COUNTS_BUFFER_INDEX_KEY)
             .and_then(|index| index.parse::<u32>().ok())
@@ -250,6 +294,7 @@ impl RowMapReader {
                 )
             })?;
         let counts = CountsMatrix::decode(&reader.read_global_buffer(buffer_index).await?)?;
+        counts.validate()?;
         if reader.num_rows() as u64 != counts.total_rows() {
             return Err(Error::corrupt_file_named(
                 "row_map",
@@ -277,7 +322,7 @@ impl RowMapReader {
                 Some(&[LABEL_COLUMN]),
             )
             .await?;
-        Ok(batch.column(0).as_primitive::<UInt16Type>().clone())
+        Ok(label_column(&batch)?.clone())
     }
 
     /// Translate one physical source row (concatenated scan order). Returns
@@ -316,7 +361,7 @@ impl RowMapReader {
             .reader
             .read_ranges(&ranges, Some(&[LABEL_COLUMN]))
             .await?;
-        let labels = batch.column(0).as_primitive::<UInt16Type>();
+        let labels = label_column(&batch)?;
         let mut block_starts = Vec::with_capacity(blocks.len());
         let mut start = 0usize;
         for range in &ranges {
@@ -329,7 +374,7 @@ impl RowMapReader {
                 let slot = blocks.binary_search(&block).unwrap();
                 let range = &ranges[slot];
                 let block_labels = labels.slice(block_starts[slot], range.end - range.start);
-                let pos = row as usize - range.start;
+                let pos = (row - range.start as u64) as usize;
                 translate_in_block(
                     &self.counts,
                     block,
@@ -395,6 +440,8 @@ mod tests {
     use futures::FutureExt;
     use lance_core::utils::tempfile::TempDir;
     use lance_io::object_store::ObjectStore;
+    use rand::rngs::StdRng;
+    use rand::{Rng, SeedableRng};
     use std::collections::HashMap;
 
     fn test_store(tempdir: &TempDir) -> Arc<dyn IndexStore> {
@@ -409,19 +456,6 @@ mod tests {
         Arc::new(LanceIndexStore::new(object_store, test_path, cache))
     }
 
-    /// Deterministic pseudo-random labels without a rand dependency.
-    struct Lcg(u64);
-
-    impl Lcg {
-        fn next(&mut self) -> u64 {
-            self.0 = self
-                .0
-                .wrapping_mul(6364136223846793005)
-                .wrapping_add(1442695040888963407);
-            self.0 >> 33
-        }
-    }
-
     struct TestMap {
         sources: Vec<SourceRows>,
         /// Live-row labels in scan order: what the rewrite job feeds.
@@ -433,7 +467,7 @@ mod tests {
     /// Build sources with deterministic deletions and labels, plus the
     /// reference translation computed with per-destination counters.
     fn make_test_map(source_rows: &[u64], num_destinations: u32, seed: u64) -> TestMap {
-        let mut lcg = Lcg(seed);
+        let mut rng = StdRng::seed_from_u64(seed);
         let mut sources = Vec::new();
         let mut live_labels = Vec::new();
         let mut expected = Vec::new();
@@ -442,7 +476,7 @@ mod tests {
             let mut deleted = RoaringBitmap::new();
             for offset in 0..physical_rows {
                 // ~1/5 of rows deleted.
-                if lcg.next().is_multiple_of(5) {
+                if rng.random_ratio(1, 5) {
                     deleted.insert(offset as u32);
                 }
             }
@@ -450,7 +484,7 @@ mod tests {
                 if deleted.contains(offset as u32) {
                     expected.push(None);
                 } else {
-                    let label = (lcg.next() % u64::from(num_destinations)) as u16;
+                    let label = rng.random_range(0..num_destinations) as u16;
                     let counter = counters.entry(label).or_insert(0u32);
                     live_labels.push(label);
                     expected.push(Some((label, *counter)));
@@ -636,5 +670,25 @@ mod tests {
             )
             .is_err()
         );
+    }
+
+    #[tokio::test]
+    async fn test_open_rejects_wrong_schema() {
+        // Opening a file that is not a row map fails with an error instead of
+        // panicking on the column cast.
+        let tempdir = TempDir::default();
+        let store = test_store(&tempdir);
+        let schema = Arc::new(arrow_schema::Schema::new(vec![arrow_schema::Field::new(
+            "foo",
+            arrow_schema::DataType::Int32,
+            false,
+        )]));
+        let mut writer = store
+            .new_index_file("not_a_row_map.lance", schema)
+            .await
+            .unwrap();
+        writer.finish().await.unwrap();
+        let reader = store.open_index_file("not_a_row_map.lance").await.unwrap();
+        assert!(RowMapReader::open(reader).await.is_err());
     }
 }

--- a/rust/lance-index/src/frag_reuse/row_map.rs
+++ b/rust/lance-index/src/frag_reuse/row_map.rs
@@ -1,0 +1,640 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+//! Row map file IO for stable-partition (reordered) rewrites.
+//!
+//! A reordered rewrite persists its per-row destination labels as one Lance
+//! file with a single nullable u16 column, one row per physical source row in
+//! concatenated scan order:
+//!
+//! * value — the index of the row's destination fragment in the rewrite's
+//!   ordered destination list,
+//! * NULL — the row was deleted at the source; the rewrite moved it nowhere.
+//!
+//! The per-block cumulative counts
+//! ([`CountsMatrix`](lance_core::utils::stable_partition::CountsMatrix)) are
+//! serialized into a global buffer of the same file, so opening costs one tail
+//! read and no label IO. Point translations read one block of labels; sweeps
+//! stream blocks in order. The translation arithmetic itself lives in
+//! [`lance_core::utils::stable_partition`].
+//!
+//! The writer is fed labels of *live* rows only, in source scan order, and
+//! interleaves the NULL rows itself from the source deletion vectors: the
+//! rewrite job scans with deletions applied, so it never sees a deleted row.
+
+use std::ops::Range;
+use std::sync::Arc;
+
+use arrow_array::builder::UInt16Builder;
+use arrow_array::cast::AsArray;
+use arrow_array::types::UInt16Type;
+use arrow_array::{Array, RecordBatch, UInt16Array};
+use arrow_schema::{DataType, Field, Schema as ArrowSchema};
+use bytes::Bytes;
+use lance_core::utils::stable_partition::{
+    CountsMatrix, CountsMatrixBuilder, DEFAULT_BLOCK_ROWS, SweepTranslator, translate_in_block,
+};
+use lance_core::{Error, Result};
+use roaring::RoaringBitmap;
+
+use crate::scalar::{IndexFile, IndexReader, IndexWriter};
+
+/// The single column of a row map file.
+pub const LABEL_COLUMN: &str = "label";
+
+/// Schema-metadata key holding the global buffer index of the encoded counts
+/// matrix.
+const COUNTS_BUFFER_INDEX_KEY: &str = "lance:stable_partition:counts_buffer_index";
+
+fn label_schema() -> Arc<ArrowSchema> {
+    Arc::new(ArrowSchema::new(vec![Field::new(
+        LABEL_COLUMN,
+        DataType::UInt16,
+        true,
+    )]))
+}
+
+/// The physical layout of one source fragment, in scan order.
+#[derive(Debug, Clone)]
+pub struct SourceRows {
+    /// Physical rows of the fragment, including deleted rows.
+    pub physical_rows: u64,
+    /// Deleted row offsets within the fragment at the rewrite's read version.
+    pub deleted: Option<RoaringBitmap>,
+}
+
+/// Streaming writer for a row map file.
+///
+/// Feed the destination labels of live source rows in scan order via
+/// [`Self::append_labels`]; deleted rows become NULLs automatically. The
+/// caller creates the underlying [`IndexWriter`] (choosing store and file
+/// name) via `IndexStore::new_index_file` with [`RowMapWriter::schema`].
+pub struct RowMapWriter {
+    writer: Box<dyn IndexWriter>,
+    counts: CountsMatrixBuilder,
+    sources: Vec<SourceRows>,
+    src_idx: usize,
+    src_offset: u64,
+    pending: UInt16Builder,
+    pending_rows: u32,
+    block_rows: u32,
+}
+
+impl RowMapWriter {
+    /// The Arrow schema of a row map file, for `IndexStore::new_index_file`.
+    pub fn schema() -> Arc<ArrowSchema> {
+        label_schema()
+    }
+
+    pub fn try_new(
+        writer: Box<dyn IndexWriter>,
+        sources: Vec<SourceRows>,
+        num_destinations: u32,
+    ) -> Result<Self> {
+        Self::try_new_with_block_rows(writer, sources, num_destinations, DEFAULT_BLOCK_ROWS)
+    }
+
+    pub fn try_new_with_block_rows(
+        writer: Box<dyn IndexWriter>,
+        sources: Vec<SourceRows>,
+        num_destinations: u32,
+        block_rows: u32,
+    ) -> Result<Self> {
+        for (i, source) in sources.iter().enumerate() {
+            if source.physical_rows > u64::from(u32::MAX) {
+                return Err(Error::invalid_input(format!(
+                    "source fragment {i} claims {} physical rows, beyond the row-address offset range",
+                    source.physical_rows
+                )));
+            }
+            if let Some(deleted) = &source.deleted
+                && deleted
+                    .max()
+                    .is_some_and(|max| u64::from(max) >= source.physical_rows)
+            {
+                return Err(Error::invalid_input(format!(
+                    "source fragment {i} has a deleted row offset outside its {} physical rows",
+                    source.physical_rows
+                )));
+            }
+        }
+        Ok(Self {
+            writer,
+            counts: CountsMatrixBuilder::try_new(num_destinations, block_rows)?,
+            sources,
+            src_idx: 0,
+            src_offset: 0,
+            pending: UInt16Builder::with_capacity(block_rows as usize),
+            pending_rows: 0,
+            block_rows,
+        })
+    }
+
+    /// Record one physical source row and flush a full block of labels.
+    async fn emit(&mut self, label: Option<u16>) -> Result<()> {
+        self.counts.push(label)?;
+        match label {
+            Some(label) => self.pending.append_value(label),
+            None => self.pending.append_null(),
+        }
+        self.pending_rows += 1;
+        if self.pending_rows == self.block_rows {
+            self.flush().await?;
+        }
+        Ok(())
+    }
+
+    async fn flush(&mut self) -> Result<()> {
+        if self.pending_rows == 0 {
+            return Ok(());
+        }
+        let labels = self.pending.finish();
+        let batch = RecordBatch::try_new(label_schema(), vec![Arc::new(labels)])?;
+        self.writer.write_record_batch(batch).await?;
+        self.pending_rows = 0;
+        Ok(())
+    }
+
+    /// Emit NULLs for deleted rows at the physical cursor, stopping at the
+    /// next live row (or the end of the sources).
+    async fn skip_deleted(&mut self) -> Result<bool> {
+        while let Some(source) = self.sources.get(self.src_idx) {
+            if self.src_offset >= source.physical_rows {
+                self.src_idx += 1;
+                self.src_offset = 0;
+                continue;
+            }
+            let deleted = source
+                .deleted
+                .as_ref()
+                .is_some_and(|deleted| deleted.contains(self.src_offset as u32));
+            if !deleted {
+                return Ok(true);
+            }
+            self.emit(None).await?;
+            self.src_offset += 1;
+        }
+        Ok(false)
+    }
+
+    /// Append the destination labels of the next live source rows, in scan
+    /// order.
+    pub async fn append_labels(&mut self, labels: &[u16]) -> Result<()> {
+        for &label in labels {
+            if !self.skip_deleted().await? {
+                return Err(Error::invalid_input(
+                    "more labels than live rows in the source fragments",
+                ));
+            }
+            self.emit(Some(label)).await?;
+            self.src_offset += 1;
+        }
+        Ok(())
+    }
+
+    /// Finish the file: drain trailing deleted rows, write the counts matrix
+    /// into a global buffer, and close the writer.
+    pub async fn finish(mut self) -> Result<(IndexFile, CountsMatrix)> {
+        if self.skip_deleted().await? {
+            return Err(Error::invalid_input(
+                "fewer labels than live rows in the source fragments",
+            ));
+        }
+        self.flush().await?;
+        let counts = self.counts.finish();
+        let buffer_index = self
+            .writer
+            .add_global_buffer(Bytes::from(counts.encode()))
+            .await?;
+        let file = self
+            .writer
+            .finish_with_metadata(
+                [(
+                    COUNTS_BUFFER_INDEX_KEY.to_string(),
+                    buffer_index.to_string(),
+                )]
+                .into(),
+            )
+            .await?;
+        Ok((file, counts))
+    }
+}
+
+/// Reader over a row map file: one tail read at open, block reads on demand.
+pub struct RowMapReader {
+    reader: Arc<dyn IndexReader>,
+    counts: CountsMatrix,
+}
+
+impl std::fmt::Debug for RowMapReader {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("RowMapReader")
+            .field("counts", &self.counts)
+            .finish_non_exhaustive()
+    }
+}
+
+impl RowMapReader {
+    /// Open a row map file: decodes the counts matrix from its global buffer
+    /// without touching any label data.
+    pub async fn open(reader: Arc<dyn IndexReader>) -> Result<Self> {
+        let buffer_index = reader
+            .schema()
+            .metadata
+            .get(COUNTS_BUFFER_INDEX_KEY)
+            .and_then(|index| index.parse::<u32>().ok())
+            .ok_or_else(|| {
+                Error::corrupt_file_named(
+                    "row_map",
+                    format!("row map file is missing the {COUNTS_BUFFER_INDEX_KEY} metadata"),
+                )
+            })?;
+        let counts = CountsMatrix::decode(&reader.read_global_buffer(buffer_index).await?)?;
+        if reader.num_rows() as u64 != counts.total_rows() {
+            return Err(Error::corrupt_file_named(
+                "row_map",
+                format!(
+                    "row map file holds {} labels but its counts describe {} source rows",
+                    reader.num_rows(),
+                    counts.total_rows()
+                ),
+            ));
+        }
+        Ok(Self { reader, counts })
+    }
+
+    pub fn counts(&self) -> &CountsMatrix {
+        &self.counts
+    }
+
+    /// The decoded labels of one block.
+    pub async fn block_labels(&self, block: usize) -> Result<UInt16Array> {
+        let range = self.counts.block_range(block);
+        let batch = self
+            .reader
+            .read_range(
+                range.start as usize..range.end as usize,
+                Some(&[LABEL_COLUMN]),
+            )
+            .await?;
+        Ok(batch.column(0).as_primitive::<UInt16Type>().clone())
+    }
+
+    /// Translate one physical source row (concatenated scan order). Returns
+    /// `None` when the row was deleted at the source, otherwise
+    /// `(destination index, destination row offset)`. Reads one block.
+    pub async fn translate(&self, row: u64) -> Result<Option<(u16, u32)>> {
+        self.check_row(row)?;
+        let block = self.counts.block_of(row);
+        let labels = self.block_labels(block).await?;
+        let pos = (row - self.counts.block_range(block).start) as usize;
+        translate_in_block(&self.counts, block, labels.values(), labels.nulls(), pos)
+    }
+
+    /// Translate a batch of physical source rows with one coalesced read of
+    /// the touched blocks.
+    pub async fn translate_many(&self, rows: &[u64]) -> Result<Vec<Option<(u16, u32)>>> {
+        for &row in rows {
+            self.check_row(row)?;
+        }
+        let mut blocks: Vec<usize> = rows.iter().map(|&row| self.counts.block_of(row)).collect();
+        blocks.sort_unstable();
+        blocks.dedup();
+        if blocks.is_empty() {
+            return Ok(Vec::new());
+        }
+        let ranges: Vec<Range<usize>> = blocks
+            .iter()
+            .map(|&block| {
+                let range = self.counts.block_range(block);
+                range.start as usize..range.end as usize
+            })
+            .collect();
+        // One coalesced read; the result concatenates the requested block
+        // ranges in order.
+        let batch = self
+            .reader
+            .read_ranges(&ranges, Some(&[LABEL_COLUMN]))
+            .await?;
+        let labels = batch.column(0).as_primitive::<UInt16Type>();
+        let mut block_starts = Vec::with_capacity(blocks.len());
+        let mut start = 0usize;
+        for range in &ranges {
+            block_starts.push(start);
+            start += range.end - range.start;
+        }
+        rows.iter()
+            .map(|&row| {
+                let block = self.counts.block_of(row);
+                let slot = blocks.binary_search(&block).unwrap();
+                let range = &ranges[slot];
+                let block_labels = labels.slice(block_starts[slot], range.end - range.start);
+                let pos = row as usize - range.start;
+                translate_in_block(
+                    &self.counts,
+                    block,
+                    block_labels.values(),
+                    block_labels.nulls(),
+                    pos,
+                )
+            })
+            .collect()
+    }
+
+    /// Translate every physical source row in `rows` in order, block by
+    /// block, calling `f(row, translation)` for each. O(1) per row after the
+    /// per-block read.
+    pub async fn sweep(
+        &self,
+        rows: Range<u64>,
+        mut f: impl FnMut(u64, Option<(u16, u32)>) -> Result<()>,
+    ) -> Result<()> {
+        if rows.is_empty() {
+            return Ok(());
+        }
+        self.check_row(rows.start)?;
+        self.check_row(rows.end - 1)?;
+        let start_block = self.counts.block_of(rows.start);
+        let end_block = self.counts.block_of(rows.end - 1);
+        // The sweep counters start at a block boundary; rows before
+        // `rows.start` in the first block are translated and discarded.
+        let mut translator = SweepTranslator::new(&self.counts, start_block)?;
+        for block in start_block..=end_block {
+            let labels = self.block_labels(block).await?;
+            let block_start = self.counts.block_range(block).start;
+            let validity = labels.nulls();
+            for (i, &value) in labels.values().iter().enumerate() {
+                let label = validity
+                    .is_none_or(|validity| validity.is_valid(i))
+                    .then_some(value);
+                let translated = translator.advance(label)?;
+                let row = block_start + i as u64;
+                if rows.contains(&row) {
+                    f(row, translated)?;
+                }
+            }
+        }
+        Ok(())
+    }
+
+    fn check_row(&self, row: u64) -> Result<()> {
+        if row >= self.counts.total_rows() {
+            return Err(Error::invalid_input(format!(
+                "source row {row} is outside the {} rows of this row map",
+                self.counts.total_rows()
+            )));
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::scalar::{IndexStore, lance_format::LanceIndexStore};
+    use futures::FutureExt;
+    use lance_core::utils::tempfile::TempDir;
+    use lance_io::object_store::ObjectStore;
+    use std::collections::HashMap;
+
+    fn test_store(tempdir: &TempDir) -> Arc<dyn IndexStore> {
+        let test_path = tempdir.obj_path();
+        let (object_store, test_path) = ObjectStore::from_uri(test_path.as_ref())
+            .now_or_never()
+            .unwrap()
+            .unwrap();
+        let cache = Arc::new(lance_core::cache::LanceCache::with_capacity(
+            128 * 1024 * 1024,
+        ));
+        Arc::new(LanceIndexStore::new(object_store, test_path, cache))
+    }
+
+    /// Deterministic pseudo-random labels without a rand dependency.
+    struct Lcg(u64);
+
+    impl Lcg {
+        fn next(&mut self) -> u64 {
+            self.0 = self
+                .0
+                .wrapping_mul(6364136223846793005)
+                .wrapping_add(1442695040888963407);
+            self.0 >> 33
+        }
+    }
+
+    struct TestMap {
+        sources: Vec<SourceRows>,
+        /// Live-row labels in scan order: what the rewrite job feeds.
+        live_labels: Vec<u16>,
+        /// Per physical source row: the expected translation.
+        expected: Vec<Option<(u16, u32)>>,
+    }
+
+    /// Build sources with deterministic deletions and labels, plus the
+    /// reference translation computed with per-destination counters.
+    fn make_test_map(source_rows: &[u64], num_destinations: u32, seed: u64) -> TestMap {
+        let mut lcg = Lcg(seed);
+        let mut sources = Vec::new();
+        let mut live_labels = Vec::new();
+        let mut expected = Vec::new();
+        let mut counters = HashMap::new();
+        for &physical_rows in source_rows {
+            let mut deleted = RoaringBitmap::new();
+            for offset in 0..physical_rows {
+                // ~1/5 of rows deleted.
+                if lcg.next().is_multiple_of(5) {
+                    deleted.insert(offset as u32);
+                }
+            }
+            for offset in 0..physical_rows {
+                if deleted.contains(offset as u32) {
+                    expected.push(None);
+                } else {
+                    let label = (lcg.next() % u64::from(num_destinations)) as u16;
+                    let counter = counters.entry(label).or_insert(0u32);
+                    live_labels.push(label);
+                    expected.push(Some((label, *counter)));
+                    *counter += 1;
+                }
+            }
+            sources.push(SourceRows {
+                physical_rows,
+                deleted: (!deleted.is_empty()).then_some(deleted),
+            });
+        }
+        TestMap {
+            sources,
+            live_labels,
+            expected,
+        }
+    }
+
+    async fn write_map(
+        store: &Arc<dyn IndexStore>,
+        map: &TestMap,
+        num_destinations: u32,
+        block_rows: u32,
+        labels_per_append: usize,
+    ) -> (IndexFile, CountsMatrix) {
+        let writer = store
+            .new_index_file("row_map.lance", RowMapWriter::schema())
+            .await
+            .unwrap();
+        let mut writer = RowMapWriter::try_new_with_block_rows(
+            writer,
+            map.sources.clone(),
+            num_destinations,
+            block_rows,
+        )
+        .unwrap();
+        for chunk in map.live_labels.chunks(labels_per_append) {
+            writer.append_labels(chunk).await.unwrap();
+        }
+        writer.finish().await.unwrap()
+    }
+
+    #[tokio::test]
+    async fn test_row_map_round_trip() {
+        let num_destinations = 4u32;
+        let map = make_test_map(&[10, 7, 5], num_destinations, 7);
+        let tempdir = TempDir::default();
+        let store = test_store(&tempdir);
+        // block_rows=8 forces multiple blocks with a short final block, and
+        // appends of 3 labels cross block boundaries mid-call.
+        let (file, written_counts) = write_map(&store, &map, num_destinations, 8, 3).await;
+        assert!(file.size_bytes > 0);
+        written_counts.validate().unwrap();
+
+        let reader = RowMapReader::open(store.open_index_file("row_map.lance").await.unwrap())
+            .await
+            .unwrap();
+        let counts = reader.counts();
+        assert_eq!(counts, &written_counts);
+        assert_eq!(counts.total_rows(), 22);
+        assert_eq!(
+            counts.total_live_rows(),
+            map.live_labels.len() as u64,
+            "every live row is labeled, every deleted row is not"
+        );
+        // Conservation: per-destination totals match the reference counters.
+        for label in 0..num_destinations as u16 {
+            let expected_total = map
+                .expected
+                .iter()
+                .flatten()
+                .filter(|(l, _)| *l == label)
+                .count() as u32;
+            assert_eq!(counts.total(label), expected_total);
+        }
+
+        // Point lookups: every physical source row.
+        for (row, &expected) in map.expected.iter().enumerate() {
+            assert_eq!(
+                reader.translate(row as u64).await.unwrap(),
+                expected,
+                "row {row}"
+            );
+        }
+        assert!(reader.translate(22).await.is_err());
+
+        // Batch lookup in arbitrary order with one coalesced read.
+        let rows: Vec<u64> = vec![21, 0, 13, 13, 7, 20];
+        let translated = reader.translate_many(&rows).await.unwrap();
+        for (&row, translated) in rows.iter().zip(&translated) {
+            assert_eq!(translated, &map.expected[row as usize], "row {row}");
+        }
+        assert!(reader.translate_many(&[3, 22]).await.is_err());
+
+        // Sweeps: the full range and one starting mid-block.
+        for start in [0u64, 11] {
+            let mut swept = Vec::new();
+            reader
+                .sweep(start..22, |row, translated| {
+                    swept.push((row, translated));
+                    Ok(())
+                })
+                .await
+                .unwrap();
+            let expected: Vec<_> = (start..22)
+                .map(|row| (row, map.expected[row as usize]))
+                .collect();
+            assert_eq!(swept, expected, "sweep from {start}");
+        }
+    }
+
+    #[tokio::test]
+    async fn test_row_map_larger_multi_block() {
+        // 1000 rows in blocks of 64 across unevenly-sized sources.
+        let num_destinations = 5u32;
+        let map = make_test_map(&[400, 1, 599], num_destinations, 42);
+        let tempdir = TempDir::default();
+        let store = test_store(&tempdir);
+        let (_, _) = write_map(&store, &map, num_destinations, 64, 100).await;
+        let reader = RowMapReader::open(store.open_index_file("row_map.lance").await.unwrap())
+            .await
+            .unwrap();
+        let rows: Vec<u64> = (0..1000).collect();
+        assert_eq!(
+            reader.translate_many(&rows).await.unwrap(),
+            map.expected,
+            "batch translation of every row"
+        );
+        let mut swept = Vec::new();
+        reader
+            .sweep(0..1000, |_, translated| {
+                swept.push(translated);
+                Ok(())
+            })
+            .await
+            .unwrap();
+        assert_eq!(swept, map.expected);
+    }
+
+    #[tokio::test]
+    async fn test_writer_label_count_mismatches() {
+        let tempdir = TempDir::default();
+        let store = test_store(&tempdir);
+        let sources = vec![SourceRows {
+            physical_rows: 4,
+            deleted: Some(RoaringBitmap::from_iter([1u32])),
+        }];
+
+        // Too many labels: 4 physical - 1 deleted = 3 live rows.
+        let writer = store
+            .new_index_file("too_many.lance", RowMapWriter::schema())
+            .await
+            .unwrap();
+        let mut writer =
+            RowMapWriter::try_new_with_block_rows(writer, sources.clone(), 2, 8).unwrap();
+        assert!(writer.append_labels(&[0, 1, 0, 1]).await.is_err());
+
+        // Too few labels are caught at finish.
+        let writer = store
+            .new_index_file("too_few.lance", RowMapWriter::schema())
+            .await
+            .unwrap();
+        let mut writer =
+            RowMapWriter::try_new_with_block_rows(writer, sources.clone(), 2, 8).unwrap();
+        writer.append_labels(&[0, 1]).await.unwrap();
+        assert!(writer.finish().await.is_err());
+
+        // A deleted offset outside the fragment's physical rows is rejected
+        // up front.
+        let writer = store
+            .new_index_file("bad_dv.lance", RowMapWriter::schema())
+            .await
+            .unwrap();
+        assert!(
+            RowMapWriter::try_new_with_block_rows(
+                writer,
+                vec![SourceRows {
+                    physical_rows: 4,
+                    deleted: Some(RoaringBitmap::from_iter([4u32])),
+                }],
+                2,
+                8,
+            )
+            .is_err()
+        );
+    }
+}


### PR DESCRIPTION
#### Stack migration

The unchanged codec is now in draft #9064 on `lance-format/lance:lu/fri-row-map`, so the series can use GitHub’s native Stack API. This PR remains the original review record. Fork PR #8972 itself cannot be added to a native stack.

Planned series: **#9064 (codec) → #9065 (format proposal) → implementation layers**. The next two PRs will use the unified tagged FRI history discussed below; they replace the old manifest-level design in #9007. GitHub native stack #9066 is now registered with #9064 and #9065. Open either replacement PR to view it.

---

## What

Part 1 of adding first-class support for **reordered rewrites** to the fragment reuse machinery. A reordered rewrite (e.g. reclustering rows by a sort or clustering key) reads `n` source fragments in scan order and distributes their live rows across `m` destination fragments. Compaction's existing remapping (`CompactRowAddrRemap`) derives the old-to-new address mapping from row order alone, which only works because compaction preserves relative row order; a reordered rewrite breaks that assumption, so the mapping must be recorded explicitly.

This PR adds the standalone format capability that records and replays that mapping. It has **no transaction or read-path integration yet** (that comes in follow-up PRs); everything here is a self-contained module with its own tests and benchmarks.

## Design

### What is recorded

A reordered rewrite is a **stable partition**: it scans the source fragments in order and appends each live row to exactly one destination fragment, so within every destination, rows keep their relative source order. As the rewrite job scans, it makes one routing decision per row — *which destination does this row go to* — and that decision is the only information the mapping needs, because the row's offset inside its destination is derivable (see below). The recorded decision is called the row's **label**.

Worked example used throughout. Sources `F1` (5 physical rows, row 2 deleted) then `F2` (3 rows); the rewrite produced two destinations, listed in order as `[F10, F11]`. The job's routing decisions, in scan order:

```
F1 row 0  -> written to F10      label 0
F1 row 1  -> written to F11      label 1
F1 row 2  -> deleted, not moved  label NULL
F1 row 3  -> written to F10      label 0
F1 row 4  -> written to F10      label 0
F2 row 0  -> written to F11      label 1
F2 row 1  -> written to F10      label 0
F2 row 2  -> written to F11      label 1
```

A label is the destination's *index in the ordered destination list* (0 = F10, 1 = F11), not the fragment id itself: u16 indices cover up to 65,536 destinations per rewrite, and the small id list is stored once elsewhere.

**The label column** is that right-hand column persisted as one Lance file: a single nullable u16 column, one row per *physical* source row (deleted rows included), in concatenated scan order. With an illustrative block size of 4 rows (real block size: 64K):

```
source row     0    1    2     3    4  |  5    6    7        (F1 rows 0-4, F2 rows 0-2)
label          0    1    NULL  0    0  |  1    0    1
               └────── block 0 ──────┘   └── block 1 ──┘
```

Reading the labels left to right and counting per destination replays the whole rewrite: F10 received source rows 0, 3, 4, 6 (as its rows 0-3), F11 received rows 1, 5, 7.

**The counts, in the same file's global buffer.** Translating one row must not require replaying the file from the start. So for every 64K-row block boundary the file stores, per destination, the cumulative *"rows so far"* count. For the example (block = 4 rows):

```
                  F10  F11
after block 0:     2    1        (rows 0-3: two F10 labels, one F11, one NULL)
after block 1:     4    3        (final row = per-destination totals)
```

This is a dense `num_blocks x m` grid of u32s — exact and data-independent: ~1.5 MB for a 50M-row rewrite across 500 destinations, ~61 MB at a 1B-row rewrite across 1000, read once at open. The encoded header names the representation, so sparser encodings (e.g. per-destination postings for strongly local redistributions) can be added later without breaking readers; unknown tags fail with a clear error. Deleted counts are implied (block length − sum of the block's deltas), and the final row doubles as the per-destination totals for conservation checks.

The arithmetic rests on an explicit ordering contract (documented in the module): labels are recorded in source physical-row order, each destination receives its rows in that same order and is never re-sorted, and the destination list is fixed for the whole rewrite. A rewrite that routes rows through parallel writers must restore per-destination source order before recording the mapping.

That contract is deliberate scope: this format represents **stable partitions only**. A rewrite that sorts rows *within* a destination is not representable by destination labels (two rows with equal labels rank in source order, not output order); such a rewrite needs a per-row final-offset (permutation) encoding, which would be a separate format rather than a relaxation of this one.

### How it is read

**Open** = one tail read (file footer + the counts global buffer) plus an in-memory consistency check of the counts, so a corrupt buffer fails at open instead of mistranslating rows. No label IO.

**Point lookup** ("where did source row `g` go?") reads one block:

1. `block = g / 64K`, `pos = g mod 64K`; read that one block of labels.
2. If the label at `pos` is NULL → the row was deleted, done.
3. Otherwise `destination offset = counts[block-1][label] + (labels equal to it in this block before pos)`.

Example: source row 6 lands in block 1 at position 2 with label 0 (= F10). Base = counts after block 0 for F10 = 2. Within block 1, one earlier row (row 4) is labeled F10. So row 6 is `(F10, row 3)` — matching the replay above. The in-block count scans at most 64K u16s (3.8 µs measured); the block read is one aligned range read.

**Sweep** ("translate everything from here on") seeds per-destination counters from a block boundary (`counters = counts[block-1]`, zeros for block 0), then for each row: `offset = counter[label]++`. O(1) per row, no rank computation — used for bulk translation, and it works from *any* block boundary, not just the file start (~170M rows/s measured).

### Where the code lives

- `lance-core/src/utils/stable_partition.rs` — the arithmetic above, no IO: `CountsMatrix` (+ builder, codec, `validate()`), `translate_in_block`, `SweepTranslator`. Sibling of `row_addr_remap.rs`, which is the order-preserving (compaction) counterpart.
- `lance-index/src/frag_reuse/row_map.rs` — the file: `RowMapWriter` / `RowMapReader` on the existing `IndexStore` / `IndexWriter` / `IndexReader` traits, no new IO plumbing. The writer takes labels for *live* rows only (a rewrite job scans with deletions applied, so it never sees a deleted row) and interleaves the NULLs itself from the source deletion vectors. The reader offers point, coalesced-batch (`read_ranges`) and sweep translation.

Counts blocks are *logical* 64K-row blocks addressed by row-number range reads, deliberately decoupled from physical page boundaries: correctness never depends on how the encoder cut pages.

## Benchmarks

2M rows, 1000 destinations, ~1/8 deleted, local FS (`benches/stable_partition_row_map.rs`):

| metric | result |
|---|---|
| encoded size, uniform-random labels (nominal width is 10 bits) | **11.15 bits/row** |
| encoded size, labels with block locality (each 64K block draws from ~16 destinations) | 6.27 bits/row |
| sweep translation throughput | ~170M rows/s |
| label rank over a full 64K block (in-memory point-lookup cost) | 3.8 µs |
| end-to-end point translation (one block read + decode + rank) | ~240 µs (V2_1) |

Uniform-random is the number to budget with: a first-pass reclustering exists precisely because arrival order does not correlate with the clustering key, so a 64K-row source block scatters across all destinations and page dictionaries cannot beat the nominal width (11.15 = 10 bits + validity + page overhead; ~1.4 GB per billion source rows). The locality row is the upside case — time-correlated clustering keys, or incremental re-clustering of mostly-sorted data — where per-page dictionaries kick in. Format version matters either way: the 2.1 miniblock path is what reaches these numbers at all (2.0 stores plain u16, ~17 bits/row).

## Tests

- Property tests: point lookup and sweep independently checked against a per-destination-counter reference map over seeded-random labels with deletions, across block boundaries, short final blocks, and mid-block sweep starts.
- Writer conservation: too many / too few labels vs live source rows, deleted offsets outside a fragment's physical rows, per-destination totals vs reference.
- Counts codec: round trip; decode rejects bad magic, truncation, and unknown representation tags; `validate()` rejects non-monotone counts and over-budget blocks.
- Open hardening: `RowMapReader::open` enforces the schema contract (exactly one column, named `label`, u16, nullable), runs the full counts consistency check, and reconciles the label row count, so a corrupt or foreign file errors instead of panicking or silently mistranslating.
- Deterministic NULL/empty shapes: a fully-deleted source, a zero-physical-row source, a deleted tail drained by `finish()`, and empty `translate_many` / `sweep` inputs.

`cargo test -p lance-core -p lance-index`: 1556 passed, 0 failed. Clippy clean for the new code (`--no-deps`; the two pre-existing nightly-drift lints in `lance-encoding` and `inverted/cross_column.rs` are untouched).

## Follow-ups (separate PRs)

1. Transition record + commit path: attach `{sources, destinations, row_map}` to `Operation::Rewrite`, conservation validation at commit, legalize deferred index remap for reordered groups.
2. Read integration: coverage derivation and decode-time translation through the existing `RowIdRemapper` seams.
3. Conflict handling: deletion-vector fold on rebase via the sweep translator, and combining disjoint concurrent rewrites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


