### PR TITLE
fix(python): reject a num_partitions that disagrees with ivf_centroids_file

### DIFF
--- a/python/python/lance/dataset.py
+++ b/python/python/lance/dataset.py
@@ -4045,7 +4045,9 @@ class LanceDataset(pa.dataset.Dataset):
                 fs, path = FileSystem.from_uri(ivf_centroids_file)
                 with fs.open_input_file(path) as f:
                     ivf_centroids = np.load(f)
-                num_partitions = ivf_centroids.shape[0]
+                file_clusters = ivf_centroids.shape[0]
+            else:
+                file_clusters = None
 
             if isinstance(num_partitions, float):
                 warnings.warn("num_partitions is float, converting to int")
@@ -4054,6 +4056,14 @@ class LanceDataset(pa.dataset.Dataset):
                 raise TypeError(
                     f"num_partitions must be int, got {type(num_partitions)}"
                 )
+
+            if file_clusters is not None:
+                if num_partitions is not None and file_clusters != num_partitions:
+                    raise ValueError(
+                        f"Ivf centroids file has {file_clusters} clusters, "
+                        f"but num_partitions={num_partitions}"
+                    )
+                num_partitions = file_clusters
             if num_partitions is not None:
                 kwargs["num_partitions"] = num_partitions
             if target_partition_size is not None:
@@ -4267,6 +4277,11 @@ class LanceDataset(pa.dataset.Dataset):
             :py:class:`pyarrow.FixedShapeTensorArray`.
             A ``num_partitions x dimension`` array of existing K-mean centroids
             for IVF clustering. If not provided, a new KMeans model will be trained.
+        ivf_centroids_file : str, optional
+            Path to a ``.npy`` file holding the same array as ``ivf_centroids``.
+            Mutually exclusive with it. The file's row count sets the number of
+            IVF partitions, so passing a ``num_partitions`` that disagrees with
+            it is an error.
         pq_codebook : optional,
             It can be :py:class:`np.ndarray`, :py:class:`pyarrow.FixedSizeListArray`,
             or :py:class:`pyarrow.FixedShapeTensorArray`.

--- a/python/python/tests/test_vector_index.py
+++ b/python/python/tests/test_vector_index.py
@@ -1530,6 +1530,35 @@ def test_pre_populated_ivf_centroids(dataset, tmp_path: Path):
     assert all([partition_keys == set(p.keys()) for p in partitions])
 
 
+def test_ivf_centroids_file_num_partitions_mismatch(dataset, tmp_path: Path):
+    centroids = np.random.randn(4, 128).astype(np.float32)
+    centroids_dir = tmp_path / "centroids"
+    centroids_dir.mkdir()
+    centroids_file = centroids_dir / "centroids.npy"
+    np.save(centroids_file, centroids)
+
+    with pytest.raises(ValueError, match="has 4 clusters, but num_partitions=8"):
+        dataset.create_index(
+            ["vector"],
+            index_type="IVF_PQ",
+            ivf_centroids_file=str(centroids_file),
+            num_partitions=8,
+            num_sub_vectors=8,
+        )
+
+    # Omitting num_partitions is the case that shows the file's count is what
+    # sets the partition count; with num_partitions=4 the assertion would hold
+    # either way.
+    indexed = dataset.create_index(
+        ["vector"],
+        index_type="IVF_PQ",
+        ivf_centroids_file=str(centroids_file),
+        num_sub_vectors=8,
+    )
+    stats = indexed.stats.index_stats("vector_idx")
+    assert stats["indices"][0]["num_partitions"] == 4
+
+
 def test_create_ivf_pq_skip_transpose(dataset, tmp_path: Path):
     ds = lance.write_dataset(
         dataset.to_table(), tmp_path / "indexed_skip_transpose.lance"


### PR DESCRIPTION
## Problem

The `ivf_centroids_file` branch overwrote `num_partitions` with the file's cluster count, unconditionally and with no warning, so `create_index(num_partitions=8, ivf_centroids_file=<4-cluster .npy>)` built a 4-partition index. The numpy-path mismatch guard runs after the overwrite, so it compares the value against itself and can never fire here.

Fixes #9008.

## What this changes

Compare before overwriting, and name both counts. Rejecting rather than warning matches the surrounding code: the same function already rejects a numpy centroid count that disagrees with `num_partitions`, and root `AGENTS.md` says to reject invalid values with descriptive errors rather than silently adjust.

The check now sits after the `num_partitions` type normalization, so a non-int still gets the `TypeError` rather than a mismatch message computed from an unnormalized value.

`ivf_centroids_file` is a public parameter with no docstring entry; it gets one, saying the file's row count sets the partition count.

Worth noting for review: the Rust core already rejects this pair (`rust/lance/src/index/vector.rs:563-570`), and the overwrite is the only reason its check never fires. Deleting the overwrite instead would also work, but only on top of #9001, which is what stops the numpy-path guard from rejecting centroids supplied without `num_partitions`. Checking here keeps the two changes independent and fails one FFI hop earlier.

## Test plan

`test_ivf_centroids_file_num_partitions_mismatch` saves a 4 cluster `.npy`, asserts that `num_partitions=8` against it raises with both counts, then builds with `num_partitions` omitted and asserts the index has 4 partitions. Omitting it is the case that shows the file's count is what sets the partition count; passing 4 would satisfy the assertion either way.

Without the fix the first half fails with `DID NOT RAISE <class 'ValueError'>`.

- `uv run pytest python/tests/test_vector_index.py` 93 passed, 11 skipped, 1 deselected
- The deselected one is `test_create_index_progress_callback_error_before_completion_propagates`, which fails the same way with upstream's `dataset.py` on this machine.
- `uv run make lint` clean
