### PR TITLE
ci: run the Python suite when .cargo/config.toml or clippy.toml changes

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -11,6 +11,8 @@ on:
       - release/**
     paths:
       - Cargo.*
+      - .cargo/config.toml
+      - clippy.toml
       - python/**
       - rust/**
       - protos/**


### PR DESCRIPTION
## What this changes

`.cargo/config.toml` and `clippy.toml` join `python.yml`'s `pull_request` `paths:` filter. Two lines, no job changes. Closes #8906.

## Why the root `.cargo/config.toml` reaches the Python builds

Cargo merges configuration up the directory hierarchy, so a build rooted in `python/` reads both `python/.cargo/config.toml` and the repository-root file. Measured, because the interesting part is what happens to a key both files set: with `[target.aarch64-apple-darwin] rustflags = ["--cfg", "outer_flag"]` in a parent `.cargo/config.toml` and `["--cfg", "inner_flag"]` in the child's, `cargo build -v` in the child passes both to rustc. Arrays are joined rather than shadowed, so a root-only edit to either `rustflags` line changes what the Python extension compiles with even though the sibling sets the same key. On top of that, `[profile.release-no-lto]` and `[profile.bench]` are defined only in the root file, so the Python builds take them from there outright.

## Why `clippy.toml` as well

`python.yml`'s `lint` job runs `cargo clippy` with `working-directory: python`, and clippy reads an ancestor `clippy.toml`. Measured the same way: a crate in a subdirectory of a directory holding a `clippy.toml` with an unknown field fails with `error reading Clippy's configuration file: unknown field`. The repository has exactly one `clippy.toml`, at the root, and no `python/clippy.toml`, so that file is what this job's clippy run uses. Its `disallowed-macros` entries gate the Rust code behind the Python extension, and editing them currently triggers no Python job.

## Test plan

`yaml.safe_load` parses the file and returns the filter with the two new entries in place.

The trigger itself is not exercisable from inside this pull request: proving the new entries match would take a pull request whose only change is one of those two files. What this one does show is the existing behaviour, since it edits `.github/workflows/python.yml`, which the filter already lists, so the Python jobs run here.

`rust.yml` got the same two entries in #8867.
