### PR TITLE
fix(index): reject cosine and hamming in float kmeans instead of panicking

### DIFF
--- a/python/python/lance/util.py
+++ b/python/python/lance/util.py
@@ -123,7 +123,9 @@ class KMeans:
             The number of clusters to create.
         metric_type: str, default="l2"
             The metric to use for calculating distances between vectors.
-            Supported distance metrics: "l2", "cosine", "dot"
+            Supported distance metrics: "l2", "cosine", "dot". "cosine"
+            normalizes the vectors to unit length and clusters them with "l2",
+            so ``predict`` normalizes its input the same way.
         max_iters: int
             The maximum number of iterations to run the KMeans algorithm. Default: 50.
         centroids (pyarrow.FixedSizeListArray, optional.) – Provide existing centroids.

--- a/python/python/tests/test_kmeans.py
+++ b/python/python/tests/test_kmeans.py
@@ -28,9 +28,26 @@ def test_kmeans_dot():
     kmeans.fit(data)
 
 
-def test_precomputed_kmeans():
+def test_kmeans_cosine():
+    # Cosine trains and predicts over unit-length vectors, so a row and a
+    # scaled copy of it must land in the same cluster. This also used to panic
+    # rather than train at this size.
+    kmeans = lance.util.KMeans(8, metric_type="cosine")
     data = np.random.randn(1000, 128).astype(np.float32)
-    kmeans = lance.util.KMeans(8, metric_type="l2")
+    kmeans.fit(data)
+
+    centroids = np.stack(kmeans.centroids.to_numpy(zero_copy_only=False))
+    assert centroids.shape == (8, 128)
+
+    clusters = kmeans.predict(data).to_numpy(zero_copy_only=False)
+    scaled = kmeans.predict(data * 7.0).to_numpy(zero_copy_only=False)
+    np.testing.assert_array_equal(clusters, scaled)
+
+
+@pytest.mark.parametrize("metric_type", ["l2", "cosine"])
+def test_precomputed_kmeans(metric_type):
+    data = np.random.randn(1000, 128).astype(np.float32)
+    kmeans = lance.util.KMeans(8, metric_type=metric_type)
     kmeans.fit(data)
     original_clusters = kmeans.predict(data)
 
@@ -38,7 +55,7 @@ def test_precomputed_kmeans():
     centroids = pa.FixedSizeListArray.from_arrays(values, list_size=128)
 
     # Initialize a new KMeans with precomputed centroids.
-    new_kmeans = lance.util.KMeans(8, metric_type="l2", centroids=centroids)
+    new_kmeans = lance.util.KMeans(8, metric_type=metric_type, centroids=centroids)
     new_clusters = new_kmeans.predict(data)
 
     # Verify the predictions are the same for both KMeans instances.

--- a/python/src/utils.rs
+++ b/python/src/utils.rs
@@ -32,6 +32,7 @@ use lance_index::vector::kmeans::{
 };
 use lance_index::vector::v3::subindex::IvfSubIndex;
 use lance_linalg::distance::DistanceType;
+use lance_linalg::kernels::normalize_fsl_owned;
 use lance_table::io::manifest::ManifestDescribing;
 use pyo3::intern;
 use pyo3::types::PyNone;
@@ -72,6 +73,27 @@ pub struct KMeans {
     trained_kmeans: Option<LanceKMeans>,
 }
 
