### PR TITLE
feat(table): stable partition transition on the rewrite commit path

### DIFF
--- a/protos/table.proto
+++ b/protos/table.proto
@@ -627,6 +627,56 @@ message FragmentReuseIndexDetails {
   }
 }
 
+// Details of the stable partition system index, which records reordered
+// rewrites (e.g. reclustering). Unlike FragmentReuseIndexDetails, whose
+// mapping is derived from row order (a rewrite that preserves it), a
+// reordered rewrite distributes source rows across destinations in an order
+// the reader cannot derive, so each transition references a row map file
+// holding one destination label per physical source row.
+message StablePartitionIndexDetails {
+
+  oneof content {
+    // if < 200KB, store the content inline, otherwise store the InlineContent bytes in external file
+    InlineContent inline = 1;
+    ExternalFile external = 2;
+  }
+
+  message InlineContent {
+    repeated Transition transitions = 1;
+  }
+
+  message FragmentDigest {
+    uint64 id = 1;
+
+    uint64 physical_rows = 2;
+
+    uint64 num_deleted_rows = 3;
+  }
+
+  // One reordered rewrite: n source fragments scanned in order, m
+  // destination fragments filled in that same order (a stable partition).
+  message Transition {
+    // The dataset version whose commit installed this transition.
+    uint64 dataset_version = 1;
+
+    // Source fragments in scan order. Their physical row counts are the
+    // addressing base of the row map: prefix sums position each source
+    // fragment's rows in the concatenated label sequence.
+    repeated FragmentDigest sources = 2;
+
+    // Destination fragment ids in label order: a row map label is an index
+    // into this list.
+    repeated uint64 destinations = 3;
+
+    // The row map file lives at `{indices dir}/{row_map_id}/row_map.lance`:
+    // one nullable u16 label per physical source row in scan order, with the
+    // per-block cumulative counts in a global buffer.
+    string row_map_id = 4;
+
+    uint64 row_map_size_bytes = 5;
+  }
+}
+
 // ============================================================================
 // MemWAL Index Types
 // ============================================================================

--- a/rust/lance-table/src/system_index.rs
+++ b/rust/lance-table/src/system_index.rs
@@ -13,12 +13,16 @@
 
 pub mod frag_reuse;
 pub mod mem_wal;
+pub mod stable_partition;
 
 use crate::format::IndexMetadata;
 use frag_reuse::FRAG_REUSE_INDEX_NAME;
 use mem_wal::MEM_WAL_INDEX_NAME;
+use stable_partition::STABLE_PARTITION_INDEX_NAME;
 
 /// Whether `index_meta` describes one of the system indices defined in this module.
 pub fn is_system_index(index_meta: &IndexMetadata) -> bool {
-    index_meta.name == FRAG_REUSE_INDEX_NAME || index_meta.name == MEM_WAL_INDEX_NAME
+    index_meta.name == FRAG_REUSE_INDEX_NAME
+        || index_meta.name == MEM_WAL_INDEX_NAME
+        || index_meta.name == STABLE_PARTITION_INDEX_NAME
 }

