### PR TITLE
fix(sql): classify malformed SQL queries as invalid input

### DIFF
--- a/rust/lance-core/src/error.rs
+++ b/rust/lance-core/src/error.rs
@@ -983,6 +983,22 @@ impl From<datafusion_common::DataFusionError> for Error {
     #[track_caller]
     fn from(e: datafusion_common::DataFusionError) -> Self {
         match e {
+            // DataFusion wraps an error to attach end-user context and source
+            // spans (`Diagnostic`), a description of what was running
+            // (`Context`), or to report several failures at once
+            // (`Collection`). All three are display-transparent, so the
+            // category has to come from the error underneath; classifying the
+            // wrapper itself reports a malformed query as an internal failure.
+            datafusion_common::DataFusionError::Diagnostic(_, inner)
+            | datafusion_common::DataFusionError::Context(_, inner) => Self::from(*inner),
+            datafusion_common::DataFusionError::Collection(errors) => {
+                match errors.into_iter().next() {
+                    // `Collection` reports the first error's message, so take
+                    // its category too.
+                    Some(first) => Self::from(first),
+                    None => Self::execution("DataFusion returned an empty error collection"),
+                }
+            }
             datafusion_common::DataFusionError::SQL(..)
             | datafusion_common::DataFusionError::Plan(..)
             | datafusion_common::DataFusionError::Configuration(..)
@@ -1379,6 +1395,86 @@ mod test {
                 );
             }
             _ => panic!("Expected InvalidInput variant, got {:?}", lance_err),
+        }
+    }
+
+    /// DataFusion wraps errors to attach end-user context (`Diagnostic`), a
+    /// description of what was running (`Context`), or to report several at
+    /// once (`Collection`). All three are display-transparent, so a wrapped
+    /// user error looks exactly like an unwrapped one but would be classified
+    /// as an internal failure if the conversion matched on the wrapper.
+    #[cfg(feature = "datafusion")]
+    #[rstest::rstest]
+    #[case::diagnostic(|inner| datafusion_common::DataFusionError::Diagnostic(
+        Box::new(datafusion_common::Diagnostic::new_error("invalid function", None)),
+        Box::new(inner),
+    ))]
+    #[case::context(|inner| datafusion_common::DataFusionError::Context(
+        "type_coercion".to_string(),
+        Box::new(inner),
+    ))]
+    #[case::collection(|inner| datafusion_common::DataFusionError::Collection(vec![inner]))]
+    #[case::nested(|inner| datafusion_common::DataFusionError::Diagnostic(
+        Box::new(datafusion_common::Diagnostic::new_error("invalid function", None)),
+        Box::new(datafusion_common::DataFusionError::Context(
+            "type_coercion".to_string(),
+            Box::new(inner),
+        )),
+    ))]
+    fn test_datafusion_wrapped_plan_error_is_invalid_input(
+        #[case] wrap: fn(datafusion_common::DataFusionError) -> datafusion_common::DataFusionError,
+    ) {
+        let df_err = wrap(datafusion_common::DataFusionError::Plan(
+            "Invalid function 'no_such_function'".to_string(),
+        ));
+        let lance_err = Error::from(df_err);
+
+        assert!(
+            matches!(lance_err, Error::InvalidInput { .. }),
+            "expected InvalidInput, got {lance_err:?}"
+        );
+        assert!(
+            lance_err.to_string().contains("no_such_function"),
+            "expected the function name to survive, got: {lance_err}"
+        );
+    }
+
+    /// Unwrapping must classify by the inner error rather than assume the
+    /// wrapper always hides a user error.
+    #[cfg(feature = "datafusion")]
+    #[test]
+    fn test_datafusion_wrapped_internal_error_is_not_invalid_input() {
+        let df_err = datafusion_common::DataFusionError::Context(
+            "while running".to_string(),
+            Box::new(datafusion_common::DataFusionError::Internal(
+                "invariant violated".to_string(),
+            )),
+        );
+
+        assert!(
+            matches!(Error::from(df_err), Error::IO { .. }),
+            "an internal DataFusion failure must not be reported as user input"
+        );
+    }
+
+    /// A Lance error that round-trips through DataFusion keeps its own
+    /// category even when DataFusion wraps it on the way back.
+    #[cfg(feature = "datafusion")]
+    #[test]
+    fn test_wrapped_external_lance_error_keeps_its_category() {
+        let df_err = datafusion_common::DataFusionError::Context(
+            "while scanning".to_string(),
+            Box::new(datafusion_common::DataFusionError::from(Error::io(
+                "object store unavailable",
+            ))),
+        );
+
+        match Error::from(df_err) {
+            Error::IO { source, .. } => assert!(
+                source.to_string().contains("object store unavailable"),
+                "expected the original message, got: {source}"
+            ),
+            other => panic!("expected the original IO error, got {other:?}"),
         }
     }
 

