### PR TITLE
docs: add Apache Doris integration

### DIFF
--- a/docs/src/integrations/index.md
+++ b/docs/src/integrations/index.md
@@ -19,6 +19,7 @@ GitHub organization.
 |---|---|---|
 | [Apache DataFusion](datafusion.md) | Register Lance datasets as DataFusion tables and run SQL with predicate/projection pushdown. Available in both Rust and Python. | Built-in |
 | [Apache Spark](spark/index.md) | Read and write Lance datasets from Spark SQL and DataFrames. | [lance-format/lance-spark](https://github.com/lance-format/lance-spark) |
+| [Apache Doris](https://doris.apache.org/docs/4.x/lakehouse/catalogs/lance-catalog/) | Query Lance datasets with Doris SQL through filesystem and REST catalogs, with predicate pushdown and vector search. Read-only. | [apache/doris](https://github.com/apache/doris) |
 | [DuckDB](duckdb) | Query Lance datasets directly from DuckDB. | [lance-format/lance-duckdb](https://github.com/lance-format/lance-duckdb) |
 | [Trino](trino) | Federate Lance into Trino alongside other connectors. | [lance-format/lance-trino](https://github.com/lance-format/lance-trino) |
 


### PR DESCRIPTION
## Summary

- add Apache Doris to the Query Engines and SQL integrations table
- link to the Apache Doris Lance Catalog documentation and source repository
- describe the current read-only catalog, predicate pushdown, and vector search capabilities

## References

- Documentation: https://doris.apache.org/docs/4.x/lakehouse/catalogs/lance-catalog/
- Implementation: https://github.com/apache/doris/pull/65730

## Verification

- `make build`
- `make check-links`