+/// Cosine is trained and assigned as L2 over unit-length vectors, the way the
+/// index build path does it. The float kmeans dispatch itself does not take
+/// cosine, so the vectors have to be normalized on the way in.
+fn kmeans_metric(metric_type: DistanceType) -> DistanceType {
+    match metric_type {
+        DistanceType::Cosine => DistanceType::L2,
+        other => other,
+    }
+}
+
+fn normalize_for_cosine(
+    metric_type: DistanceType,
+    vectors: FixedSizeListArray,
+) -> PyResult<FixedSizeListArray> {
+    if metric_type != DistanceType::Cosine {
+        return Ok(vectors);
+    }
+    normalize_fsl_owned(vectors)
+        .map_err(|e| PyValueError::new_err(format!("Error normalizing cosine input: {}", e)))
+}
+
 #[pymethods]
 impl KMeans {
     #[new]
@@ -82,14 +104,21 @@ impl KMeans {
         max_iters: u32,
         centroids_arr: Option<&Bound<PyAny>>,
     ) -> PyResult<Self> {
+        let metric_type: DistanceType = metric_type
+            .try_into()
+            .map_err(|e| PyValueError::new_err(format!("Invalid metric_type: {}", e)))?;
         let trained_kmeans = if let Some(arr) = centroids_arr {
             let data = ArrayData::from_pyarrow_bound(arr)?;
             if !matches!(data.data_type(), DataType::FixedSizeList(_, _)) {
                 return Err(PyValueError::new_err("Must be a FixedSizeList"));
             }
+            // Not normalized: these are centroids, which is model state, not
+            // input data. A cosine fit leaves its centroids as means of unit
+            // vectors, so normalizing them here would move every prediction
+            // away from the model they were taken from.
             let fixed_size_arr = FixedSizeListArray::from(data);
             let params = KMeansParams {
-                distance_type: metric_type.try_into().unwrap(),
+                distance_type: kmeans_metric(metric_type),
                 max_iters,
                 ..Default::default()
             };
@@ -106,7 +135,7 @@ impl KMeans {
         };
         Ok(Self {
             k,
-            metric_type: metric_type.try_into().unwrap(),
+            metric_type,
             max_iters,
             trained_kmeans,
         })
@@ -118,9 +147,10 @@ impl KMeans {
         if !matches!(data.data_type(), DataType::FixedSizeList(_, _)) {
             return Err(PyValueError::new_err("Must be a FixedSizeList"));
         }
-        let fixed_size_arr = FixedSizeListArray::from(data);
+        let fixed_size_arr =
+            normalize_for_cosine(self.metric_type, FixedSizeListArray::from(data))?;
         let params = KMeansParams {
-            distance_type: self.metric_type,
+            distance_type: kmeans_metric(self.metric_type),
             max_iters: self.max_iters,
             ..Default::default()
         };
@@ -153,6 +183,9 @@ impl KMeans {
         if !matches!(fixed_size_arr.value_type(), DataType::Float32) {
             return Err(PyValueError::new_err("Must be a FixedSizeList of Float32"));
         };
+        // The model was trained over unit-length vectors for cosine, so the
+        // query has to be normalized the same way before it is assigned.
+        let fixed_size_arr = normalize_for_cosine(self.metric_type, fixed_size_arr)?;
         let values = fixed_size_arr.values().as_primitive();
         let centroids = kmeans.centroids.as_primitive();
         let cluster_ids = UInt32Array::from(

--- a/rust/lance-index/src/vector/kmeans.rs
+++ b/rust/lance-index/src/vector/kmeans.rs
@@ -3,10 +3,11 @@
 
 //! KMeans implementation for Apache Arrow Arrays.
 //!
-//! Support ``l2``, ``cosine`` and ``dot`` distances, see [DistanceType].
+//! Supports ``l2`` and ``dot`` over float vectors and ``hamming`` over
+//! ``uint8`` vectors, see [DistanceType].
 //!
-//! ``Cosine`` distance are calculated by normalizing the vectors to unit length,
-//! and run ``l2`` distance on the unit vectors.
+//! ``Cosine`` is not supported: callers normalize the vectors to unit length
+//! and train with ``l2``.
 //!
 
 use core::f32;
@@ -814,18 +815,36 @@ impl KMeans {
             )));
         }
 
+        // Before the optional centroid index is built, not after: the index is
+        // built from `self.distance_type`, and HNSW construction panics on a
+        // metric its kernels do not implement, which would beat the dispatch
+        // below to the rejection.
+        let combination = (
+            data.value_type(),
+            self.centroids.data_type().clone(),
+            self.distance_type,
+        );
+        match &combination {
+            (DataType::Float16, DataType::Float16, DistanceType::L2 | DistanceType::Dot)
+            | (DataType::Float32, DataType::Float32, DistanceType::L2 | DistanceType::Dot)
+            | (DataType::Float64, DataType::Float64, DistanceType::L2 | DistanceType::Dot)
+            | (DataType::UInt8, DataType::UInt8, DistanceType::Hamming) => {}
+            (value_type, centroid_type, distance_type) => {
+                return Err(ArrowError::InvalidArgumentError(format!(
+                    "KMeans: can not compute membership for data type {} with centroid type {} and distance type {}",
+                    value_type, centroid_type, distance_type
+                )));
+            }
+        }
+
         let index = SimpleIndex::may_train_index(
             self.centroids.clone(),
             self.dimension,
             self.distance_type,
         )
         .map_err(|e| ArrowError::ExternalError(Box::new(e)))?;
-        match (
-            data.value_type(),
-            self.centroids.data_type(),
-            self.distance_type,
-        ) {
-            (DataType::Float16, DataType::Float16, _) => {
+        match combination {
+            (DataType::Float16, DataType::Float16, DistanceType::L2 | DistanceType::Dot) => {
                 let data_values = data.values().as_primitive::<Float16Type>().values();
                 let centroids = self.centroids.as_primitive::<Float16Type>().values();
                 Ok(KMeansAlgoFloat::<Float16Type>::compute_membership_and_dist(
@@ -838,7 +857,7 @@ impl KMeans {
                     index.as_ref(),
                 ))
             }
-            (DataType::Float32, DataType::Float32, _) => {
+            (DataType::Float32, DataType::Float32, DistanceType::L2 | DistanceType::Dot) => {
                 let data_values = data.values().as_primitive::<Float32Type>().values();
                 let centroids = self.centroids.as_primitive::<Float32Type>().values();
                 Ok(KMeansAlgoFloat::<Float32Type>::compute_membership_and_dist(
@@ -851,7 +870,7 @@ impl KMeans {
                     index.as_ref(),
                 ))
             }
-            (DataType::Float64, DataType::Float64, _) => {
+            (DataType::Float64, DataType::Float64, DistanceType::L2 | DistanceType::Dot) => {
                 let data_values = data.values().as_primitive::<Float64Type>().values();
                 let centroids = self.centroids.as_primitive::<Float64Type>().values();
                 Ok(KMeansAlgoFloat::<Float64Type>::compute_membership_and_dist(
@@ -1315,7 +1334,8 @@ impl KMeans {
 
     /// Train a [`KMeans`] model with full parameters.
     ///
-    /// If the DistanceType is `Cosine`, the input vectors will be normalized with each iteration.
+    /// `Cosine` is not supported here: callers must normalize the input
+    /// vectors themselves and train with [`DistanceType::L2`].
     pub fn new_with_params(
         data: &FixedSizeListArray,
         k: usize,
@@ -1336,18 +1356,21 @@ impl KMeans {
         if k > 256 && params.hierarchical_k > 1 {
             log::debug!("Using hierarchical clustering for k={}", k);
             return match (data.value_type(), params.distance_type) {
-                (DataType::Float16, _) => Self::train_hierarchical_kmeans::<
-                    Float16Type,
-                    KMeansAlgoFloat<Float16Type>,
-                >(data, k, params),
-                (DataType::Float32, _) => Self::train_hierarchical_kmeans::<
-                    Float32Type,
-                    KMeansAlgoFloat<Float32Type>,
-                >(data, k, params),
-                (DataType::Float64, _) => Self::train_hierarchical_kmeans::<
-                    Float64Type,
-                    KMeansAlgoFloat<Float64Type>,
-                >(data, k, params),
+                (DataType::Float16, DistanceType::L2 | DistanceType::Dot) => {
+                    Self::train_hierarchical_kmeans::<Float16Type, KMeansAlgoFloat<Float16Type>>(
+                        data, k, params,
+                    )
+                }
+                (DataType::Float32, DistanceType::L2 | DistanceType::Dot) => {
+                    Self::train_hierarchical_kmeans::<Float32Type, KMeansAlgoFloat<Float32Type>>(
+                        data, k, params,
+                    )
+                }
+                (DataType::Float64, DistanceType::L2 | DistanceType::Dot) => {
+                    Self::train_hierarchical_kmeans::<Float64Type, KMeansAlgoFloat<Float64Type>>(
+                        data, k, params,
+                    )
+                }
                 (DataType::UInt8, DistanceType::Hamming) => {
                     Self::train_hierarchical_kmeans::<UInt8Type, KModeAlgo>(data, k, params)
                 }
@@ -1360,14 +1383,14 @@ impl KMeans {
         }
 
         match (data.value_type(), params.distance_type) {
-            (DataType::Float16, _) => {
+            (DataType::Float16, DistanceType::L2 | DistanceType::Dot) => {
                 Self::train_kmeans::<Float16Type, KMeansAlgoFloat<Float16Type>>(data, k, params)
             }
 
-            (DataType::Float32, _) => {
+            (DataType::Float32, DistanceType::L2 | DistanceType::Dot) => {
                 Self::train_kmeans::<Float32Type, KMeansAlgoFloat<Float32Type>>(data, k, params)
             }
-            (DataType::Float64, _) => {
+            (DataType::Float64, DistanceType::L2 | DistanceType::Dot) => {
                 Self::train_kmeans::<Float64Type, KMeansAlgoFloat<Float64Type>>(data, k, params)
             }
             (DataType::UInt8, DistanceType::Hamming) => {
@@ -1794,6 +1817,82 @@ mod tests {
                 );
             }
         }
+    }
+
+    #[test]
+    fn test_kmeans_rejects_cosine_and_hamming_for_floats() {
+        // Cosine/Hamming used to be accepted by the float dispatch arms and
+        // then hit a panic in the first membership pass; they must be
+        // rejected up front (callers normalize cosine input and train L2).
+        let dimension = 8;
+        let values: Vec<f32> = (0..16).map(|i| i as f32 * 0.5).collect();
+        let data =
+            FixedSizeListArray::try_new_from_values(Float32Array::from(values), dimension).unwrap();
+        for distance_type in [DistanceType::Cosine, DistanceType::Hamming] {
+            let params = KMeansParams {
+                distance_type,
+                max_iters: 1,
+                ..KMeansParams::default()
+            };
+            let err = KMeans::new_with_params(&data, 2, &params).unwrap_err();
+            assert!(
+                err.to_string().contains("can not train"),
+                "expected rejection for {distance_type}, got: {err}"
+            );
+        }
+
+        // The hierarchical dispatch (k > 256 with default hierarchical_k)
+        // is a separate match that used to keep the wildcard arms.
+        let dimension = 8;
+        let values: Vec<f32> = (0..257 * dimension).map(|i| i as f32 * 0.5).collect();
+        let data =
+            FixedSizeListArray::try_new_from_values(Float32Array::from(values), dimension).unwrap();
+        let params = KMeansParams {
+            distance_type: DistanceType::Cosine,
+            max_iters: 1,
+            ..KMeansParams::default()
+        };
+        let err = KMeans::new_with_params(&data, 257, &params).unwrap_err();
+        assert!(err.to_string().contains("can not train"), "got: {err}");
+    }
+
+    /// Assignment dispatches on the same triple as training, so it has to
+    /// reject the same combinations: a caller that builds a cosine model with
+    /// `with_centroids` used to reach the panic through this path instead.
+    ///
+    /// The rejection has to happen before the optional centroid index is built.
+    /// This test only covers that ordering when the index is actually built,
+    /// which the default `Auto` mode does not do at this size: run it with
+    /// `LANCE_USE_HNSW_SPEEDUP_INDEXING=enabled` to exercise that path, where
+    /// validating after the build panics in the HNSW kernels instead.
+    #[test]
+    fn test_compute_membership_rejects_cosine_and_hamming_for_floats() {
+        let dimension = 8;
+        let values: Vec<f32> = (0..16).map(|i| i as f32 * 0.5).collect();
+        let data =
+            FixedSizeListArray::try_new_from_values(Float32Array::from(values.clone()), dimension)
+                .unwrap();
+        let centroids = Arc::new(Float32Array::from(values));
+
+        for distance_type in [DistanceType::Cosine, DistanceType::Hamming] {
+            let kmeans = KMeans::with_centroids(
+                centroids.clone(),
+                dimension as usize,
+                distance_type,
+                f64::MAX,
+            );
+            let err = kmeans.compute_membership_and_distances(&data).unwrap_err();
+            assert!(
+                err.to_string().contains("can not compute membership"),
+                "expected rejection for {distance_type}, got: {err}"
+            );
+        }
+
+        let kmeans =
+            KMeans::with_centroids(centroids, dimension as usize, DistanceType::L2, f64::MAX);
+        kmeans
+            .compute_membership_and_distances(&data)
+            .expect("l2 must still be assigned");
     }
 
     #[test]


### PR DESCRIPTION
## Problem

`KMeans::new_with_params` dispatches a float column against any distance type, so cosine and hamming reach the float algorithm, whose membership pass panics with `KMeans::find_partitions: cosine is not supported`. `compute_membership_and_distances` has the same shape, so a cosine model built with the public `with_centroids` panics on assignment too. Both matches already end in an arm that returns a descriptive error.

There is one exception, and it is why `lance.util.KMeans(k, "cosine")` looked like it worked: when the centroid set is large enough for `may_train_index` to build an HNSW over it, the assignment goes through the index and never reads the distance type, so training completes. Below that threshold the same call panics.

Fixes #9026.

## What this changes

Narrow the float arms in both dispatches to `L2 | Dot`, so cosine and hamming fall through to the error arm that was already there. Dot stays because the float path implements it.

Assignment validates the combination before building the optional centroid index rather than after. The index is built from the requested metric, and HNSW construction panics on a metric its kernels do not implement, so validating afterwards let float plus hamming panic at `distance.rs:313` before the dispatch could return the error.

`lance.util.KMeans` documents cosine, so the binding now normalizes its `fit` and `predict` input and clusters with l2, which is what the index build path does before every training call. Cosine then behaves the same at every `k` rather than panicking below the HNSW threshold, and a row and a scaled copy of it land in the same cluster. Precomputed centroids are model state rather than input, so they are taken as given: a cosine fit leaves its centroids as means of unit vectors, and normalizing them again would move the predictions of a model rebuilt from another model's centroids.

The module and `new_with_params` doc comments claimed cosine inputs are normalized each iteration. That was implemented in #1723 and removed in #2015 while the comment was carried forward, so both now say what callers actually do.

One thing this does not cover: calling the lower-level `compute_partitions` or `KMeansAlgoFloat::compute_membership_and_dist` directly still panics for cosine, since the check lives in the dispatch rather than in the algorithm. Moving it would mean making the hot membership loop fallible.

## Test plan

`test_kmeans_rejects_cosine_and_hamming_for_floats` covers training through both dispatch blocks: cosine and hamming over an f32 column at `k=2`, then cosine at `k=257` for the hierarchical route. `test_compute_membership_rejects_cosine_and_hamming_for_floats` covers assignment through `with_centroids`, and asserts l2 still works so the narrowing is not over-wide. Restoring the wildcard arms makes each of them panic at `kmeans.rs:511` instead.

`test_kmeans_cosine` covers the Python surface at `k=8`, which is the size that used to panic: it trains, and it asserts that scaling the input by 7 does not move any row's cluster, which is what fails if either `fit` or `predict` skips the normalization.

`test_precomputed_kmeans` now runs for cosine as well as l2, which is what catches the centroid round trip: re-normalizing the centroids moves about 1% of the rows to a different cluster, and the test asserts every row matches.

The validation ordering needs the centroid index to actually be built, which the default `Auto` mode does not do at test sizes. `LANCE_USE_HNSW_SPEEDUP_INDEXING=enabled cargo test -p lance-index --lib vector::kmeans` covers it, and the assignment test carries a note saying so; on the previous head that run panicked with `not yet implemented` at `rust/lance-linalg/src/distance.rs:313`.

- `cargo test -p lance-index --lib vector::kmeans` 17 passed, 1 ignored, and the same with `LANCE_USE_HNSW_SPEEDUP_INDEXING=enabled`
- `cargo test -p lance --lib index::vector` 285 passed, 1 ignored
- `uv run pytest python/tests/test_kmeans.py` 5 passed
- `cargo clippy --all --tests --benches -- -D warnings` and the same for `python/Cargo.toml` clean
- `cargo fmt --all --check` clean, `uv run make lint` clean
