### PR TITLE
fix(encoding): emit NIL control words when rep/def levels are non-empty but zero-width

### DIFF
--- a/rust/lance-encoding/src/repdef.rs
+++ b/rust/lance-encoding/src/repdef.rs
@@ -2415,6 +2415,15 @@ pub fn build_control_word_iterator<'a>(
     };
     let def_mask = if max_def == 0 { 0 } else { get_mask(def_width) };
     let total_width = rep_width + def_width;
+    // A levels array can be non-empty while the corresponding max level is 0:
+    // e.g. a page holding only valid rows after a page split has all zero
+    // definition levels.  With a zero total width the decoder reads a NIL
+    // layout (zero bytes per control word), so the writer must also emit the
+    // NIL writer instead of a Unary/Binary writer that would write one
+    // all-zero byte per word.
+    if total_width == 0 {
+        return ControlWordIterator::Nilary(NilaryControlWordIterator { len, idx: 0 });
+    }
     match (rep, def) {
         (Some(rep), Some(def)) => {
             let iter = rep.iter().copied().zip(def.iter().copied());
@@ -3653,6 +3662,102 @@ mod tests {
 
         // No rep, no def, no bytes
         check(&[], &[], Vec::default(), 0, 0, 0);
+    }
+
+    #[test]
+    fn test_control_words_def_only_all_zero_levels() {
+        // A page split can produce a page whose rows are all valid, so its
+        // definition levels are all zero and the max value in the (non-empty)
+        // buffer is 0.  The decoder reads a zero-bit layout as NIL (zero bytes
+        // per control word), so the writer must emit the NIL iterator too:
+        // zero bytes per word, no writes, one new-row/visible item per level.
+        // Writing one all-zero byte per word (the pre-fix Unary behavior)
+        // would disagree with the decoder and corrupt the stream.
+        let def = [0_u16; 5];
+
+        let mut iter = super::build_control_word_iterator(
+            None,
+            0,
+            Some(&def),
+            /*max_def=*/ 0,
+            /*max_visible_def=*/ u16::MAX,
+            def.len(),
+        );
+        assert_eq!(iter.bytes_per_word(), 0);
+        assert_eq!(iter.bits_rep(), 0);
+        assert_eq!(iter.bits_def(), 0);
+
+        let mut cw_vec = Vec::new();
+        for _ in 0..def.len() {
+            let word_desc = iter.append_next(&mut cw_vec).unwrap();
+            assert!(word_desc.is_new_row);
+            assert!(word_desc.is_visible);
+        }
+        assert!(iter.append_next(&mut cw_vec).is_none());
+        // The NIL layout writes nothing, matching what ControlWordParser::new(0, 0)
+        // reads back (Self::NIL parses nothing).
+        assert!(cw_vec.is_empty());
+
+        // The parser side of the same layout must also be NIL: zero bits on
+        // both levels parse zero bytes and yield nothing.
+        let parser = super::ControlWordParser::new(0, 0);
+        let mut rep_out = Vec::new();
+        let mut def_out = Vec::new();
+        parser.parse(&[], &mut rep_out, &mut def_out);
+        assert!(rep_out.is_empty());
+        assert!(def_out.is_empty());
+    }
+
+    #[test]
+    fn test_control_words_rep_only_all_zero_levels() {
+        // Same NIL-layout requirement as the definition-only case, for the
+        // repetition-only branches.  Repetition levels are normally never all
+        // zero (the first entry of every list row is the schema max rep), so
+        // this is a defensive check that the writer matches the decoder if a
+        // zero-width rep buffer is ever produced.
+        let rep = [0_u16; 5];
+        let mut iter = super::build_control_word_iterator(
+            Some(&rep),
+            /*max_rep=*/ 0,
+            None,
+            0,
+            /*max_visible_def=*/ u16::MAX,
+            rep.len(),
+        );
+        assert_eq!(iter.bytes_per_word(), 0);
+        let mut cw_vec = Vec::new();
+        for _ in 0..rep.len() {
+            assert!(iter.append_next(&mut cw_vec).unwrap().is_new_row);
+        }
+        assert!(iter.append_next(&mut cw_vec).is_none());
+        assert!(cw_vec.is_empty());
+    }
+
+    #[test]
+    fn test_control_words_both_levels_all_zero() {
+        // Both levels non-empty but all zero: the Binary writer would emit one
+        // zero byte per word while the decoder reads a NIL layout (zero bytes
+        // per word).  The unified zero-width early return avoids that
+        // write/read asymmetry.
+        let rep = [0_u16; 5];
+        let def = [0_u16; 5];
+        let mut iter = super::build_control_word_iterator(
+            Some(&rep),
+            /*max_rep=*/ 0,
+            Some(&def),
+            /*max_def=*/ 0,
+            /*max_visible_def=*/ u16::MAX,
+            rep.len(),
+        );
+        assert_eq!(iter.bytes_per_word(), 0);
+        assert_eq!(iter.bits_rep(), 0);
+        assert_eq!(iter.bits_def(), 0);
+        let mut cw_vec = Vec::new();
+        for _ in 0..rep.len() {
+            assert!(iter.append_next(&mut cw_vec).unwrap().is_new_row);
+        }
+        assert!(iter.append_next(&mut cw_vec).is_none());
+        assert!(cw_vec.is_empty());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

The structural full-zip encoder wrote one all-zero control-word byte per item for pages whose rep/def level buffers are non-empty but have a computed bit width of zero, while the decoder reads such a zero-bit layout as NIL (zero bytes per control word). The mismatch interleaves phantom bytes into the zipped value stream and corrupts every value that follows.

This adds a zero-width early return in `build_control_word_iterator`: when `total_width == 0` (i.e. `max_rep == 0 && max_def == 0`), emit `ControlWordIterator::Nilary` regardless of which level buffers are present, so the writer agrees with the decoder's NIL interpretation.

## Root cause

`encode_full_zip` (`rust/lance-encoding/src/encodings/logical/primitive.rs`) computes `max_rep`/`max_def` from the per-page sliced level buffers, not the schema. When a page's levels are all zero (e.g. a page holding only valid rows of a nullable column after page splitting), `total_width == 0` and the layout metadata records `bits_rep = 0, bits_def = 0`. The decoder reconstructs `ControlWordParser::new(0, 0)` → `NIL` (`bytes_per_word() == 0`), but the writer selected its branch purely on buffer presence, producing a `Unary8`/`Binary8` writer that emits one `0x00` byte per item (`bytes_per_word() == 1`). In the full-zip layout control words and values are interleaved per item, so the decoder's 0-byte step mis-aligns the value stream by one byte per item.

## Testing

- `test_control_words_def_only_all_zero_levels`: unit-level regression for the NIL branch — a non-empty all-zero definition buffer with `max_def == 0` must produce a zero-byte-per-word NIL iterator, and `ControlWordParser::new(0, 0)` must parse zero bytes back (write/read symmetry).
- `test_control_words_rep_only_all_zero_levels` / `test_control_words_both_levels_all_zero`: defensive sibling checks for the repetition-only and both-levels branches.
- Full-zip round-trip tests and the wire-compatibility suite pass unchanged.
