### PR TITLE
fix(index): keep the shuffler scratch directory alive for the whole build

### DIFF
--- a/rust/lance/src/index/vector.rs
+++ b/rust/lance/src/index/vector.rs
@@ -511,6 +511,9 @@ impl IndexParams for VectorIndexParams {
 /// These paths emit different file layouts, but they follow the same rules for
 /// validating the vector column, deriving the effective index type, sizing IVF
 /// partitions, and constructing the shuffler.
+///
+/// The shuffler carries only the path of its scratch directory, so the returned
+/// [`TempStdDir`] guard owns that directory: hold it until the build finishes.
 async fn prepare_vector_segment_build(
     dataset: &Dataset,
     column: &str,
@@ -519,7 +522,13 @@ async fn prepare_vector_segment_build(
     mode: &str,
     require_precomputed_ivf: bool,
     fragment_ids: Option<&[u32]>,
-) -> Result<(DataType, IndexType, IvfBuildParams, Box<dyn Shuffler>)> {
+) -> Result<(
+    DataType,
+    IndexType,
+    IvfBuildParams,
+    Box<dyn Shuffler>,
+    TempStdDir,
+)> {
     let stages = &params.stages;
 
     if stages.is_empty() {
@@ -596,7 +605,7 @@ async fn prepare_vector_segment_build(
         Some(progress),
     );
 
-    Ok((element_type, index_type, ivf_params, shuffler))
+    Ok((element_type, index_type, ivf_params, shuffler, temp_dir))
 }
 
 /// Build a Distributed Vector Index for specific fragments
@@ -612,16 +621,17 @@ pub(crate) async fn build_distributed_vector_index(
     fragment_ids: &[u32],
     progress: Arc<dyn IndexBuildProgress>,
 ) -> Result<(Uuid, Vec<IndexFile>)> {
-    let (element_type, index_type, ivf_params, shuffler) = prepare_vector_segment_build(
-        dataset,
-        column,
-        params,
-        progress.clone(),
-        "Build Distributed Vector Index",
-        true,
-        Some(fragment_ids),
-    )
-    .await?;
+    let (element_type, index_type, ivf_params, shuffler, _shuffle_temp_dir) =
+        prepare_vector_segment_build(
+            dataset,
+            column,
+            params,
+            progress.clone(),
+            "Build Distributed Vector Index",
+            true,
+            Some(fragment_ids),
+        )
+        .await?;
     let stages = &params.stages;
 
     let ivf_centroids = ivf_params
@@ -1013,16 +1023,17 @@ async fn build_vector_index_impl(
     progress: Arc<dyn IndexBuildProgress>,
     fragment_ids: Option<&[u32]>,
 ) -> Result<Vec<IndexFile>> {
-    let (element_type, index_type, ivf_params, shuffler) = prepare_vector_segment_build(
-        dataset,
-        column,
-        params,
-        progress.clone(),
-        "Build Vector Index",
-        false,
-        fragment_ids,
-    )
-    .await?;
+    let (element_type, index_type, ivf_params, shuffler, _shuffle_temp_dir) =
+        prepare_vector_segment_build(
+            dataset,
+            column,
+            params,
+            progress.clone(),
+            "Build Vector Index",
+            false,
+            fragment_ids,
+        )
+        .await?;
     let stages = &params.stages;
 
     match index_type {
@@ -2190,11 +2201,13 @@ mod tests {
     use arrow_array::Array;
     use arrow_array::RecordBatch;
     use arrow_array::types::{Float32Type, Int32Type};
+    use arrow_array::{Int32Array, UInt32Array};
     use arrow_schema::{DataType as ArrowDataType, Field, Schema as ArrowSchema};
     use lance_core::utils::tempfile::TempStrDir;
     use lance_datagen::{BatchCount, RowCount, array};
     use lance_file::writer::FileWriterOptions;
     use lance_index::metrics::NoOpMetricsCollector;
+    use lance_index::vector::PART_ID_COLUMN;
     use lance_linalg::distance::MetricType;
 
     /// `open_index_file` skips the HEAD when the size is known and still falls
@@ -2523,6 +2536,173 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(results.num_rows(), 10, "Should return 10 nearest neighbors");
+    }
+
+    /// The shuffler carries only the scratch-directory path, so the
+    /// `TempStdDir` guard has to be handed back to the caller. Dropping it
+    /// inside `prepare_vector_segment_build` removed the directory before the
+    /// shuffle wrote into it, the writer recreated it, and nothing owned it
+    /// afterwards: one leaked scratch directory per index build, holding the
+    /// full shuffled copy of the vector column.
+    #[tokio::test]
+    async fn test_prepare_vector_segment_build_keeps_scratch_dir_alive() {
+        let test_dir = TempStrDir::default();
+        let uri = format!("{}/ds", test_dir.as_str());
+        let reader = lance_datagen::gen_batch()
+            .col("id", array::step::<Int32Type>())
+            .col("vector", array::rand_vec::<Float32Type>(8.into()))
+            .into_reader_rows(RowCount::from(64), BatchCount::from(1));
+        let dataset = Dataset::write(reader, &uri, None).await.unwrap();
+
+        let params = VectorIndexParams::ivf_flat(2, MetricType::L2);
+        let (_, _, _, shuffler, scratch_dir) = prepare_vector_segment_build(
+            &dataset,
+            "vector",
+            &params,
+            noop_progress(),
+            "test",
+            false,
+            None,
+        )
+        .await
+        .unwrap();
+
+        let scratch_path = scratch_dir.to_path_buf();
+        assert!(
+            scratch_path.is_dir(),
+            "the scratch directory must still be there when the helper returns: {scratch_path:?}"
+        );
+
+        // Drive the shuffler so the scratch directory holds real output: that
+        // is what the guard has to outlive, and what used to be left behind.
+        // `record_batch!` would make both fields nullable; the shuffler's own
+        // tests declare `__ivf_part_id` non-null, so spell the schema out.
+        let schema = Arc::new(ArrowSchema::new(vec![
+            Field::new(PART_ID_COLUMN, ArrowDataType::UInt32, false),
+            Field::new("val", ArrowDataType::Int32, false),
+        ]));
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(UInt32Array::from(vec![0u32, 1, 0])),
+                Arc::new(Int32Array::from(vec![10, 20, 30])),
+            ],
+        )
+        .unwrap();
+        shuffler
+            .shuffle(Box::new(lance_io::stream::RecordBatchStreamAdapter::new(
+                schema,
+                stream::iter(vec![Ok(batch)]),
+            )))
+            .await
+            .unwrap();
+        assert!(
+            std::fs::read_dir(&scratch_path).unwrap().next().is_some(),
+            "the shuffle output must land under the returned guard: {scratch_path:?}"
+        );
+
+        drop(shuffler);
+        drop(scratch_dir);
+        assert!(
+            !scratch_path.exists(),
+            "dropping the guard must remove the scratch directory and the shuffle output in it: {scratch_path:?}"
+        );
+    }
+
+    /// The scratch directory the guard owns has to be gone once the build is
+    /// over, or the OS temp dir grows by one shuffled copy of the vector column
+    /// per index build.
+    ///
+    /// The OS temp dir is process-global, so an in-process check cannot
+    /// attribute a leftover directory to our own build. Run the build in a child
+    /// process with `TMPDIR` pointed at an isolated dir we own, then assert
+    /// nothing survives. Same shape as
+    /// `index::vector::ivf::io::tests::test_hnsw_pq_scratch_dir_is_not_leaked`,
+    /// which covers the legacy partition-staging dir.
+    #[test]
+    fn test_shuffle_scratch_dir_is_not_leaked() {
+        let isolated_root = TempStdDir::default();
+
+        let child_test = "index::vector::tests::build_vector_index_in_child_process";
+        let output = std::process::Command::new(std::env::current_exe().unwrap())
+            .args([child_test, "--exact", "--ignored", "--nocapture"])
+            .env("TMPDIR", isolated_root.as_ref())
+            .env("LANCE_SHUFFLE_LEAK_TEST_ROOT", isolated_root.as_ref())
+            .output()
+            .expect("failed to spawn child test process");
+        assert!(
+            output.status.success(),
+            "child build process failed:\n--- stdout ---\n{}\n--- stderr ---\n{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr),
+        );
+
+        // A libtest filter that matches nothing also exits 0, so without this
+        // the whole test would silently pass if `child_test` ever went stale.
+        // The child writes its dataset here before it builds anything.
+        assert!(
+            isolated_root.join("dataset").is_dir(),
+            "the child test did not run; is {child_test} still the right name?"
+        );
+
+        // Every scratch dir a build creates sits directly under TMPDIR and is
+        // owned by a guard, so none should survive the child process.
+        let leaked: Vec<std::path::PathBuf> = std::fs::read_dir(&isolated_root)
+            .expect("read isolated temp root")
+            .flatten()
+            .map(|entry| entry.path())
+            .filter(|path| {
+                path.is_dir()
+                    && path
+                        .file_name()
+                        .and_then(|name| name.to_str())
+                        .is_some_and(|name| name.starts_with(".tmp"))
+            })
+            .collect();
+
+        assert!(
+            leaked.is_empty(),
+            "vector index build leaked {} scratch director{} under the temp dir: {:?}",
+            leaked.len(),
+            if leaked.len() == 1 { "y" } else { "ies" },
+            leaked,
+        );
+    }
+
+    /// Child half of [`test_shuffle_scratch_dir_is_not_leaked`]. Ignored so it
+    /// only runs when the parent spawns it with `TMPDIR` and
+    /// `LANCE_SHUFFLE_LEAK_TEST_ROOT` pointed at an isolated dir.
+    #[tokio::test]
+    #[ignore = "spawned as a child process by test_shuffle_scratch_dir_is_not_leaked"]
+    async fn build_vector_index_in_child_process() {
+        // A bare `--ignored` run leaves the variable unset, so no-op rather
+        // than fail.
+        let Ok(root) = std::env::var("LANCE_SHUFFLE_LEAK_TEST_ROOT") else {
+            return;
+        };
+
+        // Keep the dataset out of the temp dir's `.tmp*` namespace so the parent
+        // never mistakes it for a leaked scratch directory.
+        let uri = format!("{root}/dataset");
+        let reader = lance_datagen::gen_batch()
+            .col("id", array::step::<Int32Type>())
+            .col("vector", array::rand_vec::<Float32Type>(8.into()))
+            .into_reader_rows(RowCount::from(256), BatchCount::from(1));
+        let mut dataset = Dataset::write(reader, &uri, None).await.unwrap();
+
+        let params = VectorIndexParams::ivf_flat(2, MetricType::L2);
+        for i in 0..2 {
+            dataset
+                .create_index(
+                    &["vector"],
+                    IndexType::Vector,
+                    Some(format!("vector_idx_{i}")),
+                    &params,
+                    false,
+                )
+                .await
+                .unwrap();
+        }
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Problem

`prepare_vector_segment_build` creates the shuffle scratch directory as a local `TempStdDir` and returns only the shuffler, which carries just the directory path. The guard drops when the helper returns, so the directory is removed before the build writes into it. The shuffle writer recreates it, and from then on nothing owns it. Every vector index build leaks one scratch directory, and each one holds a shuffled copy of the vector column.

Fixes #8992.

## What this changes

The helper returns the guard alongside the shuffler, and both callers hold it until the build finishes. The incremental build path and the optimize path already keep their guards in the enclosing function scope and are untouched.

#6980 fixed the same thing for the legacy IVF_HNSW partition staging directory.

## Test plan

`test_shuffle_scratch_dir_is_not_leaked` runs two real index builds in a child process with `TMPDIR` pointed at an isolated directory, then asserts no scratch directory survives. Negative control: with the guard bound as bare `_` at the local call site, it fails and lists both directories, one per build. The builds go through `create_index`, so the test covers the local path; the distributed path needs precomputed centroids and is not exercised by it.

End to end, one index build with `TMPDIR` pointed at an empty directory:

| | left behind |
|---|---|
| `abcd800cd` | `.tmpXXXXXX/` with `shuffle_data.lance`, `shuffle_data.spill`, `shuffle_offsets.lance`, `shuffle_offsets.spill` |
| this branch | nothing |
