### PR TITLE
fix(index): report a partition the IVF layout does not cover

### DIFF
--- a/rust/lance-index/src/vector/ivf/storage.rs
+++ b/rust/lance-index/src/vector/ivf/storage.rs
@@ -140,10 +140,39 @@ impl IvfModel {
         self.centroids.as_ref()
     }
 
+    /// Row range of `partition` in the storage file.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the model carries no layout entry for `partition`. Use
+    /// [`Self::try_row_range`] to get that reported instead.
+    #[deprecated(note = "use IvfModel::try_row_range")]
     pub fn row_range(&self, partition: usize) -> Range<usize> {
         let start = self.offsets[partition];
         let end = start + self.lengths[partition] as usize;
         start..end
+    }
+
+    /// Row range of `partition` in the storage file.
+    ///
+    /// A partition the layout carries with no rows is valid and gives an empty
+    /// range at its own offset. A partition the layout does not carry is an
+    /// error: offsets and lengths come from the index file, so a partition the
+    /// caller can name and the layout does not cover means the two disagree.
+    pub fn try_row_range(&self, partition: usize) -> Result<Range<usize>> {
+        let (Some(&start), Some(&len)) = (self.offsets.get(partition), self.lengths.get(partition))
+        else {
+            return Err(Error::corrupt_file_named(
+                "ivf metadata",
+                format!(
+                    "partition {partition} has no row range: the layout covers {} partitions, \
+                     the model reports {}",
+                    self.offsets.len().min(self.lengths.len()),
+                    self.num_partitions()
+                ),
+            ));
+        };
+        Ok(start..start + len as usize)
     }
 
     pub async fn load(reader: &V1FileReader) -> Result<Self> {
@@ -270,8 +299,34 @@ mod tests {
         ivf.add_partition(20);
         ivf.add_partition(50);
 
-        assert_eq!(ivf.row_range(0), 0..20);
-        assert_eq!(ivf.row_range(1), 20..70);
+        assert_eq!(ivf.try_row_range(0).unwrap(), 0..20);
+        assert_eq!(ivf.try_row_range(1).unwrap(), 20..70);
+    }
+
+    /// A partition the layout does not cover has to be reported: the consumers
+    /// read the returned range and treat an empty one as an empty partition, so
+    /// an absent entry that answers `0..0` reads as a partition with no rows.
+    #[test]
+    fn test_try_row_range_rejects_absent_partition() {
+        let mut ivf = IvfModel::empty();
+        ivf.add_partition(20);
+
+        for partition in [1, usize::MAX] {
+            let error = ivf.try_row_range(partition).unwrap_err();
+            assert!(
+                matches!(&error, Error::CorruptFile { .. }),
+                "expected CorruptFile, got {error:?}"
+            );
+            assert!(
+                error.to_string().contains(&partition.to_string()),
+                "the error must name the partition asked for: {error}"
+            );
+        }
+
+        // A partition the layout does carry with no rows stays valid, at its
+        // own offset rather than at zero.
+        ivf.add_partition(0);
+        assert_eq!(ivf.try_row_range(1).unwrap(), 20..20);
     }
 
     #[tokio::test]

--- a/rust/lance-index/src/vector/quantizer.rs
+++ b/rust/lance-index/src/vector/quantizer.rs
@@ -416,7 +416,7 @@ impl<Q: Quantization> IvfQuantizationStorage<Q> {
     ///
     ///
     pub async fn load_partition(&self, part_id: usize) -> Result<Q::Storage> {
-        let range = self.ivf.row_range(part_id);
+        let range = self.ivf.try_row_range(part_id)?;
         Q::Storage::load_partition(
             &self.reader,
             range,

--- a/rust/lance-index/src/vector/storage.rs
+++ b/rust/lance-index/src/vector/storage.rs
@@ -673,7 +673,7 @@ impl<Q: Quantization> IvfQuantizationStorage<Q> {
         part_id: usize,
         io_stats: Option<IoStats>,
     ) -> Result<Q::Storage> {
-        let range = self.ivf.row_range(part_id);
+        let range = self.ivf.try_row_range(part_id)?;
         let batch = if range.is_empty() {
             let schema = self.reader.schema();
             let arrow_schema = arrow_schema::Schema::from(schema.as_ref());

--- a/rust/lance/src/index/vector/ivf.rs
+++ b/rust/lance/src/index/vector/ivf.rs
@@ -310,7 +310,7 @@ impl IVFIndex {
                     )));
                 }
 
-                let range = self.ivf.row_range(partition_id);
+                let range = self.ivf.try_row_range(partition_id)?;
                 let idx = self
                     .sub_index
                     .load_partition(
@@ -2947,7 +2947,7 @@ async fn write_hnsw_root_index_from_auxiliary(
         .await?;
 
     for partition_id in 0..aux_ivf.num_partitions() {
-        let row_range = aux_ivf.row_range(partition_id);
+        let row_range = aux_ivf.try_row_range(partition_id)?;
         if row_range.is_empty() {
             index_ivf.add_partition(0);
             partition_index_metadata.push(String::new());

--- a/rust/lance/src/index/vector/ivf/v2.rs
+++ b/rust/lance/src/index/vector/ivf/v2.rs
@@ -1311,7 +1311,7 @@ impl<S: IvfSubIndex + 'static, Q: Quantization> IVFIndex<S, Q> {
         let batch = match self.reader.metadata().num_rows {
             0 => RecordBatch::new_empty(schema),
             _ => {
-                let row_range = self.ivf.row_range(partition_id);
+                let row_range = self.ivf.try_row_range(partition_id)?;
                 if row_range.is_empty() {
                     RecordBatch::new_empty(schema)
                 } else {
@@ -5449,7 +5449,7 @@ mod tests {
             .expect("HNSW declares a read projection");
         assert_eq!(projection.schema.fields.len(), 2);
 
-        let row_range = hnsw.ivf.row_range(0);
+        let row_range = hnsw.ivf.try_row_range(0).unwrap();
         assert!(!row_range.is_empty(), "partition 0 should hold rows");
         let store = dataset.object_store.as_ref();
 
@@ -5528,7 +5528,7 @@ mod tests {
 
         let mut compared = 0;
         for partition_id in 0..hnsw.ivf.num_partitions() {
-            let range = hnsw.ivf.row_range(partition_id);
+            let range = hnsw.ivf.try_row_range(partition_id).unwrap();
             if range.is_empty() {
                 continue;
             }


### PR DESCRIPTION
## Problem

`IvfModel::row_range` indexes `offsets` and `lengths` directly, so a partition the layout does not carry panics on the slice index. Returning an empty range instead is not an improvement: both consumers read the range and treat an empty one as an empty partition, so an absent entry becomes indistinguishable from a partition with no rows. `IvfIndex::load_partition_entry` would return an empty batch and then panic anyway on `sub_index_metadata[partition_id]` forty lines later, and `write_hnsw_root_index_from_auxiliary` would record every absent partition as `add_partition(0)` and write a wrong index.

Fixes #9012.

## What this changes

Adds `IvfModel::try_row_range`, which returns `Err(CorruptFile)` naming the partition and both counts, and keeps a layout entry with `len == 0` valid as an empty range at its own offset. The five in-tree consumers all return `Result` already, so each one propagates with `?`. `row_range` keeps its behaviour and is deprecated in favour of the fallible version, since it is public API.

Worth stating plainly: I could not construct the failing state through the public API. User-supplied partition ids are range-checked at `load_partition`, search-path ids come from `find_partitions` over the centroids, and neither the builder nor the distributed merger emits a model whose `num_partitions()` exceeds its `offsets`. What this buys is that a mismatch between the centroid count and the layout, if a file ever carries one, is reported at the read instead of panicking or producing an index with silently empty partitions.

## Test plan

`test_try_row_range_rejects_absent_partition` asks a one-partition model for partition 1 and `usize::MAX`, checks both give `CorruptFile` naming the partition, then adds a zero-length partition to show a present-but-empty entry still gives `20..20` rather than `0..0`. Restoring the empty-range fallback makes it fail.

- `cargo test -p lance-index --lib` 1231 passed, 3 ignored
- `cargo test -p lance --lib index::vector::ivf` 172 passed, 1 ignored, also with `--test-threads=1`
- `cargo clippy --all --tests --benches -- -D warnings` clean, which is also what proves no in-tree caller still uses the deprecated method
- `cargo fmt --all --check` clean
