### PR TITLE
fix(python): accept numpy ivf_centroids without num_partitions

### DIFF
--- a/python/python/lance/dataset.py
+++ b/python/python/lance/dataset.py
@@ -4110,6 +4110,13 @@ class LanceDataset(pa.dataset.Dataset):
                             f"Ivf centroids must be 2D array: (clusters, dim), "
                             f"got {ivf_centroids.shape}"
                         )
+                    if ivf_centroids.shape[0] == 0:
+                        # num_partitions was derived from shape[0] above, and
+                        # zero partitions panics in the Rust residual step.
+                        raise ValueError(
+                            "Ivf centroids must have at least one cluster, "
+                            f"got {ivf_centroids.shape}"
+                        )
                     if (
                         num_partitions is not None
                         and ivf_centroids.shape[0] != num_partitions

--- a/python/python/lance/dataset.py
+++ b/python/python/lance/dataset.py
@@ -4105,13 +4105,18 @@ class LanceDataset(pa.dataset.Dataset):
                 if _check_for_numpy(ivf_centroids) and isinstance(
                     ivf_centroids, np.ndarray
                 ):
-                    if (
-                        len(ivf_centroids.shape) != 2
-                        or ivf_centroids.shape[0] != num_partitions
-                    ):
+                    if len(ivf_centroids.shape) != 2:
                         raise ValueError(
                             f"Ivf centroids must be 2D array: (clusters, dim), "
                             f"got {ivf_centroids.shape}"
+                        )
+                    if (
+                        num_partitions is not None
+                        and ivf_centroids.shape[0] != num_partitions
+                    ):
+                        raise ValueError(
+                            f"Ivf centroids has {ivf_centroids.shape[0]} clusters, "
+                            f"but num_partitions={num_partitions}"
                         )
                     if ivf_centroids.dtype not in [np.float16, np.float32, np.float64]:
                         raise TypeError(
@@ -4265,8 +4270,9 @@ class LanceDataset(pa.dataset.Dataset):
             It can be either :py:class:`np.ndarray`,
             :py:class:`pyarrow.FixedSizeListArray` or
             :py:class:`pyarrow.FixedShapeTensorArray`.
-            A ``num_partitions x dimension`` array of existing K-mean centroids
-            for IVF clustering. If not provided, a new KMeans model will be trained.
+            A ``num_clusters x dimension`` array of existing K-mean centroids
+            for IVF clustering. The row count determines the number of IVF
+            partitions. If not provided, a new KMeans model will be trained.
         pq_codebook : optional,
             It can be :py:class:`np.ndarray`, :py:class:`pyarrow.FixedSizeListArray`,
             or :py:class:`pyarrow.FixedShapeTensorArray`.

--- a/python/python/tests/test_vector_index.py
+++ b/python/python/tests/test_vector_index.py
@@ -1559,6 +1559,19 @@ def test_pre_populated_ivf_centroids(dataset, tmp_path: Path):
             num_sub_vectors=8,
         )
 
+    # A zero-row array passes the 2D check, and the Rust residual step panics on
+    # the empty centroid buffer.
+    with pytest.raises(ValueError, match="at least one cluster"):
+        dataset.create_index(
+            ["vector"],
+            index_type="IVF_PQ",
+            metric="cosine",
+            ivf_centroids=np.empty((0, 128), dtype=np.float32),
+            num_sub_vectors=8,
+            # Otherwise the duplicate-name check intercepts first.
+            replace=True,
+        )
+
 
 def test_create_ivf_pq_skip_transpose(dataset, tmp_path: Path):
     ds = lance.write_dataset(

--- a/python/python/tests/test_vector_index.py
+++ b/python/python/tests/test_vector_index.py
@@ -1529,6 +1529,36 @@ def test_pre_populated_ivf_centroids(dataset, tmp_path: Path):
     partition_keys = {"size"}
     assert all([partition_keys == set(p.keys()) for p in partitions])
 
+    # num_partitions is deprecated in favor of target_partition_size, so
+    # centroids supplied without it must not be rejected. Seven clusters, so the
+    # assertion below tells the new index apart from the five-cluster one above
+    # and from the four target_partition_size would have picked.
+    new_centroids = np.random.randn(7, 128).astype(np.float32)
+    dataset_with_index = dataset.create_index(
+        ["vector"],
+        index_type="IVF_PQ",
+        metric="cosine",
+        ivf_centroids=new_centroids,
+        # 1000 rows / 250 = 4, so this diverges from the centroid count.
+        target_partition_size=250,
+        num_sub_vectors=8,
+        replace=True,
+    )
+    stats = dataset_with_index.stats.index_stats("vector_idx")
+    assert stats["indices"][0]["num_partitions"] == 7
+
+    # A count that disagrees with an explicitly passed num_partitions is still
+    # rejected, and the message now names both numbers.
+    with pytest.raises(ValueError, match="but num_partitions=4"):
+        dataset.create_index(
+            ["vector"],
+            index_type="IVF_PQ",
+            metric="cosine",
+            ivf_centroids=new_centroids,
+            num_partitions=4,
+            num_sub_vectors=8,
+        )
+
 
 def test_create_ivf_pq_skip_transpose(dataset, tmp_path: Path):
     ds = lance.write_dataset(


### PR DESCRIPTION
## Problem

The numpy `ivf_centroids` branch compared the centroid count against `num_partitions` in the same condition as the shape check. `num_partitions` defaults to None and is documented as deprecated in favor of `target_partition_size`, so a valid 2D array supplied without it failed, reported as "Ivf centroids must be 2D array" against a 2D shape.

Fixes #9000.

## What this changes

The two checks are separate now: a non-2D array is still rejected with the same message, and the count is compared only when the caller set `num_partitions`, with a message that names both numbers. The Rust core already resolves the partition count from the centroids when `num_partitions` is absent.

The `ivf_centroids` docstring said `num_partitions x dimension`, which no longer describes how the count is derived; it now says the row count determines the number of partitions.

## Test plan

`test_pre_populated_ivf_centroids` gets two cases. The first supplies a 7 cluster array with `target_partition_size=250` and no `num_partitions`, then asserts the built index has 7 partitions. 7 tells it apart from the 5 partition index built earlier in the same test and from the 4 that `target_partition_size` would have produced. The second passes `num_partitions=4` against the same array and asserts the new mismatch message.

Without the fix the first case raises `ValueError: Ivf centroids must be 2D array: (clusters, dim), got (7, 128)`.

- `uv run pytest python/tests/test_vector_index.py` 92 passed, 11 skipped, 1 failed
- The failure is `test_create_index_progress_callback_error_before_completion_propagates`, which fails the same way with upstream's `dataset.py` on this machine, so it is not from this change.
- `uv run make lint` clean
