### PR TITLE
fix(index): stop appending a spurious byte in binary_quantization

### DIFF
--- a/rust/lance-index/src/vector/bq.rs
+++ b/rust/lance-index/src/vector/bq.rs
@@ -68,23 +68,24 @@ impl BinaryQuantization {
 /// Use the sign bit of the float vector to represent the binary vector.
 fn binary_quantization<T: Float>(data: &[T]) -> impl Iterator<Item = u8> + '_ {
     let iter = data.chunks_exact(8);
-    iter.clone()
-        .map(|c| {
-            // Auto vectorized.
-            // Before changing this code, please check the assembly output.
-            let mut bits: u8 = 0;
-            c.iter().enumerate().for_each(|(idx, v)| {
-                bits |= (v.is_sign_positive() as u8) << idx;
-            });
-            bits
-        })
-        .chain(once(0).map(move |_| {
-            let mut bits: u8 = 0;
-            iter.remainder().iter().enumerate().for_each(|(idx, v)| {
-                bits |= (v.is_sign_positive() as u8) << idx;
-            });
-            bits
-        }))
+    // Only append a byte for the tail when a tail exists: an input whose
+    // length is a multiple of 8 must yield exactly ceil(len / 8) bytes.
+    let has_remainder = !iter.remainder().is_empty();
+    let mut remainder_bits: u8 = 0;
+    iter.remainder()
+        .iter()
+        .enumerate()
+        .for_each(|(idx, v)| remainder_bits |= (v.is_sign_positive() as u8) << idx);
+    iter.map(|c| {
+        // Auto vectorized.
+        // Before changing this code, please check the assembly output.
+        let mut bits: u8 = 0;
+        c.iter().enumerate().for_each(|(idx, v)| {
+            bits |= (v.is_sign_positive() as u8) << idx;
+        });
+        bits
+    })
+    .chain(once(remainder_bits).filter(move |_| has_remainder))
 }
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
@@ -207,7 +208,10 @@ impl Default for RQBuildParams {
 mod tests {
     use super::*;
 
+    use arrow_array::types::UInt8Type;
+    use arrow_array::{FixedSizeListArray, Float32Array};
     use half::{bf16, f16};
+    use lance_arrow::FixedSizeListArrayExt;
 
     fn test_bq<T: Float>() {
         let data: Vec<T> = [1.0, -1.0, 1.0, -5.0, -7.0, -1.0, 1.0, -1.0, -0.2, 1.2, 3.2]
@@ -225,6 +229,62 @@ mod tests {
         test_bq::<f16>();
         test_bq::<f32>();
         test_bq::<f64>();
+    }
+
+    #[test]
+    fn test_binary_quantization_length_multiple_of_eight() {
+        // A full-chunk input must produce exactly ceil(len / 8) bytes; the
+        // remainder byte may only be appended when a remainder exists.
+        let data: Vec<f32> = [1.0, -1.0, 1.0, -1.0, 1.0, -1.0, 1.0, -1.0]
+            .iter()
+            .cycle()
+            .take(16)
+            .copied()
+            .collect();
+        let result = binary_quantization(&data).collect::<Vec<_>>();
+        assert_eq!(result, vec![0b01010101, 0b01010101]);
+    }
+
+    #[test]
+    fn test_transform_packs_rows_at_ceil_dim_over_eight() {
+        // The public entry point returns a flat array, so the per-row width is
+        // the caller's ceil(dim / 8). A dimension that is a multiple of 8 used
+        // to get one extra byte per row here.
+        const DIM: usize = 8;
+        const ROWS: usize = 3;
+        let values = Float32Array::from_iter_values(
+            (0..ROWS * DIM).map(|i| if i % 2 == 0 { 1.0 } else { -1.0 }),
+        );
+        let data = FixedSizeListArray::try_new_from_values(values, DIM as i32).unwrap();
+
+        let codes = BinaryQuantization::default().transform(&data).unwrap();
+
+        assert_eq!(codes.len(), ROWS * DIM.div_ceil(8));
+        assert_eq!(
+            codes.as_primitive::<UInt8Type>().values(),
+            &[0b01010101; ROWS]
+        );
+    }
+
+    #[test]
+    fn test_transform_keeps_the_tail_byte_for_a_partial_chunk() {
+        // The other branch: a dimension that is not a multiple of 8 still gets
+        // its tail byte, so rows stay ceil(dim / 8) wide either way.
+        const DIM: usize = 12;
+        const ROWS: usize = 2;
+        let values = Float32Array::from_iter_values(
+            (0..ROWS * DIM).map(|i| if i % 2 == 0 { 1.0 } else { -1.0 }),
+        );
+        let data = FixedSizeListArray::try_new_from_values(values, DIM as i32).unwrap();
+
+        let codes = BinaryQuantization::default().transform(&data).unwrap();
+
+        assert_eq!(codes.len(), ROWS * DIM.div_ceil(8));
+        // 8 alternating bits, then the 4 that remain.
+        assert_eq!(
+            codes.as_primitive::<UInt8Type>().values(),
+            &[0b01010101, 0b00000101, 0b01010101, 0b00000101]
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Problem

`binary_quantization` appends the tail byte unconditionally, so an input whose length is a multiple of 8 produces `floor(len / 8) + 1` bytes instead of `ceil(len / 8)`. Through `BinaryQuantization::transform` that is one extra zero byte per row for any dimension that is a multiple of 8.

Fixes #9028.

## What this changes

Compute the tail byte once and chain it only when `chunks_exact(8)` left a remainder. The closure mapped over the full chunks is untouched, so the loop the "auto vectorized" comment refers to is the same code as before.

`BinaryQuantization` has no callers in this repository, so no in-tree width changes. The old width also contradicted the crate's own sizing helper, `rabit_binary_code_bytes`, which is `div_ceil(8)`. Deleting the type is the other option, since `RabitQuantizer` is what IVF_RQ uses, but it is public API and the behaviour is cheap to fix.

## Test plan

`test_binary_quantization_length_multiple_of_eight` pins the helper at 16 values, and two tests pin the public entry point on both branches: 3 rows of dimension 8, and 2 rows of dimension 12 where the tail byte must still appear. Restoring the old implementation makes them fail with `[85, 85, 0]` against `[85, 85]` and 6 bytes against 3. The existing `test_binary_quantization` covers the remainder case at 11 values, so both branches stay asserted.

- `cargo test -p lance-index --lib vector::bq` 233 passed
- `cargo clippy --all --tests --benches -- -D warnings` clean
- `cargo fmt --all --check` clean
