### PR TITLE
fix(index): narrow f16/f64 training chunks to f32 in streaming IVF trainers

### DIFF
--- a/rust/lance/src/index/vector/ivf.rs
+++ b/rust/lance/src/index/vector/ivf.rs
@@ -32,7 +32,7 @@ use arrow::datatypes::UInt8Type;
 use arrow_arith::numeric::sub;
 use arrow_array::Float32Array;
 use arrow_array::{
-    Array, ArrayRef, FixedSizeListArray, PrimitiveArray, RecordBatch, UInt32Array,
+    Array, ArrayRef, BooleanArray, FixedSizeListArray, PrimitiveArray, RecordBatch, UInt32Array,
     cast::AsArray,
     types::{ArrowPrimitiveType, Float16Type, Float32Type, Float64Type},
 };
@@ -3676,6 +3676,58 @@ fn update_refined_centroids(
     f32_fsl_from_values(next, dimension)
 }
 
+/// The streaming trainers accumulate and re-dispatch in f32, so training
+/// chunks must arrive as Float32. `convert_to_floating_point` cannot do this
+/// on its own: it returns f16 and f64 inputs unchanged, and the trainers'
+/// f32-only kernels hit those as a downcast panic.
+fn cast_training_data_to_f32(training_data: FixedSizeListArray) -> Result<FixedSizeListArray> {
+    let value_type = training_data.value_type();
+    match value_type {
+        DataType::Float32 => Ok(training_data),
+        DataType::Float16 | DataType::Float64 | DataType::Int8 => {
+            let (field, dimension, values, nulls) = training_data.into_parts();
+            let values = arrow::compute::cast(&values, &DataType::Float32)?;
+            let field = Arc::new(field.as_ref().clone().with_data_type(DataType::Float32));
+            let cast = FixedSizeListArray::try_new(field, dimension, values, nulls)?;
+            if value_type == DataType::Float64 {
+                return drop_rows_that_saturated(cast);
+            }
+            Ok(cast)
+        }
+        value_type => Err(Error::invalid_input(format!(
+            "streaming IVF training supports f16/f32/f64 and i8 vector columns, got {value_type}"
+        ))),
+    }
+}
+
+/// An f64 above `f32::MAX` saturates to an infinity instead of failing the
+/// cast, and the samplers filter for finite values before the cast runs, so the
+/// invariant has to be re-established here or the trainers accumulate
+/// infinities into their centroids.
+///
+/// This drops exactly the rows the narrowing broke, so null rows pass through
+/// as they do for every other value type.
+fn drop_rows_that_saturated(cast: FixedSizeListArray) -> Result<FixedSizeListArray> {
+    let values = cast.values().as_primitive::<Float32Type>().values();
+    if values.iter().all(|value| value.is_finite()) {
+        return Ok(cast);
+    }
+    let dimension = cast.value_length() as usize;
+    let keep = BooleanArray::from_iter(
+        values
+            .chunks(dimension)
+            .map(|row| Some(row.iter().all(|value| value.is_finite()))),
+    );
+    let kept = keep.true_count();
+    warn!(
+        "Dropped {} of {} streaming IVF training rows: their f64 values exceed the f32 range the trainers use",
+        cast.len() - kept,
+        cast.len()
+    );
+    let filtered = arrow::compute::filter(&cast, &keep)?;
+    Ok(filtered.as_fixed_size_list().clone())
+}
+
 async fn refine_streaming_f32_kmeans_with_sampler(
     sampler: &FixedIvfTrainingSampler<'_>,
     metric_type: MetricType,
@@ -3696,17 +3748,13 @@ async fn refine_streaming_f32_kmeans_with_sampler(
             let ranges = sample_ranges.chunk(row_offset, streaming_sample_size.max(1));
             row_offset += ranges.iter().map(range_len).sum::<usize>();
             let (training_data, mt) = sampler.sample_ranges(&ranges, metric_type).await?;
-            let training_data = if training_data.value_type() == DataType::Float32 {
-                training_data
-            } else {
-                training_data.convert_to_floating_point()?
-            };
             if mt != DistanceType::L2 {
                 return Err(Error::invalid_input(format!(
                     "streaming IVF refinement currently supports L2/Cosine training, got {}",
                     metric_type
                 )));
             }
+            let training_data = cast_training_data_to_f32(training_data)?;
             loss += accumulate_refine_assignments(
                 &training_data,
                 &centroids,
@@ -3758,17 +3806,13 @@ async fn refine_streaming_f32_kmeans_with_resampling(
                 fragment_ids,
             )
             .await?;
-            let training_data = if training_data.value_type() == DataType::Float32 {
-                training_data
-            } else {
-                training_data.convert_to_floating_point()?
-            };
             if mt != DistanceType::L2 {
                 return Err(Error::invalid_input(format!(
                     "streaming IVF refinement currently supports L2/Cosine training, got {}",
                     metric_type
                 )));
             }
+            let training_data = cast_training_data_to_f32(training_data)?;
             loss += accumulate_refine_assignments(
                 &training_data,
                 &centroids,
@@ -4552,17 +4596,13 @@ async fn train_streaming_coreset_ivf_model(
                 )
                 .await?
             };
-            let training_data = if training_data.value_type() == DataType::Float32 {
-                training_data
-            } else {
-                training_data.convert_to_floating_point()?
-            };
             if mt != DistanceType::L2 {
                 return Err(Error::invalid_input(format!(
                     "streaming coreset IVF currently supports L2/Cosine training, got {}",
                     metric_type
                 )));
             }
+            let training_data = cast_training_data_to_f32(training_data)?;
             if training_data.len() < num_partitions {
                 return Err(Error::index(format!(
                     "Not enough training vectors for streaming coreset IVF. Requires at least {} rows but sampled {} rows",
@@ -4908,8 +4948,8 @@ mod tests {
 
     use arrow_array::types::UInt64Type;
     use arrow_array::{
-        FixedSizeListArray, Float16Array, Float32Array, RecordBatch, RecordBatchIterator,
-        RecordBatchReader, UInt64Array, make_array,
+        FixedSizeListArray, Float16Array, Float32Array, Float64Array, Int8Array, RecordBatch,
+        RecordBatchIterator, RecordBatchReader, UInt16Array, UInt64Array, make_array,
     };
     use arrow_buffer::{BooleanBuffer, NullBuffer};
     use arrow_schema::{DataType, Field, Schema};
@@ -4921,6 +4961,7 @@ mod tests {
     use lance_datagen::{ArrayGeneratorExt, BatchCount, Dimension, RowCount, array, gen_batch};
     use lance_index::VECTOR_INDEX_VERSION;
     use lance_index::metrics::NoOpMetricsCollector;
+    use lance_index::progress::noop_progress;
     use lance_index::scalar::OldIndexDataFilter;
     use lance_index::vector::sq::builder::SQBuildParams;
     use lance_linalg::distance::l2_distance_batch;
@@ -6404,6 +6445,211 @@ mod tests {
         assert!(
             progress.progress_calls.load(Ordering::Relaxed) > 0,
             "expected the progress worker to receive at least one report"
+        );
+    }
+
+    /// f16 and f64 columns used to survive the streaming trainer's dtype
+    /// normalization unchanged (`convert_to_floating_point` only converts
+    /// integer types) and then hit the unconditional Float32 downcast in the
+    /// coreset path, panicking the build instead of training.
+    ///
+    /// The two cases also take different routes into the trainer: a
+    /// non-nullable column gets the fixed-range sampler, a nullable one the
+    /// resampling path, and each has its own normalization site.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_streaming_coreset_ivf_training_float16() {
+        let values = generate_random_array_with_seed::<Float16Type>(2048 * 8, [22; 32]);
+        streaming_coreset_training_completes(values, 8, false).await;
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_streaming_coreset_ivf_training_float64_nullable() {
+        let values = generate_random_array_with_seed::<Float64Type>(2048 * 8, [22; 32]);
+        streaming_coreset_training_completes(values, 8, true).await;
+    }
+
+    async fn streaming_coreset_training_completes<T: arrow_array::Array + 'static>(
+        values: T,
+        dimension: usize,
+        nullable: bool,
+    ) {
+        let test_dir = TempStrDir::default();
+        let uri = format!("{}/ds", test_dir.as_str());
+        let fsl = FixedSizeListArray::try_new_from_values(values, dimension as i32).unwrap();
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "vector",
+            fsl.data_type().clone(),
+            nullable,
+        )]));
+        let batch = RecordBatch::try_new(schema.clone(), vec![Arc::new(fsl)]).unwrap();
+        let reader = RecordBatchIterator::new(vec![batch].into_iter().map(Ok), schema);
+        let dataset = Dataset::write(reader, &uri, None).await.unwrap();
+
+        let mut params = IvfBuildParams::new(257);
+        params.sample_rate = 8;
+        params.streaming_sample_rate = Some(4);
+        params.streaming_refine_passes = 1;
+        params.max_iters = 2;
+
+        let ivf_model = build_ivf_model(
+            &dataset,
+            "vector",
+            dimension,
+            MetricType::L2,
+            &params,
+            None,
+            noop_progress(),
+        )
+        .await
+        .unwrap();
+        assert_eq!(ivf_model.num_partitions(), 257);
+        assert_eq!(ivf_model.dimension(), dimension);
+        let centroids = ivf_model.centroids_array().expect("trained model");
+        assert_eq!(centroids.value_type(), DataType::Float32);
+        let centroid_values = centroids.values().as_primitive::<Float32Type>();
+        // The generator draws from [0, 1), and a centroid is a weighted mean of
+        // training rows, so anything outside that range means the cast produced
+        // the wrong values rather than the wrong type.
+        assert!(
+            centroid_values
+                .values()
+                .iter()
+                .all(|v| (0.0..=1.0).contains(v)),
+            "centroid outside the training range: {:?}",
+            centroid_values
+                .values()
+                .iter()
+                .find(|v| !(0.0..=1.0).contains(*v)),
+        );
+    }
+
+    /// Read the f32 values of a training chunk row by row.
+    fn f32_rows(array: &FixedSizeListArray) -> Vec<Vec<f32>> {
+        let dimension = array.value_length() as usize;
+        let values = array.values().as_primitive::<Float32Type>().values();
+        values
+            .chunks(dimension)
+            .map(|row| row.to_vec())
+            .collect::<Vec<_>>()
+    }
+
+    /// `cast_training_data_to_f32` is the only place the streaming trainers
+    /// normalize dtypes, so it has to keep the values, the row boundaries and
+    /// the nulls intact for every type it accepts, and reject the rest with an
+    /// error rather than let a downstream downcast panic.
+    #[test]
+    fn test_cast_training_data_to_f32_converts_supported_types() {
+        let expected = vec![vec![1.0f32, 2.0], vec![3.0, 4.0]];
+
+        let f32_input = FixedSizeListArray::try_new_from_values(
+            Float32Array::from(vec![1.0f32, 2.0, 3.0, 4.0]),
+            2,
+        )
+        .unwrap();
+        let out = cast_training_data_to_f32(f32_input).unwrap();
+        assert_eq!(f32_rows(&out), expected, "Float32 must pass through");
+
+        let f16_input = FixedSizeListArray::try_new_from_values(
+            Float16Array::from(vec![
+                f16::from_f32(1.0),
+                f16::from_f32(2.0),
+                f16::from_f32(3.0),
+                f16::from_f32(4.0),
+            ]),
+            2,
+        )
+        .unwrap();
+        let out = cast_training_data_to_f32(f16_input).unwrap();
+        assert_eq!(f32_rows(&out), expected, "Float16 must widen exactly");
+        assert_eq!(out.value_type(), DataType::Float32);
+
+        let f64_input = FixedSizeListArray::try_new_from_values(
+            Float64Array::from(vec![1.0f64, 2.0, 3.0, 4.0]),
+            2,
+        )
+        .unwrap();
+        let out = cast_training_data_to_f32(f64_input).unwrap();
+        assert_eq!(f32_rows(&out), expected, "Float64 must narrow exactly");
+
+        let i8_input =
+            FixedSizeListArray::try_new_from_values(Int8Array::from(vec![1i8, 2, 3, 4]), 2)
+                .unwrap();
+        let out = cast_training_data_to_f32(i8_input).unwrap();
+        assert_eq!(f32_rows(&out), expected, "Int8 must convert");
+    }
+
+    /// The samplers hand over sliced chunks, so the cast has to follow the
+    /// slice rather than the whole underlying buffer.
+    #[test]
+    fn test_cast_training_data_to_f32_follows_a_slice() {
+        let input = FixedSizeListArray::try_new_from_values(
+            Float64Array::from(vec![10.0f64, 11.0, 20.0, 21.0, 30.0, 31.0, 40.0, 41.0]),
+            2,
+        )
+        .unwrap();
+        let out = cast_training_data_to_f32(input.slice(1, 2)).unwrap();
+        assert_eq!(
+            f32_rows(&out),
+            vec![vec![20.0f32, 21.0], vec![30.0, 31.0]],
+            "a sliced chunk must map to the rows it points at"
+        );
+    }
+
+    #[test]
+    fn test_cast_training_data_to_f32_keeps_nulls() {
+        let values = Float16Array::from(vec![
+            f16::from_f32(1.0),
+            f16::from_f32(2.0),
+            f16::ZERO,
+            f16::ZERO,
+            f16::from_f32(3.0),
+            f16::from_f32(4.0),
+        ]);
+        let field = Arc::new(Field::new("item", DataType::Float16, false));
+        let nulls = NullBuffer::from(vec![true, false, true]);
+        let input = FixedSizeListArray::try_new(field, 2, Arc::new(values), Some(nulls)).unwrap();
+        let out = cast_training_data_to_f32(input).unwrap();
+        assert_eq!(out.len(), 3);
+        assert_eq!(out.null_count(), 1, "the null row must survive the cast");
+        assert!(out.is_null(1), "the null must stay on the same row");
+    }
+
+    /// An f64 above `f32::MAX` saturates to an infinity instead of failing the
+    /// cast, so the samplers' finite filter no longer covers what the trainers
+    /// get and the cast has to drop those rows itself. A null row is not one of
+    /// them, so it stays.
+    #[test]
+    fn test_cast_training_data_to_f32_drops_rows_that_overflow_f32() {
+        let values = Float64Array::from(vec![1.0f64, 2.0, 1e39, 4.0, 0.0, 0.0, 5.0, 6.0]);
+        let field = Arc::new(Field::new("item", DataType::Float64, false));
+        let nulls = NullBuffer::from(vec![true, true, false, true]);
+        let input = FixedSizeListArray::try_new(field, 2, Arc::new(values), Some(nulls)).unwrap();
+        let out = cast_training_data_to_f32(input).unwrap();
+        assert_eq!(
+            f32_rows(&out),
+            vec![vec![1.0f32, 2.0], vec![0.0, 0.0], vec![5.0, 6.0]],
+            "the row that saturated to an infinity must be dropped, the null row must not"
+        );
+        assert_eq!(out.null_count(), 1, "the null row must survive the filter");
+        assert!(
+            out.is_null(1),
+            "the null must land on the row it started on"
+        );
+    }
+
+    #[test]
+    fn test_cast_training_data_to_f32_rejects_unsupported_types() {
+        let input =
+            FixedSizeListArray::try_new_from_values(UInt16Array::from(vec![1u16, 2, 3, 4]), 2)
+                .unwrap();
+        let error = cast_training_data_to_f32(input).unwrap_err();
+        assert!(
+            matches!(error, Error::InvalidInput { .. }),
+            "expected InvalidInput, got {error:?}"
+        );
+        assert!(
+            error.to_string().contains("UInt16"),
+            "the error must name the rejected type: {error}"
         );
     }
 

--- a/rust/lance/src/lib.rs
+++ b/rust/lance/src/lib.rs
@@ -1,6 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright The Lance Authors
 
+// The streaming IVF training tests await the whole training stack, whose future
+// type nests past the default 128 in the lib test build. benches/streaming_ivf_training.rs
+// raises the limit for the same stack.
+#![cfg_attr(test, recursion_limit = "256")]
+
 //! Lance Columnar Data Format
 //!
 //! Lance columnar data format is an alternative to Parquet. It provides 100x faster for random access,


### PR DESCRIPTION
## Problem

The three streaming IVF normalization sites called `convert_to_floating_point`, which returns f16 and f64 unchanged and only widens integer types. Those columns reached the trainers' unconditional Float32 downcast and panicked the build.

Fixes #8995.

## What this changes

All three sites now go through one helper that casts the chunk to Float32. Two details worth calling out.

An f64 above `f32::MAX` saturates to an infinity rather than failing the cast. The samplers run their finite filter before the cast (ivf.rs:3193 and :3518), so without something else the trainers could receive infinities, and `lance-index/src/vector/kmeans.rs:840` has no finite guard: the centroids would come out inf or NaN with no error. `drop_rows_that_saturated` removes exactly the rows the narrowing broke and logs how many, so a null row still passes through the way it does for every other value type.

The helper takes the array apart with `into_parts` rather than rebuilding the field by hand, which keeps the inner field's metadata and drops an unreachable branch. Its accept list is f16/f32/f64/i8, matching what a vector column can actually hold (rust/lance/src/index/vector/utils.rs:244).

The `num_partitions <= 256` streaming path dispatches on value type already and is untouched.

Note for whoever reviews #8610: that PR moves this same `convert_to_floating_point` call into a new helper without changing it, so it carries the panic forward. Landing this first, or folding it in, avoids that.

## Test plan

Five unit tests on the helper: the dtype matrix compared value by value, a sliced chunk mapping to the rows it points at, nulls staying on their row, an f64 that overflows f32 being dropped while a null row beside it survives, and an unsupported type returning `InvalidInput` with the type named. Removing the saturation filter makes the overflow test report `[[1.0, 2.0], [inf, 4.0], [5.0, 6.0]]`.

Two end-to-end cases train a 257 partition model with streaming enabled, one f16 and one f64. They take different routes on purpose: a non-nullable column gets the fixed-range sampler, a nullable one the resampling path, and each has its own normalization site, so the two cases cover two of the three sites rather than differing only in dtype. Restoring the old normalization at the coreset site makes both panic in arrow's cast.

- `cargo test -p lance --lib` 3387 passed, 3 ignored
- `cargo test -p lance --lib index::vector::ivf::tests::` 51 passed
- `cargo clippy --all --tests --benches -- -D warnings` clean
- `cargo fmt --all --check` clean