--- a/rust/lance-table/src/system_index/stable_partition.rs
+++ b/rust/lance-table/src/system_index/stable_partition.rs
@@ -1,0 +1,222 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+//! The stable partition system index: the ledger of reordered rewrites.
+//!
+//! A reordered rewrite (e.g. reclustering) scans `n` source fragments in
+//! order and distributes their live rows across `m` destination fragments,
+//! preserving relative row order within each destination. The mapping cannot
+//! be derived from row order the way [`super::frag_reuse`] derives it for
+//! compaction, so each rewrite records a [`StablePartitionTransition`]:
+//! the ordered sources (whose physical row counts are the addressing base of
+//! the row map), the ordered destinations (a row map label indexes this
+//! list), and a reference to the row map file written with
+//! `lance-index`'s `RowMapWriter`.
+//!
+//! The transitions accumulate in one manifest index entry named
+//! [`STABLE_PARTITION_INDEX_NAME`], separate from the fragment reuse index so
+//! readers that predate it skip the entry instead of misreading it. The
+//! entry's fragment bitmap holds the union of all transition source ids:
+//! provenance, deliberately including fragments no longer in the dataset
+//! (see `IndexMetadata::fragment_bitmap`).
+
+use lance_core::deepsize::DeepSizeOf;
+use lance_core::{Error, Result};
+use roaring::RoaringBitmap;
+use serde::{Deserialize, Serialize};
+
+use super::frag_reuse::FragDigest;
+use crate::format::pb::stable_partition_index_details::InlineContent;
+use crate::format::{ExternalFile, pb};
+
+pub const STABLE_PARTITION_INDEX_NAME: &str = "__lance_stable_partition";
+pub const STABLE_PARTITION_DETAILS_FILE_NAME: &str = "details.binpb";
+/// The row map file of a transition, under `{indices dir}/{row_map_id}/`.
+pub const ROW_MAP_FILE_NAME: &str = "row_map.lance";
+
+/// One reordered rewrite.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, DeepSizeOf)]
+pub struct StablePartitionTransition {
+    /// The dataset version whose commit installed this transition.
+    pub dataset_version: u64,
+    /// Source fragments in scan order; prefix sums of their physical rows
+    /// position each fragment's rows in the row map's label sequence.
+    pub sources: Vec<FragDigest>,
+    /// Destination fragment ids in label order: a row map label is an index
+    /// into this list.
+    pub destinations: Vec<u64>,
+    /// Directory id of the row map file: `{indices dir}/{row_map_id}/row_map.lance`.
+    pub row_map_id: String,
+    pub row_map_size_bytes: u64,
+}
+
+impl StablePartitionTransition {
+    pub fn source_ids(&self) -> RoaringBitmap {
+        RoaringBitmap::from_iter(self.sources.iter().map(|frag| frag.id as u32))
+    }
+
+    pub fn destination_ids(&self) -> RoaringBitmap {
+        RoaringBitmap::from_iter(self.destinations.iter().map(|&id| id as u32))
+    }
+
+    /// Total physical source rows: the row count of the row map file.
+    pub fn total_source_rows(&self) -> u64 {
+        self.sources
+            .iter()
+            .map(|frag| frag.physical_rows as u64)
+            .sum()
+    }
+}
+
+impl From<&FragDigest> for pb::stable_partition_index_details::FragmentDigest {
+    fn from(digest: &FragDigest) -> Self {
+        Self {
+            id: digest.id,
+            physical_rows: digest.physical_rows as u64,
+            num_deleted_rows: digest.num_deleted_rows as u64,
+        }
+    }
+}
+
+impl TryFrom<pb::stable_partition_index_details::FragmentDigest> for FragDigest {
+    type Error = Error;
+
+    fn try_from(digest: pb::stable_partition_index_details::FragmentDigest) -> Result<Self> {
+        Ok(Self {
+            id: digest.id,
+            physical_rows: digest.physical_rows as usize,
+            num_deleted_rows: digest.num_deleted_rows as usize,
+        })
+    }
+}
+
+impl From<&StablePartitionTransition> for pb::stable_partition_index_details::Transition {
+    fn from(transition: &StablePartitionTransition) -> Self {
+        Self {
+            dataset_version: transition.dataset_version,
+            sources: transition.sources.iter().map(|f| f.into()).collect(),
+            destinations: transition.destinations.clone(),
+            row_map_id: transition.row_map_id.clone(),
+            row_map_size_bytes: transition.row_map_size_bytes,
+        }
+    }
+}
+
+impl TryFrom<pb::stable_partition_index_details::Transition> for StablePartitionTransition {
+    type Error = Error;
+
+    fn try_from(transition: pb::stable_partition_index_details::Transition) -> Result<Self> {
+        Ok(Self {
+            dataset_version: transition.dataset_version,
+            sources: transition
+                .sources
+                .into_iter()
+                .map(FragDigest::try_from)
+                .collect::<Result<_>>()?,
+            destinations: transition.destinations,
+            row_map_id: transition.row_map_id,
+            row_map_size_bytes: transition.row_map_size_bytes,
+        })
+    }
+}
+
+/// All transitions of the stable partition index entry, oldest first.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, DeepSizeOf)]
+pub struct StablePartitionIndexDetails {
+    pub transitions: Vec<StablePartitionTransition>,
+}
+
+impl StablePartitionIndexDetails {
+    /// The union of every transition's source ids: the entry's fragment
+    /// bitmap. Sources are retired at commit, so these ids are provenance,
+    /// not live coverage.
+    pub fn source_bitmap(&self) -> RoaringBitmap {
+        self.transitions
+            .iter()
+            .fold(RoaringBitmap::new(), |mut bitmap, transition| {
+                bitmap |= transition.source_ids();
+                bitmap
+            })
+    }
+}
+
+impl From<&StablePartitionIndexDetails> for InlineContent {
+    fn from(details: &StablePartitionIndexDetails) -> Self {
+        let mut transitions: Vec<pb::stable_partition_index_details::Transition> =
+            details.transitions.iter().map(|t| t.into()).collect();
+        // sort from oldest to latest version
+        transitions.sort_by_key(|t| t.dataset_version);
+        Self { transitions }
+    }
+}
+
+impl TryFrom<InlineContent> for StablePartitionIndexDetails {
+    type Error = Error;
+
+    fn try_from(content: InlineContent) -> Result<Self> {
+        Ok(Self {
+            transitions: content
+                .transitions
+                .into_iter()
+                .map(|t| t.try_into())
+                .collect::<Result<Vec<_>>>()?,
+        })
+    }
+}
+
+/// The details payload of the manifest entry: inline below the 200KB spill
+/// threshold, otherwise a reference to an external `details.binpb`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, DeepSizeOf)]
+pub enum StablePartitionDetailsContentType {
+    Inline(StablePartitionIndexDetails),
+    External(ExternalFile),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use prost::Message;
+
+    fn sample_details() -> StablePartitionIndexDetails {
+        StablePartitionIndexDetails {
+            transitions: vec![StablePartitionTransition {
+                dataset_version: 7,
+                sources: vec![
+                    FragDigest {
+                        id: 1,
+                        physical_rows: 100,
+                        num_deleted_rows: 10,
+                    },
+                    FragDigest {
+                        id: 2,
+                        physical_rows: 50,
+                        num_deleted_rows: 0,
+                    },
+                ],
+                destinations: vec![10, 11, 12],
+                row_map_id: "d4c9…".to_string(),
+                row_map_size_bytes: 12345,
+            }],
+        }
+    }
+
+    #[test]
+    fn test_details_proto_round_trip() {
+        let details = sample_details();
+        let content = InlineContent::from(&details);
+        let decoded = StablePartitionIndexDetails::try_from(
+            InlineContent::decode(content.encode_to_vec().as_slice()).unwrap(),
+        )
+        .unwrap();
+        assert_eq!(decoded, details);
+
+        let transition = &details.transitions[0];
+        assert_eq!(transition.total_source_rows(), 150);
+        assert_eq!(transition.source_ids(), RoaringBitmap::from_iter([1u32, 2]));
+        assert_eq!(
+            transition.destination_ids(),
+            RoaringBitmap::from_iter([10u32, 11, 12])
+        );
+        assert_eq!(details.source_bitmap(), RoaringBitmap::from_iter([1u32, 2]));
+    }
+}

