### PR TITLE
style(protos): use /* ... */ for multi-line comments

### DIFF
--- a/.github/workflows/ci-scripts.yml
+++ b/.github/workflows/ci-scripts.yml
@@ -16,6 +16,8 @@ on:
       - ci/format_vote_gate.py
       - ci/test_format_vote_gate.py
       - ci/test_labeler_area.py
+      - ci/check_proto_comments.py
+      - ci/test_check_proto_comments.py
       - .github/labeler-area.yml
       - .github/workflows/format-vote-gate.yml
       - .github/workflows/ci-scripts.yml
@@ -37,4 +39,4 @@ jobs:
       - name: Install test dependencies
         run: pip install pytest PyYAML
       - name: Run tests
-        run: pytest ci/test_format_vote_gate.py ci/test_labeler_area.py
+        run: pytest ci/test_format_vote_gate.py ci/test_labeler_area.py ci/test_check_proto_comments.py

--- a/.github/workflows/proto-lint.yml
+++ b/.github/workflows/proto-lint.yml
@@ -1,0 +1,30 @@
+name: Protobuf lint
+on:
+  push:
+    branches:
+      - main
+      - release/**
+  pull_request:
+    branches:
+      - main
+      - release/**
+    paths:
+      - "**/*.proto"
+      - ci/check_proto_comments.py
+      - .github/workflows/proto-lint.yml
+permissions:
+  contents: read
+
+jobs:
+  comment-style:
+    name: Multi-line comment style
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: "3.12"
+      - name: Check .proto comment style
+        run: python ci/check_proto_comments.py

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,3 +28,9 @@ repos:
         language: system
         files: '(^|/)Cargo\.(toml|lock)$'
         pass_filenames: false
+
+      - id: proto-comment-style
+        name: Multi-line .proto comments use /* ... */
+        entry: python3 ci/check_proto_comments.py --fix
+        language: system
+        files: '\.proto$'

--- a/ci/check_proto_comments.py
+++ b/ci/check_proto_comments.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+"""Require `/* ... */` for multi-line comments in .proto files.
+
+Multi-line `//` runs cannot be folded by editors, which makes the long design
+notes in these schemas hard to skim. The `/* text` + ` * text` layout keeps every
+content column exactly where the `//` form had it, so protoc extracts identical
+leading_comments and the generated Rust, Python and Java doc comments do not
+change.
+
+The SPDX header is exempt; license-header-check requires it verbatim.
+"""
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+DEFAULT_ROOTS = (".",)
+SKIP_DIRS = {".git", ".venv", "node_modules", "target"}
+
+COMMENT_LINE = re.compile(r"^(\s*)(///?)(.*)$")
+SPDX_LINE = re.compile(r"^//\s*SPDX-")
+
+
+def violations(lines):
+    """Yield (start, indent, contents) for each multi-line `//` comment run."""
+    i = 0
+    while i < len(lines) and SPDX_LINE.match(lines[i]):
+        i += 1
+    while i < len(lines):
+        match = COMMENT_LINE.match(lines[i])
+        if match is None:
+            i += 1
+            continue
+        indent = match.group(1)
+        contents = []
+        j = i
+        while j < len(lines):
+            line = COMMENT_LINE.match(lines[j])
+            if line is None or line.group(1) != indent:
+                break
+            contents.append(line.group(3))
+            j += 1
+        if len(contents) > 1:
+            yield i, indent, contents
+        i = j
+
+
+def rewrite(text):
+    lines = text.split("\n")
+    out = []
+    i = 0
+    for start, indent, contents in violations(lines):
+        out.extend(lines[i:start])
+        out.append((indent + "/*" + contents[0]).rstrip())
+        out.extend((indent + " *" + content).rstrip() for content in contents[1:])
+        out.append(indent + " */")
+        i = start + len(contents)
+    out.extend(lines[i:])
+    return "\n".join(out)
+
+
+def collect(paths):
+    files = []
+    for path in paths:
+        path = Path(path)
+        if not path.is_dir():
+            files.append(path)
+            continue
+        found = path.rglob("*.proto")
+        files.extend(sorted(p for p in found if SKIP_DIRS.isdisjoint(p.parts)))
+    return files
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "paths", nargs="*", default=DEFAULT_ROOTS, help="files or directories to check"
+    )
+    parser.add_argument(
+        "--fix", action="store_true", help="rewrite offending comments in place"
+    )
+    args = parser.parse_args(argv)
+
+    failed = False
+    for file in collect(args.paths):
+        original = file.read_text()
+        offenders = list(violations(original.split("\n")))
+        if not offenders:
+            continue
+        failed = True
+        if args.fix:
+            file.write_text(rewrite(original))
+            print(f"{file}: rewrote {len(offenders)} multi-line comment(s)")
+        else:
+            for start, _, contents in offenders:
+                print(
+                    f"{file}:{start + 1}: multi-line comment must use /* ... */ ({len(contents)} lines)"
+                )
+
+    if failed and not args.fix:
+        print(
+            "\nRun `python ci/check_proto_comments.py --fix` to convert them.",
+            file=sys.stderr,
+        )
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/ci/test_check_proto_comments.py
+++ b/ci/test_check_proto_comments.py
@@ -1,0 +1,82 @@
+"""Unit tests for the .proto multi-line comment style check.
+
+Run with: pytest ci/test_check_proto_comments.py
+"""
+
+import pytest
+
+from check_proto_comments import rewrite
+
+HEADER = "// SPDX-License-Identifier: Apache-2.0\n// SPDX-FileCopyrightText: Copyright The Lance Authors\n"
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        pytest.param(HEADER, id="license_header"),
+        pytest.param("// A single line comment.\nmessage M {}\n", id="single_line"),
+        pytest.param("/// A single doc comment.\nmessage M {}\n", id="single_doc_line"),
+        pytest.param(
+            "message M {\n  int32 a = 1; // Trailing.\n  int32 b = 2; // Also trailing.\n}\n",
+            id="trailing",
+        ),
+        pytest.param(
+            "/* Already a block\n * comment.\n */\nmessage M {}\n", id="already_block"
+        ),
+    ],
+)
+def test_leaves_compliant_comments_alone(source):
+    assert rewrite(source) == source
+
+
+def test_rewrites_multi_line_run_as_block():
+    source = "// First line.\n// Second line.\nmessage M {}\n"
+    assert rewrite(source) == "/* First line.\n * Second line.\n */\nmessage M {}\n"
+
+
+def test_preserves_content_columns_and_indent():
+    source = "message M {\n  // Offsets are laid out as:\n  //   i == 0: 0\n  //   i >  0: prev\n  int32 a = 1;\n}\n"
+    assert rewrite(source) == (
+        "message M {\n  /* Offsets are laid out as:\n   *   i == 0: 0\n   *   i >  0: prev\n   */\n  int32 a = 1;\n}\n"
+    )
+
+
+def test_blank_comment_lines_carry_no_trailing_whitespace():
+    source = "// First paragraph.\n//\n// Second paragraph.\nmessage M {}\n"
+    assert (
+        rewrite(source)
+        == "/* First paragraph.\n *\n * Second paragraph.\n */\nmessage M {}\n"
+    )
+
+
+def test_rewrites_doc_comment_run():
+    source = "/// First line.\n/// Second line.\nmessage M {}\n"
+    assert rewrite(source) == "/* First line.\n * Second line.\n */\nmessage M {}\n"
+
+
+def test_splits_runs_at_differing_indent():
+    source = "// Outer.\n// Outer continued.\nmessage M {\n  // Inner.\n  // Inner continued.\n  int32 a = 1;\n}\n"
+    assert rewrite(source) == (
+        "/* Outer.\n * Outer continued.\n */\nmessage M {\n  /* Inner.\n   * Inner continued.\n   */\n  int32 a = 1;\n}\n"
+    )
+
+
+def test_keeps_license_header_when_file_starts_with_it():
+    source = HEADER + "\n// Doc line one.\n// Doc line two.\nmessage M {}\n"
+    assert (
+        rewrite(source)
+        == HEADER + "\n/* Doc line one.\n * Doc line two.\n */\nmessage M {}\n"
+    )
+
+
+def test_is_idempotent():
+    once = rewrite("// First line.\n// Second line.\nmessage M {}\n")
+    assert rewrite(once) == once
+
+
+def test_converts_a_comment_run_that_abuts_the_license_header():
+    source = HEADER + "// Doc line one.\n// Doc line two.\nmessage M {}\n"
+    assert (
+        rewrite(source)
+        == HEADER + "/* Doc line one.\n * Doc line two.\n */\nmessage M {}\n"
+    )

--- a/protos/AGENTS.md
+++ b/protos/AGENTS.md
@@ -24,3 +24,4 @@ Also see [root AGENTS.md](../AGENTS.md) for cross-language standards.
 
 - Document the semantic meaning of both present and absent states for `optional` fields — explain when each case applies.
 - Use precise domain terminology in field descriptions — avoid ambiguous abbreviations or terms that collide with domain concepts.
+- Write multi-line comments as `/* text` / ` * text` / ` */` blocks so editors can fold them; keep single-line comments as `//`. The `ci/check_proto_comments.py` check (pre-commit hook and the `Protobuf lint` workflow) enforces this and can rewrite offenders with `--fix`.

--- a/protos/ann.proto
+++ b/protos/ann.proto
@@ -9,17 +9,19 @@ import "table_identifier.proto";
 import "table.proto";
 import "index.proto";
 
-// Query-time approximation mode for vector search.
-//
-// This currently only affects RQ-quantized vector indexes, such as IVF_RQ.
-// Other index types ignore this setting.
+/* Query-time approximation mode for vector search.
+ *
+ * This currently only affects RQ-quantized vector indexes, such as IVF_RQ.
+ * Other index types ignore this setting.
+ */
 enum VectorApproxMode {
   // Use all RQ bits for query-time scoring with u8-quantized lookup tables.
   Normal = 0;
   // Use only one RQ bit for query-time scoring, even for multi-bit indexes.
   Fast = 1;
-  // Use all RQ bits for query-time scoring with u16-quantized lookup tables
-  // to reduce estimator quantization error.
+  /* Use all RQ bits for query-time scoring with u16-quantized lookup tables
+   * to reduce estimator quantization error.
+   */
   Accurate = 2;
 }
 
@@ -40,17 +42,19 @@ message VectorQueryProto {
   bool use_index = 11;
   optional float dist_q_c = 12;
   optional int32 query_parallelism = 13;
-  // Query-time approximation mode. Currently only affects RQ-quantized vector
-  // indexes, such as IVF_RQ. Other index types ignore this setting.
+  /* Query-time approximation mode. Currently only affects RQ-quantized vector
+   * indexes, such as IVF_RQ. Other index types ignore this setting.
+   */
   VectorApproxMode approx_mode = 14;
 }
 
