### PR TITLE
fix(io): create the spill temp directory on first use, not in Session::new

### DIFF
--- a/rust/lance-io/src/spill.rs
+++ b/rust/lance-io/src/spill.rs
@@ -21,26 +21,27 @@
 //!   written twice — there is no second-writer path to guard against.
 //! - **Write-before-read.** [`Spill::reader`] fails until the writer has been
 //!   shut down, so partially written bytes are never read back.
-//! - **RAII.** Dropping the [`Spill`] deletes the file and releases its bytes
-//!   back to the store's disk budget. The store's temp directory is the
-//!   backstop for anything leaked if a handle is forgotten.
+//! - **RAII.** Dropping the [`Spill`] releases its bytes back to the store's
+//!   budget and reclaims the storage: the disk backing deletes the file, with
+//!   the store's temp directory as the backstop for anything leaked, and the
+//!   in-memory fallback frees the bytes with the last handle to them.
 //!
 //! # Disk cap
 //!
 //! [`LocalSpillStore::with_cap`] enforces a byte budget shared across all live
 //! handles, returning a typed [`lance_core::Error::DiskCapExceeded`] rather than
-//! silently filling the disk. Accounting is reserve-on-write + release-on-drop
-//! (by stat), which is exact for the write-once contract. Two minor
-//! inexactnesses are not engineered around: a write aborted at the cap leaks its
-//! reservation until the store is dropped, and a file whose size cannot be
-//! stat-ed on drop is not released. The in-memory fallback has no file to stat,
-//! so it releases the bytes its writer accepted instead.
+//! silently filling the disk. Accounting is reserve-on-write + release-on-drop,
+//! by stat on the disk backing and from a counter of accepted bytes in the
+//! in-memory fallback, which has no file to stat. The release is best effort: it
+//! returns whatever the stat or the counter can see when the handle drops, which
+//! is nothing if the stat fails, and nothing on the disk backing before the
+//! writer has been shut down, since the file is not in place until then.
 
 use std::io;
 use std::path::PathBuf;
 use std::pin::Pin;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
-use std::sync::{Arc, Mutex, OnceLock};
+use std::sync::{Arc, Mutex, Once, OnceLock};
 use std::task::{Context, Poll};
 
 use async_trait::async_trait;
@@ -198,25 +199,22 @@ impl Writer for SpillWriter {
     }
 }
 
