### PR TITLE
fix(index): keep the requested index name after a failed uncommitted build

### DIFF
--- a/rust/lance/src/index/create.rs
+++ b/rust/lance/src/index/create.rs
@@ -267,8 +267,10 @@ impl<'a> CreateIndexBuilder<'a> {
             .dataset
             .open_frag_reuse_index(&NoOpMetricsCollector)
             .await?;
-        let index_name = if let Some(name) = self.name.take() {
-            name
+        // Read without consuming: a failed build must leave the requested name in
+        // place so a retry commits under it instead of an auto-generated one.
+        let index_name = if let Some(name) = self.name.as_deref() {
+            name.to_string()
         } else {
             // Generate default name with collision handling.
             // A name is available when there is no existing index with:
@@ -709,8 +711,10 @@ impl<'a> CreateIndexBuilder<'a> {
         };
 
         let indices = load_all_indices(self.dataset).await?;
-        let index_name = if let Some(name) = self.name.take() {
-            name
+        // Matches execute_uncommitted. Unobservable here, since the only caller
+        // consumes the builder.
+        let index_name = if let Some(name) = self.name.as_deref() {
+            name.to_string()
         } else {
             let column_path = default_index_name(&names);
             let base_name = format!("{column_path}_idx");
@@ -1497,6 +1501,52 @@ mod tests {
         assert_eq!(resolved[1].as_ref().unwrap().id() as u32, first);
         assert_eq!(resolved[2].as_ref().unwrap().id() as u32, second);
         assert!(resolved[3].is_none());
+    }
+
+    /// A failed `execute_uncommitted` must not consume the requested index
+    /// name: the method takes `&mut self`, so a caller can hold the builder and
+    /// retry, and a retry that lost the name commits under `<column>_idx`.
+    #[tokio::test]
+    async fn test_failed_execute_uncommitted_preserves_name() {
+        let tmpdir = TempStrDir::default();
+        let dataset_uri = format!("file://{}", tmpdir.as_str());
+        let batch = create_text_batch(0, 10);
+        let batches = RecordBatchIterator::new(vec![Ok(batch)], create_text_batch(0, 1).schema());
+        let mut dataset = Dataset::write(batches, &dataset_uri, None).await.unwrap();
+
+        let params = InvertedIndexParams::default();
+        dataset
+            .create_index_builder(&["text"], IndexType::Inverted, &params)
+            .name("retry_idx".to_string())
+            .execute()
+            .await
+            .unwrap();
+
+        // replace defaults to false, so the duplicate name is rejected. That
+        // rejection happens after the name is read, which is the point.
+        let mut builder = dataset
+            .create_index_builder(&["text"], IndexType::Inverted, &params)
+            .name("retry_idx".to_string());
+        let error = builder.execute_uncommitted().await.unwrap_err();
+        assert!(
+            error.to_string().contains("already exists"),
+            "the build must fail on the duplicate name, which is downstream of \
+             the name read; got {error}"
+        );
+
+        assert_eq!(builder.name.as_deref(), Some("retry_idx"));
+
+        // The retry a caller would make. Losing the name here would commit a
+        // second index called text_idx instead of replacing retry_idx.
+        builder.replace(true).execute().await.unwrap();
+        let names = dataset
+            .load_indices()
+            .await
+            .unwrap()
+            .iter()
+            .map(|idx| idx.name.clone())
+            .collect::<Vec<_>>();
+        assert_eq!(names, ["retry_idx"], "the retry must reuse the name");
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Problem

`execute_uncommitted` takes the name out of the builder before it rejects a duplicate, so a build that fails there leaves `self.name` empty. A caller that holds the builder and retries then falls into default-name generation and commits under `<column>_idx` instead of the name it asked for. The method is `pub` on `&mut self`, so holding it across a retry is a supported shape.

Fixes #9010.

## What this changes

Read the name without consuming it. The same `take()` in `execute_multi_segment_fmindex` is unobservable, since its only caller consumes the builder, but it is changed for consistency.

One behaviour change worth naming: a second `execute_uncommitted` on a builder whose first call already committed under that name now returns `Index name 'X' already exists` where before it quietly succeeded under `<column>_idx`. Nothing in the repo does that, and silently renaming the caller's index is the bug being fixed, but it is a new error on a path that used to succeed.

## Test plan

`test_failed_execute_uncommitted_preserves_name` builds `retry_idx`, then runs `execute_uncommitted` on a held builder against the same name so it fails on the duplicate, and asserts the name survived. It then does the retry a caller would do and asserts the dataset still has exactly one index.

Restoring the `take()` fails both assertions independently: the field reads `None`, and with that assertion removed the retry commits a second index, so the last check reports `["retry_idx", "text_idx"]` against `["retry_idx"]`.

- `cargo test -p lance --lib` 3381 passed, 3 ignored
- `cargo test -p lance --lib index::create::` 43 passed
- `cargo clippy --all --tests --benches -- -D warnings` clean
- `cargo fmt --all --check` clean