--- a/rust/lance-table/src/transaction.rs
+++ b/rust/lance-table/src/transaction.rs
@@ -41,8 +41,8 @@ pub(crate) mod test_support;
 
 pub use builder::{Transaction, TransactionBuilder};
 pub use operation::{
-    DataOverlayGroup, DataReplacementGroup, Operation, RewriteGroup, RewrittenIndex, UpdateMode,
-    UpdatedFragmentOffsets,
+    DataOverlayGroup, DataReplacementGroup, Operation, RewriteGroup, RewrittenIndex,
+    StablePartitionRewrite, UpdateMode, UpdatedFragmentOffsets,
 };
 pub use update_map::{
     UpdateMap, UpdateMapEntry, translate_config_updates, translate_schema_metadata_updates,

--- a/rust/lance-table/src/transaction/conflicts.rs
+++ b/rust/lance-table/src/transaction/conflicts.rs
@@ -99,16 +99,19 @@ impl PartialEq for Operation {
                     groups: a_groups,
                     rewritten_indices: a_indices,
                     frag_reuse_index: a_frag_reuse_index,
+                    stable_partition: a_stable_partition,
                 },
                 Self::Rewrite {
                     groups: b_groups,
                     rewritten_indices: b_indices,
                     frag_reuse_index: b_frag_reuse_index,
+                    stable_partition: b_stable_partition,
                 },
             ) => {
                 compare_vec(a_groups, b_groups)
                     && compare_vec(a_indices, b_indices)
                     && a_frag_reuse_index == b_frag_reuse_index
+                    && a_stable_partition == b_stable_partition
             }
             (
                 Self::Merge {
@@ -1036,6 +1039,7 @@ mod tests {
             groups: vec![],
             rewritten_indices: vec![],
             frag_reuse_index: None,
+            stable_partition: None,
         };
         assert_ne!(overlay(1), rewrite);
     }

--- a/rust/lance-table/src/transaction/index_maintenance.rs
+++ b/rust/lance-table/src/transaction/index_maintenance.rs
@@ -13,7 +13,7 @@ use crate::format::overlay::staleness::collect_overlay_stale_frags;
 use crate::format::{Fragment, IndexMetadata};
 use crate::system_index::frag_reuse::FRAG_REUSE_INDEX_NAME;
 use crate::system_index::is_system_index;
-use crate::transaction::{RewriteGroup, RewrittenIndex, Transaction};
+use crate::transaction::{RewriteGroup, RewrittenIndex, StablePartitionRewrite, Transaction};
 use lance_core::datatypes::Schema;
 use lance_core::{Error, Result};
 use roaring::RoaringBitmap;
@@ -241,7 +241,12 @@ impl Transaction {
             std::collections::HashMap::new();
 
         for index in indices.iter() {
-            if index.name != FRAG_REUSE_INDEX_NAME {
+            // System indices (fragment reuse, stable partition, MemWAL) are
+            // exempt from coverage-based retention: their bitmaps carry
+            // provenance, deliberately including retired fragment ids, so an
+            // empty intersection with the live fragments does not mean the
+            // entry is obsolete.
+            if !is_system_index(index) {
                 indices_by_name
                     .entry(index.name.clone())
                     .or_default()
@@ -306,9 +311,39 @@ impl Transaction {
             }
         }
 
-        indices.retain(|index| {
-            index.name == FRAG_REUSE_INDEX_NAME || uuids_to_keep.contains(&index.uuid)
-        });
+        indices.retain(|index| is_system_index(index) || uuids_to_keep.contains(&index.uuid));
+    }
+
+    /// The rewrite groups whose index bitmaps follow the rewrite (source ids
+    /// swapped for destination ids). Groups covered by the stable partition
+    /// rewrite's sources are excluded: they redistribute rows, so their
+    /// bitmaps keep the retired source ids as provenance and the stable
+    /// partition index entry records the row-level translation. A group must
+    /// be entirely reordered or entirely order-preserving.
+    pub(super) fn ordered_rewrite_groups(
+        groups: &[RewriteGroup],
+        stable_partition: Option<&StablePartitionRewrite>,
+    ) -> Result<Vec<RewriteGroup>> {
+        let Some(stable_partition) = stable_partition else {
+            return Ok(groups.to_vec());
+        };
+        let sources = &stable_partition.reordered_sources;
+        let mut ordered = Vec::new();
+        for group in groups {
+            let covered = group
+                .old_fragments
+                .iter()
+                .filter(|frag| sources.contains(frag.id as u32))
+                .count();
+            if covered == 0 {
+                ordered.push(group.clone());
+            } else if covered != group.old_fragments.len() {
+                return Err(Error::invalid_input(
+                    "a rewrite group mixes reordered and order-preserving source fragments",
+                ));
+            }
+        }
+        Ok(ordered)
     }
 
     pub(super) fn recalculate_fragment_bitmap(
@@ -452,6 +487,43 @@ mod tests {
     use super::*;
     use crate::transaction::test_support::overlay_with_field;
     use uuid::Uuid;
+
+    #[test]
+    fn test_ordered_rewrite_groups_split_and_mixed() {
+        use crate::transaction::StablePartitionRewrite;
+        let group = |old_ids: &[u64], new_ids: &[u64]| RewriteGroup {
+            old_fragments: old_ids.iter().map(|&id| Fragment::new(id)).collect(),
+            new_fragments: new_ids.iter().map(|&id| Fragment::new(id)).collect(),
+        };
+        let groups = vec![group(&[0, 1], &[10]), group(&[2], &[11])];
+
+        // No stable partition: every group takes part in bitmap maintenance.
+        assert_eq!(
+            Transaction::ordered_rewrite_groups(&groups, None)
+                .unwrap()
+                .len(),
+            2
+        );
+
+        // Group [0, 1] is reordered: only group [2] remains ordered.
+        let stable_partition = StablePartitionRewrite {
+            index: create_system_index(
+                crate::system_index::stable_partition::STABLE_PARTITION_INDEX_NAME,
+                99,
+            ),
+            reordered_sources: RoaringBitmap::from_iter([0u32, 1]),
+            base_entry_version: None,
+        };
+        let ordered =
+            Transaction::ordered_rewrite_groups(&groups, Some(&stable_partition)).unwrap();
+        assert_eq!(ordered.len(), 1);
+        assert_eq!(ordered[0].old_fragments[0].id, 2);
+
+        // A group straddling reordered and order-preserving sources is
+        // rejected.
+        let mixed = vec![group(&[1, 2], &[10])];
+        assert!(Transaction::ordered_rewrite_groups(&mixed, Some(&stable_partition)).is_err());
+    }
 
     #[test]
     fn test_rewrite_fragments() {

--- a/rust/lance-table/src/transaction/manifest_build.rs
+++ b/rust/lance-table/src/transaction/manifest_build.rs
@@ -801,6 +801,7 @@ impl Transaction {
                 groups,
                 rewritten_indices,
                 frag_reuse_index,
+                stable_partition,
             } => {
                 final_fragments.extend(maybe_existing_fragments?.clone());
                 let current_version = current_manifest.map(|m| m.version).unwrap_or_default();
@@ -811,6 +812,15 @@ impl Transaction {
                     current_version,
                     next_row_id.as_ref(),
                 )?;
+
+                // Groups covered by the stable partition rewrite redistribute
+                // rows across their destinations, so index bitmaps must not
+                // follow them: the retired source ids stay in the bitmaps as
+                // provenance and the stable partition index entry records the
+                // row-level translation. Only the order-preserving groups
+                // take part in bitmap maintenance below.
+                let ordered_groups =
+                    Self::ordered_rewrite_groups(groups, stable_partition.as_ref())?;
 
                 if next_row_id.is_some() {
                     // We can re-use indices, but need to rewrite the fragment bitmaps
@@ -827,14 +837,18 @@ impl Transaction {
                                 // that no longer resolve, so drop the rewritten fragments from
                                 // its coverage instead and let the scanner fall back to a full
                                 // scan for them.
-                                Self::drop_rewritten_fragments(fragment_bitmap, groups)
+                                Self::drop_rewritten_fragments(fragment_bitmap, &ordered_groups)
                             } else {
-                                Self::recalculate_fragment_bitmap(fragment_bitmap, groups)?
+                                Self::recalculate_fragment_bitmap(fragment_bitmap, &ordered_groups)?
                             };
                         }
                     }
                 } else {
-                    Self::handle_rewrite_indices(&mut final_indices, rewritten_indices, groups)?;
+                    Self::handle_rewrite_indices(
+                        &mut final_indices,
+                        rewritten_indices,
+                        &ordered_groups,
+                    )?;
                 }
 
                 // A full compaction materializes a fragment's overlays into fresh
@@ -846,6 +860,24 @@ impl Transaction {
                 if let Some(frag_reuse_index) = frag_reuse_index {
                     final_indices.retain(|idx| idx.name != frag_reuse_index.name);
                     final_indices.push(frag_reuse_index.clone());
+                }
+                if let Some(stable_partition) = stable_partition {
+                    let existing_version = final_indices
+                        .iter()
+                        .find(|idx| idx.name == stable_partition.index.name)
+                        .map(|idx| idx.dataset_version);
+                    if existing_version != stable_partition.base_entry_version {
+                        return Err(Error::invalid_input(format!(
+                            "the {} index entry changed (version {:?}, this rewrite was built on {:?}): \
+                             a concurrent reordered rewrite landed, rebuild the transition against \
+                             the latest version and retry",
+                            stable_partition.index.name,
+                            existing_version,
+                            stable_partition.base_entry_version,
+                        )));
+                    }
+                    final_indices.retain(|idx| idx.name != stable_partition.index.name);
+                    final_indices.push(stable_partition.index.clone());
                 }
             }
             Operation::CreateIndex {

--- a/rust/lance-table/src/transaction/operation.rs
+++ b/rust/lance-table/src/transaction/operation.rs
@@ -88,6 +88,11 @@ pub enum Operation {
         rewritten_indices: Vec<RewrittenIndex>,
         /// The fragment reuse index to be created or updated to
         frag_reuse_index: Option<IndexMetadata>,
+        /// The reordered part of this rewrite, if any. In-memory only, like
+        /// `frag_reuse_index`: never serialized into the transaction file,
+        /// because other writers' conflict decisions only need the fragment
+        /// sets in `groups`, which are exact either way.
+        stable_partition: Option<StablePartitionRewrite>,
     },
     /// Replace data in a column in the dataset with new data. This is used for
     /// null column population where we replace an entirely null column with a
@@ -270,6 +275,40 @@ impl std::fmt::Display for Operation {
             Self::UpdateMemWalState { .. } => write!(f, "UpdateMemWalState"),
             Self::UpdateBases { .. } => write!(f, "UpdateBases"),
         }
+    }
+}
+
+/// A reordered rewrite's contribution to a [`Operation::Rewrite`] commit.
+///
+/// Unlike compaction, the groups of a reordered rewrite redistribute rows
+/// across destinations, so index fragment bitmaps must not be swapped from
+/// old to new fragments: the retired source ids stay in the bitmaps as
+/// provenance and the stable partition index entry records how to translate
+/// (see `lance_table::system_index::stable_partition`).
+#[derive(Debug, Clone, PartialEq)]
+pub struct StablePartitionRewrite {
+    /// The accumulated stable partition index entry to install, spliced into
+    /// the manifest's index list by name.
+    pub index: IndexMetadata,
+    /// Source fragment ids of this commit's reordered groups. A rewrite
+    /// group whose old fragments fall in this set skips fragment-bitmap
+    /// recalculation; a group must be entirely in or entirely out.
+    pub reordered_sources: RoaringBitmap,
+    /// `dataset_version` of the stable partition entry that `index` was
+    /// built by appending onto (`None` when this rewrite creates the entry).
+    /// The transaction field is never serialized, so a concurrent reordered
+    /// rewrite cannot be detected from the other transaction; instead the
+    /// commit fails when the manifest's entry no longer matches this base,
+    /// because splicing would silently drop the concurrent transition. The
+    /// caller rebuilds against the latest entry and retries.
+    pub base_entry_version: Option<u64>,
+}
+
+impl DeepSizeOf for StablePartitionRewrite {
+    fn deep_size_of_children(&self, context: &mut lance_core::deepsize::Context) -> usize {
+        // Roaring does not expose its allocation capacity; its serialized
+        // size is a stable proxy.
+        self.index.deep_size_of_children(context) + self.reordered_sources.serialized_size()
     }
 }
 

--- a/rust/lance-table/src/transaction/proto.rs
+++ b/rust/lance-table/src/transaction/proto.rs
@@ -180,6 +180,7 @@ impl TryFrom<pb::Transaction> for Transaction {
                     groups,
                     rewritten_indices,
                     frag_reuse_index: None,
+                    stable_partition: None,
                 }
             }
             Some(pb::transaction::Operation::CreateIndex(pb::transaction::CreateIndex {
@@ -556,6 +557,7 @@ impl From<&Transaction> for pb::Transaction {
                 groups,
                 rewritten_indices,
                 frag_reuse_index: _,
+                stable_partition: _,
             } => pb::transaction::Operation::Rewrite(pb::transaction::Rewrite {
                 groups: groups
                     .iter()

--- a/rust/lance/src/dataset/optimize.rs
+++ b/rust/lance/src/dataset/optimize.rs
@@ -3014,6 +3014,7 @@ pub async fn commit_compaction(
             groups: rewrite_groups,
             rewritten_indices,
             frag_reuse_index,
+            stable_partition: None,
         },
     )
     .transaction_properties(options.transaction_properties.clone())

--- a/rust/lance/src/index.rs
+++ b/rust/lance/src/index.rs
@@ -84,6 +84,7 @@ pub mod mem_wal;
 pub mod prefilter;
 pub mod scalar;
 pub(crate) mod scalar_logical;
+pub mod stable_partition;
 pub mod vector;
 
 use self::append::merge_indices;

--- a/rust/lance/src/index/stable_partition.rs
+++ b/rust/lance/src/index/stable_partition.rs
@@ -1,0 +1,502 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+//! Building and loading the stable partition system index entry.
+//!
+//! A reordered rewrite job writes its row map file first (see
+//! `lance_index::frag_reuse::row_map`), then calls
+//! [`build_stable_partition_rewrite`] with the sources, destinations and the
+//! counts matrix the row map writer returned. The result rides on
+//! `Operation::Rewrite::stable_partition` through the ordinary commit path;
+//! `lance-table`'s manifest build splices the entry and leaves the reordered
+//! groups' index bitmaps untouched.
+
+use crate::Dataset;
+use crate::index::DatasetIndexExt;
+use lance_core::Error;
+use lance_core::utils::stable_partition::CountsMatrix;
+use lance_table::format::pb::ExternalFile;
+use lance_table::format::pb::StablePartitionIndexDetails as PbStablePartitionIndexDetails;
+use lance_table::format::pb::stable_partition_index_details::{Content, InlineContent};
+use lance_table::format::{Fragment, IndexMetadata};
+use lance_table::system_index::frag_reuse::FragDigest;
+use lance_table::system_index::stable_partition::{
+    STABLE_PARTITION_DETAILS_FILE_NAME, STABLE_PARTITION_INDEX_NAME, StablePartitionIndexDetails,
+    StablePartitionTransition,
+};
+use lance_table::transaction::StablePartitionRewrite;
+use prost::Message;
+use tokio::io::AsyncWriteExt;
+use uuid::Uuid;
+
+/// Load the stable partition details from an index metadata entry.
+pub async fn load_stable_partition_details(
+    dataset: &Dataset,
+    index: &IndexMetadata,
+) -> lance_core::Result<StablePartitionIndexDetails> {
+    let details_any = index.index_details.as_ref();
+    if details_any.is_none_or(|details| !details.type_url.ends_with("StablePartitionIndexDetails"))
+    {
+        return Err(Error::index(
+            "Index details is not for the stable partition index",
+        ));
+    }
+
+    let proto = details_any
+        .unwrap()
+        .to_msg::<PbStablePartitionIndexDetails>()?;
+    match &proto.content {
+        None => Err(Error::index("Index details content is not found")),
+        Some(Content::Inline(content)) => StablePartitionIndexDetails::try_from(content.clone()),
+        Some(Content::External(external_file)) => {
+            let file_path = dataset
+                .indices_dir()
+                .join(index.uuid.to_string())
+                .join(external_file.path.clone());
+            let range = external_file.offset as usize
+                ..(external_file.offset as usize + external_file.size as usize);
+            let data = dataset
+                .object_store
+                .open(&file_path)
+                .await?
+                .get_range(range)
+                .await?;
+            StablePartitionIndexDetails::try_from(InlineContent::decode(data)?)
+        }
+    }
+}
+
+/// Validate one reordered rewrite against its row map counts and build the
+/// [`StablePartitionRewrite`] to attach to `Operation::Rewrite`.
+///
+/// `sources` are the rewrite's source fragments in scan order; `destinations`
+/// are the new fragments in label order (a row map label indexes this slice);
+/// `counts` is the matrix returned by the row map writer's `finish`.
+///
+/// Conservation checks, all against the counts the row map file itself
+/// carries:
+///
+/// * every destination's physical rows equal its label total,
+/// * the row map covers exactly the sources' physical rows,
+/// * the labeled (live) rows equal the sources' live rows.
+pub async fn build_stable_partition_rewrite(
+    dataset: &Dataset,
+    sources: Vec<FragDigest>,
+    destinations: &[Fragment],
+    row_map_id: String,
+    row_map_size_bytes: u64,
+    counts: &CountsMatrix,
+) -> lance_core::Result<StablePartitionRewrite> {
+    if destinations.len() as u64 != u64::from(counts.num_destinations()) {
+        return Err(Error::invalid_input(format!(
+            "the rewrite lists {} destinations but its row map labels {}",
+            destinations.len(),
+            counts.num_destinations()
+        )));
+    }
+    for (label, destination) in destinations.iter().enumerate() {
+        let physical_rows = destination.physical_rows.ok_or_else(|| {
+            Error::invalid_input(format!(
+                "destination fragment {} has no physical row count",
+                destination.id
+            ))
+        })? as u64;
+        let labeled = u64::from(counts.total(label as u16));
+        if physical_rows != labeled {
+            return Err(Error::invalid_input(format!(
+                "destination fragment {} holds {physical_rows} rows but the row map labels {labeled}",
+                destination.id
+            )));
+        }
+    }
+    let source_physical: u64 = sources.iter().map(|frag| frag.physical_rows as u64).sum();
+    if counts.total_rows() != source_physical {
+        return Err(Error::invalid_input(format!(
+            "the row map covers {} rows but the source fragments hold {source_physical}",
+            counts.total_rows()
+        )));
+    }
+    let source_live: u64 = sources
+        .iter()
+        .map(|frag| (frag.physical_rows - frag.num_deleted_rows) as u64)
+        .sum();
+    if counts.total_live_rows() != source_live {
+        return Err(Error::invalid_input(format!(
+            "the row map labels {} live rows but the source fragments hold {source_live}",
+            counts.total_live_rows()
+        )));
+    }
+
+    let transition = StablePartitionTransition {
+        dataset_version: dataset.manifest.version,
+        sources,
+        destinations: destinations.iter().map(|frag| frag.id).collect(),
+        row_map_id,
+        row_map_size_bytes,
+    };
+    let reordered_sources = transition.source_ids();
+
+    let index_meta = dataset.load_indices().await.map(|indices| {
+        indices
+            .iter()
+            .find(|idx| idx.name == STABLE_PARTITION_INDEX_NAME)
+            .cloned()
+    })?;
+    let new_details = match &index_meta {
+        None => StablePartitionIndexDetails {
+            transitions: vec![transition],
+        },
+        Some(index_meta) => {
+            let current = load_stable_partition_details(dataset, index_meta).await?;
+            let mut transitions = current.transitions;
+            transitions.push(transition);
+            StablePartitionIndexDetails { transitions }
+        }
+    };
+
+    let index_id = Uuid::new_v4();
+    let inline = InlineContent::from(&new_details);
+    let proto = if inline.encoded_len() > 204800 {
+        let file_path = dataset
+            .indices_dir()
+            .join(index_id.to_string())
+            .join(STABLE_PARTITION_DETAILS_FILE_NAME);
+        let mut writer = dataset.object_store.create(&file_path).await?;
+        writer.write_all(inline.encode_to_vec().as_slice()).await?;
+        writer.shutdown().await?;
+        PbStablePartitionIndexDetails {
+            content: Some(Content::External(ExternalFile {
+                path: STABLE_PARTITION_DETAILS_FILE_NAME.to_owned(),
+                offset: 0,
+                size: inline.encoded_len() as u64,
+            })),
+        }
+    } else {
+        PbStablePartitionIndexDetails {
+            content: Some(Content::Inline(inline)),
+        }
+    };
+
+    let index = IndexMetadata {
+        uuid: index_id,
+        name: STABLE_PARTITION_INDEX_NAME.to_string(),
+        fields: vec![],
+        covering_fields: vec![],
+        dataset_version: dataset.manifest.version,
+        // Provenance: the union of every transition's source ids,
+        // deliberately keeping retired fragments (see
+        // `IndexMetadata::fragment_bitmap`).
+        fragment_bitmap: Some(new_details.source_bitmap()),
+        index_details: Some(std::sync::Arc::new(prost_types::Any::from_msg(&proto)?)),
+        index_version: index_meta
+            .as_ref()
+            .map_or(0, |index_meta| index_meta.index_version),
+        created_at: Some(chrono::Utc::now()),
+        base_id: None,
+        // The row map files live in their own `{indices dir}/{row_map_id}/`
+        // directories referenced from the details, not under this entry's
+        // uuid; lifecycle integration comes with the read path.
+        files: None,
+    };
+
+    Ok(StablePartitionRewrite {
+        index,
+        reordered_sources,
+        base_entry_version: index_meta.map(|index_meta| index_meta.dataset_version),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::dataset::transaction::{Operation, RewriteGroup, TransactionBuilder};
+    use crate::index::{DatasetIndexExt, IndexType};
+    use crate::utils::test::{DatagenExt, FragmentCount, FragmentRowCount};
+    use arrow_array::types::Int32Type;
+    use lance_index::frag_reuse::row_map::{RowMapWriter, SourceRows};
+    use lance_index::scalar::lance_format::LanceIndexStore;
+    use lance_index::scalar::{IndexStore, ScalarIndexParams};
+    use lance_table::system_index::is_system_index;
+    use lance_table::system_index::stable_partition::ROW_MAP_FILE_NAME;
+    use std::sync::Arc;
+
+    async fn test_dataset() -> Dataset {
+        let mut dataset = lance_datagen::gen_batch()
+            .col("i", lance_datagen::array::step::<Int32Type>())
+            .into_ram_dataset(FragmentCount::from(2), FragmentRowCount::from(100))
+            .await
+            .unwrap();
+        dataset
+            .create_index(
+                &["i"],
+                IndexType::Scalar,
+                Some("scalar".into()),
+                &ScalarIndexParams::default(),
+                false,
+            )
+            .await
+            .unwrap();
+        dataset
+    }
+
+    /// Write a row map that alternates the concatenated source rows across
+    /// two destinations, returning `(row_map_id, size, counts)`.
+    async fn write_alternating_row_map(
+        dataset: &Dataset,
+        sources: Vec<SourceRows>,
+    ) -> (String, u64, CountsMatrix) {
+        let row_map_id = Uuid::new_v4().to_string();
+        let store = LanceIndexStore::new(
+            dataset.object_store.clone(),
+            dataset.indices_dir().join(row_map_id.clone()),
+            Arc::new(lance_core::cache::LanceCache::with_capacity(1024 * 1024)),
+        );
+        let writer = store
+            .new_index_file(ROW_MAP_FILE_NAME, RowMapWriter::schema())
+            .await
+            .unwrap();
+        let total: u64 = sources.iter().map(|s| s.physical_rows).sum();
+        let mut writer = RowMapWriter::try_new(writer, sources, 2).unwrap();
+        let labels: Vec<u16> = (0..total).map(|row| (row % 2) as u16).collect();
+        writer.append_labels(&labels).await.unwrap();
+        let (file, counts) = writer.finish().await.unwrap();
+        (row_map_id, file.size_bytes, counts)
+    }
+
+    /// The commit path of a reordered rewrite: the stable partition entry is
+    /// installed, the scalar index bitmap keeps the retired source ids, and
+    /// queries degrade to correct full scans.
+    #[tokio::test]
+    async fn test_reordered_rewrite_commit() {
+        let mut dataset = test_dataset().await;
+        let old_fragments: Vec<Fragment> = dataset.fragments().iter().cloned().collect();
+        assert_eq!(old_fragments.len(), 2);
+        let sources: Vec<FragDigest> = old_fragments.iter().map(FragDigest::from).collect();
+
+        let (row_map_id, row_map_size, counts) = write_alternating_row_map(
+            &dataset,
+            old_fragments
+                .iter()
+                .map(|frag| SourceRows {
+                    physical_rows: frag.physical_rows.unwrap() as u64,
+                    deleted: None,
+                })
+                .collect(),
+        )
+        .await;
+
+        // The destinations reuse the source data files under new fragment
+        // ids: the commit path validates metadata and conservation, not row
+        // placement, so this stands in for a real reordered rewrite.
+        let new_fragments: Vec<Fragment> = old_fragments
+            .iter()
+            .enumerate()
+            .map(|(i, frag)| {
+                let mut new_fragment = frag.clone();
+                new_fragment.id = 2 + i as u64;
+                new_fragment
+            })
+            .collect();
+
+        let stable_partition = build_stable_partition_rewrite(
+            &dataset,
+            sources.clone(),
+            &new_fragments,
+            row_map_id.clone(),
+            row_map_size,
+            &counts,
+        )
+        .await
+        .unwrap();
+        assert_eq!(stable_partition.base_entry_version, None);
+        assert_eq!(
+            stable_partition.reordered_sources,
+            roaring::RoaringBitmap::from_iter([0u32, 1])
+        );
+
+        let transaction = TransactionBuilder::new(
+            dataset.manifest.version,
+            Operation::Rewrite {
+                groups: vec![RewriteGroup {
+                    old_fragments: old_fragments.clone(),
+                    new_fragments: new_fragments.clone(),
+                }],
+                rewritten_indices: vec![],
+                frag_reuse_index: None,
+                stable_partition: Some(stable_partition),
+            },
+        )
+        .build();
+        dataset
+            .apply_commit(transaction, &Default::default(), &Default::default())
+            .await
+            .unwrap();
+
+        // Fragments swapped.
+        let live_ids: Vec<u64> = dataset.fragments().iter().map(|frag| frag.id).collect();
+        assert_eq!(live_ids, vec![2, 3]);
+
+        let indices = dataset.load_indices().await.unwrap();
+        // The scalar index keeps its retired source ids as provenance
+        // instead of following the rewrite.
+        let scalar = indices.iter().find(|idx| idx.name == "scalar").unwrap();
+        assert_eq!(
+            scalar.fragment_bitmap.as_ref().unwrap(),
+            &roaring::RoaringBitmap::from_iter([0u32, 1])
+        );
+        // The stable partition entry is installed and round-trips.
+        let entry = indices
+            .iter()
+            .find(|idx| idx.name == STABLE_PARTITION_INDEX_NAME)
+            .unwrap();
+        assert!(is_system_index(entry));
+        assert_eq!(
+            entry.fragment_bitmap.as_ref().unwrap(),
+            &roaring::RoaringBitmap::from_iter([0u32, 1])
+        );
+        let details = load_stable_partition_details(&dataset, entry)
+            .await
+            .unwrap();
+        assert_eq!(details.transitions.len(), 1);
+        let transition = &details.transitions[0];
+        assert_eq!(transition.sources, sources);
+        assert_eq!(transition.destinations, vec![2, 3]);
+        assert_eq!(transition.row_map_id, row_map_id);
+        assert_eq!(transition.total_source_rows(), 200);
+
+        // Reads degrade instead of erroring: the scalar index covers no live
+        // fragment, so this filter falls back to a scan and stays correct.
+        assert_eq!(dataset.count_rows(None).await.unwrap(), 200);
+        assert_eq!(
+            dataset
+                .count_rows(Some("i >= 100".to_string()))
+                .await
+                .unwrap(),
+            100
+        );
+
+        // A second reordered rewrite built against the pre-commit entry state
+        // (base = None) must be rejected: splicing it would drop the
+        // transition that just landed.
+        let stale = StablePartitionRewrite {
+            base_entry_version: None,
+            ..build_stable_partition_rewrite(
+                &dataset,
+                dataset.fragments().iter().map(FragDigest::from).collect(),
+                &{
+                    let mut fragments: Vec<Fragment> =
+                        dataset.fragments().iter().cloned().collect();
+                    for (i, fragment) in fragments.iter_mut().enumerate() {
+                        fragment.id = 4 + i as u64;
+                    }
+                    fragments
+                },
+                row_map_id.clone(),
+                row_map_size,
+                &counts,
+            )
+            .await
+            .unwrap()
+        };
+        let old_fragments: Vec<Fragment> = dataset.fragments().iter().cloned().collect();
+        let new_fragments: Vec<Fragment> = old_fragments
+            .iter()
+            .enumerate()
+            .map(|(i, frag)| {
+                let mut new_fragment = frag.clone();
+                new_fragment.id = 4 + i as u64;
+                new_fragment
+            })
+            .collect();
+        let transaction = TransactionBuilder::new(
+            dataset.manifest.version,
+            Operation::Rewrite {
+                groups: vec![RewriteGroup {
+                    old_fragments,
+                    new_fragments,
+                }],
+                rewritten_indices: vec![],
+                frag_reuse_index: None,
+                stable_partition: Some(stale),
+            },
+        )
+        .build();
+        let err = dataset
+            .apply_commit(transaction, &Default::default(), &Default::default())
+            .await
+            .unwrap_err();
+        assert!(
+            err.to_string().contains("concurrent reordered rewrite"),
+            "{err}"
+        );
+    }
+
+    /// Conservation violations are rejected before any transaction exists.
+    #[tokio::test]
+    async fn test_conservation_validation() {
+        let dataset = test_dataset().await;
+        let old_fragments: Vec<Fragment> = dataset.fragments().iter().cloned().collect();
+        let sources: Vec<FragDigest> = old_fragments.iter().map(FragDigest::from).collect();
+        let (row_map_id, row_map_size, counts) = write_alternating_row_map(
+            &dataset,
+            old_fragments
+                .iter()
+                .map(|frag| SourceRows {
+                    physical_rows: frag.physical_rows.unwrap() as u64,
+                    deleted: None,
+                })
+                .collect(),
+        )
+        .await;
+
+        // A destination whose physical rows disagree with its label total.
+        let mut wrong_rows: Vec<Fragment> = old_fragments.clone();
+        for (i, fragment) in wrong_rows.iter_mut().enumerate() {
+            fragment.id = 2 + i as u64;
+        }
+        wrong_rows[0].physical_rows = Some(99);
+        let err = build_stable_partition_rewrite(
+            &dataset,
+            sources.clone(),
+            &wrong_rows,
+            row_map_id.clone(),
+            row_map_size,
+            &counts,
+        )
+        .await
+        .unwrap_err();
+        assert!(err.to_string().contains("row map labels"), "{err}");
+
+        // A destination count that disagrees with the row map's m.
+        let err = build_stable_partition_rewrite(
+            &dataset,
+            sources.clone(),
+            &old_fragments[..1],
+            row_map_id.clone(),
+            row_map_size,
+            &counts,
+        )
+        .await
+        .unwrap_err();
+        assert!(err.to_string().contains("destinations"), "{err}");
+
+        // Sources that disagree with the row map's row count.
+        let err = build_stable_partition_rewrite(
+            &dataset,
+            sources[..1].to_vec(),
+            &{
+                let mut fragments = old_fragments.clone();
+                for (i, fragment) in fragments.iter_mut().enumerate() {
+                    fragment.id = 2 + i as u64;
+                }
+                fragments
+            },
+            row_map_id,
+            row_map_size,
+            &counts,
+        )
+        .await
+        .unwrap_err();
+        assert!(err.to_string().contains("row map covers"), "{err}");
+    }
+}

--- a/rust/lance/src/io/commit/conflict_resolver.rs
+++ b/rust/lance/src/io/commit/conflict_resolver.rs
@@ -3073,6 +3073,7 @@ mod tests {
                 }],
                 rewritten_indices: vec![],
                 frag_reuse_index: None,
+                stable_partition: None,
             },
             Operation::ReserveFragments { num_fragments: 3 },
             Operation::Update {
@@ -3212,6 +3213,7 @@ mod tests {
                     }],
                     rewritten_indices: Vec::new(),
                     frag_reuse_index: None,
+                    stable_partition: None,
                 },
                 [
                     Compatible,    // append
@@ -3234,6 +3236,7 @@ mod tests {
                     }],
                     rewritten_indices: Vec::new(),
                     frag_reuse_index: None,
+                    stable_partition: None,
                 },
                 [
                     Compatible,    // append
@@ -3591,6 +3594,7 @@ mod tests {
             }],
             rewritten_indices: vec![],
             frag_reuse_index: None,
+            stable_partition: None,
         };
 
         let fragment0 = Fragment::new(0);
@@ -3736,6 +3740,7 @@ mod tests {
             }],
             rewritten_indices: vec![],
             frag_reuse_index: None,
+            stable_partition: None,
         };
 
         for (other, expect_conflict) in [(overlay_on(1), true), (overlay_on(0), false)] {
@@ -4399,6 +4404,7 @@ mod tests {
                 }],
                 rewritten_indices: vec![],
                 frag_reuse_index: Some(frag_reuse_index),
+                stable_partition: None,
             },
             None,
         );