-/// Where a [`LocalSpillStore`]'s bytes live, resolved on first use.
-enum SpillBacking {
-    /// A temp directory on local disk.
-    Disk {
-        store: Arc<ObjectStore>,
-        /// Backstop cleanup: removes the whole scratch directory on drop.
-        temp_dir: Arc<tempfile::TempDir>,
-    },
-    /// Fallback for a host where the temp directory cannot be created. The
-    /// bytes stay in this process and are reclaimed with the store.
-    Memory { store: Arc<ObjectStore> },
+/// The local-disk scratch directory a [`LocalSpillStore`] writes into, resolved
+/// on first use.
+struct DiskBacking {
+    store: Arc<ObjectStore>,
+    /// Backstop cleanup: removes the whole scratch directory on drop.
+    temp_dir: Arc<tempfile::TempDir>,
 }
 
 /// A [`SpillStore`] that writes temporary files to a local temp directory.
 ///
 /// The directory is created on the first [`SpillStore::new_spill`] call rather
-/// than at construction, so a process that never spills never touches it. If it
-/// cannot be created, the store logs a warning and keeps spills in memory
-/// instead for the rest of its life.
+/// than at construction, so a process that never spills never touches it. A call
+/// that cannot create it keeps that one spill in memory instead, and the next
+/// call tries the directory again. A spill kept in memory is bounded only by the
+/// store's byte cap, so an uncapped store trades a hard failure for memory
+/// pressure.
 ///
 /// By default there is no disk cap. Use [`LocalSpillStore::with_cap`] to
 /// configure one shared across every handle this store produces.
@@ -224,7 +222,12 @@ enum SpillBacking {
 /// The temp directory is deleted when the store is dropped, cleaning up any
 /// files whose handles have already been dropped.
 pub struct LocalSpillStore {
-    backing: OnceLock<SpillBacking>,
+    backing: OnceLock<DiskBacking>,
+    /// How to create the scratch directory. A field so a test can drive the
+    /// failing path without a host whose temp directory is unusable.
+    temp_dir_factory: fn() -> io::Result<tempfile::TempDir>,
+    /// Gates the fallback warning, which would otherwise repeat per spill.
+    warned: Once,
     file_counter: Arc<AtomicU64>,
     /// Byte budget shared across every handle, enforced while writing.
     quota: Option<DiskQuota>,
@@ -248,30 +251,37 @@ impl LocalSpillStore {
         })
     }
 
-    fn backing(&self) -> &SpillBacking {
-        self.backing
-            .get_or_init(|| Self::resolve_backing(tempfile::tempdir()))
-    }
-
-    /// Take the temp directory if there is one, and fall back to memory if not.
+    /// The scratch directory, or `None` when it cannot be created and the caller
+    /// should keep this spill in memory.
     ///
-    /// Split from [`Self::backing`] so a test can drive the failing arm without
-    /// a host whose temp directory is unusable.
-    fn resolve_backing(attempt: io::Result<tempfile::TempDir>) -> SpillBacking {
-        match attempt {
-            Ok(temp_dir) => SpillBacking::Disk {
-                store: Arc::new(ObjectStore::local()),
-                temp_dir: Arc::new(temp_dir),
-            },
+    /// Only success is cached, so a transient failure does not decide where every
+    /// later spill goes. The returned reference borrows from the cache rather
+    /// than from a local, which is what keeps a lost `set` race from handing out
+    /// a path under a [`tempfile::TempDir`] that is about to be dropped.
+    fn disk_backing(&self) -> Option<&DiskBacking> {
+        if let Some(backing) = self.backing.get() {
+            return Some(backing);
+        }
+        match (self.temp_dir_factory)() {
+            Ok(temp_dir) => {
+                // Losing the race drops this directory again, empty: nothing is
+                // written until after this returns.
+                let _ = self.backing.set(DiskBacking {
+                    store: Arc::new(ObjectStore::local()),
+                    temp_dir: Arc::new(temp_dir),
+                });
+                self.backing.get()
+            }
             Err(err) => {
-                tracing::warn!(
-                    error = %err,
-                    "could not create a temp directory for spilling; \
-                     keeping spills in memory instead"
-                );
-                SpillBacking::Memory {
-                    store: Arc::new(ObjectStore::memory()),
-                }
+                self.warned.call_once(|| {
+                    tracing::warn!(
+                        error = %err,
+                        "could not create a temp directory for spilling; \
+                         keeping this spill in memory and retrying on the next"
+                    );
+                });
+                tracing::debug!(error = %err, "spill directory unavailable");
+                None
             }
         }
     }
@@ -281,6 +291,8 @@ impl Default for LocalSpillStore {
     fn default() -> Self {
         Self {
             backing: OnceLock::new(),
+            temp_dir_factory: tempfile::tempdir,
+            warned: Once::new(),
             file_counter: Arc::new(AtomicU64::new(0)),
             quota: None,
         }
@@ -294,8 +306,8 @@ impl SpillStore for LocalSpillStore {
         let name = format!("spill_{idx:06}.bin");
         let finished = Arc::new(AtomicBool::new(false));
 
-        match self.backing() {
-            SpillBacking::Disk { store, temp_dir } => {
+        match self.disk_backing() {
+            Some(DiskBacking { store, temp_dir }) => {
                 let fs_path = temp_dir.path().join(name);
                 let os_path = Path::from_absolute_path(&fs_path)?;
                 let writer = Box::new(SpillWriter {
@@ -314,7 +326,10 @@ impl SpillStore for LocalSpillStore {
                 });
                 Ok((writer, spill))
             }
-            SpillBacking::Memory { store } => {
+            None => {
+                // One backend per spill, so the bytes go with the last `Arc` to
+                // it: nothing to delete, and no runtime needed to do it.
+                let store = Arc::new(ObjectStore::memory());
                 let os_path = Path::from(name);
                 let written = self.quota.as_ref().map(|_| Arc::new(AtomicU64::new(0)));
                 let writer = Box::new(SpillWriter {
@@ -324,7 +339,7 @@ impl SpillStore for LocalSpillStore {
                     finished: finished.clone(),
                 });
                 let spill = Box::new(MemorySpill {
-                    store: store.clone(),
+                    store,
                     os_path,
                     quota: self.quota.clone(),
                     written,
@@ -378,11 +393,11 @@ impl Drop for LocalSpill {
     }
 }
 
-/// The readable half of an in-memory spill.
+/// The readable half of an in-memory spill, and the owner of its backend.
 ///
-/// There is no file to unlink, so removal goes through the store, which is
-/// async: it runs on the current runtime when there is one, and otherwise the
-/// bytes are reclaimed when the store itself is dropped.
+/// The backend holds this one object and nothing else, so the bytes go with the
+/// last `Arc` to it. A reader keeps its own reference, which puts residency on
+/// the same footing as the disk path's unlink with an open descriptor.
 struct MemorySpill {
     store: Arc<ObjectStore>,
     os_path: Path,
@@ -407,15 +422,10 @@ impl Spill for MemorySpill {
 
 impl Drop for MemorySpill {
     fn drop(&mut self) {
+        // Returning the reservation is all there is to do: dropping this handle
+        // drops its backend unless a reader or the writer still holds one.
         if let (Some(quota), Some(written)) = (&self.quota, &self.written) {
             quota.release(written.load(Ordering::Relaxed));
-        }
-        if let Ok(handle) = tokio::runtime::Handle::try_current() {
-            let store = self.store.clone();
-            let os_path = self.os_path.clone();
-            handle.spawn(async move {
-                let _ = store.delete(&os_path).await;
-            });
         }
     }
 }
@@ -587,8 +597,8 @@ mod tests {
     }
 
     /// A [`Writer`] whose `poll_write` accepts a fixed number of bytes per call,
-    /// or fails, so we can drive the [`SpillWriter`] release arms that the local
-    /// backend (which accepts every write in full) never hits.
+    /// or fails, so the [`SpillWriter`] release arms can be driven directly
+    /// rather than by arranging for a real backend to short-write.
     struct ControlledWriter {
         outcome: Poll<io::Result<usize>>,
     }
@@ -626,14 +636,16 @@ mod tests {
     #[tokio::test]
     async fn test_spill_writer_releases_unaccepted_bytes() {
         // Short write: the inner writer accepts only 10 of the 40 reserved bytes,
-        // so the 30-byte remainder must be returned to the budget.
+        // so the 30-byte remainder must be returned to the budget, and the
+        // counter the in-memory arm releases from must record 10 rather than 40.
         let quota = DiskQuota::new(100);
+        let written = Arc::new(AtomicU64::new(0));
         let mut writer = SpillWriter {
             inner: Box::new(ControlledWriter {
                 outcome: Poll::Ready(Ok(10)),
             }),
             quota: Some(quota.clone()),
-            written: None,
+            written: Some(written.clone()),
             finished: Arc::new(AtomicBool::new(false)),
         };
         let n = writer.write(&[0u8; 40]).await.unwrap();
@@ -643,18 +655,22 @@ mod tests {
             10,
             "only the accepted bytes should remain reserved"
         );
+        assert_eq!(written.load(Ordering::Relaxed), 10);
 
-        // Failed write: the full reservation must be released.
+        // Failed write: the full reservation must be released, and nothing may be
+        // counted as written.
         let quota = DiskQuota::new(100);
+        let written = Arc::new(AtomicU64::new(0));
         let mut writer = SpillWriter {
             inner: Box::new(ControlledWriter {
                 outcome: Poll::Ready(Err(io::Error::other("boom"))),
             }),
             quota: Some(quota.clone()),
-            written: None,
+            written: Some(written.clone()),
             finished: Arc::new(AtomicBool::new(false)),
         };
         writer.write(&[0u8; 40]).await.unwrap_err();
+        assert_eq!(written.load(Ordering::Relaxed), 0);
         assert_eq!(
             *quota.used.lock().unwrap(),
             0,
@@ -662,22 +678,26 @@ mod tests {
         );
     }
 
-    /// Seed a store with the backing an unusable temp directory produces.
-    fn force_memory_backing(store: &LocalSpillStore) {
-        let backing =
-            LocalSpillStore::resolve_backing(Err(io::Error::from(io::ErrorKind::PermissionDenied)));
-        assert!(store.backing.set(backing).is_ok());
-        assert!(matches!(
-            store.backing.get(),
-            Some(SpillBacking::Memory { .. })
-        ));
+    /// A temp-directory factory that always fails, standing in for a host whose
+    /// temp directory is unusable.
+    fn no_temp_dir() -> io::Result<tempfile::TempDir> {
+        Err(io::Error::from(io::ErrorKind::PermissionDenied))
+    }
+
+    /// A store that can never resolve a disk backing.
+    fn memory_only_store(quota: Option<DiskQuota>) -> LocalSpillStore {
+        LocalSpillStore {
+            temp_dir_factory: no_temp_dir,
+            quota,
+            ..Default::default()
+        }
     }
 
     /// The temp directory of a store whose backing has resolved to disk.
     fn disk_temp_dir(store: &LocalSpillStore) -> &std::path::Path {
         match store.backing.get() {
-            Some(SpillBacking::Disk { temp_dir, .. }) => temp_dir.path(),
-            _ => panic!("expected a disk backing"),
+            Some(backing) => backing.temp_dir.path(),
+            None => panic!("expected a resolved disk backing"),
         }
     }
 
@@ -702,16 +722,12 @@ mod tests {
         let store = LocalSpillStore::new().unwrap();
         let (writer, _spill) = store.new_spill().await.unwrap();
         finish_writer(writer, b"resolved").await.unwrap();
-        assert!(matches!(
-            store.backing.get(),
-            Some(SpillBacking::Disk { .. })
-        ));
+        assert!(store.backing.get().is_some());
     }
 
     #[tokio::test]
     async fn test_memory_backing_round_trips() {
-        let store = LocalSpillStore::new().unwrap();
-        force_memory_backing(&store);
+        let store = memory_only_store(None);
 
         let (writer, spill) = store.new_spill().await.unwrap();
         let data = b"spilled without a temp dir";
@@ -719,29 +735,101 @@ mod tests {
 
         let reader = spill.reader().await.unwrap();
         assert_eq!(reader.get_all().await.unwrap().as_ref(), data);
+        assert!(
+            store.backing.get().is_none(),
+            "a failed temp dir must not be cached as a backing"
+        );
     }
 
     #[tokio::test]
     async fn test_memory_backing_rejects_a_reader_before_shutdown() {
-        let store = LocalSpillStore::new().unwrap();
-        force_memory_backing(&store);
+        let store = memory_only_store(None);
 
         let (_writer, spill) = store.new_spill().await.unwrap();
-        assert!(spill.reader().await.is_err());
+        let err = spill.reader().await.unwrap_err();
+        assert!(
+            matches!(err, Error::InvalidInput { .. }),
+            "expected the write-before-read rejection, got {err:?}"
+        );
     }
 
     #[tokio::test]
     async fn test_memory_backing_releases_the_quota_on_drop() {
-        let store = LocalSpillStore::with_cap(50).unwrap();
-        force_memory_backing(&store);
+        let quota = DiskQuota::new(60);
+        let store = memory_only_store(Some(quota.clone()));
+
+        // A second spill stays alive across the drop, so an over-release shows up
+        // as its bytes going missing from the budget: `release` saturates, which
+        // otherwise makes a `u64::MAX` release indistinguishable from a correct
+        // one.
+        let (other_writer, _other) = store.new_spill().await.unwrap();
+        finish_writer(other_writer, &[0u8; 10]).await.unwrap();
 
         let (writer, spill) = store.new_spill().await.unwrap();
         finish_writer(writer, &[0u8; 40]).await.unwrap();
+        assert_eq!(*quota.used.lock().unwrap(), 50);
+        drop(spill);
+        assert_eq!(*quota.used.lock().unwrap(), 10);
+    }
+
+    #[tokio::test]
+    async fn test_a_reader_outlives_the_memory_spill_handle() {
+        // The disk path tolerates this because unlink leaves an open descriptor
+        // readable; the in-memory backend has to hold its bytes for the reader
+        // the same way.
+        let store = memory_only_store(None);
+        let (writer, spill) = store.new_spill().await.unwrap();
+        let data = b"read after the handle is gone";
+        finish_writer(writer, data).await.unwrap();
+
+        let reader = spill.reader().await.unwrap();
+        drop(spill);
+        // The yield is what makes this discriminating: an earlier revision
+        // reclaimed through a task spawned in `Drop`, and with no scheduling
+        // point that task could not run before the read.
+        tokio::task::yield_now().await;
+        assert_eq!(reader.get_all().await.unwrap().as_ref(), data);
+    }
+
+    /// One failing attempt must not decide where later spills go. Uses a process
+    /// -wide counter, so it is the only test driving this factory.
+    static TEMP_DIR_FAILURES_LEFT: AtomicU64 = AtomicU64::new(1);
+
+    fn temp_dir_failing_once() -> io::Result<tempfile::TempDir> {
+        if TEMP_DIR_FAILURES_LEFT
+            .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |n| n.checked_sub(1))
+            .is_ok()
+        {
+            no_temp_dir()
+        } else {
+            tempfile::tempdir()
+        }
+    }
+
+    #[tokio::test]
+    async fn test_a_transient_temp_dir_failure_is_retried() {
+        // Reset rather than rely on the initial value, so a repeat run of this
+        // test in one process still sees exactly one failure.
+        TEMP_DIR_FAILURES_LEFT.store(1, Ordering::Relaxed);
+        let store = LocalSpillStore {
+            temp_dir_factory: temp_dir_failing_once,
+            ..Default::default()
+        };
+
+        let (writer, spill) = store.new_spill().await.unwrap();
+        finish_writer(writer, b"in memory").await.unwrap();
+        assert!(
+            store.backing.get().is_none(),
+            "the first attempt failed, so nothing may be cached"
+        );
         drop(spill);
 
-        // Without the release this second write would exceed the 50-byte cap,
-        // which is what a stat-based release cannot do with no file to stat.
         let (writer, _spill) = store.new_spill().await.unwrap();
-        finish_writer(writer, &[0u8; 40]).await.unwrap();
+        finish_writer(writer, b"on disk").await.unwrap();
+        assert!(
+            store.backing.get().is_some(),
+            "the second attempt succeeded, so the directory must now be cached"
+        );
+        assert!(disk_temp_dir(&store).join("spill_000001.bin").exists());
     }
 }

--- a/rust/lance-io/src/spill.rs
+++ b/rust/lance-io/src/spill.rs
@@ -50,6 +50,7 @@ use std::task::{Context, Poll};
 use async_trait::async_trait;
 use bytes::Bytes;
 use futures::future::BoxFuture;
+use futures::stream::StreamExt;
 use lance_core::deepsize::DeepSizeOf;
 use object_store::path::Path;
 use tokio::io::AsyncWrite;
@@ -452,7 +453,7 @@ impl Spill for MemorySpill {
         Ok(match &self.reservation {
             Some(reservation) => Box::new(ChargedReader {
                 inner,
-                _reservation: reservation.clone(),
+                reservation: reservation.clone(),
             }),
             None => inner,
         })
@@ -462,11 +463,22 @@ impl Spill for MemorySpill {
 /// A [`Reader`] that holds a share of its spill's quota reservation.
 ///
 /// Delegates everything; it exists only so the bytes a retained reader keeps
-/// resident stay charged to the cap.
+/// resident stay charged to the cap. `get_range` and the two stream methods hand
+/// out products that own the backing and outlive this reader, so each of them
+/// carries its own share.
 #[derive(Debug)]
 struct ChargedReader {
     inner: Box<dyn Reader>,
-    _reservation: Arc<Reservation>,
+    reservation: Arc<Reservation>,
+}
+
+/// Tie `reservation` to the life of `stream`, which is `'static` and can outlive
+/// the reader that produced it.
+fn charged_stream(stream: ByteStream, reservation: Arc<Reservation>) -> ByteStream {
+    Box::pin(stream.map(move |item| {
+        let _ = &reservation;
+        item
+    }))
 }
 
 impl DeepSizeOf for ChargedReader {
@@ -493,7 +505,13 @@ impl Reader for ChargedReader {
     }
 
     fn get_range(&self, range: Range<usize>) -> BoxFuture<'static, object_store::Result<Bytes>> {
-        self.inner.get_range(range)
+        let reservation = self.reservation.clone();
+        let inner = self.inner.get_range(range);
+        Box::pin(async move {
+            let result = inner.await;
+            drop(reservation);
+            result
+        })
     }
 
     fn get_all(&self) -> BoxFuture<'_, object_store::Result<Bytes>> {
@@ -501,14 +519,22 @@ impl Reader for ChargedReader {
     }
 
     fn get_stream(&self) -> BoxFuture<'_, object_store::Result<ByteStream>> {
-        self.inner.get_stream()
+        let reservation = self.reservation.clone();
+        Box::pin(async move {
+            let stream = self.inner.get_stream().await?;
+            Ok(charged_stream(stream, reservation))
+        })
     }
 
     fn get_range_stream(
         &self,
         range: Range<usize>,
     ) -> BoxFuture<'_, object_store::Result<ByteStream>> {
-        self.inner.get_range_stream(range)
+        let reservation = self.reservation.clone();
+        Box::pin(async move {
+            let stream = self.inner.get_range_stream(range).await?;
+            Ok(charged_stream(stream, reservation))
+        })
     }
 }
 
@@ -899,6 +925,53 @@ mod tests {
         assert!(matches!(err, Error::DiskCapExceeded { .. }), "{err:?}");
 
         drop(retained);
+        assert_eq!(*quota.used.lock().unwrap(), 0);
+    }
+
+    /// A reader's detached products own the backing too, so each of them has to
+    /// keep the charge. One test per API that hands one out.
+    #[rstest::rstest]
+    #[case::get_range(0)]
+    #[case::get_stream(1)]
+    #[case::get_range_stream(2)]
+    #[tokio::test]
+    async fn test_a_detached_reader_product_stays_charged_to_the_cap(#[case] api: u8) {
+        let quota = DiskQuota::new(50);
+        let store = memory_only_store(Some(quota.clone()));
+
+        let (writer, spill) = store.new_spill().await.unwrap();
+        finish_writer(writer, &[1u8; 40]).await.unwrap();
+        let reader = spill.reader().await.unwrap();
+
+        // Each of these owns the in-memory backing and outlives the reader.
+        let mut detached_future = None;
+        let mut detached_stream = None;
+        match api {
+            0 => detached_future = Some(reader.get_range(0..40)),
+            1 => detached_stream = Some(reader.get_stream().await.unwrap()),
+            _ => detached_stream = Some(reader.get_range_stream(0..40).await.unwrap()),
+        }
+        drop(reader);
+        drop(spill);
+
+        assert_eq!(
+            *quota.used.lock().unwrap(),
+            40,
+            "the bytes are still reachable, so they stay charged"
+        );
+        let (writer, _second) = store.new_spill().await.unwrap();
+        let err = finish_writer(writer, &[2u8; 40]).await.unwrap_err();
+        assert!(matches!(err, Error::DiskCapExceeded { .. }), "{err:?}");
+
+        // And the product still reads what it was created for.
+        match (detached_future, detached_stream) {
+            (Some(fut), None) => assert_eq!(fut.await.unwrap().as_ref(), &[1u8; 40]),
+            (None, Some(stream)) => {
+                let chunks: Vec<Bytes> = stream.map(|c| c.unwrap()).collect().await;
+                assert_eq!(chunks.concat(), vec![1u8; 40]);
+            }
+            _ => unreachable!(),
+        }
         assert_eq!(*quota.used.lock().unwrap(), 0);
     }
 

--- a/rust/lance-io/src/spill.rs
+++ b/rust/lance-io/src/spill.rs
@@ -33,13 +33,14 @@
 //! (by stat), which is exact for the write-once contract. Two minor
 //! inexactnesses are not engineered around: a write aborted at the cap leaks its
 //! reservation until the store is dropped, and a file whose size cannot be
-//! stat-ed on drop is not released.
+//! stat-ed on drop is not released. The in-memory fallback has no file to stat,
+//! so it releases the bytes its writer accepted instead.
 
 use std::io;
 use std::path::PathBuf;
 use std::pin::Pin;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, OnceLock};
 use std::task::{Context, Poll};
 
 use async_trait::async_trait;
@@ -130,6 +131,9 @@ impl DiskQuota {
 struct SpillWriter {
     inner: Box<dyn Writer>,
     quota: Option<DiskQuota>,
+    /// Bytes the inner writer accepted, tracked only alongside a `quota`: a
+    /// backing with no file to stat needs this to release its reservation.
+    written: Option<Arc<AtomicU64>>,
     finished: Arc<AtomicBool>,
 }
 
@@ -151,7 +155,12 @@ impl AsyncWrite for SpillWriter {
         }
         let poll = Pin::new(this.inner.as_mut()).poll_write(cx, buf);
         match &poll {
-            Poll::Ready(Ok(n)) => quota.release((buf.len() - *n) as u64),
+            Poll::Ready(Ok(n)) => {
+                quota.release((buf.len() - *n) as u64);
+                if let Some(written) = &this.written {
+                    written.fetch_add(*n as u64, Ordering::Relaxed);
+                }
+            }
             _ => quota.release(buf.len() as u64),
         }
         poll
@@ -189,7 +198,25 @@ impl Writer for SpillWriter {
     }
 }
 
+/// Where a [`LocalSpillStore`]'s bytes live, resolved on first use.
+enum SpillBacking {
+    /// A temp directory on local disk.
+    Disk {
+        store: Arc<ObjectStore>,
+        /// Backstop cleanup: removes the whole scratch directory on drop.
+        temp_dir: Arc<tempfile::TempDir>,
+    },
+    /// Fallback for a host where the temp directory cannot be created. The
+    /// bytes stay in this process and are reclaimed with the store.
+    Memory { store: Arc<ObjectStore> },
+}
+
 /// A [`SpillStore`] that writes temporary files to a local temp directory.
+///
+/// The directory is created on the first [`SpillStore::new_spill`] call rather
+/// than at construction, so a process that never spills never touches it. If it
+/// cannot be created, the store logs a warning and keeps spills in memory
+/// instead for the rest of its life.
 ///
 /// By default there is no disk cap. Use [`LocalSpillStore::with_cap`] to
 /// configure one shared across every handle this store produces.
@@ -197,9 +224,7 @@ impl Writer for SpillWriter {
 /// The temp directory is deleted when the store is dropped, cleaning up any
 /// files whose handles have already been dropped.
 pub struct LocalSpillStore {
-    store: Arc<ObjectStore>,
-    /// Backstop cleanup: removes the whole scratch directory on drop.
-    temp_dir: Arc<tempfile::TempDir>,
+    backing: OnceLock<SpillBacking>,
     file_counter: Arc<AtomicU64>,
     /// Byte budget shared across every handle, enforced while writing.
     quota: Option<DiskQuota>,
@@ -207,30 +232,58 @@ pub struct LocalSpillStore {
 
 impl LocalSpillStore {
     /// Create a store with no disk cap.
+    ///
+    /// The `Result` is kept for callers that already handle one; constructing a
+    /// store does no I/O and cannot fail.
     pub fn new() -> Result<Self> {
-        Ok(Self {
-            store: Arc::new(ObjectStore::local()),
-            temp_dir: Arc::new(tempfile::tempdir()?),
-            file_counter: Arc::new(AtomicU64::new(0)),
-            quota: None,
-        })
+        Ok(Self::default())
     }
 
     /// Create a store that returns [`lance_core::Error::DiskCapExceeded`] once
     /// total bytes written across all live handles would exceed `cap_bytes`.
     pub fn with_cap(cap_bytes: u64) -> Result<Self> {
         Ok(Self {
-            store: Arc::new(ObjectStore::local()),
-            temp_dir: Arc::new(tempfile::tempdir()?),
-            file_counter: Arc::new(AtomicU64::new(0)),
             quota: Some(DiskQuota::new(cap_bytes)),
+            ..Self::default()
         })
+    }
+
+    fn backing(&self) -> &SpillBacking {
+        self.backing
+            .get_or_init(|| Self::resolve_backing(tempfile::tempdir()))
+    }
+
+    /// Take the temp directory if there is one, and fall back to memory if not.
+    ///
+    /// Split from [`Self::backing`] so a test can drive the failing arm without
+    /// a host whose temp directory is unusable.
+    fn resolve_backing(attempt: io::Result<tempfile::TempDir>) -> SpillBacking {
+        match attempt {
+            Ok(temp_dir) => SpillBacking::Disk {
+                store: Arc::new(ObjectStore::local()),
+                temp_dir: Arc::new(temp_dir),
+            },
+            Err(err) => {
+                tracing::warn!(
+                    error = %err,
+                    "could not create a temp directory for spilling; \
+                     keeping spills in memory instead"
+                );
+                SpillBacking::Memory {
+                    store: Arc::new(ObjectStore::memory()),
+                }
+            }
+        }
     }
 }
 
 impl Default for LocalSpillStore {
     fn default() -> Self {
-        Self::new().expect("failed to create temp directory for LocalSpillStore")
+        Self {
+            backing: OnceLock::new(),
+            file_counter: Arc::new(AtomicU64::new(0)),
+            quota: None,
+        }
     }
 }
 
@@ -238,24 +291,48 @@ impl Default for LocalSpillStore {
 impl SpillStore for LocalSpillStore {
     async fn new_spill(&self) -> Result<(Box<dyn Writer>, Box<dyn Spill>)> {
         let idx = self.file_counter.fetch_add(1, Ordering::Relaxed);
-        let fs_path = self.temp_dir.path().join(format!("spill_{idx:06}.bin"));
-        let os_path = Path::from_absolute_path(&fs_path)?;
+        let name = format!("spill_{idx:06}.bin");
         let finished = Arc::new(AtomicBool::new(false));
 
-        let writer = Box::new(SpillWriter {
-            inner: self.store.create(&os_path).await?,
-            quota: self.quota.clone(),
-            finished: finished.clone(),
-        });
-        let spill = Box::new(LocalSpill {
-            store: self.store.clone(),
-            os_path,
-            fs_path,
-            quota: self.quota.clone(),
-            finished,
-            _temp_dir: self.temp_dir.clone(),
-        });
-        Ok((writer, spill))
+        match self.backing() {
+            SpillBacking::Disk { store, temp_dir } => {
+                let fs_path = temp_dir.path().join(name);
+                let os_path = Path::from_absolute_path(&fs_path)?;
+                let writer = Box::new(SpillWriter {
+                    inner: store.create(&os_path).await?,
+                    quota: self.quota.clone(),
+                    written: None,
+                    finished: finished.clone(),
+                });
+                let spill = Box::new(LocalSpill {
+                    store: store.clone(),
+                    os_path,
+                    fs_path,
+                    quota: self.quota.clone(),
+                    finished,
+                    _temp_dir: temp_dir.clone(),
+                });
+                Ok((writer, spill))
+            }
+            SpillBacking::Memory { store } => {
+                let os_path = Path::from(name);
+                let written = self.quota.as_ref().map(|_| Arc::new(AtomicU64::new(0)));
+                let writer = Box::new(SpillWriter {
+                    inner: store.create(&os_path).await?,
+                    quota: self.quota.clone(),
+                    written: written.clone(),
+                    finished: finished.clone(),
+                });
+                let spill = Box::new(MemorySpill {
+                    store: store.clone(),
+                    os_path,
+                    quota: self.quota.clone(),
+                    written,
+                    finished,
+                });
+                Ok((writer, spill))
+            }
+        }
     }
 }
 
@@ -298,6 +375,48 @@ impl Drop for LocalSpill {
         }
         // Best-effort removal; the temp dir is the backstop.
         let _ = std::fs::remove_file(&self.fs_path);
+    }
+}
+
+/// The readable half of an in-memory spill.
+///
+/// There is no file to unlink, so removal goes through the store, which is
+/// async: it runs on the current runtime when there is one, and otherwise the
+/// bytes are reclaimed when the store itself is dropped.
+struct MemorySpill {
+    store: Arc<ObjectStore>,
+    os_path: Path,
+    quota: Option<DiskQuota>,
+    /// Bytes the paired writer accepted, present only alongside a `quota`.
+    written: Option<Arc<AtomicU64>>,
+    /// Set by the paired [`SpillWriter`] once it has been shut down.
+    finished: Arc<AtomicBool>,
+}
+
+#[async_trait]
+impl Spill for MemorySpill {
+    async fn reader(&self) -> Result<Box<dyn Reader>> {
+        if !self.finished.load(Ordering::Relaxed) {
+            return Err(Error::invalid_input(
+                "spill reader requested before the writer was shut down",
+            ));
+        }
+        self.store.open(&self.os_path).await
+    }
+}
+
+impl Drop for MemorySpill {
+    fn drop(&mut self) {
+        if let (Some(quota), Some(written)) = (&self.quota, &self.written) {
+            quota.release(written.load(Ordering::Relaxed));
+        }
+        if let Ok(handle) = tokio::runtime::Handle::try_current() {
+            let store = self.store.clone();
+            let os_path = self.os_path.clone();
+            handle.spawn(async move {
+                let _ = store.delete(&os_path).await;
+            });
+        }
     }
 }
 
@@ -392,7 +511,7 @@ mod tests {
         finish_writer(writer, b"some bytes").await.unwrap();
 
         // The first spill gets a deterministic name under the store's temp dir.
-        let path = store.temp_dir.path().join("spill_000000.bin");
+        let path = disk_temp_dir(&store).join("spill_000000.bin");
         assert!(path.exists());
         drop(spill);
         assert!(!path.exists(), "spill file should be deleted on drop");
@@ -514,6 +633,7 @@ mod tests {
                 outcome: Poll::Ready(Ok(10)),
             }),
             quota: Some(quota.clone()),
+            written: None,
             finished: Arc::new(AtomicBool::new(false)),
         };
         let n = writer.write(&[0u8; 40]).await.unwrap();
@@ -531,6 +651,7 @@ mod tests {
                 outcome: Poll::Ready(Err(io::Error::other("boom"))),
             }),
             quota: Some(quota.clone()),
+            written: None,
             finished: Arc::new(AtomicBool::new(false)),
         };
         writer.write(&[0u8; 40]).await.unwrap_err();
@@ -539,5 +660,88 @@ mod tests {
             0,
             "a failed write should release its entire reservation"
         );
+    }
+
+    /// Seed a store with the backing an unusable temp directory produces.
+    fn force_memory_backing(store: &LocalSpillStore) {
+        let backing =
+            LocalSpillStore::resolve_backing(Err(io::Error::from(io::ErrorKind::PermissionDenied)));
+        assert!(store.backing.set(backing).is_ok());
+        assert!(matches!(
+            store.backing.get(),
+            Some(SpillBacking::Memory { .. })
+        ));
+    }
+
+    /// The temp directory of a store whose backing has resolved to disk.
+    fn disk_temp_dir(store: &LocalSpillStore) -> &std::path::Path {
+        match store.backing.get() {
+            Some(SpillBacking::Disk { temp_dir, .. }) => temp_dir.path(),
+            _ => panic!("expected a disk backing"),
+        }
+    }
+
+    #[test]
+    fn test_construction_resolves_no_backing() {
+        // Constructing a session used to create the temp directory, so a host
+        // that cannot create one aborted on an unrelated path. Nothing may be
+        // resolved until the first spill.
+        assert!(LocalSpillStore::new().unwrap().backing.get().is_none());
+        assert!(LocalSpillStore::default().backing.get().is_none());
+        assert!(
+            LocalSpillStore::with_cap(1 << 20)
+                .unwrap()
+                .backing
+                .get()
+                .is_none()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_first_spill_resolves_the_disk_backing() {
+        let store = LocalSpillStore::new().unwrap();
+        let (writer, _spill) = store.new_spill().await.unwrap();
+        finish_writer(writer, b"resolved").await.unwrap();
+        assert!(matches!(
+            store.backing.get(),
+            Some(SpillBacking::Disk { .. })
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_memory_backing_round_trips() {
+        let store = LocalSpillStore::new().unwrap();
+        force_memory_backing(&store);
+
+        let (writer, spill) = store.new_spill().await.unwrap();
+        let data = b"spilled without a temp dir";
+        finish_writer(writer, data).await.unwrap();
+
+        let reader = spill.reader().await.unwrap();
+        assert_eq!(reader.get_all().await.unwrap().as_ref(), data);
+    }
+
+    #[tokio::test]
+    async fn test_memory_backing_rejects_a_reader_before_shutdown() {
+        let store = LocalSpillStore::new().unwrap();
+        force_memory_backing(&store);
+
+        let (_writer, spill) = store.new_spill().await.unwrap();
+        assert!(spill.reader().await.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_memory_backing_releases_the_quota_on_drop() {
+        let store = LocalSpillStore::with_cap(50).unwrap();
+        force_memory_backing(&store);
+
+        let (writer, spill) = store.new_spill().await.unwrap();
+        finish_writer(writer, &[0u8; 40]).await.unwrap();
+        drop(spill);
+
+        // Without the release this second write would exceed the 50-byte cap,
+        // which is what a stat-based release cannot do with no file to stat.
+        let (writer, _spill) = store.new_spill().await.unwrap();
+        finish_writer(writer, &[0u8; 40]).await.unwrap();
     }
 }

--- a/rust/lance-io/src/spill.rs
+++ b/rust/lance-io/src/spill.rs
@@ -32,12 +32,15 @@
 //! handles, returning a typed [`lance_core::Error::DiskCapExceeded`] rather than
 //! silently filling the disk. Accounting is reserve-on-write + release-on-drop,
 //! by stat on the disk backing and from a counter of accepted bytes in the
-//! in-memory fallback, which has no file to stat. The release is best effort: it
-//! returns whatever the stat or the counter can see when the handle drops, which
-//! is nothing if the stat fails, and nothing on the disk backing before the
-//! writer has been shut down, since the file is not in place until then.
+//! in-memory fallback, which has no file to stat. The disk backing releases when
+//! the handle drops, best effort: it returns what the stat can see then, which is
+//! nothing if the stat fails, and nothing before the writer has been shut down,
+//! since the file is not in place until then. The in-memory fallback instead
+//! charges its bytes until the last owner of that spill's backing drops, writer
+//! and readers included, so a retained reader keeps them on the budget.
 
 use std::io;
+use std::ops::Range;
 use std::path::PathBuf;
 use std::pin::Pin;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
@@ -45,6 +48,9 @@ use std::sync::{Arc, Mutex, Once, OnceLock};
 use std::task::{Context, Poll};
 
 use async_trait::async_trait;
+use bytes::Bytes;
+use futures::future::BoxFuture;
+use lance_core::deepsize::DeepSizeOf;
 use object_store::path::Path;
 use tokio::io::AsyncWrite;
 
@@ -52,7 +58,7 @@ use lance_core::{Error, Result};
 
 use crate::object_store::ObjectStore;
 use crate::object_writer::WriteResult;
-use crate::traits::{Reader, Writer};
+use crate::traits::{ByteStream, Reader, Writer};
 
 /// A factory for scratch storage.
 ///
@@ -132,10 +138,31 @@ impl DiskQuota {
 struct SpillWriter {
     inner: Box<dyn Writer>,
     quota: Option<DiskQuota>,
-    /// Bytes the inner writer accepted, tracked only alongside a `quota`: a
-    /// backing with no file to stat needs this to release its reservation.
-    written: Option<Arc<AtomicU64>>,
+    /// Present only for a backing with no file to stat, which needs the accepted
+    /// byte count to release its reservation. Held rather than just written to,
+    /// so bytes this writer adds after its [`Spill`] is dropped are still
+    /// counted before the release.
+    reservation: Option<Arc<Reservation>>,
     finished: Arc<AtomicBool>,
+}
+
+/// A quota reservation released when its last owner drops.
+///
+/// The in-memory backing is reclaimed by the last `Arc` to it, and a reader is
+/// one of those owners, so the reservation has to be tied to the same set of
+/// owners: releasing it when the [`Spill`] alone drops would take bytes off the
+/// budget while a retained reader still holds them.
+#[derive(Debug)]
+struct Reservation {
+    quota: DiskQuota,
+    /// Bytes the paired writer's inner writer accepted.
+    written: AtomicU64,
+}
+
+impl Drop for Reservation {
+    fn drop(&mut self) {
+        self.quota.release(self.written.load(Ordering::Relaxed));
+    }
 }
 
 impl AsyncWrite for SpillWriter {
@@ -158,8 +185,8 @@ impl AsyncWrite for SpillWriter {
         match &poll {
             Poll::Ready(Ok(n)) => {
                 quota.release((buf.len() - *n) as u64);
-                if let Some(written) = &this.written {
-                    written.fetch_add(*n as u64, Ordering::Relaxed);
+                if let Some(reservation) = &this.reservation {
+                    reservation.written.fetch_add(*n as u64, Ordering::Relaxed);
                 }
             }
             _ => quota.release(buf.len() as u64),
@@ -313,7 +340,7 @@ impl SpillStore for LocalSpillStore {
                 let writer = Box::new(SpillWriter {
                     inner: store.create(&os_path).await?,
                     quota: self.quota.clone(),
-                    written: None,
+                    reservation: None,
                     finished: finished.clone(),
                 });
                 let spill = Box::new(LocalSpill {
@@ -331,18 +358,22 @@ impl SpillStore for LocalSpillStore {
                 // it: nothing to delete, and no runtime needed to do it.
                 let store = Arc::new(ObjectStore::memory());
                 let os_path = Path::from(name);
-                let written = self.quota.as_ref().map(|_| Arc::new(AtomicU64::new(0)));
+                let reservation = self.quota.as_ref().map(|quota| {
+                    Arc::new(Reservation {
+                        quota: quota.clone(),
+                        written: AtomicU64::new(0),
+                    })
+                });
                 let writer = Box::new(SpillWriter {
                     inner: store.create(&os_path).await?,
                     quota: self.quota.clone(),
-                    written: written.clone(),
+                    reservation: reservation.clone(),
                     finished: finished.clone(),
                 });
                 let spill = Box::new(MemorySpill {
                     store,
                     os_path,
-                    quota: self.quota.clone(),
-                    written,
+                    reservation,
                     finished,
                 });
                 Ok((writer, spill))
@@ -401,9 +432,10 @@ impl Drop for LocalSpill {
 struct MemorySpill {
     store: Arc<ObjectStore>,
     os_path: Path,
-    quota: Option<DiskQuota>,
-    /// Bytes the paired writer accepted, present only alongside a `quota`.
-    written: Option<Arc<AtomicU64>>,
+    /// Shared with the paired writer and with every reader handed out, so the
+    /// bytes leave the budget with the last owner of the backend rather than
+    /// with this handle.
+    reservation: Option<Arc<Reservation>>,
     /// Set by the paired [`SpillWriter`] once it has been shut down.
     finished: Arc<AtomicBool>,
 }
@@ -416,17 +448,67 @@ impl Spill for MemorySpill {
                 "spill reader requested before the writer was shut down",
             ));
         }
-        self.store.open(&self.os_path).await
+        let inner = self.store.open(&self.os_path).await?;
+        Ok(match &self.reservation {
+            Some(reservation) => Box::new(ChargedReader {
+                inner,
+                _reservation: reservation.clone(),
+            }),
+            None => inner,
+        })
     }
 }
 
-impl Drop for MemorySpill {
-    fn drop(&mut self) {
-        // Returning the reservation is all there is to do: dropping this handle
-        // drops its backend unless a reader or the writer still holds one.
-        if let (Some(quota), Some(written)) = (&self.quota, &self.written) {
-            quota.release(written.load(Ordering::Relaxed));
-        }
+/// A [`Reader`] that holds a share of its spill's quota reservation.
+///
+/// Delegates everything; it exists only so the bytes a retained reader keeps
+/// resident stay charged to the cap.
+#[derive(Debug)]
+struct ChargedReader {
+    inner: Box<dyn Reader>,
+    _reservation: Arc<Reservation>,
+}
+
+impl DeepSizeOf for ChargedReader {
+    fn deep_size_of_children(&self, context: &mut lance_core::deepsize::Context) -> usize {
+        self.inner.deep_size_of_children(context)
+    }
+}
+
+impl Reader for ChargedReader {
+    fn path(&self) -> &Path {
+        self.inner.path()
+    }
+
+    fn block_size(&self) -> usize {
+        self.inner.block_size()
+    }
+
+    fn io_parallelism(&self) -> usize {
+        self.inner.io_parallelism()
+    }
+
+    fn size(&self) -> BoxFuture<'_, object_store::Result<usize>> {
+        self.inner.size()
+    }
+
+    fn get_range(&self, range: Range<usize>) -> BoxFuture<'static, object_store::Result<Bytes>> {
+        self.inner.get_range(range)
+    }
+
+    fn get_all(&self) -> BoxFuture<'_, object_store::Result<Bytes>> {
+        self.inner.get_all()
+    }
+
+    fn get_stream(&self) -> BoxFuture<'_, object_store::Result<ByteStream>> {
+        self.inner.get_stream()
+    }
+
+    fn get_range_stream(
+        &self,
+        range: Range<usize>,
+    ) -> BoxFuture<'_, object_store::Result<ByteStream>> {
+        self.inner.get_range_stream(range)
     }
 }
 
@@ -639,13 +721,16 @@ mod tests {
         // so the 30-byte remainder must be returned to the budget, and the
         // counter the in-memory arm releases from must record 10 rather than 40.
         let quota = DiskQuota::new(100);
-        let written = Arc::new(AtomicU64::new(0));
+        let reservation = Arc::new(Reservation {
+            quota: quota.clone(),
+            written: AtomicU64::new(0),
+        });
         let mut writer = SpillWriter {
             inner: Box::new(ControlledWriter {
                 outcome: Poll::Ready(Ok(10)),
             }),
             quota: Some(quota.clone()),
-            written: Some(written.clone()),
+            reservation: Some(reservation.clone()),
             finished: Arc::new(AtomicBool::new(false)),
         };
         let n = writer.write(&[0u8; 40]).await.unwrap();
@@ -655,22 +740,25 @@ mod tests {
             10,
             "only the accepted bytes should remain reserved"
         );
-        assert_eq!(written.load(Ordering::Relaxed), 10);
+        assert_eq!(reservation.written.load(Ordering::Relaxed), 10);
 
         // Failed write: the full reservation must be released, and nothing may be
         // counted as written.
         let quota = DiskQuota::new(100);
-        let written = Arc::new(AtomicU64::new(0));
+        let reservation = Arc::new(Reservation {
+            quota: quota.clone(),
+            written: AtomicU64::new(0),
+        });
         let mut writer = SpillWriter {
             inner: Box::new(ControlledWriter {
                 outcome: Poll::Ready(Err(io::Error::other("boom"))),
             }),
             quota: Some(quota.clone()),
-            written: Some(written.clone()),
+            reservation: Some(reservation.clone()),
             finished: Arc::new(AtomicBool::new(false)),
         };
         writer.write(&[0u8; 40]).await.unwrap_err();
-        assert_eq!(written.load(Ordering::Relaxed), 0);
+        assert_eq!(reservation.written.load(Ordering::Relaxed), 0);
         assert_eq!(
             *quota.used.lock().unwrap(),
             0,
@@ -789,6 +877,29 @@ mod tests {
         // point that task could not run before the read.
         tokio::task::yield_now().await;
         assert_eq!(reader.get_all().await.unwrap().as_ref(), data);
+    }
+
+    #[tokio::test]
+    async fn test_a_retained_reader_stays_charged_to_the_cap() {
+        let quota = DiskQuota::new(50);
+        let store = memory_only_store(Some(quota.clone()));
+
+        let (writer, spill) = store.new_spill().await.unwrap();
+        finish_writer(writer, &[1u8; 40]).await.unwrap();
+        let retained = spill.reader().await.unwrap();
+        drop(spill);
+
+        // The reader still holds the bytes, so releasing here would let the next
+        // spill over a cap the process is already using up.
+        assert_eq!(retained.get_all().await.unwrap().len(), 40);
+        assert_eq!(*quota.used.lock().unwrap(), 40);
+
+        let (writer, _spill) = store.new_spill().await.unwrap();
+        let err = finish_writer(writer, &[2u8; 40]).await.unwrap_err();
+        assert!(matches!(err, Error::DiskCapExceeded { .. }), "{err:?}");
+
+        drop(retained);
+        assert_eq!(*quota.used.lock().unwrap(), 0);
     }
 
     /// One failing attempt must not decide where later spills go. Uses a process


### PR DESCRIPTION
## What this changes

`LocalSpillStore` creates its scratch directory on the first `new_spill` call rather than at construction, and a call that cannot create it keeps that one spill in memory instead, retrying the directory on the next call. `new` and `with_cap` keep their `Result` signatures and now do no I/O, and `Default` no longer panics. Closes #8948.

## Why

`Session::new` builds `LocalSpillStore::default()` (`rust/lance/src/session.rs:130` and `:150`), and that `Default` impl was `Self::new().expect("failed to create temp directory for LocalSpillStore")`. Opening a dataset therefore created a temp directory whether or not anything would ever spill, and on a host where that fails the process aborted from inside a `Default` impl, where no caller can handle it. On Windows CI runners it surfaces as `Access is denied` in tests that have nothing to do with spilling.

This follows the direction wjones127 gave on the issue: detect the failure on first use, warn, and fall back to an in-memory mode.

## The fallback, and why it is per spill rather than per store

Each fallback spill gets its own `ObjectStore::memory()`. That backend holds exactly one object, so the bytes go with the last `Arc` to it: `MemorySpill::drop` deletes nothing and spawns nothing, and a reader that still holds its own reference keeps the bytes readable after the handle is gone, which is the same shape as unlinking a file someone still has open. Residency is bounded by the last live handle rather than by the store's lifetime.

Only success is cached in the `OnceLock`, so a failure decides where one spill goes, not where every later spill goes: `/tmp` that is briefly full, or an `EMFILE`, does not pin the process to memory. The warning fires once per store, with a `debug!` on each later failure.

Reclamation on that arm cannot stat a file, so the reservation is a `Reservation` holding the quota and a counter of the bytes the inner writer accepted, released by its own `Drop`. The writer, the `Spill` and every reader it hands out each hold an `Arc` of it, so the bytes leave the budget with the last owner of the backing rather than with the handle: a reader retained past its `Spill` keeps them charged, which is what makes `with_cap` an actual ceiling rather than a counter that a retained reader can walk away from. Handing a reader its share needs a wrapper, `ChargedReader`, which delegates every `Reader` method and exists only to own that `Arc`. Three of those methods hand out something that owns the backing and outlives the reader, so each carries its own share: `get_range` returns a `'static` future, and `get_stream` and `get_range_stream` return `'static` streams.

## What this costs, since the fallback is not free

An uncapped store trades a hard failure for memory pressure: all three `Session` constructors build the uncapped store, so on a host with no usable temp directory a large spill goes to RAM with one warning as the signal. With `with_cap` the budget does bound it, but it then bounds memory rather than disk while the error is still `Error::DiskCapExceeded`, and at commit time the writer's part buffer and the assembled object coexist, so the real peak runs to roughly twice the figure the counter releases.

Also worth naming: on the disk backing the release is best effort. A handle dropped before its writer has been shut down returns only what the stat can see at that moment, which is nothing, because the file is staged in a `NamedTempFile` and only renamed into place at shutdown. That predates this change; the module doc now says so. The in-memory arm does not have that hole, since its release waits for the last owner.

## Test plan

Seven new tests in `rust/lance-io/src/spill.rs`. `temp_dir_factory` is a field, so the failing path is drivable without a host whose temp directory is actually unusable.

- `test_construction_resolves_no_backing`: `new`, `default` and `with_cap` all leave the `OnceLock` empty
- `test_first_spill_resolves_the_disk_backing`
- `test_memory_backing_round_trips`
- `test_memory_backing_rejects_a_reader_before_shutdown`, asserting the `InvalidInput` variant
- `test_memory_backing_releases_the_quota_on_drop`, with a second spill alive across the drop so an over-release shows up
- `test_a_reader_outlives_the_memory_spill_handle`
- `test_a_retained_reader_stays_charged_to_the_cap`, which is a reproducer from the review on this pull request
- `test_a_detached_reader_product_stays_charged_to_the_cap`, three cases, one per API that hands out a detached product, also from the review
- `test_a_transient_temp_dir_failure_is_retried`

Eight mutations, each run: restoring eager resolution in `new()` fails `test_construction_resolves_no_backing`; deleting the quota release fails the quota test; releasing `u64::MAX` instead of the counter also fails it, at `left: 0 right: 10`; reintroducing the spawned delete in `Drop` fails `test_a_reader_outlives_the_memory_spill_handle`; caching the failure again fails `test_a_transient_temp_dir_failure_is_retried`; putting the release back on `MemorySpill::drop` fails `test_a_retained_reader_stays_charged_to_the_cap` at `left: 0 right: 40`; and dropping the share from `get_range`'s future or from `get_stream`'s stream fails only that API's case. Counting `buf.len()` instead of the accepted bytes fails `test_spill_writer_releases_unaccepted_bytes`, which is why that test now passes a reservation in.

`cargo test --profile ci -p lance-io --lib` is 315 passed, and `cargo test --profile ci -p lance --lib -- session` is 22 passed. `cargo fmt --all -- --check` and `cargo clippy --profile ci -p lance-io --all-targets -- -D warnings` are clean.

## Not covered

Nothing here reproduces the Windows temp-directory failure itself; the fallback is reached by handing the factory an error. The capped in-memory arm is not exercised with a payload large enough to cross several internal part buffers, and the `OnceLock` race is reasoned about rather than stress-tested.
