### PR TITLE
fix(java): remove duplicate IntoJava impl for &BasePath

### DIFF
--- a/java/lance-jni/src/transaction.rs
+++ b/java/lance-jni/src/transaction.rs
@@ -25,7 +25,7 @@ use lance::io::ObjectStoreParams;
 use lance::io::commit::namespace_manifest::LanceNamespaceExternalManifestStore;
 use lance::table::format::key_existence::{FilterType, KeyExistenceFilter};
 use lance::table::format::overlay::{DataOverlayFile, OverlayCoverage};
-use lance::table::format::{BasePath, DataFile, Fragment, IndexFile, IndexMetadata};
+use lance::table::format::{DataFile, Fragment, IndexFile, IndexMetadata};
 use lance_core::datatypes::Field;
 use lance_core::datatypes::Schema as LanceSchema;
 use lance_file::version::{LanceFileVersion, V2_FORMAT_2_0, V2_FORMAT_2_1, V2_FORMAT_2_2};
@@ -120,34 +120,6 @@ fn export_unsigned_longs<'a>(
         .map(|(index, value)| u64_to_jlong(&format!("{field}[{index}]"), *value).map(JLance))
         .collect::<Result<Vec<_>>>()?;
     export_vec(env, &values)
-}
-
-impl IntoJava for &BasePath {
-    fn into_java<'a>(self, env: &mut JNIEnv<'a>) -> Result<JObject<'a>> {
-        let name = match &self.name {
-            Some(name) => env.new_string(name)?.into(),
-            None => JObject::null(),
-        };
-        let java_name = env
-            .call_static_method(
-                "java/util/Optional",
-                "ofNullable",
-                "(Ljava/lang/Object;)Ljava/util/Optional;",
-                &[JValue::Object(&name)],
-            )?
-            .l()?;
-        let path = env.new_string(&self.path)?;
-        Ok(env.new_object(
-            "org/lance/BasePath",
-            "(ILjava/util/Optional;Ljava/lang/String;Z)V",
-            &[
-                JValue::Int(u32_to_jint("basePath.id", self.id)?),
-                JValue::Object(&java_name),
-                JValue::Object(&path),
-                JValue::Bool(self.is_dataset_root as u8),
-            ],
-        )?)
-    }
 }
 
 impl IntoJava for &IndexFile {


### PR DESCRIPTION
## Summary

The Java JNI build on `main` is broken since #8925 ([failing run](https://github.com/lance-format/lance/actions/runs/33884542905/job/101061005145)):

```
error[E0119]: conflicting implementations of trait `IntoJava` for type `&lance_table::format::BasePath`
   --> src/transaction.rs:125:1
    |
125 | impl IntoJava for &BasePath {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ conflicting implementation for `&lance_table::format::BasePath`
    |
::: src/blocking_dataset.rs:89:1
 89 | impl IntoJava for &BasePath {
    | --------------------------- first implementation here
```

#8925 added an `impl IntoJava for &BasePath` in `transaction.rs` that duplicates the pre-existing, behaviorally identical impl in `blocking_dataset.rs`. This removes the duplicate; the `Overwrite.initial_bases` export in `transaction.rs` resolves to the impl in `blocking_dataset.rs`, and the now-unused `BasePath` import is dropped.

## Test Plan

- `cargo check --manifest-path java/lance-jni/Cargo.toml` — passes (previously E0119)
- `cargo clippy --tests --manifest-path java/lance-jni/Cargo.toml` — clean
- `cargo test --manifest-path java/lance-jni/Cargo.toml --lib` — 22 passed (incl. `transaction::tests::test_checked_transaction_integer_conversions`, which covers the `basePath.id` overflow conversion)
- Reintroducing a duplicate impl is caught by the compiler itself (E0119), so no new test is needed for the removal