### PR TITLE
fix(index): reject RabitQ metadata without a code dimension

### DIFF
--- a/rust/lance-index/src/vector/bq/storage.rs
+++ b/rust/lance-index/src/vector/bq/storage.rs
@@ -2467,8 +2467,21 @@ impl QuantizerStorage for RabitQuantizationStorage {
         validate_rq_num_bits(metadata.num_bits)?;
         let row_ids = batch[ROW_ID].as_primitive::<UInt64Type>().clone();
         let codes = batch[RABIT_CODE_COLUMN].as_fixed_size_list().clone();
+        // `rotated_dim() == 0` means the metadata never recorded a code
+        // dimension, so the width check below could only ever report that the
+        // column needs 0 bytes. Reject up front with the real cause.
+        if metadata.rotated_dim() == 0 {
+            return Err(Error::corrupt_file_named(
+                "rabitq metadata",
+                format!(
+                    "no code dimension: code_dim is 0 and the rotation matrix is not loaded \
+                     (rotation_type={:?}, rotate_mat_position={:?})",
+                    metadata.rotation_type, metadata.rotate_mat_position
+                ),
+            ));
+        }
         let expected_code_bytes = metadata.binary_code_bytes();
-        if expected_code_bytes > 0 && codes.value_length() as usize != expected_code_bytes {
+        if codes.value_length() as usize != expected_code_bytes {
             return Err(Error::invalid_input(format!(
                 "RabitQ code byte width mismatch: column {} has {} bytes, metadata rotated_dim={} requires {} bytes",
                 RABIT_CODE_COLUMN,
@@ -3031,6 +3044,57 @@ mod tests {
     fn test_new_rabit_metadata_uses_raw_query_estimator() {
         let metadata = make_test_metadata(64);
         assert_eq!(metadata.query_estimator, RabitQueryEstimator::RawQuery);
+    }
+
+    #[test]
+    fn test_degenerate_metadata_rejects_any_code_width() {
+        // Metadata with no code dimension (code_dim absent, so 0, and the
+        // rotation matrix not loaded) made the code-width check below it
+        // compare against 0, which the check read as "nothing to compare" and
+        // skipped, so a code column of any width loaded.
+        let metadata: RabitQuantizationMetadata =
+            serde_json::from_str(r#"{"num_bits":1,"packed":true}"#).unwrap();
+        assert_eq!(metadata.rotated_dim(), 0);
+
+        let codes =
+            FixedSizeListArray::try_new_from_values(UInt8Array::from(vec![0u8; 16]), 8).unwrap();
+        let batch = make_test_batch(codes);
+        let err =
+            RabitQuantizationStorage::try_from_batch(batch, &metadata, DistanceType::L2, None)
+                .expect_err("metadata without a code dimension must be rejected");
+        assert!(
+            matches!(err, Error::CorruptFile { .. }),
+            "expected CorruptFile, got {err:?}"
+        );
+        assert!(err.to_string().contains("no code dimension"), "got: {err}");
+    }
+
+    /// Metadata written before #6024 carries no `code_dim` and depends on the
+    /// rotation matrix for the dimension, so the rejection above must not fire
+    /// once `parse_buffer` has installed it.
+    #[test]
+    fn test_metadata_without_code_dim_loads_from_the_rotation_matrix() {
+        const DIM: usize = 64;
+        let mut metadata: RabitQuantizationMetadata =
+            serde_json::from_str(r#"{"num_bits":1,"packed":true}"#).unwrap();
+        metadata.rotate_mat = Some(
+            FixedSizeListArray::try_new_from_values(
+                Float32Array::from(vec![0.0; DIM * DIM]),
+                DIM as i32,
+            )
+            .unwrap(),
+        );
+        assert_eq!(metadata.rotated_dim(), DIM);
+
+        let code_bytes = metadata.binary_code_bytes();
+        let codes = FixedSizeListArray::try_new_from_values(
+            UInt8Array::from(vec![0u8; 2 * code_bytes]),
+            code_bytes as i32,
+        )
+        .unwrap();
+        let batch = make_test_batch(codes);
+        RabitQuantizationStorage::try_from_batch(batch, &metadata, DistanceType::L2, None)
+            .expect("a code dimension recovered from the rotation matrix must still load");
     }
 
     fn make_test_batch(codes: FixedSizeListArray) -> RecordBatch {


### PR DESCRIPTION
## Problem

The code-width check in `RabitQuantizationStorage::try_from_batch` is gated on the expected width being positive, so metadata that carries no code dimension (`code_dim` absent and no rotation matrix to recover it from) makes the check compare against zero and skip itself, and a code column of any width loads.

Fixes #9024.

## What this changes

Reject `rotated_dim() == 0` before the width check, as `CorruptFile`, and drop the `> 0` gate so the width comparison always runs.

No in-tree writer produces that metadata: since #6024 the writer always sets `code_dim`, and before that it always stored the rotation matrix that `parse_buffer` recovers the dimension from. So this is corrupt-metadata handling rather than a fix for a state a lance version can write, which is also why the `> 0` gate was not protecting a real case: it arrived in #7021, after every writer already emitted `code_dim`.

## Test plan

`test_degenerate_metadata_rejects_any_code_width` deserializes `{"num_bits":1,"packed":true}`, checks `rotated_dim()` is 0, and asserts that an 8-byte code column is rejected with `CorruptFile`. Restoring the `> 0` gate makes it fail: the call returns a storage with `code_dim: 0` alongside an 8-byte code column.

`test_metadata_without_code_dim_loads_from_the_rotation_matrix` covers the shape the rejection must not touch, which is the pre-#6024 one: no `code_dim`, dimension recovered from the rotation matrix that `parse_buffer` installs.

- `cargo test -p lance-index --lib vector::bq` 232 passed
- `cargo clippy --all --tests --benches -- -D warnings` clean
- `cargo fmt --all --check` clean
