### PR TITLE
feat(mem_wal): populate what a flushed SSTable holds

### DIFF
--- a/docs/src/format/table/mem_wal.md
+++ b/docs/src/format/table/mem_wal.md
@@ -145,6 +145,29 @@ _mem_wal/{shard_id}/{random8}_gen_{i}/
 If a flush attempt fails, a retry writes a different directory instead of reusing a partially written one.
 The shard manifest records the successful directory name in the SSTable's `path`.
 
+### SSTable Accounting
+
+Alongside `generation` and `path`, a shard manifest entry may record what the
+SSTable holds, as the writer's MemTable accounted for it at flush:
+
+- `in_memory_bytes`: payload size of the rows, summed over the MemTable's
+  buffers as the window each one holds.
+- `physical_rows`: rows held, counting the older duplicates of a primary key
+  that the generation's deletion vector masks. A scan applying the deletion
+  vector yields fewer.
+- `primary_key_bytes`: total payload size of the primary-key columns over every
+  row in `physical_rows`. Not a per-row size, which varies for a
+  variable-length key.
+
+All three are estimates of payload, not bounds on what reading the SSTable
+costs: they exclude the per-array structure a reader materializes, and
+`primary_key_bytes` is not the size of any encoded form of the key. A consumer
+budgeting memory from them adds its own headroom.
+
+All three are optional. An entry written before they existed records none of
+them, and a reader must not treat an absent value as zero; `primary_key_bytes`
+is also absent on a table with no primary key.
+
 The SSTable directory is a standard Lance dataset written with the base table's data storage version.
 Each SSTable is written as one fragment.
 Additional MemWAL sidecars may be present:

--- a/protos/table.proto
+++ b/protos/table.proto
@@ -768,6 +768,33 @@ message SsTable {
 
   // Directory name relative to the shard directory.
   string path = 2;
+
+  /* Payload size of the rows, as the writer's MemTable accounted for them: the
+     sum over its buffers of the window each one holds.
+
+     An estimate of the payload, not a bound on what reading the SSTable costs.
+     It excludes the per-array structure a reader materializes, so a consumer
+     budgeting memory from it must add its own headroom.
+
+     Absent on an SSTable written before this field existed, so a reader must
+     not read a missing value as zero. The same applies to the two below. */
+  optional uint64 in_memory_bytes = 3;
+
+  /* Rows held, counting the older duplicates of a primary key that the
+     generation's deletion vector masks. A scan that applies the deletion vector
+     yields fewer. */
+  optional uint64 physical_rows = 4;
+
+  /* Total payload size of the primary-key columns, summed over every row in
+     `physical_rows`. Not a per-row size: a variable-length key differs from row
+     to row, and a consumer wanting a mean divides by the row count.
+
+     Accounted the same way as `in_memory_bytes`, so the same caveat applies --
+     it is not the size of any encoded form of the key, such as a comparable
+     byte-ordered encoding a reader might build for sorting or deduplication.
+
+     Absent also on a table with no primary key. */
+  optional uint64 primary_key_bytes = 5;
 }
 
 // A pointer to the latest SSTable compacted for a shard.

--- a/rust/lance-table/src/system_index/mem_wal.rs
+++ b/rust/lance-table/src/system_index/mem_wal.rs
@@ -33,6 +33,38 @@ pub type ShardId = Uuid;
 pub struct SsTable {
     pub generation: u64,
     pub path: String,
+    /// Payload size of the rows, as the writer's MemTable accounted for them.
+    ///
+    /// An estimate of the payload, not a bound on what reading the SSTable
+    /// costs: it excludes the per-array structure a reader materializes, so a
+    /// consumer budgeting memory from it must add its own headroom.
+    ///
+    /// `None` on an SSTable written before these fields existed, which a reader
+    /// must carry as unmeasured rather than as zero. The same applies to the two
+    /// below.
+    pub in_memory_bytes: Option<u64>,
+    /// Rows held, counting the older duplicates of a primary key that the
+    /// generation's deletion vector masks.
+    pub physical_rows: Option<u64>,
+    /// Total payload size of the primary-key columns over every row in
+    /// [`Self::physical_rows`] -- not a per-row size, which varies for a
+    /// variable-length key. Carries the same estimate caveat as
+    /// [`Self::in_memory_bytes`], and is also `None` on a table with no primary
+    /// key.
+    pub primary_key_bytes: Option<u64>,
+}
+
+impl SsTable {
+    /// An SSTable whose contents were not measured at flush.
+    pub fn unmeasured(generation: u64, path: String) -> Self {
+        Self {
+            generation,
+            path,
+            in_memory_bytes: None,
+            physical_rows: None,
+            primary_key_bytes: None,
+        }
+    }
 }
 
 impl From<&SsTable> for pb::SsTable {
@@ -40,6 +72,9 @@ impl From<&SsTable> for pb::SsTable {
         Self {
             generation: sstable.generation,
             path: sstable.path.clone(),
+            in_memory_bytes: sstable.in_memory_bytes,
+            physical_rows: sstable.physical_rows,
+            primary_key_bytes: sstable.primary_key_bytes,
         }
     }
 }
