### PR TITLE
fix(arrow): deep-copy the right rows from a sliced boolean column

### DIFF
--- a/rust/lance-arrow/src/deepcopy.rs
+++ b/rust/lance-arrow/src/deepcopy.rs
@@ -91,8 +91,10 @@ pub fn deep_copy_array_data_sliced(data: &ArrayData) -> ArrayData {
     // Use MutableArrayData to efficiently copy just the slice
     let mut mutable = MutableArrayData::new(vec![data], false, data.len());
 
-    // Copy from offset to offset+len (the visible slice)
-    mutable.extend(0, data.offset(), data.offset() + data.len());
+    // `extend` indexes from the source array's first logical element; arrow
+    // adds `ArrayData::offset` itself. Passing the offset here would apply it
+    // twice and copy the wrong elements.
+    mutable.extend(0, 0, data.len());
 
     // Freeze into immutable ArrayData
     mutable.freeze()
@@ -119,7 +121,7 @@ pub fn deep_copy_batch_sliced(batch: &RecordBatch) -> crate::Result<RecordBatch>
 mod tests {
     use std::sync::Arc;
 
-    use arrow_array::{Array, Int32Array, RecordBatch, StringArray};
+    use arrow_array::{Array, BooleanArray, Int32Array, RecordBatch, StringArray};
     use arrow_schema::{DataType, Field, Schema};
 
     #[test]
@@ -234,5 +236,35 @@ mod tests {
         assert!(copied_int.is_valid(1)); // Some(3)
         assert!(!copied_int.is_valid(2)); // None
         assert_eq!(copied_int.value(1), 3);
+    }
+
+    /// Boolean is the array kind that keeps a non-zero `ArrayData::offset`
+    /// after a slice: a bit offset cannot be folded into the buffer pointer
+    /// the way the byte offset of a primitive array can. The copy has to start
+    /// at the slice's first element anyway.
+    #[test]
+    fn test_deep_copy_array_sliced_boolean_keeps_offset() {
+        let array = BooleanArray::from(vec![
+            Some(false),
+            None,
+            Some(false),
+            Some(true),
+            Some(true),
+            Some(false),
+            Some(true),
+            None,
+            Some(true),
+            Some(true),
+        ]);
+        let sliced = array.slice(3, 4);
+        assert_eq!(sliced.to_data().offset(), 3);
+
+        let copied = super::deep_copy_array_sliced(&sliced);
+        let copied = copied.as_any().downcast_ref::<BooleanArray>().unwrap();
+
+        assert_eq!(
+            copied.iter().collect::<Vec<_>>(),
+            sliced.iter().collect::<Vec<_>>()
+        );
     }
 }


### PR DESCRIPTION
`deep_copy_array_data_sliced` in `rust/lance-arrow/src/deepcopy.rs` copied from the wrong place: `mutable.extend(0, data.offset(), data.offset() + data.len())`. `MutableArrayData::extend` already indexes from the source array's first logical element. `ArrayData::buffer` hands the value extenders a slice that starts at `self.offset`, and the null-bit extender adds `nulls.offset()` itself. Passing the offset in as `start` applies it a second time, so the copy begins `offset` elements past the slice.

Most arrays hide this, because `to_data()` folds a slice into the buffer pointer and leaves `ArrayData::offset` at 0. A boolean array cannot: a bit offset has no byte pointer to fold into, so `From<BooleanArray> for ArrayData` sets `.offset(array.values.offset())` and a sliced boolean column keeps a non-zero offset. Its deep copy comes back shifted by that many bits, values and validity alike.

Two public entry points reach it. `RecordBatchExt::shrink_to_fit` is a direct call into `deep_copy_batch_sliced`. And `rechunk_stream_by_size_deep_copy` deep-copies every slice it produces, which is how `HardCapBatchSizeExec` caps batch sizes ahead of a DataFusion sort, so a large batch with a boolean column comes back through that node with the wrong booleans and no error.

The fix is to copy from 0. The regression test slices a boolean array that has nulls at offset 3, asserts the slice really does carry `ArrayData::offset == 3`, and compares the copy against the slice element by element.

Verification, run from `rust/` on 1.97.0:

`cargo test -p lance-arrow` passes, 102 unit tests and 6 doctests. Reverting just the one-line fix and keeping the test makes `test_deep_copy_array_sliced_boolean_keeps_offset` fail with `left: [Some(true), Some(false), Some(true), Some(true)]` against `right: [Some(true), Some(true), Some(false), Some(true)]`, while the five deepcopy tests that were already there still pass, which is why this went unnoticed.

`cargo clippy -p lance-arrow --all-targets --all-features -- -D warnings` is clean, and so is `cargo fmt --all -- --check`.