@@ -4884,6 +4890,7 @@ mod tests {
                     }],
                     rewritten_indices: vec![],
                     frag_reuse_index: None,
+                    stable_partition: None,
                 },
                 Retryable,
             ),
@@ -4899,6 +4906,7 @@ mod tests {
                     }],
                     rewritten_indices: vec![],
                     frag_reuse_index: None,
+                    stable_partition: None,
                 },
                 Compatible,
             ),


### PR DESCRIPTION
#### Stack

| | PR |
|---|---|
| **2** | 👉 #8978 — transition + commit path |
| 1 | #8972 — row map format (base of this stack) |

---

## What

Part 2 of reordered-rewrite support, **stacked on #8972** (the first four commits are that PR; review the last commit here). This wires the row map format into the commit path: a reordered rewrite now commits through the ordinary `Operation::Rewrite`, carrying a new **stable partition transition** that lands in the manifest as its own system index entry.

## Design

### The transaction carries nothing new on disk

`Operation::Rewrite` gains an in-memory `stable_partition` field following the `frag_reuse_index` precedent exactly: it is dropped when the transaction serializes and `None` when one is read back. Other writers' conflict decisions only need the fragment sets in `groups`, which are exact either way — so a reader or writer that predates this feature sees a perfectly ordinary rewrite transaction, not an unknown field.