@@ -49,6 +84,9 @@ impl From<pb::SsTable> for SsTable {
         Self {
             generation: sstable.generation,
             path: sstable.path,
+            in_memory_bytes: sstable.in_memory_bytes,
+            physical_rows: sstable.physical_rows,
+            primary_key_bytes: sstable.primary_key_bytes,
         }
     }
 }
@@ -574,4 +612,46 @@ pub fn new_mem_wal_index_meta(
         // Memory WAL index is inline (no files)
         files: None,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// An SSTable written before the size fields existed decodes as
+    /// unmeasured, not as zero. A reader that saw zero would treat a full
+    /// generation as costing nothing.
+    #[test]
+    fn an_sstable_without_the_size_fields_decodes_as_unmeasured() {
+        let legacy = pb::SsTable {
+            generation: 7,
+            path: "aaa_gen_7".to_string(),
+            in_memory_bytes: None,
+            physical_rows: None,
+            primary_key_bytes: None,
+        };
+        let decoded = SsTable::from(legacy);
+        assert_eq!(decoded.generation, 7);
+        assert_eq!(decoded.in_memory_bytes, None);
+        assert_eq!(decoded.physical_rows, None);
+        assert_eq!(decoded.primary_key_bytes, None);
+    }
+
+    /// All three survive the round trip, so a reader sees what the flush
+    /// measured rather than a default.
+    #[test]
+    fn the_recorded_size_survives_the_round_trip() {
+        let recorded = SsTable {
+            generation: 7,
+            path: "aaa_gen_7".to_string(),
+            in_memory_bytes: Some(4_096),
+            physical_rows: Some(10),
+            primary_key_bytes: Some(80),
+        };
+        let encoded = pb::SsTable::from(&recorded);
+        assert_eq!(encoded.in_memory_bytes, Some(4_096));
+        assert_eq!(encoded.physical_rows, Some(10));
+        assert_eq!(encoded.primary_key_bytes, Some(80));
+        assert_eq!(SsTable::from(encoded), recorded);
+    }
 }