--- a/rust/lance/src/dataset/sql.rs
+++ b/rust/lance/src/dataset/sql.rs
@@ -6,9 +6,11 @@ use crate::datafusion::LanceTableProvider;
 use crate::dataset::scanner::validate_batch_size;
 use crate::dataset::utils::SchemaAdapter;
 use arrow_array::RecordBatch;
+use datafusion::common::DataFusionError;
 use datafusion::dataframe::DataFrame;
 use datafusion::execution::SendableRecordBatchStream;
 use datafusion::logical_expr::{Expr as LogicalExpr, LogicalPlan};
+use datafusion::physical_plan::execute_stream;
 use datafusion::prelude::{SessionConfig, SessionContext};
 use datafusion::sql::{
     parser::Statement as DFStatement,
@@ -147,10 +149,15 @@ impl SqlQueryBuilder {
         register_functions(&ctx);
         let state = ctx.state();
         let dialect = state.config_options().sql_parser.dialect;
-        let statement = state.sql_to_statement(&self.sql, &dialect)?;
+        let statement = state
+            .sql_to_statement(&self.sql, &dialect)
+            .map_err(planning_error)?;
         let mut projected = statement.clone();
         let columns = [(self.with_row_id, ROW_ID), (self.with_row_addr, ROW_ADDR)];
-        let plan = state.statement_to_plan(statement).await?;
+        let plan = state
+            .statement_to_plan(statement)
+            .await
+            .map_err(planning_error)?;
         let plan = if safe_to_inject_system_columns(&plan, &columns)
             && project_system_columns(&mut projected, &columns)
         {
@@ -161,7 +168,10 @@ impl SqlQueryBuilder {
         } else {
             plan
         };
-        let df = ctx.execute_logical_plan(plan).await?;
+        let df = ctx
+            .execute_logical_plan(plan)
+            .await
+            .map_err(planning_error)?;
         Ok(SqlQuery::new(df))
     }
 }
@@ -277,17 +287,46 @@ pub struct SqlQuery {
     dataframe: DataFrame,
 }
 
+/// Classify a failure raised while DataFusion was building a plan.
+///
+/// A query that fails to plan is malformed input, but DataFusion does not
+/// report these under a consistent error variant: `get_field` rejects an
+/// unsupported base type with `exec_err!`, and the analyzer wraps that in
+/// `Context`, so it would otherwise reach callers as an internal failure.
+///
+/// Errors Lance itself raised reach DataFusion through `External` and already
+/// carry an accurate category — a scan that cannot read its index metadata is
+/// IO, not bad input — so those keep the category they came with.
+fn planning_error(error: DataFusionError) -> lance_core::Error {
+    let raised_by_lance = matches!(error.find_root(), DataFusionError::External(_));
+    let error = lance_core::Error::from(error);
+    if raised_by_lance {
+        return error;
+    }
+    match error {
+        error @ (lance_core::Error::Execution { .. } | lance_core::Error::IO { .. }) => {
+            lance_core::Error::invalid_input_source(Box::new(error))
+        }
+        error => error,
+    }
+}
+
 impl SqlQuery {
     pub fn new(dataframe: DataFrame) -> Self {
         Self { dataframe }
     }
 
     pub async fn into_stream(self) -> lance_core::Result<SendableRecordBatchStream> {
-        let exec_node = self
+        // Physical planning runs the analyzer, so a malformed query can still
+        // fail here rather than in `SqlQueryBuilder::build`. Keep it separate
+        // from execution so the two phases can be classified differently.
+        let task_ctx = Arc::new(self.dataframe.task_ctx());
+        let plan = self
             .dataframe
-            .execute_stream()
+            .create_physical_plan()
             .await
-            .map_err(lance_core::Error::from)?;
+            .map_err(planning_error)?;
+        let exec_node = execute_stream(plan, task_ctx).map_err(lance_core::Error::from)?;
         let schema = exec_node.schema();
         if SchemaAdapter::requires_logical_conversion(&schema) {
             let adapter = SchemaAdapter::new(schema);
@@ -876,5 +915,50 @@ mod tests {
         pretty_assertions::assert_eq!(batch.num_rows(), 1);
         pretty_assertions::assert_eq!(batch.num_columns(), 1);
         pretty_assertions::assert_eq!(batch.column(0).as_primitive::<Int32Type>().value(0), 1);
+    }
+
+    /// A malformed query is user error and must surface as [`Error::InvalidInput`]
+    /// so that bindings and servers can map it to a client error rather than a
+    /// generic failure.
+    ///
+    /// Neither case reaches that variant on its own: DataFusion reports an
+    /// unknown function as a `Plan` error wrapped in `Diagnostic`, and rejects
+    /// a subscript on a non-struct column with `exec_err!` wrapped in
+    /// `Context`. Both would otherwise be classified as internal failures.
+    #[rstest]
+    #[case::unknown_function("SELECT id FROM dataset WHERE no_such_function(data) = 'Alice'")]
+    #[case::subscript_on_json_column("SELECT id FROM dataset WHERE data['user'] = 'Alice'")]
+    #[tokio::test]
+    async fn test_sql_malformed_query_is_invalid_input(#[case] sql: &str) {
+        let mut metadata = HashMap::new();
+        metadata.insert(
+            ARROW_EXT_NAME_KEY.to_string(),
+            ARROW_JSON_EXT_NAME.to_string(),
+        );
+        let schema = Arc::new(ArrowSchema::new(vec![
+            Field::new("id", DataType::Int32, false),
+            Field::new("data", DataType::Utf8, true).with_metadata(metadata),
+        ]));
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(Int32Array::from(vec![1])),
+                Arc::new(StringArray::from(vec![Some(r#"{"user": "Alice"}"#)])),
+            ],
+        )
+        .unwrap();
+        let reader = RecordBatchIterator::new(vec![Ok(batch)], schema.clone());
+        let ds = Dataset::write(reader, "memory://test_sql_malformed_query", None)
+            .await
+            .unwrap();
+
+        let result = async { ds.sql(sql).build().await?.into_batch_records().await }.await;
+        let Err(error) = result else {
+            panic!("expected `{sql}` to fail");
+        };
+        assert!(
+            matches!(error, Error::InvalidInput { .. }),
+            "expected InvalidInput, got {error:?}"
+        );
     }
 }

--- a/rust/lance/src/dataset/sql.rs
+++ b/rust/lance/src/dataset/sql.rs
@@ -356,6 +356,7 @@ mod tests {
     use std::collections::HashMap;
     use std::sync::Arc;
 
+    use super::planning_error;
     use crate::dataset::ReadParams;
     use crate::dataset::builder::DatasetBuilder;
     use crate::dataset::write::WriteParams;
@@ -366,6 +367,7 @@ mod tests {
     use arrow_array::{Int32Array, RecordBatch, RecordBatchIterator, StringArray};
     use arrow_schema::Schema as ArrowSchema;
     use arrow_schema::{DataType, Field};
+    use datafusion::common::DataFusionError;
     use lance_arrow::json::ARROW_JSON_EXT_NAME;
     use lance_arrow::{ARROW_EXT_NAME_KEY, SchemaExt};
     use lance_core::datatypes::BlobHandling;
@@ -921,15 +923,26 @@ mod tests {
     /// so that bindings and servers can map it to a client error rather than a
     /// generic failure.
     ///
-    /// Neither case reaches that variant on its own: DataFusion reports an
-    /// unknown function as a `Plan` error wrapped in `Diagnostic`, and rejects
-    /// a subscript on a non-struct column with `exec_err!` wrapped in
-    /// `Context`. Both would otherwise be classified as internal failures.
+    /// The cases differ in how DataFusion reports them: a syntax error is a
+    /// `SQL` error, an unknown function is a `Plan` error wrapped in
+    /// `Diagnostic`, and a subscript on a non-struct column is `exec_err!`
+    /// wrapped in `Context`. Only the first is classified as user input on its
+    /// own; the other two would otherwise read as internal failures.
     #[rstest]
-    #[case::unknown_function("SELECT id FROM dataset WHERE no_such_function(data) = 'Alice'")]
-    #[case::subscript_on_json_column("SELECT id FROM dataset WHERE data['user'] = 'Alice'")]
+    #[case::syntax_error("SELEC id FROM dataset", "found: SELEC at")]
+    #[case::unknown_function(
+        "SELECT id FROM dataset WHERE no_such_function(data) = 'Alice'",
+        "no_such_function"
+    )]
+    #[case::subscript_on_json_column(
+        "SELECT id FROM dataset WHERE data['user'] = 'Alice'",
+        "Cannot access field"
+    )]
     #[tokio::test]
-    async fn test_sql_malformed_query_is_invalid_input(#[case] sql: &str) {
+    async fn test_sql_malformed_query_is_invalid_input(
+        #[case] sql: &str,
+        #[case] expected_message: &str,
+    ) {
         let mut metadata = HashMap::new();
         metadata.insert(
             ARROW_EXT_NAME_KEY.to_string(),
@@ -960,5 +973,28 @@ mod tests {
             matches!(error, Error::InvalidInput { .. }),
             "expected InvalidInput, got {error:?}"
         );
+        assert!(
+            error.to_string().contains(expected_message),
+            "expected the message to name {expected_message:?}, got: {error}"
+        );
+    }
+
+    /// `LanceTableProvider::scan` runs during physical planning and reports
+    /// every Lance failure as `DataFusionError::External`, so storage that is
+    /// unreachable while planning must not be reported as a malformed query.
+    #[test]
+    fn test_planning_error_keeps_lance_error_category() {
+        let df_error = DataFusionError::Context(
+            "while scanning".to_string(),
+            Box::new(DataFusionError::from(Error::io("object store unavailable"))),
+        );
+
+        match planning_error(df_error) {
+            Error::IO { source, .. } => assert!(
+                source.to_string().contains("object store unavailable"),
+                "expected the original message, got: {source}"
+            ),
+            other => panic!("expected the original IO error, got {other:?}"),
+        }
     }
 }

--- a/rust/lance/src/dataset/sql.rs
+++ b/rust/lance/src/dataset/sql.rs
@@ -294,9 +294,15 @@ pub struct SqlQuery {
 /// unsupported base type with `exec_err!`, and the analyzer wraps that in
 /// `Context`, so it would otherwise reach callers as an internal failure.
 ///
-/// Errors Lance itself raised reach DataFusion through `External` and already
-/// carry an accurate category — a scan that cannot read its index metadata is
-/// IO, not bad input — so those keep the category they came with.
+/// Only the execution category is re-classified. Every other category is either
+/// already accurate or describes a failure the caller did not cause: an
+/// unreachable object store is not a malformed query, and any other SQL would
+/// have hit it too.
+///
+/// Errors Lance itself raised reach DataFusion through `External` and keep the
+/// category they came with. Lance uses the execution category for its own
+/// internal failures as well — a spill file that cannot be created, a poisoned
+/// lock — and those are not bad input either.
 fn planning_error(error: DataFusionError) -> lance_core::Error {
     let raised_by_lance = matches!(error.find_root(), DataFusionError::External(_));
     let error = lance_core::Error::from(error);
@@ -304,7 +310,7 @@ fn planning_error(error: DataFusionError) -> lance_core::Error {
         return error;
     }
     match error {
-        error @ (lance_core::Error::Execution { .. } | lance_core::Error::IO { .. }) => {
+        error @ lance_core::Error::Execution { .. } => {
             lance_core::Error::invalid_input_source(Box::new(error))
         }
         error => error,
@@ -980,21 +986,44 @@ mod tests {
     }
 
     /// `LanceTableProvider::scan` runs during physical planning and reports
-    /// every Lance failure as `DataFusionError::External`, so storage that is
-    /// unreachable while planning must not be reported as a malformed query.
+    /// every Lance failure as `DataFusionError::External`. Lance raises
+    /// [`Error::Execution`] for its own internal failures, which is the one
+    /// category `planning_error` re-classifies, so these must be recognized as
+    /// Lance's own and left alone rather than blamed on the query.
     #[test]
     fn test_planning_error_keeps_lance_error_category() {
         let df_error = DataFusionError::Context(
             "while scanning".to_string(),
-            Box::new(DataFusionError::from(Error::io("object store unavailable"))),
+            Box::new(DataFusionError::from(Error::execution(
+                "failed to create spill file",
+            ))),
         );
 
         match planning_error(df_error) {
-            Error::IO { source, .. } => assert!(
-                source.to_string().contains("object store unavailable"),
-                "expected the original message, got: {source}"
+            Error::Execution { message, .. } => assert!(
+                message.contains("failed to create spill file"),
+                "expected the original message, got: {message}"
             ),
-            other => panic!("expected the original IO error, got {other:?}"),
+            other => panic!("expected the original execution error, got {other:?}"),
         }
+    }
+
+    /// A failure that is neither the caller's fault nor Lance's own — DataFusion
+    /// hitting a resource limit while planning — must not be reported as a
+    /// malformed query just because it surfaced during planning.
+    #[test]
+    fn test_planning_error_keeps_internal_datafusion_error() {
+        let df_error = DataFusionError::Context(
+            "while planning".to_string(),
+            Box::new(DataFusionError::ResourcesExhausted(
+                "failed to allocate memory".to_string(),
+            )),
+        );
+
+        let error = planning_error(df_error);
+        assert!(
+            !matches!(error, Error::InvalidInput { .. }),
+            "expected the error not to be blamed on the query, got {error:?}"
+        );
     }
 }


### PR DESCRIPTION
Previously, a malformed SQL query passed to `Dataset::sql` surfaced as `Error::IO`. The Python and Java bindings map that to `IOError`/`IOException`, so a service reports it as an internal failure rather than a client error. Calling an unknown function, or using `my_column['field']` on a JSON column instead of `json_extract()`, both produced a 500.

There are two causes.

DataFusion wraps errors to attach end-user context and source spans (`Diagnostic`), a description of what was running (`Context`), or to report several failures at once (`Collection`). All three render exactly like the error they wrap, so the problem is invisible in the message: the text reads like a plain planning complaint while the variant underneath says something else. `From<DataFusionError>` matched on the wrapper rather than the `Plan` or `SchemaError` inside it, and fell through to `Error::IO`.

Separately, DataFusion does not classify planning failures consistently. `get_field` rejects an unsupported base type with `exec_err!`, so `my_column['field']` on a non-struct column is reported as an execution failure even though it is raised while the plan is still being built.

This PR unwraps the three wrapper variants so the category comes from the error underneath, and classifies failures raised while building a SQL plan as invalid input. Errors that Lance itself raised reach DataFusion through `External` and keep the category they came with, so a scan that cannot read its index metadata is still reported as IO rather than as a bad query.

## Not included

The Python `SqlQuery` bindings still discard the error category: `to_batch_records` maps everything to `ValueError` and `to_stream_reader` maps everything to `PyIOError`, rather than using the existing `infer_error` mapper. That is a separate change.

The underlying `exec_err!` in DataFusion's `get_field` is arguably an upstream bug — the adjacent match arm uses `plan_datafusion_err!` for a missing struct field, which is the same class of user error in the same function. Worth reporting upstream, but this PR does not depend on it.