### The manifest carries a new system index entry

`__lance_stable_partition` (separate from `__lance_frag_reuse`, whose proto is untouched) accumulates one **transition** per reordered rewrite:

- `sources` — ordered fragment digests; their physical row counts are the row map's addressing base (prefix sums position each fragment's rows in the concatenated label sequence),
- `destinations` — ordered fragment ids; a row map label is an index into this list,
- the row map file reference (`{indices dir}/{row_map_id}/row_map.lance`).

Inline below 200KB, spilled to an external `details.binpb` above it, mirroring the fragment reuse entry. The entry's fragment bitmap is the union of all transition source ids — provenance, deliberately keeping retired fragments (`IndexMetadata::fragment_bitmap` documents that ids may no longer exist).

### What the commit path does differently for reordered groups

For an ordinary (compaction) group, manifest build swaps index fragment bitmaps from old to new fragments — legal only because row order is preserved. A reordered group redistributes rows, so its groups **skip bitmap maintenance entirely, for every index kind**: the bitmaps keep the retired source ids. That single choice is what makes existing readers degrade instead of lie — a bitmap of retired ids intersects the live fragments as empty, so the index is skipped for those rows and queries fall back to correct scans. A group straddling reordered and order-preserving sources is rejected.

Coverage-based index retention now exempts all system indices (previously only the fragment reuse entry), since their bitmaps are provenance and an empty intersection with live fragments does not mean the entry is obsolete.

