### PR TITLE
fix(index): report corrupt IVF metadata instead of aborting

### DIFF
--- a/rust/lance-index/src/vector/ivf/storage.rs
+++ b/rust/lance-index/src/vector/ivf/storage.rs
@@ -205,6 +205,13 @@ impl TryFrom<PbIvf> for IvfModel {
         } else if !proto.centroids.is_empty() {
             // For backward-compatibility
             debug!("Ivf: loading IVF centroids from index format v1");
+            if proto.lengths.is_empty() {
+                return Err(Error::corrupt_file_named(
+                    "ivf metadata",
+                    "v1 IVF centroids are present but no partition lengths are, \
+                     so the centroid dimension cannot be derived",
+                ));
+            }
             let f32_centroids = Float32Array::from(proto.centroids.clone());
             let dimension = f32_centroids.len() / proto.lengths.len();
             Some(FixedSizeListArray::try_new_from_values(
@@ -232,7 +239,16 @@ impl TryFrom<PbIvf> for IvfModel {
                 .collect_vec(),
             _ => proto.offsets.iter().map(|x| *x as usize).collect(),
         };
-        assert_eq!(offsets.len(), proto.lengths.len());
+        if offsets.len() != proto.lengths.len() {
+            return Err(Error::corrupt_file_named(
+                "ivf metadata",
+                format!(
+                    "{} partition offsets do not match {} partition lengths",
+                    offsets.len(),
+                    proto.lengths.len()
+                ),
+            ));
+        }
         Ok(Self {
             centroids,
             offsets,
@@ -272,6 +288,65 @@ mod tests {
 
         assert_eq!(ivf.row_range(0), 0..20);
         assert_eq!(ivf.row_range(1), 20..70);
+    }
+
+    /// A corrupt or foreign index file can carry mismatched offsets and
+    /// lengths. `assert_eq!` survives release builds, so the parse boundary
+    /// aborted the process instead of reporting the file.
+    #[test]
+    fn test_ivf_model_rejects_mismatched_proto_lengths() {
+        let proto = pb::Ivf {
+            lengths: vec![1, 2, 3],
+            offsets: vec![0, 3],
+            ..Default::default()
+        };
+        let error = IvfModel::try_from(proto).unwrap_err();
+        assert!(
+            matches!(error, Error::CorruptFile { .. }),
+            "expected CorruptFile, got {error:?}"
+        );
+        let message = error.to_string();
+        assert!(
+            message.contains("2 partition offsets") && message.contains("3 partition lengths"),
+            "the error must give both counts: {message}"
+        );
+    }
+
+    /// The v1 branch derives the centroid dimension by dividing by the number
+    /// of partition lengths, so a damaged file with centroids and no lengths
+    /// used to divide by zero. Integer division by zero is not compiled out,
+    /// so this had to be a check rather than an assert.
+    #[test]
+    fn test_ivf_model_rejects_v1_centroids_without_lengths() {
+        let proto = pb::Ivf {
+            centroids: vec![1.0, 2.0, 3.0, 4.0],
+            lengths: vec![],
+            offsets: vec![],
+            ..Default::default()
+        };
+        let error = IvfModel::try_from(proto).unwrap_err();
+        assert!(
+            matches!(error, Error::CorruptFile { .. }),
+            "expected CorruptFile, got {error:?}"
+        );
+        assert!(
+            error.to_string().contains("cannot be derived"),
+            "the error must say why the dimension is unknown: {error}"
+        );
+    }
+
+    /// An empty offsets vector is the normal v3 shape: the offsets are derived
+    /// by scanning the lengths, so the mismatch check must not fire there.
+    #[test]
+    fn test_ivf_model_derives_offsets_from_lengths() {
+        let proto = pb::Ivf {
+            lengths: vec![1, 2, 3],
+            offsets: vec![],
+            ..Default::default()
+        };
+        let ivf = IvfModel::try_from(proto).unwrap();
+        assert_eq!(ivf.offsets, vec![0, 1, 3]);
+        assert_eq!(ivf.lengths, vec![1, 2, 3]);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Problem

`TryFrom<PbIvf> for IvfModel` had two ways to abort on a damaged index file. It asserted that the offsets and lengths vectors matched in length, and `assert_eq!` is compiled into release builds. The v1 centroid branch derived the centroid dimension by dividing the value count by the number of partition lengths, which divides by zero when a file carries centroids and no lengths; integer division by zero cannot be compiled out at all.

Fixes #9005.

## What this changes

Return `corrupt_file` from both, with the counts. `rust/AGENTS.md` maps format and integrity failures to that variant and reserves `assert!` for conditions that prevent data corruption.

These are read-side guards. Nothing in Lance writes either shape: `add_partition` grows both vectors together and the serializer copies both, so the trigger is damaged or foreign input.

## Test plan

`test_ivf_model_rejects_mismatched_proto_lengths` parses a proto with 2 offsets and 3 lengths; with the `assert_eq!` restored it fails on the assertion instead. `test_ivf_model_rejects_v1_centroids_without_lengths` parses v1 centroids with no lengths; without the guard it fails with `attempt to divide by zero`. `test_ivf_model_derives_offsets_from_lengths` pins the normal shape the mismatch check has to leave alone, where offsets are empty and derived by scanning the lengths.

- `cargo test -p lance-index --lib` 1233 passed, 3 ignored
- `cargo clippy --all --tests --benches -- -D warnings` clean
- `cargo fmt --all --check` clean

## Not in this change

`IvfModel::find_partitions` still does `self.centroids.clone().unwrap()` (storage.rs:113), and `row_range` and `centroid` index by partition without a bound. Those are post-parse, in different functions, and worth a separate look.
