### PR TITLE
chore(java): bump lance-namespace client to 0.12.0

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -111,12 +111,12 @@
         <dependency>
             <groupId>org.lance</groupId>
             <artifactId>lance-namespace-core</artifactId>
-            <version>0.11.1</version>
+            <version>0.12.0</version>
         </dependency>
         <dependency>
             <groupId>org.lance</groupId>
             <artifactId>lance-namespace-apache-client</artifactId>
-            <version>0.11.1</version>
+            <version>0.12.0</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>


### PR DESCRIPTION
The Rust `lance-namespace-reqwest-client` dependency was already bumped to 0.12.0 in #8915, which changed `MergeInsertIntoTableRequest.on` from a single string to a repeated field so `merge_insert` can express a composite key. The Java `lance-namespace-core`/`lance-namespace-apache-client` dependencies in `java/pom.xml` were left behind at 0.11.1, where the generated model still only has a single `on` string.

This PR bumps those two Java dependencies to 0.12.0 to match, so `org.lance:lance-core` can send composite `on` keys as a real `List<String>` instead of relying on the legacy comma-joined string encoding.

## Not included

Wiring an actual `mergeInsert` Java client method that uses the new `List<String>` `on` field is separate downstream work (in `lancedb`'s Java bindings), not part of this dependency bump.
