### PR TITLE
fix: let analyze_plan run under a caller-provided TaskContext

### DIFF
--- a/rust/lance-datafusion/src/exec.rs
+++ b/rust/lance-datafusion/src/exec.rs
@@ -723,6 +723,22 @@ pub async fn analyze_plan(
     plan: Arc<dyn ExecutionPlan>,
     options: LanceExecutionOptions,
 ) -> Result<String> {
+    analyze_plan_with_context(plan, options, None).await
+}
+
+/// Analyze a plan, optionally under a caller-provided [`TaskContext`].
+///
+/// When `task_context` is `Some`, the plan executes under it instead of the
+/// context derived from `options`. Callers whose nodes read session-config
+/// extensions at execution time (e.g. distributed routing identity) must pass
+/// the context carrying those extensions; otherwise the nodes error during
+/// `execute` and `AnalyzeExec` reports an empty, unexecuted plan tree instead
+/// of surfacing the error.
+pub async fn analyze_plan_with_context(
+    plan: Arc<dyn ExecutionPlan>,
+    options: LanceExecutionOptions,
+    task_context: Option<Arc<TaskContext>>,
+) -> Result<String> {
     // This is needed as AnalyzeExec launches a thread task per
     // partition, and we want these to be connected to the parent span
     let plan = Arc::new(TracedExec::new(plan, Span::current()));
@@ -739,9 +755,10 @@ pub async fn analyze_plan(
     ));
 
     let session_ctx = get_session_context(&options);
+    let task_context = task_context.unwrap_or_else(|| get_task_context(&session_ctx, &options));
     assert_eq!(analyze.properties().partitioning.partition_count(), 1);
     let mut stream = analyze
-        .execute(0, get_task_context(&session_ctx, &options))
+        .execute(0, task_context)
         .map_err(|err| Error::io(format!("Failed to execute analyze plan: {}", err)))?;
 
     // fully execute the plan
@@ -1342,5 +1359,120 @@ mod tests {
             ..Default::default()
         };
         assert_eq!(opts.mem_pool_size(), 50 * 1024 * 1024);
+    }
+
+    /// A marker a node reads from the session-config extensions at execute time.
+    #[derive(Debug)]
+    struct RequiredExtension;
+
+    /// Execution node that only succeeds when [`RequiredExtension`] is present
+    /// on the task context's session config. This mirrors distributed routing
+    /// nodes that read a session-config identity extension during `execute`.
+    #[derive(Debug)]
+    struct NeedsExtensionExec {
+        properties: Arc<PlanProperties>,
+    }
+
+    impl NeedsExtensionExec {
+        fn new() -> Self {
+            let schema = Arc::new(ArrowSchema::empty());
+            Self {
+                properties: Arc::new(PlanProperties::new(
+                    EquivalenceProperties::new(schema),
+                    Partitioning::UnknownPartitioning(1),
+                    EmissionType::Incremental,
+                    Boundedness::Bounded,
+                )),
+            }
+        }
+    }
+
+    impl DisplayAs for NeedsExtensionExec {
+        fn fmt_as(&self, _t: DisplayFormatType, f: &mut Formatter) -> fmt::Result {
+            write!(f, "NeedsExtensionExec")
+        }
+    }
+
+    impl ExecutionPlan for NeedsExtensionExec {
+        fn name(&self) -> &str {
+            "NeedsExtensionExec"
+        }
+        fn properties(&self) -> &Arc<PlanProperties> {
+            &self.properties
+        }
+        fn children(&self) -> Vec<&Arc<dyn ExecutionPlan>> {
+            vec![]
+        }
+        fn with_new_children(
+            self: Arc<Self>,
+            _children: Vec<Arc<dyn ExecutionPlan>>,
+        ) -> datafusion_common::Result<Arc<dyn ExecutionPlan>> {
+            Ok(self)
+        }
+        fn execute(
+            &self,
+            _partition: usize,
+            context: Arc<TaskContext>,
+        ) -> datafusion_common::Result<SendableRecordBatchStream> {
+            if context
+                .session_config()
+                .get_extension::<RequiredExtension>()
+                .is_none()
+            {
+                return Err(DataFusionError::Execution(
+                    "missing required session-config extension".to_string(),
+                ));
+            }
+            let schema = self.schema();
+            Ok(Box::pin(RecordBatchStreamAdapter::new(
+                schema,
+                stream::empty(),
+            )))
+        }
+    }
+
+    // Regression: analyze must run under a caller-provided TaskContext so nodes
+    // that read a session-config extension at execute time see it. Without the
+    // context the node errors and AnalyzeExec would otherwise report an empty,
+    // unexecuted plan tree.
+    #[tokio::test]
+    async fn test_analyze_plan_uses_provided_task_context() {
+        let plan: Arc<dyn ExecutionPlan> = Arc::new(NeedsExtensionExec::new());
+
+        // Default context lacks the extension: the node errors during execute,
+        // but AnalyzeExec absorbs that per-partition failure and reports an
+        // empty, unexecuted plan tree (no `metrics=[...]` on the leaf) rather
+        // than propagating the error. This is the regression symptom.
+        let report = analyze_plan(plan.clone(), LanceExecutionOptions::default())
+            .await
+            .expect("AnalyzeExec swallows the node's execute error into an Ok report");
+        assert!(
+            report.contains("NeedsExtensionExec, metrics=[]"),
+            "expected an empty, unexecuted NeedsExtensionExec node, got: {report}"
+        );
+
+        // A context carrying the extension executes the node successfully.
+        let options = LanceExecutionOptions::default();
+        let session_ctx = get_session_context(&options);
+        let config = session_ctx
+            .task_ctx()
+            .session_config()
+            .clone()
+            .with_extension(Arc::new(RequiredExtension));
+        let task_ctx = session_ctx.task_ctx();
+        let task_ctx = Arc::new(TaskContext::new(
+            task_ctx.task_id(),
+            task_ctx.session_id(),
+            config,
+            task_ctx.scalar_functions().clone(),
+            task_ctx.higher_order_functions().clone(),
+            task_ctx.aggregate_functions().clone(),
+            task_ctx.window_functions().clone(),
+            task_ctx.runtime_env(),
+        ));
+        let report = analyze_plan_with_context(plan, options, Some(task_ctx))
+            .await
+            .expect("analyze should succeed when the extension is present");
+        assert!(report.contains("NeedsExtensionExec"));
     }
 }

