### PR TITLE
feat: integrate stable partitions with FRI V1

### DIFF
--- a/docs/design/fragment-reuse-v2.md
+++ b/docs/design/fragment-reuse-v2.md
@@ -1,0 +1,339 @@
+# Mixed FRI V1/V2: stable-partition integration draft
+
+Status: informal design for discussion. This is not a format specification or
+an activation proposal. We will start the format-change process after the design
+is agreed. No protobuf field numbers, feature bits, or new file contracts are
+allocated by this document.
+
+This is the proposed replacement direction for [#8978](https://github.com/lance-format/lance/pull/8978),
+stacked on [#8972](https://github.com/lance-format/lance/pull/8972).
+PR #8972 already supplies the stable-partition row-map writer, reader, counts,
+and translation algorithms. Keep that foundation. This proposal addresses the
+dataset lifecycle around it; it does not repeat the codec work.
+
+## 1. What we want
+
+People can continue compacting into the existing FRI V1 format. Stable partition
+writes V2 metadata referencing the row maps from #8972. Our new reader and writer
+handle the two paths together. No up-front rewrite of all existing indices or
+mandatory conversion of V1 history is required.
+
+    Existing compaction -> V1 FRI details --+
+                                          +-> shared rewrite handling
+    Stable partition -> V2 transitions ---+
+
+Eventually V2 should also represent order-preserving compaction. That is a later
+extension, not a prerequisite for this integration. The two physical formats
+must already behave as one logical history before mixed operations are enabled.
+
+The initial implementation can use conservative coverage and conflict rules.
+The format should not depend on pretending an old client understands new
+maintenance semantics merely because it can parse the manifest.
+
+## 2. Stable partition, precisely
+
+Inputs are ordered source fragments from one snapshot. Within a source, visit
+rows in ascending physical offset. Each surviving row is routed to one of an
+ordered list of destination fragments. Every destination preserves the relative
+source order of its rows; values do not change.
+
+This is not a persistent partition-key declaration. Later appends may add
+ordinary fragments without routing through the same destinations. It is also
+not arbitrary sorting: sorting within a destination needs a permutation encoding.
+
+    Source A: [a, b, deleted, c]
+    Source B: [d, e]
+    Labels:   [0, 1, NULL, 0, 1, 0]
+    Dest C:   [a, c, e]
+    Dest D:   [b, d]
+
+The label is a destination-list position, not a fragment ID. For physical source
+position g, its new offset is the number of earlier occurrences of label[g].
+A NULL label means that position was deleted in the rewrite's input snapshot.
+
+Destinations have fresh, reserved fragment IDs and no deletion vectors at
+creation. Parallel writers must restore source order within each destination.
+Counts validate conservation, but cannot prove row identity or order: the writer
+must emit data and labels from the same routing decisions.
+
+## 3. Proposed V2 metadata
+
+Use immutable mapping payloads and a small catalog of transition references.
+The preferred home for that catalog is a dedicated manifest field/section.
+It describes table structure, not a searchable index. Its exact placement is
+still a review decision; a system-index envelope is an alternative only if it
+has explicit preservation and file-reachability rules.
+
+    Manifest
+    +-- existing V1 FRI entry, unchanged wire format
+    +-- V2 transition catalog
+        +-- catalog format version
+        +-- transition references[]
+            +-- immutable transition ID
+            +-- actual commit version
+            +-- descriptor file reference
+
+    _row_maps/<transition-id>/       # proposed placement, not finalized
+    +-- transition.binpb
+    +-- row_map.lance                # #8972 format
+
+The descriptor's proposed fields are:
+
+| Field | Meaning |
+| --- | --- |
+| format_version | Descriptor version, independent of the Lance data-file version |
+| transition_id | Immutable identity; also used for idempotent publication |
+| read_version | Snapshot used to produce the outputs |
+| sources | Ordered fragment IDs and physical row counts |
+| destinations | Ordered fragment IDs and physical row counts |
+| mapping | Versioned discriminator; initially only stable partition |
+| row_map | Explicit storage base, relative path, and byte length |
+
+The exact source snapshot, including deletion and overlay metadata, is also
+carried by the rewrite transaction for OCC validation. Do not introduce a second
+incomplete source identity based only on physical/deleted row counts.
+
+The catalog supplies actual commit version because workers write immutable files
+before the successful commit version is known. Do not mutate a descriptor after
+publication to stamp a version. Unknown mapping variants fail closed.
+
+Creating a new transition writes its descriptor and row map once. Publishing a
+new manifest copies the small references, not the historical mapping payloads.
+Old snapshots retain their own reference lists. This still costs O(retained
+transitions) catalog bytes per manifest; pagination/segmentation can wait for
+measurements. It avoids V1's full-history payload rewrite on the V2 path.
+
+PR #8972's row_map.lance remains one nullable UInt16 label per physical source
+row, with cumulative per-destination counts in its global buffer. Default
+logical blocks contain 65,536 rows. NULL positions preserve source deletions.
+Point lookup reads one logical block; batches coalesce block reads; sweeps stream
+blocks. Logical block boundaries need not be physical Lance page boundaries.
+
+## 4. One dependency graph over both formats
+
+Adapt each V1 group and V2 transition into an in-memory rewrite node with ordered
+sources, destinations, and its mapping implementation. This adapter does not
+rewrite V1's persisted protobuf or introduce labels into V1.
+
+    A,B --V1--> C --V2--> D,E --V1--> F
+
+A candidate address in A must follow all three edges. Running all V1 mappings
+and then all V2 mappings is incorrect.
+
+Use fragment lineage to establish dependencies. If a node produces a fragment
+that another node consumes, the producer precedes the consumer. Validate that a
+source has at most one consuming rewrite in a snapshot's retained history,
+destinations are uniquely produced, and the graph has no cycles. Independent
+nodes may execute in either order. Fragment IDs are never reused.
+
+This avoids relying on V1 dataset_version as a successful commit timestamp:
+that field records the builder's snapshot. Preserve it for existing purposes;
+do not reinterpret it. V2 records actual commit version for diagnostics and
+maintenance, but graph dependencies establish address translation order.
+
+For point/batch translation, dispatch by the current address's fragment ID,
+translate through that consuming node, and repeat until the fragment is live
+or the mapping reports deletion. Full-fragment removals are terminal deletions;
+current fragment existence and deletion vectors still determine visibility.
+Missing historical edges cannot silently be treated as deletion: mixed writers
+and retention must guarantee chain completeness. Where completeness cannot be
+established, disable the affected index and scan, or return a corruption error.
+
+## 5. Coverage is separate from stored addresses
+
+An index bitmap may already have been advanced by V1 coverage maintenance even
+though its payload still stores old row addresses. Do not relabel such a bitmap
+as the payload's original address space. Likewise, deriving current coverage
+does not mean the index bytes have been remapped.
+
+The proposed integration maintains an explicit coverage frontier for each index
+segment: fragments it can completely answer at a known snapshot. On first V2
+use, obtain that frontier through the existing V1 coverage path at the pinned
+snapshot; this does not require remapping index bytes. A persisted coverage
+frontier/version may be added to IndexMetadata, or updated atomically as ordinary
+coverage metadata. That schema choice needs agreement before implementation.
+
+For each later rewrite in dependency order, let S be its sources and D its
+destinations. Remove S from the frontier. Add D only if the index covered all
+of S before removal. Otherwise add none of D. Intersect with current live
+fragments at the end. This conservative rule works for either encoding.
+
+Example: an index covers A but not B; a partition mixes both into C and D.
+Neither C nor D is claimed as fully indexed. Queries scan them. We can later
+add source/destination incidence metadata or finer-grained coverage, but the
+first integration need not solve that optimization. Planning rewrite groups
+with equal coverage signatures preserves more index reuse.
+
+Retain lineage needed by the payload independently of effective coverage. A
+bitmap reaching current fragments is not evidence that an old V1 record can be
+trimmed. Only rebuilding/remapping the bytes, withdrawing the segment, or a
+sound dependency analysis can establish that.
+
+Index results must be translated and restricted to the selected segment's
+effective coverage. A partly usable index must not leak candidates into the
+scan portion and produce duplicates. Overlapping segments/generations still
+require the existing query planner's selection/merge rules.
+
+For index kinds whose decoding relies on physical ordering or fragment-level
+summaries, require explicit integration or rebuild. A generic address callback
+is not proof that every index format supports reordered output. Physical
+addresses and stable logical row IDs must stay distinct; logical IDs use their
+existing lookup path.
+
+## 6. Write and commit
+
+1. Pin snapshot V, choose ordered sources, reserve destination IDs, and retain
+   the complete source metadata used by the scan.
+2. Stream live rows to destination writers and labels to #8972's RowMapWriter.
+   It interleaves deleted source positions from the source deletion vectors.
+3. Finish files. Validate per-destination totals, source row count, label bounds,
+   and source deletion positions. Write the immutable descriptor.
+4. Submit a serializable Rewrite delta containing the descriptor reference and
+   exact source/destination lists. Do not submit a replacement accumulated catalog
+   built from an earlier snapshot. Do not drop the transition on serialization.
+5. Against the latest manifest, validate unchanged source snapshots, matching
+   descriptor/group order and reserved IDs, and completed files. Merge the delta
+   into the latest catalog and assign actual commit version.
+6. Atomically publish new fragments, catalog, and coverage changes in one manifest.
+
+Disjoint rewrites can rebase and merge deltas. Overlapping sources conflict.
+Source deletes, updates, overlays, and other changes affecting the prepared
+outputs require retry from a new snapshot. Reusing the same read version while
+replacing the source metadata with current metadata is not a valid retry.
+
+Failed publication leaves immutable orphan files for normal age-protected
+cleanup. Retrying an already committed transaction must not append a duplicate
+transition. Existing transaction idempotency plus transition identity should
+enforce that contract.
+
+Ordinary compaction keeps its V1 wire format. Its orchestration must change on
+mixed datasets: it must record the next V1 edge when any old index or V2 lineage
+can depend on it, including destinations that appear unindexed in today's
+bitmap. A simple initial policy is to record every address-changing compaction
+while retained V2 transitions exist. Eager remapping cannot erase the needs of
+other segments or in-flight index builds.
+
+Concurrent V1 catalog replacement/trim must follow existing conflict handling
+plus the mixed-retention checks. A V2 delta being disjoint from another rewrite
+does not authorize it to overwrite a stale V1 or V2 catalog snapshot.
+
+## 7. Reads, appends, and deletes
+
+### Reads
+
+A full scan reads current fragments and deletion vectors without historical
+label I/O. An indexed read derives coverage, decodes candidate addresses, follows
+both mapping kinds, filters to coverage, and applies current row visibility.
+Uncovered fragments use the normal scan path.
+
+At a stable-partition hop, group candidate addresses by source label block and
+asynchronously load each required block. Offset equals the count for the label
+before the block plus its rank before the row within the block. For bulk work,
+seed per-label counters at a block boundary and sweep. Regroup after each hop:
+a sequential first hop may scatter the second hop's accesses.
+
+The current RowIdRemapper is synchronous. Introduce asynchronous batched
+preparation/translation at decode boundaries and keep arithmetic over prepared
+blocks synchronous. Do not hide object-store I/O inside the synchronous trait
+or load all labels merely to satisfy it.
+
+Cache immutable labels by storage identity, transition ID and block. Cache
+translated index units/coverage by segment generation and target manifest
+identity, incorporating both histories. The V1 FRI UUID alone is insufficient.
+
+### Appending table rows
+
+Append fresh fragments normally. No existing addresses move, so no rewrite
+transition is needed. Existing indices do not automatically cover appended
+fragments. An index built on V records that read snapshot even if it publishes
+later; publication must validate that its required history remains available.
+
+Appending a V2 transition is different: publish another immutable descriptor
+reference. Do not append bytes to an old row-map file.
+
+### Deleting rows
+
+Evaluate against a pinned snapshot, translating indexed candidates into current
+addresses first. Write deletion vectors for current fragments. Historical labels
+stay immutable: they describe relocation then, not visibility now.
+
+If A:3 mapped to C:1 and C:1 is deleted, an old index candidate A:3 translates to
+C:1 and is suppressed by C's current deletion vector. If later V1 compaction
+moves C to F, its survivor bitmap drops C:1 and the composed mapping reports
+deletion. Entirely deleted fragments may disappear without a replacement map.
+
+If delete commits first, a prepared rewrite fails source validation. If rewrite
+commits first, a stale delete against its retired sources retries/re-evaluates.
+Disjoint operations can rebase. Folding concurrent deletion vectors through a
+prepared row map can be a later optimization; it is not implicit in this format.
+
+Value-changing updates/overlays are not pure relocation. Index invalidation must
+use current derived coverage. Initially withdraw affected segments and rebuild
+them, preserving logical index definitions, rather than treating relocation as
+proof that indexed values remain valid.
+
+## 8. Retention and cleanup
+
+Keep V1 and V2 logically separate on disk but coordinate retention. In particular,
+the existing V1-only caught-up calculation must not trim an edge that feeds a
+retained V2 edge or an old payload reachable through it.
+
+Safe first policy: while V2 history is retained, preserve all retained V1/V2
+mapping records. Make V1-only trim explicitly defer on such a dataset. This
+conservatively increases metadata retention; it does not stop compaction,
+append, delete, or query operations. A later coordinated drain rebuilds/remaps
+all dependent segments and retires obsolete history atomically.
+
+For concurrent index builders, record a history-retention floor when draining.
+A stale builder whose required history predates the floor must retry/rebuild
+before publication. Validate against the latest manifest on every commit retry.
+An active builder is not automatically protected by an assumed lease.
+
+Physical cleanup roots are all retained/tagged manifests. For each, follow its
+V1 external details and V2 catalog -> descriptor -> row-map references, including
+storage bases. A live descriptor must protect its row map even when they reside
+outside an index UUID directory. Unreferenced files become eligible only after
+the ordinary in-progress protection period.
+
+Cloning/restoring must preserve the reference graph and ownership of referenced
+bases. Namespace and out-of-band cleanup must check the same capabilities.
+Unknown formats must prevent destructive cleanup, not merely dataset queries.
+
+## 9. Compatibility and rollout
+
+Allocate fresh reader and writer capability flags when the final format is
+approved. Old binaries must reject mixed datasets initially. Keeping V1's wire
+format unchanged does not make old maintenance code safe on V2 dependencies.
+Flags must survive recomputation, retry, clone, and restore, and gate destructive
+maintenance. Do not choose a numeric bit already reserved by another feature.
+
+V1-only datasets keep existing behavior. Activation of mixed handling validates
+V1 metadata and initializes coverage frontiers; it does not force eager remap
+of existing index bytes. Malformed/ambiguous legacy coverage must fall back
+conservatively rather than invent a fully indexed frontier.
+
+Later, add order-preserving writes directly to V2's mapping discriminator and
+change the compaction writer when ready. Keep the V1 reader adapter for existing
+snapshots. No V2 order-preserving codec is defined or required by this draft.
+
+## 10. Decisions to settle together
+
+- Dedicated manifest catalog versus a system-index envelope with explicit
+  structural semantics; prefer the former, but assess integration cost.
+- Exact descriptor/FileRef schema, base-path rules, and validation limits.
+- Coverage frontier persistence: dedicated metadata versus atomically maintained
+  existing coverage, without conflating it with payload address space.
+- Initial supported index kinds and where each performs asynchronous translation.
+- Whether conservative V1/V2 history retention is acceptable for first activation,
+  or coordinated draining must be implemented at the same time.
+- Which clone/namespace paths must be supported before activation.
+
+Before enabling mixed writes, require real-data tests for V1 -> V2 -> V1 and
+V2 -> V1 -> V2, partial coverage, source deletions, later deletes, append, both
+delete/rewrite commit orders, disjoint rewrite rebase, late index publication,
+cache refresh, and cleanup with retained/tagged snapshots. Validate actual row
+identities and output order, not only counts or a query falling back to scans.
+
+This draft can evolve while implementation is underway. Formal schema allocation,
+format review/voting, and release compatibility commitments follow only after
+we are comfortable with the contract.

--- a/docs/design/fragment-reuse-v2.md
+++ b/docs/design/fragment-reuse-v2.md
@@ -1,339 +1,182 @@
-# Mixed FRI V1/V2: stable-partition integration draft
+# Mixed FRI V1/V2 implementation draft
 
-Status: informal design for discussion. This is not a format specification or
-an activation proposal. We will start the format-change process after the design
-is agreed. No protobuf field numbers, feature bits, or new file contracts are
-allocated by this document.
+This is experimental implementation work stacked on
+[#8972](https://github.com/lance-format/lance/pull/8972), replacing
+[#8978](https://github.com/lance-format/lance/pull/8978). The format changes here
+are provisional. Formal format review comes after the implementation and its
+semantics are agreed.
 
-This is the proposed replacement direction for [#8978](https://github.com/lance-format/lance/pull/8978),
-stacked on [#8972](https://github.com/lance-format/lance/pull/8972).
-PR #8972 already supplies the stable-partition row-map writer, reader, counts,
-and translation algorithms. Keep that foundation. This proposal addresses the
-dataset lifecycle around it; it does not repeat the codec work.
+## Stable partition
 
-## 1. What we want
+A stable partition is a value-preserving rewrite. It visits ordered source
+fragments in physical row order, skips deleted rows, and routes every live row
+to exactly one destination. Within each destination, relative source order is
+preserved. It does not declare a permanent partition key: subsequent appends
+can create ordinary fragments. Sorting within a destination is not representable
+by this encoding.
 
-People can continue compacting into the existing FRI V1 format. Stable partition
-writes V2 metadata referencing the row maps from #8972. Our new reader and writer
-handle the two paths together. No up-front rewrite of all existing indices or
-mandatory conversion of V1 history is required.
+    Sources:      A [a, b, deleted, c], B [d, e]
+    Labels:         0  1    NULL    0     1  0
+    Destinations: C [a, c, e], D [b, d]
 
-    Existing compaction -> V1 FRI details --+
-                                          +-> shared rewrite handling
-    Stable partition -> V2 transitions ---+
+The row-map implementation is reused directly from #8972:
 
-Eventually V2 should also represent order-preserving compaction. That is a later
-extension, not a prerequisite for this integration. The two physical formats
-must already behave as one logical history before mixed operations are enabled.
+- `RowMapWriter` interleaves deleted positions from source deletion vectors into
+  the stream of live-row destination labels.
+- `RowMapReader` opens the counts matrix without reading labels. A point or
+  batch lookup reads only the relevant logical blocks. Mixed translation sorts
+  requested offsets and limits each read to sixteen blocks to bound label memory.
+- A non-NULL label selects an entry in the ordered destination list. Its rank
+  among earlier equal labels is the destination offset.
 
-The initial implementation can use conservative coverage and conflict rules.
-The format should not depend on pretending an old client understands new
-maintenance semantics merely because it can parse the manifest.
+Counts check conservation; they cannot prove value identity or output order.
+The rewrite worker must write destination data and labels from the same routing
+decisions and preserve order within each destination.
 
-## 2. Stable partition, precisely
-
-Inputs are ordered source fragments from one snapshot. Within a source, visit
-rows in ascending physical offset. Each surviving row is routed to one of an
-ordered list of destination fragments. Every destination preserves the relative
-source order of its rows; values do not change.
-
-This is not a persistent partition-key declaration. Later appends may add
-ordinary fragments without routing through the same destinations. It is also
-not arbitrary sorting: sorting within a destination needs a permutation encoding.
-
-    Source A: [a, b, deleted, c]
-    Source B: [d, e]
-    Labels:   [0, 1, NULL, 0, 1, 0]
-    Dest C:   [a, c, e]
-    Dest D:   [b, d]
-
-The label is a destination-list position, not a fragment ID. For physical source
-position g, its new offset is the number of earlier occurrences of label[g].
-A NULL label means that position was deleted in the rewrite's input snapshot.
-
-Destinations have fresh, reserved fragment IDs and no deletion vectors at
-creation. Parallel writers must restore source order within each destination.
-Counts validate conservation, but cannot prove row identity or order: the writer
-must emit data and labels from the same routing decisions.
-
-## 3. Proposed V2 metadata
-
-Use immutable mapping payloads and a small catalog of transition references.
-The preferred home for that catalog is a dedicated manifest field/section.
-It describes table structure, not a searchable index. Its exact placement is
-still a review decision; a system-index envelope is an alternative only if it
-has explicit preservation and file-reachability rules.
+## Persisted state
 
     Manifest
-    +-- existing V1 FRI entry, unchanged wire format
-    +-- V2 transition catalog
-        +-- catalog format version
-        +-- transition references[]
-            +-- immutable transition ID
-            +-- actual commit version
-            +-- descriptor file reference
+    +-- index section
+    |   +-- __lance_frag_reuse (existing V1 representation)
+    +-- stable_partition_transitions[]
+        +-- source_dataset_version
+        +-- committed_version
+        +-- ordered source fragment digests
+        +-- ordered destination fragment digests
+        +-- row_map_id, row_map_size_bytes, optional base_id
 
-    _row_maps/<transition-id>/       # proposed placement, not finalized
-    +-- transition.binpb
-    +-- row_map.lance                # #8972 format
+    _row_maps/<row_map_id>/
+    +-- row_map.lance                 (#8972 labels + counts)
 
-The descriptor's proposed fields are:
+Each transition owns one immutable row-map file. `row_map_id` is an artifact
+identity, not the UUID of a searchable index or of the mutable V1 catalog.
+Updating V1 history or rebuilding a column index does not relocate or rewrite
+this file. The dedicated namespace also protects maps from older cleanup
+implementations that scan `_indices` without checking historical feature flags.
+The new cleaner explicitly marks and sweeps row-map directories from retained
+manifest references, with the usual protection for recent uncommitted files.
 
-| Field | Meaning |
-| --- | --- |
-| format_version | Descriptor version, independent of the Lance data-file version |
-| transition_id | Immutable identity; also used for idempotent publication |
-| read_version | Snapshot used to produce the outputs |
-| sources | Ordered fragment IDs and physical row counts |
-| destinations | Ordered fragment IDs and physical row counts |
-| mapping | Versioned discriminator; initially only stable partition |
-| row_map | Explicit storage base, relative path, and byte length |
+There is no external copy of the complete transition catalog and no V2
+`details.binpb`. Appends copy the small manifest descriptors, not mapping labels.
+V1 continues to use its existing inline/external details representation and
+its existing rewrite-on-update writer.
 
-The exact source snapshot, including deletion and overlay metadata, is also
-carried by the rewrite transaction for OCC validation. Do not introduce a second
-incomplete source identity based only on physical/deleted row counts.
+The experimental reader and writer feature bit is `1 << 9`. The reserved
+mixed-data-file-version bit (`1 << 8`) remains unsupported. Every manifest with
+V2 references requires bit 9 in both the reader and writer words to prevent
+older readers or writers from ignoring the mapping lifecycle. The new reader accepts ordinary V1-only
+datasets without this bit.
 
-The catalog supplies actual commit version because workers write immutable files
-before the successful commit version is known. Do not mutate a descriptor after
-publication to stamp a version. Unknown mapping variants fail closed.
+## Writing and committing
 
-Creating a new transition writes its descriptor and row map once. Publishing a
-new manifest copies the small references, not the historical mapping payloads.
-Old snapshots retain their own reference lists. This still costs O(retained
-transitions) catalog bytes per manifest; pagination/segmentation can wait for
-measurements. It avoids V1's full-history payload rewrite on the V2 path.
+`commit_stable_partition` in `lance::index::frag_reuse_v2` commits a prepared
+rewrite through the existing transaction machinery:
 
-PR #8972's row_map.lance remains one nullable UInt16 label per physical source
-row, with cumulative per-destination counts in its global buffer. Default
-logical blocks contain 65,536 rows. NULL positions preserve source deletions.
-Point lookup reads one logical block; batches coalesce block reads; sweeps stream
-blocks. Logical block boundaries need not be physical Lance page boundaries.
+1. Read source fragments from one snapshot. Produce destination data and a row
+   map using #8972's writer with Lance data-file version 2.1, which encodes
+   destination labels compactly. Reserve fresh destination fragment IDs.
+2. Open the completed row map and validate its source length, destination
+   counts, and declared file size.
+3. Commit `Operation::Rewrite` with its stable-partition descriptor. The commit
+   validates the exact source metadata, destination reservations, row counts,
+   ordering of fragment lists, and absence of conflicting index rewrites.
+4. Publish destination fragments and the descriptor in the same manifest. Stamp
+   the actual installing version at commit; retain the worker's source version
+   separately. A failed commit publishes neither.
 
-## 4. One dependency graph over both formats
+This API accepts prepared fragments; it is not a clustering scheduler or a new
+Python/Java routing API. Low-level transaction callers have the same obligation
+to finish and validate their referenced files before committing.
 
-Adapt each V1 group and V2 transition into an in-memory rewrite node with ordered
-sources, destinations, and its mapping implementation. This adapter does not
-rewrite V1's persisted protobuf or introduce labels into V1.
+Disjoint stable partitions can rebase: each appends its descriptor to the
+latest manifest. A concurrent delete, update, or rewrite touching a source
+requires rebuilding from a new snapshot. This draft deliberately does not fold
+new source deletions into an already-written row map.
 
-    A,B --V1--> C --V2--> D,E --V1--> F
+## Reading mixed history
 
-A candidate address in A must follow all three edges. Running all V1 mappings
-and then all V2 mappings is incorrect.
+`MixedFragReuseIndex` composes existing V1 compaction groups and V2 descriptors.
+An edge connects a rewrite producing a fragment to the rewrite consuming it.
+Topological order follows physical fragment lineage, not V1's recorded builder
+version, which is not guaranteed to equal its installing version. Duplicate
+producers, duplicate consumers, and cycles are rejected.
 
-Use fragment lineage to establish dependencies. If a node produces a fragment
-that another node consumes, the producer precedes the consumer. Validate that a
-source has at most one consuming rewrite in a snapshot's retained history,
-destinations are uniquely produced, and the graph has no cycles. Independent
-nodes may execute in either order. Fragment IDs are never reused.
+For each requested address:
 
-This avoids relying on V1 dataset_version as a successful commit timestamp:
-that field records the builder's snapshot. Preserve it for existing purposes;
-do not reinterpret it. V2 records actual commit version for diagnostics and
-maintenance, but graph dependencies establish address translation order.
+- A V1 node applies the existing compact bitmap-rank remapper.
+- A V2 node resolves the concatenated source offset with #8972's reader and
+  returns the destination fragment and offset, or deletion.
+- Addresses outside a node's sources pass through unchanged.
 
-For point/batch translation, dispatch by the current address's fragment ID,
-translate through that consuming node, and repeat until the fragment is live
-or the mapping reports deletion. Full-fragment removals are terminal deletions;
-current fragment existence and deletion vectors still determine visibility.
-Missing historical edges cannot silently be treated as deletion: mixed writers
-and retention must guarantee chain completeness. Where completeness cannot be
-established, disable the affected index and scan, or return a corruption error.
+The existing Python `Dataset.remap_row_addrs` method uses the same Rust mixed
+translation and preserves NULL input addresses.
 
-## 5. Coverage is separate from stored addresses
+Current snapshot deletion vectors still apply after translation. The mapping
+records deletions at rewrite time, not future tombstones.
 
-An index bitmap may already have been advanced by V1 coverage maintenance even
-though its payload still stores old row addresses. Do not relabel such a bitmap
-as the payload's original address space. Likewise, deriving current coverage
-does not mean the index bytes have been remapped.
+B-tree page reads translate physical addresses before predicate evaluation.
+Translation also applies to pages streamed for index maintenance. Cache identity
+includes the mixed history and target snapshot so cached pages cannot return
+addresses from an earlier layout. Row-map file metadata uses the dataset's
+shared metadata cache.
 
-The proposed integration maintains an explicit coverage frontier for each index
-segment: fragments it can completely answer at a known snapshot. On first V2
-use, obtain that frontier through the existing V1 coverage path at the pinned
-snapshot; this does not require remapping index bytes. A persisted coverage
-frontier/version may be added to IndexMetadata, or updated atomically as ordinary
-coverage metadata. That schema choice needs agreement before implementation.
+Stored source bitmaps remain provenance across appends and other commits.
+Query coverage is derived separately: the union of a logical index's segment
+bitmaps must cover all sources before its destinations count as covered. Every
+contributing segment is then probed. Derived probe bitmaps can overlap; they
+are never persisted as source ownership. A new segment naming a destination
+directly takes priority, and old segments discard translated entries for that
+destination before evaluating predicates.
 
-For each later rewrite in dependency order, let S be its sources and D its
-destinations. Remove S from the frontier. Add D only if the index covered all
-of S before removal. Otherwise add none of D. Intersect with current live
-fragments at the end. This conservative rule works for either encoding.
+A destination mixing indexed and unindexed rows must be scanned. Index types without asynchronous V2 translation are excluded
+from query selection when their payloads require it; their metadata remains
+in the manifest. They can be rebuilt on current fragments.
 
-Example: an index covers A but not B; a partition mixes both into C and D.
-Neither C nor D is claimed as fully indexed. Queries scan them. We can later
-add source/destination incidence metadata or finer-grained coverage, but the
-first integration need not solve that optimization. Planning rewrite groups
-with equal coverage signatures preserves more index reuse.
+## Append, delete, and compaction
 
-Retain lineage needed by the payload independently of effective coverage. A
-bitmap reaching current fragments is not evidence that an old V1 record can be
-trimmed. Only rebuilding/remapping the bytes, withdrawing the segment, or a
-sound dependency analysis can establish that.
+Append creates ordinary fragments and preserves both histories. Existing indices
+do not claim the new rows. A later stable partition can include these fragments,
+subject to the same conservative coverage rule. The prepared-commit API requires
+full index coverage unless the caller explicitly selects
+`StablePartitionCoverage::AllowUnindexed`. An unresolved destination cannot be
+repartitioned again while an index still depends on its translated entries;
+rebuild direct coverage first. This restriction also follows intervening V1
+compactions and is checked at the commit boundary.
 
-Index results must be translated and restricted to the selected segment's
-effective coverage. A partly usable index must not leak candidates into the
-scan portion and produce duplicates. Overlapping segments/generations still
-require the existing query planner's selection/merge rules.
+Delete updates current fragment tombstones without rewriting either mapping
+format. A later rewrite records deleted physical positions as NULL labels or
+uses the existing V1 survivor bitmap.
 
-For index kinds whose decoding relies on physical ordering or fragment-level
-summaries, require explicit integration or rebuild. A generic address callback
-is not proof that every index format supports reordered output. Physical
-addresses and stable logical row IDs must stay distinct; logical IDs use their
-existing lookup path.
+Compaction continues writing V1 groups. In a mixed dataset it records the V1
+mapping even when current index coverage is empty, since retained V2 mappings
+may still point at the compacted sources. Both eager and deferred B-tree index
+maintenance use the composed mapping. No V1-to-V2 migration is required.
 
-## 6. Write and commit
+V2 may eventually acquire an order-preserving representation. This PR does not
+need that encoding to coexist correctly with V1 compaction.
 
-1. Pin snapshot V, choose ordered sources, reserve destination IDs, and retain
-   the complete source metadata used by the scan.
-2. Stream live rows to destination writers and labels to #8972's RowMapWriter.
-   It interleaves deleted source positions from the source deletion vectors.
-3. Finish files. Validate per-destination totals, source row count, label bounds,
-   and source deletion positions. Write the immutable descriptor.
-4. Submit a serializable Rewrite delta containing the descriptor reference and
-   exact source/destination lists. Do not submit a replacement accumulated catalog
-   built from an earlier snapshot. Do not drop the transition on serialization.
-5. Against the latest manifest, validate unchanged source snapshots, matching
-   descriptor/group order and reserved IDs, and completed files. Merge the delta
-   into the latest catalog and assign actual commit version.
-6. Atomically publish new fragments, catalog, and coverage changes in one manifest.
+## Retention and current limits
 
-Disjoint rewrites can rebase and merge deltas. Overlapping sources conflict.
-Source deletes, updates, overlays, and other changes affecting the prepared
-outputs require retry from a new snapshot. Reusing the same read version while
-replacing the source metadata with current metadata is not a valid retry.
+Cleanup marks row-map directories from retained manifests. V1 history cleanup
+is suspended while V2 references remain, because pruning V1 independently can
+break a mixed chain. Coordinated history draining and descriptor pruning are
+follow-up work; retaining extra history is deliberate.
 
-Failed publication leaves immutable orphan files for normal age-protected
-cleanup. Retrying an already committed transaction must not append a duplicate
-transition. Existing transaction idempotency plus transition identity should
-enforce that contract.
+This draft supports physical row addresses and one storage base. Stable logical
+row IDs, shallow/deep clone of mixed datasets, and cross-base row-map reads are
+rejected explicitly. The protobuf reserves optional base ownership so it can
+be implemented without confusing local cleanup with external ownership.
 
-Ordinary compaction keeps its V1 wire format. Its orchestration must change on
-mixed datasets: it must record the next V1 edge when any old index or V2 lineage
-can depend on it, including destinations that appear unindexed in today's
-bitmap. A simple initial policy is to record every address-changing compaction
-while retained V2 transitions exist. Eager remapping cannot erase the needs of
-other segments or in-flight index builds.
+Initial query integration supports B-tree indices. Other affected index types
+use scan fallback until they gain asynchronous translation. Arbitrary output
+permutations, automatic clustering, concurrent deletion folding, and complete
+history draining remain outside this implementation.
 
-Concurrent V1 catalog replacement/trim must follow existing conflict handling
-plus the mixed-retention checks. A V2 delta being disjoint from another rewrite
-does not authorize it to overwrite a stale V1 or V2 catalog snapshot.
+## Validation
 
-## 7. Reads, appends, and deletes
-
-### Reads
-
-A full scan reads current fragments and deletion vectors without historical
-label I/O. An indexed read derives coverage, decodes candidate addresses, follows
-both mapping kinds, filters to coverage, and applies current row visibility.
-Uncovered fragments use the normal scan path.
-
-At a stable-partition hop, group candidate addresses by source label block and
-asynchronously load each required block. Offset equals the count for the label
-before the block plus its rank before the row within the block. For bulk work,
-seed per-label counters at a block boundary and sweep. Regroup after each hop:
-a sequential first hop may scatter the second hop's accesses.
-
-The current RowIdRemapper is synchronous. Introduce asynchronous batched
-preparation/translation at decode boundaries and keep arithmetic over prepared
-blocks synchronous. Do not hide object-store I/O inside the synchronous trait
-or load all labels merely to satisfy it.
-
-Cache immutable labels by storage identity, transition ID and block. Cache
-translated index units/coverage by segment generation and target manifest
-identity, incorporating both histories. The V1 FRI UUID alone is insufficient.
-
-### Appending table rows
-
-Append fresh fragments normally. No existing addresses move, so no rewrite
-transition is needed. Existing indices do not automatically cover appended
-fragments. An index built on V records that read snapshot even if it publishes
-later; publication must validate that its required history remains available.
-
-Appending a V2 transition is different: publish another immutable descriptor
-reference. Do not append bytes to an old row-map file.
-
-### Deleting rows
-
-Evaluate against a pinned snapshot, translating indexed candidates into current
-addresses first. Write deletion vectors for current fragments. Historical labels
-stay immutable: they describe relocation then, not visibility now.
-
-If A:3 mapped to C:1 and C:1 is deleted, an old index candidate A:3 translates to
-C:1 and is suppressed by C's current deletion vector. If later V1 compaction
-moves C to F, its survivor bitmap drops C:1 and the composed mapping reports
-deletion. Entirely deleted fragments may disappear without a replacement map.
-
-If delete commits first, a prepared rewrite fails source validation. If rewrite
-commits first, a stale delete against its retired sources retries/re-evaluates.
-Disjoint operations can rebase. Folding concurrent deletion vectors through a
-prepared row map can be a later optimization; it is not implicit in this format.
-
-Value-changing updates/overlays are not pure relocation. Index invalidation must
-use current derived coverage. Initially withdraw affected segments and rebuild
-them, preserving logical index definitions, rather than treating relocation as
-proof that indexed values remain valid.
-
-## 8. Retention and cleanup
-
-Keep V1 and V2 logically separate on disk but coordinate retention. In particular,
-the existing V1-only caught-up calculation must not trim an edge that feeds a
-retained V2 edge or an old payload reachable through it.
-
-Safe first policy: while V2 history is retained, preserve all retained V1/V2
-mapping records. Make V1-only trim explicitly defer on such a dataset. This
-conservatively increases metadata retention; it does not stop compaction,
-append, delete, or query operations. A later coordinated drain rebuilds/remaps
-all dependent segments and retires obsolete history atomically.
-
-For concurrent index builders, record a history-retention floor when draining.
-A stale builder whose required history predates the floor must retry/rebuild
-before publication. Validate against the latest manifest on every commit retry.
-An active builder is not automatically protected by an assumed lease.
-
-Physical cleanup roots are all retained/tagged manifests. For each, follow its
-V1 external details and V2 catalog -> descriptor -> row-map references, including
-storage bases. A live descriptor must protect its row map even when they reside
-outside an index UUID directory. Unreferenced files become eligible only after
-the ordinary in-progress protection period.
-
-Cloning/restoring must preserve the reference graph and ownership of referenced
-bases. Namespace and out-of-band cleanup must check the same capabilities.
-Unknown formats must prevent destructive cleanup, not merely dataset queries.
-
-## 9. Compatibility and rollout
-
-Allocate fresh reader and writer capability flags when the final format is
-approved. Old binaries must reject mixed datasets initially. Keeping V1's wire
-format unchanged does not make old maintenance code safe on V2 dependencies.
-Flags must survive recomputation, retry, clone, and restore, and gate destructive
-maintenance. Do not choose a numeric bit already reserved by another feature.
-
-V1-only datasets keep existing behavior. Activation of mixed handling validates
-V1 metadata and initializes coverage frontiers; it does not force eager remap
-of existing index bytes. Malformed/ambiguous legacy coverage must fall back
-conservatively rather than invent a fully indexed frontier.
-
-Later, add order-preserving writes directly to V2's mapping discriminator and
-change the compaction writer when ready. Keep the V1 reader adapter for existing
-snapshots. No V2 order-preserving codec is defined or required by this draft.
-
-## 10. Decisions to settle together
-
-- Dedicated manifest catalog versus a system-index envelope with explicit
-  structural semantics; prefer the former, but assess integration cost.
-- Exact descriptor/FileRef schema, base-path rules, and validation limits.
-- Coverage frontier persistence: dedicated metadata versus atomically maintained
-  existing coverage, without conflating it with payload address space.
-- Initial supported index kinds and where each performs asynchronous translation.
-- Whether conservative V1/V2 history retention is acceptable for first activation,
-  or coordinated draining must be implemented at the same time.
-- Which clone/namespace paths must be supported before activation.
-
-Before enabling mixed writes, require real-data tests for V1 -> V2 -> V1 and
-V2 -> V1 -> V2, partial coverage, source deletions, later deletes, append, both
-delete/rewrite commit orders, disjoint rewrite rebase, late index publication,
-cache refresh, and cleanup with retained/tagged snapshots. Validate actual row
-identities and output order, not only counts or a query falling back to scans.
-
-This draft can evolve while implementation is underway. Formal schema allocation,
-format review/voting, and release compatibility commitments follow only after
-we are comfortable with the contract.
+Tests exercise V1 → V2 → V1 with eager and deferred compaction, indexed reads,
+deletions, cleanup, reopening, repartitioning after direct rebuild, rejection of
+unresolved repartitioning, joint segment coverage, direct-destination priority,
+append-induced partial coverage, unsupported-index fallback, disjoint commits, and stale source
+rejection. Table tests cover descriptor serialization, malformed descriptors,
+and the paired reader/writer fence.

--- a/java/lance-jni/src/transaction.rs
+++ b/java/lance-jni/src/transaction.rs
@@ -535,7 +535,14 @@ fn convert_to_java_operation_inner<'local>(
             groups,
             rewritten_indices,
             frag_reuse_index,
+            stable_partition,
         } => {
+            if stable_partition.is_some() {
+                return Err(lance::Error::not_supported(
+                    "Java operation objects do not yet support stable-partition descriptors",
+                )
+                .into());
+            }
             let java_groups = export_vec(env, &groups)?;
             let java_indices = export_vec(env, &rewritten_indices)?;
             let java_frag_reuse_index = match frag_reuse_index {
@@ -1273,6 +1280,7 @@ fn convert_to_rust_operation(
                 groups,
                 rewritten_indices,
                 frag_reuse_index,
+                stable_partition: None,
             }
         }
         "Update" => {

--- a/protos/table.proto
+++ b/protos/table.proto
@@ -220,7 +220,25 @@ message Manifest {
 
   // The branch of the dataset. None means main branch.
   optional string branch = 20;
+
+  // Immutable stable-partition mappings. Compaction continues to use FRI V1.
+  // Both histories must be retained and translated together.
+  repeated StablePartitionTransition stable_partition_transitions = 22;
 } // Manifest
+
+// An experimental stable-partition rewrite using the row-map format.
+message StablePartitionTransition {
+  uint64 source_dataset_version = 1;
+  repeated FragmentReuseIndexDetails.FragmentDigest sources = 2;
+  repeated FragmentReuseIndexDetails.FragmentDigest destinations = 3;
+  // UUID directory under _row_maps containing row_map.lance.
+  string row_map_id = 4;
+  uint64 row_map_size_bytes = 5;
+  // Absent means this dataset's storage base.
+  optional uint32 base_id = 6;
+  // Zero in a prepared transaction; stamped when installed in a manifest.
+  uint64 committed_version = 7;
+}
 
 // external dataset base path
 message BasePath {

--- a/protos/transaction.proto
+++ b/protos/transaction.proto
@@ -132,6 +132,8 @@ message Transaction {
     repeated RewriteGroup groups = 3;
     // Indices that have been rewritten
     repeated RewrittenIndex rewritten_indices = 4;
+    // Immutable mapping delta, merged with the latest manifest at commit.
+    optional StablePartitionTransition stable_partition = 5;
   }
 
   // An operation that merges in a new column, altering the schema.

--- a/python/python/lance/dataset.py
+++ b/python/python/lance/dataset.py
@@ -1175,12 +1175,12 @@ class LanceDataset(pa.dataset.Dataset):
         return self._ds.describe_indices()
 
     def remap_row_addrs(self, addrs: "pa.Array") -> "Optional[pa.Array]":
-        """Remap row addresses across compactions still recorded in the
-        fragment-reuse index. Rows a compaction dropped become null. The index
-        retains only recent rounds (older ones are pruned as index remap catches
-        up), so remap promptly: an address whose round was pruned is returned
-        unchanged, not remapped. Returns ``None`` when there is no fragment-reuse
-        index.
+        """Remap nullable UInt64 addresses through retained rewrites.
+
+        Rows dropped by rewrites become null; later deletion vectors are not
+        applied. Compaction history may be pruned, so remap promptly: addresses
+        outside retained history pass through unchanged. Returns ``None`` when
+        no mapping history exists.
         """
         return self._ds.remap_row_addrs(addrs)
 

--- a/python/python/tests/test_optimize.py
+++ b/python/python/tests/test_optimize.py
@@ -820,6 +820,8 @@ def test_remap_row_addrs(tmp_path: Path):
     # No fragment-reuse index yet -> None (nothing to remap against).
     addrs = pa.array([0, 1 << 32, (5 << 32) | 7], pa.uint64())
     assert ds.remap_row_addrs(addrs) is None
+    with pytest.raises(TypeError, match="UInt64"):
+        ds.remap_row_addrs(pa.array([0], pa.int32()))
 
     before = ds.scanner(columns=["id"], with_row_address=True).to_table()
     old = dict(zip(before["id"].to_pylist(), before["_rowaddr"].to_pylist()))
@@ -842,3 +844,5 @@ def test_remap_row_addrs(tmp_path: Path):
         pa.array([old[i] for i in sample], pa.uint64())
     ).to_pylist()
     assert remapped == [new[i] for i in sample]
+    nullable = ds.remap_row_addrs(pa.array([old[0], None, old[999]], pa.uint64()))
+    assert nullable.to_pylist() == [new[0], None, new[999]]

--- a/python/src/dataset.rs
+++ b/python/src/dataset.rs
@@ -60,10 +60,7 @@ use lance::dataset::{
     transaction::{Operation, Transaction},
 };
 use lance::index::vector::utils::get_vector_type;
-use lance::index::{
-    DatasetIndexExt, DatasetIndexInternalExt, IndexSegment, IntoIndexSegment,
-    vector::VectorIndexParams,
-};
+use lance::index::{DatasetIndexExt, IndexSegment, IntoIndexSegment, vector::VectorIndexParams};
 use lance::{dataset::builder::DatasetBuilder, index::vector::IndexFileVersion};
 use lance_arrow::as_fixed_size_list_array;
 use lance_core::Error;
@@ -1170,30 +1167,25 @@ impl Dataset {
             })
     }
 
-    /// Remap row addresses across compactions still recorded in the
-    /// fragment-reuse index. Rows a compaction dropped become null. The index
-    /// retains only recent rounds (older ones are pruned as index remap catches
-    /// up), so remap promptly: an address whose round was pruned is returned
-    /// unchanged, not remapped. Returns None when there is no fragment-reuse
-    /// index.
+    /// Translate nullable UInt64 addresses through retained compactions and stable partitions.
+    /// Rows dropped by rewrites become null; later deletion vectors are not applied.
+    /// Addresses outside retained history pass through. Returns None when no history exists.
     fn remap_row_addrs(
         &self,
         py: Python,
         addrs: PyArrowType<ArrayData>,
     ) -> PyResult<Option<PyArrowType<ArrayData>>> {
-        use lance_index::metrics::NoOpMetricsCollector;
-
         let array = make_array(addrs.0);
-        let frag_reuse_index = rt()
+        let addresses = array
+            .as_primitive_opt::<arrow_array::types::UInt64Type>()
+            .ok_or_else(|| PyTypeError::new_err("row addresses must be a UInt64 Arrow array"))?;
+        let remapped = rt()
             .block_on(
                 Some(py),
-                self.ds.open_frag_reuse_index(&NoOpMetricsCollector),
+                lance::index::frag_reuse_v2::remap_row_addrs(self.ds.as_ref(), addresses),
             )?
-            .map_err(|err| {
-                PyIOError::new_err(format!("failed to open fragment reuse index: {err}"))
-            })?;
-
-        Ok(frag_reuse_index.map(|fri| PyArrowType(fri.remap_row_ids_array(array).to_data())))
+            .map_err(|err| PyIOError::new_err(format!("failed to remap row addresses: {err}")))?;
+        Ok(remapped.map(|array| PyArrowType(array.to_data())))
     }
 
     fn serialized_manifest(&self, py: Python) -> Py<PyAny> {

--- a/python/src/transaction.rs
+++ b/python/src/transaction.rs
@@ -495,6 +495,7 @@ impl FromPyObject<'_, '_> for PyLance<Operation> {
                     rewritten_indices,
                     // TODO: pass frag_reuse_index when available
                     frag_reuse_index: None,
+                    stable_partition: None,
                 };
                 Ok(Self(op))
             }
@@ -728,8 +729,14 @@ impl<'py> IntoPyObject<'py> for PyLance<&Operation> {
             Operation::Rewrite {
                 groups,
                 rewritten_indices,
+                stable_partition,
                 ..
             } => {
+                if stable_partition.is_some() {
+                    return Err(pyo3::exceptions::PyNotImplementedError::new_err(
+                        "Python operation objects do not yet support stable-partition descriptors",
+                    ));
+                }
                 let groups_py = export_vec(py, groups.as_slice())?;
                 let rewritten_indices_py = export_vec(py, rewritten_indices.as_slice())?;
                 let cls = namespace

--- a/rust/lance-table/src/feature_flags.rs
+++ b/rust/lance-table/src/feature_flags.rs
@@ -55,9 +55,11 @@ pub const FLAG_COVERED_INDEX_METADATA: u64 = 1 << 7;
 pub const FLAG_MIXED_DATA_FILE_VERSIONS: u64 = 1 << 8;
 /// The first bit that is unknown as a feature flag
 pub const FLAG_UNKNOWN: u64 = 1 << 8;
+/// Experimental immutable stable-partition mappings composed with FRI V1.
+pub const FLAG_STABLE_PARTITION: u64 = 1 << 9;
 
-// Supported flags stay below the unknown boundary; the mixed-version bit is
-// reserved at the boundary until its storage contract lands.
+// The mixed-version bit remains reserved at the unknown boundary. Stable
+// partitions are supported explicitly above it without enabling that bit.
 const _: () = assert!(FLAG_COVERED_INDEX_METADATA < FLAG_UNKNOWN);
 // The fence needs a bit the current released build already refuses, which means
 // at or above the boundary that build shipped with (bit 7).
@@ -84,6 +86,8 @@ pub fn apply_feature_flags(
     let covered_index_metadata = (manifest.reader_feature_flags | manifest.writer_feature_flags)
         & FLAG_COVERED_INDEX_METADATA;
     let sticky_paired_flags = validated_sticky_paired_flags(manifest)?;
+
+    let stable_partition = !manifest.stable_partition_transitions.is_empty();
 
     // Reset flags
     manifest.reader_feature_flags = 0;
@@ -143,6 +147,10 @@ pub fn apply_feature_flags(
         manifest.writer_feature_flags |= FLAG_DISABLE_TRANSACTION_FILE;
     }
 
+    if stable_partition {
+        manifest.reader_feature_flags |= FLAG_STABLE_PARTITION;
+        manifest.writer_feature_flags |= FLAG_STABLE_PARTITION;
+    }
     manifest.reader_feature_flags |= covered_index_metadata;
     manifest.writer_feature_flags |= covered_index_metadata;
     manifest.reader_feature_flags |= sticky_paired_flags;
@@ -187,7 +195,7 @@ fn mark_supported(flags: &mut u64, flag: u64, feature_enabled: bool) {
 /// is enabled. Split out from [`supported_flags`] so the policy is testable
 /// without toggling the build profile or environment.
 fn supported_flags_when(overlay_enabled: bool) -> u64 {
-    let mut supported = FLAG_UNKNOWN - 1;
+    let mut supported = (FLAG_UNKNOWN - 1) | FLAG_STABLE_PARTITION;
     mark_supported(
         &mut supported,
         FLAG_UNSTABLE_DATA_OVERLAY_FILES,
@@ -211,6 +219,16 @@ pub fn can_write_dataset(writer_flags: u64) -> bool {
 /// Refuse reads from manifests whose required reader features this build does
 /// not support or whose paired capabilities are inconsistent.
 pub fn ensure_can_read_manifest(manifest: &Manifest) -> Result<()> {
+    if !manifest.stable_partition_transitions.is_empty()
+        && (manifest.reader_feature_flags & FLAG_STABLE_PARTITION == 0
+            || manifest.writer_feature_flags & FLAG_STABLE_PARTITION == 0)
+    {
+        return Err(Error::corrupt_file_named(
+            "manifest",
+            "stable-partition transitions require both reader and writer capability flags",
+        ));
+    }
+
     validate_paired_feature_flags(manifest)?;
     if !can_read_dataset(manifest.reader_feature_flags) {
         return Err(Error::not_supported_source(
@@ -228,6 +246,16 @@ pub fn ensure_can_read_manifest(manifest: &Manifest) -> Result<()> {
 /// Refuse writes to manifests whose required writer features this build does
 /// not support or whose paired capabilities are inconsistent.
 pub fn ensure_can_write_manifest(manifest: &Manifest) -> Result<()> {
+    if !manifest.stable_partition_transitions.is_empty()
+        && (manifest.reader_feature_flags & FLAG_STABLE_PARTITION == 0
+            || manifest.writer_feature_flags & FLAG_STABLE_PARTITION == 0)
+    {
+        return Err(Error::corrupt_file_named(
+            "manifest",
+            "stable-partition transitions require both reader and writer capability flags",
+        ));
+    }
+
     validate_paired_feature_flags(manifest)?;
     if !can_write_dataset(manifest.writer_feature_flags) {
         return Err(Error::not_supported_source(
@@ -523,6 +551,54 @@ mod tests {
         let err = ensure_can_write_manifest(&manifest).unwrap_err();
         assert!(matches!(err, Error::NotSupported { .. }));
         assert!(err.to_string().contains("cannot be written"), "{err}");
+    }
+
+    #[test]
+    fn stable_partition_flags_survive_manifest_derivation() {
+        use crate::format::StablePartitionTransition;
+        use crate::system_index::frag_reuse::FragDigest;
+        use std::sync::Arc;
+
+        let mut manifest = empty_manifest();
+        Arc::make_mut(&mut manifest.stable_partition_transitions).push(StablePartitionTransition {
+            source_dataset_version: 1,
+            sources: vec![FragDigest {
+                id: 0,
+                physical_rows: 1,
+                num_deleted_rows: 0,
+            }],
+            destinations: vec![FragDigest {
+                id: 1,
+                physical_rows: 1,
+                num_deleted_rows: 0,
+            }],
+            row_map_id: uuid::Uuid::new_v4(),
+            row_map_size_bytes: 100,
+            base_id: None,
+            committed_version: 2,
+        });
+        let error = ensure_can_read_manifest(&manifest).unwrap_err();
+        assert!(matches!(error, Error::CorruptFile { .. }));
+        assert!(error.to_string().contains("both reader and writer"));
+        apply_feature_flags(&mut manifest, false, false).unwrap();
+        assert_eq!(manifest.reader_feature_flags, FLAG_STABLE_PARTITION);
+        assert_eq!(manifest.writer_feature_flags, FLAG_STABLE_PARTITION);
+        ensure_can_read_manifest(&manifest).unwrap();
+        ensure_can_write_manifest(&manifest).unwrap();
+        let next = Manifest::new_from_previous(
+            &manifest,
+            manifest.schema.clone(),
+            manifest.fragments.clone(),
+        );
+        ensure_can_read_manifest(&next).unwrap();
+        ensure_can_write_manifest(&next).unwrap();
+        assert_eq!(
+            next.stable_partition_transitions,
+            manifest.stable_partition_transitions
+        );
+        // Released readers reject bit 9; reserved bit 8 stays unsupported here.
+        assert_ne!(FLAG_STABLE_PARTITION & !(FLAG_UNKNOWN - 1), 0);
+        assert!(!can_read_dataset(FLAG_MIXED_DATA_FILE_VERSIONS));
     }
 
     fn empty_manifest() -> Manifest {

--- a/rust/lance-table/src/format.rs
+++ b/rust/lance-table/src/format.rs
@@ -8,6 +8,8 @@ mod fragment;
 mod index;
 pub mod key_existence;
 mod manifest;
+mod stable_partition;
+pub use stable_partition::{ROW_MAP_FILE_NAME, ROW_MAPS_DIR, StablePartitionTransition};
 pub mod overlay;
 mod row_ids;
 mod transaction;

--- a/rust/lance-table/src/format/manifest.rs
+++ b/rust/lance-table/src/format/manifest.rs
@@ -60,6 +60,9 @@ pub struct Manifest {
     /// The file position of the index metadata.
     pub index_section: Option<usize>,
 
+    /// Immutable row maps for stable partitions, composed with FRI V1.
+    pub stable_partition_transitions: Arc<Vec<super::StablePartitionTransition>>,
+
     /// The creation timestamp with nanosecond resolution as 128-bit integer
     pub timestamp_nanos: u128,
 
@@ -186,6 +189,7 @@ impl Manifest {
             fragments,
             version_aux_data: 0,
             index_section: None,
+            stable_partition_transitions: Arc::new(Vec::new()),
             timestamp_nanos: 0,
             tag: None,
             reader_feature_flags: 0, // These will be set on commit
@@ -216,11 +220,14 @@ impl Manifest {
             writer_version: Some(WriterVersion::default()),
             fragments,
             version_aux_data: 0,
+            stable_partition_transitions: previous.stable_partition_transitions.clone(),
             index_section: None, // Caller should update index if they want to keep them.
             timestamp_nanos: 0,  // This will be set on commit
             tag: None,
-            reader_feature_flags: previous.reader_feature_flags & STICKY_PAIRED_FLAGS,
-            writer_feature_flags: previous.writer_feature_flags & STICKY_PAIRED_FLAGS,
+            reader_feature_flags: previous.reader_feature_flags
+                & (STICKY_PAIRED_FLAGS | crate::feature_flags::FLAG_STABLE_PARTITION),
+            writer_feature_flags: previous.writer_feature_flags
+                & (STICKY_PAIRED_FLAGS | crate::feature_flags::FLAG_STABLE_PARTITION),
             max_fragment_id: previous.max_fragment_id,
             transaction_file: None,
             transaction_section: None,
@@ -273,6 +280,18 @@ impl Manifest {
             writer_version: self.writer_version.clone(),
             fragments: Arc::new(cloned_fragments),
             version_aux_data: self.version_aux_data,
+            stable_partition_transitions: Arc::new(
+                self.stable_partition_transitions
+                    .iter()
+                    .cloned()
+                    .map(|mut transition| {
+                        if transition.base_id.is_none() {
+                            transition.base_id = Some(ref_base_id);
+                        }
+                        transition
+                    })
+                    .collect(),
+            ),
             index_section: None, // These will be set on commit
             timestamp_nanos: self.timestamp_nanos,
             tag: None,
@@ -286,9 +305,13 @@ impl Manifest {
             // Sticky capabilities are also retained because the clone keeps the
             // source file identities that require them.
             reader_feature_flags: self.reader_feature_flags
-                & (FLAG_COVERED_INDEX_METADATA | STICKY_PAIRED_FLAGS),
+                & (FLAG_COVERED_INDEX_METADATA
+                    | STICKY_PAIRED_FLAGS
+                    | crate::feature_flags::FLAG_STABLE_PARTITION),
             writer_feature_flags: self.writer_feature_flags
-                & (FLAG_COVERED_INDEX_METADATA | STICKY_PAIRED_FLAGS),
+                & (FLAG_COVERED_INDEX_METADATA
+                    | STICKY_PAIRED_FLAGS
+                    | crate::feature_flags::FLAG_STABLE_PARTITION),
             max_fragment_id: self.max_fragment_id,
             transaction_file: Some(transaction_file),
             transaction_section: None,
@@ -991,6 +1014,12 @@ impl TryFrom<pb::Manifest> for Manifest {
             writer_version,
             version_aux_data: p.version_aux_data as usize,
             index_section: p.index_section.map(|i| i as usize),
+            stable_partition_transitions: Arc::new(
+                p.stable_partition_transitions
+                    .into_iter()
+                    .map(TryInto::try_into)
+                    .collect::<Result<_>>()?,
+            ),
             timestamp_nanos: timestamp_nanos.unwrap_or(0),
             tag: if p.tag.is_empty() { None } else { Some(p.tag) },
             reader_feature_flags: p.reader_feature_flags,
@@ -1053,6 +1082,11 @@ impl From<&Manifest> for pb::Manifest {
             table_metadata: m.table_metadata.clone(),
             version_aux_data: m.version_aux_data as u64,
             index_section: m.index_section.map(|i| i as u64),
+            stable_partition_transitions: m
+                .stable_partition_transitions
+                .iter()
+                .map(Into::into)
+                .collect(),
             timestamp: timestamp_nanos,
             tag: m.tag.clone().unwrap_or_default(),
             reader_feature_flags: m.reader_feature_flags,

--- a/rust/lance-table/src/format/stable_partition.rs
+++ b/rust/lance-table/src/format/stable_partition.rs
@@ -1,0 +1,244 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+//! Manifest references to immutable stable-partition row maps.
+
+use lance_core::deepsize::DeepSizeOf;
+use lance_core::{Error, Result};
+use roaring::RoaringBitmap;
+use uuid::Uuid;
+
+use super::pb;
+use crate::system_index::frag_reuse::FragDigest;
+
+/// Managed subtree for immutable stable-partition mappings.
+pub const ROW_MAPS_DIR: &str = "_row_maps";
+
+/// File containing destination labels and cumulative counts.
+pub const ROW_MAP_FILE_NAME: &str = "row_map.lance";
+
+/// A value-preserving rewrite whose destinations retain source order.
+///
+/// Sources and destinations are ordered: labels address the concatenated
+/// physical sources and index the destination list. Row maps are immutable.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StablePartitionTransition {
+    /// Snapshot scanned by the rewrite job.
+    pub source_dataset_version: u64,
+    /// Sources in physical scan order, including deleted positions.
+    pub sources: Vec<FragDigest>,
+    /// Destinations in label order, without deletions at creation.
+    pub destinations: Vec<FragDigest>,
+    /// Directory under `_row_maps` containing [`ROW_MAP_FILE_NAME`].
+    pub row_map_id: Uuid,
+    /// Complete immutable row-map file length.
+    pub row_map_size_bytes: u64,
+    /// Storage base, or this dataset's base when absent.
+    pub base_id: Option<u32>,
+    /// Installing manifest version; zero while preparing the transaction.
+    pub committed_version: u64,
+}
+
+impl DeepSizeOf for StablePartitionTransition {
+    fn deep_size_of_children(&self, context: &mut lance_core::deepsize::Context) -> usize {
+        self.sources.deep_size_of_children(context)
+            + self.destinations.deep_size_of_children(context)
+    }
+}
+
+impl StablePartitionTransition {
+    /// Source fragment membership, independent of source scan order.
+    pub fn source_ids(&self) -> RoaringBitmap {
+        self.sources.iter().map(|f| f.id as u32).collect()
+    }
+
+    /// Destination fragment membership, independent of label order.
+    pub fn destination_ids(&self) -> RoaringBitmap {
+        self.destinations.iter().map(|f| f.id as u32).collect()
+    }
+
+    /// Validate address bounds and uniqueness before writing or reading metadata.
+    pub fn validate(&self) -> Result<()> {
+        if self.sources.is_empty()
+            || self.destinations.is_empty()
+            || self.destinations.len() > 65536
+            || self.row_map_size_bytes == 0
+        {
+            return Err(Error::invalid_input(
+                "stable partition requires nonempty sources, 1..=65536 destinations, and a nonempty row map",
+            ));
+        }
+        let mut ids = RoaringBitmap::new();
+        for fragment in self.sources.iter().chain(&self.destinations) {
+            let id = u32::try_from(fragment.id).map_err(|_| {
+                Error::invalid_input(format!("fragment id {} exceeds u32", fragment.id))
+            })?;
+            if !ids.insert(id)
+                || fragment.physical_rows > u32::MAX as usize
+                || fragment.num_deleted_rows > fragment.physical_rows
+            {
+                return Err(Error::invalid_input(format!(
+                    "invalid or repeated stable-partition fragment {}: physical_rows={}, deleted_rows={}",
+                    fragment.id, fragment.physical_rows, fragment.num_deleted_rows
+                )));
+            }
+        }
+        if self
+            .destinations
+            .iter()
+            .any(|f| f.id == 0 || f.num_deleted_rows != 0)
+        {
+            return Err(Error::invalid_input(
+                "stable-partition destinations require reserved nonzero IDs and no deleted rows",
+            ));
+        }
+        let live: u64 = self
+            .sources
+            .iter()
+            .map(|f| (f.physical_rows - f.num_deleted_rows) as u64)
+            .sum();
+        let written: u64 = self
+            .destinations
+            .iter()
+            .map(|f| f.physical_rows as u64)
+            .sum();
+        if live != written {
+            return Err(Error::invalid_input(format!(
+                "stable-partition source live rows {live} differ from destination rows {written}"
+            )));
+        }
+        Ok(())
+    }
+}
+
+impl From<&StablePartitionTransition> for pb::StablePartitionTransition {
+    fn from(t: &StablePartitionTransition) -> Self {
+        Self {
+            source_dataset_version: t.source_dataset_version,
+            sources: t.sources.iter().map(Into::into).collect(),
+            destinations: t.destinations.iter().map(Into::into).collect(),
+            row_map_id: t.row_map_id.to_string(),
+            row_map_size_bytes: t.row_map_size_bytes,
+            base_id: t.base_id,
+            committed_version: t.committed_version,
+        }
+    }
+}
+
+impl TryFrom<pb::StablePartitionTransition> for StablePartitionTransition {
+    type Error = Error;
+    fn try_from(t: pb::StablePartitionTransition) -> Result<Self> {
+        let transition = Self {
+            source_dataset_version: t.source_dataset_version,
+            sources: t
+                .sources
+                .into_iter()
+                .map(TryInto::try_into)
+                .collect::<Result<_>>()?,
+            destinations: t
+                .destinations
+                .into_iter()
+                .map(TryInto::try_into)
+                .collect::<Result<_>>()?,
+            row_map_id: Uuid::parse_str(&t.row_map_id).map_err(|e| {
+                Error::invalid_input(format!("invalid row_map_id {}: {e}", t.row_map_id))
+            })?,
+            row_map_size_bytes: t.row_map_size_bytes,
+            base_id: t.base_id,
+            committed_version: t.committed_version,
+        };
+        transition.validate()?;
+        Ok(transition)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use prost::Message;
+
+    fn transition() -> StablePartitionTransition {
+        StablePartitionTransition {
+            source_dataset_version: 4,
+            sources: vec![FragDigest {
+                id: 0,
+                physical_rows: 3,
+                num_deleted_rows: 1,
+            }],
+            destinations: vec![FragDigest {
+                id: 5,
+                physical_rows: 2,
+                num_deleted_rows: 0,
+            }],
+            row_map_id: Uuid::new_v4(),
+            row_map_size_bytes: 1024,
+            base_id: None,
+            committed_version: 6,
+        }
+    }
+
+    #[test]
+    fn protobuf_preserves_mapping_identity_and_order() {
+        let transition = transition();
+        let bytes = pb::StablePartitionTransition::from(&transition).encode_to_vec();
+        let decoded = pb::StablePartitionTransition::decode(bytes.as_slice()).unwrap();
+        assert_eq!(
+            StablePartitionTransition::try_from(decoded).unwrap(),
+            transition
+        );
+    }
+
+    #[test]
+    fn transaction_round_trip_preserves_the_partition_descriptor() {
+        use crate::format::Fragment;
+        use crate::transaction::{Operation, RewriteGroup, Transaction};
+
+        let mut descriptor = transition();
+        descriptor.committed_version = 0;
+        let mut source = Fragment::new(0);
+        source.physical_rows = Some(3);
+        let mut destination = Fragment::new(5);
+        destination.physical_rows = Some(2);
+        let transaction = Transaction::new(
+            4,
+            Operation::Rewrite {
+                groups: vec![RewriteGroup {
+                    old_fragments: vec![source],
+                    new_fragments: vec![destination],
+                }],
+                rewritten_indices: Vec::new(),
+                frag_reuse_index: None,
+                stable_partition: Some(Box::new(descriptor.clone())),
+            },
+            None,
+        );
+        let bytes = pb::Transaction::from(&transaction).encode_to_vec();
+        let decoded =
+            Transaction::try_from(pb::Transaction::decode(bytes.as_slice()).unwrap()).unwrap();
+        let Operation::Rewrite {
+            stable_partition, ..
+        } = decoded.operation
+        else {
+            panic!("expected rewrite")
+        };
+        assert_eq!(*stable_partition.unwrap(), descriptor);
+    }
+
+    #[rstest::rstest]
+    #[case::duplicate_source(0, 2, "repeated")]
+    #[case::address_overflow(u64::from(u32::MAX) + 1, 2, "exceeds u32")]
+    #[case::row_count_mismatch(5, 1, "source live rows")]
+    #[test]
+    fn invalid_destinations_are_rejected(
+        #[case] id: u64,
+        #[case] rows: usize,
+        #[case] message: &str,
+    ) {
+        let mut transition = transition();
+        transition.destinations[0].id = id;
+        transition.destinations[0].physical_rows = rows;
+        let error = transition.validate().unwrap_err();
+        assert!(matches!(error, Error::InvalidInput { .. }));
+        assert!(error.to_string().contains(message), "{error}");
+    }
+}

--- a/rust/lance-table/src/transaction/conflicts.rs
+++ b/rust/lance-table/src/transaction/conflicts.rs
@@ -99,16 +99,19 @@ impl PartialEq for Operation {
                     groups: a_groups,
                     rewritten_indices: a_indices,
                     frag_reuse_index: a_frag_reuse_index,
+                    stable_partition: a_partition,
                 },
                 Self::Rewrite {
                     groups: b_groups,
                     rewritten_indices: b_indices,
                     frag_reuse_index: b_frag_reuse_index,
+                    stable_partition: b_partition,
                 },
             ) => {
                 compare_vec(a_groups, b_groups)
                     && compare_vec(a_indices, b_indices)
                     && a_frag_reuse_index == b_frag_reuse_index
+                    && a_partition == b_partition
             }
             (
                 Self::Merge {
@@ -1036,6 +1039,7 @@ mod tests {
             groups: vec![],
             rewritten_indices: vec![],
             frag_reuse_index: None,
+            stable_partition: None,
         };
         assert_ne!(overlay(1), rewrite);
     }

--- a/rust/lance-table/src/transaction/manifest_build.rs
+++ b/rust/lance-table/src/transaction/manifest_build.rs
@@ -52,6 +52,99 @@ use std::sync::Arc;
 use uuid::Uuid;
 
 impl Transaction {
+    fn validate_stable_partition(
+        groups: &[crate::transaction::RewriteGroup],
+        transition: &crate::format::StablePartitionTransition,
+        current: Option<&Manifest>,
+        read_version: u64,
+    ) -> Result<()> {
+        transition.validate()?;
+        if transition.source_dataset_version != read_version || transition.committed_version != 0 {
+            return Err(Error::invalid_input(
+                "stable partition must refer to the transaction read version and be uncommitted",
+            ));
+        }
+        let current = current
+            .ok_or_else(|| Error::invalid_input("stable partition requires an existing dataset"))?;
+        if transition.base_id.is_some()
+            || !current.base_paths.is_empty()
+            || current.uses_stable_row_ids()
+        {
+            return Err(Error::not_supported(
+                "stable-partition writes currently require physical row IDs and a single storage base",
+            ));
+        }
+        if current
+            .stable_partition_transitions
+            .iter()
+            .any(|t| t.row_map_id == transition.row_map_id)
+        {
+            return Err(Error::invalid_input(format!(
+                "row map {} is already committed",
+                transition.row_map_id
+            )));
+        }
+        let sources = groups
+            .iter()
+            .flat_map(|g| &g.old_fragments)
+            .collect::<Vec<_>>();
+        let destinations = groups
+            .iter()
+            .flat_map(|g| &g.new_fragments)
+            .collect::<Vec<_>>();
+        if sources.len() != transition.sources.len()
+            || destinations.len() != transition.destinations.len()
+        {
+            return Err(Error::invalid_input(
+                "stable-partition fragment lists differ from rewrite groups",
+            ));
+        }
+        for (source, digest) in sources.iter().zip(&transition.sources) {
+            if source
+                .deletion_file
+                .as_ref()
+                .is_some_and(|file| file.num_deleted_rows.is_none())
+            {
+                return Err(Error::invalid_input(format!(
+                    "stable-partition source {} is missing its deleted row count",
+                    source.id,
+                )));
+            }
+            if source.id != digest.id
+                || source.physical_rows != Some(digest.physical_rows)
+                || source
+                    .deletion_file
+                    .as_ref()
+                    .and_then(|d| d.num_deleted_rows)
+                    .unwrap_or(0)
+                    != digest.num_deleted_rows
+                || !current.fragments.iter().any(|f| f == *source)
+            {
+                return Err(Error::invalid_input(format!(
+                    "stable-partition source {} changed or differs from its descriptor; rebuild from the current snapshot",
+                    source.id
+                )));
+            }
+        }
+        for (destination, digest) in destinations.iter().zip(&transition.destinations) {
+            if destination.id != digest.id
+                || destination.physical_rows != Some(digest.physical_rows)
+                || destination.deletion_file.is_some()
+                || !destination.overlays.is_empty()
+                || current.fragments.iter().any(|f| f.id == destination.id)
+                || current
+                    .max_fragment_id
+                    .is_none_or(|id| destination.id > u64::from(id))
+            {
+                return Err(Error::invalid_input(format!(
+                    "stable-partition destination {} differs from its descriptor or is not reserved",
+                    destination.id
+                )));
+            }
+        }
+        Ok(())
+    }
+
     pub(super) fn fragments_with_ids<'a, T>(
         new_fragments: T,
         fragment_id: &'a mut u64,
@@ -801,7 +894,21 @@ impl Transaction {
                 groups,
                 rewritten_indices,
                 frag_reuse_index,
+                stable_partition,
             } => {
+                if let Some(transition) = stable_partition {
+                    Self::validate_stable_partition(
+                        groups,
+                        transition,
+                        current_manifest,
+                        self.read_version,
+                    )?;
+                    if !rewritten_indices.is_empty() || frag_reuse_index.is_some() {
+                        return Err(Error::invalid_input(
+                            "stable partition cannot carry eager index rewrites or an FRI V1 replacement",
+                        ));
+                    }
+                }
                 final_fragments.extend(maybe_existing_fragments?.clone());
                 let current_version = current_manifest.map(|m| m.version).unwrap_or_default();
                 Self::handle_rewrite_fragments(
@@ -812,7 +919,10 @@ impl Transaction {
                     next_row_id.as_ref(),
                 )?;
 
-                if next_row_id.is_some() {
+                if stable_partition.is_some() {
+                    // Keep the original coverage; the mixed reader derives coverage
+                    // only for index types that implement asynchronous translation.
+                } else if next_row_id.is_some() {
                     // We can re-use indices, but need to rewrite the fragment bitmaps
                     debug_assert!(rewritten_indices.is_empty());
                     for index in final_indices.iter_mut() {
@@ -1290,6 +1400,17 @@ impl Transaction {
             )
         };
 
+        if let Operation::Rewrite {
+            stable_partition: Some(transition),
+            ..
+        } = &self.operation
+        {
+            let mut transition = transition.as_ref().clone();
+            transition.committed_version = new_version;
+            Arc::make_mut(&mut manifest.stable_partition_transitions).push(transition);
+            manifest.reader_feature_flags |= crate::feature_flags::FLAG_STABLE_PARTITION;
+            manifest.writer_feature_flags |= crate::feature_flags::FLAG_STABLE_PARTITION;
+        }
         manifest.tag.clone_from(&self.tag);
 
         if config.auto_set_feature_flags {

--- a/rust/lance-table/src/transaction/operation.rs
+++ b/rust/lance-table/src/transaction/operation.rs
@@ -88,6 +88,9 @@ pub enum Operation {
         rewritten_indices: Vec<RewrittenIndex>,
         /// The fragment reuse index to be created or updated to
         frag_reuse_index: Option<IndexMetadata>,
+        /// Prepared stable-partition mapping, appended atomically to the manifest.
+        /// None retains the existing order-preserving compaction semantics.
+        stable_partition: Option<Box<crate::format::StablePartitionTransition>>,
     },
     /// Replace data in a column in the dataset with new data. This is used for
     /// null column population where we replace an entirely null column with a

--- a/rust/lance-table/src/transaction/proto.rs
+++ b/rust/lance-table/src/transaction/proto.rs
@@ -153,6 +153,7 @@ impl TryFrom<pb::Transaction> for Transaction {
                 new_fragments,
                 groups,
                 rewritten_indices,
+                stable_partition,
             })) => {
                 let groups = if !groups.is_empty() {
                     groups
@@ -180,6 +181,9 @@ impl TryFrom<pb::Transaction> for Transaction {
                     groups,
                     rewritten_indices,
                     frag_reuse_index: None,
+                    stable_partition: stable_partition
+                        .map(|t| t.try_into().map(Box::new))
+                        .transpose()?,
                 }
             }
             Some(pb::transaction::Operation::CreateIndex(pb::transaction::CreateIndex {
@@ -556,7 +560,9 @@ impl From<&Transaction> for pb::Transaction {
                 groups,
                 rewritten_indices,
                 frag_reuse_index: _,
+                stable_partition,
             } => pb::transaction::Operation::Rewrite(pb::transaction::Rewrite {
+                stable_partition: stable_partition.as_deref().map(Into::into),
                 groups: groups
                     .iter()
                     .map(pb::transaction::rewrite::RewriteGroup::from)

--- a/rust/lance/src/dataset.rs
+++ b/rust/lance/src/dataset.rs
@@ -2225,6 +2225,11 @@ impl Dataset {
         self.base.clone().join(INDICES_DIR)
     }
 
+    /// Directory containing immutable stable-partition row maps.
+    pub fn row_maps_dir(&self) -> Path {
+        self.base.clone().join(lance_table::format::ROW_MAPS_DIR)
+    }
+
     pub fn transactions_dir(&self) -> Path {
         self.base.clone().join(TRANSACTIONS_DIR)
     }
@@ -3318,6 +3323,11 @@ impl Dataset {
         // Resolve source dataset and its manifest using checkout_version
         let src_ds = self.checkout_version(version).await?;
         ensure_can_write_manifest(&src_ds.manifest)?;
+        if !src_ds.manifest.stable_partition_transitions.is_empty() {
+            return Err(Error::not_supported(
+                "cloning datasets with stable-partition mappings is not yet supported",
+            ));
+        }
         let src_paths = src_ds.collect_paths().await?;
 
         // Prepare target object store and base path

--- a/rust/lance/src/dataset/cleanup.rs
+++ b/rust/lance/src/dataset/cleanup.rs
@@ -77,6 +77,7 @@ struct ReferencedFiles {
     delete_paths: HashSet<Path>,
     tx_paths: HashSet<Path>,
     index_uuids: HashSet<String>,
+    row_map_uuids: HashSet<String>,
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
@@ -451,6 +452,7 @@ impl<'a> CleanupTask<'a> {
     }
 
     async fn run(self) -> Result<CleanupRunResult> {
+        lance_table::feature_flags::ensure_can_write_manifest(&self.dataset.manifest)?;
         let mut final_result = CleanupRunResult::default();
         let candidate_file_limit = self.action.candidate_file_limit();
         // First check if we need to clean referenced branches
@@ -555,6 +557,7 @@ impl<'a> CleanupTask<'a> {
         let manifest_and_indexes = async {
             let manifest =
                 read_manifest(&self.dataset.object_store, &location.path, location.size).await?;
+            lance_table::feature_flags::ensure_can_read_manifest(&manifest)?;
             let indexes =
                 read_manifest_indexes(&self.dataset.object_store, &location, &manifest).await?;
             Ok::<_, Error>((manifest, indexes))
@@ -661,6 +664,13 @@ impl<'a> CleanupTask<'a> {
             let uuid_str = index.uuid.to_string();
             referenced_files.index_uuids.insert(uuid_str);
         }
+        for transition in manifest.stable_partition_transitions.iter() {
+            if transition.base_id.is_none() {
+                referenced_files
+                    .row_map_uuids
+                    .insert(transition.row_map_id.to_string());
+            }
+        }
         Ok(())
     }
 
@@ -744,6 +754,7 @@ impl<'a> CleanupTask<'a> {
             // a retained-manifest cutoff can otherwise skip newer artifacts and lose
             // the proof when the old manifests are removed by this cleanup pass.
             build_listing_stream(self.dataset.indices_dir(), None),
+            build_listing_stream(self.dataset.row_maps_dir(), None),
             build_listing_stream(self.dataset.deletions_dir(), unmodified_since),
         ];
         let unreferenced_files = stream::iter(streams).flatten().boxed();
@@ -910,6 +921,32 @@ impl<'a> CleanupTask<'a> {
                     size_bytes,
                 ));
             }
+        }
+        if relative_path.prefix_matches(&Path::from(lance_table::format::ROW_MAPS_DIR)) {
+            let Some(uuid) = relative_path.parts().nth(1) else {
+                return Ok(None);
+            };
+            if inspection
+                .referenced_files
+                .row_map_uuids
+                .contains(uuid.as_ref())
+            {
+                return Ok(None);
+            }
+            let verified = inspection
+                .verified_files
+                .row_map_uuids
+                .contains(uuid.as_ref());
+            if verified || !maybe_in_progress {
+                // Count row maps with the other row-address mapping artifacts.
+                return Ok(cleanup_file(
+                    path,
+                    CleanupFileKind::Index,
+                    !verified,
+                    size_bytes,
+                ));
+            }
+            return Ok(None);
         }
         if relative_path.as_ref().starts_with("_indices") {
             // Indices are referenced by UUID so we need to examine the UUID

--- a/rust/lance/src/dataset/index/frag_reuse.rs
+++ b/rust/lance/src/dataset/index/frag_reuse.rs
@@ -45,6 +45,10 @@ use roaring::RoaringBitmap;
 /// [`compact_files`]: crate::dataset::optimize::compact_files
 /// [`remap_column_index`]: crate::dataset::optimize::remapping::remap_column_index
 pub async fn cleanup_frag_reuse_index(dataset: &mut Dataset) -> lance_core::Result<()> {
+    if !dataset.manifest.stable_partition_transitions.is_empty() {
+        log::debug!("retaining FRI V1 history required by stable-partition transitions");
+        return Ok(());
+    }
     // check against index metadata before auto-remap
     let indices = read_manifest_indexes(
         &dataset.object_store,

--- a/rust/lance/src/dataset/optimize.rs
+++ b/rust/lance/src/dataset/optimize.rs
@@ -2329,6 +2329,7 @@ async fn rewrite_files(
     // an index to remap now, or a deferred remap through the FRI.
     let capture_row_addrs = !dataset.manifest.uses_stable_row_ids()
         && (options.defer_index_remap
+            || !dataset.manifest.stable_partition_transitions.is_empty()
             || load_indices_for_remapping(dataset.as_ref())
                 .await?
                 .is_some());
@@ -2856,7 +2857,7 @@ pub async fn commit_compaction(
     } else {
         RoaringBitmap::new()
     };
-    let mut any_group_indexed = false;
+    let mut any_group_indexed = !dataset.manifest.stable_partition_transitions.is_empty();
 
     for task in completed_tasks {
         metrics += task.metrics;
@@ -2865,6 +2866,17 @@ pub async fn commit_compaction(
             new_fragments: task.new_fragments.clone(),
         };
 
+        if !dataset.manifest.stable_partition_transitions.is_empty() && !options.defer_index_remap {
+            let changed_row_addrs = task.row_addrs.clone().ok_or_else(|| {
+                Error::invalid_input("mixed FRI compaction requires captured source addresses")
+            })?;
+            frag_reuse_groups.push(FragReuseGroup {
+                changed_row_addrs,
+                old_frags: task.original_fragments.iter().map(Into::into).collect(),
+                new_frags: task.new_fragments.iter().map(Into::into).collect(),
+            });
+            new_fragment_bitmap.extend(task.new_fragments.iter().map(|f| f.id as u32));
+        }
         if index_remapper.is_some() {
             if let Some(row_addrs_bytes) = task.row_addrs {
                 let row_addrs =
@@ -2990,7 +3002,9 @@ pub async fn commit_compaction(
     };
 
     // No indexed/chain data touched -> no FRI (all-or-nothing, see above).
-    let frag_reuse_index = if options.defer_index_remap && any_group_indexed {
+    let frag_reuse_index = if (options.defer_index_remap && any_group_indexed)
+        || !dataset.manifest.stable_partition_transitions.is_empty()
+    {
         Some(build_new_frag_reuse_index(dataset, frag_reuse_groups, new_fragment_bitmap).await?)
     } else {
         if options.defer_index_remap {
@@ -3014,6 +3028,7 @@ pub async fn commit_compaction(
             groups: rewrite_groups,
             rewritten_indices,
             frag_reuse_index,
+            stable_partition: None,
         },
     )
     .transaction_properties(options.transaction_properties.clone())

--- a/rust/lance/src/index.rs
+++ b/rust/lance/src/index.rs
@@ -80,6 +80,7 @@ mod api;
 pub(crate) mod append;
 mod create;
 pub mod frag_reuse;
+pub mod frag_reuse_v2;
 pub mod mem_wal;
 pub mod prefilter;
 pub mod scalar;
@@ -1873,16 +1874,51 @@ impl DatasetIndexExt for Dataset {
 
     async fn load_indices(&self) -> Result<Arc<Vec<IndexMetadata>>> {
         let indices = load_all_indices(self).await?;
-        if indices.iter().all(index_is_usable) {
-            return Ok(indices);
+        if self.manifest.stable_partition_transitions.is_empty() {
+            if indices.iter().all(index_is_usable) {
+                return Ok(indices);
+            }
+            return Ok(Arc::new(
+                indices
+                    .iter()
+                    .filter(|index| index_is_usable(index))
+                    .cloned()
+                    .collect(),
+            ));
         }
-        Ok(Arc::new(
-            indices
-                .iter()
-                .filter(|idx| index_is_usable(idx))
-                .cloned()
-                .collect(),
-        ))
+        let mixed = frag_reuse_v2::MixedFragReuseIndex::open(self).await?;
+        let mut indices = indices
+            .iter()
+            .filter(|index| {
+                index_is_usable(index)
+                    && (index.name == FRAG_REUSE_INDEX_NAME
+                        || index
+                            .index_details
+                            .as_ref()
+                            .is_some_and(|details| details.type_url.ends_with("BTreeIndexDetails"))
+                        || !mixed.requires_partition_translation(index.fragment_bitmap.as_ref()))
+            })
+            .cloned()
+            .collect::<Vec<_>>();
+        let mut groups: HashMap<String, Vec<(usize, RoaringBitmap)>> = HashMap::new();
+        for (position, index) in indices.iter().enumerate() {
+            if let Some(provenance) = &index.fragment_bitmap {
+                groups
+                    .entry(index.name.clone())
+                    .or_default()
+                    .push((position, provenance.clone()));
+            }
+        }
+        for members in groups.into_values() {
+            let (positions, provenance): (Vec<_>, Vec<_>) = members.into_iter().unzip();
+            for (position, coverage) in positions
+                .into_iter()
+                .zip(mixed.segment_coverage(&provenance))
+            {
+                indices[position].fragment_bitmap = Some(coverage);
+            }
+        }
+        Ok(Arc::new(indices))
     }
 
     async fn merge_existing_index_segments(
@@ -2808,6 +2844,10 @@ pub(crate) async fn load_all_indices(dataset: &Dataset) -> Result<Arc<Vec<IndexM
         }
     }
 
+    if !dataset.manifest.stable_partition_transitions.is_empty() {
+        // Commits need stored provenance. Only query metadata derives current coverage.
+        return Ok(indices);
+    }
     if let Some(frag_reuse_index_meta) =
         indices.iter().find(|idx| idx.name == FRAG_REUSE_INDEX_NAME)
     {
@@ -3411,10 +3451,13 @@ impl DatasetIndexInternalExt for Dataset {
 
     async fn frag_reuse_index_uuid(&self) -> Option<Uuid> {
         if let Ok(indices) = self.load_indices().await {
-            indices
-                .iter()
-                .find(|idx| idx.name == FRAG_REUSE_INDEX_NAME)
-                .map(|idx| idx.uuid)
+            frag_reuse_v2::mixed_cache_id(
+                self,
+                indices
+                    .iter()
+                    .find(|idx| idx.name == FRAG_REUSE_INDEX_NAME)
+                    .map(|idx| idx.uuid),
+            )
         } else {
             None
         }

--- a/rust/lance/src/index/frag_reuse_v2.rs
+++ b/rust/lance/src/index/frag_reuse_v2.rs
@@ -1,0 +1,1697 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+//! Stable-partition commits and asynchronous translation through mixed FRI histories.
+
+use std::collections::{HashMap, VecDeque};
+use std::hash::{Hash, Hasher};
+use std::ops::Range;
+use std::pin::Pin;
+use std::sync::Arc;
+
+use arrow_array::cast::AsArray;
+use arrow_array::{Array, RecordBatch, UInt32Array, UInt64Array};
+use async_trait::async_trait;
+use futures::TryStreamExt;
+use lance_core::deepsize::{Context, DeepSizeOf};
+use lance_index::scalar::{IndexFile, IndexReader, IndexWriter};
+use lance_io::stream::{RecordBatchStream, RecordBatchStreamAdapter};
+
+use lance_core::utils::address::RowAddress;
+use lance_core::utils::stable_partition::CountsMatrix;
+use lance_core::{Error, Result};
+use lance_index::frag_reuse::row_map::RowMapReader;
+use lance_index::frag_reuse::{
+    CompactFragReuseIndex, FRAG_REUSE_INDEX_NAME, FragReuseIndexDetails, FragReuseVersion,
+};
+use lance_index::scalar::IndexStore;
+use lance_index::scalar::lance_format::LanceIndexStore;
+use lance_table::format::{Fragment, ROW_MAP_FILE_NAME, StablePartitionTransition};
+use lance_table::system_index::frag_reuse::FragDigest;
+use lance_table::transaction::{Operation, RewriteGroup, Transaction};
+use roaring::RoaringBitmap;
+use tokio::sync::OnceCell;
+use uuid::Uuid;
+
+use crate::Dataset;
+use crate::index::frag_reuse::load_frag_reuse_index_details;
+use crate::index::{DatasetIndexExt, DatasetIndexInternalExt};
+use lance_index::metrics::NoOpMetricsCollector;
+use lance_table::io::manifest::read_manifest_indexes;
+
+enum Mapping {
+    Ordered(CompactFragReuseIndex),
+    Partition {
+        transition: StablePartitionTransition,
+        store: Box<LanceIndexStore>,
+        reader: OnceCell<RowMapReader>,
+    },
+}
+
+struct Rewrite {
+    sources: RoaringBitmap,
+    destinations: RoaringBitmap,
+    mapping: Mapping,
+}
+
+/// A snapshot's V1 compactions and V2 stable partitions in fragment-lineage order.
+///
+/// Row-map labels are loaded only for requested blocks. Metadata does not need
+/// to pretend V1's builder version is its successful commit timestamp.
+pub struct MixedFragReuseIndex {
+    rewrites: Vec<Rewrite>,
+}
+
+impl DeepSizeOf for MixedFragReuseIndex {
+    fn deep_size_of_children(&self, context: &mut Context) -> usize {
+        self.rewrites.capacity() * std::mem::size_of::<Rewrite>()
+            + self
+                .rewrites
+                .iter()
+                .map(|rewrite| {
+                    rewrite.sources.serialized_size()
+                        + rewrite.destinations.serialized_size()
+                        + match &rewrite.mapping {
+                            Mapping::Ordered(mapping) => mapping.deep_size_of_children(context),
+                            Mapping::Partition {
+                                transition,
+                                store,
+                                reader,
+                            } => {
+                                transition.deep_size_of_children(context)
+                                    + store.deep_size_of_children(context)
+                                    + reader.get().map_or(0, |reader| {
+                                        reader.counts().num_blocks()
+                                            * reader.counts().num_destinations() as usize
+                                            * std::mem::size_of::<u32>()
+                                    })
+                            }
+                        }
+                })
+                .sum::<usize>()
+    }
+}
+
+impl MixedFragReuseIndex {
+    /// Load rewrite metadata, leaving stable-partition label files unopened.
+    pub async fn open(dataset: &Dataset) -> Result<Self> {
+        let mut rewrites = Vec::new();
+        let indices = read_manifest_indexes(
+            &dataset.object_store,
+            &dataset.manifest_location,
+            &dataset.manifest,
+        )
+        .await?;
+        if let Some(index) = indices
+            .iter()
+            .find(|index| index.name == FRAG_REUSE_INDEX_NAME)
+        {
+            let details = load_frag_reuse_index_details(dataset, index).await?;
+            for version in &details.versions {
+                for group in &version.groups {
+                    rewrites.push(Rewrite {
+                        sources: group.old_frags.iter().map(|f| f.id as u32).collect(),
+                        destinations: group.new_frags.iter().map(|f| f.id as u32).collect(),
+                        mapping: Mapping::Ordered(CompactFragReuseIndex::try_new(
+                            index.uuid,
+                            FragReuseIndexDetails {
+                                versions: vec![FragReuseVersion {
+                                    dataset_version: version.dataset_version,
+                                    groups: vec![group.clone()],
+                                }],
+                            },
+                        )?),
+                    });
+                }
+            }
+        }
+        for transition in dataset.manifest.stable_partition_transitions.iter() {
+            transition.validate()?;
+            if transition.committed_version <= transition.source_dataset_version
+                || transition.committed_version > dataset.manifest.version
+            {
+                return Err(Error::corrupt_file_named(
+                    "manifest",
+                    format!(
+                        "row map {} has invalid commit version {} for source {} and manifest {}",
+                        transition.row_map_id,
+                        transition.committed_version,
+                        transition.source_dataset_version,
+                        dataset.manifest.version,
+                    ),
+                ));
+            }
+            if transition.base_id.is_some() {
+                return Err(Error::not_supported(
+                    "mixed row-map reads from external storage bases are not implemented",
+                ));
+            }
+            let directory = dataset
+                .row_maps_dir()
+                .join(transition.row_map_id.to_string());
+            let cache = dataset.metadata_cache.file_metadata_cache(&directory);
+            let store =
+                LanceIndexStore::new(dataset.object_store.clone(), directory, Arc::new(cache))
+                    .with_file_sizes(HashMap::from([(
+                        ROW_MAP_FILE_NAME.to_string(),
+                        transition.row_map_size_bytes,
+                    )]));
+            rewrites.push(Rewrite {
+                sources: transition.source_ids(),
+                destinations: transition.destination_ids(),
+                mapping: Mapping::Partition {
+                    transition: transition.clone(),
+                    store: Box::new(store),
+                    reader: OnceCell::new(),
+                },
+            });
+        }
+        let order = rewrite_order(&rewrites)?;
+        let mut nodes: Vec<Option<Rewrite>> = rewrites.into_iter().map(Some).collect();
+        let mut rewrites = Vec::with_capacity(nodes.len());
+        for index in order {
+            if let Some(node) = nodes[index].take() {
+                rewrites.push(node);
+            }
+        }
+        Ok(Self { rewrites })
+    }
+
+    /// Derive conservative full-fragment coverage through both mapping kinds.
+    pub fn remap_fragment_bitmap(&self, coverage: &RoaringBitmap) -> RoaringBitmap {
+        let mut coverage = coverage.clone();
+        for rewrite in &self.rewrites {
+            let all = rewrite.sources.is_subset(&coverage);
+            coverage -= &rewrite.sources;
+            if all {
+                coverage |= &rewrite.destinations;
+            }
+        }
+        coverage
+    }
+
+    /// Derive each segment's probe coverage using the logical index's joint provenance.
+    ///
+    /// Derived bitmaps may overlap: all contributing segments must be searched.
+    /// A segment already naming a destination owns it directly, so translated
+    /// entries from older segments are excluded before predicate evaluation.
+    pub(crate) fn segment_coverage(&self, sources: &[RoaringBitmap]) -> Vec<RoaringBitmap> {
+        let mut coverage = sources.to_vec();
+        for rewrite in &self.rewrites {
+            let union = coverage
+                .iter()
+                .fold(RoaringBitmap::new(), |mut union, bitmap| {
+                    union |= bitmap;
+                    union
+                });
+            let complete = rewrite.sources.is_subset(&union);
+            let direct = &union & &rewrite.destinations;
+            for bitmap in &mut coverage {
+                let contributes = !bitmap.is_disjoint(&rewrite.sources);
+                *bitmap -= &rewrite.sources;
+                if complete && contributes {
+                    *bitmap |= &rewrite.destinations - &direct;
+                }
+            }
+        }
+        coverage
+    }
+
+    fn direct_coverage(&self, coverage: &RoaringBitmap) -> RoaringBitmap {
+        let mut coverage = coverage.clone();
+        for rewrite in &self.rewrites {
+            let complete = rewrite.sources.is_subset(&coverage);
+            coverage -= &rewrite.sources;
+            if complete && matches!(rewrite.mapping, Mapping::Ordered(_)) {
+                coverage |= &rewrite.destinations;
+            }
+        }
+        coverage
+    }
+
+    /// Whether this index's stored addresses need a stable-partition mapping.
+    pub(crate) fn requires_partition_translation(&self, coverage: Option<&RoaringBitmap>) -> bool {
+        let Some(coverage) = coverage else {
+            return true;
+        };
+        let mut coverage = coverage.clone();
+        for rewrite in &self.rewrites {
+            if !rewrite.sources.is_disjoint(&coverage)
+                && matches!(rewrite.mapping, Mapping::Partition { .. })
+            {
+                return true;
+            }
+            let affected = !rewrite.sources.is_disjoint(&coverage);
+            coverage -= &rewrite.sources;
+            if affected {
+                coverage |= &rewrite.destinations;
+            }
+        }
+        false
+    }
+
+    /// Translate physical addresses, preserving input order and deleted positions.
+    ///
+    /// Deletions that happened after the last rewrite must still be checked in
+    /// the target snapshot's deletion vectors before returning query results.
+    pub async fn translate(&self, addresses: &[RowAddress]) -> Result<Vec<Option<RowAddress>>> {
+        let mut translated: Vec<Option<RowAddress>> = addresses.iter().copied().map(Some).collect();
+        for rewrite in &self.rewrites {
+            match &rewrite.mapping {
+                Mapping::Ordered(mapping) => {
+                    for address in &mut translated {
+                        if let Some(current) = *address {
+                            *address = mapping.remap_row_id(current.into()).map(RowAddress::from);
+                        }
+                    }
+                }
+                Mapping::Partition {
+                    transition,
+                    store,
+                    reader,
+                } => {
+                    let mut base = 0u64;
+                    let sources: HashMap<u32, (u64, usize)> = transition
+                        .sources
+                        .iter()
+                        .map(|source| {
+                            let start = base;
+                            base += source.physical_rows as u64;
+                            (source.id as u32, (start, source.physical_rows))
+                        })
+                        .collect();
+                    let mut requests = Vec::new();
+                    for (position, address) in translated.iter().enumerate() {
+                        let Some(address) = address else { continue };
+                        let Some(&(start, rows)) = sources.get(&address.fragment_id()) else {
+                            continue;
+                        };
+                        if address.row_offset() as usize >= rows {
+                            return Err(Error::invalid_input(format!(
+                                "row offset {} exceeds source fragment {} length {rows}",
+                                address.row_offset(),
+                                address.fragment_id(),
+                            )));
+                        }
+                        requests.push((start + u64::from(address.row_offset()), position));
+                    }
+                    if requests.is_empty() {
+                        continue;
+                    }
+                    let reader = reader
+                        .get_or_try_init(|| async {
+                            let reader =
+                                RowMapReader::open(store.open_index_file(ROW_MAP_FILE_NAME).await?)
+                                    .await?;
+                            validate_counts(transition, reader.counts())?;
+                            Ok::<_, Error>(reader)
+                        })
+                        .await?;
+                    // Limit scattered index pages to sixteen logical label blocks
+                    // per read, instead of materializing every touched block at once.
+                    requests.sort_unstable_by_key(|&(row, _)| row);
+                    let block_rows = u64::from(reader.counts().block_rows());
+                    let mut remaining = requests.as_slice();
+                    while let Some(&(first_row, _)) = remaining.first() {
+                        let first_block = first_row / block_rows;
+                        let count = remaining
+                            .partition_point(|&(row, _)| row / block_rows - first_block < 16);
+                        let (batch, rest) = remaining.split_at(count);
+                        let source_rows = batch.iter().map(|&(row, _)| row).collect::<Vec<_>>();
+                        for (&(_, position), address) in
+                            batch.iter().zip(reader.translate_many(&source_rows).await?)
+                        {
+                            translated[position] = address.map(|(label, offset)| {
+                                RowAddress::new_from_parts(
+                                    transition.destinations[usize::from(label)].id as u32,
+                                    offset,
+                                )
+                            });
+                        }
+                        remaining = rest;
+                    }
+                }
+            }
+        }
+        Ok(translated)
+    }
+}
+
+fn rewrite_order(rewrites: &[Rewrite]) -> Result<Vec<usize>> {
+    let mut consumers = HashMap::new();
+    let mut produced = RoaringBitmap::new();
+    for (index, rewrite) in rewrites.iter().enumerate() {
+        for source in &rewrite.sources {
+            if consumers.insert(source, index).is_some() {
+                return Err(Error::invalid_input(format!(
+                    "fragment {source} is consumed by multiple rewrites"
+                )));
+            }
+        }
+        for destination in &rewrite.destinations {
+            if !produced.insert(destination) {
+                return Err(Error::invalid_input(format!(
+                    "fragment {destination} is produced by multiple rewrites"
+                )));
+            }
+        }
+    }
+    let mut successors = vec![RoaringBitmap::new(); rewrites.len()];
+    let mut incoming = vec![0usize; rewrites.len()];
+    for (index, rewrite) in rewrites.iter().enumerate() {
+        for destination in &rewrite.destinations {
+            if let Some(&next) = consumers.get(&destination)
+                && successors[index].insert(next as u32)
+            {
+                incoming[next] += 1;
+            }
+        }
+    }
+    let mut ready: VecDeque<usize> = incoming
+        .iter()
+        .enumerate()
+        .filter_map(|(i, &n)| (n == 0).then_some(i))
+        .collect();
+    let mut order = Vec::with_capacity(rewrites.len());
+    while let Some(index) = ready.pop_front() {
+        order.push(index);
+        for next in &successors[index] {
+            incoming[next as usize] -= 1;
+            if incoming[next as usize] == 0 {
+                ready.push_back(next as usize);
+            }
+        }
+    }
+    if order.len() != rewrites.len() {
+        return Err(Error::invalid_input("cycle in fragment rewrite history"));
+    }
+    Ok(order)
+}
+
+fn validate_counts(transition: &StablePartitionTransition, counts: &CountsMatrix) -> Result<()> {
+    let physical: u64 = transition
+        .sources
+        .iter()
+        .map(|f| f.physical_rows as u64)
+        .sum();
+    if counts.total_rows() != physical
+        || counts.num_destinations() as usize != transition.destinations.len()
+    {
+        return Err(Error::invalid_input(
+            "row-map source or destination dimensions differ from transition metadata",
+        ));
+    }
+    for (label, destination) in transition.destinations.iter().enumerate() {
+        if u64::from(counts.total(label as u16)) != destination.physical_rows as u64 {
+            return Err(Error::invalid_input(format!(
+                "row-map label {label} count differs from destination {} row count",
+                destination.id
+            )));
+        }
+    }
+    Ok(())
+}
+
+pub(crate) fn mixed_cache_id(dataset: &Dataset, v1: Option<Uuid>) -> Option<Uuid> {
+    if dataset.manifest.stable_partition_transitions.is_empty() {
+        return v1;
+    }
+    let mut hash = std::collections::hash_map::DefaultHasher::new();
+    dataset.uri().hash(&mut hash);
+    dataset.manifest_location.path.hash(&mut hash);
+    dataset.manifest_location.e_tag.hash(&mut hash);
+    v1.hash(&mut hash);
+    for t in dataset.manifest.stable_partition_transitions.iter() {
+        t.row_map_id.hash(&mut hash);
+    }
+    Some(Uuid::from_u128(
+        (u128::from(hash.finish()) << 64) | u128::from(dataset.manifest.version),
+    ))
+}
+
+/// B-tree decode adapter. Translates bounded batches before the scalar index
+/// evaluates predicates, preserving lazy row-map I/O and current coverage.
+#[derive(Clone)]
+pub(crate) struct TranslatedIndexStore {
+    inner: Arc<dyn IndexStore>,
+    mapping: Arc<MixedFragReuseIndex>,
+    coverage: RoaringBitmap,
+}
+
+impl std::fmt::Debug for TranslatedIndexStore {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("TranslatedIndexStore")
+            .field("inner", &self.inner)
+            .finish_non_exhaustive()
+    }
+}
+
+impl DeepSizeOf for TranslatedIndexStore {
+    fn deep_size_of_children(&self, context: &mut Context) -> usize {
+        self.inner.deep_size_of_children(context)
+            + self.mapping.deep_size_of_children(context)
+            + self.coverage.serialized_size()
+    }
+}
+
+impl TranslatedIndexStore {
+    pub(crate) async fn new(
+        dataset: &Dataset,
+        inner: Arc<dyn IndexStore>,
+        coverage: RoaringBitmap,
+    ) -> Result<Self> {
+        Ok(Self {
+            inner,
+            mapping: Arc::new(MixedFragReuseIndex::open(dataset).await?),
+            coverage,
+        })
+    }
+}
+
+#[async_trait]
+impl IndexStore for TranslatedIndexStore {
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+    fn clone_arc(&self) -> Arc<dyn IndexStore> {
+        Arc::new(self.clone())
+    }
+    fn io_parallelism(&self) -> usize {
+        self.inner.io_parallelism()
+    }
+    async fn new_index_file(
+        &self,
+        name: &str,
+        schema: Arc<arrow_schema::Schema>,
+    ) -> Result<Box<dyn IndexWriter>> {
+        self.inner.new_index_file(name, schema).await
+    }
+    async fn open_index_file(&self, name: &str) -> Result<Arc<dyn IndexReader>> {
+        Ok(Arc::new(TranslatedIndexReader {
+            inner: self.inner.open_index_file(name).await?,
+            mapping: self.mapping.clone(),
+            coverage: self.coverage.clone(),
+        }))
+    }
+    fn with_io_priority(&self, priority: u64) -> Arc<dyn IndexStore> {
+        Arc::new(Self {
+            inner: self.inner.with_io_priority(priority),
+            ..self.clone()
+        })
+    }
+    async fn copy_index_file(
+        &self,
+        name: &str,
+        _destination: &dyn IndexStore,
+    ) -> Result<IndexFile> {
+        Err(Error::not_supported(format!(
+            "copying translated B-tree file {name} requires rebuilding its page lookup"
+        )))
+    }
+
+    async fn rename_index_file(&self, name: &str, new_name: &str) -> Result<IndexFile> {
+        self.inner.rename_index_file(name, new_name).await
+    }
+    async fn delete_index_file(&self, name: &str) -> Result<()> {
+        self.inner.delete_index_file(name).await
+    }
+    async fn list_files_with_sizes(&self) -> Result<Vec<IndexFile>> {
+        self.inner.list_files_with_sizes().await
+    }
+}
+
+#[derive(Clone)]
+struct TranslatedIndexReader {
+    inner: Arc<dyn IndexReader>,
+    mapping: Arc<MixedFragReuseIndex>,
+    coverage: RoaringBitmap,
+}
+
+impl TranslatedIndexReader {
+    async fn translate(&self, batch: RecordBatch) -> Result<RecordBatch> {
+        let Ok(column) = batch.schema().index_of("ids") else {
+            return Ok(batch);
+        };
+        // B-tree page files store physical row addresses in the `ids` column.
+        let ids = batch
+            .column_by_name("ids")
+            .ok_or_else(|| Error::invalid_input("B-tree page is missing its ids column"))?
+            .as_primitive_opt::<arrow_array::types::UInt64Type>()
+            .ok_or_else(|| Error::invalid_input("B-tree row addresses must be UInt64"))?;
+        let addresses: Vec<RowAddress> =
+            ids.values().iter().copied().map(RowAddress::from).collect();
+        let translated = self.mapping.translate(&addresses).await?;
+        let mut positions = Vec::with_capacity(batch.num_rows());
+        let mut addresses = Vec::with_capacity(batch.num_rows());
+        for (position, address) in translated.into_iter().enumerate() {
+            if ids.is_valid(position)
+                && let Some(address) = address
+                && self.coverage.contains(address.fragment_id())
+            {
+                positions.push(position as u32);
+                addresses.push(u64::from(address));
+            }
+        }
+        let positions = UInt32Array::from(positions);
+        let mut columns = batch
+            .columns()
+            .iter()
+            .map(|array| arrow::compute::take(array, &positions, None))
+            .collect::<std::result::Result<Vec<_>, _>>()?;
+        columns[column] = Arc::new(UInt64Array::from(addresses));
+        Ok(RecordBatch::try_new(batch.schema(), columns)?)
+    }
+}
+
+#[async_trait]
+impl IndexReader for TranslatedIndexReader {
+    async fn read_record_batch(&self, n: u64, batch_size: u64) -> Result<RecordBatch> {
+        self.translate(self.inner.read_record_batch(n, batch_size).await?)
+            .await
+    }
+    async fn read_range(
+        &self,
+        range: Range<usize>,
+        projection: Option<&[&str]>,
+    ) -> Result<RecordBatch> {
+        self.translate(self.inner.read_range(range, projection).await?)
+            .await
+    }
+    async fn read_range_stream(
+        &self,
+        range: Range<usize>,
+        projection: Option<&[&str]>,
+    ) -> Result<Pin<Box<dyn RecordBatchStream>>> {
+        let stream = self.inner.read_range_stream(range, projection).await?;
+        let schema = stream.schema();
+        let reader = self.clone();
+        let stream = stream.and_then(move |batch| {
+            let reader = reader.clone();
+            async move { reader.translate(batch).await }
+        });
+        Ok(Box::pin(RecordBatchStreamAdapter::new(schema, stream)))
+    }
+    async fn read_global_buffer(&self, index: u32) -> Result<bytes::Bytes> {
+        self.inner.read_global_buffer(index).await
+    }
+    async fn num_batches(&self, batch_size: u64) -> u32 {
+        self.inner.num_batches(batch_size).await
+    }
+    fn num_rows(&self) -> usize {
+        self.inner.num_rows()
+    }
+    fn schema(&self) -> &lance_core::datatypes::Schema {
+        self.inner.schema()
+    }
+    fn file_size_bytes(&self) -> Option<u64> {
+        self.inner.file_size_bytes()
+    }
+}
+
+/// Remap nullable physical row addresses through the retained V1/V2 history.
+///
+/// Returns `None` when no mapping history exists. Input NULLs and rows dropped
+/// by a rewrite remain NULL; addresses outside retained history pass through.
+/// Current deletion vectors must still be applied by the caller.
+///
+/// ```
+/// # use lance::{Dataset, Result};
+/// # use arrow_array::UInt64Array;
+/// # use lance::index::frag_reuse_v2::remap_row_addrs;
+/// # async fn remap(dataset: &Dataset, addresses: UInt64Array) -> Result<()> {
+/// let translated = remap_row_addrs(dataset, &addresses).await?;
+/// # Ok(())
+/// # }
+/// ```
+pub async fn remap_row_addrs(
+    dataset: &Dataset,
+    addresses: &UInt64Array,
+) -> Result<Option<UInt64Array>> {
+    if dataset.manifest.stable_partition_transitions.is_empty() {
+        let index = dataset.open_frag_reuse_index(&NoOpMetricsCollector).await?;
+        return Ok(index.map(|index| index.remap_row_ids_array(Arc::new(addresses.clone()))));
+    }
+    let (positions, inputs): (Vec<usize>, Vec<RowAddress>) = addresses
+        .iter()
+        .enumerate()
+        .filter_map(|(position, value)| value.map(|value| (position, RowAddress::from(value))))
+        .unzip();
+    let mapping = MixedFragReuseIndex::open(dataset).await?;
+    let translated = mapping.translate(&inputs).await?;
+    let mut output = vec![None; addresses.len()];
+    for (position, address) in positions.into_iter().zip(translated) {
+        output[position] = address.map(u64::from);
+    }
+    Ok(Some(UInt64Array::from(output)))
+}
+
+/// Admission policy for sources that are not fully covered by an existing index.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum StablePartitionCoverage {
+    /// Reject a rewrite that would leave destinations uncovered by an existing index.
+    #[default]
+    RequireFull,
+    /// Explicitly accept scanning destinations for indices with incomplete coverage.
+    AllowUnindexed,
+}
+
+/// Reject another stable partition while a source still needs translated index entries.
+/// This also follows V1 compactions of unresolved destinations.
+pub(crate) async fn validate_partition_sources(
+    dataset: &Dataset,
+    operation: &Operation,
+) -> Result<()> {
+    let Operation::Rewrite {
+        stable_partition: Some(transition),
+        ..
+    } = operation
+    else {
+        return Ok(());
+    };
+    let mapping = MixedFragReuseIndex::open(dataset).await?;
+    let indices = read_manifest_indexes(
+        &dataset.object_store,
+        &dataset.manifest_location,
+        &dataset.manifest,
+    )
+    .await?;
+    let mut provenance: HashMap<&str, RoaringBitmap> = HashMap::new();
+    for index in &indices {
+        if index.name != FRAG_REUSE_INDEX_NAME
+            && let Some(bitmap) = &index.fragment_bitmap
+        {
+            *provenance.entry(&index.name).or_default() |= bitmap;
+        }
+    }
+    for (name, bitmap) in provenance {
+        let unresolved = mapping.remap_fragment_bitmap(&bitmap) - mapping.direct_coverage(&bitmap);
+        let affected = &unresolved & transition.source_ids();
+        if !affected.is_empty() {
+            return Err(Error::invalid_input(format!(
+                "stable partition sources {:?} still require translated entries from index '{name}'; rebuild their indices before repartitioning",
+                affected.iter().collect::<Vec<_>>()
+            )));
+        }
+    }
+    Ok(())
+}
+
+/// Commit a prepared stable partition and its immutable row map atomically.
+///
+/// Write `row_map.lance` under `_row_maps/<row_map_id>` using `RowMapWriter`
+/// first. Sources must be from this dataset snapshot, destinations must have
+/// reserved IDs, and their rows must match the stable-partition label order.
+///
+/// ```
+/// # use lance::{Dataset, Result};
+/// # use lance::index::frag_reuse_v2::{commit_stable_partition, StablePartitionCoverage};
+/// # use lance_table::format::Fragment;
+/// # use uuid::Uuid;
+/// # async fn install(dataset: &mut Dataset, sources: Vec<Fragment>, destinations: Vec<Fragment>,
+/// #                  row_map_id: Uuid, file_size: u64) -> Result<()> {
+/// commit_stable_partition(dataset, sources, destinations, row_map_id, file_size, StablePartitionCoverage::RequireFull).await
+/// # }
+/// ```
+pub async fn commit_stable_partition(
+    dataset: &mut Dataset,
+    sources: Vec<Fragment>,
+    destinations: Vec<Fragment>,
+    row_map_id: Uuid,
+    row_map_size_bytes: u64,
+    coverage: StablePartitionCoverage,
+) -> Result<()> {
+    if coverage == StablePartitionCoverage::RequireFull {
+        let mut indexed: HashMap<String, RoaringBitmap> = HashMap::new();
+        for index in dataset.load_indices().await?.iter() {
+            if index.name != FRAG_REUSE_INDEX_NAME {
+                *indexed.entry(index.name.clone()).or_default() |=
+                    index.fragment_bitmap.clone().unwrap_or_default();
+            }
+        }
+        // Include affected unsupported indices: hiding them from queries must not
+        // turn a request to preserve their coverage into implicit permission to scan.
+        for index in read_manifest_indexes(
+            &dataset.object_store,
+            &dataset.manifest_location,
+            &dataset.manifest,
+        )
+        .await?
+        {
+            if index.name != FRAG_REUSE_INDEX_NAME {
+                indexed.entry(index.name).or_default();
+            }
+        }
+        let source_ids: RoaringBitmap = sources.iter().map(|fragment| fragment.id as u32).collect();
+        for (name, bitmap) in indexed {
+            if !source_ids.is_subset(&bitmap) {
+                return Err(Error::invalid_input(format!(
+                    "index '{name}' does not cover every stable-partition source; use StablePartitionCoverage::AllowUnindexed to accept scan fallback"
+                )));
+            }
+        }
+    }
+    let digest = |fragment: &Fragment| -> Result<FragDigest> {
+        if fragment
+            .deletion_file
+            .as_ref()
+            .is_some_and(|file| file.num_deleted_rows.is_none())
+        {
+            return Err(Error::invalid_input(format!(
+                "fragment {} is missing its deleted row count",
+                fragment.id,
+            )));
+        }
+        Ok(FragDigest {
+            id: fragment.id,
+            physical_rows: fragment.physical_rows.ok_or_else(|| {
+                Error::invalid_input(format!(
+                    "fragment {} has no physical row count",
+                    fragment.id
+                ))
+            })?,
+            num_deleted_rows: fragment
+                .deletion_file
+                .as_ref()
+                .and_then(|d| d.num_deleted_rows)
+                .unwrap_or(0),
+        })
+    };
+    let transition = StablePartitionTransition {
+        source_dataset_version: dataset.manifest.version,
+        sources: sources.iter().map(digest).collect::<Result<_>>()?,
+        destinations: destinations.iter().map(digest).collect::<Result<_>>()?,
+        row_map_id,
+        row_map_size_bytes,
+        base_id: None,
+        committed_version: 0,
+    };
+    transition.validate()?;
+    let store = LanceIndexStore::new(
+        dataset.object_store.clone(),
+        dataset.row_maps_dir().join(row_map_id.to_string()),
+        Arc::new(lance_core::cache::LanceCache::with_capacity(1024 * 1024)),
+    );
+    let file = store.open_index_file(ROW_MAP_FILE_NAME).await?;
+    if file
+        .file_size_bytes()
+        .is_some_and(|size| size != row_map_size_bytes)
+    {
+        return Err(Error::invalid_input(format!(
+            "row map {row_map_id} file size {:?} differs from declared size {row_map_size_bytes}",
+            file.file_size_bytes()
+        )));
+    }
+    let reader = RowMapReader::open(file).await?;
+    validate_counts(&transition, reader.counts())?;
+    let transaction = Transaction::new(
+        dataset.manifest.version,
+        Operation::Rewrite {
+            groups: vec![RewriteGroup {
+                old_fragments: sources,
+                new_fragments: destinations,
+            }],
+            rewritten_indices: Vec::new(),
+            frag_reuse_index: None,
+            stable_partition: Some(Box::new(transition)),
+        },
+        None,
+    );
+    dataset
+        .apply_commit(transaction, &Default::default(), &Default::default())
+        .await?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::dataset::cleanup::{CleanupPolicyBuilder, cleanup_old_versions};
+    use crate::dataset::index::frag_reuse::cleanup_frag_reuse_index;
+    use crate::dataset::optimize::{CompactionOptions, compact_files};
+    use crate::dataset::{InsertBuilder, WriteMode, WriteParams};
+    use crate::index::DatasetIndexExt;
+    use crate::utils::test::{DatagenExt, FragmentCount, FragmentRowCount};
+    use arrow_array::types::Int32Type;
+    use lance_index::IndexType;
+    use lance_index::frag_reuse::row_map::{RowMapWriter, SourceRows};
+    use lance_index::scalar::ScalarIndexParams;
+
+    async fn prepare(dataset: &mut Dataset) -> (Vec<Fragment>, Vec<Fragment>, Uuid, u64) {
+        prepare_sources(dataset, dataset.fragments().to_vec()).await
+    }
+
+    async fn prepare_sources(
+        dataset: &mut Dataset,
+        sources: Vec<Fragment>,
+    ) -> (Vec<Fragment>, Vec<Fragment>, Uuid, u64) {
+        let batch = dataset
+            .scan()
+            .with_fragments(sources.clone())
+            .try_into_batch()
+            .await
+            .unwrap();
+        let values = batch["i"].as_primitive::<Int32Type>();
+        let labels: Vec<u16> = values.iter().map(|v| (v.unwrap_or(0) % 2) as u16).collect();
+        let mut destinations = Vec::new();
+        for label in 0..2 {
+            let positions = UInt32Array::from(
+                labels
+                    .iter()
+                    .enumerate()
+                    .filter_map(|(position, &destination)| {
+                        (destination == label).then_some(position as u32)
+                    })
+                    .collect::<Vec<_>>(),
+            );
+            let batch = RecordBatch::try_new(
+                batch.schema(),
+                vec![arrow::compute::take(values, &positions, None).unwrap()],
+            )
+            .unwrap();
+            let transaction = InsertBuilder::new(Arc::new(dataset.clone()))
+                .with_params(&WriteParams {
+                    mode: WriteMode::Append,
+                    ..Default::default()
+                })
+                .execute_uncommitted(vec![batch])
+                .await
+                .unwrap();
+            let Operation::Append { fragments } = transaction.operation else {
+                panic!("expected append")
+            };
+            destinations.extend(fragments);
+        }
+        dataset
+            .apply_commit(
+                Transaction::new(
+                    dataset.manifest.version,
+                    Operation::ReserveFragments {
+                        num_fragments: destinations.len() as u32,
+                    },
+                    None,
+                ),
+                &Default::default(),
+                &Default::default(),
+            )
+            .await
+            .unwrap();
+        let first = dataset.manifest.max_fragment_id.unwrap() + 1 - destinations.len() as u32;
+        for (i, destination) in destinations.iter_mut().enumerate() {
+            destination.id = u64::from(first) + i as u64;
+        }
+        let mut source_rows = Vec::new();
+        for source in &sources {
+            let fragment = dataset.get_fragment(source.id as usize).unwrap();
+            let deleted = fragment
+                .get_deletion_vector()
+                .await
+                .unwrap()
+                .map(|v| v.iter().collect());
+            source_rows.push(SourceRows {
+                physical_rows: fragment.metadata().physical_rows.unwrap() as u64,
+                deleted,
+            });
+        }
+        let id = Uuid::new_v4();
+        let store = LanceIndexStore::with_format_version(
+            dataset.object_store.clone(),
+            dataset.row_maps_dir().join(id.to_string()),
+            Arc::new(lance_core::cache::LanceCache::with_capacity(1024 * 1024)),
+            lance_file::version::ConcreteFileVersion::V2_1,
+        );
+        let writer = store
+            .new_index_file(ROW_MAP_FILE_NAME, RowMapWriter::schema())
+            .await
+            .unwrap();
+        let mut writer = RowMapWriter::try_new_with_block_rows(writer, source_rows, 2, 1).unwrap();
+        writer.append_labels(&labels).await.unwrap();
+        let (file, _) = writer.finish().await.unwrap();
+        (sources, destinations, id, file.size_bytes)
+    }
+
+    async fn dataset() -> Dataset {
+        let mut dataset = lance_datagen::gen_batch()
+            .col("i", lance_datagen::array::step::<Int32Type>())
+            .into_ram_dataset(FragmentCount::from(4), FragmentRowCount::from(4))
+            .await
+            .unwrap();
+        // The generated values are already sorted. Avoid making tiny test
+        // fixtures compete for DataFusion's shared sort-spill reservations.
+        let batch = dataset
+            .scan()
+            .with_row_id()
+            .project_with_transform(&[("value", "i")])
+            .unwrap()
+            .try_into_batch()
+            .await
+            .unwrap();
+        let reader = arrow_array::RecordBatchIterator::new(vec![Ok(batch.clone())], batch.schema());
+        let params = ScalarIndexParams::default();
+        let index = crate::index::create::CreateIndexBuilder::new(
+            &mut dataset,
+            &["i"],
+            IndexType::BTree,
+            &params,
+        )
+        .name("i_idx".to_string())
+        .preprocessed_data(Box::new(reader))
+        .execute_uncommitted()
+        .await
+        .unwrap();
+        dataset
+            .apply_commit(
+                Transaction::new(
+                    dataset.manifest.version,
+                    Operation::CreateIndex {
+                        new_indices: vec![index],
+                        removed_indices: Vec::new(),
+                    },
+                    None,
+                ),
+                &Default::default(),
+                &Default::default(),
+            )
+            .await
+            .unwrap();
+        dataset
+    }
+
+    #[rstest::rstest]
+    #[case::deferred(true)]
+    #[case::eager(false)]
+    #[tokio::test]
+    async fn mixed_rewrites_preserve_rows_and_index_queries(#[case] deferred: bool) {
+        let mut dataset = dataset().await;
+        let original = dataset
+            .scan()
+            .with_row_address()
+            .try_into_batch()
+            .await
+            .unwrap();
+        let original_addresses: Vec<RowAddress> = original[lance_core::ROW_ADDR]
+            .as_primitive::<arrow_array::types::UInt64Type>()
+            .values()
+            .iter()
+            .copied()
+            .map(RowAddress::from)
+            .collect();
+        compact_files(
+            &mut dataset,
+            CompactionOptions {
+                target_rows_per_fragment: 8,
+                defer_index_remap: true,
+                ..Default::default()
+            },
+            None,
+        )
+        .await
+        .unwrap();
+        dataset.delete("i = 3").await.unwrap();
+        let (sources, destinations, id, size) = prepare(&mut dataset).await;
+        commit_stable_partition(
+            &mut dataset,
+            sources,
+            destinations,
+            id,
+            size,
+            StablePartitionCoverage::RequireFull,
+        )
+        .await
+        .unwrap();
+        assert_eq!(dataset.manifest.stable_partition_transitions.len(), 1);
+        let index = dataset.load_index_by_name("i_idx").await.unwrap().unwrap();
+        assert_eq!(
+            index.fragment_bitmap.as_ref().unwrap(),
+            dataset.fragment_bitmap.as_ref()
+        );
+        let plan = dataset
+            .scan()
+            .filter("i = 2")
+            .unwrap()
+            .explain_plan(false)
+            .await
+            .unwrap();
+        assert!(plan.contains("ScalarIndexQuery"), "{plan}");
+        for value in [0, 2, 3, 8, 15] {
+            assert_eq!(
+                dataset
+                    .count_rows(Some(format!("i = {value}")))
+                    .await
+                    .unwrap(),
+                usize::from(value != 3)
+            );
+        }
+        dataset.delete("i = 8").await.unwrap();
+        compact_files(
+            &mut dataset,
+            CompactionOptions {
+                target_rows_per_fragment: 32,
+                defer_index_remap: deferred,
+                ..Default::default()
+            },
+            None,
+        )
+        .await
+        .unwrap();
+        let mapping = MixedFragReuseIndex::open(&dataset).await.unwrap();
+        let translated = mapping.translate(&original_addresses).await.unwrap();
+        let nullable = UInt64Array::from(vec![
+            Some(u64::from(original_addresses[0])),
+            None,
+            Some(u64::from(original_addresses[3])),
+        ]);
+        assert_eq!(
+            remap_row_addrs(&dataset, &nullable).await.unwrap().unwrap(),
+            UInt64Array::from(vec![
+                translated[0].map(u64::from),
+                None,
+                translated[3].map(u64::from)
+            ])
+        );
+        let current = dataset
+            .scan()
+            .with_row_address()
+            .try_into_batch()
+            .await
+            .unwrap();
+        let values = current["i"].as_primitive::<Int32Type>();
+        let current_addresses =
+            current[lance_core::ROW_ADDR].as_primitive::<arrow_array::types::UInt64Type>();
+        let actual: HashMap<i32, u64> = values
+            .values()
+            .iter()
+            .copied()
+            .zip(current_addresses.values().iter().copied())
+            .collect();
+        for (value, translated) in translated.iter().enumerate() {
+            assert_eq!(
+                translated.map(u64::from),
+                actual.get(&(value as i32)).copied()
+            );
+        }
+        assert_eq!(dataset.count_rows(Some("i >= 0".into())).await.unwrap(), 14);
+        let versions = load_frag_reuse_index_details(
+            &dataset,
+            &dataset
+                .load_index_by_name(FRAG_REUSE_INDEX_NAME)
+                .await
+                .unwrap()
+                .unwrap(),
+        )
+        .await
+        .unwrap()
+        .versions
+        .len();
+        cleanup_frag_reuse_index(&mut dataset).await.unwrap();
+        assert_eq!(
+            load_frag_reuse_index_details(
+                &dataset,
+                &dataset
+                    .load_index_by_name(FRAG_REUSE_INDEX_NAME)
+                    .await
+                    .unwrap()
+                    .unwrap()
+            )
+            .await
+            .unwrap()
+            .versions
+            .len(),
+            versions
+        );
+        cleanup_old_versions(
+            &dataset,
+            CleanupPolicyBuilder::default()
+                .delete_unverified(true)
+                .build(),
+        )
+        .await
+        .unwrap();
+        let reopened = dataset
+            .checkout_version(dataset.manifest.version)
+            .await
+            .unwrap();
+        assert_eq!(
+            MixedFragReuseIndex::open(&reopened)
+                .await
+                .unwrap()
+                .translate(&original_addresses)
+                .await
+                .unwrap(),
+            translated
+        );
+        assert_eq!(reopened.count_rows(Some("i = 15".into())).await.unwrap(), 1);
+    }
+
+    #[tokio::test]
+    async fn segmented_coverage_and_direct_destinations() {
+        let mut dataset = dataset().await;
+        dataset.drop_index("i_idx").await.unwrap();
+        let params = ScalarIndexParams::default();
+        let mut segments = Vec::new();
+        for fragments in [vec![0, 1], vec![2, 3]] {
+            let sources = dataset
+                .fragments()
+                .iter()
+                .filter(|fragment| fragments.contains(&(fragment.id as u32)))
+                .cloned()
+                .collect();
+            let batch = dataset
+                .scan()
+                .with_fragments(sources)
+                .with_row_id()
+                .project_with_transform(&[("value", "i")])
+                .unwrap()
+                .try_into_batch()
+                .await
+                .unwrap();
+            let reader =
+                arrow_array::RecordBatchIterator::new(vec![Ok(batch.clone())], batch.schema());
+            segments.push(
+                dataset
+                    .create_index_builder(&["i"], IndexType::BTree, &params)
+                    .name("i_idx".to_string())
+                    .fragments(fragments)
+                    .preprocessed_data(Box::new(reader))
+                    .execute_uncommitted()
+                    .await
+                    .unwrap(),
+            );
+        }
+        dataset
+            .commit_existing_index_segments("i_idx", "i", segments)
+            .await
+            .unwrap();
+        let original = dataset.load_indices_by_name("i_idx").await.unwrap();
+        let (sources, destinations, id, size) = prepare(&mut dataset).await;
+        commit_stable_partition(
+            &mut dataset,
+            sources,
+            destinations,
+            id,
+            size,
+            StablePartitionCoverage::RequireFull,
+        )
+        .await
+        .unwrap();
+        let derived = dataset.load_indices_by_name("i_idx").await.unwrap();
+        assert_eq!(derived.len(), 2);
+        for segment in &derived {
+            assert_eq!(
+                segment.fragment_bitmap.as_ref().unwrap(),
+                dataset.fragment_bitmap.as_ref()
+            );
+        }
+        for value in 0..16 {
+            assert_eq!(
+                dataset
+                    .count_rows(Some(format!("i = {value}")))
+                    .await
+                    .unwrap(),
+                1
+            );
+        }
+        let plan = dataset
+            .scan()
+            .filter("i = 2")
+            .unwrap()
+            .explain_plan(false)
+            .await
+            .unwrap();
+        assert!(plan.contains("ScalarIndexQuery"), "{plan}");
+        let persisted = read_manifest_indexes(
+            &dataset.object_store,
+            &dataset.manifest_location,
+            &dataset.manifest,
+        )
+        .await
+        .unwrap();
+        for segment in &original {
+            assert_eq!(
+                persisted
+                    .iter()
+                    .find(|index| index.uuid == segment.uuid)
+                    .unwrap()
+                    .fragment_bitmap,
+                segment.fragment_bitmap
+            );
+        }
+        let destination = dataset.fragments()[0].clone();
+        let batch = dataset
+            .scan()
+            .with_fragments(vec![destination.clone()])
+            .with_row_id()
+            .project_with_transform(&[("value", "i")])
+            .unwrap()
+            .try_into_batch()
+            .await
+            .unwrap();
+        let reader = arrow_array::RecordBatchIterator::new(vec![Ok(batch.clone())], batch.schema());
+        let direct = dataset
+            .create_index_builder(&["i"], IndexType::BTree, &params)
+            .name("i_idx".to_string())
+            .replace(true)
+            .fragments(vec![destination.id as u32])
+            .preprocessed_data(Box::new(reader))
+            .execute_uncommitted()
+            .await
+            .unwrap();
+        dataset
+            .apply_commit(
+                Transaction::new(
+                    dataset.manifest.version,
+                    Operation::CreateIndex {
+                        new_indices: vec![direct],
+                        removed_indices: vec![],
+                    },
+                    None,
+                ),
+                &Default::default(),
+                &Default::default(),
+            )
+            .await
+            .unwrap();
+        let segments = dataset.load_indices_by_name("i_idx").await.unwrap();
+        assert_eq!(segments.len(), 3);
+        for segment in &segments {
+            if original.iter().any(|old| old.uuid == segment.uuid) {
+                assert!(
+                    !segment
+                        .fragment_bitmap
+                        .as_ref()
+                        .unwrap()
+                        .contains(destination.id as u32)
+                );
+            }
+        }
+        for value in 0..16 {
+            assert_eq!(
+                dataset
+                    .count_rows(Some(format!("i = {value}")))
+                    .await
+                    .unwrap(),
+                1
+            );
+        }
+        // A later ordinary commit must not persist derived, overlapping bitmaps.
+        compact_files(
+            &mut dataset,
+            CompactionOptions {
+                target_rows_per_fragment: 32,
+                defer_index_remap: true,
+                ..Default::default()
+            },
+            None,
+        )
+        .await
+        .unwrap();
+        let persisted = read_manifest_indexes(
+            &dataset.object_store,
+            &dataset.manifest_location,
+            &dataset.manifest,
+        )
+        .await
+        .unwrap();
+        for segment in &original {
+            assert_eq!(
+                persisted
+                    .iter()
+                    .find(|index| index.uuid == segment.uuid)
+                    .unwrap()
+                    .fragment_bitmap,
+                segment.fragment_bitmap
+            );
+        }
+        assert_eq!(dataset.count_rows(Some("i >= 0".into())).await.unwrap(), 16);
+        for value in 0..16 {
+            assert_eq!(
+                dataset
+                    .count_rows(Some(format!("i = {value}")))
+                    .await
+                    .unwrap(),
+                1
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn append_and_repeated_partitions_keep_partial_index_coverage_safe() {
+        let mut dataset = dataset().await;
+        let (sources, destinations, id, size) = prepare(&mut dataset).await;
+        commit_stable_partition(
+            &mut dataset,
+            sources,
+            destinations,
+            id,
+            size,
+            StablePartitionCoverage::RequireFull,
+        )
+        .await
+        .unwrap();
+        let (sources, destinations, id, size) = prepare(&mut dataset).await;
+        let error = commit_stable_partition(
+            &mut dataset,
+            sources,
+            destinations,
+            id,
+            size,
+            StablePartitionCoverage::AllowUnindexed,
+        )
+        .await
+        .unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("still require translated entries")
+        );
+        // Rebuild direct coverage before another order-changing rewrite.
+        dataset
+            .create_index(
+                &["i"],
+                IndexType::BTree,
+                Some("i_idx".into()),
+                &ScalarIndexParams::default(),
+                true,
+            )
+            .await
+            .unwrap();
+        let batch = arrow_array::record_batch!(("i", Int32, [16, 17])).unwrap();
+        let transaction = InsertBuilder::new(Arc::new(dataset.clone()))
+            .with_params(&WriteParams {
+                mode: WriteMode::Append,
+                ..Default::default()
+            })
+            .execute_uncommitted(vec![batch])
+            .await
+            .unwrap();
+        dataset
+            .apply_commit(transaction, &Default::default(), &Default::default())
+            .await
+            .unwrap();
+        assert_eq!(dataset.manifest.stable_partition_transitions.len(), 1);
+        assert_eq!(dataset.count_rows(Some("i >= 0".into())).await.unwrap(), 18);
+        assert_eq!(dataset.count_rows(Some("i = 17".into())).await.unwrap(), 1);
+        let before = dataset
+            .scan()
+            .with_row_address()
+            .try_into_batch()
+            .await
+            .unwrap();
+        let (sources, destinations, id, size) = prepare(&mut dataset).await;
+        let error = commit_stable_partition(
+            &mut dataset,
+            sources.clone(),
+            destinations.clone(),
+            id,
+            size,
+            StablePartitionCoverage::RequireFull,
+        )
+        .await
+        .unwrap_err();
+        assert!(error.to_string().contains("AllowUnindexed"));
+        commit_stable_partition(
+            &mut dataset,
+            sources,
+            destinations,
+            id,
+            size,
+            StablePartitionCoverage::AllowUnindexed,
+        )
+        .await
+        .unwrap();
+        let addresses = before[lance_core::ROW_ADDR]
+            .as_primitive::<arrow_array::types::UInt64Type>()
+            .values()
+            .iter()
+            .copied()
+            .map(RowAddress::from)
+            .collect::<Vec<_>>();
+        let mapped = MixedFragReuseIndex::open(&dataset)
+            .await
+            .unwrap()
+            .translate(&addresses)
+            .await
+            .unwrap();
+        let current = dataset
+            .scan()
+            .with_row_address()
+            .try_into_batch()
+            .await
+            .unwrap();
+        let actual = current["i"]
+            .as_primitive::<Int32Type>()
+            .values()
+            .iter()
+            .copied()
+            .zip(
+                current[lance_core::ROW_ADDR]
+                    .as_primitive::<arrow_array::types::UInt64Type>()
+                    .values()
+                    .iter()
+                    .copied(),
+            )
+            .collect::<HashMap<_, _>>();
+        for (value, address) in before["i"]
+            .as_primitive::<Int32Type>()
+            .values()
+            .iter()
+            .zip(mapped)
+        {
+            assert_eq!(address.map(u64::from), actual.get(value).copied());
+        }
+        assert_eq!(dataset.manifest.stable_partition_transitions.len(), 2);
+        // Appended rows were never indexed, so mixed destinations cannot claim full coverage.
+        let index = dataset.load_index_by_name("i_idx").await.unwrap().unwrap();
+        assert!(index.fragment_bitmap.as_ref().unwrap().is_empty());
+        assert_eq!(dataset.count_rows(Some("i >= 0".into())).await.unwrap(), 18);
+        assert_eq!(dataset.count_rows(Some("i = 17".into())).await.unwrap(), 1);
+    }
+
+    #[tokio::test]
+    async fn unsupported_index_falls_back_without_losing_its_metadata() {
+        let mut dataset = dataset().await;
+        dataset
+            .create_index(
+                &["i"],
+                IndexType::Scalar,
+                Some("bitmap".to_string()),
+                &ScalarIndexParams::for_builtin(lance_index::scalar::BuiltinIndexType::Bitmap),
+                false,
+            )
+            .await
+            .unwrap();
+        let (sources, destinations, id, size) = prepare(&mut dataset).await;
+        commit_stable_partition(
+            &mut dataset,
+            sources,
+            destinations,
+            id,
+            size,
+            StablePartitionCoverage::RequireFull,
+        )
+        .await
+        .unwrap();
+        assert!(
+            dataset
+                .load_index_by_name("bitmap")
+                .await
+                .unwrap()
+                .is_none()
+        );
+        let all = crate::index::load_all_indices(&dataset).await.unwrap();
+        assert!(all.iter().any(|index| index.name == "bitmap"));
+        dataset.drop_index("i_idx").await.unwrap();
+        let plan = dataset
+            .scan()
+            .filter("i = 5")
+            .unwrap()
+            .explain_plan(false)
+            .await
+            .unwrap();
+        assert!(!plan.contains("ScalarIndexQuery"), "{plan}");
+        assert_eq!(dataset.count_rows(Some("i = 5".into())).await.unwrap(), 1);
+    }
+
+    #[tokio::test]
+    async fn disjoint_partitions_rebase_and_preserve_both_row_maps() {
+        let mut dataset = dataset().await;
+        let first_sources = dataset.fragments()[..2].to_vec();
+        let second_sources = dataset.fragments()[2..].to_vec();
+        let (sources_a, destinations_a, id_a, size_a) =
+            prepare_sources(&mut dataset, first_sources).await;
+        let (sources_b, destinations_b, id_b, size_b) =
+            prepare_sources(&mut dataset, second_sources).await;
+        let mut stale = dataset.clone();
+        commit_stable_partition(
+            &mut dataset,
+            sources_a,
+            destinations_a,
+            id_a,
+            size_a,
+            StablePartitionCoverage::RequireFull,
+        )
+        .await
+        .unwrap();
+        commit_stable_partition(
+            &mut stale,
+            sources_b,
+            destinations_b,
+            id_b,
+            size_b,
+            StablePartitionCoverage::RequireFull,
+        )
+        .await
+        .unwrap();
+        assert_eq!(stale.manifest.stable_partition_transitions.len(), 2);
+        assert_eq!(stale.count_rows(Some("i >= 0".into())).await.unwrap(), 16);
+        for value in [1, 5, 9, 13] {
+            assert_eq!(
+                stale
+                    .count_rows(Some(format!("i = {value}")))
+                    .await
+                    .unwrap(),
+                1
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn cleanup_retains_committed_maps_and_removes_abandoned_maps() {
+        let mut dataset = dataset().await;
+        let (sources, destinations, committed, size) = prepare(&mut dataset).await;
+        commit_stable_partition(
+            &mut dataset,
+            sources,
+            destinations,
+            committed,
+            size,
+            StablePartitionCoverage::RequireFull,
+        )
+        .await
+        .unwrap();
+        let (_, _, abandoned, _) = prepare(&mut dataset).await;
+        let committed_path = dataset
+            .row_maps_dir()
+            .join(committed.to_string())
+            .join(ROW_MAP_FILE_NAME);
+        let abandoned_path = dataset
+            .row_maps_dir()
+            .join(abandoned.to_string())
+            .join(ROW_MAP_FILE_NAME);
+        cleanup_old_versions(&dataset, CleanupPolicyBuilder::default().build())
+            .await
+            .unwrap();
+        assert!(dataset.object_store.size(&abandoned_path).await.is_ok());
+        cleanup_old_versions(
+            &dataset,
+            CleanupPolicyBuilder::default()
+                .delete_unverified(true)
+                .build(),
+        )
+        .await
+        .unwrap();
+        assert_eq!(
+            dataset.object_store.size(&committed_path).await.unwrap(),
+            size
+        );
+        let error = dataset
+            .object_store
+            .size(&abandoned_path)
+            .await
+            .unwrap_err();
+        assert!(error.is_not_found(), "{error}");
+        assert_eq!(dataset.count_rows(Some("i = 9".into())).await.unwrap(), 1);
+    }
+
+    #[tokio::test]
+    async fn indexed_null_values_survive_partition_and_delete() {
+        let batch = arrow_array::record_batch!((
+            "i",
+            Int32,
+            [Some(0), None, Some(1), None, Some(2), Some(3)]
+        ))
+        .unwrap();
+        let reader = arrow_array::RecordBatchIterator::new(vec![Ok(batch.clone())], batch.schema());
+        let mut dataset = Dataset::write(
+            reader,
+            "memory://",
+            Some(WriteParams {
+                max_rows_per_file: 2,
+                ..Default::default()
+            }),
+        )
+        .await
+        .unwrap();
+        dataset
+            .create_index(
+                &["i"],
+                IndexType::Scalar,
+                Some("nullable".to_string()),
+                &ScalarIndexParams::default(),
+                false,
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            dataset.count_rows(Some("i IS NULL".into())).await.unwrap(),
+            2
+        );
+        let (sources, destinations, id, size) = prepare(&mut dataset).await;
+        commit_stable_partition(
+            &mut dataset,
+            sources,
+            destinations,
+            id,
+            size,
+            StablePartitionCoverage::RequireFull,
+        )
+        .await
+        .unwrap();
+        assert_eq!(
+            dataset.count_rows(Some("i IS NULL".into())).await.unwrap(),
+            2
+        );
+        assert_eq!(
+            dataset
+                .count_rows(Some("i IS NOT NULL".into()))
+                .await
+                .unwrap(),
+            4
+        );
+        dataset.delete("i IS NULL").await.unwrap();
+        assert_eq!(
+            dataset.count_rows(Some("i IS NULL".into())).await.unwrap(),
+            0
+        );
+        assert_eq!(
+            dataset
+                .count_rows(Some("i IS NOT NULL".into()))
+                .await
+                .unwrap(),
+            4
+        );
+    }
+
+    #[tokio::test]
+    async fn stale_source_delete_rejects_partition() {
+        let mut dataset = dataset().await;
+        let (sources, destinations, id, size) = prepare(&mut dataset).await;
+        let mut stale = dataset.clone();
+        dataset.delete("i = 1").await.unwrap();
+        let error = commit_stable_partition(
+            &mut stale,
+            sources,
+            destinations,
+            id,
+            size,
+            StablePartitionCoverage::RequireFull,
+        )
+        .await
+        .unwrap_err();
+        assert!(matches!(
+            error,
+            Error::RetryableCommitConflict { .. } | Error::InvalidInput { .. }
+        ));
+        assert_eq!(dataset.count_rows(Some("i = 1".into())).await.unwrap(), 0);
+        assert!(dataset.manifest.stable_partition_transitions.is_empty());
+    }
+}

--- a/rust/lance/src/index/scalar.rs
+++ b/rust/lance/src/index/scalar.rs
@@ -527,7 +527,7 @@ async fn validate_label_list_index_compatibility(
     dataset: &Dataset,
     column: &str,
     index: &IndexMetadata,
-    index_store: &Arc<LanceIndexStore>,
+    index_store: &dyn IndexStore,
 ) -> Result<()> {
     let Some(field) = dataset.schema().field(column) else {
         return Ok(());
@@ -574,12 +574,39 @@ pub async fn open_scalar_index(
 
     let frag_reuse_index = dataset.open_frag_reuse_index(metrics).await?;
 
+    let cache_id = crate::index::frag_reuse_v2::mixed_cache_id(
+        dataset,
+        frag_reuse_index.as_ref().map(|f| f.uuid),
+    );
     let index_cache = dataset
         .index_cache
-        .for_index(&index.uuid, frag_reuse_index.as_ref().map(|f| &f.uuid));
+        .for_index(&index.uuid, cache_id.as_ref());
+    let uses_mixed_mapping = !dataset.manifest.stable_partition_transitions.is_empty()
+        && index_details.type_url.ends_with("BTreeIndexDetails");
 
-    let frag_reuse_index: Option<Arc<dyn RowIdRemapper>> = frag_reuse_index
-        .map(|f| Arc::new(CompactFragReuseIndexHandle(f)) as Arc<dyn RowIdRemapper>);
+    let frag_reuse_index: Option<Arc<dyn RowIdRemapper>> = if uses_mixed_mapping {
+        None
+    } else {
+        frag_reuse_index.map(|f| Arc::new(CompactFragReuseIndexHandle(f)) as Arc<dyn RowIdRemapper>)
+    };
+    // B-tree caches reconstruct their readers from this store even on a cold
+    // load. Supply the adapter to both loading and cache reconstruction.
+    let index_store: Arc<dyn IndexStore> = if uses_mixed_mapping {
+        let coverage = dataset
+            .load_indices()
+            .await?
+            .iter()
+            .find(|metadata| metadata.uuid == index.uuid)
+            .and_then(|metadata| metadata.fragment_bitmap.clone())
+            .unwrap_or_default()
+            & dataset.fragment_bitmap.as_ref();
+        Arc::new(
+            crate::index::frag_reuse_v2::TranslatedIndexStore::new(dataset, index_store, coverage)
+                .await?,
+        )
+    } else {
+        index_store
+    };
 
     // Runs only on a cold miss, and at most once even under concurrent opens
     // (the plugin coalesces). The compat check lives here because a warm hit was
@@ -590,8 +617,13 @@ pub async fn open_scalar_index(
         let index_cache = index_cache.clone();
         async move {
             if index_details.type_url.ends_with("LabelListIndexDetails") {
-                validate_label_list_index_compatibility(dataset, column, index, &index_store)
-                    .await?;
+                validate_label_list_index_compatibility(
+                    dataset,
+                    column,
+                    index,
+                    index_store.as_ref(),
+                )
+                .await?;
             }
 
             let index = plugin

--- a/rust/lance/src/io/commit.rs
+++ b/rust/lance/src/io/commit.rs
@@ -386,6 +386,11 @@ async fn do_commit_new_dataset(
         )
         .await?;
         ensure_can_write_manifest(&source_manifest)?;
+        if !source_manifest.stable_partition_transitions.is_empty() {
+            return Err(Error::not_supported(
+                "cloning datasets with stable-partition mappings is not yet supported",
+            ));
+        }
         Some((source_store, source_manifest_location, source_manifest))
     } else {
         None
@@ -1119,6 +1124,8 @@ pub(crate) async fn do_commit_detached_transaction(
     retry_timeout: Duration,
 ) -> Result<(Manifest, ManifestLocation)> {
     ensure_can_write_manifest(&dataset.manifest)?;
+    crate::index::frag_reuse_v2::validate_partition_sources(dataset, &transaction.operation)
+        .await?;
     let pb_transaction = pb::Transaction::from(transaction);
     let inline_transaction = pb_transaction.encoded_len() <= MAX_INLINE_TRANSACTION_BYTES;
     // Classified from the operation itself. Reading it back off the inline
@@ -1474,6 +1481,9 @@ pub(crate) async fn commit_transaction(
         } else {
             ensure_can_write_manifest(&dataset.manifest)?;
         }
+
+        crate::index::frag_reuse_v2::validate_partition_sources(&dataset, &transaction.operation)
+            .await?;
 
         // Recomputed every attempt: the rebase above may have rewritten the
         // transaction.

--- a/rust/lance/src/io/commit/conflict_resolver.rs
+++ b/rust/lance/src/io/commit/conflict_resolver.rs
@@ -3073,6 +3073,7 @@ mod tests {
                 }],
                 rewritten_indices: vec![],
                 frag_reuse_index: None,
+                stable_partition: None,
             },
             Operation::ReserveFragments { num_fragments: 3 },
             Operation::Update {
@@ -3212,6 +3213,7 @@ mod tests {
                     }],
                     rewritten_indices: Vec::new(),
                     frag_reuse_index: None,
+                    stable_partition: None,
                 },
                 [
                     Compatible,    // append
@@ -3234,6 +3236,7 @@ mod tests {
                     }],
                     rewritten_indices: Vec::new(),
                     frag_reuse_index: None,
+                    stable_partition: None,
                 },
                 [
                     Compatible,    // append
@@ -3591,6 +3594,7 @@ mod tests {
             }],
             rewritten_indices: vec![],
             frag_reuse_index: None,
+            stable_partition: None,
         };
 
         let fragment0 = Fragment::new(0);
@@ -3736,6 +3740,7 @@ mod tests {
             }],
             rewritten_indices: vec![],
             frag_reuse_index: None,
+            stable_partition: None,
         };
 
         for (other, expect_conflict) in [(overlay_on(1), true), (overlay_on(0), false)] {
@@ -4399,6 +4404,7 @@ mod tests {
                 }],
                 rewritten_indices: vec![],
                 frag_reuse_index: Some(frag_reuse_index),
+                stable_partition: None,
             },
             None,
         );
@@ -4884,6 +4890,7 @@ mod tests {
                     }],
                     rewritten_indices: vec![],
                     frag_reuse_index: None,
+                    stable_partition: None,
                 },
                 Retryable,
             ),
@@ -4899,6 +4906,7 @@ mod tests {
                     }],
                     rewritten_indices: vec![],
                     frag_reuse_index: None,
+                    stable_partition: None,
                 },
                 Compatible,
             ),


### PR DESCRIPTION
Stable partitions can retain existing B-tree segments while compaction continues writing FRI V1. This implements the mixed lifecycle using #8972's `RowMapWriter` and `RowMapReader`, without duplicating the codec or migrating V1 history.

- Publish prepared stable partitions and immutable `_row_maps/<uuid>/row_map.lance` references atomically through `Operation::Rewrite`, with paired reader/writer capability flags.
- Keep stored segment bitmaps as source provenance. Derive coverage from the union of a logical index's segments, probe every contributor, and give directly indexed destinations priority over translated entries.
- Compose V1 and V2 by fragment lineage. Translate B-tree pages on cold, cached, and streamed reads with bounded row-map block reads; route Python `remap_row_addrs` through the same Rust translator.
- Preserve mappings across append/delete and subsequent eager or deferred V1 compaction. Reject changed sources and unresolved repartitioning, allow disjoint partitions to rebase, and protect committed mapping files during cleanup. The prepared-commit API requires an explicit `AllowUnindexed` policy to accept incomplete source coverage.

Experimental scope: physical row addresses, one storage base, and B-tree query/maintenance integration. Other affected index types fall back to scanning. Automatic clustering, coordinated draining/pruning, and cloning mixed datasets remain outside this implementation. This is a draft; the formal format-change process is deferred until the design is agreed.

Stack: #8972 → **this PR**, with base branch `lu/friv2`. Replaces closed #8978. GitHub's native stack API rejects fork PRs, so the dependency is represented by the PR base branch.

Validation: 17 FRI tests and 6 table-format/transaction/flag tests passed; 2 targeted Python regression tests passed. Workspace `cargo fmt --all` and `cargo clippy --all --tests --benches -- -D warnings`, Python `uv run make lint`, JNI Clippy, and commit hooks passed. The Python extension was rebuilt with `make build`.
