### PR TITLE
fix: count only visible nulls in the 2.1+ writer

### DIFF
--- a/rust/lance-file/src/versions/v2_0/writer.rs
+++ b/rust/lance-file/src/versions/v2_0/writer.rs
@@ -311,7 +311,8 @@ impl Writer {
 
     /// Reject a null in a non-nullable field whether or not a null ancestor
     /// masks it: the 2.0 logical encoders cannot store such a slot. The 2.1+
-    /// structural writer counts only visible nulls (`writer::nullability`).
+    /// structural writer counts only visible nulls
+    /// (`writer::structural::FileWriter::verify_field_nullability`).
     fn verify_field_nullability(arr: &ArrayData, field: &Field) -> Result<()> {
         if !field.nullable && arr.null_count() > 0 {
             return Err(Error::invalid_input(format!(

--- a/rust/lance-file/src/writer/structural.rs
+++ b/rust/lance-file/src/writer/structural.rs
@@ -5,7 +5,9 @@ use core::panic;
 use std::{collections::HashMap, sync::Arc};
 
 use arrow_array::{ArrayRef, RecordBatch};
+use arrow_buffer::BooleanBuffer;
 use arrow_data::ArrayData;
+use arrow_schema::DataType;
 use bytes::{Buf, Bytes, BytesMut};
 use futures::{StreamExt, stream::FuturesOrdered};
 use lance_core::{
@@ -450,14 +452,64 @@ impl EncodingPipeline {
     }
 
     fn verify_field_nullability(array: &ArrayData, field: &Field) -> Result<()> {
-        if !field.nullable && array.null_count() > 0 {
+        Self::verify_field_nullability_where_reachable(array, field, None)
+    }
+
+    /// `reachable` marks the slots a valid parent can actually see, or `None`
+    /// at the top level where every slot is reachable.
+    ///
+    /// A null struct slot leaves its children undefined, so a child null there
+    /// says nothing about whether the child is nullable. Arrow draws the line
+    /// the same way -- `StructArray::try_new` rejects only nulls in a
+    /// non-nullable child that the parent's null mask does not cover -- and a
+    /// reader is free to hand back nulls under a null parent for a column this
+    /// writer produced with values there. Judging those would make a column
+    /// unwritable after a round trip.
+    fn verify_field_nullability_where_reachable(
+        array: &ArrayData,
+        field: &Field,
+        reachable: Option<&BooleanBuffer>,
+    ) -> Result<()> {
+        let offending = match (array.nulls(), reachable) {
+            (None, _) => 0,
+            (Some(nulls), None) => nulls.null_count(),
+            (Some(nulls), Some(reachable)) => (&!nulls.inner() & reachable).count_set_bits(),
+        };
+        if !field.nullable && offending > 0 {
             return Err(Error::invalid_input(format!(
                 "The field `{}` contained null values even though the field is marked non-null in the schema",
                 field.name
             )));
         }
+        if field.children.is_empty() {
+            return Ok(());
+        }
+        // Only a struct's children sit one slot per parent slot. List-like
+        // children are addressed through offsets, so the parent's validity
+        // does not map onto them and they are checked as before.
+        if !matches!(array.data_type(), DataType::Struct(_)) {
+            for (child_field, child_array) in field.children.iter().zip(array.child_data()) {
+                Self::verify_field_nullability_where_reachable(child_array, child_field, None)?;
+            }
+            return Ok(());
+        }
+        let own = array
+            .nulls()
+            .map(|nulls| nulls.inner().clone())
+            .unwrap_or_else(|| BooleanBuffer::new_set(array.len()));
+        let child_reachable = match reachable {
+            Some(reachable) => &own & reachable,
+            None => own,
+        };
         for (child_field, child_array) in field.children.iter().zip(array.child_data()) {
-            Self::verify_field_nullability(child_array, child_field)?;
+            // Line the child up with the parent's window before comparing it
+            // against a mask built from the parent's slots.
+            let child_array = child_array.slice(array.offset(), array.len());
+            Self::verify_field_nullability_where_reachable(
+                &child_array,
+                child_field,
+                Some(&child_reachable),
+            )?;
         }
         Ok(())
     }
@@ -839,4 +891,79 @@ pub fn encode_batch_body(batch: &EncodedBatch, write_schema: bool) -> Result<Enc
         num_global_buffers,
         num_columns: batch.page_table.len() as u32,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use arrow_array::{ArrayRef, BooleanArray, StructArray};
+    use arrow_buffer::NullBuffer;
+    use arrow_schema::{Field as ArrowField, Fields, Schema as ArrowSchema};
+    use lance_core::datatypes::Schema;
+
+    use super::FileWriter;
+
+    /// `analysis: struct<changed: bool>` where the child is declared
+    /// non-nullable, built with a nullable child so the array can carry the
+    /// nulls a reader hands back.
+    fn analysis(parent_valid: Vec<bool>, changed: Vec<Option<bool>>) -> (ArrayRef, Schema) {
+        let child = Arc::new(BooleanArray::from(changed)) as ArrayRef;
+        let array = Arc::new(StructArray::new(
+            Fields::from(vec![ArrowField::new(
+                "changed",
+                arrow_schema::DataType::Boolean,
+                true,
+            )]),
+            vec![child],
+            Some(NullBuffer::from(parent_valid)),
+        )) as ArrayRef;
+        let declared = ArrowSchema::new(vec![ArrowField::new(
+            "analysis",
+            arrow_schema::DataType::Struct(Fields::from(vec![ArrowField::new(
+                "changed",
+                arrow_schema::DataType::Boolean,
+                false,
+            )])),
+            true,
+        )]);
+        (array, Schema::try_from(&declared).unwrap())
+    }
+
+    #[test]
+    fn child_nulls_under_a_null_parent_are_writable() {
+        // A null struct slot leaves its child undefined, and a reader returns
+        // null there for a column this writer stored a value in. Rejecting it
+        // would make the column unwritable after a round trip.
+        let (array, schema) = analysis(
+            vec![true, false, true, false],
+            vec![Some(true), None, Some(false), None],
+        );
+        FileWriter::verify_field_nullability(&array.to_data(), &schema.fields[0]).unwrap();
+    }
+
+    #[test]
+    fn child_nulls_under_a_valid_parent_are_still_rejected() {
+        let (array, schema) = analysis(
+            vec![true, true, true, false],
+            vec![Some(true), None, Some(false), None],
+        );
+        let error = FileWriter::verify_field_nullability(&array.to_data(), &schema.fields[0])
+            .expect_err("a null the parent does not mask violates the schema");
+        assert!(
+            error.to_string().contains("`changed`"),
+            "should name the offending child: {error}"
+        );
+    }
+
+    #[test]
+    fn a_sliced_parent_lines_up_with_its_children() {
+        let (array, schema) = analysis(
+            vec![true, false, true, true],
+            vec![Some(true), None, Some(false), Some(true)],
+        );
+        // Dropping the first row leaves the null parent at slot 0.
+        let sliced = array.slice(1, 3);
+        FileWriter::verify_field_nullability(&sliced.to_data(), &schema.fields[0]).unwrap();
+    }
 }

--- a/rust/lance-file/src/writer/structural.rs
+++ b/rust/lance-file/src/writer/structural.rs
@@ -4,7 +4,7 @@
 use core::panic;
 use std::{collections::HashMap, sync::Arc};
 
-use arrow_array::{ArrayRef, RecordBatch};
+use arrow_array::{Array, ArrayRef, RecordBatch, StructArray, make_array};
 use arrow_buffer::BooleanBuffer;
 use arrow_data::ArrayData;
 use arrow_schema::DataType;
@@ -451,7 +451,7 @@ impl EncodingPipeline {
         self.schema.is_some()
     }
 
-    fn verify_field_nullability(array: &ArrayData, field: &Field) -> Result<()> {
+    fn verify_field_nullability(array: &dyn Array, field: &Field) -> Result<()> {
         Self::verify_field_nullability_where_reachable(array, field, None)
     }
 
@@ -465,12 +465,18 @@ impl EncodingPipeline {
     /// reader is free to hand back nulls under a null parent for a column this
     /// writer produced with values there. Judging those would make a column
     /// unwritable after a round trip.
+    ///
+    /// Nulls are read through `logical_nulls`, which is what Arrow validates
+    /// against. A dictionary key pointing at a null value is a null the
+    /// physical validity buffer does not carry, and masking physical validity
+    /// alone would let one through into a file Arrow refuses on readback.
     fn verify_field_nullability_where_reachable(
-        array: &ArrayData,
+        array: &dyn Array,
         field: &Field,
         reachable: Option<&BooleanBuffer>,
     ) -> Result<()> {
-        let offending = match (array.nulls(), reachable) {
+        let nulls = array.logical_nulls();
+        let offending = match (nulls.as_ref(), reachable) {
             (None, _) => 0,
             (Some(nulls), None) => nulls.null_count(),
             (Some(nulls), Some(reachable)) => (&!nulls.inner() & reachable).count_set_bits(),
@@ -487,26 +493,31 @@ impl EncodingPipeline {
         // Only a struct's children sit one slot per parent slot. List-like
         // children are addressed through offsets, so the parent's validity
         // does not map onto them and they are checked as before.
-        if !matches!(array.data_type(), DataType::Struct(_)) {
-            for (child_field, child_array) in field.children.iter().zip(array.child_data()) {
-                Self::verify_field_nullability_where_reachable(child_array, child_field, None)?;
+        let Some(parent) = array.as_any().downcast_ref::<StructArray>() else {
+            for (child_field, child_array) in
+                field.children.iter().zip(array.to_data().child_data())
+            {
+                Self::verify_field_nullability_where_reachable(
+                    make_array(child_array.clone()).as_ref(),
+                    child_field,
+                    None,
+                )?;
             }
             return Ok(());
-        }
-        let own = array
-            .nulls()
+        };
+        let own = nulls
+            .as_ref()
             .map(|nulls| nulls.inner().clone())
             .unwrap_or_else(|| BooleanBuffer::new_set(array.len()));
         let child_reachable = match reachable {
             Some(reachable) => &own & reachable,
             None => own,
         };
-        for (child_field, child_array) in field.children.iter().zip(array.child_data()) {
-            // Line the child up with the parent's window before comparing it
-            // against a mask built from the parent's slots.
-            let child_array = child_array.slice(array.offset(), array.len());
+        // `StructArray::columns` are already cut to the parent's window, so
+        // they line up with a mask built from the parent's slots.
+        for (child_field, child_array) in field.children.iter().zip(parent.columns()) {
             Self::verify_field_nullability_where_reachable(
-                &child_array,
+                child_array.as_ref(),
                 child_field,
                 Some(&child_reachable),
             )?;
@@ -520,7 +531,7 @@ impl EncodingPipeline {
             .iter()
             .zip(self.schema.as_ref().unwrap().fields.iter())
         {
-            Self::verify_field_nullability(&column.to_data(), field)?;
+            Self::verify_field_nullability(column.as_ref(), field)?;
         }
         Ok(())
     }
@@ -650,7 +661,7 @@ impl EncodingPipeline {
                 "cannot write Lance files with more than 2^32 rows".into(),
             ));
         }
-        Self::verify_field_nullability(&array.to_data(), field)?;
+        Self::verify_field_nullability(array.as_ref(), field)?;
         if array.is_empty() {
             return Ok(());
         }
@@ -939,7 +950,7 @@ mod tests {
             vec![true, false, true, false],
             vec![Some(true), None, Some(false), None],
         );
-        EncodingPipeline::verify_field_nullability(&array.to_data(), &schema.fields[0]).unwrap();
+        EncodingPipeline::verify_field_nullability(array.as_ref(), &schema.fields[0]).unwrap();
     }
 
     #[test]
@@ -948,12 +959,45 @@ mod tests {
             vec![true, true, true, false],
             vec![Some(true), None, Some(false), None],
         );
-        let error = EncodingPipeline::verify_field_nullability(&array.to_data(), &schema.fields[0])
+        let error = EncodingPipeline::verify_field_nullability(array.as_ref(), &schema.fields[0])
             .expect_err("a null the parent does not mask violates the schema");
         assert!(
             error.to_string().contains("`changed`"),
             "should name the offending child: {error}"
         );
+    }
+
+    /// A dictionary key can point at a null value, which the physical
+    /// validity buffer does not record. Masking physical validity alone would
+    /// admit that null and produce a file Arrow rejects on readback.
+    #[test]
+    fn a_logical_null_in_a_dictionary_child_is_rejected() {
+        use arrow_array::{DictionaryArray, Int32Array};
+        use arrow_schema::DataType;
+
+        let values = Arc::new(Int32Array::from(vec![Some(10), None])) as ArrayRef;
+        let keys = Int32Array::from(vec![Some(0), Some(1), None]);
+        let child = Arc::new(DictionaryArray::new(keys, values)) as ArrayRef;
+        let child_type = child.data_type().clone();
+        // Row 2's key is physically null but the parent masks it; row 1 is a
+        // logical null the parent does not mask.
+        let array = Arc::new(StructArray::new(
+            Fields::from(vec![ArrowField::new("code", child_type.clone(), true)]),
+            vec![child],
+            Some(NullBuffer::from(vec![true, true, false])),
+        )) as ArrayRef;
+        let declared = ArrowSchema::new(vec![ArrowField::new(
+            "wrapper",
+            DataType::Struct(Fields::from(vec![ArrowField::new(
+                "code", child_type, false,
+            )])),
+            true,
+        )]);
+        let schema = Schema::try_from(&declared).unwrap();
+
+        let error = EncodingPipeline::verify_field_nullability(array.as_ref(), &schema.fields[0])
+            .expect_err("the visible logical null at row 1 must be rejected");
+        assert!(error.to_string().contains("`code`"), "{error}");
     }
 
     #[test]
@@ -964,6 +1008,6 @@ mod tests {
         );
         // Dropping the first row leaves the null parent at slot 0.
         let sliced = array.slice(1, 3);
-        EncodingPipeline::verify_field_nullability(&sliced.to_data(), &schema.fields[0]).unwrap();
+        EncodingPipeline::verify_field_nullability(sliced.as_ref(), &schema.fields[0]).unwrap();
     }
 }

--- a/rust/lance-file/src/writer/structural.rs
+++ b/rust/lance-file/src/writer/structural.rs
@@ -902,7 +902,7 @@ mod tests {
     use arrow_schema::{Field as ArrowField, Fields, Schema as ArrowSchema};
     use lance_core::datatypes::Schema;
 
-    use super::FileWriter;
+    use super::EncodingPipeline;
 
     /// `analysis: struct<changed: bool>` where the child is declared
     /// non-nullable, built with a nullable child so the array can carry the
@@ -939,7 +939,7 @@ mod tests {
             vec![true, false, true, false],
             vec![Some(true), None, Some(false), None],
         );
-        FileWriter::verify_field_nullability(&array.to_data(), &schema.fields[0]).unwrap();
+        EncodingPipeline::verify_field_nullability(&array.to_data(), &schema.fields[0]).unwrap();
     }
 
     #[test]
@@ -948,7 +948,7 @@ mod tests {
             vec![true, true, true, false],
             vec![Some(true), None, Some(false), None],
         );
-        let error = FileWriter::verify_field_nullability(&array.to_data(), &schema.fields[0])
+        let error = EncodingPipeline::verify_field_nullability(&array.to_data(), &schema.fields[0])
             .expect_err("a null the parent does not mask violates the schema");
         assert!(
             error.to_string().contains("`changed`"),
@@ -964,6 +964,6 @@ mod tests {
         );
         // Dropping the first row leaves the null parent at slot 0.
         let sliced = array.slice(1, 3);
-        FileWriter::verify_field_nullability(&sliced.to_data(), &schema.fields[0]).unwrap();
+        EncodingPipeline::verify_field_nullability(&sliced.to_data(), &schema.fields[0]).unwrap();
     }
 }

--- a/rust/lance-file/src/writer/structural.rs
+++ b/rust/lance-file/src/writer/structural.rs
@@ -6,8 +6,6 @@ use std::{collections::HashMap, sync::Arc};
 
 use arrow_array::{Array, ArrayRef, RecordBatch, StructArray, make_array};
 use arrow_buffer::BooleanBuffer;
-use arrow_data::ArrayData;
-use arrow_schema::DataType;
 use bytes::{Buf, Bytes, BytesMut};
 use futures::{StreamExt, stream::FuturesOrdered};
 use lance_core::{
@@ -910,7 +908,7 @@ mod tests {
 
     use arrow_array::{ArrayRef, BooleanArray, StructArray};
     use arrow_buffer::NullBuffer;
-    use arrow_schema::{Field as ArrowField, Fields, Schema as ArrowSchema};
+    use arrow_schema::{DataType, Field as ArrowField, Fields, Schema as ArrowSchema};
     use lance_core::datatypes::Schema;
 
     use super::EncodingPipeline;
@@ -921,19 +919,15 @@ mod tests {
     fn analysis(parent_valid: Vec<bool>, changed: Vec<Option<bool>>) -> (ArrayRef, Schema) {
         let child = Arc::new(BooleanArray::from(changed)) as ArrayRef;
         let array = Arc::new(StructArray::new(
-            Fields::from(vec![ArrowField::new(
-                "changed",
-                arrow_schema::DataType::Boolean,
-                true,
-            )]),
+            Fields::from(vec![ArrowField::new("changed", DataType::Boolean, true)]),
             vec![child],
             Some(NullBuffer::from(parent_valid)),
         )) as ArrayRef;
         let declared = ArrowSchema::new(vec![ArrowField::new(
             "analysis",
-            arrow_schema::DataType::Struct(Fields::from(vec![ArrowField::new(
+            DataType::Struct(Fields::from(vec![ArrowField::new(
                 "changed",
-                arrow_schema::DataType::Boolean,
+                DataType::Boolean,
                 false,
             )])),
             true,
@@ -973,7 +967,6 @@ mod tests {
     #[test]
     fn a_logical_null_in_a_dictionary_child_is_rejected() {
         use arrow_array::{DictionaryArray, Int32Array};
-        use arrow_schema::DataType;
 
         let values = Arc::new(Int32Array::from(vec![Some(10), None])) as ArrayRef;
         let keys = Int32Array::from(vec![Some(0), Some(1), None]);


### PR DESCRIPTION
A struct column this writer produced cannot be written back after a round trip.

`verify_field_nullability` walked into a struct's children without regard for the parent's validity, so a null in a non-nullable child failed the write even where a null parent slot masked it:

```
Invalid user input: The field `changed` contained null values even though
the field is marked non-null in the schema
```

A reader hands back exactly that. A null struct slot leaves its children undefined, and they materialize as null — so `write(read(write(x)))` fails on data this writer had just accepted. It showed up in a filtered UDF refresh, which merges stored values with recomputed ones and therefore re-writes rows it read; a full refresh writes only freshly built arrays and never hit it.

Arrow draws the line where this now does. `StructArray::try_new` rejects only the nulls in a non-nullable child that the parent's null mask does not cover, and in fact refuses to construct the array this check was reporting:

```
InvalidArgumentError("Found unmasked nulls for non-nullable StructArray field \"changed\"")
```

The 2.0 writer already documented the split — "the 2.1+ structural writer counts only visible nulls (`writer::nullability`)" — but that module was never written. The comment now points at the real thing, and 2.0 keeps rejecting masked nulls, since its logical encoders genuinely cannot store the slot.

Struct children are the only ones that sit one slot per parent slot, so they are the only ones masked; list-like children are addressed through offsets and are checked as before. Children are sliced to the parent's window first so a sliced batch lines up, which the third test covers.