### PR TITLE
fix(index): reject a supplied PQ codebook that does not match the column

### DIFF
--- a/python/python/tests/test_indices.py
+++ b/python/python/tests/test_indices.py
@@ -556,6 +556,23 @@ def test_vector_transform(tmpdir, small_rand_dataset, small_rand_ivf, small_rand
     assert reader.metadata().num_rows == SMALL_NUM_ROWS
 
 
+def test_vector_transform_mismatched_codebook(
+    tmpdir, small_rand_dataset, small_rand_ivf
+):
+    # The dimension comes from the column and the codebook from the caller, and
+    # the codebook is sliced with column-derived offsets.
+    dtype = small_rand_dataset.schema.field("vectors").type.value_type.to_pandas_dtype()
+    codebook = np.random.default_rng(42).random(DIMENSION * 256 * 2).astype(dtype)
+    codebook = pa.FixedSizeListArray.from_arrays(codebook, DIMENSION)
+    pq = PqModel(NUM_SUBVECTORS, codebook)
+
+    builder = IndicesBuilder(small_rand_dataset, "vectors")
+    with pytest.raises(ValueError, match="PQ codebook has"):
+        builder.transform_vectors(
+            small_rand_ivf, pq, str(tmpdir / "transformed"), fragments=None
+        )
+
+
 @pytest.mark.cuda
 def test_vector_transform_with_precomputed_partitions(
     tmpdir, small_rand_dataset, small_rand_ivf, small_rand_pq

--- a/python/src/indices.rs
+++ b/python/src/indices.rs
@@ -420,6 +420,13 @@ pub fn transform_vectors(
     let ivf_centroids = FixedSizeListArray::from(ivf_centroids);
     let codebook = pq_codebook.0;
     let codebook = FixedSizeListArray::from(codebook);
+    lance_index::vector::pq::validate_supplied_codebook(
+        codebook.values().len(),
+        dimension,
+        num_subvectors as usize,
+        num_bits as usize,
+    )
+    .infer_error()?;
     let distance_type = DistanceType::try_from(distance_type).unwrap();
     let pq = ProductQuantizer::new(
         num_subvectors as usize,
@@ -583,6 +590,13 @@ pub fn load_shuffled_vectors(
 
     let codebook = pq_codebook.0;
     let codebook = FixedSizeListArray::from(codebook);
+    lance_index::vector::pq::validate_supplied_codebook(
+        codebook.values().len(),
+        pq_dimension,
+        num_subvectors as usize,
+        num_bits as usize,
+    )
+    .infer_error()?;
 
     let distance_type = DistanceType::try_from(distance_type).unwrap();
     let pq_model = ProductQuantizer::new(

--- a/rust/lance-index/src/vector/pq.rs
+++ b/rust/lance-index/src/vector/pq.rs
@@ -444,6 +444,45 @@ impl ProductQuantizer {
     }
 }
 
+/// Reject a caller-supplied codebook whose size disagrees with the column.
+///
+/// The codebook buffer is sliced by column-derived arithmetic downstream
+/// (`get_sub_vector_centroids` computes the sub-vector width as
+/// `dimension / num_sub_vectors`), so a wrong size is not a local error: an
+/// oversized codebook has its sub-vector boundaries read at the wrong offsets
+/// and trains a garbage index without complaining, and an undersized one slices
+/// out of bounds and panics.
+pub fn validate_supplied_codebook(
+    codebook_len: usize,
+    dimension: usize,
+    num_sub_vectors: usize,
+    num_bits: usize,
+) -> Result<()> {
+    if num_sub_vectors == 0 || dimension == 0 || !dimension.is_multiple_of(num_sub_vectors) {
+        return Err(Error::invalid_input(format!(
+            "PQ codebook requires a nonzero vector dimension divisible by num_sub_vectors, \
+             got dimension {dimension} and num_sub_vectors {num_sub_vectors}"
+        )));
+    }
+    let num_centroids = u32::try_from(num_bits)
+        .ok()
+        .filter(|num_bits| *num_bits > 0)
+        .and_then(|num_bits| 1usize.checked_shl(num_bits));
+    let expected = num_centroids.and_then(|num_centroids| num_centroids.checked_mul(dimension));
+    let (Some(num_centroids), Some(expected)) = (num_centroids, expected) else {
+        return Err(Error::invalid_input(format!(
+            "PQ codebook size is not representable: num_bits {num_bits}, dimension {dimension}"
+        )));
+    };
+    if codebook_len != expected {
+        return Err(Error::invalid_input(format!(
+            "PQ codebook has {codebook_len} values, but the vector column requires {expected} \
+             ({num_centroids} centroids x dimension {dimension} for num_bits {num_bits})"
+        )));
+    }
+    Ok(())
+}
+
 impl Quantization for ProductQuantizer {
     type BuildParams = PQBuildParams;
     type Metadata = ProductQuantizationMetadata;
@@ -461,10 +500,17 @@ impl Quantization for ProductQuantizer {
         )))?;
 
         if let Some(codebook) = params.codebook.as_ref() {
+            let dimension = fsl.value_length() as usize;
+            validate_supplied_codebook(
+                codebook.len(),
+                dimension,
+                params.num_sub_vectors,
+                params.num_bits,
+            )?;
             return Ok(Self::new(
                 params.num_sub_vectors,
                 params.num_bits as u32,
-                fsl.value_length() as usize,
+                dimension,
                 FixedSizeListArray::try_new_from_values(codebook.clone(), fsl.value_length())?,
                 distance_type,
             ));
@@ -817,6 +863,53 @@ mod tests {
                 .values()
                 .as_primitive::<UInt8Type>()
                 .values()
+        );
+    }
+
+    /// A caller-supplied codebook is sliced by column-derived arithmetic, so a
+    /// size that disagrees with the column has to be rejected here: oversized
+    /// would read the sub-vector boundaries at the wrong offsets and train a
+    /// garbage index, undersized would slice out of bounds and panic.
+    #[test]
+    fn test_validate_supplied_codebook() {
+        const DIM: usize = 128;
+        const NUM_SUB_VECTORS: usize = 8;
+        let expected = 256 * DIM;
+
+        validate_supplied_codebook(expected, DIM, NUM_SUB_VECTORS, 8).unwrap();
+        validate_supplied_codebook(16 * DIM, DIM, NUM_SUB_VECTORS, 4).unwrap();
+
+        let error = validate_supplied_codebook(expected * 2, DIM, NUM_SUB_VECTORS, 8).unwrap_err();
+        assert!(
+            matches!(error, Error::InvalidInput { .. }),
+            "expected InvalidInput, got {error:?}"
+        );
+        let message = error.to_string();
+        assert!(
+            message.contains(&(expected * 2).to_string())
+                && message.contains(&expected.to_string()),
+            "the error must give both the supplied and the required size: {message}"
+        );
+
+        let error = validate_supplied_codebook(expected / 2, DIM, NUM_SUB_VECTORS, 8).unwrap_err();
+        assert!(matches!(error, Error::InvalidInput { .. }));
+
+        let error = validate_supplied_codebook(expected, DIM, 5, 8).unwrap_err();
+        assert!(
+            error.to_string().contains("divisible by num_sub_vectors"),
+            "a dimension that does not divide by num_sub_vectors must say so: {error}"
+        );
+
+        let error = validate_supplied_codebook(DIM, DIM, NUM_SUB_VECTORS, 0).unwrap_err();
+        assert!(
+            error.to_string().contains("not representable"),
+            "num_bits 0 must be rejected rather than accepting one centroid: {error}"
+        );
+
+        let error = validate_supplied_codebook(expected, DIM, NUM_SUB_VECTORS, 1024).unwrap_err();
+        assert!(
+            error.to_string().contains("not representable"),
+            "an absurd num_bits must be reported rather than wrapping: {error}"
         );
     }
 }

--- a/rust/lance-index/src/vector/pq/builder.rs
+++ b/rust/lance-index/src/vector/pq/builder.rs
@@ -19,6 +19,7 @@ use lance_linalg::distance::{Dot, L2, Normalize};
 
 use super::ProductQuantizer;
 use super::utils::divide_to_subvectors;
+use super::validate_supplied_codebook;
 use crate::vector::kmeans::{KMeansParams, train_kmeans};
 
 /// Parameters for building product quantizer.
@@ -204,6 +205,25 @@ impl PQBuildParams {
             data.data_type()
         )))?;
 
+        if let Some(codebook) = self.codebook.as_ref() {
+            // build_from_fsl slices this buffer with offsets derived from the
+            // column dimension, so a size that disagrees with the column reads
+            // the sub-vector boundaries at the wrong offsets or slices out of
+            // bounds.
+            let codebook = codebook.as_fixed_size_list_opt().ok_or_else(|| {
+                Error::invalid_input(format!(
+                    "PQ builder: codebook is not a FixedSizeList: {}",
+                    codebook.data_type()
+                ))
+            })?;
+            validate_supplied_codebook(
+                codebook.values().len(),
+                fsl.value_length() as usize,
+                self.num_sub_vectors,
+                self.num_bits,
+            )?;
+        }
+
         let num_centroids = self.num_centroids()?;
         if data.len() < num_centroids {
             return Err(Error::unprocessable(format!(
@@ -336,5 +356,40 @@ mod tests {
         );
         assert!(matches!(&error, Error::InvalidInput { .. }), "{error}");
         assert!(error.to_string().contains(&expected), "{error}");
+    }
+
+    /// A supplied codebook is sliced with offsets derived from the column, so a
+    /// size that disagrees with the column used to pass through here: oversized
+    /// read the sub-vector boundaries at the wrong offsets and trained a garbage
+    /// quantizer, undersized sliced out of bounds and panicked.
+    #[test]
+    fn test_build_rejects_mismatched_codebook() {
+        const DIM: usize = 8;
+        const NUM_SUB_VECTORS: usize = 2;
+        const NUM_BITS: usize = 2;
+        const K: usize = 1 << NUM_BITS;
+
+        let values = Float32Array::from_iter((0..64 * DIM).map(|v| v as f32));
+        let fsl = FixedSizeListArray::try_new_from_values(values, DIM as i32).unwrap();
+        let codebook = |num_centroids: usize| -> ArrayRef {
+            let values = Float32Array::from_iter((0..num_centroids * DIM).map(|v| v as f32));
+            Arc::new(FixedSizeListArray::try_new_from_values(values, DIM as i32).unwrap())
+        };
+
+        PQBuildParams::with_codebook(NUM_SUB_VECTORS, NUM_BITS, codebook(K))
+            .build(&fsl, DistanceType::L2)
+            .expect("a codebook sized for the column must still be accepted");
+
+        for supplied in [K * 2, K / 2] {
+            let error = PQBuildParams::with_codebook(NUM_SUB_VECTORS, NUM_BITS, codebook(supplied))
+                .build(&fsl, DistanceType::L2)
+                .unwrap_err();
+            assert!(matches!(&error, Error::InvalidInput { .. }), "{error}");
+            assert!(
+                error.to_string().contains(&(supplied * DIM).to_string())
+                    && error.to_string().contains(&(K * DIM).to_string()),
+                "the error must give the supplied and the required size: {error}"
+            );
+        }
     }
 }

--- a/rust/lance/src/index/vector.rs
+++ b/rust/lance/src/index/vector.rs
@@ -656,6 +656,12 @@ pub(crate) async fn build_distributed_vector_index(
             .codebook
             .clone()
             .expect("checked above that PQ codebook is present");
+        lance_index::vector::pq::validate_supplied_codebook(
+            pre_codebook.len(),
+            dim,
+            pq_params.num_sub_vectors,
+            pq_params.num_bits,
+        )?;
         let codebook_fsl =
             arrow_array::FixedSizeListArray::try_new_from_values(pre_codebook, dim as i32)?;
 

--- a/rust/lance/src/index/vector/ivf.rs
+++ b/rust/lance/src/index/vector/ivf.rs
@@ -6638,6 +6638,64 @@ mod tests {
         );
     }
 
+    /// A codebook whose sub-vector width disagrees with the column used to be
+    /// accepted: the PQ transform derives the width from the column, so an
+    /// oversized codebook had its sub-vector boundaries read at the wrong
+    /// offsets and produced a searchable but wrong index, with no error.
+    ///
+    /// The two index file versions reach the codebook through different
+    /// writers, so both are covered.
+    #[rstest]
+    #[case::v3(IndexFileVersion::V3)]
+    #[case::legacy(IndexFileVersion::Legacy)]
+    #[tokio::test]
+    async fn test_create_ivf_pq_rejects_mismatched_codebook(#[case] version: IndexFileVersion) {
+        const DIM: usize = 32;
+        let test_dir = TempStrDir::default();
+        let test_uri = test_dir.as_str();
+
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "vector",
+            DataType::FixedSizeList(
+                Arc::new(Field::new("item", DataType::Float32, true)),
+                DIM as i32,
+            ),
+            true,
+        )]));
+        let arr = generate_random_array_with_seed::<Float32Type>(1000 * DIM, [22; 32]);
+        let fsl = FixedSizeListArray::try_new_from_values(arr, DIM as i32).unwrap();
+        let batch = RecordBatch::try_new(schema.clone(), vec![Arc::new(fsl)]).unwrap();
+        let batches = RecordBatchIterator::new(vec![batch].into_iter().map(Ok), schema.clone());
+        let mut dataset = Dataset::write(batches, test_uri, None).await.unwrap();
+
+        // Twice the required 256 * DIM. Divisible by the column dimension, so
+        // nothing downstream complains on its own.
+        let codebook = Arc::new(generate_random_array_with_seed::<Float32Type>(
+            256 * DIM * 2,
+            [22; 32],
+        ));
+        let mut params = VectorIndexParams::with_ivf_pq_params(
+            MetricType::L2,
+            fast_ivf_params(2),
+            PQBuildParams::with_codebook(4, 8, codebook),
+        );
+        params.version = version;
+        let error = dataset
+            .create_index(&["vector"], IndexType::Vector, None, &params, false)
+            .await
+            .expect_err("a codebook that does not match the column must be rejected");
+        assert!(
+            matches!(error, Error::InvalidInput { .. }),
+            "expected InvalidInput, got {error:?}"
+        );
+        let message = error.to_string();
+        assert!(
+            message.contains(&(256 * DIM * 2).to_string())
+                && message.contains(&(256 * DIM).to_string()),
+            "the error must give the supplied and the required size: {message}"
+        );
+    }
+
     #[tokio::test]
     async fn test_create_ivf_flat_f16() {
         let test_dir = TempStrDir::default();

--- a/rust/lance/src/index/vector/pq.rs
+++ b/rust/lance/src/index/vector/pq.rs
@@ -551,8 +551,6 @@ pub async fn build_pq_model_in_fragments(
     ivf: Option<&IvfModel>,
     fragment_ids: Option<&[u32]>,
 ) -> Result<ProductQuantizer> {
-    let num_codes = 2_usize.pow(params.num_bits as u32);
-
     if let Some(codebook) = &params.codebook {
         lance_index::vector::pq::validate_supplied_codebook(
             codebook.len(),
@@ -588,8 +586,10 @@ pub async fn build_pq_model_in_fragments(
         "Start to train PQ code: PQ{}, bits={}",
         params.num_sub_vectors, params.num_bits
     );
-    let expected_sample_size =
-        lance_index::vector::pq::num_centroids(params.num_bits as u32) * params.sample_rate;
+    // 2^num_bits panics on an unrepresentable num_bits, so it stays below the
+    // supplied-codebook branch, which rejects that input instead.
+    let num_codes = lance_index::vector::pq::num_centroids(params.num_bits as u32);
+    let expected_sample_size = num_codes * params.sample_rate;
     info!(
         "Loading training data for PQ. Sample size: {}",
         expected_sample_size
@@ -906,6 +906,41 @@ mod tests {
             .unwrap_err();
 
         assert!(matches!(err, Error::Unprocessable { .. }));
+    }
+
+    /// The supplied codebook is checked before 2^num_bits is derived, so a
+    /// num_bits that does not fit reports the input rather than overflowing.
+    #[tokio::test]
+    async fn test_build_pq_model_rejects_unrepresentable_num_bits() {
+        let test_dir = TempStrDir::default();
+        let test_uri = test_dir.as_str();
+
+        let dim = 16;
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "vector",
+            DataType::FixedSizeList(
+                Arc::new(Field::new("item", DataType::Float32, true)),
+                dim as i32,
+            ),
+            false,
+        )]));
+
+        let vectors = generate_random_array_with_seed::<Float32Type>(dim * 10, [11u8; 32]);
+        let fsl = FixedSizeListArray::try_new_from_values(vectors, dim as i32).unwrap();
+        let batch = RecordBatch::try_new(schema.clone(), vec![Arc::new(fsl)]).unwrap();
+        let reader = RecordBatchIterator::new(vec![Ok(batch)], schema.clone());
+        let dataset = Dataset::write(reader, test_uri, None).await.unwrap();
+
+        let codebook = Arc::new(generate_random_array_with_seed::<Float32Type>(
+            dim, [12u8; 32],
+        ));
+        let params = PQBuildParams::with_codebook(4, usize::BITS as usize, codebook);
+        let err = build_pq_model(&dataset, "vector", dim, MetricType::L2, &params, None)
+            .await
+            .unwrap_err();
+
+        assert!(matches!(err, Error::InvalidInput { .. }), "got {err:?}");
+        assert!(err.to_string().contains("not representable"), "got {err}");
     }
 
     struct TestPreFilter {

--- a/rust/lance/src/index/vector/pq.rs
+++ b/rust/lance/src/index/vector/pq.rs
@@ -554,6 +554,12 @@ pub async fn build_pq_model_in_fragments(
     let num_codes = 2_usize.pow(params.num_bits as u32);
 
     if let Some(codebook) = &params.codebook {
+        lance_index::vector::pq::validate_supplied_codebook(
+            codebook.len(),
+            dim,
+            params.num_sub_vectors,
+            params.num_bits,
+        )?;
         let dt = if metric_type == MetricType::Cosine {
             info!("Normalize training data for PQ training: Cosine");
             MetricType::L2


### PR DESCRIPTION
## Problem

The PQ transform derives the sub-vector width from the column dimension, so a caller-supplied codebook of the wrong size is not a local error. An oversized codebook has its sub-vector boundaries read at the wrong offsets and builds a searchable but wrong index without complaining; an undersized one slices out of bounds and panics.

Fixes #8998.

## What this changes

`validate_supplied_codebook` in lance-index rejects a codebook whose length is not `num_centroids * dimension`, and reports the size as not representable instead of wrapping for `num_bits` of 0 or something absurd.

Three sites consume a supplied codebook and all three now call it: the v3 quantizer build, the legacy IVF_PQ writer (`build_pq_model_in_fragments`), and the distributed global PQ (`make_global_pq`, where a codebook is mandatory). Putting the check at a language boundary instead would leave the Rust and Java callers unguarded, since `PQBuildParams::with_codebook` is public Rust API.

## Test plan

`test_validate_supplied_codebook` covers the rule directly: the correct size for 8 and 4 bits, oversized, undersized, a dimension that does not divide by `num_sub_vectors`, `num_bits = 0`, and `num_bits = 1024`.

`test_create_ivf_pq_rejects_mismatched_codebook` drives a real `create_index` for both index file versions, which reach the codebook through different writers. Negative controls: with the core check removed the v3 case succeeds and writes `index.idx` (586 bytes) plus `auxiliary.idx` (71803 bytes); with the legacy writer's check removed the legacy case succeeds and writes `index.idx` (77908 bytes). Undersized panics at pq.rs:92 with `range end index 6144 out of range for slice of length 4096`.

- `cargo test -p lance --lib` 3382 passed, 3 ignored
- `cargo test -p lance-index --lib vector::pq::tests::` 5 passed
- `cargo clippy --all --tests --benches -- -D warnings` clean
- `cargo fmt --all --check` clean

## Not in this change

The IVF centroid width is unvalidated too, but a mismatch there already errors rather than building a bad index: `IVF centroids length mismatch: 2 != 64` (rust/lance/src/index/vector/ivf.rs:1696). That message compares a row count against a value count, so it is worth fixing, separately.