-// Serializable form of ANNIvfSubIndexExec — the IVF sub-index search node.
-//
-// The prefilter child ExecutionPlan is serialized by DataFusion's codec
-// automatically via children() / with_new_children(). The prefilter_type
-// field tells the decoder which PreFilterSource variant to use when
-// reconstructing from the deserialized child inputs.
+/* Serializable form of ANNIvfSubIndexExec — the IVF sub-index search node.
+ *
+ * The prefilter child ExecutionPlan is serialized by DataFusion's codec
+ * automatically via children() / with_new_children(). The prefilter_type
+ * field tells the decoder which PreFilterSource variant to use when
+ * reconstructing from the deserialized child inputs.
+ */
 message ANNIvfSubIndexExecProto {
   enum PreFilterType {
     NONE = 0;

--- a/protos/encodings_v2_0.proto
+++ b/protos/encodings_v2_0.proto
@@ -7,38 +7,40 @@ package lance.encodings;
 
 import "google/protobuf/empty.proto";
 
-// This file contains a specification for encodings that can be used
-// to store and load Arrow data into a Lance file for the 2.0 format.  It
-// has been superseded by encodings21.proto which is used for the 2.1 format.
-//
-// # Types
-//
-// This file assumes the user wants to load data into Arrow arrays and
-// explains how to map Arrow arrays into Lance files.  Encodings are divided
-// into "array encoding" (which maps to an Arrow array and may contain multiple
-// buffers) and "buffer encoding" (which encodes a single buffer of data).
-//
-// # Encoding Tree
-//
-// Most encodings are layered on top of each other.  These form a tree of
-// encodings with a single root node.  To encode an array you will typically
-// start with the root node and then take the output from that root encoding
-// and feed it into child encodings.  The decoding process works in reverse.
-//
-// # Multi-column Encodings
-//
-// Some Arrow arrays will map to more than one column of Lance data.  For
-// example, struct arrays and list arrays.  This file only contains encodings
-// for a single column.  However, it does describe how multi-column arrays can
-// be encoded.
+/* This file contains a specification for encodings that can be used
+ * to store and load Arrow data into a Lance file for the 2.0 format.  It
+ * has been superseded by encodings21.proto which is used for the 2.1 format.
+ *
+ * # Types
+ *
+ * This file assumes the user wants to load data into Arrow arrays and
+ * explains how to map Arrow arrays into Lance files.  Encodings are divided
+ * into "array encoding" (which maps to an Arrow array and may contain multiple
+ * buffers) and "buffer encoding" (which encodes a single buffer of data).
+ *
+ * # Encoding Tree
+ *
+ * Most encodings are layered on top of each other.  These form a tree of
+ * encodings with a single root node.  To encode an array you will typically
+ * start with the root node and then take the output from that root encoding
+ * and feed it into child encodings.  The decoding process works in reverse.
+ *
+ * # Multi-column Encodings
+ *
+ * Some Arrow arrays will map to more than one column of Lance data.  For
+ * example, struct arrays and list arrays.  This file only contains encodings
+ * for a single column.  However, it does describe how multi-column arrays can
+ * be encoded.
+ */
 
-// A pointer to a buffer in a Lance file
-//
-// A writer can place a buffer in three different locations.  The buffer
-// can go in the data page, in the column metadata, or in the file metadata.
-// The writer is free to choose whatever is most appropriate (for example, a dictionary
-// that is shared across all pages in a column will probably go in the column
-// metadata).  This specification does not dictate where the buffer should go.
+/* A pointer to a buffer in a Lance file
+ *
+ * A writer can place a buffer in three different locations.  The buffer
+ * can go in the data page, in the column metadata, or in the file metadata.
+ * The writer is free to choose whatever is most appropriate (for example, a dictionary
+ * that is shared across all pages in a column will probably go in the column
+ * metadata).  This specification does not dictate where the buffer should go.
+ */
 message Buffer {
     // The index of the buffer in the collection of buffers
     uint32 buffer_index = 1;
@@ -54,9 +56,10 @@ message Buffer {
     BufferType buffer_type = 2;
 }
 
-// An encoding that adds nullability to another array encoding
-//
-// This can wrap any array encoding and add nullability information
+/* An encoding that adds nullability to another array encoding
+ *
+ * This can wrap any array encoding and add nullability information
+ */
 message Nullable {
   message NoNull {
     ArrayEncoding values = 1;
@@ -78,74 +81,77 @@ message Nullable {
 
 // An array encoding for variable-length list fields
 message List {
-    // An array containing the offsets into an items array.
-    //
-    // This array will have num_rows items and will never
-    // have nulls.
-    //
-    // If the list at index i is not null then offsets[i] will
-    // contain `base + len(list)` where `base` is defined as:
-    //   i == 0: 0
-    //   i >  0: (offsets[i-1] % null_offset_adjustment)
-    //
-    // To help understand we can consider the following example list:
-    // [ [A, B], null, [], [C, D, E] ]
-    //
-    // The offsets will be [2, ?, 2, 5]
-    //
-    // If the incoming list at index i IS null then offsets[i] will
-    // contain `base + len(list) + null_offset_adjustment` where `base`
-    // is defined the same as above.
-    //
-    // To complete the above example let's assume that `null_offset_adjustment`
-    // is 7.  Then the offsets will be [2, 9, 2, 5]
-    //
-    // If there are no nulls then the offsets we write here are exactly the
-    // same as the offsets in an Arrow list array (except we omit the leading
-    // 0 which is redundant)
-    //
-    // The reason we do this is so that reading a single list at index i only
-    // requires us to load the indices at i and i-1.
-    //
-    // If the offset at index i is greater than `null_offset_adjustment``
-    // then the list at index i is null.
-    //
-    // Otherwise the length of the list is `offsets[i] - base` where
-    // base is defined the same as above.
-    //
-    // Let's consider our example offsets: [2, 9, 2, 5]
-    //
-    // We can take any range of lists and determine how many list items are
-    // referenced by the sublist.
-    //
-    // 0..3: [_, 5] -> items 0..5 (base = 0* and end is 5)
-    // 0..2: [_, 2] -> items 0..2 (base = 0* and end is 2)
-    // 0..1: [_, 9] -> items 0..2 (base = 0* and end is 9 % 7)
-    // 1..3: [2, 5] -> items 2..5 (base = 2 and end is 5)
-    // 1..2: [2, 2] -> items 2..2 (base = 2 and end is 2)
-    // 2..3: [9, 5] -> items 2..5 (base = 9 % 7 and end is 5)
-    //
-    // * When the start of our range is the 0th item the base is always 0 and we only
-    //   need to load a single index from disk to determine the range.
-    //
-    // The data type of the offsets array is flexible and does not need
-    // to match the data type of the destination array.  Please note that the offsets
-    // array is very likely to be efficiently encoded by bit packing deltas.
+    /* An array containing the offsets into an items array.
+     *
+     * This array will have num_rows items and will never
+     * have nulls.
+     *
+     * If the list at index i is not null then offsets[i] will
+     * contain `base + len(list)` where `base` is defined as:
+     *   i == 0: 0
+     *   i >  0: (offsets[i-1] % null_offset_adjustment)
+     *
+     * To help understand we can consider the following example list:
+     * [ [A, B], null, [], [C, D, E] ]
+     *
+     * The offsets will be [2, ?, 2, 5]
+     *
+     * If the incoming list at index i IS null then offsets[i] will
+     * contain `base + len(list) + null_offset_adjustment` where `base`
+     * is defined the same as above.
+     *
+     * To complete the above example let's assume that `null_offset_adjustment`
+     * is 7.  Then the offsets will be [2, 9, 2, 5]
+     *
+     * If there are no nulls then the offsets we write here are exactly the
+     * same as the offsets in an Arrow list array (except we omit the leading
+     * 0 which is redundant)
+     *
+     * The reason we do this is so that reading a single list at index i only
+     * requires us to load the indices at i and i-1.
+     *
+     * If the offset at index i is greater than `null_offset_adjustment``
+     * then the list at index i is null.
+     *
+     * Otherwise the length of the list is `offsets[i] - base` where
+     * base is defined the same as above.
+     *
+     * Let's consider our example offsets: [2, 9, 2, 5]
+     *
+     * We can take any range of lists and determine how many list items are
+     * referenced by the sublist.
+     *
+     * 0..3: [_, 5] -> items 0..5 (base = 0* and end is 5)
+     * 0..2: [_, 2] -> items 0..2 (base = 0* and end is 2)
+     * 0..1: [_, 9] -> items 0..2 (base = 0* and end is 9 % 7)
+     * 1..3: [2, 5] -> items 2..5 (base = 2 and end is 5)
+     * 1..2: [2, 2] -> items 2..2 (base = 2 and end is 2)
+     * 2..3: [9, 5] -> items 2..5 (base = 9 % 7 and end is 5)
+     *
+     * * When the start of our range is the 0th item the base is always 0 and we only
+     *   need to load a single index from disk to determine the range.
+     *
+     * The data type of the offsets array is flexible and does not need
+     * to match the data type of the destination array.  Please note that the offsets
+     * array is very likely to be efficiently encoded by bit packing deltas.
+     */
     ArrayEncoding offsets = 1;
-    // If a list is null then we add this value to the offset
-    //
-    // This value must be greater than the length of the items so that
-    // (offset + null_offset_adjustment) is never used by a non-null list.
-    //
-    // Note that this value cannot be equal to the length of the items
-    // because then a page with a single list would store [ X ] and we
-    // couldn't know if that is a null list or a list with X items.
-    //
-    // Therefore, the best choice for this value is 1 + # of items.
-    // Choosing this will maximize the bit packing that we can apply to the offsets.
+    /* If a list is null then we add this value to the offset
+     *
+     * This value must be greater than the length of the items so that
+     * (offset + null_offset_adjustment) is never used by a non-null list.
+     *
+     * Note that this value cannot be equal to the length of the items
+     * because then a page with a single list would store [ X ] and we
+     * couldn't know if that is a null list or a list with X items.
+     *
+     * Therefore, the best choice for this value is 1 + # of items.
+     * Choosing this will maximize the bit packing that we can apply to the offsets.
+     */
     uint64 null_offset_adjustment = 2;
-    // How many items are referenced by these offsets.  This is needed in
-    // order to determine which items pages map to this offsets page.
+    /* How many items are referenced by these offsets.  This is needed in
+     * order to determine which items pages map to this offsets page.
+     */
     uint64 num_items = 3;
 }
 
@@ -166,16 +172,18 @@ message Compression {
 
 // Fixed width items placed contiguously in a buffer
 message Flat {
-  // the number of bits per value, must be greater than 0, does
-  // not need to be a multiple of 8
+  /* the number of bits per value, must be greater than 0, does
+   * not need to be a multiple of 8
+   */
   uint64 bits_per_value = 1;
   // the buffer of values
   Buffer buffer = 2;
-  // The Compression message can specify the compression scheme (e.g. zstd) and any
-  // other information that is needed for decompression.
-  //
-  // If this array is compressed then the bits_per_value refers to the uncompressed
-  // data.
+  /* The Compression message can specify the compression scheme (e.g. zstd) and any
+   * other information that is needed for decompression.
+   *
+   * If this array is compressed then the bits_per_value refers to the uncompressed
+   * data.
+   */
   Compression compression = 3;
 }
 
@@ -226,11 +234,12 @@ message OutOfLineBitpacking {
   uint64 compressed_bits_per_value = 3;
 }
 
-// An array encoding for shredded structs that will never be null
-//
-// There is no actual data in this column.
-//
-// TODO: Struct validity bitmaps will be placed here.
+/* An array encoding for shredded structs that will never be null
+ *
+ * There is no actual data in this column.
+ *
+ * TODO: Struct validity bitmaps will be placed here.
+ */
 message SimpleStruct {}
 
 // An array encoding for binary fields
@@ -322,16 +331,18 @@ message ArrayEncoding {
     }
 }
 
-// Wraps a column with a zone map index that can be used
-// to apply pushdown filters
+/* Wraps a column with a zone map index that can be used
+ * to apply pushdown filters
+ */
 message ZoneIndex {
   uint32 rows_per_zone = 1;
   Buffer zone_map_buffer = 2;
   ColumnEncoding inner = 3;
 }
 
-// Marks a column as blob data.  It will contain a packed struct
-// with fields position and size (u64)
+/* Marks a column as blob data.  It will contain a packed struct
+ * with fields position and size (u64)
+ */
 message Blob {
   ColumnEncoding inner = 1;
 }

--- a/protos/encodings_v2_1.proto
+++ b/protos/encodings_v2_1.proto
@@ -5,49 +5,52 @@ syntax = "proto3";
 
 package lance.encodings21;
 
-// This file contains a specification for encodings that can be used
-// to store and load Arrow data into a Lance file for the 2.1 format.
-//
-// # Types
-//
-// This file assumes the user wants to load data into Arrow arrays and
-// explains how to map Arrow arrays into Lance files.  Encodings are divided
-// into "structural encodings" (which are used to encode the structure of the
-// data such as any list or struct layers) and "compressive encodings" (which
-// are used to compress the actual data values).
-//
-// # Standardized Interpretation of Counting Terms
-//
-// When working with 2.1 encodings we have a number of different "counting terms" and it can be
-// difficult to understand what we mean when we are talking about a "number of values".  Here is
-// a standard interpretation of these terms:
-//
-// To understand these definitions consider a data type FIXED_SIZE_LIST<LIST<INT32>>.
-//
-// A "value" is an abstract term when we aren't being specific.
-//
-// - num_rows: This is the highest level counting term.  A single row includes everything in the
-//             fixed size list.  This is what the user asks for when they asks for a range of rows.
-// - num_elements: The number of elements is the number of rows multiplied by the dimension of any
-//             fixed size list wrappers.  This is what you get when you flatten the FSL layer and
-//             is the starting point for structural encoding.  Note that an element can be a list
-//             value or a single primitive value.
-// - num_items: The number of items is the number of values in the repetition and definition vectors
-//             after everything has been flattened.
-// - num_visible_items: The number of visible items is the number of items after invisible items
-//             have been removed.  Invisible items are rep/def levels that don't correspond to an
-//             actual value.
+/* This file contains a specification for encodings that can be used
+ * to store and load Arrow data into a Lance file for the 2.1 format.
+ *
+ * # Types
+ *
+ * This file assumes the user wants to load data into Arrow arrays and
+ * explains how to map Arrow arrays into Lance files.  Encodings are divided
+ * into "structural encodings" (which are used to encode the structure of the
+ * data such as any list or struct layers) and "compressive encodings" (which
+ * are used to compress the actual data values).
+ *
+ * # Standardized Interpretation of Counting Terms
+ *
+ * When working with 2.1 encodings we have a number of different "counting terms" and it can be
+ * difficult to understand what we mean when we are talking about a "number of values".  Here is
+ * a standard interpretation of these terms:
+ *
+ * To understand these definitions consider a data type FIXED_SIZE_LIST<LIST<INT32>>.
+ *
+ * A "value" is an abstract term when we aren't being specific.
+ *
+ * - num_rows: This is the highest level counting term.  A single row includes everything in the
+ *             fixed size list.  This is what the user asks for when they asks for a range of rows.
+ * - num_elements: The number of elements is the number of rows multiplied by the dimension of any
+ *             fixed size list wrappers.  This is what you get when you flatten the FSL layer and
+ *             is the starting point for structural encoding.  Note that an element can be a list
+ *             value or a single primitive value.
+ * - num_items: The number of items is the number of values in the repetition and definition vectors
+ *             after everything has been flattened.
+ * - num_visible_items: The number of visible items is the number of items after invisible items
+ *             have been removed.  Invisible items are rep/def levels that don't correspond to an
+ *             actual value.
+ */
 
 
-// # Structural Encodings
-//
-// The following message are used to describe the structural encoding of the
-// data.  In this document, we refer to these structural encodings as layouts.
+/* # Structural Encodings
+ *
+ * The following message are used to describe the structural encoding of the
+ * data.  In this document, we refer to these structural encodings as layouts.
+ */
 
-// Repetition and definition levels are described in more detail elsewhere.  As we peel through
-// the structure of an array we will encounter layers of struct and list.  Each of these layers
-// potentially adds a new level to the repetition and definition levels.  This message describes
-// the meaning of each layer.
+/* Repetition and definition levels are described in more detail elsewhere.  As we peel through
+ * the structure of an array we will encounter layers of struct and list.  Each of these layers
+ * potentially adds a new level to the repetition and definition levels.  This message describes
+ * the meaning of each layer.
+ */
 enum RepDefLayer {
   // Should never be used, included for debugging purporses and general protobuf best practice
   REPDEF_UNSPECIFIED = 0;
@@ -65,72 +68,81 @@ enum RepDefLayer {
   REPDEF_NULL_AND_EMPTY_LIST = 6;
 }
 
-// A layout used for pages where the data is small
-//
-// In this case we can fit many values into a single disk sector and transposing buffers is
-// expensive.  As a result, we do not transpose the buffers but compress the data into small
-// chunks (called mini blocks) which are roughly the size of a disk sector.
-//
-// The end result is a small amount of read amplification (since we must read an entire page
-// at a time) but we have more flexibility in compression and do less work per value when
-// compressing and decompressing in bulk.
+/* A layout used for pages where the data is small
+ *
+ * In this case we can fit many values into a single disk sector and transposing buffers is
+ * expensive.  As a result, we do not transpose the buffers but compress the data into small
+ * chunks (called mini blocks) which are roughly the size of a disk sector.
+ *
+ * The end result is a small amount of read amplification (since we must read an entire page
+ * at a time) but we have more flexibility in compression and do less work per value when
+ * compressing and decompressing in bulk.
+ */
 message MiniBlockLayout {
-  // Description of the compression of repetition levels (e.g. how many bits per rep)
-  //
-  // Optional, if there is no repetition then this field is not present
+  /* Description of the compression of repetition levels (e.g. how many bits per rep)
+   *
+   * Optional, if there is no repetition then this field is not present
+   */
   CompressiveEncoding rep_compression = 1;
-  // Description of the compression of definition levels (e.g. how many bits per def)
-  //
-  // Optional, if there is no definition then this field is not present
+  /* Description of the compression of definition levels (e.g. how many bits per def)
+   *
+   * Optional, if there is no definition then this field is not present
+   */
   CompressiveEncoding def_compression = 2;
   // Description of the compression of values
   CompressiveEncoding value_compression = 3;
-  // Description of the compression of the dictionary data
-  //
-  // Optional, if there is no dictionary then this field is not present
+  /* Description of the compression of the dictionary data
+   *
+   * Optional, if there is no dictionary then this field is not present
+   */
   CompressiveEncoding dictionary = 4;
   // Number of items in the dictionary
   uint64 num_dictionary_items = 5;
   // The meaning of each repdef layer, used to interpret repdef buffers correctly
   repeated RepDefLayer layers = 6;
-  // The number of buffers in each mini-block, this is determined by the compression and does
-  // NOT include the repetition or definition buffers (the presence of these buffers can be determined
-  // by looking at the rep_compression and def_compression fields)
+  /* The number of buffers in each mini-block, this is determined by the compression and does
+   * NOT include the repetition or definition buffers (the presence of these buffers can be determined
+   * by looking at the rep_compression and def_compression fields)
+   */
   uint64 num_buffers = 7;
-  // The depth of the repetition index.
-  //
-  // If there is repetition then the depth must be at least 1.  If there are many layers
-  // of repetition then deeper repetition indices will support deeper nested random access.  For
-  // example, given 5 layers of repetition then the repetition index depth must be at least
-  // 3 to support access like `rows[50][17][3]`.
-  //
-  // We require `repetition_index_depth + 1` u64 values per mini-block to store the repetition
-  // index if the `repetition_index_depth` is greater than 0.  The +1 is because we need to store
-  // the number of "leftover items" at the end of the chunk.  Otherwise, we wouldn't have any way
-  // to know if the final item in a chunk is valid or not.
+  /* The depth of the repetition index.
+   *
+   * If there is repetition then the depth must be at least 1.  If there are many layers
+   * of repetition then deeper repetition indices will support deeper nested random access.  For
+   * example, given 5 layers of repetition then the repetition index depth must be at least
+   * 3 to support access like `rows[50][17][3]`.
+   *
+   * We require `repetition_index_depth + 1` u64 values per mini-block to store the repetition
+   * index if the `repetition_index_depth` is greater than 0.  The +1 is because we need to store
+   * the number of "leftover items" at the end of the chunk.  Otherwise, we wouldn't have any way
+   * to know if the final item in a chunk is valid or not.
+   */
   uint32 repetition_index_depth = 8;
-  // The page already records how many rows are in the page.  For mini-block we also need to know how
-  // many "items" are in the page.  A row and an item are the same thing unless the page has lists.
+  /* The page already records how many rows are in the page.  For mini-block we also need to know how
+   * many "items" are in the page.  A row and an item are the same thing unless the page has lists.
+   */
   uint64 num_items = 9;
 
   // Since Lance 2.2, miniblocks have larger chunk sizes (>= 64KB)
   bool has_large_chunk = 10;
 }
 
-// A layout used for pages where the data is large
-//
-// In this case the cost of transposing the data is relatively small (compared to the cost of writing the data)
-// and so we just zip the buffers together
+/* A layout used for pages where the data is large
+ *
+ * In this case the cost of transposing the data is relatively small (compared to the cost of writing the data)
+ * and so we just zip the buffers together
+ */
 message FullZipLayout {
   // The number of bits of repetition info (0 if there is no repetition)
   uint32 bits_rep = 1;
   // The number of bits of definition info (0 if there is no definition)
   uint32 bits_def = 2;
-  // The number of bits of value info
-  //
-  // Note: we use bits here (and not bytes) for consistency with other encodings.  However, in practice,
-  // there is never a reason to use a bits per value that is not a multiple of 8.  The complexity is not
-  // worth the small savings in space since this encoding is typically used with large values already.
+  /* The number of bits of value info
+   *
+   * Note: we use bits here (and not bytes) for consistency with other encodings.  However, in practice,
+   * there is never a reason to use a bits per value that is not a multiple of 8.  The complexity is not
+   * worth the small savings in space since this encoding is typically used with large values already.
+   */
   oneof details {
     // If this is a fixed width block then we need to have a fixed number of bits per value
     uint32 bits_per_value = 3;
@@ -147,35 +159,39 @@ message FullZipLayout {
   repeated RepDefLayer layers = 8;
 }
 
-// A layout used for sparse flat or nested pages where Arrow structure is represented directly
-// in layer-local slot domains instead of as dense repetition / definition events.
-//
-// Structural layers are ordered from outer-most to inner-most. Values remain mini-block
-// compressed and are split into independently readable chunks.
+/* A layout used for sparse flat or nested pages where Arrow structure is represented directly
+ * in layer-local slot domains instead of as dense repetition / definition events.
+ *
+ * Structural layers are ordered from outer-most to inner-most. Values remain mini-block
+ * compressed and are split into independently readable chunks.
+ */
 message SparseLayout {
   // Description of the compression of values.
   CompressiveEncoding value_compression = 1;
   // Number of value buffers in each mini-block chunk. This does not include structural buffers.
   uint64 num_buffers = 2;
-  // Number of entries in the equivalent dense repetition / definition stream. This equals
-  // num_visible_items plus one structural placeholder for every list slot without children.
-  // Null leaf slots count as visible items because they still occupy positions in Arrow's
-  // leaf value buffer. For example, a nullable primitive with 100 slots, 30 of them null,
-  // has num_items = num_visible_items = 100.
+  /* Number of entries in the equivalent dense repetition / definition stream. This equals
+   * num_visible_items plus one structural placeholder for every list slot without children.
+   * Null leaf slots count as visible items because they still occupy positions in Arrow's
+   * leaf value buffer. For example, a nullable primitive with 100 slots, 30 of them null,
+   * has num_items = num_visible_items = 100.
+   */
   uint64 num_items = 3;
   // Number of leaf value slots encoded in the value chunks, including null leaf slots.
   uint64 num_visible_items = 4;
   // If true, chunk-local value buffer sizes use u32. Otherwise they use u16.
   bool has_large_chunk = 5;
-  // Structural layers ordered from outer-most to inner-most. This may be empty for a flat,
-  // non-nullable leaf page whose scheduling domain equals num_visible_items.
+  /* Structural layers ordered from outer-most to inner-most. This may be empty for a flat,
+   * non-nullable leaf page whose scheduling domain equals num_visible_items.
+   */
   repeated SparseStructuralLayer structural_layers = 6;
 }
 
-// A domain is a layer-local integer coordinate space [0, num_slots). A slot is one
-// element in that space. The outer-most domain is the page's top-level rows; each
-// layer's child domain is the next layer's parent domain, and the terminal child
-// domain contains num_visible_items leaf value slots.
+/* A domain is a layer-local integer coordinate space [0, num_slots). A slot is one
+ * element in that space. The outer-most domain is the page's top-level rows; each
+ * layer's child domain is the next layer's parent domain, and the terminal child
+ * domain contains num_visible_items leaf value slots.
+ */
 message SparseStructuralLayer {
   // Exactly one layer kind is required.
   oneof layer {
@@ -269,31 +285,35 @@ message SparseCountSet {
   }
 }
 
-// A layout used for pages where all (visible) values are the same scalar value.
-//
-// This generalizes the prior AllNullLayout semantics for file_version >= 2.2.
-//
-// There may be buffers of repetition and definition information if required in order
-// to interpret what kind of nulls are present / which items are visible.
+/* A layout used for pages where all (visible) values are the same scalar value.
+ *
+ * This generalizes the prior AllNullLayout semantics for file_version >= 2.2.
+ *
+ * There may be buffers of repetition and definition information if required in order
+ * to interpret what kind of nulls are present / which items are visible.
+ */
 message ConstantLayout {
   // The meaning of each repdef layer, used to interpret repdef buffers correctly
   repeated RepDefLayer layers = 5;
 
-  // Inline fixed-width scalar value bytes.
-  //
-  // This MUST only be used for types where a single non-null element is represented by a single
-  // fixed-width Arrow value buffer (i.e. no offsets buffer, no child data).
-  //
-  // Constraints:
-  // - MUST be absent for an all-null page
-  // - MUST be <= 32 bytes if present
+  /* Inline fixed-width scalar value bytes.
+   *
+   * This MUST only be used for types where a single non-null element is represented by a single
+   * fixed-width Arrow value buffer (i.e. no offsets buffer, no child data).
+   *
+   * Constraints:
+   * - MUST be absent for an all-null page
+   * - MUST be <= 32 bytes if present
+   */
   optional bytes inline_value = 6;
 
-  // Optional compression algorithm used for the repetition buffer.
-  // If absent, repetition levels are stored as raw u16 values.
+  /* Optional compression algorithm used for the repetition buffer.
+   * If absent, repetition levels are stored as raw u16 values.
+   */
   CompressiveEncoding rep_compression = 7;
-  // Optional compression algorithm used for the definition buffer.
-  // If absent, definition levels are stored as raw u16 values.
+  /* Optional compression algorithm used for the definition buffer.
+   * If absent, definition levels are stored as raw u16 values.
+   */
   CompressiveEncoding def_compression = 8;
   // Number of values in repetition buffer after decompression.
   uint64 num_rep_values = 9;
@@ -301,18 +321,20 @@ message ConstantLayout {
   uint64 num_def_values = 10;
 }
 
-// A layout where large binary data is encoded externally and only
-// the descriptions (position + size) are placed in the page
-//
-// Repdef information is stored in the descriptions.  A description with a size of
-// 0 and a position of 0 is an empty value.  A description with a size of 0 and a
-// non-zero position is a null value and the position is the repdef value.
+/* A layout where large binary data is encoded externally and only
+ * the descriptions (position + size) are placed in the page
+ *
+ * Repdef information is stored in the descriptions.  A description with a size of
+ * 0 and a position of 0 is an empty value.  A description with a size of 0 and a
+ * non-zero position is a null value and the position is the repdef value.
+ */
 message BlobLayout {
   // The inner layout used to store the descriptions
   PageLayout inner_layout = 1;
-  // The meaning of each repdef layer, used to interpret repdef buffers correctly
-  //
-  // The inner layout's repdef layers will always be 1 all valid item layer
+  /* The meaning of each repdef layer, used to interpret repdef buffers correctly
+   *
+   * The inner layout's repdef layers will always be 1 all valid item layer
+   */
   repeated RepDefLayer layers = 2;
 }
 
@@ -325,32 +347,34 @@ message PageLayout {
     ConstantLayout constant_layout = 2;
     // A layout used for pages where the data is large
     FullZipLayout full_zip_layout = 3;
-    // A layout where large binary data is encoded externally
-    // and only the descriptions are put in the page
+    /* A layout where large binary data is encoded externally
+     * and only the descriptions are put in the page
+     */
     BlobLayout blob_layout = 4;
     // A sparse structural layout. This variant requires file version 2.3 or later.
     SparseLayout sparse_layout = 5;
   }
 }
 
-// # Compressive Encodings
-//
-// These encodings describe how an array is compressed.  An encoding may split an
-// array into multiple buffers.  The buffers can then be compressed further (and split
-// into yet more buffers).  The entire process forms a tree of encodings with the root
-// of the tree being the initial array and the leaves being the final compressed buffers.
-//
-// # Data blocks and buffers
-//
-// Data blocks are a simplified version of arrays and represent a collection of buffers grouped
-// with some kind of interpretation.  Data blocks are the input and output of compressive encodings.
-// There are different kinds of data blocks:
-// - Fixed width data blocks (e.g. u8, u16, ...)
-// - Variable width data blocks (e.g. strings, binary)
-// - Struct data blocks (note: this is for packed structs, normal structs are encoded in the structural encoding)
-//
-// In addition, leaf encodings may output "buffers".  These are fully compressed buffers of data that
-// are stored in the page and no longer compressed.
+/* # Compressive Encodings
+ *
+ * These encodings describe how an array is compressed.  An encoding may split an
+ * array into multiple buffers.  The buffers can then be compressed further (and split
+ * into yet more buffers).  The entire process forms a tree of encodings with the root
+ * of the tree being the initial array and the leaves being the final compressed buffers.
+ *
+ * # Data blocks and buffers
+ *
+ * Data blocks are a simplified version of arrays and represent a collection of buffers grouped
+ * with some kind of interpretation.  Data blocks are the input and output of compressive encodings.
+ * There are different kinds of data blocks:
+ * - Fixed width data blocks (e.g. u8, u16, ...)
+ * - Variable width data blocks (e.g. strings, binary)
+ * - Struct data blocks (note: this is for packed structs, normal structs are encoded in the structural encoding)
+ *
+ * In addition, leaf encodings may output "buffers".  These are fully compressed buffers of data that
+ * are stored in the page and no longer compressed.
+ */
 
 enum CompressionScheme {
   COMPRESSION_ALGORITHM_UNSPECIFIED = 0;
@@ -358,56 +382,61 @@ enum CompressionScheme {
   COMPRESSION_ALGORITHM_ZSTD = 2;
 }
 
-// Compression applied to a single buffer of data
-//
-// A buffer is the leaf of the compression tree.  Unlike data blocks, which can
-// be further compressed with a variety of techniques, a buffer cannot be understood
-// in any particular way.
-//
-// A general compression scheme may be applied to a buffer.  This is something like
-// zstd, lz4, etc.  The entire buffer is compressed as a single unit.  If this happens
-// then any parent encoding becomes opaque, even if it would normally be transparent.
-//
-// This is a leaf, no further compression is applied to the data.
+/* Compression applied to a single buffer of data
+ *
+ * A buffer is the leaf of the compression tree.  Unlike data blocks, which can
+ * be further compressed with a variety of techniques, a buffer cannot be understood
+ * in any particular way.
+ *
+ * A general compression scheme may be applied to a buffer.  This is something like
+ * zstd, lz4, etc.  The entire buffer is compressed as a single unit.  If this happens
+ * then any parent encoding becomes opaque, even if it would normally be transparent.
+ *
+ * This is a leaf, no further compression is applied to the data.
+ */
 message BufferCompression {
   // A general compression scheme to apply to the buffer
   CompressionScheme scheme = 1;
-  // The compression level
-  //
-  // Optional, if not present a scheme-specific default value will be used.
-  //
-  // Interpretation of this value depends on the compression scheme.  Generally, larger
-  // values indicate more compression at the expense of more CPU time.
+  /* The compression level
+   *
+   * Optional, if not present a scheme-specific default value will be used.
+   *
+   * Interpretation of this value depends on the compression scheme.  Generally, larger
+   * values indicate more compression at the expense of more CPU time.
+   */
   optional int32 level = 2;
 }
 
-// Fixed width items placed contiguously in a single buffer
-//
-// This is a leaf encoding, there is no compression applied to the data.
-//
-// This is a transparent encoding by definition.
-//
-// The input is a fixed-width data block.
-// The output is a single buffer.
+/* Fixed width items placed contiguously in a single buffer
+ *
+ * This is a leaf encoding, there is no compression applied to the data.
+ *
+ * This is a transparent encoding by definition.
+ *
+ * The input is a fixed-width data block.
+ * The output is a single buffer.
+ */
 message Flat {
-  // the number of bits per value, must be greater than 0, does
-  // not need to be a multiple of 8
+  /* the number of bits per value, must be greater than 0, does
+   * not need to be a multiple of 8
+   */
   uint64 bits_per_value = 1;
   // The compression applied to the data
   optional BufferCompression data = 2;
 }
 
-// Variable width items have the values stored in one buffer and the
-// offsets are output as a data block that may be further compressed.
-//
-// This is a partial leaf encoding.  Values are not compressed but
-// the offsets may be further compressed.
-//
-// This is a transparent encoding by definition.
-//
-// The input is a variable-width data block.
-// The output is a single fixed-width data block (the offsets) and
-// a single buffer (the values)
+/* Variable width items have the values stored in one buffer and the
+ * offsets are output as a data block that may be further compressed.
+ *
+ * This is a partial leaf encoding.  Values are not compressed but
+ * the offsets may be further compressed.
+ *
+ * This is a transparent encoding by definition.
+ *
+ * The input is a variable-width data block.
+ * The output is a single fixed-width data block (the offsets) and
+ * a single buffer (the values)
+ */
 message Variable {
   // Describes how the offsets data block is compressed
   CompressiveEncoding offsets = 1;
@@ -415,30 +444,32 @@ message Variable {
   optional BufferCompression values = 2;
 }
 
-// Compression algorithm where all values have a constant value (encoded in the description)
-//
-// This is a leaf encoding, there is no compression applied to the data.
-//
-// The input can be any kind of data block.
-// There is no output.
+/* Compression algorithm where all values have a constant value (encoded in the description)
+ *
+ * This is a leaf encoding, there is no compression applied to the data.
+ *
+ * The input can be any kind of data block.
+ * There is no output.
+ */
 message Constant {
   // The value (TODO: define encoding for literals?)
   optional bytes value = 1;
 }
 
-// A compression scheme in which a single fixed-width block is "packed" into
-// a smaller fixed-width block values where each value has fewer bits.
-//
-// This is typically done by throwing away the most significant bits of each value when
-// those bits are all the same.
-//
-// In this scheme the number of bits per value is fixed across the entire buffer and stored
-// in this message.
-//
-// This is a transparent encoding.
-//
-// The input is a fixed-width data block.
-// The output is a single fixed-width data block.
+/* A compression scheme in which a single fixed-width block is "packed" into
+ * a smaller fixed-width block values where each value has fewer bits.
+ *
+ * This is typically done by throwing away the most significant bits of each value when
+ * those bits are all the same.
+ *
+ * In this scheme the number of bits per value is fixed across the entire buffer and stored
+ * in this message.
+ *
+ * This is a transparent encoding.
+ *
+ * The input is a fixed-width data block.
+ * The output is a single fixed-width data block.
+ */
 message OutOfLineBitpacking {
   // the number of bits of the uncompressed value. e.g. for a u32, this will be 32
   uint64 uncompressed_bits_per_value = 1;
@@ -446,15 +477,16 @@ message OutOfLineBitpacking {
   CompressiveEncoding values = 3;
 }
 
-// Bitpacking variant where the bits per value are stored inline in the chunks themselves
-//
-// This variation of bitpacking allows for the number of bits per value to change throughout the
-// buffer, which makes the compression more robust to outliers.
-//
-// This is an opaque encoding.
-//
-// The input is a fixed-width data block.
-// The output is a single buffer.
+/* Bitpacking variant where the bits per value are stored inline in the chunks themselves
+ *
+ * This variation of bitpacking allows for the number of bits per value to change throughout the
+ * buffer, which makes the compression more robust to outliers.
+ *
+ * This is an opaque encoding.
+ *
+ * The input is a fixed-width data block.
+ * The output is a single buffer.
+ */
 message InlineBitpacking {
   // the number of bits of the uncompressed value. e.g. for a u32, this will be 32
   uint64 uncompressed_bits_per_value = 1;
@@ -462,16 +494,17 @@ message InlineBitpacking {
   optional BufferCompression values = 2;
 }
 
-// A compression scheme for variable-width data
-//
-// A small dictionary (referred to as a "symbol table") is used to compress the values.
-// In this scheme there is a single symbol table for the entire page and it is stored in the
-// encoding description itself.
-//
-// This is a transparent encoding.
-//
-// The input is a variable-width data block.
-// The output is a single variable-width data block.
+/* A compression scheme for variable-width data
+ *
+ * A small dictionary (referred to as a "symbol table") is used to compress the values.
+ * In this scheme there is a single symbol table for the entire page and it is stored in the
+ * encoding description itself.
+ *
+ * This is a transparent encoding.
+ *
+ * The input is a variable-width data block.
+ * The output is a single variable-width data block.
+ */
 message Fsst {
   // The FSST symbol table
   bytes symbol_table = 1;
@@ -479,15 +512,16 @@ message Fsst {
   CompressiveEncoding values = 2;
 }
 
-// A compression scheme where common values are stored in a dictionary and the values are
-// encoded as indices into the dictionary.
-//
-// This is an opaque encoding unless the dictionary is considered metadata.
-//
-// The input is a any kind of data block.
-// There are two outputs:
-// - A data block of the same kind as the input (the dictionary)
-// - A fixed-width data block containing the indices into the dictionary.
+/* A compression scheme where common values are stored in a dictionary and the values are
+ * encoded as indices into the dictionary.
+ *
+ * This is an opaque encoding unless the dictionary is considered metadata.
+ *
+ * The input is a any kind of data block.
+ * There are two outputs:
+ * - A data block of the same kind as the input (the dictionary)
+ * - A fixed-width data block containing the indices into the dictionary.
+ */
 message Dictionary {
   // The compression used to store the indices data block
   CompressiveEncoding indices = 1;
@@ -497,14 +531,15 @@ message Dictionary {
   uint32 num_dictionary_items = 3;
 }
 
-// A compression scheme where runs of common values are encoded as a single value and a count
-//
-// This is an opaque encoding unless the run lengths are considered metadata.
-//
-// The input is a single data block of any kind.
-// There are two outputs:
-// - A data block of the same kind as the input (the run values)
-// - A fixed-width data block containing the lengths of the runs
+/* A compression scheme where runs of common values are encoded as a single value and a count
+ *
+ * This is an opaque encoding unless the run lengths are considered metadata.
+ *
+ * The input is a single data block of any kind.
+ * There are two outputs:
+ * - A data block of the same kind as the input (the run values)
+ * - A fixed-width data block containing the lengths of the runs
+ */
 message Rle {
   // The compression used to store the run values data block
   CompressiveEncoding values = 1;
@@ -512,14 +547,15 @@ message Rle {
   CompressiveEncoding run_lengths = 2;
 }
 
-// Converts a fixed-size-list of values into a flattened list of values
-//
-// This encoding does not actually compress the data, it just flattens out the FSL layers.
-//
-// This is a transparent encoding.
-//
-// The input is a single block of fixed-width data (with a wide width and few items)
-// The output is a single block of fixed-width data (with a narrow width and many items)
+/* Converts a fixed-size-list of values into a flattened list of values
+ *
+ * This encoding does not actually compress the data, it just flattens out the FSL layers.
+ *
+ * This is a transparent encoding.
+ *
+ * The input is a single block of fixed-width data (with a wide width and few items)
+ * The output is a single block of fixed-width data (with a narrow width and many items)
+ */
 message FixedSizeList {
   // The number of items in this layer of FSL
   uint64 items_per_value = 1;
@@ -529,10 +565,11 @@ message FixedSizeList {
   CompressiveEncoding values = 2;
 }
 
-// Packs a struct containing only fixed-width children into a single fixed-width data block
-//
-// The children are concatenated row by row and stored as a single fixed-width buffer. This is
-// the legacy packed struct representation and remains available for backwards compatibility.
+/* Packs a struct containing only fixed-width children into a single fixed-width data block
+ *
+ * The children are concatenated row by row and stored as a single fixed-width buffer. This is
+ * the legacy packed struct representation and remains available for backwards compatibility.
+ */
 message PackedStruct {
   // The number of bits contributed by each child field in the packed row
   repeated uint64 bits_per_value = 1;
@@ -540,12 +577,13 @@ message PackedStruct {
   CompressiveEncoding values = 2;
 }
 
-// Variable-width packed struct encoding (2.2 extension)
-//
-// Each child value is compressed independently before being transposed into
-// a row-major layout. This preserves per-field compression boundaries at the
-// cost of disabling mini-block compression. Readers must prefer this field
-// when present and fall back to the legacy encoding otherwise.
+/* Variable-width packed struct encoding (2.2 extension)
+ *
+ * Each child value is compressed independently before being transposed into
+ * a row-major layout. This preserves per-field compression boundaries at the
+ * cost of disabling mini-block compression. Readers must prefer this field
+ * when present and fall back to the legacy encoding otherwise.
+ */
 message VariablePackedStruct {
   // Per-field encoding metadata in struct order
   repeated FieldEncoding fields = 1;
@@ -563,32 +601,33 @@ message VariablePackedStruct {
   }
 }
 
-// A compression scheme that wraps the underlying data with general compression
-//
-// Note: The application of wrapped compression will depend on the layout of the data.
-// If we apply it to mini-block data then we compress entire mini-blocks.  If we apply
-// it to full-zip data then we compress each value individually.
-//
-// Note: Wrapped compression is somewhat unique at the moment as it is applied to the
-// output of the inner encoding and not the input like all other compressive encodings.
-//
-// Note: General compression can usually be applied in two spots.  We can apply
-// it to individual buffers or we can apply it here, to the entire array.
-//
-// For example, let's say we are storing mini-blocks of strings and we are using
-// FSST and bitpacking the offsets.  We have something like this...
-//
-// WRAPPED(†3) -> FSST -> VARIABLE -(offsets)-> INLINE_BITPACKING -(data)-> FLAT -> BUFFER (†1)
-//                                 -(data)-> BUFFER (†2)
-//
-// General compression can be applied at †1, †2, or †3 (or any combination of these).
-//
-// If we apply it at †1 then we apply it just to the bitpacked offsets
-// If we apply it at †2 then we apply it just to the FSST compressed data
-// If we apply it at †3 then we apply it to the entire mini-block (both offsets and data)
-//
-// The input is a single data block of any kind.
-// The output is a single data block of the same kind as the input.
+/* A compression scheme that wraps the underlying data with general compression
+ *
+ * Note: The application of wrapped compression will depend on the layout of the data.
+ * If we apply it to mini-block data then we compress entire mini-blocks.  If we apply
+ * it to full-zip data then we compress each value individually.
+ *
+ * Note: Wrapped compression is somewhat unique at the moment as it is applied to the
+ * output of the inner encoding and not the input like all other compressive encodings.
+ *
+ * Note: General compression can usually be applied in two spots.  We can apply
+ * it to individual buffers or we can apply it here, to the entire array.
+ *
+ * For example, let's say we are storing mini-blocks of strings and we are using
+ * FSST and bitpacking the offsets.  We have something like this...
+ *
+ * WRAPPED(†3) -> FSST -> VARIABLE -(offsets)-> INLINE_BITPACKING -(data)-> FLAT -> BUFFER (†1)
+ *                                 -(data)-> BUFFER (†2)
+ *
+ * General compression can be applied at †1, †2, or †3 (or any combination of these).
+ *
+ * If we apply it at †1 then we apply it just to the bitpacked offsets
+ * If we apply it at †2 then we apply it just to the FSST compressed data
+ * If we apply it at †3 then we apply it to the entire mini-block (both offsets and data)
+ *
+ * The input is a single data block of any kind.
+ * The output is a single data block of the same kind as the input.
+ */
 message General {
   // The compression to apply to the values
   BufferCompression compression = 1;
@@ -596,20 +635,21 @@ message General {
   CompressiveEncoding values = 3;
 }
 
-// A compression scheme where fixed-width values are transposed into a series of byte streams
-//
-// This is commonly used for floating point values where the upper bits (the mantissa) have a
-// significantly different meaning than the lower bits.  By splitting the values into byte streams
-// we group the mantissa bits together and the exponent bits together.  The end result is typically
-// more compressible.
-//
-// Note that this encoding is mostly useful when combined with other encodings.  It does not do any
-// compression on its own.
-//
-// This is an opaque encoding.
-//
-// The input is a fixed-width data block
-// The output is a single fixed-width data block
+/* A compression scheme where fixed-width values are transposed into a series of byte streams
+ *
+ * This is commonly used for floating point values where the upper bits (the mantissa) have a
+ * significantly different meaning than the lower bits.  By splitting the values into byte streams
+ * we group the mantissa bits together and the exponent bits together.  The end result is typically
+ * more compressible.
+ *
+ * Note that this encoding is mostly useful when combined with other encodings.  It does not do any
+ * compression on its own.
+ *
+ * This is an opaque encoding.
+ *
+ * The input is a fixed-width data block
+ * The output is a single fixed-width data block
+ */
 message ByteStreamSplit {
   // The compression used to store the values
   CompressiveEncoding values = 1;

--- a/protos/file.proto
+++ b/protos/file.proto
@@ -23,62 +23,69 @@ message Schema {
 
 // Metadata of one Lance file.
 message Metadata {
-  // 4 was used for StatisticsMetadata in the past, but has been moved to
-  // prevent a bug in older readers.
+  /* 4 was used for StatisticsMetadata in the past, but has been moved to
+   * prevent a bug in older readers.
+   */
   reserved 4;
 
-  // Position of the manifest in the file. If it is zero, the manifest is stored
-  // externally.
+  /* Position of the manifest in the file. If it is zero, the manifest is stored
+   * externally.
+   */
   uint64 manifest_position = 1;
 
-  // Logical offsets of each chunk group, i.e., number of the rows in each
-  // chunk.
+  /* Logical offsets of each chunk group, i.e., number of the rows in each
+   * chunk.
+   */
   repeated int32 batch_offsets = 2;
 
-  // The file position that page table is stored.
-  //
-  // A page table is a matrix of N x M x 2, where N = num_fields, and M =
-  // num_batches. Each cell in the table is a pair of <position:int64,
-  // length:int64> of the page. Both position and length are int64 values. The
-  // <position, length> of all the pages in the same column are then
-  // contiguously stored.
-  //
-  // Every field that is a part of the file will have a run in the page table.
-  // This includes struct columns, which will have a run of length 0 since
-  // they don't store any actual data.
-  //
-  // For example, for the column 5 and batch 4, we have:
-  // ```text
-  //   position = page_table[5][4][0];
-  //   length = page_table[5][4][1];
-  // ```
+  /* The file position that page table is stored.
+   *
+   * A page table is a matrix of N x M x 2, where N = num_fields, and M =
+   * num_batches. Each cell in the table is a pair of <position:int64,
+   * length:int64> of the page. Both position and length are int64 values. The
+   * <position, length> of all the pages in the same column are then
+   * contiguously stored.
+   *
+   * Every field that is a part of the file will have a run in the page table.
+   * This includes struct columns, which will have a run of length 0 since
+   * they don't store any actual data.
+   *
+   * For example, for the column 5 and batch 4, we have:
+   * ```text
+   *   position = page_table[5][4][0];
+   *   length = page_table[5][4][1];
+   * ```
+   */
   uint64 page_table_position = 3;
 
   message StatisticsMetadata {
-    // The schema of the statistics.
-    //
-    // This might be empty, meaning there are no statistics. It also might not
-    // contain statistics for every field.
+    /* The schema of the statistics.
+     *
+     * This might be empty, meaning there are no statistics. It also might not
+     * contain statistics for every field.
+     */
     repeated Field schema = 1;
 
-    // The field ids of the statistics leaf fields.
-    //
-    // This plays a similar role to the `fields` field in the DataFile message.
-    // Each of these field ids corresponds to a field in the stats_schema. There
-    // is one per column in the stats page table.
+    /* The field ids of the statistics leaf fields.
+     *
+     * This plays a similar role to the `fields` field in the DataFile message.
+     * Each of these field ids corresponds to a field in the stats_schema. There
+     * is one per column in the stats page table.
+     */
     repeated int32 fields = 2;
 
-    // The file position of the statistics page table
-    //
-    // The page table is a matrix of N x 2, where N = length of stats_fields.
-    // This is the same layout as the main page table, except there is always
-    // only one batch.
-    //
-    // For example, to get the stats column 5, we have:
-    // ```text
-    //   position = stats_page_table[5][0];
-    //   length = stats_page_table[5][1];
-    // ```
+    /* The file position of the statistics page table
+     *
+     * The page table is a matrix of N x 2, where N = length of stats_fields.
+     * This is the same layout as the main page table, except there is always
+     * only one batch.
+     *
+     * For example, to get the stats column 5, we have:
+     * ```text
+     *   position = stats_page_table[5][0];
+     *   length = stats_page_table[5][1];
+     * ```
+     */
     uint64 page_table_position = 3;
   }
 
@@ -101,10 +108,11 @@ enum Encoding {
 
 // Dictionary field metadata
 message Dictionary {
-  /// The file offset for storing the dictionary value.
-  /// It is only valid if encoding is DICTIONARY.
-  ///
-  /// The logic type presents the value type of the column, i.e., string value.
+  /* The file offset for storing the dictionary value.
+   * It is only valid if encoding is DICTIONARY.
+   *
+   * The logic type presents the value type of the column, i.e., string value.
+   */
   int64 offset = 1;
 
   /// The length of dictionary values.
@@ -122,41 +130,43 @@ message Field {
 
   // Fully qualified name.
   string name = 2;
-  /// Field Id.
-  ///
-  /// See the comment in `DataFile.fields` for how field ids are assigned.
+  /* Field Id.
+   *
+   * See the comment in `DataFile.fields` for how field ids are assigned.
+   */
   int32 id = 3;
   /// Parent Field ID. If not set, this is a top-level column.
   int32 parent_id = 4;
 
-  // Logical types, support parameterized Arrow Type.
-  //
-  // PARENT types will always have logical type "struct".
-  //
-  // REPEATED types may have logical types:
-  // * "list"
-  // * "large_list"
-  // * "list.struct"
-  // * "large_list.struct"
-  // The final two are used if the list values are structs, and therefore the
-  // field is both implicitly REPEATED and PARENT.
-  //
-  // LEAF types may have logical types:
-  // * "null"
-  // * "bool"
-  // * "int8" / "uint8"
-  // * "int16" / "uint16"
-  // * "int32" / "uint32"
-  // * "int64" / "uint64"
-  // * "halffloat" / "float" / "double"
-  // * "string" / "large_string"
-  // * "binary" / "large_binary"
-  // * "date32:day"
-  // * "date64:ms"
-  // * "decimal:128:{precision}:{scale}" / "decimal:256:{precision}:{scale}"
-  // * "time:{unit}" / "timestamp:{unit}" / "duration:{unit}", where unit is
-  // "s", "ms", "us", "ns"
-  // * "dict:{value_type}:{index_type}:false"
+  /* Logical types, support parameterized Arrow Type.
+   *
+   * PARENT types will always have logical type "struct".
+   *
+   * REPEATED types may have logical types:
+   * * "list"
+   * * "large_list"
+   * * "list.struct"
+   * * "large_list.struct"
+   * The final two are used if the list values are structs, and therefore the
+   * field is both implicitly REPEATED and PARENT.
+   *
+   * LEAF types may have logical types:
+   * * "null"
+   * * "bool"
+   * * "int8" / "uint8"
+   * * "int16" / "uint16"
+   * * "int32" / "uint32"
+   * * "int64" / "uint64"
+   * * "halffloat" / "float" / "double"
+   * * "string" / "large_string"
+   * * "binary" / "large_binary"
+   * * "date32:day"
+   * * "date64:ms"
+   * * "decimal:128:{precision}:{scale}" / "decimal:256:{precision}:{scale}"
+   * * "time:{unit}" / "timestamp:{unit}" / "duration:{unit}", where unit is
+   * "s", "ms", "us", "ns"
+   * * "dict:{value_type}:{index_type}:false"
+   */
   string logical_type = 5;
   // If this field is nullable.
   bool nullable = 6;
@@ -166,42 +176,48 @@ message Field {
 
   bool unenforced_primary_key = 12;
 
-  // Position of this field in the primary key (1-based).
-  // 0 means the field is part of the primary key but uses schema field id for ordering.
-  // When set to a positive value, primary key fields are ordered by this position.
+  /* Position of this field in the primary key (1-based).
+   * 0 means the field is part of the primary key but uses schema field id for ordering.
+   * When set to a positive value, primary key fields are ordered by this position.
+   */
   uint32 unenforced_primary_key_position = 13;
 
   // Reserved for future use. Use unenforced_clustering_key_position instead.
   bool unenforced_clustering_key = 14;
 
-  // Position of this field in the clustering key (1-based).
-  // 0 means the field is not part of the clustering key.
+  /* Position of this field in the clustering key (1-based).
+   * 0 means the field is not part of the clustering key.
+   */
   uint32 unenforced_clustering_key_position = 15;
 
   // DEPRECATED ----------------------------------------------------------------
 
-  // Deprecated: Only used in V1 file format. V2 uses variable encodings defined
-  // per page.
-  //
-  // The global encoding to use for this field.
+  /* Deprecated: Only used in V1 file format. V2 uses variable encodings defined
+   * per page.
+   *
+   * The global encoding to use for this field.
+   */
   Encoding encoding = 7;
 
-  // Deprecated: Only used in V1 file format. V2 dynamically chooses when to
-  // do dictionary encoding and keeps the dictionary in the data files.
-  //
-  // The file offset for storing the dictionary value.
-  // It is only valid if encoding is DICTIONARY.
-  //
-  // The logic type presents the value type of the column, i.e., string value.
+  /* Deprecated: Only used in V1 file format. V2 dynamically chooses when to
+   * do dictionary encoding and keeps the dictionary in the data files.
+   *
+   * The file offset for storing the dictionary value.
+   * It is only valid if encoding is DICTIONARY.
+   *
+   * The logic type presents the value type of the column, i.e., string value.
+   */
   Dictionary dictionary = 8;
 
-  // Deprecated: optional extension type name, use metadata field
-  // ARROW:extension:name
+  /* Deprecated: optional extension type name, use metadata field
+   * ARROW:extension:name
+   */
   string extension_name = 9;
 
-  // Field number 11 was previously `string storage_class`.
-  // Keep it reserved so older manifests remain compatible while new writers
-  // avoid reusing the slot.
+  /* Field number 11 was previously `string storage_class`.
+   * Keep it reserved so older manifests remain compatible while new writers
+   * avoid reusing the slot.
+   */
   reserved 11;
   reserved "storage_class";
 }

--- a/protos/file2.proto
+++ b/protos/file2.proto
@@ -8,144 +8,149 @@ package lance.file.v2;
 import "google/protobuf/any.proto";
 import "google/protobuf/empty.proto";
 
-// # Lance v2.X File Format
-//
-// The Lance file format is a barebones format for serializing columnar data
-// into a file.
-//
-// * Each Lance file contains between 0 and 4Gi columns
-// * Each column contains between 0 and 4Gi pages
-// * Each page contains between 0 and 2^64 items
-// * Different pages within a column can have different items counts
-// * Columns may have up to 2^64 items
-// * Different columns within a file can have different item counts
-//
-// The Lance file format does not have any notion of a type system or schemas.
-// From the perspective of the file format all data is arbitrary buffers of
-// bytes with an extensible metadata block to describe the data.  It is up to
-// the user to interpret these bytes meaningfully.
-//
-// Data buffers are written to the file first.  These data buffers can be
-// referenced from three different places in the file:
-//
-// * Page encodings can reference data buffers.  This is the most common way
-//   that actual data is stored.
-// * Column encodings can reference data buffers.  For example, a column encoding
-//   may reference data buffer(s) containing statistics or dictionaries.
-// * Finally, the global buffer offset table can reference data buffers.  This
-//   is useful for storing data that is shared across multiple columns.
-//   This is also useful for global file metadata (e.g. a schema that describes
-//   the file)
-//
-// ## File Layout
-//
-// Note: the number of buffers (BN) is independent of the number of columns (CN)
-//       and pages.
-//
-//       Buffers often need to be aligned.  64-byte alignment is common when
-//       working with SIMD operations.  4096-byte alignment is common when
-//       working with direct I/O.  In order to ensure these buffers are aligned
-//       writers may need to insert padding before the buffers.
-//       
-//       If direct I/O is required then most (but not all) fields described
-//       below must be sector aligned.  We have marked these fields with an
-//       asterisk for clarity.  Readers should assume there will be optional
-//       padding inserted before these fields.
-//
-//       All footer fields are unsigned integers written with  little endian
-//       byte order.
-//
-// ├──────────────────────────────────┤
-// | Data Pages                       |
-// |   Data Buffer 0*                 |
-// |   ...                            |
-// |   Data Buffer BN*                |
-// ├──────────────────────────────────┤
-// | Column Metadatas                 |
-// | |A| Column 0 Metadata*           |
-// |     Column 1 Metadata*           |
-// |     ...                          |
-// |     Column CN Metadata*          |
-// ├──────────────────────────────────┤
-// | Column Metadata Offset Table     |
-// | |B| Column 0 Metadata Position*  |
-// |     Column 0 Metadata Size       |
-// |     ...                          |
-// |     Column CN Metadata Position  |
-// |     Column CN Metadata Size      |
-// ├──────────────────────────────────┤
-// | Global Buffers Offset Table      |
-// | |C| Global Buffer 0 Position*    |
-// |     Global Buffer 0 Size         |
-// |     ...                          |
-// |     Global Buffer GN Position    |
-// |     Global Buffer GN Size        |
-// ├──────────────────────────────────┤
-// | Footer                           |
-// | A u64: Offset to column meta 0   |
-// | B u64: Offset to CMO table       |
-// | C u64: Offset to GBO table       |
-// |   u32: Number of global bufs     |
-// |   u32: Number of columns         |
-// |   u16: Major version             |
-// |   u16: Minor version             |
-// |   "LANC"                         |
-// ├──────────────────────────────────┤
-//
-// File Layout-End
-//
-// ## Data Pages
-//
-// A lot of flexibility is provided in how data is stored.  A page's buffers do
-// not strictly need to be contiguous on the disk.  However, it is recommended
-// that buffers within a page be grouped together for best performance.
-//
-// Data pages should be large.  The only time a page should be written to disk
-// is when the writer needs to flush the page to disk because it has accumulated
-// too much data.  Pages are not read in sequential order and if pages are too
-// small then the seek overhead (or request overhead) will be problematic.  We
-// generally advise that pages be at least 8MB or larger.
-//
-// ## Encodings
-//
-// Specific encodings are not part of this minimal format.  They are provided
-// by extensions. Readers and writers should be designed so that encodings can
-// be easily added and removed. Ideally, they should allow for this without
-// requiring recompilation through some kind of plugin system.
+/* # Lance v2.X File Format
+ *
+ * The Lance file format is a barebones format for serializing columnar data
+ * into a file.
+ *
+ * * Each Lance file contains between 0 and 4Gi columns
+ * * Each column contains between 0 and 4Gi pages
+ * * Each page contains between 0 and 2^64 items
+ * * Different pages within a column can have different items counts
+ * * Columns may have up to 2^64 items
+ * * Different columns within a file can have different item counts
+ *
+ * The Lance file format does not have any notion of a type system or schemas.
+ * From the perspective of the file format all data is arbitrary buffers of
+ * bytes with an extensible metadata block to describe the data.  It is up to
+ * the user to interpret these bytes meaningfully.
+ *
+ * Data buffers are written to the file first.  These data buffers can be
+ * referenced from three different places in the file:
+ *
+ * * Page encodings can reference data buffers.  This is the most common way
+ *   that actual data is stored.
+ * * Column encodings can reference data buffers.  For example, a column encoding
+ *   may reference data buffer(s) containing statistics or dictionaries.
+ * * Finally, the global buffer offset table can reference data buffers.  This
+ *   is useful for storing data that is shared across multiple columns.
+ *   This is also useful for global file metadata (e.g. a schema that describes
+ *   the file)
+ *
+ * ## File Layout
+ *
+ * Note: the number of buffers (BN) is independent of the number of columns (CN)
+ *       and pages.
+ *
+ *       Buffers often need to be aligned.  64-byte alignment is common when
+ *       working with SIMD operations.  4096-byte alignment is common when
+ *       working with direct I/O.  In order to ensure these buffers are aligned
+ *       writers may need to insert padding before the buffers.
+ *
+ *       If direct I/O is required then most (but not all) fields described
+ *       below must be sector aligned.  We have marked these fields with an
+ *       asterisk for clarity.  Readers should assume there will be optional
+ *       padding inserted before these fields.
+ *
+ *       All footer fields are unsigned integers written with  little endian
+ *       byte order.
+ *
+ * ├──────────────────────────────────┤
+ * | Data Pages                       |
+ * |   Data Buffer 0*                 |
+ * |   ...                            |
+ * |   Data Buffer BN*                |
+ * ├──────────────────────────────────┤
+ * | Column Metadatas                 |
+ * | |A| Column 0 Metadata*           |
+ * |     Column 1 Metadata*           |
+ * |     ...                          |
+ * |     Column CN Metadata*          |
+ * ├──────────────────────────────────┤
+ * | Column Metadata Offset Table     |
+ * | |B| Column 0 Metadata Position*  |
+ * |     Column 0 Metadata Size       |
+ * |     ...                          |
+ * |     Column CN Metadata Position  |
+ * |     Column CN Metadata Size      |
+ * ├──────────────────────────────────┤
+ * | Global Buffers Offset Table      |
+ * | |C| Global Buffer 0 Position*    |
+ * |     Global Buffer 0 Size         |
+ * |     ...                          |
+ * |     Global Buffer GN Position    |
+ * |     Global Buffer GN Size        |
+ * ├──────────────────────────────────┤
+ * | Footer                           |
+ * | A u64: Offset to column meta 0   |
+ * | B u64: Offset to CMO table       |
+ * | C u64: Offset to GBO table       |
+ * |   u32: Number of global bufs     |
+ * |   u32: Number of columns         |
+ * |   u16: Major version             |
+ * |   u16: Minor version             |
+ * |   "LANC"                         |
+ * ├──────────────────────────────────┤
+ *
+ * File Layout-End
+ *
+ * ## Data Pages
+ *
+ * A lot of flexibility is provided in how data is stored.  A page's buffers do
+ * not strictly need to be contiguous on the disk.  However, it is recommended
+ * that buffers within a page be grouped together for best performance.
+ *
+ * Data pages should be large.  The only time a page should be written to disk
+ * is when the writer needs to flush the page to disk because it has accumulated
+ * too much data.  Pages are not read in sequential order and if pages are too
+ * small then the seek overhead (or request overhead) will be problematic.  We
+ * generally advise that pages be at least 8MB or larger.
+ *
+ * ## Encodings
+ *
+ * Specific encodings are not part of this minimal format.  They are provided
+ * by extensions. Readers and writers should be designed so that encodings can
+ * be easily added and removed. Ideally, they should allow for this without
+ * requiring recompilation through some kind of plugin system.
+ */
 
-// The deferred encoding is used to place the encoding itself in a different
-// part of the file.  This is most commonly used to allow encodings to be shared
-// across different columns.  For example, when writing a file with thousands of
-// columns, where many pages have the exact same encoding, it can be useful
-// to cut down on the size of the metadata by using a deferred encoding.
+/* The deferred encoding is used to place the encoding itself in a different
+ * part of the file.  This is most commonly used to allow encodings to be shared
+ * across different columns.  For example, when writing a file with thousands of
+ * columns, where many pages have the exact same encoding, it can be useful
+ * to cut down on the size of the metadata by using a deferred encoding.
+ */
 message DeferredEncoding {
-   // Location of the buffer containing the encoding.
-   //
-   // * If sharing encodings across columns then this will be in a global buffer
-   // * If sharing encodings across pages within a column this could be in a
-   //   column metadata buffer.
-   // * This could also be a page buffer if the encoding is not shared, needs
-   //   to be written before the file ends, and the encoding is too large to load
-   //   unless we first determine the page needs to be read.  This combination
-   //   seems unusual.
+   /* Location of the buffer containing the encoding.
+    *
+    * * If sharing encodings across columns then this will be in a global buffer
+    * * If sharing encodings across pages within a column this could be in a
+    *   column metadata buffer.
+    * * This could also be a page buffer if the encoding is not shared, needs
+    *   to be written before the file ends, and the encoding is too large to load
+    *   unless we first determine the page needs to be read.  This combination
+    *   seems unusual.
+    */
    uint64 buffer_location = 1;
    uint64 buffer_length = 2;
 }
 
 // The encoding is placed directly in the metadata section
 message DirectEncoding {
-    // The bytes that make up the encoding embedded directly in the metadata
-    //
-    // This is the most common approach.
+    /* The bytes that make up the encoding embedded directly in the metadata
+     *
+     * This is the most common approach.
+     */
     bytes encoding = 1;
 }
 
-// An encoding stores the information needed to decode a column or page
-//
-// For example, it could describe if the page is using bit packing, and how many bits
-// there are in each individual value.
-//
-// At the column level it can be used to wrap columns with dictionaries or statistics.
+/* An encoding stores the information needed to decode a column or page
+ *
+ * For example, it could describe if the page is using bit packing, and how many bits
+ * there are in each individual value.
+ *
+ * At the column level it can be used to wrap columns with dictionaries or statistics.
+ */
 message Encoding {
     oneof location {
         // The encoding is stored elsewhere and not part of this protobuf message
@@ -159,52 +164,60 @@ message Encoding {
 
 // ## Metadata
 
-// Each column has a metadata block that is placed at the end of the file.
-// These may be read individually to allow for column projection.
+/* Each column has a metadata block that is placed at the end of the file.
+ * These may be read individually to allow for column projection.
+ */
 message ColumnMetadata {
 
   // This describes a page of column data.
   message Page {
-    // The file offsets for each of the page buffers
-    //
-    // The number of buffers is variable and depends on the encoding.  There
-    // may be zero buffers (e.g. constant encoded data) in which case this
-    // could be empty.
+    /* The file offsets for each of the page buffers
+     *
+     * The number of buffers is variable and depends on the encoding.  There
+     * may be zero buffers (e.g. constant encoded data) in which case this
+     * could be empty.
+     */
     repeated uint64 buffer_offsets = 1;
-    // The size (in bytes) of each of the page buffers
-    //
-    // This field will have the same length as `buffer_offsets` and
-    // may be empty.
+    /* The size (in bytes) of each of the page buffers
+     *
+     * This field will have the same length as `buffer_offsets` and
+     * may be empty.
+     */
     repeated uint64 buffer_sizes = 2;
     // Logical length (e.g. # rows) of the page
     uint64 length = 3;
     // The encoding used to encode the page
     Encoding encoding = 4;
-    // The priority of the page
-    //
-    // For tabular data this will be the top-level row number of the first row
-    // in the page (and top-level rows should not split across pages).
+    /* The priority of the page
+     *
+     * For tabular data this will be the top-level row number of the first row
+     * in the page (and top-level rows should not split across pages).
+     */
     uint64 priority = 5;
   }
-  // Encoding information about the column itself.  This typically describes
-  // how to interpret the column metadata buffers.  For example, it could
-  // describe how statistics or dictionaries are stored in the column metadata.
+  /* Encoding information about the column itself.  This typically describes
+   * how to interpret the column metadata buffers.  For example, it could
+   * describe how statistics or dictionaries are stored in the column metadata.
+   */
   Encoding encoding = 1;
   // The pages in the column
   repeated Page pages = 2;   
-  // The file offsets of each of the column metadata buffers
-  //
-  // There may be zero buffers.
+  /* The file offsets of each of the column metadata buffers
+   *
+   * There may be zero buffers.
+   */
   repeated uint64 buffer_offsets = 3;
-  // The size (in bytes) of each of the column metadata buffers
-  //
-  // This field will have the same length as `buffer_offsets` and
-  // may be empty.
+  /* The size (in bytes) of each of the column metadata buffers
+   *
+   * This field will have the same length as `buffer_offsets` and
+   * may be empty.
+   */
   repeated uint64 buffer_sizes = 4;
 } // Metadata-End
 
-// ## Where is the rest?
-//
-// This file format is extremely minimal.  It is a building block for
-// creating more useful readers and writers and not terribly useful by itself.
-// Other protobuf files will describe how this can be extended.
+/* ## Where is the rest?
+ *
+ * This file format is extremely minimal.  It is a building block for
+ * creating more useful readers and writers and not terribly useful by itself.
+ * Other protobuf files will describe how this can be extended.
+ */

--- a/protos/filtered_read.proto
+++ b/protos/filtered_read.proto
@@ -62,32 +62,37 @@ message FilteredReadOptionsProto {
   optional uint64 io_buffer_size_bytes = 11;
   // Arrow IPC schema for decoding Substrait filters (may be wider than projection).
   optional bytes filter_schema_ipc = 12;
-  // If present, a nonzero upper bound on bytes reserved by Blob v2
-  // materialization awaiting ordered emission in one scanner execution.
-  // Admission follows output order; one oversized output batch may exceed the
-  // bound when no other batch is reserved. If absent, Blob v2 materialization
-  // has no independent memory bound.
+  /* If present, a nonzero upper bound on bytes reserved by Blob v2
+   * materialization awaiting ordered emission in one scanner execution.
+   * Admission follows output order; one oversized output batch may exceed the
+   * bound when no other batch is reserved. If absent, Blob v2 materialization
+   * has no independent memory bound.
+   */
   optional uint64 materialization_readahead_bytes = 13;
-  // If present, the scanner-level byte budget for output batches. When set,
-  // the file reader uses it as an additional batch boundary alongside the
-  // row-based batch_size. This corresponds to FileReaderOptions.batch_size_bytes.
+  /* If present, the scanner-level byte budget for output batches. When set,
+   * the file reader uses it as an additional batch boundary alongside the
+   * row-based batch_size. This corresponds to FileReaderOptions.batch_size_bytes.
+   */
   optional uint64 batch_size_bytes = 14;
 }
 
-// Serializable form of FilteredReadPlan (planned/distributed mode).
-// RowAddrTreeMap serialized via its built-in serialize_into/deserialize_from.
-// Per-fragment filters are Substrait-encoded and deduplicated.
+/* Serializable form of FilteredReadPlan (planned/distributed mode).
+ * RowAddrTreeMap serialized via its built-in serialize_into/deserialize_from.
+ * Per-fragment filters are Substrait-encoded and deduplicated.
+ */
 message FilteredReadPlanProto {
   bytes row_addr_tree_map = 1;
   optional U64Range scan_range_after_filter = 2;
   // Arrow IPC schema for decoding Substrait filters (matches the schema used at encode time).
   optional bytes filter_schema_ipc = 3;
-  // Per-fragment filter mapping. Key is fragment id, value is a list index into
-  // filter_expressions. Multiple fragments can share the same list index when
-  // they have the same filter, avoiding duplicate Substrait encoding.
+  /* Per-fragment filter mapping. Key is fragment id, value is a list index into
+   * filter_expressions. Multiple fragments can share the same list index when
+   * they have the same filter, avoiding duplicate Substrait encoding.
+   */
   map<uint32, uint32> fragment_filter_ids = 4;
-  // Deduplicated Substrait-encoded filter expressions. Each entry is referenced
-  // by one or more values in fragment_filter_ids.
+  /* Deduplicated Substrait-encoded filter expressions. Each entry is referenced
+   * by one or more values in fragment_filter_ids.
+   */
   repeated bytes filter_expressions = 5;
 }
 
@@ -95,15 +100,17 @@ message FilteredReadPlanProto {
 message FilteredReadExecProto {
   TableIdentifier table = 1;
   FilteredReadOptionsProto options = 2;
-  // FilteredRead has two modes
-  // Plan-then-execute (distributed): The planner creates a FilteredReadPlan and sends it to a remote executor.
-  // Plan-and-execute (local): The executor creates the plan itself at execution time.
+  /* FilteredRead has two modes
+   * Plan-then-execute (distributed): The planner creates a FilteredReadPlan and sends it to a remote executor.
+   * Plan-and-execute (local): The executor creates the plan itself at execution time.
+   */
   optional FilteredReadPlanProto plan = 3;
-  // Note: FilteredReadExec.index_input (child ExecutionPlan) is NOT serialized here.
-  // DataFusion's PhysicalExtensionCodec handles child plans automatically: it walks
-  // the plan tree via children() / with_new_children(), serializes each node, and
-  // passes deserialized children back as the `inputs` parameter in try_decode.
-  // This means any ExecutionPlan in the tree (including index_input) must also
-  // implement try_encode/try_decode in the PhysicalExtensionCodec.
-  // TODO: implement serialize/deserialize for lance-specific index input ExecutionPlans.
+  /* Note: FilteredReadExec.index_input (child ExecutionPlan) is NOT serialized here.
+   * DataFusion's PhysicalExtensionCodec handles child plans automatically: it walks
+   * the plan tree via children() / with_new_children(), serializes each node, and
+   * passes deserialized children back as the `inputs` parameter in try_decode.
+   * This means any ExecutionPlan in the tree (including index_input) must also
+   * implement try_encode/try_decode in the PhysicalExtensionCodec.
+   * TODO: implement serialize/deserialize for lance-specific index input ExecutionPlans.
+   */
 }

--- a/protos/index.proto
+++ b/protos/index.proto
@@ -55,9 +55,10 @@ message Tensor {
 
 // Inverted Index File Metadata.
 message IVF {
-  // Centroids of partitions. `dimension * num_partitions` of float32s.
-  //
-  // Deprecated, use centroids_tensor instead.
+  /* Centroids of partitions. `dimension * num_partitions` of float32s.
+   *
+   * Deprecated, use centroids_tensor instead.
+   */
   repeated float centroids = 1;  // [deprecated = true];
 
   // File offset of each partition.
@@ -171,13 +172,14 @@ message VectorIndex {
   // Vector dimension;
   uint32 dimension = 2;
 
-  // Composed vector index stages.
-  //
-  // For example, `IVF_PQ` index type can be expressed as:
-  //
-  // ```text
-  // let stages = vec![Ivf{}, PQ{num_bits: 8, num_sub_vectors: 16}]
-  // ```
+  /* Composed vector index stages.
+   *
+   * For example, `IVF_PQ` index type can be expressed as:
+   *
+   * ```text
+   * let stages = vec![Ivf{}, PQ{num_bits: 8, num_sub_vectors: 16}]
+   * ```
+   */
   repeated VectorIndexStage stages = 3;
 
   // Vector distance metrics type
@@ -188,8 +190,9 @@ message VectorIndex {
 message VectorIndexDetails {
   VectorMetricType metric_type = 1;
 
-  // The target number of vectors per partition.
-  // 0 means unset.
+  /* The target number of vectors per partition.
+   * 0 means unset.
+   */
   uint64 target_partition_size = 2;
 
   // Optional HNSW index configuration. If set, the index has an HNSW layer.
@@ -221,20 +224,23 @@ message VectorIndexDetails {
     FlatCompression flat = 8;
   }
 
-  // Runtime hints: optional build preferences that don't affect index structure.
-  // Keys use reverse-DNS namespacing (e.g., "lance.ivf.max_iters", "lancedb.accelerator").
-  // Unrecognized keys must be silently ignored by all runtimes.
+  /* Runtime hints: optional build preferences that don't affect index structure.
+   * Keys use reverse-DNS namespacing (e.g., "lance.ivf.max_iters", "lancedb.accelerator").
+   * Unrecognized keys must be silently ignored by all runtimes.
+   */
   map<string, string> runtime_hints = 9;
 }
 
 // Hierarchical Navigable Small World (HNSW) parameters, used as an optional configuration for IVF indexes.
 message HnswParameters {
-  // The maximum number of outgoing edges per node in the HNSW graph. Higher values
-  // means more connections, better recall, but more memory and slower builds.
-  // Referred to as "M" in the HNSW literature.
+  /* The maximum number of outgoing edges per node in the HNSW graph. Higher values
+   * means more connections, better recall, but more memory and slower builds.
+   * Referred to as "M" in the HNSW literature.
+   */
   uint32 max_connections = 1;
-  // "construction exploration factor": The size of the dynamic list used during
-  // index construction.
+  /* "construction exploration factor": The size of the dynamic list used during
+   * index construction.
+   */
   uint32 construction_ef = 2;
   // The maximum number of levels in the HNSW graph.
   uint32 max_level = 3;

--- a/protos/index_old.proto
+++ b/protos/index_old.proto
@@ -5,45 +5,50 @@ syntax = "proto3";
 
 package lance.table;
 
-// NOTE: Do *NOT* add new index details here.  Add them to the index.proto file instead.
-// This file is in the lance.table package namespace while the index.proto file is in the
-// lance.index package namespace.
-//
-// These are only here for forward compatibility.  Older versions of Lance expect btree indexes
-// to have lance.table in the package namespace.
-//
-// If you need to modify these messages (e.g. to add new fields to btree or bitmap) then
-// it is ok to modify them here.
+/* NOTE: Do *NOT* add new index details here.  Add them to the index.proto file instead.
+ * This file is in the lance.table package namespace while the index.proto file is in the
+ * lance.index package namespace.
+ *
+ * These are only here for forward compatibility.  Older versions of Lance expect btree indexes
+ * to have lance.table in the package namespace.
+ *
+ * If you need to modify these messages (e.g. to add new fields to btree or bitmap) then
+ * it is ok to modify them here.
+ */
 
-// Currently many of these are empty messages because all needed details are either hard-coded (e.g.
-// filenames) or stored in the index itself.  However, we may want to add more details in the
-// future, in particular we can add details that may be useful for planning queries (e.g. don't
-// force us to load the index until we know we can make use of it)
+/* Currently many of these are empty messages because all needed details are either hard-coded (e.g.
+ * filenames) or stored in the index itself.  However, we may want to add more details in the
+ * future, in particular we can add details that may be useful for planning queries (e.g. don't
+ * force us to load the index until we know we can make use of it)
+ */
 
 message BTreeIndexDetails {}
 message BitmapIndexDetails {}
 message LabelListIndexDetails {}
 message NGramIndexDetails {}
 message ZoneMapIndexDetails {
-  // Number of rows per zone. Optional for backwards compatibility: absent on
-  // datasets written before this field was added. When absent, no seed writer
-  // is created for the index.
+  /* Number of rows per zone. Optional for backwards compatibility: absent on
+   * datasets written before this field was added. When absent, no seed writer
+   * is created for the index.
+   */
   optional uint64 rows_per_zone = 1;
-  // Whether seed-based incremental updates are enabled for this index.
-  // On-disk semantics: absent means seeds are disabled (old datasets written
-  // before this field was added). Present false means explicitly disabled.
-  // Present true means seeds are enabled: the index will embed per-fragment
-  // seed buffers in data files and harvest them during incremental updates
-  // to skip full column scans.
-  // Creation-time default: index creation code sets this to true for
-  // variable-length types (strings, binary) and fixed-width types wider than
-  // 8 bytes, and to false for narrow fixed-width types (e.g. Int64, Float64).
+  /* Whether seed-based incremental updates are enabled for this index.
+   * On-disk semantics: absent means seeds are disabled (old datasets written
+   * before this field was added). Present false means explicitly disabled.
+   * Present true means seeds are enabled: the index will embed per-fragment
+   * seed buffers in data files and harvest them during incremental updates
+   * to skip full column scans.
+   * Creation-time default: index creation code sets this to true for
+   * variable-length types (strings, binary) and fixed-width types wider than
+   * 8 bytes, and to false for narrow fixed-width types (e.g. Int64, Float64).
+   */
   optional bool use_seeds = 2;
-  // Whether this index tracks exact null row addresses in a separate bitmap.
-  // Absent or false means legacy format: null positions are not tracked and
-  // IS NULL searches fall back to approximate zone-level statistics. Present
-  // true means IS NULL is exact and IS NOT NULL can be answered without a
-  // full scan.
+  /* Whether this index tracks exact null row addresses in a separate bitmap.
+   * Absent or false means legacy format: null positions are not tracked and
+   * IS NULL searches fall back to approximate zone-level statistics. Present
+   * true means IS NULL is exact and IS NOT NULL can be answered without a
+   * full scan.
+   */
   optional bool has_null_bitmap = 3;
 }
 message InvertedIndexDetails {
@@ -53,28 +58,33 @@ message InvertedIndexDetails {
   }
 
   message CodeTokenizerConfig {
-    // Split one lexical identifier into subwords, e.g. getUserName ->
-    // get/user/name.
+    /* Split one lexical identifier into subwords, e.g. getUserName ->
+     * get/user/name.
+     */
     bool split_identifiers = 1;
-    // Split identifier subwords across letter/number boundaries, e.g.
-    // HTML2JSON -> html/2/json. An absent value uses the code tokenizer default;
-    // a present value records the explicit index-time choice.
+    /* Split identifier subwords across letter/number boundaries, e.g.
+     * HTML2JSON -> html/2/json. An absent value uses the code tokenizer default;
+     * a present value records the explicit index-time choice.
+     */
     optional bool split_on_numerics = 2;
-    // Keep the complete lexical identifier in addition to subwords, e.g.
-    // user_name plus user/name. An absent value uses the code tokenizer default;
-    // a present value records the explicit index-time choice.
+    /* Keep the complete lexical identifier in addition to subwords, e.g.
+     * user_name plus user/name. An absent value uses the code tokenizer default;
+     * a present value records the explicit index-time choice.
+     */
     optional bool preserve_original = 3;
-    // Index operator tokens such as "::", "->", and "!=". Operators are not
-    // indexed by default because they are often high-frequency noise.
+    /* Index operator tokens such as "::", "->", and "!=". Operators are not
+     * indexed by default because they are often high-frequency noise.
+     */
     bool index_operators = 4;
   }
 
-  // Lexical tokenizer used after document-level text extraction. This is an
-  // implementation component such as "simple", "icu", "ngram", or "code".
-  // Input-time analyzer profiles are expanded into this field and the concrete
-  // options below before these details are persisted.
-  // Marking this field as optional as old versions of the index store blank details and we
-  // need to make sure we have a proper optional field to detect this.
+  /* Lexical tokenizer used after document-level text extraction. This is an
+   * implementation component such as "simple", "icu", "ngram", or "code".
+   * Input-time analyzer profiles are expanded into this field and the concrete
+   * options below before these details are persisted.
+   * Marking this field as optional as old versions of the index store blank details and we
+   * need to make sure we have a proper optional field to detect this.
+   */
   optional string base_tokenizer = 1;
   string language = 2;
   bool with_position = 3;
@@ -86,19 +96,23 @@ message InvertedIndexDetails {
   uint32 min_ngram_length = 9;
   uint32 max_ngram_length = 10;
   bool prefix_only = 11;
-  // Number of documents per compressed posting block. An absent value means
-  // the index predates this field and must use the legacy block size of 128.
-  // A present value records the block size used by the index; 256 is valid
-  // with format versions 3 and 4.
+  /* Number of documents per compressed posting block. An absent value means
+   * the index predates this field and must use the legacy block size of 128.
+   * A present value records the block size used by the index; 256 is valid
+   * with format versions 3 and 4.
+   */
   optional uint32 block_size = 12;
-  // Options for base_tokenizer = "code". Presence records the code tokenizer
-  // configuration used to build the index; absence means there is no
-  // code-specific configuration to apply.
+  /* Options for base_tokenizer = "code". Presence records the code tokenizer
+   * configuration used to build the index; absence means there is no
+   * code-specific configuration to apply.
+   */
   CodeTokenizerConfig code_config = 13;
-  // The logical FTS document boundary. The protobuf default preserves the
-  // legacy row-document behavior when this field is absent.
+  /* The logical FTS document boundary. The protobuf default preserves the
+   * legacy row-document behavior when this field is absent.
+   */
   DocumentGranularity document_granularity = 14;
-  // The posting-list payload format. This is separate from index_version,
-  // which identifies the overall inverted-index layout.
+  /* The posting-list payload format. This is separate from index_version,
+   * which identifies the overall inverted-index layout.
+   */
   optional uint32 posting_format_version = 15;
 }

--- a/protos/rowids.proto
+++ b/protos/rowids.proto
@@ -4,13 +4,15 @@
 syntax = "proto3";
 
 package lance.table;
-// TODO: what would it take to store this in a LanceV2 file?
-// Or would flatbuffers be better for this?
+/* TODO: what would it take to store this in a LanceV2 file?
+ * Or would flatbuffers be better for this?
+ */
 
-/// A sequence of row IDs. This is split up into one or more segments,
-/// each of which can be encoded in different ways. The encodings are optimized
-/// for values that are sorted, which will often be the case with row ids.
-/// They also have optimized forms depending on how sparse the values are.
+/* A sequence of row IDs. This is split up into one or more segments,
+ * each of which can be encoded in different ways. The encodings are optimized
+ * for values that are sorted, which will often be the case with row ids.
+ * They also have optimized forms depending on how sparse the values are.
+ */
 message RowIdSequence {
     repeated U64Segment segments = 1;
 }
@@ -31,11 +33,12 @@ message U64Segment {
         uint64 start = 1;
         /// The end of the range, exclusive.
         uint64 end = 2;
-        /// The holes in the range, as a sorted array of values;
-        /// Binary search can be used to check whether a value is a hole and should
-        /// be skipped. This can also be used to count the number of holes before a
-        /// given value, if you need to find the logical offset of a value in the
-        /// segment.
+        /* The holes in the range, as a sorted array of values;
+         * Binary search can be used to check whether a value is a hole and should
+         * be skipped. This can also be used to count the number of holes before a
+         * given value, if you need to find the logical offset of a value in the
+         * segment.
+         */
         EncodedU64Array holes = 3;
     }
 
@@ -45,13 +48,14 @@ message U64Segment {
         uint64 start = 1;
         /// The end of the range, exclusive.
         uint64 end = 2;
-        /// A bitmap of the values in the range. The bitmap is a sequence of bytes,
-        /// where each byte represents 8 values. The first byte represents values
-        /// start to start + 7, the second byte represents values start + 8 to
-        /// start + 15, and so on. The most significant bit of each byte represents
-        /// the first value in the range, and the least significant bit represents
-        /// the last value in the range. If the bit is set, the value is in the
-        /// range; if it is not set, the value is not in the range.
+        /* A bitmap of the values in the range. The bitmap is a sequence of bytes,
+         * where each byte represents 8 values. The first byte represents values
+         * start to start + 7, the second byte represents values start + 8 to
+         * start + 15, and so on. The most significant bit of each byte represents
+         * the first value in the range, and the least significant bit represents
+         * the last value in the range. If the bit is set, the value is in the
+         * range; if it is not set, the value is not in the range.
+         */
         bytes bitmap = 3;
     }
 
@@ -73,15 +77,17 @@ message U64Segment {
 message EncodedU64Array {
     message U16Array {
         uint64 base = 1;
-        /// The deltas are stored as 16-bit unsigned integers.
-        /// (protobuf doesn't support 16-bit integers, so we use bytes instead)
+        /* The deltas are stored as 16-bit unsigned integers.
+         * (protobuf doesn't support 16-bit integers, so we use bytes instead)
+         */
         bytes offsets = 2;
     }
 
     message U32Array {
         uint64 base = 1;
-        /// The deltas are stored as 32-bit unsigned integers.
-        /// (we use bytes instead of uint32 to avoid overhead of varint encoding)
+        /* The deltas are stored as 32-bit unsigned integers.
+         * (we use bytes instead of uint32 to avoid overhead of varint encoding)
+         */
         bytes offsets = 2;
     }
 
@@ -97,9 +103,10 @@ message EncodedU64Array {
     }
 }
 
-/// A sequence of dataset versions. Similar to RowIdSequence but tracks
-/// version runs. It uses RLE (Run-Length Encoding) to efficiently
-// represent consecutive rows with the same version.
+/* A sequence of dataset versions. Similar to RowIdSequence but tracks
+ * version runs. It uses RLE (Run-Length Encoding) to efficiently
+ * represent consecutive rows with the same version.
+ */
 message RowDatasetVersionSequence {
     repeated RowDatasetVersionRun runs = 1;
 }

--- a/protos/table.proto
+++ b/protos/table.proto
@@ -46,51 +46,56 @@ message Manifest {
   // Snapshot version number.
   uint64 version = 3;
 
-  // The file position of the version auxiliary data.
-  //  * It is not inheritable between versions.
-  //  * It is not loaded by default during query.
+  /* The file position of the version auxiliary data.
+   *  * It is not inheritable between versions.
+   *  * It is not loaded by default during query.
+   */
   uint64 version_aux_data = 4;
 
   message WriterVersion {
     // The name of the library that created this file.
     string library = 1;
-    // The version of the library that created this file. Because we cannot assume
-    // that the library is semantically versioned, this is a string. However, if it
-    // is semantically versioned, it should be a valid semver string without any 'v'
-    // prefix. For example: `2.0.0`, `2.0.0-rc.1`.
-    //
-    // For forward compatibility with older readers, when writing new manifests this
-    // field should contain only the core version (major.minor.patch) without any
-    // prerelease or build metadata. The prerelease/build info should be stored in
-    // the separate prerelease and build_metadata fields instead.
+    /* The version of the library that created this file. Because we cannot assume
+     * that the library is semantically versioned, this is a string. However, if it
+     * is semantically versioned, it should be a valid semver string without any 'v'
+     * prefix. For example: `2.0.0`, `2.0.0-rc.1`.
+     *
+     * For forward compatibility with older readers, when writing new manifests this
+     * field should contain only the core version (major.minor.patch) without any
+     * prerelease or build metadata. The prerelease/build info should be stored in
+     * the separate prerelease and build_metadata fields instead.
+     */
     string version = 2;
-    // Optional semver prerelease identifier.
-    //
-    // This field stores the prerelease portion of a semantic version separately
-    // from the core version number. For example, if the full version is "2.0.0-rc.1",
-    // the version field would contain "2.0.0" and prerelease would contain "rc.1".
-    //
-    // This separation ensures forward compatibility: older readers can parse the
-    // clean version field without errors, while newer readers can reconstruct the
-    // full semantic version by combining version, prerelease, and build_metadata.
-    //
-    // If absent, the version field is used as-is.
+    /* Optional semver prerelease identifier.
+     *
+     * This field stores the prerelease portion of a semantic version separately
+     * from the core version number. For example, if the full version is "2.0.0-rc.1",
+     * the version field would contain "2.0.0" and prerelease would contain "rc.1".
+     *
+     * This separation ensures forward compatibility: older readers can parse the
+     * clean version field without errors, while newer readers can reconstruct the
+     * full semantic version by combining version, prerelease, and build_metadata.
+     *
+     * If absent, the version field is used as-is.
+     */
     optional string prerelease = 3;
-    // Optional semver build metadata.
-    //
-    // This field stores the build metadata portion of a semantic version separately
-    // from the core version number. For example, if the full version is
-    // "2.0.0-rc.1+build.123", the version field would contain "2.0.0", prerelease
-    // would contain "rc.1", and build_metadata would contain "build.123".
-    //
-    // If absent, no build metadata is present.
+    /* Optional semver build metadata.
+     *
+     * This field stores the build metadata portion of a semantic version separately
+     * from the core version number. For example, if the full version is
+     * "2.0.0-rc.1+build.123", the version field would contain "2.0.0", prerelease
+     * would contain "rc.1", and build_metadata would contain "build.123".
+     *
+     * If absent, no build metadata is present.
+     */
     optional string build_metadata = 4;
   }
 
-  // The version of the writer that created this file.
-  //
-  // This information may be used to detect whether the file may have known bugs
-  // associated with that writer.
+  /* The version of the writer that created this file.
+   *
+   * This information may be used to detect whether the file may have known bugs
+   * associated with that writer.
+   */
   WriterVersion writer_version = 13;
 
   // If present, the file position of the index metadata.
@@ -102,120 +107,131 @@ message Manifest {
   // Optional version tag
   string tag = 8;
 
-  // Feature flags for readers.
-  //
-  // A bitmap of flags that indicate which features are required to be able to
-  // read the table. If a reader does not recognize a flag that is set, it
-  // should not attempt to read the dataset.
-  //
-  // Known flags:
-  // * 1 << 0: deletion files are present
-  // * 1 << 1: row ids are stable and stored as part of the fragment metadata.
-  // * 1 << 2: use v2 format (deprecated)
-  // * 1 << 3: table config is present
-  // * 1 << 4: dataset uses multiple base paths
-  // * 1 << 5: transaction file writes are disabled
-  // * 1 << 6: data overlay files are present (see DataOverlayFile). Readers that do
-  //   not understand overlays must refuse the dataset, since ignoring an overlay
-  //   would silently return stale base values.
-  // * 1 << 7: some index declares covering columns, so IndexMetadata.fields means
-  //   the keyed columns followed by the carried ones named in covering_fields (see
-  //   IndexMetadata). Readers that do not understand it must refuse the dataset,
-  //   since selecting an index by membership of fields would answer a query on a
-  //   merely-carried column with an index keyed on a different column. Writers must
-  //   refuse it too: one that treats every entry of fields as keyed would maintain
-  //   the index against the wrong dependency set.
-  // * 1 << 8: reserved for datasets that may reference recognized V2 data files
-  //   with different exact versions. Implementations that do not support the
-  //   per-file exact-version contract must treat this bit as unknown.
+  /* Feature flags for readers.
+   *
+   * A bitmap of flags that indicate which features are required to be able to
+   * read the table. If a reader does not recognize a flag that is set, it
+   * should not attempt to read the dataset.
+   *
+   * Known flags:
+   * * 1 << 0: deletion files are present
+   * * 1 << 1: row ids are stable and stored as part of the fragment metadata.
+   * * 1 << 2: use v2 format (deprecated)
+   * * 1 << 3: table config is present
+   * * 1 << 4: dataset uses multiple base paths
+   * * 1 << 5: transaction file writes are disabled
+   * * 1 << 6: data overlay files are present (see DataOverlayFile). Readers that do
+   *   not understand overlays must refuse the dataset, since ignoring an overlay
+   *   would silently return stale base values.
+   * * 1 << 7: some index declares covering columns, so IndexMetadata.fields means
+   *   the keyed columns followed by the carried ones named in covering_fields (see
+   *   IndexMetadata). Readers that do not understand it must refuse the dataset,
+   *   since selecting an index by membership of fields would answer a query on a
+   *   merely-carried column with an index keyed on a different column. Writers must
+   *   refuse it too: one that treats every entry of fields as keyed would maintain
+   *   the index against the wrong dependency set.
+   * * 1 << 8: reserved for datasets that may reference recognized V2 data files
+   *   with different exact versions. Implementations that do not support the
+   *   per-file exact-version contract must treat this bit as unknown.
+   */
   uint64 reader_feature_flags = 9;
 
-  // Feature flags for writers.
-  //
-  // A bitmap of flags that indicate which features must be used when writing to the
-  // dataset. If a writer does not recognize a flag that is set, it should not attempt to
-  // write to the dataset.
-  //
-  // The flag identities are the same as for reader_feature_flags, but the values of
-  // reader_feature_flags and writer_feature_flags are not required to be identical.
+  /* Feature flags for writers.
+   *
+   * A bitmap of flags that indicate which features must be used when writing to the
+   * dataset. If a writer does not recognize a flag that is set, it should not attempt to
+   * write to the dataset.
+   *
+   * The flag identities are the same as for reader_feature_flags, but the values of
+   * reader_feature_flags and writer_feature_flags are not required to be identical.
+   */
   uint64 writer_feature_flags = 10;
 
-  // The highest fragment ID that has been used so far.
-  //
-  // This ID is not guaranteed to be present in the current version, but it may
-  // have been used in previous versions.
-  //
-  // For a single fragment, will be zero. For no fragments, will be absent.
+  /* The highest fragment ID that has been used so far.
+   *
+   * This ID is not guaranteed to be present in the current version, but it may
+   * have been used in previous versions.
+   *
+   * For a single fragment, will be zero. For no fragments, will be absent.
+   */
   optional uint32 max_fragment_id = 11;
 
-  // Path to the transaction file, relative to `{root}/_transactions`. The file at that
-  // location contains a wire-format serialized Transaction message representing the
-  // transaction that created this version.
-  //
-  // This string field "transaction_file" may be empty if no transaction file was written.
-  //
-  // The path format is "{read_version}-{uuid}.txn" where {read_version} is the version of
-  // the table the transaction read from (serialized to decimal with no padding digits),
-  // and {uuid} is a hyphen-separated UUID.
+  /* Path to the transaction file, relative to `{root}/_transactions`. The file at that
+   * location contains a wire-format serialized Transaction message representing the
+   * transaction that created this version.
+   *
+   * This string field "transaction_file" may be empty if no transaction file was written.
+   *
+   * The path format is "{read_version}-{uuid}.txn" where {read_version} is the version of
+   * the table the transaction read from (serialized to decimal with no padding digits),
+   * and {uuid} is a hyphen-separated UUID.
+   */
   string transaction_file = 12;
 
-  // The file position of the transaction content. None if transaction is empty
-  // This transaction content begins with the transaction content length as u32
-  // If the transaction proto message has a length of `len`, the message ends at `len` + 4
+  /* The file position of the transaction content. None if transaction is empty
+   * This transaction content begins with the transaction content length as u32
+   * If the transaction proto message has a length of `len`, the message ends at `len` + 4
+   */
   optional uint64 transaction_section = 21;
 
-  // The next unused row id. If zero, then the table does not have any rows.
-  //
-  // This is only used if the "stable_row_ids" feature flag is set.
+  /* The next unused row id. If zero, then the table does not have any rows.
+   *
+   * This is only used if the "stable_row_ids" feature flag is set.
+   */
   uint64 next_row_id = 14;
 
   message DataStorageFormat {
     // The format of the data files (e.g. "lance")
     string file_format = 1;
-    // The max format version of the data files. The format of the version can vary by
-    // file_format and is not required to follow semver.
-    //
-    // Every file in this version of the dataset has the same file_format version.
+    /* The max format version of the data files. The format of the version can vary by
+     * file_format and is not required to follow semver.
+     *
+     * Every file in this version of the dataset has the same file_format version.
+     */
     string version = 2;
   }
 
-  // The data storage format
-  //
-  // This specifies what format is used to store the data files.
+  /* The data storage format
+   *
+   * This specifies what format is used to store the data files.
+   */
   DataStorageFormat data_format = 15;
 
-  // Table config.
-  //
-  // Keys with the prefix "lance." are reserved for the Lance library. Other
-  // libraries may wish to similarly prefix their configuration keys
-  // appropriately.
+  /* Table config.
+   *
+   * Keys with the prefix "lance." are reserved for the Lance library. Other
+   * libraries may wish to similarly prefix their configuration keys
+   * appropriately.
+   */
   map<string, string> config = 16;
 
-  // Metadata associated with the table.
-  //
-  // This is a key-value map that can be used to store arbitrary metadata
-  // associated with the table.
-  //
-  // This is different than configuration, which is used to tell libraries how
-  // to read, write, or manage the table.
-  //
-  // This is different than schema metadata, which is used to describe the
-  // data itself and is attached to the output schema of scans.
+  /* Metadata associated with the table.
+   *
+   * This is a key-value map that can be used to store arbitrary metadata
+   * associated with the table.
+   *
+   * This is different than configuration, which is used to tell libraries how
+   * to read, write, or manage the table.
+   *
+   * This is different than schema metadata, which is used to describe the
+   * data itself and is attached to the output schema of scans.
+   */
   map<string, string> table_metadata = 19;
 
   // Field number 17 (`blob_dataset_version`) was used for a secondary blob dataset.
   reserved 17;
   reserved "blob_dataset_version";
 
-  // The base paths of data files.
-  //
-  // This is used to determine the base path of a data file. In common cases data file paths are under current dataset base path.
-  // But for shallow cloning, importing file and other multi-tier storage cases, the actual data files could be outside of the current dataset.
-  // This field is used with the `base_id` in `lance.file.File` and `lance.file.DeletionFile`.
-  //
-  // For example, if we have a dataset with base path `s3://bucket/dataset`, we have a DataFile with base_id 0, we get the actual data file path by:
-  // base_paths[id = 0] + /data/ + file.path
-  // the key(a.k.a index) starts from 0, increased by 1 for each new base path.
+  /* The base paths of data files.
+   *
+   * This is used to determine the base path of a data file. In common cases data file paths are under current dataset base path.
+   * But for shallow cloning, importing file and other multi-tier storage cases, the actual data files could be outside of the current dataset.
+   * This field is used with the `base_id` in `lance.file.File` and `lance.file.DeletionFile`.
+   *
+   * For example, if we have a dataset with base path `s3://bucket/dataset`, we have a DataFile with base_id 0, we get the actual data file path by:
+   * base_paths[id = 0] + /data/ + file.path
+   * the key(a.k.a index) starts from 0, increased by 1 for each new base path.
+   */
   repeated BasePath base_paths = 18;
 
   // The branch of the dataset. None means main branch.
@@ -225,19 +241,22 @@ message Manifest {
 // external dataset base path
 message BasePath {
   uint32 id = 1;
-  // This is an alias name of the base path, it is optional.
-  // When we use shallow clone and the target version is a tag, the tag name will be set here.
+  /* This is an alias name of the base path, it is optional.
+   * When we use shallow clone and the target version is a tag, the tag name will be set here.
+   */
   optional string name = 2;
-  // Flag indicating whether this path is a dataset root path or file directory:
-  // - true:  Path is a dataset root (actual files under subdirectories like `data`, '_deletions')
-  // - false: Path is a direct file directory (scenario like importing files)
+  /* Flag indicating whether this path is a dataset root path or file directory:
+   * - true:  Path is a dataset root (actual files under subdirectories like `data`, '_deletions')
+   * - false: Path is a direct file directory (scenario like importing files)
+   */
   bool is_dataset_root = 3;
   // Note: This absolute path will be directly used by Path:parse(),
   string path = 4;
 }
 
-// Auxiliary Data attached to a version.
-// Only load on-demand.
+/* Auxiliary Data attached to a version.
+ * Only load on-demand.
+ */
 message VersionAuxData {
   // key-value metadata.
   map<string, bytes> metadata = 3;
@@ -248,10 +267,11 @@ message IndexMetadata {
   // Unique ID of an index. It is unique across all the dataset versions.
   UUID uuid = 1;
 
-  // The columns to build the index. These refer to file.Field.id.
-  //
-  // fields[0] is always a column the index is keyed on. Trailing entries may
-  // instead be merely carried, not keyed on -- see `covering_fields` below.
+  /* The columns to build the index. These refer to file.Field.id.
+   *
+   * fields[0] is always a column the index is keyed on. Trailing entries may
+   * instead be merely carried, not keyed on -- see `covering_fields` below.
+   */
   repeated int32 fields = 2;
 
   // Index name. Must be unique within one dataset version.
@@ -260,72 +280,78 @@ message IndexMetadata {
   // The version of the dataset this index was built from.
   uint64 dataset_version = 4;
 
-  // A bitmap of the included fragment ids.
-  //
-  // This may by used to determine how much of the dataset is covered by the
-  // index. This information can be retrieved from the dataset by looking at
-  // the dataset at `dataset_version`. However, since the old version may be
-  // deleted while the index is still in use, this information is also stored
-  // in the index.
-  //
-  // The bitmap is stored as a 32-bit Roaring bitmap.
+  /* A bitmap of the included fragment ids.
+   *
+   * This may by used to determine how much of the dataset is covered by the
+   * index. This information can be retrieved from the dataset by looking at
+   * the dataset at `dataset_version`. However, since the old version may be
+   * deleted while the index is still in use, this information is also stored
+   * in the index.
+   *
+   * The bitmap is stored as a 32-bit Roaring bitmap.
+   */
   bytes fragment_bitmap = 5;
 
-  // Details, specific to the index type, which are needed to load / interpret the index
-  //
-  // Indices should avoid putting large amounts of information in this field, as it will
-  // bloat the manifest.
-  //
-  // Indexes are plugins, and so the format of the details message is flexible and not fully
-  // defined by the table format.  However, there are some conventions that should be followed:
-  //
-  // - When Lance APIs refer to indexes they will use the type URL of the index details as the
-  //   identifier for the index type.  If a user provides a simple string identifier like
-  //   "btree" then it will be converted to "/lance.table.BTreeIndexDetails"
-  // - Type URLs comparisons are case-insensitive.  Thereform an index must have a unique type
-  //   URL ignoring case.
+  /* Details, specific to the index type, which are needed to load / interpret the index
+   *
+   * Indices should avoid putting large amounts of information in this field, as it will
+   * bloat the manifest.
+   *
+   * Indexes are plugins, and so the format of the details message is flexible and not fully
+   * defined by the table format.  However, there are some conventions that should be followed:
+   *
+   * - When Lance APIs refer to indexes they will use the type URL of the index details as the
+   *   identifier for the index type.  If a user provides a simple string identifier like
+   *   "btree" then it will be converted to "/lance.table.BTreeIndexDetails"
+   * - Type URLs comparisons are case-insensitive.  Thereform an index must have a unique type
+   *   URL ignoring case.
+   */
   google.protobuf.Any index_details = 6;
 
   // The minimum lance version that this index is compatible with.
   optional int32 index_version = 7;
 
-  // Timestamp when the index was created (UTC timestamp in milliseconds since epoch)
-  //
-  // This field is optional for backward compatibility. For existing indices created before
-  // this field was added, this will be None/null.
+  /* Timestamp when the index was created (UTC timestamp in milliseconds since epoch)
+   *
+   * This field is optional for backward compatibility. For existing indices created before
+   * this field was added, this will be None/null.
+   */
   optional uint64 created_at = 8;
 
-  // The base path index of the data file. Used when the file is imported or referred from another dataset.
-  // Lance use it as key of the base_paths field in Manifest to determine the actual base path of the data file.
+  /* The base path index of the data file. Used when the file is imported or referred from another dataset.
+   * Lance use it as key of the base_paths field in Manifest to determine the actual base path of the data file.
+   */
   optional uint32 base_id = 9;
 
-  // List of files and their sizes for this index segment.
-  // This enables skipping HEAD calls when opening indices and allows reporting
-  // of index sizes without extra IO.
-  // If this is empty, the index files sizes are unknown.
+  /* List of files and their sizes for this index segment.
+   * This enables skipping HEAD calls when opening indices and allows reporting
+   * of index sizes without extra IO.
+   * If this is empty, the index files sizes are unknown.
+   */
   repeated IndexFile files = 10;
 
-  // The subset of `fields` whose values this index co-locates alongside its own
-  // data, so a query projecting only those columns can be answered from the
-  // index without a take against the base table.
-  //
-  // Must be a suffix of `fields`: the columns the index is keyed on come first,
-  // the columns it merely carries come last, and at least one keyed column
-  // always remains. Empty for an index that carries no extra columns, which is
-  // every index written before this field existed.
-  //
-  // Carried columns are listed in `fields` as well. That is deliberate: every
-  // consumer that reads `fields` as the index's dependency set -- staleness,
-  // commit conflict detection, schema evolution guards -- then covers them with
-  // no change and no way to forget one.
-  //
-  // This declaration is not authoritative for what the segment can actually
-  // serve. The segment's own storage schema is: a reader must confirm the
-  // storage carries a column before answering a query from it, and fall back to
-  // a take against the base table otherwise. A declaration naming columns the
-  // storage does not hold is a legal state, not corruption -- a maintenance
-  // operation that cannot carry the values through a rebuild is permitted to
-  // withdraw the payload while leaving this declaration in place.
+  /* The subset of `fields` whose values this index co-locates alongside its own
+   * data, so a query projecting only those columns can be answered from the
+   * index without a take against the base table.
+   *
+   * Must be a suffix of `fields`: the columns the index is keyed on come first,
+   * the columns it merely carries come last, and at least one keyed column
+   * always remains. Empty for an index that carries no extra columns, which is
+   * every index written before this field existed.
+   *
+   * Carried columns are listed in `fields` as well. That is deliberate: every
+   * consumer that reads `fields` as the index's dependency set -- staleness,
+   * commit conflict detection, schema evolution guards -- then covers them with
+   * no change and no way to forget one.
+   *
+   * This declaration is not authoritative for what the segment can actually
+   * serve. The segment's own storage schema is: a reader must confirm the
+   * storage carries a column before answering a query from it, and fall back to
+   * a take against the base table otherwise. A declaration naming columns the
+   * storage does not hold is a legal state, not corruption -- a maintenance
+   * operation that cannot carry the values through a rebuild is permitted to
+   * withdraw the payload while leaving this declaration in place.
+   */
   repeated int32 covering_fields = 11;
 }
 
@@ -342,23 +368,25 @@ message IndexSection {
   repeated IndexMetadata indices = 1;
 }
 
-// A DataFragment is a set of files which represent the different columns of the same
-// rows. If column exists in the schema of a dataset, but the file for that column does
-// not exist within a DataFragment of that dataset, that column consists entirely of
-// nulls.
+/* A DataFragment is a set of files which represent the different columns of the same
+ * rows. If column exists in the schema of a dataset, but the file for that column does
+ * not exist within a DataFragment of that dataset, that column consists entirely of
+ * nulls.
+ */
 message DataFragment {
   // The ID of a DataFragment is unique within a dataset.
   uint64 id = 1;
 
   repeated DataFile files = 2;
 
-  // Optional overlay files for this fragment, which supply new values for a
-  // subset of cells without rewriting the base data files. This MUST be empty
-  // if the data overlay files feature flag (64) is not set in the manifest.
-  //
-  // Order is significant: a later entry is newer than an earlier one. When two
-  // overlays cover the same (offset, field) and share a `committed_version`, the
-  // later entry wins. See DataOverlayFile for the full resolution rules.
+  /* Optional overlay files for this fragment, which supply new values for a
+   * subset of cells without rewriting the base data files. This MUST be empty
+   * if the data overlay files feature flag (64) is not set in the manifest.
+   *
+   * Order is significant: a later entry is newer than an earlier one. When two
+   * overlays cover the same (offset, field) and share a `committed_version`, the
+   * later entry wins. See DataOverlayFile for the full resolution rules.
+   */
   repeated DataOverlayFile overlays = 11;
 
   // File that indicates which rows, if any, should be considered deleted.
@@ -366,11 +394,12 @@ message DataFragment {
 
   // TODO: What's the simplest way we can allow an inline tombstone bitmap?
 
-  // A serialized RowIdSequence message (see rowids.proto).
-  //
-  // These are the row ids for the fragment, in order of the rows as they appear.
-  // That is, if a fragment has 3 rows, and the row ids are [1, 42, 3], then the
-  // first row is row 1, the second row is row 42, and the third row is row 3.
+  /* A serialized RowIdSequence message (see rowids.proto).
+   *
+   * These are the row ids for the fragment, in order of the rows as they appear.
+   * That is, if a fragment has 3 rows, and the row ids are [1, 42, 3], then the
+   * first row is row 1, the second row is row 42, and the third row is row 3.
+   */
   oneof row_id_sequence {
     // If small (< 200KB), the row ids are stored inline.
     bytes inline_row_ids = 5;
@@ -392,169 +421,184 @@ message DataFragment {
     ExternalFile external_created_at_versions = 10;
   } // created_at_version_sequence
 
-  // Number of original rows in the fragment, this includes rows that are now marked with
-  // deletion tombstones. To compute the current number of rows, subtract
-  // `deletion_file.num_deleted_rows` from this value.
+  /* Number of original rows in the fragment, this includes rows that are now marked with
+   * deletion tombstones. To compute the current number of rows, subtract
+   * `deletion_file.num_deleted_rows` from this value.
+   */
   uint64 physical_rows = 4;
 }
 
 message DataFile {
   // Path to the root relative to the dataset's URI.
   string path = 1;
-  // The ids of the fields/columns in this file.
-  //
-  // When a DataFile object is created in memory, every value in fields is assigned -1 by
-  // default. An object with a value in fields of -1 must not be stored to disk. -2 is
-  // used for "tombstoned", meaning a field that is no longer in use. This is often
-  // because the original field id was reassigned to a different data file.
-  //
-  // In Lance v1 IDs are assigned based on position in the file, offset by the max
-  // existing field id in the table (if any already). So when a fragment is first created
-  // with one file of N columns, the field ids will be 1, 2, ..., N. If a second fragment
-  // is created with M columns, the field ids will be N+1, N+2, ..., N+M.
-  //
-  // In Lance v1 there is one field for each field in the input schema, this includes
-  // nested fields (both struct and list).  Fixed size list fields have only a single
-  // field id (these are not considered nested fields in Lance v1).
-  //
-  // This allows column indices to be calculated from field IDs and the input schema.
-  //
-  // In Lance v2 the field IDs generally follow the same pattern but there is no
-  // way to calculate the column index from the field ID.  This is because a given
-  // field could be encoded in many different ways, some of which occupy a different
-  // number of columns.  For example, a struct field could be encoded into N + 1 columns
-  // or it could be encoded into a single packed column.  To determine column indices
-  // the column_indices property should be used instead.
-  //
-  // In Lance v1 these ids must be sorted but might not always be contiguous.
+  /* The ids of the fields/columns in this file.
+   *
+   * When a DataFile object is created in memory, every value in fields is assigned -1 by
+   * default. An object with a value in fields of -1 must not be stored to disk. -2 is
+   * used for "tombstoned", meaning a field that is no longer in use. This is often
+   * because the original field id was reassigned to a different data file.
+   *
+   * In Lance v1 IDs are assigned based on position in the file, offset by the max
+   * existing field id in the table (if any already). So when a fragment is first created
+   * with one file of N columns, the field ids will be 1, 2, ..., N. If a second fragment
+   * is created with M columns, the field ids will be N+1, N+2, ..., N+M.
+   *
+   * In Lance v1 there is one field for each field in the input schema, this includes
+   * nested fields (both struct and list).  Fixed size list fields have only a single
+   * field id (these are not considered nested fields in Lance v1).
+   *
+   * This allows column indices to be calculated from field IDs and the input schema.
+   *
+   * In Lance v2 the field IDs generally follow the same pattern but there is no
+   * way to calculate the column index from the field ID.  This is because a given
+   * field could be encoded in many different ways, some of which occupy a different
+   * number of columns.  For example, a struct field could be encoded into N + 1 columns
+   * or it could be encoded into a single packed column.  To determine column indices
+   * the column_indices property should be used instead.
+   *
+   * In Lance v1 these ids must be sorted but might not always be contiguous.
+   */
   repeated int32 fields = 2;
-  // The top-level column indices for each field in the file.
-  //
-  // If the data file is version 1 then this property will be empty
-  //
-  // Otherwise there must be one entry for each field in `fields`.
-  //
-  // Some fields may not correspond to a top-level column in the file.  In these cases
-  // the index will -1.
-  //
-  // For example, consider the schema:
-  //
-  // - dimension: packed-struct (0):
-  //   - x: u32 (1)
-  //   - y: u32 (2)
-  // - path: `list<u32>` (3)
-  // - embedding: `fsl<768>` (4)
-  //   - fp64
-  // - borders: `fsl<4>` (5)
-  //   - simple-struct (6)
-  //     - margin: fp64 (7)
-  //     - padding: fp64 (8)
-  //
-  // One possible column indices array could be:
-  // [0, -1, -1, 1, 3, 4, 5, 6, 7]
-  //
-  // This reflects quite a few phenomenon:
-  // - The packed struct is encoded into a single column and there is no top-level column
-  //   for the x or y fields
-  // - The variable sized list is encoded into two columns
-  // - The embedding is encoded into a single column (common for FSL of primitive) and there
-  //   is not "FSL column"
-  // - The borders field actually does have an "FSL column"
-  //
-  // The column indices table may not have duplicates (other than -1)
+  /* The top-level column indices for each field in the file.
+   *
+   * If the data file is version 1 then this property will be empty
+   *
+   * Otherwise there must be one entry for each field in `fields`.
+   *
+   * Some fields may not correspond to a top-level column in the file.  In these cases
+   * the index will -1.
+   *
+   * For example, consider the schema:
+   *
+   * - dimension: packed-struct (0):
+   *   - x: u32 (1)
+   *   - y: u32 (2)
+   * - path: `list<u32>` (3)
+   * - embedding: `fsl<768>` (4)
+   *   - fp64
+   * - borders: `fsl<4>` (5)
+   *   - simple-struct (6)
+   *     - margin: fp64 (7)
+   *     - padding: fp64 (8)
+   *
+   * One possible column indices array could be:
+   * [0, -1, -1, 1, 3, 4, 5, 6, 7]
+   *
+   * This reflects quite a few phenomenon:
+   * - The packed struct is encoded into a single column and there is no top-level column
+   *   for the x or y fields
+   * - The variable sized list is encoded into two columns
+   * - The embedding is encoded into a single column (common for FSL of primitive) and there
+   *   is not "FSL column"
+   * - The borders field actually does have an "FSL column"
+   *
+   * The column indices table may not have duplicates (other than -1)
+   */
   repeated int32 column_indices = 3;
   // The major file version used to create the file
   uint32 file_major_version = 4;
-  // The minor file version used to create the file
-  //
-  // If both `file_major_version` and `file_minor_version` are set to 0,
-  // then this is a version 0.1 or version 0.2 file.
+  /* The minor file version used to create the file
+   *
+   * If both `file_major_version` and `file_minor_version` are set to 0,
+   * then this is a version 0.1 or version 0.2 file.
+   */
   uint32 file_minor_version = 5;
 
-  // The known size of the file on disk in bytes.
-  //
-  // This is used to quickly find the footer of the file.
-  //
-  // When this is zero, it should be interpreted as "unknown".
+  /* The known size of the file on disk in bytes.
+   *
+   * This is used to quickly find the footer of the file.
+   *
+   * When this is zero, it should be interpreted as "unknown".
+   */
   uint64 file_size_bytes = 6;
 
-  // The base path index of the data file. Used when the file is imported or referred from another dataset.
-  // Lance use it as key of the base_paths field in Manifest to determine the actual base path of the data file.
+  /* The base path index of the data file. Used when the file is imported or referred from another dataset.
+   * Lance use it as key of the base_paths field in Manifest to determine the actual base path of the data file.
+   */
   optional uint32 base_id = 7;
 } // DataFile
 
-// An overlay file supplies new values for a subset of (row offset, field) cells
-// within a fragment, without rewriting the fragment's base data files. It is
-// used for efficient updates when only a small fraction of rows and/or columns
-// change.
-//
-// On read, a cell is resolved by consulting the fragment's overlays from newest
-// to oldest: the first overlay that covers that (offset, field) wins; if none
-// cover it, the value falls through to the base data file. Because deletions
-// take precedence over overlays, an overlay value for an offset that is also
-// marked deleted is dead and is ignored.
-//
-// The overlay's data file does NOT store a row-offset key column. Within a value
-// column, the position of a covered offset's value is the rank (0-based count of
-// set bits below it) of that offset within the field's coverage bitmap. Because
-// fields may cover different offset sets, the value columns of a single overlay
-// data file may have different lengths (which the Lance file format permits).
+/* An overlay file supplies new values for a subset of (row offset, field) cells
+ * within a fragment, without rewriting the fragment's base data files. It is
+ * used for efficient updates when only a small fraction of rows and/or columns
+ * change.
+ *
+ * On read, a cell is resolved by consulting the fragment's overlays from newest
+ * to oldest: the first overlay that covers that (offset, field) wins; if none
+ * cover it, the value falls through to the base data file. Because deletions
+ * take precedence over overlays, an overlay value for an offset that is also
+ * marked deleted is dead and is ignored.
+ *
+ * The overlay's data file does NOT store a row-offset key column. Within a value
+ * column, the position of a covered offset's value is the rank (0-based count of
+ * set bits below it) of that offset within the field's coverage bitmap. Because
+ * fields may cover different offset sets, the value columns of a single overlay
+ * data file may have different lengths (which the Lance file format permits).
+ */
 message DataOverlayFile {
-  // The data file storing the overlay's new cell values, one value column per
-  // field in `data_file.fields`. No row-offset key column is stored.
+  /* The data file storing the overlay's new cell values, one value column per
+   * field in `data_file.fields`. No row-offset key column is stored.
+   */
   DataFile data_file = 1;
 
   // Which (offset, field) cells this overlay provides values for.
   oneof coverage {
-    // A single 32-bit Roaring bitmap of physical row offsets that applies to
-    // every field in `data_file.fields` (a "dense" / rectangular overlay).
-    // Every covered offset has a value for every field. This is the common case
-    // for a plain UPDATE, where one SET list is applied to one set of rows.
+    /* A single 32-bit Roaring bitmap of physical row offsets that applies to
+     * every field in `data_file.fields` (a "dense" / rectangular overlay).
+     * Every covered offset has a value for every field. This is the common case
+     * for a plain UPDATE, where one SET list is applied to one set of rows.
+     */
     bytes shared_offset_bitmap = 2;
-    // Per-field coverage for a "sparse" overlay, used when different fields cover
-    // different offset sets (e.g. a MERGE with multiple WHEN MATCHED branches).
+    /* Per-field coverage for a "sparse" overlay, used when different fields cover
+     * different offset sets (e.g. a MERGE with multiple WHEN MATCHED branches).
+     */
     FieldCoverage field_coverage = 4;
   }
 
-  // The dataset version at which this overlay became effective: the version of
-  // the commit that introduced it, NOT the version it was read from. It is
-  // stamped at commit time and re-stamped if the commit is retried, in the same
-  // way as the created-at / last-updated-at version sequences.
-  //
-  // This drives two orderings:
-  //  * Versus index builds: an index whose `dataset_version` >= this value
-  //    already incorporates this overlay. Otherwise the overlay's covered cells
-  //    are excluded from index results for the affected fields and re-evaluated
-  //    against their current values (see the Data Overlay Files specification).
-  //  * Versus other overlays: when two overlays cover the same (offset, field),
-  //    the one with the higher `committed_version` wins. Overlays that share a
-  //    `committed_version` are ordered by their position in
-  //    `DataFragment.overlays`, where a later entry is newer and wins.
+  /* The dataset version at which this overlay became effective: the version of
+   * the commit that introduced it, NOT the version it was read from. It is
+   * stamped at commit time and re-stamped if the commit is retried, in the same
+   * way as the created-at / last-updated-at version sequences.
+   *
+   * This drives two orderings:
+   *  * Versus index builds: an index whose `dataset_version` >= this value
+   *    already incorporates this overlay. Otherwise the overlay's covered cells
+   *    are excluded from index results for the affected fields and re-evaluated
+   *    against their current values (see the Data Overlay Files specification).
+   *  * Versus other overlays: when two overlays cover the same (offset, field),
+   *    the one with the higher `committed_version` wins. Overlays that share a
+   *    `committed_version` are ordered by their position in
+   *    `DataFragment.overlays`, where a later entry is newer and wins.
+   */
   uint64 committed_version = 3;
 }
 
 // Per-field coverage for a sparse overlay.
 message FieldCoverage {
-  // One entry per field in the overlay's `data_file.fields`, in the same order.
-  // Each is a 32-bit Roaring bitmap of the physical row offsets covered for that
-  // field. An offset present in a field's bitmap but mapped to a NULL value
-  // means the cell is overridden to NULL (distinct from an offset that is absent,
-  // which falls through to the base data file).
+  /* One entry per field in the overlay's `data_file.fields`, in the same order.
+   * Each is a 32-bit Roaring bitmap of the physical row offsets covered for that
+   * field. An offset present in a field's bitmap but mapped to a NULL value
+   * means the cell is overridden to NULL (distinct from an offset that is absent,
+   * which falls through to the base data file).
+   */
   repeated bytes offset_bitmaps = 1;
 }
 
-// Deletion File
-//
-// The path of the deletion file is constructed as:
-//   {root}/_deletions/{fragment_id}-{read_version}-{id}.{extension}
-// where {extension} depends on DeletionFileType.
+/* Deletion File
+ *
+ * The path of the deletion file is constructed as:
+ *   {root}/_deletions/{fragment_id}-{read_version}-{id}.{extension}
+ * where {extension} depends on DeletionFileType.
+ */
 message DeletionFile {
-  // Type of deletion file, intended as a way to increase efficiency of the storage of deleted row
-  // offsets. If there are sparsely deleted rows, then ARROW_ARRAY is the most efficient. If there
-  // are densely deleted rows, then BITMAP is the most efficient.
+  /* Type of deletion file, intended as a way to increase efficiency of the storage of deleted row
+   * offsets. If there are sparsely deleted rows, then ARROW_ARRAY is the most efficient. If there
+   * are densely deleted rows, then BITMAP is the most efficient.
+   */
   enum DeletionFileType {
-    // A single Int32Array of deleted row offsets, stored as an Arrow IPC file with one batch and
-    // one column. Has a .arrow extension.
+    /* A single Int32Array of deleted row offsets, stored as an Arrow IPC file with one batch and
+     * one column. Has a .arrow extension.
+     */
     ARROW_ARRAY = 0;
     // A Roaring Bitmap of deleted row offsets. Has a .bin extension.
     BITMAP = 1;
@@ -564,14 +608,16 @@ message DeletionFile {
   DeletionFileType file_type = 1;
   // The version of the dataset this deletion file was built from.
   uint64 read_version = 2;
-  // An opaque id used to differentiate this file from others written by concurrent
-  // writers.
+  /* An opaque id used to differentiate this file from others written by concurrent
+   * writers.
+   */
   uint64 id = 3;
   // The number of rows that are marked as deleted.
   uint64 num_deleted_rows = 4;
-  // The base path index of the deletion file. Used when the file is imported or referred from another
-  // dataset. Lance uses it as key of the base_paths field in Manifest to determine the actual base
-  // path of the deletion file.
+  /* The base path index of the deletion file. Used when the file is imported or referred from another
+   * dataset. Lance uses it as key of the base_paths field in Manifest to determine the actual base
+   * path of the deletion file.
+   */
   optional uint32 base_id = 7;
 } // DeletionFile
 
@@ -608,10 +654,11 @@ message FragmentReuseIndexDetails {
 
   // A summarized version of the RewriteGroup information in a Rewrite transaction
   message Group {
-    // A roaring treemap of the changed row addresses.
-    // When combined with the old fragment IDs and new fragment IDs,
-    // it can recover the full mapping of old row addresses to either new row addresses or deleted.
-    // this mapping can then be used to remap indexes or satisfy index queries for the new unindexed fragments.
+    /* A roaring treemap of the changed row addresses.
+     * When combined with the old fragment IDs and new fragment IDs,
+     * it can recover the full mapping of old row addresses to either new row addresses or deleted.
+     * this mapping can then be used to remap indexes or satisfy index queries for the new unindexed fragments.
+     */
     bytes changed_row_addrs = 1;
 
     repeated FragmentDigest old_fragments = 2;
@@ -627,13 +674,15 @@ message FragmentReuseIndexDetails {
   }
 }
 
-// ============================================================================
-// MemWAL Index Types
-// ============================================================================
+/* ============================================================================
+ * MemWAL Index Types
+ * ============================================================================
+ */
 
-// Lifecycle status of a WAL shard. Drives drop-table two-phase commit:
-// a SEALED shard refuses new writer claims (reversible) until the drop
-// commits (the shard dir is deleted) or rolls back (status -> ACTIVE).
+/* Lifecycle status of a WAL shard. Drives drop-table two-phase commit:
+ * a SEALED shard refuses new writer claims (reversible) until the drop
+ * commits (the shard dir is deleted) or rolls back (status -> ACTIVE).
+ */
 enum ShardStatus {
   // Normal: the shard accepts writer claims.
   ACTIVE = 0;
@@ -641,54 +690,63 @@ enum ShardStatus {
   SEALED = 1;
 }
 
-// Shard manifest containing epoch-based fencing and WAL state.
-// Each shard has exactly one active writer at any time.
+/* Shard manifest containing epoch-based fencing and WAL state.
+ * Each shard has exactly one active writer at any time.
+ */
 message ShardManifest {
   // Shard identifier (UUID v4).
   UUID shard_id = 11;
 
-  // Manifest version number.
-  // Matches the version encoded in the filename.
+  /* Manifest version number.
+   * Matches the version encoded in the filename.
+   */
   uint64 version = 1;
 
-  // Shard spec ID this shard was created with.
-  // Set at shard creation and immutable thereafter.
-  // A value of 0 indicates a manually-created shard not governed by any spec.
+  /* Shard spec ID this shard was created with.
+   * Set at shard creation and immutable thereafter.
+   * A value of 0 indicates a manually-created shard not governed by any spec.
+   */
   uint32 shard_spec_id = 10;
 
-  // Computed shard field values as raw Arrow scalar bytes, keyed by shard
-  // field id. The byte encoding follows Arrow's little-endian convention:
-  // int32 is 4 LE bytes, utf8 is raw UTF-8 bytes, etc. The receiver looks
-  // up the result_type from the ShardingSpec to interpret each value.
+  /* Computed shard field values as raw Arrow scalar bytes, keyed by shard
+   * field id. The byte encoding follows Arrow's little-endian convention:
+   * int32 is 4 LE bytes, utf8 is raw UTF-8 bytes, etc. The receiver looks
+   * up the result_type from the ShardingSpec to interpret each value.
+   */
   repeated ShardFieldEntry shard_field_entries = 14;
 
-  // Writer fencing token - monotonically increasing.
-  // A writer must increment this when claiming the shard.
+  /* Writer fencing token - monotonically increasing.
+   * A writer must increment this when claiming the shard.
+   */
   uint64 writer_epoch = 2;
 
-  // The most recent WAL entry position that has been flushed to a MemTable.
-  // During recovery, replay starts from replay_after_wal_entry_position + 1.
-  // WAL positions are 1-based, so the default value 0 unambiguously means
-  // "no flush has ever stamped this shard" and recovery replays from 1.
+  /* The most recent WAL entry position that has been flushed to a MemTable.
+   * During recovery, replay starts from replay_after_wal_entry_position + 1.
+   * WAL positions are 1-based, so the default value 0 unambiguously means
+   * "no flush has ever stamped this shard" and recovery replays from 1.
+   */
   uint64 replay_after_wal_entry_position = 3;
 
-  // The most recent WAL entry position observed at the time the manifest was
-  // updated. WAL positions are 1-based; default 0 means no entry has been
-  // written yet. This is a hint, not authoritative - recovery must list
-  // files to find actual state.
+  /* The most recent WAL entry position observed at the time the manifest was
+   * updated. WAL positions are 1-based; default 0 means no entry has been
+   * written yet. This is a hint, not authoritative - recovery must list
+   * files to find actual state.
+   */
   uint64 wal_entry_position_last_seen = 4;
 
   // Generation to assign to the next SSTable (incremented after each MemTable flush).
   uint64 current_generation = 6;
 
-  // Field 7 removed: compaction progress lives in
-  // MemWalIndexDetails.compacted_sstables.
+  /* Field 7 removed: compaction progress lives in
+   * MemWalIndexDetails.compacted_sstables.
+   */
 
   // List of SSTables created by flushing MemTables and their directory paths.
   repeated SsTable sstables = 8;
 
-  // Lifecycle status. Default ACTIVE; SEALED marks an in-flight drop
-  // (drop-table 2PC). A SEALED manifest refuses claims at claim_epoch.
+  /* Lifecycle status. Default ACTIVE; SEALED marks an in-flight drop
+   * (drop-table 2PC). A SEALED manifest refuses claims at claim_epoch.
+   */
   ShardStatus status = 15;
 }
 
@@ -697,8 +755,9 @@ message ShardFieldEntry {
   // Shard field id (matches ShardingField.field_id in the ShardingSpec).
   string field_id = 1;
 
-  // Raw Arrow scalar value bytes in little-endian encoding.
-  // The data type is determined by the result_type of the matching ShardingField.
+  /* Raw Arrow scalar value bytes in little-endian encoding.
+   * The data type is determined by the result_type of the matching ShardingField.
+   */
   bytes value = 2;
 }
 
@@ -720,102 +779,113 @@ message CompactedSsTable {
   uint64 generation = 2;
 }
 
-// Tracks which compacted SSTable generation a base table index has been rebuilt to cover.
-// Used to determine whether to read from SSTable indexes or base table.
+/* Tracks which compacted SSTable generation a base table index has been rebuilt to cover.
+ * Used to determine whether to read from SSTable indexes or base table.
+ */
 message IndexCatchupProgress {
   // Name of the base table index (must match an entry in maintained_indexes).
   string index_name = 1;
 
-  // Per-shard progress: the generation up to which this index covers.
-  //
-  // An absent shard means *unknown*: this index has recorded no catch-up for
-  // that shard, so its SSTables must be retained and a repair scheduled.
+  /* Per-shard progress: the generation up to which this index covers.
+   *
+   * An absent shard means *unknown*: this index has recorded no catch-up for
+   * that shard, so its SSTables must be retained and a repair scheduled.
+   */
   repeated CompactedSsTable caught_up_generations = 2;
 }
 
-// Index details for MemWAL Index, stored in IndexMetadata.index_details.
-// This is the centralized structure for all MemWAL metadata:
-// - Configuration (sharding specs, indexes to maintain)
-// - SSTable compaction progress
-// - Shard state snapshots
-//
-// Writers read this index to get configuration before writing.
-// Readers may use shard snapshots in this index as a point-in-time
-// optimization. Readers that need the latest shard set should list shard
-// directories in storage and read each shard's latest manifest.
-// A background process updates the index periodically to keep shard snapshots current.
-//
-// Shard snapshots are stored as a Lance file with one row per shard.
-// The schema records shard discovery fields. Full mutable shard state remains
-// authoritative in the shard manifest files.
-//   shard_id: utf8
-//   shard_spec_id: uint32
-//   shard_field_{field_id}: typed per the matching ShardingField.result_type
+/* Index details for MemWAL Index, stored in IndexMetadata.index_details.
+ * This is the centralized structure for all MemWAL metadata:
+ * - Configuration (sharding specs, indexes to maintain)
+ * - SSTable compaction progress
+ * - Shard state snapshots
+ *
+ * Writers read this index to get configuration before writing.
+ * Readers may use shard snapshots in this index as a point-in-time
+ * optimization. Readers that need the latest shard set should list shard
+ * directories in storage and read each shard's latest manifest.
+ * A background process updates the index periodically to keep shard snapshots current.
+ *
+ * Shard snapshots are stored as a Lance file with one row per shard.
+ * The schema records shard discovery fields. Full mutable shard state remains
+ * authoritative in the shard manifest files.
+ *   shard_id: utf8
+ *   shard_spec_id: uint32
+ *   shard_field_{field_id}: typed per the matching ShardingField.result_type
+ */
 message MemWalIndexDetails {
   // Snapshot timestamp (Unix timestamp in milliseconds).
   int64 snapshot_ts_millis = 1;
 
-  // Number of shards in the snapshot.
-  // Used to determine storage format without reading the snapshot data.
+  /* Number of shards in the snapshot.
+   * Used to determine storage format without reading the snapshot data.
+   */
   uint32 num_shards = 2;
 
-  // Inline shard snapshots for small shard counts.
-  // When num_shards <= threshold (implementation-defined, e.g., 100),
-  // snapshots are stored inline as serialized bytes.
-  // Format: Lance file bytes with the shard snapshot schema.
+  /* Inline shard snapshots for small shard counts.
+   * When num_shards <= threshold (implementation-defined, e.g., 100),
+   * snapshots are stored inline as serialized bytes.
+   * Format: Lance file bytes with the shard snapshot schema.
+   */
   optional bytes inline_snapshots = 3;
 
-  // Sharding specs defining how to derive shard identifiers.
-  // This configuration determines how rows are partitioned into shards.
+  /* Sharding specs defining how to derive shard identifiers.
+   * This configuration determines how rows are partitioned into shards.
+   */
   repeated ShardingSpec sharding_specs = 7;
 
-  // Indexes from the base table to maintain in MemTables.
-  // These are index names referencing indexes defined on the base table.
-  // The primary key btree index is always maintained implicitly and
-  // should not be listed here.
-  //
-  // For vector indexes, MemTables inherit quantization parameters (PQ codebook,
-  // SQ params) from the base table index to ensure distance comparability.
+  /* Indexes from the base table to maintain in MemTables.
+   * These are index names referencing indexes defined on the base table.
+   * The primary key btree index is always maintained implicitly and
+   * should not be listed here.
+   *
+   * For vector indexes, MemTables inherit quantization parameters (PQ codebook,
+   * SQ params) from the base table index to ensure distance comparability.
+   */
   repeated string maintained_indexes = 8;
 
-  // Latest SSTable compacted into the base table for each shard.
-  // This is updated atomically with merge-insert data commits, enabling
-  // conflict resolution when multiple compactors operate concurrently.
-  //
-  // Note: This is separate from shard snapshots because:
-  // 1. compacted_sstables is updated by compactors (atomic with data commit)
-  // 2. shard snapshots are updated by background index builder
+  /* Latest SSTable compacted into the base table for each shard.
+   * This is updated atomically with merge-insert data commits, enabling
+   * conflict resolution when multiple compactors operate concurrently.
+   *
+   * Note: This is separate from shard snapshots because:
+   * 1. compacted_sstables is updated by compactors (atomic with data commit)
+   * 2. shard snapshots are updated by background index builder
+   */
   repeated CompactedSsTable compacted_sstables = 9;
 
-  // Per-index catchup progress tracking.
-  // When data is compacted into the base table, base table indexes are rebuilt
-  // asynchronously. This field tracks which generation each index covers.
-  //
-  // For indexed queries, if an index's caught_up_generation < compacted_generation,
-  // readers should use SSTable indexes for the gap instead of
-  // scanning unindexed data in the base table.
-  //
-  // An index absent from this list has recorded no catch-up, so the SSTables it
-  // would need stay live until a repair records it. Only the dedicated WAL
-  // index-repair path may add entries here;
-  // ordinary index operations have their entry removed automatically when they
-  // change an index, since they do not report what the new index covers.
+  /* Per-index catchup progress tracking.
+   * When data is compacted into the base table, base table indexes are rebuilt
+   * asynchronously. This field tracks which generation each index covers.
+   *
+   * For indexed queries, if an index's caught_up_generation < compacted_generation,
+   * readers should use SSTable indexes for the gap instead of
+   * scanning unindexed data in the base table.
+   *
+   * An index absent from this list has recorded no catch-up, so the SSTables it
+   * would need stay live until a repair records it. Only the dedicated WAL
+   * index-repair path may add entries here;
+   * ordinary index operations have their entry removed automatically when they
+   * change an index, since they do not report what the new index covers.
+   */
   repeated IndexCatchupProgress index_catchup = 10;
 
-  // Default ShardWriter configuration values for this MemWAL index.
-  //
-  // A free-form string map persisted so that every writer — across
-  // processes and restarts — starts from the same default writer
-  // configuration. These are defaults only: an individual writer may
-  // still override any value at runtime in its own ShardWriterConfig
-  // (which is not persisted).
+  /* Default ShardWriter configuration values for this MemWAL index.
+   *
+   * A free-form string map persisted so that every writer — across
+   * processes and restarts — starts from the same default writer
+   * configuration. These are defaults only: an individual writer may
+   * still override any value at runtime in its own ShardWriterConfig
+   * (which is not persisted).
+   */
   map<string, string> writer_config_defaults = 11;
 }
 
 // Sharding spec definition.
 message ShardingSpec {
-  // Unique identifier for this spec within the index.
-  // IDs are never reused.
+  /* Unique identifier for this spec within the index.
+   * IDs are never reused.
+   */
   uint32 spec_id = 1;
 
   // Sharding field definitions that determine how to compute shard identifiers.
@@ -830,12 +900,14 @@ message ShardingField {
   // Field IDs referencing source columns in the schema.
   repeated int32 source_ids = 2;
 
-  // Well-known shard transform name (e.g., "identity", "year", "bucket").
-  // Mutually exclusive with expression.
+  /* Well-known shard transform name (e.g., "identity", "year", "bucket").
+   * Mutually exclusive with expression.
+   */
   optional string transform = 3;
 
-  // DataFusion SQL expression for custom logic.
-  // Mutually exclusive with transform.
+  /* DataFusion SQL expression for custom logic.
+   * Mutually exclusive with transform.
+   */
   optional string expression = 4;
 
   // Output type of the shard value (Arrow type name).

--- a/protos/table_identifier.proto
+++ b/protos/table_identifier.proto
@@ -5,11 +5,12 @@ syntax = "proto3";
 
 package lance.datafusion;
 
-// Identifies a Lance dataset for remote reconstruction.
-//
-// Two modes:
-//   1. uri + serialized_manifest (fast): remote executor skips manifest read.
-//   2. uri + version + etag (lightweight): remote executor loads manifest from storage.
+/* Identifies a Lance dataset for remote reconstruction.
+ *
+ * Two modes:
+ *   1. uri + serialized_manifest (fast): remote executor skips manifest read.
+ *   2. uri + version + etag (lightweight): remote executor loads manifest from storage.
+ */
 message TableIdentifier {
   string uri = 1;
   uint64 version = 2;

--- a/protos/transaction.proto
+++ b/protos/transaction.proto
@@ -9,18 +9,20 @@ import "google/protobuf/any.proto";
 
 package lance.table;
 
-// A transaction represents the changes to a dataset.
-//
-// This has two purposes:
-// 1. When retrying a commit, the transaction can be used to re-build an updated
-//    manifest.
-// 2. When there's a conflict, this can be used to determine whether the other
-//    transaction is compatible with this one.
+/* A transaction represents the changes to a dataset.
+ *
+ * This has two purposes:
+ * 1. When retrying a commit, the transaction can be used to re-build an updated
+ *    manifest.
+ * 2. When there's a conflict, this can be used to determine whether the other
+ *    transaction is compatible with this one.
+ */
 message Transaction {
-  // The version of the dataset this transaction was built from.
-  //
-  // For example, for a delete transaction this means the version of the dataset
-  // that was read from while evaluating the deletion predicate.
+  /* The version of the dataset this transaction was built from.
+   *
+   * For example, for a delete transaction this means the version of the dataset
+   * that was read from while evaluating the deletion predicate.
+   */
   uint64 read_version = 1;
 
   // The UUID that unique identifies a transaction.
@@ -29,38 +31,43 @@ message Transaction {
   // Optional version tag.
   string tag = 3;
 
-  // Optional properties for the transaction
-  // __lance_commit_message is a reserved key
+  /* Optional properties for the transaction
+   * __lance_commit_message is a reserved key
+   */
   map<string, string> transaction_properties = 4;
 
   // Add new rows to the dataset.
   message Append {
-    // The new fragments to append.
-    //
-    // Fragment IDs are not yet assigned.
+    /* The new fragments to append.
+     *
+     * Fragment IDs are not yet assigned.
+     */
     repeated DataFragment fragments = 1;
   }
 
   // Mark rows as deleted.
   message Delete {
-    // The fragments to update
-    //
-    // The fragment IDs will match existing fragments in the dataset.
+    /* The fragments to update
+     *
+     * The fragment IDs will match existing fragments in the dataset.
+     */
     repeated DataFragment updated_fragments = 1;
     // The fragments to delete entirely.
     repeated uint64 deleted_fragment_ids = 2;
-    // The predicate that was evaluated
-    //
-    // This may be used to determine whether the delete would have affected 
-    // files written by a concurrent transaction.
+    /* The predicate that was evaluated
+     *
+     * This may be used to determine whether the delete would have affected
+     * files written by a concurrent transaction.
+     */
     string predicate = 3;
   }
 
   // Create or overwrite the entire dataset.
   message Overwrite {
-    // The new fragments
-    //
-    // Fragment IDs are not yet assigned.
+    /* The new fragments
+     *
+     * Fragment IDs are not yet assigned.
+     */
     repeated DataFragment fragments = 1;
     // The new schema
     repeated lance.file.Field schema = 2;
@@ -72,35 +79,40 @@ message Transaction {
     repeated BasePath initial_bases = 5;
   }
 
-  // Add or replace a new secondary index.
-  //
-  // This is also used to remove an index (we are replacing it with nothing)
-  //
-  // - new_indices: the modified indices, empty if dropping indices only
-  // - removed_indices: the indices that are being replaced
+  /* Add or replace a new secondary index.
+   *
+   * This is also used to remove an index (we are replacing it with nothing)
+   *
+   * - new_indices: the modified indices, empty if dropping indices only
+   * - removed_indices: the indices that are being replaced
+   */
   message CreateIndex {
     repeated IndexMetadata new_indices = 1;
     repeated IndexMetadata removed_indices = 2;
   }
 
-  // An operation that rewrites but does not change the data in the table. These
-  // kinds of operations just rearrange data.
+  /* An operation that rewrites but does not change the data in the table. These
+   * kinds of operations just rearrange data.
+   */
   message Rewrite {
-    // The old fragments that are being replaced
-    //
-    // DEPRECATED: use groups instead.
-    //
-    // These should all have existing fragment IDs.
+    /* The old fragments that are being replaced
+     *
+     * DEPRECATED: use groups instead.
+     *
+     * These should all have existing fragment IDs.
+     */
     repeated DataFragment old_fragments = 1;
-    // The new fragments
-    //
-    // DEPRECATED: use groups instead.
-    //
-    // These fragments IDs are not yet assigned.
+    /* The new fragments
+     *
+     * DEPRECATED: use groups instead.
+     *
+     * These fragments IDs are not yet assigned.
+     */
     repeated DataFragment new_fragments = 2;
 
-    // During a rewrite an index may be rewritten.  We only serialize the UUID
-    // since a rewrite should not change the other index parameters.
+    /* During a rewrite an index may be rewritten.  We only serialize the UUID
+     * since a rewrite should not change the other index parameters.
+     */
     message RewrittenIndex {
       // The id of the index that will be replaced
       UUID old_id = 1;
@@ -110,21 +122,24 @@ message Transaction {
       google.protobuf.Any new_index_details = 3;
       // the version of the new index
       uint32 new_index_version = 4;
-      // Files in the new index with their sizes.
-      // Empty if file sizes are not available (e.g. older writers).
+      /* Files in the new index with their sizes.
+       * Empty if file sizes are not available (e.g. older writers).
+       */
       repeated IndexFile new_index_files = 5;
     }
 
     // A group of rewrite files that are all part of the same rewrite.
     message RewriteGroup {
-      // The old fragment that is being replaced
-      //
-      // This should have an existing fragment ID.
+      /* The old fragment that is being replaced
+       *
+       * This should have an existing fragment ID.
+       */
       repeated DataFragment old_fragments = 1;
-      // The new fragment
-      //
-      // The ID should have been reserved by an earlier
-      // reserve operation
+      /* The new fragment
+       *
+       * The ID should have been reserved by an earlier
+       * reserve operation
+       */
       repeated DataFragment new_fragments = 2;
     }
 
@@ -136,19 +151,21 @@ message Transaction {
 
   // An operation that merges in a new column, altering the schema.
   message Merge {
-    // The updated fragments
-    //
-    // These should all have existing fragment IDs.
+    /* The updated fragments
+     *
+     * These should all have existing fragment IDs.
+     */
     repeated DataFragment fragments = 1;
     // The new schema
     repeated lance.file.Field schema = 2;
     // Schema metadata.
     map<string, bytes> schema_metadata = 3;
-    // Set when this merge makes no nullability-affecting schema change: it
-    // introduces no field that data staged against an earlier schema could
-    // not safely omit. Without the assertion (including transactions written
-    // before this field existed) the merge conservatively conflicts with
-    // concurrent value-writes, which can only cause a retry.
+    /* Set when this merge makes no nullability-affecting schema change: it
+     * introduces no field that data staged against an earlier schema could
+     * not safely omit. Without the assertion (including transactions written
+     * before this field existed) the merge conservatively conflicts with
+     * concurrent value-writes, which can only cause a retry.
+     */
     bool preserves_nullability = 4;
   }
 
@@ -156,11 +173,12 @@ message Transaction {
   message Project {
     // The new schema
     repeated lance.file.Field schema = 1;
-    // Set when this projection makes no nullability-affecting schema change,
-    // as a rename or a drop does not. Without the assertion (including
-    // transactions written before this field existed) the projection
-    // conservatively conflicts with concurrent value-writes, which can only
-    // cause a retry. A nullability tightening must not set this.
+    /* Set when this projection makes no nullability-affecting schema change,
+     * as a rename or a drop does not. Without the assertion (including
+     * transactions written before this field existed) the projection
+     * conservatively conflicts with concurrent value-writes, which can only
+     * cause a retry. A nullability tightening must not set this.
+     */
     bool preserves_nullability = 2;
   }
 
@@ -170,26 +188,29 @@ message Transaction {
     uint64 version = 1;
   }
 
-  // An operation that reserves fragment ids for future use in
-  // a rewrite operation.
+  /* An operation that reserves fragment ids for future use in
+   * a rewrite operation.
+   */
   message ReserveFragments {
     uint32 num_fragments = 1;
   }
 
   // An operation that clones a dataset.
   message Clone {
-    // - true:  Performs a metadata-only clone (copies manifest without data files).
-    //          The cloned dataset references original data through `base_paths`,
-    //          suitable for experimental scenarios or rapid metadata migration.
-    // - false: Performs a full deep clone using the underlying object storage's native
-    //          copy API (e.g., S3 CopyObject, GCS rewrite). This leverages server-side
-    //          bulk copy operations to bypass download/upload bottlenecks, achieving
-    //          near-linear speedup for large datasets (typically 3-10x faster than
-    //          manual file transfers). The operation maintains atomicity and data
-    //          integrity guarantees provided by the storage backend.
+    /* - true:  Performs a metadata-only clone (copies manifest without data files).
+     *          The cloned dataset references original data through `base_paths`,
+     *          suitable for experimental scenarios or rapid metadata migration.
+     * - false: Performs a full deep clone using the underlying object storage's native
+     *          copy API (e.g., S3 CopyObject, GCS rewrite). This leverages server-side
+     *          bulk copy operations to bypass download/upload bottlenecks, achieving
+     *          near-linear speedup for large datasets (typically 3-10x faster than
+     *          manual file transfers). The operation maintains atomicity and data
+     *          integrity guarantees provided by the storage backend.
+     */
     bool is_shallow = 1;
-    // the reference name in the source dataset
-    // in most cases it should be the branch or tag name in the source dataset
+    /* the reference name in the source dataset
+     * in most cases it should be the branch or tag name in the source dataset
+     */
     optional string ref_name = 2;
     // the version of the source dataset for cloning
     uint64 ref_version = 3;
@@ -199,34 +220,39 @@ message Transaction {
     optional string branch_name = 5;
   }
   
-  // Exact set of key hashes for conflict detection.
-  // Used when the number of inserted rows is small.
+  /* Exact set of key hashes for conflict detection.
+   * Used when the number of inserted rows is small.
+   */
   message ExactKeySetFilter {
     // 64-bit hashes of the inserted row keys.
     repeated uint64 key_hashes = 1;
   }
 
-  // Bloom filter for key existence tests.
-  // Used when the number of rows is large.
+  /* Bloom filter for key existence tests.
+   * Used when the number of rows is large.
+   */
   message BloomFilter {
     // Bitset backing the bloom filter (SBBF format).
     bytes bitmap = 1;
     // Number of bits in the bitmap.
     uint32 num_bits = 2;
-    // Number of items the filter was sized for.
-    // Used for intersection validation (filters with different sizes cannot be compared).
-    // Default: 8192
+    /* Number of items the filter was sized for.
+     * Used for intersection validation (filters with different sizes cannot be compared).
+     * Default: 8192
+     */
     uint64 number_of_items = 3;
-    // False positive probability the filter was sized for.
-    // Used for intersection validation (filters with different parameters cannot be compared).
-    // Default: 0.00057
+    /* False positive probability the filter was sized for.
+     * Used for intersection validation (filters with different parameters cannot be compared).
+     * Default: 0.00057
+     */
     double probability = 4;
   }
 
-  // A filter for checking key existence in set of rows inserted by a merge insert operation.
-  // Only created when the merge insert's ON columns match the schema's unenforced primary key.
-  // The presence of this filter indicates strict primary key conflict detection should be used.
-  // Can use either an exact set (for small row counts) or a Bloom filter (for large row counts).
+  /* A filter for checking key existence in set of rows inserted by a merge insert operation.
+   * Only created when the merge insert's ON columns match the schema's unenforced primary key.
+   * The presence of this filter indicates strict primary key conflict detection should be used.
+   * Can use either an exact set (for small row counts) or a Bloom filter (for large row counts).
+   */
   message KeyExistenceFilter {
     // Field IDs of columns participating in the key (must match unenforced primary key).
     repeated int32 field_ids = 1;
@@ -246,8 +272,9 @@ message Transaction {
 
   // An operation that updates rows but does not add or remove rows.
   message Update {
-    // The fragments that have been removed. These are fragments where all rows
-    // have been updated and moved to a new fragment.
+    /* The fragments that have been removed. These are fragments where all rows
+     * have been updated and moved to a new fragment.
+     */
     repeated uint64 removed_fragment_ids = 1;
     // The fragments that have been updated.
     repeated DataFragment updated_fragments = 2;
@@ -257,34 +284,40 @@ message Transaction {
     repeated uint32 fields_modified = 4;
     /// SSTables to mark as compacted after this transaction.
     repeated CompactedSsTable compacted_sstables = 5;
-    /// The fields that used to judge whether to preserve the new frag's id into
-    /// the frag bitmap of the specified indices.
+    /* The fields that used to judge whether to preserve the new frag's id into
+     * the frag bitmap of the specified indices.
+     */
     repeated uint32 fields_for_preserving_frag_bitmap = 6;
     // The mode of update
     UpdateMode update_mode = 7;
-    // Filter for checking existence of keys in newly inserted rows, used for conflict detection.
-    // Only tracks keys from INSERT operations during merge insert, not updates.
+    /* Filter for checking existence of keys in newly inserted rows, used for conflict detection.
+     * Only tracks keys from INSERT operations during merge insert, not updates.
+     */
     optional KeyExistenceFilter inserted_rows = 8;
-    // Per-fragment physical row offsets that matched an update_columns hash join (RewriteColumns).
-    // Deprecated: use updated_fragment_offset_bitmaps (field 10) instead.
+    /* Per-fragment physical row offsets that matched an update_columns hash join (RewriteColumns).
+     * Deprecated: use updated_fragment_offset_bitmaps (field 10) instead.
+     */
     map<uint64, UInt32List> updated_fragment_offsets = 9;
-    // Per-fragment matched offsets as portable RoaringBitmap bytes (replaces field 9).
-    // Writers emit field 10 only. Readers prefer field 10; fall back to field 9 for
-    // manifests written before this change.
+    /* Per-fragment matched offsets as portable RoaringBitmap bytes (replaces field 9).
+     * Writers emit field 10 only. Readers prefer field 10; fall back to field 9 for
+     * manifests written before this change.
+     */
     map<uint64, bytes> updated_fragment_offset_bitmaps = 10;
   }
 
   // The mode of update operation
   enum UpdateMode {
 
-    /// rows are deleted in current fragments and rewritten in new fragments.
-    /// This is most optimal when the majority of columns are being rewritten
-    /// or only a few rows are being updated.
+    /* rows are deleted in current fragments and rewritten in new fragments.
+     * This is most optimal when the majority of columns are being rewritten
+     * or only a few rows are being updated.
+     */
     REWRITE_ROWS = 0;
 
-    /// within each fragment, columns are fully rewritten and inserted as new data files.
-    /// Old versions of columns are tombstoned. This is most optimal when most rows are affected
-    /// but a small subset of columns are affected.
+    /* within each fragment, columns are fully rewritten and inserted as new data files.
+     * Old versions of columns are tombstoned. This is most optimal when most rows are affected
+     * but a small subset of columns are affected.
+     */
     REWRITE_COLUMNS = 1;
   }
 
@@ -298,13 +331,15 @@ message Transaction {
 
   message UpdateMap {
     repeated UpdateMapEntry update_entries = 1;
-    // If true, the map will be replaced entirely with the new entries.
-    // If false, the new entries will be merged with the existing map.
+    /* If true, the map will be replaced entirely with the new entries.
+     * If false, the new entries will be merged with the existing map.
+     */
     bool replace = 2;
   }
   
-  // An operation that updates the table config, table metadata, schema metadata,
-  // or field metadata.
+  /* An operation that updates the table config, table metadata, schema metadata,
+   * or field metadata.
+   */
   message UpdateConfig {
     UpdateMap config_updates = 6;
     UpdateMap table_metadata_updates = 7;
@@ -332,31 +367,35 @@ message Transaction {
     repeated DataReplacementGroup replacements = 1;
   }
 
-  // Overlay files to append to a single fragment, in order (the last entry is
-  // newest). The overlays are appended to the fragment's existing `overlays`
-  // list; they do not replace it, so overlays written by concurrent commits are
-  // preserved.
+  /* Overlay files to append to a single fragment, in order (the last entry is
+   * newest). The overlays are appended to the fragment's existing `overlays`
+   * list; they do not replace it, so overlays written by concurrent commits are
+   * preserved.
+   */
   message DataOverlayGroup {
     uint64 fragment_id = 1;
-    // Each DataOverlayFile.committed_version is left 0 by the writer and stamped
-    // to the new dataset version at commit time (re-stamped on retry), in the
-    // same way as the created-at / last-updated-at version sequences. The fields
-    // touched are read from each overlay's `data_file.fields`.
+    /* Each DataOverlayFile.committed_version is left 0 by the writer and stamped
+     * to the new dataset version at commit time (re-stamped on retry), in the
+     * same way as the created-at / last-updated-at version sequences. The fields
+     * touched are read from each overlay's `data_file.fields`.
+     */
     repeated DataOverlayFile overlays = 2;
   }
 
-  // Attach overlay files to fragments, supplying new values for a subset of
-  // (row offset, field) cells without rewriting the fragments' base data files.
-  // See the DataOverlayFile message in table.proto for resolution, coverage, and
-  // versioning rules, and the Data Overlay Files and Transactions specifications
-  // for the (intentionally permissive) conflict semantics.
+  /* Attach overlay files to fragments, supplying new values for a subset of
+   * (row offset, field) cells without rewriting the fragments' base data files.
+   * See the DataOverlayFile message in table.proto for resolution, coverage, and
+   * versioning rules, and the Data Overlay Files and Transactions specifications
+   * for the (intentionally permissive) conflict semantics.
+   */
   message DataOverlay {
     repeated DataOverlayGroup groups = 1;
   }
 
-  // Update SSTable compaction progress in the MemWAL index.
-  // This operation is used during merge-insert to atomically record which
-  // SSTables have been compacted into the base table.
+  /* Update SSTable compaction progress in the MemWAL index.
+   * This operation is used during merge-insert to atomically record which
+   * SSTables have been compacted into the base table.
+   */
   message UpdateMemWalState {
     // SSTables being marked as compacted.
     repeated CompactedSsTable compacted_sstables = 1;

--- a/rust/lance-index/protos-cache/cache.proto
+++ b/rust/lance-index/protos-cache/cache.proto
@@ -1,24 +1,26 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright The Lance Authors
 
-// Protobuf headers for serialized index cache entries.
-//
-// These messages describe the *cache* serialization format, not the on-disk
-// Lance format spec, so they live with the library (lance-index) rather than in
-// the top-level `protos/` spec folder.
-//
-// Field numbers and enum values are append-only across all messages here: never
-// renumber or reuse them. A change the proto cannot express transparently
-// (adding/removing/reordering the IPC/raw sections that follow a header) must
-// bump the relevant codec's `CURRENT_VERSION` instead.
+/* Protobuf headers for serialized index cache entries.
+ *
+ * These messages describe the *cache* serialization format, not the on-disk
+ * Lance format spec, so they live with the library (lance-index) rather than in
+ * the top-level `protos/` spec folder.
+ *
+ * Field numbers and enum values are append-only across all messages here: never
+ * renumber or reuse them. A change the proto cannot express transparently
+ * (adding/removing/reordering the IPC/raw sections that follow a header) must
+ * bump the relevant codec's `CURRENT_VERSION` instead.
+ */
 
 syntax = "proto3";
 
 package lance.index.cache;
 
-// ---------------------------------------------------------------------------
-// Full-text search (FTS) posting lists
-// ---------------------------------------------------------------------------
+/* ---------------------------------------------------------------------------
+ * Full-text search (FTS) posting lists
+ * ---------------------------------------------------------------------------
+ */
 
 // Header for a serialized `CompressedPostingList` cache entry.
 message CompressedPostingHeader {
@@ -28,38 +30,43 @@ message CompressedPostingHeader {
   PositionStorage position_storage = 4;
   // Only meaningful when position_storage == POSITION_STORAGE_SHARED.
   PositionStreamCodec position_stream_codec = 5;
-  // Number of documents in each compressed posting block. Older cache entries
-  // omit this field and decode as the legacy 128-doc block size.
+  /* Number of documents in each compressed posting block. Older cache entries
+   * omit this field and decode as the legacy 128-doc block size.
+   */
   uint32 block_size = 6;
   // Whether an impact IPC section follows the posting/position sections.
   bool has_impacts = 7;
 }
 
-// Header for a serialized `PlainPostingList` cache entry. Followed by an Arrow
-// IPC section of (row_ids: UInt64, frequencies: Float32), then — when
-// position_storage == POSITION_STORAGE_LEGACY — an IPC section of the per-doc
-// position list. Plain postings never carry a shared position stream.
+/* Header for a serialized `PlainPostingList` cache entry. Followed by an Arrow
+ * IPC section of (row_ids: UInt64, frequencies: Float32), then — when
+ * position_storage == POSITION_STORAGE_LEGACY — an IPC section of the per-doc
+ * position list. Plain postings never carry a shared position stream.
+ */
 message PlainPostingHeader {
-  // Absent when the posting has no precomputed block-max score (the in-memory
-  // `max_score` is `None`); present otherwise.
+  /* Absent when the posting has no precomputed block-max score (the in-memory
+   * `max_score` is `None`); present otherwise.
+   */
   optional float max_score = 1;
   // POSITION_STORAGE_NONE or POSITION_STORAGE_LEGACY only.
   PositionStorage position_storage = 2;
 }
 
-// Header for a serialized standalone `Positions` cache entry. Followed by the
-// position sections framed per `position_storage`, which is never
-// POSITION_STORAGE_NONE for a standalone entry.
+/* Header for a serialized standalone `Positions` cache entry. Followed by the
+ * position sections framed per `position_storage`, which is never
+ * POSITION_STORAGE_NONE for a standalone entry.
+ */
 message PositionsHeader {
   PositionStorage position_storage = 1;
   // Only meaningful when position_storage == POSITION_STORAGE_SHARED.
   PositionStreamCodec position_stream_codec = 2;
 }
 
-// Header for a serialized `PostingListGroup`: a member count followed by that
-// many `PostingList` bodies written inline. Each member body is
-// self-delimiting, so members need no length prefixes, and writing them inline
-// keeps their Arrow IPC sections 64-byte aligned within the group entry.
+/* Header for a serialized `PostingListGroup`: a member count followed by that
+ * many `PostingList` bodies written inline. Each member body is
+ * self-delimiting, so members need no length prefixes, and writing them inline
+ * keeps their Arrow IPC sections 64-byte aligned within the group entry.
+ */
 message PostingListGroupHeader {
   uint32 count = 1;
 }
@@ -76,34 +83,40 @@ enum PositionStreamCodec {
   POSITION_STREAM_CODEC_PACKED_DELTA = 1;
 }
 
-// Which (if any) positions accompany the posting list, and how they are framed
-// in the sections after the header.
+/* Which (if any) positions accompany the posting list, and how they are framed
+ * in the sections after the header.
+ */
 enum PositionStorage {
   POSITION_STORAGE_NONE = 0;
   // Legacy per-doc positions as a single Arrow IPC section.
   POSITION_STORAGE_LEGACY = 1;
-  // Shared stream: an Arrow IPC section of block offsets, then a raw blob of
-  // the (codec-encoded) position bytes.
+  /* Shared stream: an Arrow IPC section of block offsets, then a raw blob of
+   * the (codec-encoded) position bytes.
+   */
   POSITION_STORAGE_SHARED = 2;
 }
 
-// ---------------------------------------------------------------------------
-// Scalar indices
-// ---------------------------------------------------------------------------
+/* ---------------------------------------------------------------------------
+ * Scalar indices
+ * ---------------------------------------------------------------------------
+ */
 
-// Header for a serialized `BTreeIndexState` cache entry, followed by a single
-// Arrow IPC section holding the page-lookup batch.
+/* Header for a serialized `BTreeIndexState` cache entry, followed by a single
+ * Arrow IPC section holding the page-lookup batch.
+ */
 message BTreeIndexHeader {
   uint64 batch_size = 1;
-  // Whether an explicit page-range -> file mapping is present. Distinguishes a
-  // non-range-partitioned index (false) from a range-partitioned one whose map
-  // happens to be empty (true with no entries).
+  /* Whether an explicit page-range -> file mapping is present. Distinguishes a
+   * non-range-partitioned index (false) from a range-partitioned one whose map
+   * happens to be empty (true with no entries).
+   */
   bool has_ranges_to_files = 2;
   repeated RangeToFile ranges_to_files = 3;
 }
 
-// One entry of a `BTreeIndexState` page-range -> file mapping. The range is
-// inclusive on both ends (a `RangeInclusive<u32>`).
+/* One entry of a `BTreeIndexState` page-range -> file mapping. The range is
+ * inclusive on both ends (a `RangeInclusive<u32>`).
+ */
 message RangeToFile {
   uint32 start = 1;
   uint32 end = 2;
@@ -111,15 +124,17 @@ message RangeToFile {
   string path = 4;
 }
 
-// ---------------------------------------------------------------------------
-// Vector indices (IVF partitions)
-// ---------------------------------------------------------------------------
+/* ---------------------------------------------------------------------------
+ * Vector indices (IVF partitions)
+ * ---------------------------------------------------------------------------
+ */
 
-// Headers for serialized IVF partition cache entries (`PartitionEntry<S, Q>`).
-//
-// Each header is followed by 64-byte-aligned Arrow IPC sections in a fixed,
-// version-keyed order (sub-index, then any quantizer-specific arrays, then the
-// quantizer storage batches).
+/* Headers for serialized IVF partition cache entries (`PartitionEntry<S, Q>`).
+ *
+ * Each header is followed by 64-byte-aligned Arrow IPC sections in a fixed,
+ * version-keyed order (sub-index, then any quantizer-specific arrays, then the
+ * quantizer storage batches).
+ */
 
 // Distance metric a quantizer's storage was built for.
 enum DistanceType {
@@ -165,9 +180,10 @@ message SqPartitionHeader {
   double bounds_end = 5;
 }
 
-// Header for a serialized IVF index state (`IvfIndexState<Q>`), followed by
-// three raw blobs: the IVF model protobuf, the quantizer's extra-metadata
-// buffer (may be empty), and the auxiliary IVF model protobuf.
+/* Header for a serialized IVF index state (`IvfIndexState<Q>`), followed by
+ * three raw blobs: the IVF model protobuf, the quantizer's extra-metadata
+ * buffer (may be empty), and the auxiliary IVF model protobuf.
+ */
 message IvfStateHeader {
   reserved 8;
   reserved "cache_key_prefix";
@@ -178,23 +194,26 @@ message IvfStateHeader {
   repeated string sub_index_metadata = 4;
   string sub_index_type = 5;
   string quantization_type = 6;
-  // Per-quantizer `Q::Metadata` as JSON. Kept as a string because the metadata
-  // type is generic over the quantizer; the proto envelope still provides
-  // additive evolution for the surrounding fields.
+  /* Per-quantizer `Q::Metadata` as JSON. Kept as a string because the metadata
+   * type is generic over the quantizer; the proto envelope still provides
+   * additive evolution for the surrounding fields.
+   */
   string quantizer_metadata_json = 7;
   uint64 index_file_size = 9;
   uint64 aux_file_size = 10;
 }
 
-// RabitQ quantizer. Sections: sub-index IPC, rotate-matrix IPC (Matrix rotation
-// only), storage IPC.
+/* RabitQ quantizer. Sections: sub-index IPC, rotate-matrix IPC (Matrix rotation
+ * only), storage IPC.
+ */
 message RabitPartitionHeader {
   DistanceType distance_type = 1;
   uint32 num_bits = 2;
   uint32 code_dim = 3;
   RotationType rotation_type = 4;
-  // Fast-rotation sign vector; present only when rotation_type ==
-  // ROTATION_TYPE_FAST (the Matrix case stores its rotation as an IPC section).
+  /* Fast-rotation sign vector; present only when rotation_type ==
+   * ROTATION_TYPE_FAST (the Matrix case stores its rotation as an IPC section).
+   */
   optional bytes fast_rotation_signs = 5;
   // Estimator the RabitQ storage uses at query time (residual vs raw query).
   RabitQueryEstimator query_estimator = 6;


### PR DESCRIPTION
Multi-line comments in the `.proto` files were written as runs of `//` lines, which editors cannot fold. The long design notes in `file2.proto`, `table.proto` and the encoding schemas therefore dominate the files when you are trying to read the schema itself.

This converts every multi-line comment run to a `/* text` / ` * text` / ` */` block, and adds a check that keeps it that way. We had no protobuf linting before — `buf.yaml` exists only to publish the module to the BSR, and `buf lint` has no rule for comment syntax — so the check is a small script, `ci/check_proto_comments.py`, wired up as a pre-commit hook (which auto-fixes) and a new `Protobuf lint` workflow.

No schema field, name or number changes, and no generated code changes: the `/* text` / ` * text` layout keeps each content column exactly where the `//` form had it, so protoc extracts byte-identical leading comments. I verified this by diffing the `--include_source_info` descriptors for every proto before and after. The only differences are two incidental improvements: `///` runs no longer leave a stray `/` at the start of each generated doc line, and two stray trailing spaces are gone.

## Not included

Single-line `//` comments are untouched, as are the SPDX headers (`license-header-check` requires those verbatim). Adding `buf lint` or `buf breaking` to CI would be a separate PR.