--- a/rust/lance/src/dataset/mem_wal/memtable.rs
+++ b/rust/lance/src/dataset/mem_wal/memtable.rs
@@ -80,6 +80,10 @@ pub struct MemTable {
 
     /// Primary key bloom filter for staleness detection.
     pk_bloom_filter: Sbbf,
+    /// Decoded size of the primary-key columns across every batch appended so
+    /// far. Accumulated here because [`Self::update_bloom_filter`] already has
+    /// the key columns in hand.
+    pk_bytes: usize,
     /// Primary key field IDs (for bloom filter updates).
     pk_field_ids: Vec<i32>,
 
@@ -255,6 +259,7 @@ impl MemTable {
             generation,
             pk_bloom_filter,
             pk_field_ids,
+            pk_bytes: 0,
             // Initialize with an empty IndexStore so the visibility cursor has
             // a stable Arc shared between the scanner (via `indexes_arc()`)
             // and the WAL flush handler. Replaced via `set_indexes_arc` if
@@ -576,6 +581,12 @@ impl MemTable {
             bloom.insert_hash(hash);
         }
 
+        // Per column, not per row: the loop above is what costs something here.
+        self.pk_bytes += pk_columns
+            .iter()
+            .map(|column| batch_store::StoredBatch::estimate_array_size(&column.to_data()))
+            .sum::<usize>();
+
         Ok(())
     }
 
@@ -700,6 +711,11 @@ impl MemTable {
     }
 
     /// Get total row count.
+    /// Decoded size of the primary-key columns this memtable holds.
+    pub fn pk_bytes(&self) -> usize {
+        self.pk_bytes
+    }
+
     pub fn row_count(&self) -> usize {
         self.batch_store.total_rows()
     }

--- a/rust/lance/src/dataset/mem_wal/memtable/batch_store.rs
+++ b/rust/lance/src/dataset/mem_wal/memtable/batch_store.rs
@@ -103,7 +103,7 @@ impl StoredBatch {
     /// [`Self::view_data_buffers_size`] adds them. Those buffers are shared across
     /// zero-copy slices and are counted at full capacity for each slice — an
     /// over-count in the safe direction.
-    fn estimate_array_size(data: &ArrayData) -> usize {
+    pub(crate) fn estimate_array_size(data: &ArrayData) -> usize {
         match data.get_slice_memory_size() {
             Ok(size) => size + Self::view_data_buffers_size(data),
             // Fall back to the full-buffer sum for layouts the slice-aware call

--- a/rust/lance/src/dataset/mem_wal/memtable/flush.rs
+++ b/rust/lance/src/dataset/mem_wal/memtable/flush.rs
@@ -84,6 +84,45 @@ pub struct MemTableFlusher {
     session: Option<Arc<Session>>,
 }
 
+/// What a flushed generation holds, for the manifest entry recording it.
+///
+/// Read off the memtable being flushed, which is frozen. That matters: an
+/// appending store bumps these counters before it publishes the batch, so only
+/// a sealed one agrees with what a scan of it will see.
+#[derive(Clone, Copy)]
+struct FlushedSize {
+    in_memory_bytes: Option<u64>,
+    physical_rows: Option<u64>,
+    primary_key_bytes: Option<u64>,
+}
+
+impl FlushedSize {
+    /// Zero reads as unmeasured. An empty memtable is refused before a flush
+    /// gets here, so a flushed generation always holds rows and a zero can only
+    /// mean the accounting failed.
+    fn of(memtable: &MemTable) -> Self {
+        Self {
+            // `row_bytes`, not the store's retained heap: the window being
+            // written is what a reader of this generation gets back.
+            in_memory_bytes: Some(memtable.batch_store().row_bytes() as u64).filter(|b| *b > 0),
+            physical_rows: Some(memtable.row_count() as u64).filter(|r| *r > 0),
+            // Zero means the table has no primary key, which is not a
+            // measurement of one.
+            primary_key_bytes: Some(memtable.pk_bytes() as u64).filter(|b| *b > 0),
+        }
+    }
+
+    fn sstable(self, generation: u64, path: String) -> SsTable {
+        SsTable {
+            generation,
+            path,
+            in_memory_bytes: self.in_memory_bytes,
+            physical_rows: self.physical_rows,
+            primary_key_bytes: self.primary_key_bytes,
+        }
+    }
+}
+
 impl MemTableFlusher {
     pub fn new(
         object_store: Arc<ObjectStore>,
@@ -232,6 +271,7 @@ impl MemTableFlusher {
 
         let random_hash = generate_random_hash();
         let generation = memtable.generation();
+        let size = FlushedSize::of(memtable);
         let gen_folder_name = format!("{}_gen_{}", random_hash, generation);
         let gen_path = sstable_path(&self.base_path, &self.shard_id, &random_hash, generation);
 
@@ -273,6 +313,7 @@ impl MemTableFlusher {
                 generation,
                 &gen_folder_name,
                 covered_wal_entry_position,
+                size,
             )
             .await?;
 
@@ -282,7 +323,7 @@ impl MemTableFlusher {
         );
 
         Ok(FlushResult {
-            sstable: SsTable::unmeasured(generation, gen_folder_name),
+            sstable: size.sstable(generation, gen_folder_name),
             rows_flushed,
             covered_wal_entry_position,
         })
@@ -462,6 +503,7 @@ impl MemTableFlusher {
 
         let random_hash = generate_random_hash();
         let generation = memtable.generation();
+        let size = FlushedSize::of(memtable);
         let gen_folder_name = format!("{}_gen_{}", random_hash, generation);
         let gen_path = sstable_path(&self.base_path, &self.shard_id, &random_hash, generation);
 
@@ -574,6 +616,7 @@ impl MemTableFlusher {
                 generation,
                 &gen_folder_name,
                 covered_wal_entry_position,
+                size,
             )
             .await?;
 
@@ -583,7 +626,7 @@ impl MemTableFlusher {
         );
 
         Ok(FlushResult {
-            sstable: SsTable::unmeasured(generation, gen_folder_name),
+            sstable: size.sstable(generation, gen_folder_name),
             rows_flushed: memtable.row_count(),
             covered_wal_entry_position,
         })
@@ -1123,13 +1166,14 @@ impl MemTableFlusher {
         generation: u64,
         gen_path: &str,
         covered_wal_entry_position: u64,
+        size: FlushedSize,
     ) -> Result<ShardManifest> {
         let gen_path = gen_path.to_string();
 
         self.manifest_store
             .commit_update(epoch, |current| {
                 let mut sstables = current.sstables.clone();
-                sstables.push(SsTable::unmeasured(generation, gen_path.clone()));
+                sstables.push(size.sstable(generation, gen_path.clone()));
 
                 ShardManifest {
                     version: current.next_version(),
@@ -1187,6 +1231,60 @@ mod tests {
         let uri = format!("file://{}", temp_dir.path().display());
         let (store, path) = ObjectStore::from_uri(&uri).await.unwrap();
         (store, path, uri, temp_dir)
+    }
+
+    /// A local store with one claimed shard and a flusher over it.
+    ///
+    /// Every flush test in this module repeats this setup.
+    struct FlushFixture {
+        manifest_store: Arc<ShardManifestStore>,
+        flusher: MemTableFlusher,
+        epoch: u64,
+        _temp_dir: TempDir,
+    }
+
+    impl FlushFixture {
+        async fn new() -> Self {
+            let (store, base_path, base_uri, temp_dir) = create_local_store().await;
+            let shard_id = Uuid::new_v4();
+            let manifest_store = Arc::new(ShardManifestStore::new(
+                store.clone(),
+                &base_path,
+                shard_id,
+                2,
+            ));
+            let (epoch, _) = manifest_store.claim_epoch(0).await.unwrap();
+            let flusher =
+                MemTableFlusher::new(store, base_path, base_uri, shard_id, manifest_store.clone());
+            Self {
+                manifest_store,
+                flusher,
+                epoch,
+                _temp_dir: temp_dir,
+            }
+        }
+
+        /// Flush `memtable` and read the entry it wrote back **off storage**.
+        ///
+        /// Through `read_version`, not `latest`: the store caches the manifest
+        /// it just wrote, so `latest` returns that same Rust value and would
+        /// pass even for a field that never reached the protobuf.
+        async fn flush_and_read_back(&self, memtable: &MemTable, durable: usize) -> SsTable {
+            let result = self
+                .flusher
+                .flush(memtable, self.epoch, 1, durable)
+                .await
+                .unwrap();
+            let version = self.manifest_store.latest().await.unwrap().unwrap().version;
+            self.manifest_store
+                .read_version(version)
+                .await
+                .unwrap()
+                .sstables
+                .into_iter()
+                .find(|sstable| sstable.generation == result.sstable.generation)
+                .expect("the flush recorded its generation")
+        }
     }
 
     fn create_test_schema() -> Arc<ArrowSchema> {
@@ -1329,6 +1427,70 @@ mod tests {
         assert_eq!(updated_manifest.replay_after_wal_entry_position, 1);
         assert_eq!(updated_manifest.current_generation, 2);
         assert_eq!(updated_manifest.sstables.len(), 1);
+    }
+
+    /// A flushed generation records what it holds, read back off storage.
+    ///
+    /// The read goes through the persisted protobuf on purpose: a consumer
+    /// decides whether to open a generation from these numbers, so a field that
+    /// never reached storage is the failure worth catching.
+    #[tokio::test]
+    async fn flushed_sstable_records_what_it_holds() {
+        let fixture = FlushFixture::new().await;
+        let schema = create_test_schema();
+        let mut memtable = MemTable::new(schema.clone(), 1, vec![]).unwrap();
+        let rows = 10;
+        let frag_id = memtable
+            .insert(create_test_batch(&schema, rows))
+            .await
+            .unwrap();
+        let accounted = memtable.batch_store().row_bytes() as u64;
+
+        let entry = fixture.flush_and_read_back(&memtable, frag_id + 1).await;
+
+        assert_eq!(entry.physical_rows, Some(rows as u64));
+        assert_eq!(entry.in_memory_bytes, Some(accounted));
+        // The MemTable's own accounting, so above the raw payload (4 bytes per
+        // `id`) and not the encoded file size.
+        let payload = rows as u64 * std::mem::size_of::<i32>() as u64;
+        assert!(
+            entry.in_memory_bytes.unwrap() > payload,
+            "recorded {:?} should exceed the raw payload {payload}",
+            entry.in_memory_bytes
+        );
+        // No primary key here: absent, not zero, which a consumer would read as
+        // costing nothing.
+        assert_eq!(entry.primary_key_bytes, None);
+    }
+
+    /// With a primary key, its size is recorded too -- the term neither of the
+    /// others carries, since a narrow key over many rows and a wide key over
+    /// few weigh the same in `in_memory_bytes`.
+    #[tokio::test]
+    async fn flushed_sstable_records_its_primary_key_size() {
+        let fixture = FlushFixture::new().await;
+        let schema = create_pk_schema();
+        let mut memtable = MemTable::new(schema.clone(), 1, vec![0]).unwrap();
+        let rows = 10;
+        let frag_id = memtable
+            .insert(create_test_batch(&schema, rows))
+            .await
+            .unwrap();
+
+        let entry = fixture.flush_and_read_back(&memtable, frag_id + 1).await;
+
+        // `id` is a non-nullable Int32, so the key columns hold at least four
+        // bytes a row and cannot reach the whole MemTable's size.
+        let key_bytes = entry.primary_key_bytes.expect("a keyed table records it");
+        assert!(
+            key_bytes >= rows as u64 * std::mem::size_of::<i32>() as u64,
+            "recorded {key_bytes} is below the raw key payload"
+        );
+        assert!(
+            key_bytes < entry.in_memory_bytes.unwrap(),
+            "keys ({key_bytes}) cannot outweigh the whole MemTable ({:?})",
+            entry.in_memory_bytes
+        );
     }
 
     /// A `SsTableWarmer` that counts calls and optionally fails.

--- a/rust/lance/src/dataset/mem_wal/memtable/flush.rs
+++ b/rust/lance/src/dataset/mem_wal/memtable/flush.rs
@@ -282,10 +282,7 @@ impl MemTableFlusher {
         );
 
         Ok(FlushResult {
-            sstable: SsTable {
-                generation,
-                path: gen_folder_name,
-            },
+            sstable: SsTable::unmeasured(generation, gen_folder_name),
             rows_flushed,
             covered_wal_entry_position,
         })
@@ -586,10 +583,7 @@ impl MemTableFlusher {
         );
 
         Ok(FlushResult {
-            sstable: SsTable {
-                generation,
-                path: gen_folder_name,
-            },
+            sstable: SsTable::unmeasured(generation, gen_folder_name),
             rows_flushed: memtable.row_count(),
             covered_wal_entry_position,
         })
@@ -1135,10 +1129,7 @@ impl MemTableFlusher {
         self.manifest_store
             .commit_update(epoch, |current| {
                 let mut sstables = current.sstables.clone();
-                sstables.push(SsTable {
-                    generation,
-                    path: gen_path.clone(),
-                });
+                sstables.push(SsTable::unmeasured(generation, gen_path.clone()));
 
                 ShardManifest {
                     version: current.next_version(),


### PR DESCRIPTION
**Depends on lance-format/lance#8981**, which adds the fields; that PR's commit appears here until it merges.

The manifest entry has fields for an SSTable's payload size, row count and primary-key size, and flush writes none of them. Populate all three from the MemTable being written, which is where the numbers exist and where two of them are already maintained.

- `in_memory_bytes` and `physical_rows` are counters the batch store already keeps — the first is what the flush threshold itself is measured against.
- `primary_key_bytes` is accumulated where the bloom filter is updated, which already holds the key columns in hand: one size estimate per key column **per batch**, against a loop that already walks every row. So it costs O(columns) on a path that is already O(rows).

Read off the MemTable while it is frozen, which is load-bearing: `BatchStore::append` bumps these counters *before* it publishes `committed_len`, and a scan is bounded by `committed_len`, so only a sealed store agrees with what a scan of it will see. `FlushedSize` carries the three together so both flush paths share one measurement and neither the manifest write nor the `FlushResult` can transpose them.

A zero reads as absent, which is also how a table with no primary key reports: an empty MemTable is refused before a flush, so a flushed generation always holds rows.

**Testing.** The two new tests read the entry back through `read_version`, not `latest`. That matters: the store caches the manifest it just wrote, so `latest` returns the same Rust value and a test asserting through it passes even for a field that never reached the protobuf. Verified by dropping `primary_key_bytes` from the encode path — the old shape passed, this one fails.

`FlushFixture` carries the store/shard/flusher setup that all thirteen flush tests in the module repeat; the two new tests use it, and converting the other eleven is a mechanical follow-up.

663 `mem_wal` tests pass, 13 of them in the flush module; fmt clean.
