### PR TITLE
docs: mount lance-flink connector docs into the integrations site

### DIFF
--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -67,6 +67,11 @@ jobs:
         with:
           repository: lance-format/lance-context
           path: lance-context
+      - name: Checkout lance-flink
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          repository: lance-format/lance-flink
+          path: lance-flink
       - name: Configure Git Credentials
         run: |
           git config user.name github-actions[bot]
@@ -89,6 +94,7 @@ jobs:
           LANCE_DUCKDB_REPO: ${{ github.workspace }}/lance-duckdb
           LANCE_HUGGINGFACE_REPO: ${{ github.workspace }}/lance-huggingface
           LANCE_CONTEXT_REPO: ${{ github.workspace }}/lance-context
+          LANCE_FLINK_REPO: ${{ github.workspace }}/lance-flink
         run: |
           docs/make-full-website.sh
       - name: Deploy

--- a/docs/clean-full-website.sh
+++ b/docs/clean-full-website.sh
@@ -16,6 +16,7 @@ rm -rf "$docs_src/integrations/spark"
 rm -rf "$docs_src/integrations/ray"
 rm -rf "$docs_src/integrations/trino"
 rm -rf "$docs_src/integrations/context"
+rm -rf "$docs_src/integrations/flink"
 rm -f "$docs_src/community/project-specific/.pages"
 rm -rf "$docs_src/community/project-specific/lance"
 rm -f "$docs_src/community/project-specific/namespace.md"
@@ -24,6 +25,7 @@ rm -f "$docs_src/community/project-specific/ray.md"
 rm -f "$docs_src/community/project-specific/spark.md"
 rm -f "$docs_src/community/project-specific/trino.md"
 rm -f "$docs_src/community/project-specific/context.md"
+rm -f "$docs_src/community/project-specific/flink.md"
 
 cat > "$docs_src/format/.pages" <<'EOF'
 nav:

--- a/docs/make-full-website.sh
+++ b/docs/make-full-website.sh
@@ -14,6 +14,7 @@ Override any repo path with the matching environment variable:
   LANCE_DUCKDB_REPO
   LANCE_HUGGINGFACE_REPO
   LANCE_CONTEXT_REPO
+  LANCE_FLINK_REPO
 Defaults:
   LANCE_NAMESPACE_REPO=$HOME/oss/lance-namespace
   LANCE_NAMESPACE_IMPLS_REPO=$HOME/oss/lance-namespace-impls
@@ -23,6 +24,7 @@ Defaults:
   LANCE_DUCKDB_REPO=$HOME/oss/lance-duckdb
   LANCE_HUGGINGFACE_REPO=$HOME/oss/lance-huggingface
   LANCE_CONTEXT_REPO=$HOME/oss/lance-context
+  LANCE_FLINK_REPO=$HOME/oss/lance-flink
 EOF
 }
 
@@ -63,6 +65,7 @@ trino_repo_input=${LANCE_TRINO_REPO:-$HOME/oss/lance-trino}
 duckdb_repo_input=${LANCE_DUCKDB_REPO:-$HOME/oss/lance-duckdb}
 huggingface_repo_input=${LANCE_HUGGINGFACE_REPO:-$HOME/oss/lance-huggingface}
 context_repo_input=${LANCE_CONTEXT_REPO:-$HOME/oss/lance-context}
+flink_repo_input=${LANCE_FLINK_REPO:-$HOME/oss/lance-flink}
 
 copy_docs_dir() {
     local source_dir="$1"
@@ -138,6 +141,7 @@ trino_repo=$(resolve_repo_dir "$trino_repo_input")
 duckdb_repo=$(resolve_repo_dir "$duckdb_repo_input")
 huggingface_repo=$(resolve_repo_dir "$huggingface_repo_input")
 context_repo=$(resolve_repo_dir "$context_repo_input")
+flink_repo=$(resolve_repo_dir "$flink_repo_input")
 
 "$script_dir/clean-full-website.sh"
 
@@ -275,6 +279,12 @@ else
     warn_missing_repo "Lance Context docs" "$context_repo/docs/src"
 fi
 
+if copy_docs_dir "$flink_repo/docs/src" "$docs_src/integrations/flink"; then
+    integration_entries+=("  - Apache Flink: flink")
+else
+    warn_missing_repo "Lance Flink docs" "$flink_repo/docs/src"
+fi
+
 {
     echo "nav:"
     for entry in "${integration_entries[@]}"; do
@@ -317,6 +327,10 @@ fi
 
 if copy_file_if_exists "$context_repo/CONTRIBUTING.md" "$docs_src/community/project-specific/context.md"; then
     project_entries+=("  - Lance Context: context.md")
+fi
+
+if copy_file_if_exists "$flink_repo/CONTRIBUTING.md" "$docs_src/community/project-specific/flink.md"; then
+    project_entries+=("  - Lance Flink: flink.md")
 fi
 
 {


### PR DESCRIPTION
## Summary

Adds `LANCE_FLINK_REPO` to `docs/make-full-website.sh` so the [lance-flink](https://github.com/lance-format/lance-flink) connector docs (`docs/src/`) are aggregated under `integrations/flink`, following the existing `lance-spark` / `lance-trino` / `lance-context` pattern.

## Changes

- New `LANCE_FLINK_REPO` env var (default `$HOME/oss/lance-flink`), documented in the usage block.
- Resolve `flink_repo` via `resolve_repo_dir`.
- Mount `flink_repo/docs/src` → `docs_src/integrations/flink` and append `Apache Flink: flink` to the integrations nav.
- Mount `flink_repo/CONTRIBUTING.md` → `community/project-specific/flink.md`.

## Note

The corresponding `docs/src/` content lives in the lance-flink repository and is not part of this PR. The flink docs are still in progress; until the lance-flink `docs/src/` is merged, the build keeps the placeholder and logs a warning (same behaviour as other missing repos).

Related: lance-format/lance-flink#63