--- a/rust/lance-datafusion/src/exec.rs
+++ b/rust/lance-datafusion/src/exec.rs
@@ -1371,10 +1371,14 @@ mod tests {
     #[derive(Debug)]
     struct NeedsExtensionExec {
         properties: Arc<PlanProperties>,
+        /// Set once the node reaches execution with the extension present.
+        /// Observed by the test so that dropping context forwarding (which
+        /// makes `execute` error before this point) is detectable.
+        executed: Arc<std::sync::atomic::AtomicBool>,
     }
 
     impl NeedsExtensionExec {
-        fn new() -> Self {
+        fn new(executed: Arc<std::sync::atomic::AtomicBool>) -> Self {
             let schema = Arc::new(ArrowSchema::empty());
             Self {
                 properties: Arc::new(PlanProperties::new(
@@ -1383,6 +1387,7 @@ mod tests {
                     EmissionType::Incremental,
                     Boundedness::Bounded,
                 )),
+                executed,
             }
         }
     }
@@ -1423,6 +1428,8 @@ mod tests {
                     "missing required session-config extension".to_string(),
                 ));
             }
+            self.executed
+                .store(true, std::sync::atomic::Ordering::SeqCst);
             let schema = self.schema();
             Ok(Box::pin(RecordBatchStreamAdapter::new(
                 schema,
@@ -1437,18 +1444,25 @@ mod tests {
     // unexecuted plan tree.
     #[tokio::test]
     async fn test_analyze_plan_uses_provided_task_context() {
-        let plan: Arc<dyn ExecutionPlan> = Arc::new(NeedsExtensionExec::new());
+        use std::sync::atomic::{AtomicBool, Ordering};
 
-        // Default context lacks the extension: the node errors during execute,
-        // but AnalyzeExec absorbs that per-partition failure and reports an
-        // empty, unexecuted plan tree (no `metrics=[...]` on the leaf) rather
-        // than propagating the error. This is the regression symptom.
+        let executed = Arc::new(AtomicBool::new(false));
+        let plan: Arc<dyn ExecutionPlan> = Arc::new(NeedsExtensionExec::new(executed.clone()));
+
+        // Default context lacks the extension: the node errors during execute
+        // (never reaching the `executed` flag), but AnalyzeExec absorbs that
+        // per-partition failure and reports an empty, unexecuted plan tree
+        // rather than propagating the error. This is the regression symptom.
         let report = analyze_plan(plan.clone(), LanceExecutionOptions::default())
             .await
             .expect("AnalyzeExec swallows the node's execute error into an Ok report");
         assert!(
             report.contains("NeedsExtensionExec, metrics=[]"),
             "expected an empty, unexecuted NeedsExtensionExec node, got: {report}"
+        );
+        assert!(
+            !executed.load(Ordering::SeqCst),
+            "node must not execute successfully without the extension"
         );
 
         // A context carrying the extension executes the node successfully.
@@ -1474,5 +1488,11 @@ mod tests {
             .await
             .expect("analyze should succeed when the extension is present");
         assert!(report.contains("NeedsExtensionExec"));
+        // The node only reaches this flag when the supplied context is actually
+        // forwarded to `execute`; dropping the forwarding fails this assertion.
+        assert!(
+            executed.load(Ordering::SeqCst),
+            "supplied context must be forwarded so the node executes"
+        );
     }
 }


### PR DESCRIPTION
## Problem

`analyze_plan` executes the plan under a `TaskContext` derived solely from `LanceExecutionOptions`. Execution nodes that read a **session-config extension at execute time** (for example, a distributed routing identity) never see it, so they error inside `execute`. `AnalyzeExec` absorbs that per-partition failure and returns an empty, unexecuted plan tree — the analyze output shows the node with `metrics=[]` and no children, silently hiding the real error rather than surfacing it.

Concretely, a distributed FTS/ANN/scalar-index query executes and returns results normally, but `analyze_plan` on the same query returns a stub tree with the remote subtree unexecuted (all-zero metrics, no leaf query node).

## Fix

Add `analyze_plan_with_context(plan, options, task_context)`, which runs the plan under a caller-supplied `TaskContext` when `Some`, falling back to the options-derived context otherwise. `analyze_plan` keeps its exact signature and behavior (it now delegates with `None`).

Callers that attach execution-time session-config extensions can then hand the same enriched context to analyze that they use for the real read path, so the analyzed plan executes identically to the query.

## Test

Adds a regression test with a node that requires a session-config extension:
- through the context-less path it reproduces the empty, unexecuted tree (`NeedsExtensionExec, metrics=[]`);
- through `analyze_plan_with_context` with the extension present, it executes and appears in the report.