### Conservation is validated before the transaction exists

`build_stable_partition_rewrite` checks the rewrite against the counts the row map file itself carries — no extra IO:

- every destination's physical rows equal its label total,
- the row map covers exactly the sources' physical rows,
- labeled (live) rows equal the sources' live rows (physical − deleted).

### Concurrent reordered rewrites

Because the transaction field is never serialized, one reordered rewrite cannot detect another through the transaction file. Instead the commit records which entry version it appended onto (`base_entry_version`), and manifest build rejects the splice when the manifest's entry no longer matches — the alternative would silently drop the concurrent transition. The rejected caller rebuilds against the latest entry and retries.

## Compatibility

- Old readers: the entry is an unrecognized system index name — carried through manifests losslessly, never opened, queries degrade to scans for rows whose only index coverage was through retired sources. Verified in the end-to-end test.
- Old writers: the transaction file contains a plain `Rewrite`; nothing new to drop or misread.

## Tests

- End-to-end reordered rewrite through `apply_commit`: entry installed and round-trips (sources, destinations, row map ref), the scalar index bitmap keeps the retired source ids instead of following the rewrite, a filtered query on the now-uncovered column still answers correctly (degrade path), and a second rewrite built against a stale entry version is rejected with the concurrent-rewrite error.
- Conservation rejections: destination row count vs label total, destination count vs the row map's `m`, source rows vs row map rows.
- `ordered_rewrite_groups`: partitioning, no-op without a stable partition, and the mixed-group error.
- Details proto round trip.

`cargo test -p lance-table` (382) and the new `-p lance` tests pass; clippy clean for the new code.

## Follow-ups (separate PRs)

1. Read integration: coverage derivation and decode-time translation through the existing `RowIdRemapper` seams; row map file lifecycle (cleanup integration).
2. Conflict handling: deletion-vector fold on rebase via the sweep translator; combining disjoint concurrent rewrites instead of rejecting them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

