### PR TITLE
fix(index): reject out-of-range partition ids when computing residuals

### DIFF
--- a/rust/lance-index/src/vector/residual.rs
+++ b/rust/lance-index/src/vector/residual.rs
@@ -81,9 +81,18 @@ where
 
     let vectors_slice = vectors.values();
     let centroids_slice = centroids.values();
+    let num_centroids = centroids_slice.len() / dimension;
     let mut residuals = Vec::with_capacity(vectors.len());
     for (idx, vector) in vectors_slice.chunks_exact(dimension).enumerate() {
         let part_id = part_ids[idx] as usize;
+        // A precomputed partitions file is user data, so an id beyond the
+        // centroid count has to be an error rather than a slice panic.
+        if part_id >= num_centroids {
+            return Err(Error::invalid_input(format!(
+                "Compute residual vector: partition id {part_id} is out of range for \
+                 {num_centroids} centroids"
+            )));
+        }
         let c = &centroids_slice[part_id * dimension..(part_id + 1) * dimension];
         residuals.extend(iter::zip(vector, c).map(|(v, cent)| *v - *cent));
     }
@@ -447,5 +456,31 @@ mod tests {
         assert_eq!(field.data_type(), residual.data_type());
         assert_eq!(residual.value_type(), DataType::Float32);
         assert_eq!(f32_values(residual), vec![3.5, 7.5]);
+    }
+
+    /// Partition ids can come from a user-supplied precomputed partitions
+    /// dataset, which nothing range-checks on the way in, so an id beyond the
+    /// centroid count has to surface as an error rather than a slice panic.
+    #[test]
+    fn test_compute_residual_rejects_out_of_range_partition() {
+        let centroids = fsl(Float32Array::from(vec![0.0f32, 0.0, 1.0, 1.0]), 2);
+        let vectors = fsl(Float32Array::from(vec![0.5f32, 0.5]), 2);
+        let part_ids = UInt32Array::from(vec![5u32]);
+        let error = compute_residual(
+            &centroids,
+            &vectors,
+            Some(DistanceType::L2),
+            Some(&part_ids),
+        )
+        .unwrap_err();
+        assert!(
+            matches!(error, Error::InvalidInput { .. }),
+            "expected InvalidInput, got {error:?}"
+        );
+        let message = error.to_string();
+        assert!(
+            message.contains("partition id 5") && message.contains("2 centroids"),
+            "the error must name the id and the centroid count: {message}"
+        );
     }
 }

--- a/rust/lance/src/index/vector/ivf.rs
+++ b/rust/lance/src/index/vector/ivf.rs
@@ -5516,6 +5516,63 @@ mod tests {
         assert_eq!(5, results[0].num_rows());
     }
 
+    /// A precomputed partitions file is user data. For IVF_PQ the residual step
+    /// reaches it first and used to panic out of a spawned transform; the
+    /// shuffler's own range check (`v3/shuffler.rs`) never got a chance to run.
+    #[tokio::test]
+    async fn test_create_ivf_pq_rejects_out_of_range_precomputed_partition() {
+        let test_dir = TempStrDir::default();
+        let test_uri = format!("{}/ds", test_dir.as_str());
+        let partitions_uri = format!("{}/parts", test_dir.as_str());
+
+        let (mut dataset, _) = generate_test_dataset(&test_uri, 0.0..1.0).await;
+        let num_rows = dataset.count_rows(None).await.unwrap() as u64;
+
+        // Partition 7 does not exist in a 2-partition index.
+        let parts_schema = Arc::new(Schema::new(vec![
+            Field::new("row_id", DataType::UInt64, false),
+            Field::new("partition", DataType::UInt32, false),
+        ]));
+        let parts_batch = RecordBatch::try_new(
+            parts_schema.clone(),
+            vec![
+                Arc::new(UInt64Array::from_iter_values(0..num_rows)),
+                Arc::new(UInt32Array::from_iter_values(
+                    (0..num_rows).map(|i| if i == 3 { 7 } else { 0 }),
+                )),
+            ],
+        )
+        .unwrap();
+        let parts_reader =
+            RecordBatchIterator::new(vec![parts_batch].into_iter().map(Ok), parts_schema);
+        Dataset::write(parts_reader, &partitions_uri, None)
+            .await
+            .unwrap();
+
+        let centroids = generate_random_array(2 * DIM);
+        let ivf_centroids = FixedSizeListArray::try_new_from_values(centroids, DIM as i32).unwrap();
+        let mut ivf_params =
+            IvfBuildParams::try_with_centroids(2, Arc::new(ivf_centroids)).unwrap();
+        ivf_params.precomputed_partitions_file = Some(partitions_uri);
+        let pq_params =
+            PQBuildParams::with_codebook(4, 8, Arc::new(generate_random_array(256 * DIM)));
+        let params = VectorIndexParams::with_ivf_pq_params(MetricType::L2, ivf_params, pq_params);
+
+        let error = dataset
+            .create_index(&["vector"], IndexType::Vector, None, &params, false)
+            .await
+            .expect_err("an out-of-range precomputed partition must be rejected");
+        assert!(
+            matches!(error, Error::InvalidInput { .. }),
+            "expected InvalidInput, got {error:?}"
+        );
+        let message = error.to_string();
+        assert!(
+            message.contains("partition id 7") && message.contains("2 centroids"),
+            "the error must name the id and the centroid count: {message}"
+        );
+    }
+
     fn partition_ids(mut ids: Vec<u64>, num_parts: u32) -> Vec<Vec<u64>> {
         if num_parts > ids.len() as u32 {
             panic!("Not enough ids to break into {num_parts} parts");


### PR DESCRIPTION
## Problem

`do_compute_residual` indexes the centroid buffer with the partition id straight from the batch. Ids assigned by the transformer are in range by construction, but a `precomputed_partition_dataset` supplies them as user data and nothing range-checks it before the slice, so an id beyond the centroid count panicked.

Fixes #9003.

## What this changes

Return `invalid_input` naming the id and the centroid count instead of slicing.

The shuffler already does this for its own per-partition buffers (`v3/shuffler.rs:600-606`), but the transform chain runs before the shuffle, so for IVF_PQ the residual slice is what the id reaches first.

## Test plan

`test_compute_residual_rejects_out_of_range_partition` passes id 5 against two centroids and asserts the variant and both numbers in the message. Without the check it panics with `range start index 10 out of range for slice of length 4`.

`test_create_ivf_pq_rejects_out_of_range_precomputed_partition` builds a real IVF_PQ index from a partitions dataset that assigns one row to partition 7 out of 2, and asserts the error rather than a panic.

- `cargo test -p lance-index --lib` 1231 passed, 3 ignored
- `cargo test -p lance --lib index::vector::ivf::tests::` passed
- `cargo clippy --all --tests --benches -- -D warnings` clean
- `cargo fmt --all --check` clean

## Not in this change

`IvfShuffler`, the legacy shuffler behind `LANCE_LEGACY_SHUFFLER=1`, indexes its partition buffers without a range check (`v3/shuffler.rs:261`) and would still panic on the same input. The default `TwoFileShuffler` path is the one that checks.
