### PR TITLE
perf(fts): defer decoding for underfilled conjunctions

### DIFF
--- a/rust/lance-index/src/scalar/inverted/encoding.rs
+++ b/rust/lance-index/src/scalar/inverted/encoding.rs
@@ -1007,29 +1007,59 @@ pub fn decompress_posting_block(
     frequencies: &mut Vec<u32>,
     block_size: usize,
 ) {
+    let frequency_offset = decompress_posting_block_doc_ids(block, buffer, doc_ids, block_size);
+    decompress_posting_block_frequencies(block, frequency_offset, buffer, frequencies, block_size);
+}
+
+/// Decode only the document-id stream of a full posting block and return the
+/// byte offset at which the frequency stream starts.
+pub(super) fn decompress_posting_block_doc_ids(
+    block: &[u8],
+    buffer: &mut [u32],
+    doc_ids: &mut Vec<u32>,
+    block_size: usize,
+) -> usize {
     debug_assert!(validate_block_size(block_size).is_ok());
     debug_assert!(buffer.len() >= block_size);
-    // skip the block max score prefix (128-doc blocks only)
-    let mut block = &block[posting_block_score_prefix_len(block_size)..];
-    match block_size {
+    let prefix_len = posting_block_score_prefix_len(block_size);
+    let payload = &block[prefix_len..];
+    prefix_len
+        + match block_size {
+            BitPacker4x::BLOCK_LEN => {
+                decompress_sorted_block_with::<BitPacker4x>(payload, buffer, doc_ids)
+            }
+            BitPacker8x::BLOCK_LEN => {
+                decompress_sorted_block_with::<BitPacker8x>(payload, buffer, doc_ids)
+            }
+            _ => unreachable!("validated posting block size should be supported"),
+        }
+}
+
+/// Decode the frequency stream of a full posting block from the offset
+/// returned by [`decompress_posting_block_doc_ids`].
+pub(super) fn decompress_posting_block_frequencies(
+    block: &[u8],
+    frequency_offset: usize,
+    buffer: &mut [u32],
+    frequencies: &mut Vec<u32>,
+    block_size: usize,
+) {
+    debug_assert!(validate_block_size(block_size).is_ok());
+    debug_assert!(buffer.len() >= block_size);
+    let frequency_block = &block[frequency_offset..];
+    let num_bytes = match block_size {
         BitPacker4x::BLOCK_LEN => {
-            let num_bytes = decompress_sorted_block_with::<BitPacker4x>(block, buffer, doc_ids);
-            block = &block[num_bytes..];
-            let num_bytes = decompress_block_with::<BitPacker4x>(block, buffer, frequencies);
-            block = &block[num_bytes..];
+            decompress_block_with::<BitPacker4x>(frequency_block, buffer, frequencies)
         }
         BitPacker8x::BLOCK_LEN => {
-            let num_bytes = decompress_sorted_block_with::<BitPacker8x>(block, buffer, doc_ids);
-            block = &block[num_bytes..];
-            let num_bytes = decompress_pfor_block_with::<BitPacker8x>(block, buffer, frequencies);
-            block = &block[num_bytes..];
+            decompress_pfor_block_with::<BitPacker8x>(frequency_block, buffer, frequencies)
         }
         _ => unreachable!("validated posting block size should be supported"),
-    }
+    };
     debug_assert!(
-        block.is_empty(),
+        frequency_offset + num_bytes == block.len(),
         "posting block has {} trailing bytes after decoding",
-        block.len()
+        block.len().saturating_sub(frequency_offset + num_bytes)
     );
 }
 
@@ -1041,17 +1071,32 @@ pub fn decompress_posting_remainder(
     doc_ids: &mut Vec<u32>,
     frequencies: &mut Vec<u32>,
 ) {
-    let block = &block[posting_block_score_prefix_len(block_size)..];
+    let frequency_offset =
+        decompress_posting_remainder_doc_ids(block, n, codec, block_size, doc_ids);
+    decompress_posting_remainder_frequencies(block, frequency_offset, n, codec, frequencies);
+}
+
+/// Decode only the document-id stream of a posting tail and return the byte
+/// offset at which its frequency stream starts.
+pub(super) fn decompress_posting_remainder_doc_ids(
+    block: &[u8],
+    n: usize,
+    codec: PostingTailCodec,
+    block_size: usize,
+    doc_ids: &mut Vec<u32>,
+) -> usize {
+    let prefix_len = posting_block_score_prefix_len(block_size);
+    let payload = &block[prefix_len..];
     match codec {
         PostingTailCodec::Fixed32 => {
-            decompress_raw_remainder(block, n, doc_ids);
-            decompress_raw_remainder(&block[n * 4..], n, frequencies);
+            decompress_raw_remainder(payload, n, doc_ids);
+            prefix_len + n * 4
         }
         PostingTailCodec::VarintDelta => {
             let mut offset = 0usize;
             let mut previous = 0u32;
             for index in 0..n {
-                let delta = decode_varint_u32(block, &mut offset)
+                let delta = decode_varint_u32(payload, &mut offset)
                     .expect("posting tail doc ids should contain valid varints");
                 let doc_id = if index == 0 {
                     delta
@@ -1063,16 +1108,38 @@ pub fn decompress_posting_remainder(
                 doc_ids.push(doc_id);
                 previous = doc_id;
             }
+            prefix_len + offset
+        }
+    }
+}
+
+/// Decode the frequency stream of a posting tail from the offset returned by
+/// [`decompress_posting_remainder_doc_ids`].
+pub(super) fn decompress_posting_remainder_frequencies(
+    block: &[u8],
+    frequency_offset: usize,
+    n: usize,
+    codec: PostingTailCodec,
+    frequencies: &mut Vec<u32>,
+) {
+    let frequency_block = &block[frequency_offset..];
+    match codec {
+        PostingTailCodec::Fixed32 => {
+            decompress_raw_remainder(frequency_block, n, frequencies);
+            debug_assert_eq!(frequency_offset + n * 4, block.len());
+        }
+        PostingTailCodec::VarintDelta => {
+            let mut offset = 0usize;
             for _ in 0..n {
-                let frequency = decode_varint_u32(block, &mut offset)
+                let frequency = decode_varint_u32(frequency_block, &mut offset)
                     .expect("posting tail frequencies should contain valid varints");
                 frequencies.push(frequency);
             }
             assert_eq!(
-                offset,
+                frequency_offset + offset,
                 block.len(),
                 "posting tail block has {} trailing bytes after decoding",
-                block.len() - offset
+                block.len() - frequency_offset - offset
             );
         }
     }
@@ -1224,6 +1291,77 @@ mod tests {
                 )?;
             assert_eq!(decoded_doc_ids, doc_ids);
             assert_eq!(decoded_frequencies, frequencies);
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn test_posting_doc_ids_and_frequencies_decode_independently() -> Result<()> {
+        for block_size in [BitPacker4x::BLOCK_LEN, BitPacker8x::BLOCK_LEN] {
+            let doc_ids = (0..block_size as u32)
+                .map(|doc| doc * 3)
+                .collect::<Vec<_>>();
+            let frequencies = (0..block_size as u32)
+                .map(|value| value % 17 + 1)
+                .collect::<Vec<_>>();
+            let posting_list = compress_posting_list_with_tail_codec_and_block_size(
+                doc_ids.len(),
+                doc_ids.iter(),
+                frequencies.iter(),
+                std::iter::once(1.0),
+                PostingTailCodec::VarintDelta,
+                block_size,
+            )?;
+            let block = posting_list.value(0);
+            let mut buffer = [0; MAX_POSTING_BLOCK_SIZE];
+            let mut decoded_doc_ids = Vec::new();
+            let frequency_offset = decompress_posting_block_doc_ids(
+                block,
+                &mut buffer,
+                &mut decoded_doc_ids,
+                block_size,
+            );
+            assert_eq!(decoded_doc_ids, doc_ids);
+            let mut decoded_frequencies = Vec::new();
+            decompress_posting_block_frequencies(
+                block,
+                frequency_offset,
+                &mut buffer,
+                &mut decoded_frequencies,
+                block_size,
+            );
+            assert_eq!(decoded_frequencies, frequencies);
+
+            for codec in [PostingTailCodec::Fixed32, PostingTailCodec::VarintDelta] {
+                let tail_doc_ids = vec![2, 9, 27, 81, 82, 120, 511];
+                let tail_frequencies = vec![1, 3, 1, 8, 2, 21, 5];
+                let mut tail = Vec::new();
+                encode_remainder_posting_block_into(
+                    &tail_doc_ids,
+                    &tail_frequencies,
+                    codec,
+                    block_size,
+                    &mut tail,
+                )?;
+                let mut decoded_tail_doc_ids = Vec::new();
+                let frequency_offset = decompress_posting_remainder_doc_ids(
+                    &tail,
+                    tail_doc_ids.len(),
+                    codec,
+                    block_size,
+                    &mut decoded_tail_doc_ids,
+                );
+                assert_eq!(decoded_tail_doc_ids, tail_doc_ids);
+                let mut decoded_tail_frequencies = Vec::new();
+                decompress_posting_remainder_frequencies(
+                    &tail,
+                    frequency_offset,
+                    tail_doc_ids.len(),
+                    codec,
+                    &mut decoded_tail_frequencies,
+                );
+                assert_eq!(decoded_tail_frequencies, tail_frequencies);
+            }
         }
         Ok(())
     }

--- a/rust/lance-index/src/scalar/inverted/index/search.rs
+++ b/rust/lance-index/src/scalar/inverted/index/search.rs
@@ -739,10 +739,10 @@ impl InvertedIndex {
         }
         // For new-format indexes, aggregate_corpus_stats reads corpus stats from
         // persisted schema metadata (O(1)) without loading doc lengths as a side
-        // effect. Pre-load lengths in parallel now for partitions that contain at
-        // least one query token, so the scoring phase gets cache hits instead of
-        // issuing sequential per-partition IO.  Partitions with no matching terms
-        // are skipped to preserve the no-load optimization for no-hit queries.
+        // effect. Pre-load lengths in parallel now only for partitions whose
+        // dictionaries can satisfy the query leaf, so required-token misses avoid
+        // reading the full length column. The scoring phase then gets cache hits
+        // instead of issuing sequential per-partition IO.
         let io_parallelism = self.store.io_parallelism();
         let uncached_lengths = self
             .partitions
@@ -752,9 +752,12 @@ impl InvertedIndex {
                 if docs.cached_lengths().is_some() {
                     return None;
                 }
-                let has_match = (0..request.tokens.len())
-                    .any(|i| part.tokens.get(request.tokens.get_token(i)).is_some());
-                has_match.then_some(async move { docs.lengths().await.map(|_| ()) })
+                part.may_match_tokens(
+                    request.tokens.as_ref(),
+                    request.operator,
+                    request.params.phrase_slop.is_some(),
+                )
+                .then_some(async move { docs.lengths().await.map(|_| ()) })
             })
             .collect::<Vec<_>>();
         if !uncached_lengths.is_empty() {

--- a/rust/lance-index/src/scalar/inverted/index/tests/stats.rs
+++ b/rust/lance-index/src/scalar/inverted/index/tests/stats.rs
@@ -445,6 +445,30 @@ async fn test_no_hit_partition_does_not_load_document_columns() {
     assert!(scores.is_empty());
     assert!(!documents.lengths_loaded());
     assert!(!documents.projection_loaded());
+
+    let tokens = Arc::new(Tokens::new(
+        vec!["t0".to_owned(), "missing-token".to_owned()],
+        DocType::Text,
+    ));
+    let (row_ids, scores) = index
+        .bm25_search(
+            tokens,
+            Arc::new(FtsSearchParams::new().with_limit(Some(10))),
+            Operator::And,
+            Arc::new(NoFilter),
+            Arc::new(NoOpMetricsCollector),
+            None,
+        )
+        .await
+        .unwrap();
+
+    assert!(row_ids.is_empty());
+    assert!(scores.is_empty());
+    assert!(
+        !documents.lengths_loaded(),
+        "a missing required token must gate the full document-length read"
+    );
+    assert!(!documents.projection_loaded());
 }
 
 #[tokio::test]

--- a/rust/lance-index/src/scalar/inverted/wand.rs
+++ b/rust/lance-index/src/scalar/inverted/wand.rs
@@ -33,7 +33,9 @@ use super::{
     builder::ScoredDoc,
     encoding::{
         MAX_POSTING_BLOCK_SIZE, decode_position_stream_block, decompress_positions,
-        decompress_posting_block, decompress_posting_remainder, seek_packed_doc_positions,
+        decompress_posting_block_doc_ids, decompress_posting_block_frequencies,
+        decompress_posting_remainder_doc_ids, decompress_posting_remainder_frequencies,
+        seek_packed_doc_positions,
     },
     query::FtsSearchParams,
     scorer::Scorer,
@@ -297,7 +299,6 @@ static BULK_AND_MODE: LazyLock<BulkAndMode> = LazyLock::new(bulk_and_mode_from_e
 static HAS_AVX2: LazyLock<bool> = LazyLock::new(|| std::arch::is_x86_feature_detected!("avx2"));
 
 /// First index in `[pos, end)` where `docs[index] >= target` (scalar).
-/// Posting-block doc ids stay below 2^31, which the AVX2 variant relies on.
 #[inline]
 unsafe fn find_next_geq_scalar(docs: *const u32, mut pos: usize, end: usize, target: u32) -> usize {
     unsafe {
@@ -309,25 +310,35 @@ unsafe fn find_next_geq_scalar(docs: *const u32, mut pos: usize, end: usize, tar
 }
 
 /// AVX2 `find_next_geq` (the analogue of Lucene's VectorUtil.findNextGEQ):
-/// branchless 8-wide compare+movemask kills the mispredicted exits that
-/// dominate the scalar catch-up scan on irregular doc gaps.
+/// scalar lookahead skips windows wholly before the target, then an 8-wide
+/// compare locates the first matching lane.
 #[cfg(target_arch = "x86_64")]
 #[target_feature(enable = "avx2")]
 unsafe fn find_next_geq_avx2(docs: *const u32, mut pos: usize, end: usize, target: u32) -> usize {
     use core::arch::x86_64::*;
-    debug_assert!(target <= i32::MAX as u32);
     unsafe {
-        let target_lanes = _mm256_set1_epi32(target as i32);
-        while pos + 8 <= end {
-            let docs_lanes = _mm256_loadu_si256(docs.add(pos) as *const __m256i);
-            // lane mask of docs[i] < target; doc ids < 2^31 keep the signed
-            // compare equivalent to unsigned.
+        // Bias unsigned values around the sign bit so the signed AVX2 compare
+        // preserves the ordering of the full u32 domain.
+        let sign_bit = _mm256_set1_epi32(i32::MIN);
+        let target_lanes = _mm256_xor_si256(_mm256_set1_epi32(target as i32), sign_bit);
+        while pos + 8 < end {
+            // Skip nine-document groups that end before the target. Only the
+            // group containing the lower bound needs a vector load/compare.
+            if *docs.add(pos + 8) < target {
+                pos += 9;
+                continue;
+            }
+            let docs_lanes = _mm256_xor_si256(
+                _mm256_loadu_si256(docs.add(pos) as *const __m256i),
+                sign_bit,
+            );
+            // Lane mask of docs[i] < target.
             let below = _mm256_cmpgt_epi32(target_lanes, docs_lanes);
             let mask = _mm256_movemask_ps(_mm256_castsi256_ps(below)) as u32;
             if mask != 0xFF {
                 return pos + mask.trailing_ones() as usize;
             }
-            pos += 8;
+            return pos + 8;
         }
         find_next_geq_scalar(docs, pos, end, target)
     }
@@ -340,6 +351,18 @@ unsafe fn find_next_geq(docs: *const u32, pos: usize, end: usize, target: u32) -
         return unsafe { find_next_geq_avx2(docs, pos, end, target) };
     }
     unsafe { find_next_geq_scalar(docs, pos, end, target) }
+}
+
+/// Search a sorted posting block using AVX2 when available. Keep the binary
+/// search fallback because linear catch-up is slower on targets without AVX2.
+#[inline]
+fn find_next_geq_in_block(docs: &[u32], pos: usize, target: u32) -> usize {
+    debug_assert!(pos <= docs.len());
+    #[cfg(target_arch = "x86_64")]
+    if *HAS_AVX2 {
+        return unsafe { find_next_geq_avx2(docs.as_ptr(), pos, docs.len(), target) };
+    }
+    pos + docs[pos..].partition_point(|&doc_id| doc_id < target)
 }
 
 #[inline]
@@ -434,6 +457,12 @@ struct CompressedState {
     block_idx: usize,
     doc_ids: Vec<u32>,
     freqs: Vec<u32>,
+    frequency_offset: usize,
+    frequency_block_idx: Option<usize>,
+    #[cfg(test)]
+    frequency_blocks_decoded: usize,
+    #[cfg(test)]
+    impact_bound_computations: usize,
     buffer: Box<[u32; MAX_POSTING_BLOCK_SIZE]>,
     position_block_idx: Option<usize>,
     position_values: Vec<u32>,
@@ -462,6 +491,12 @@ impl CompressedState {
             block_idx: 0,
             doc_ids: Vec::with_capacity(block_size),
             freqs: Vec::with_capacity(block_size),
+            frequency_offset: 0,
+            frequency_block_idx: None,
+            #[cfg(test)]
+            frequency_blocks_decoded: 0,
+            #[cfg(test)]
+            impact_bound_computations: 0,
             buffer: Box::new([0; MAX_POSTING_BLOCK_SIZE]),
             position_block_idx: None,
             position_values: Vec::new(),
@@ -478,7 +513,7 @@ impl CompressedState {
     }
 
     #[inline]
-    fn decompress(
+    fn decompress_doc_ids(
         &mut self,
         block: &[u8],
         block_idx: usize,
@@ -489,30 +524,69 @@ impl CompressedState {
     ) {
         self.doc_ids.clear();
         self.freqs.clear();
+        self.frequency_block_idx = None;
 
         let remainder = length as usize % block_size;
-        if block_idx + 1 == num_blocks && remainder != 0 {
-            decompress_posting_remainder(
+        self.frequency_offset = if block_idx + 1 == num_blocks && remainder != 0 {
+            decompress_posting_remainder_doc_ids(
                 block,
                 remainder,
                 tail_codec,
                 block_size,
                 &mut self.doc_ids,
-                &mut self.freqs,
-            );
+            )
         } else {
-            decompress_posting_block(
+            decompress_posting_block_doc_ids(
                 block,
                 &mut self.buffer[..],
                 &mut self.doc_ids,
-                &mut self.freqs,
                 block_size,
-            );
-        }
+            )
+        };
         self.block_idx = block_idx;
         self.position_block_idx = None;
         self.position_values.clear();
         self.position_offsets.clear();
+    }
+
+    #[inline]
+    fn decompress_frequencies(
+        &mut self,
+        block: &[u8],
+        block_idx: usize,
+        num_blocks: usize,
+        length: u32,
+        tail_codec: super::PostingTailCodec,
+        block_size: usize,
+    ) {
+        debug_assert_eq!(self.block_idx, block_idx);
+        if self.frequency_block_idx == Some(block_idx) {
+            return;
+        }
+        self.freqs.clear();
+        let remainder = length as usize % block_size;
+        if block_idx + 1 == num_blocks && remainder != 0 {
+            decompress_posting_remainder_frequencies(
+                block,
+                self.frequency_offset,
+                remainder,
+                tail_codec,
+                &mut self.freqs,
+            );
+        } else {
+            decompress_posting_block_frequencies(
+                block,
+                self.frequency_offset,
+                &mut self.buffer[..],
+                &mut self.freqs,
+                block_size,
+            );
+        }
+        self.frequency_block_idx = Some(block_idx);
+        #[cfg(test)]
+        {
+            self.frequency_blocks_decoded += 1;
+        }
     }
 }
 
@@ -800,10 +874,31 @@ impl PostingIterator {
         list: &CompressedPostingList,
         block_idx: usize,
     ) -> *mut CompressedState {
+        let compressed = unsafe { &mut *self.ensure_compressed_doc_ids_ptr(list, block_idx) };
+        if compressed.frequency_block_idx != Some(block_idx) {
+            let block = list.blocks.value(block_idx);
+            compressed.decompress_frequencies(
+                block,
+                block_idx,
+                list.blocks.len(),
+                list.length,
+                list.posting_tail_codec,
+                list.block_size,
+            );
+        }
+        compressed as *mut CompressedState
+    }
+
+    #[inline]
+    fn ensure_compressed_doc_ids_ptr(
+        &self,
+        list: &CompressedPostingList,
+        block_idx: usize,
+    ) -> *mut CompressedState {
         let compressed = unsafe { &mut *self.compressed_state_ptr() };
         if compressed.block_idx != block_idx || compressed.doc_ids.is_empty() {
             let block = list.blocks.value(block_idx);
-            compressed.decompress(
+            compressed.decompress_doc_ids(
                 block,
                 block_idx,
                 list.blocks.len(),
@@ -1011,7 +1106,38 @@ impl PostingIterator {
 
     #[inline]
     fn doc(&self) -> Option<DocInfo> {
-        self.current_doc
+        let current_doc = self.current_doc?;
+        match self.list {
+            PostingList::Compressed(ref list) => {
+                if current_doc.frequency() != 0 {
+                    return Some(current_doc);
+                }
+                let block_idx = self.index >> list.block_shift();
+                let block_offset = self.index & list.block_mask();
+                let compressed = unsafe { &mut *self.ensure_compressed_block_ptr(list, block_idx) };
+                Some(DocInfo::Raw(RawDocInfo {
+                    doc_id: current_doc.doc_id() as u32,
+                    frequency: compressed.freqs[block_offset],
+                }))
+            }
+            PostingList::Plain(_) => Some(current_doc),
+        }
+    }
+
+    #[cfg(test)]
+    fn frequency_blocks_decoded(&self) -> usize {
+        self.compressed
+            .as_ref()
+            .map(|compressed| unsafe { &*compressed.get() }.frequency_blocks_decoded)
+            .unwrap_or_default()
+    }
+
+    #[cfg(test)]
+    fn impact_bound_computations(&self) -> usize {
+        self.compressed
+            .as_ref()
+            .map(|compressed| unsafe { &*compressed.get() }.impact_bound_computations)
+            .unwrap_or_default()
     }
 
     /// The posting's current local document before it is moved into a scorer.
@@ -1034,12 +1160,16 @@ impl PostingIterator {
             PostingList::Compressed(ref list) => {
                 let block_idx = self.index >> list.block_shift();
                 let block_offset = self.index & list.block_mask();
-                let compressed = unsafe { &mut *self.ensure_compressed_block_ptr(list, block_idx) };
+                let compressed =
+                    unsafe { &mut *self.ensure_compressed_doc_ids_ptr(list, block_idx) };
 
-                // Read from the decompressed block
+                // Frequency decoding is deferred until a scoring or position
+                // consumer calls `doc()` / `ensure_compressed_block_ptr`.
                 let doc_id = compressed.doc_ids[block_offset];
-                let frequency = compressed.freqs[block_offset];
-                let doc = DocInfo::Raw(RawDocInfo { doc_id, frequency });
+                let doc = DocInfo::Raw(RawDocInfo {
+                    doc_id,
+                    frequency: 0,
+                });
                 Some(doc)
             }
             PostingList::Plain(ref list) => Some(DocInfo::Located(list.doc(self.index))),
@@ -1239,6 +1369,56 @@ impl PostingIterator {
         }
     }
 
+    /// Move to the next document without materializing its frequency. AND
+    /// intersection uses this until a document survives every required list.
+    fn next_doc_id(&mut self, least_id: u64, is_vectorized_search_enabled: bool) {
+        match self.list {
+            PostingList::Compressed(ref list) => {
+                debug_assert!(least_id <= u32::MAX as u64);
+                let least_id = least_id as u32;
+                let shift = list.block_shift();
+                let block_idx = self.block_idx_for_doc(list, self.index >> shift, least_id);
+                self.index = self.index.max(block_idx << shift);
+                let length = list.length as usize;
+                while self.index < length {
+                    let block_idx = self.index >> shift;
+                    let block_offset = self.index & list.block_mask();
+                    let compressed =
+                        unsafe { &mut *self.ensure_compressed_doc_ids_ptr(list, block_idx) };
+                    let new_offset = if is_vectorized_search_enabled {
+                        find_next_geq_in_block(&compressed.doc_ids, block_offset, least_id)
+                    } else {
+                        block_offset
+                            + compressed.doc_ids[block_offset..]
+                                .partition_point(|&doc_id| doc_id < least_id)
+                    };
+                    if new_offset < compressed.doc_ids.len() {
+                        self.index = (block_idx << shift) + new_offset;
+                        self.block_idx = block_idx;
+                        self.current_doc = Some(DocInfo::Raw(RawDocInfo {
+                            doc_id: compressed.doc_ids[new_offset],
+                            frequency: 0,
+                        }));
+                        return;
+                    }
+                    if block_idx + 1 >= list.blocks.len() {
+                        self.index = length;
+                        self.block_idx = self.index >> shift;
+                        self.current_doc = None;
+                        break;
+                    }
+                    self.index = (block_idx + 1) << shift;
+                }
+                self.block_idx = self.index >> shift;
+                self.current_doc = None;
+            }
+            PostingList::Plain(ref list) => {
+                self.index += list.row_ids[self.index..].partition_point(|&id| id < least_id);
+                self.current_doc = (!self.empty()).then(|| DocInfo::Located(list.doc(self.index)));
+            }
+        }
+    }
+
     fn shallow_next(&mut self, least_id: u64) {
         match self.list {
             PostingList::Compressed(ref list) => {
@@ -1276,6 +1456,10 @@ impl PostingIterator {
             scorer,
             &mut compressed.block_max_window.impact_score_cache,
         );
+        #[cfg(test)]
+        {
+            compressed.impact_bound_computations += 1;
+        }
         compressed.level0_cache = Some((self.block_idx, doc_up_to, score));
         (doc_up_to, score)
     }
@@ -1302,6 +1486,10 @@ impl PostingIterator {
             scorer,
             &mut compressed.block_max_window.impact_score_cache,
         );
+        #[cfg(test)]
+        {
+            compressed.impact_bound_computations += 1;
+        }
         compressed.level1_cache = Some((group_idx, doc_up_to, score));
         (doc_up_to, score)
     }
@@ -1554,7 +1742,7 @@ pub(super) fn validate_modern_posting_doc_ids(
         ))
     })?;
     let mut state = CompressedState::new(list.block_size);
-    state.decompress(
+    state.decompress_doc_ids(
         list.blocks.value(last_block_idx),
         last_block_idx,
         list.blocks.len(),
@@ -2134,7 +2322,7 @@ impl<'a, S: Scorer, D: WandDocuments> Wand<'a, S, D> {
         let mut head = BinaryHeap::new();
         let mut lead = Vec::new();
         for posting in postings {
-            if posting.doc().is_none() {
+            if posting.current_doc_id().is_none() {
                 continue;
             }
             let posting = Box::new(posting);
@@ -3190,49 +3378,51 @@ impl<'a, S: Scorer, D: WandDocuments> Wand<'a, S, D> {
         if self.lead.len() < self.num_terms {
             return None;
         }
+        // Two- and three-clause conjunctions use the bulk SIMD kernels by
+        // default. Restrict this classic-path optimization to four and five
+        // clauses, keeping one clause as the benchmark's drift control.
+        let is_vectorized_search_enabled = matches!(self.lead.len(), 4 | 5);
         if let Some(last_doc) = self.and_last_doc
             && self
                 .lead
                 .first()
-                .and_then(|posting| posting.doc())
-                .map(|doc| doc.doc_id())
+                .and_then(|posting| posting.current_doc_id())
                 == Some(last_doc)
         {
             let next_target = self.and_advance_target(last_doc + 1);
             if next_target == TERMINATED_DOC_ID {
                 return None;
             }
-            self.lead[0].next(next_target);
+            self.lead[0].next_doc_id(next_target, is_vectorized_search_enabled);
         }
 
         'advance_head: loop {
             let doc = self
                 .lead
                 .first()
-                .and_then(|posting| posting.doc())?
-                .doc_id();
+                .and_then(|posting| posting.current_doc_id())?;
             if self.up_to.is_none_or(|up_to| doc > up_to) {
                 let next_target = self.and_advance_target(doc);
                 if next_target == TERMINATED_DOC_ID {
                     return None;
                 }
                 if next_target != doc {
-                    self.lead[0].next(next_target);
+                    self.lead[0].next_doc_id(next_target, is_vectorized_search_enabled);
                     continue;
                 }
             }
 
             for posting in self.lead.iter_mut().skip(1) {
-                if posting.doc()?.doc_id() < doc {
-                    posting.next(doc);
+                if posting.current_doc_id()? < doc {
+                    posting.next_doc_id(doc, is_vectorized_search_enabled);
                 }
-                let next = posting.doc()?.doc_id();
+                let next = posting.current_doc_id()?;
                 if next > doc {
                     let next_target = self.and_advance_target(next);
                     if next_target == TERMINATED_DOC_ID {
                         return None;
                     }
-                    self.lead[0].next(next_target);
+                    self.lead[0].next_doc_id(next_target, is_vectorized_search_enabled);
                     continue 'advance_head;
                 }
             }
@@ -3244,7 +3434,7 @@ impl<'a, S: Scorer, D: WandDocuments> Wand<'a, S, D> {
                 if next_target == TERMINATED_DOC_ID {
                     return None;
                 }
-                self.lead[0].next(next_target);
+                self.lead[0].next_doc_id(next_target, is_vectorized_search_enabled);
                 continue;
             }
 
@@ -3315,7 +3505,7 @@ impl<'a, S: Scorer, D: WandDocuments> Wand<'a, S, D> {
         // the clause sup), so every skipped doc would also fail the exact
         // per-candidate prune: results are unchanged, the work never happens.
         macro_rules! merge_kernels {
-            ($name2:ident, $name3:ident, $geq:ident $(, #[$feat:meta])?) => {
+            ($name2:ident, $name3:ident, $docs_name2:ident, $docs_name3:ident, $geq:ident $(, #[$feat:meta])?) => {
                 $(#[$feat])?
                 unsafe fn $name2(
                     wins: &[WindowList],
@@ -3396,13 +3586,88 @@ impl<'a, S: Scorer, D: WandDocuments> Wand<'a, S, D> {
                         }
                     }
                 }
+
+                $(#[$feat])?
+                unsafe fn $docs_name2(
+                    wins: &[WindowList],
+                    docs_out: &mut Vec<u32>,
+                    offs_out: &mut Vec<u8>,
+                ) {
+                    let (d0, mut p0, e0) = (wins[0].docs, wins[0].pos, wins[0].end);
+                    let (d1, mut p1, e1) = (wins[1].docs, wins[1].pos, wins[1].end);
+                    unsafe {
+                        while p0 < e0 {
+                            let doc = *d0.add(p0);
+                            p1 = $geq(d1, p1, e1, doc);
+                            if p1 >= e1 {
+                                return;
+                            }
+                            let second = *d1.add(p1);
+                            if second > doc {
+                                p0 = $geq(d0, p0 + 1, e0, second);
+                                continue;
+                            }
+                            docs_out.push(doc);
+                            offs_out.push(p0 as u8);
+                            offs_out.push(p1 as u8);
+                            p0 += 1;
+                        }
+                    }
+                }
+
+                $(#[$feat])?
+                unsafe fn $docs_name3(
+                    wins: &[WindowList],
+                    docs_out: &mut Vec<u32>,
+                    offs_out: &mut Vec<u8>,
+                ) {
+                    let (d0, mut p0, e0) = (wins[0].docs, wins[0].pos, wins[0].end);
+                    let (d1, mut p1, e1) = (wins[1].docs, wins[1].pos, wins[1].end);
+                    let (d2, mut p2, e2) = (wins[2].docs, wins[2].pos, wins[2].end);
+                    unsafe {
+                        'outer: while p0 < e0 {
+                            let doc = *d0.add(p0);
+                            p1 = $geq(d1, p1, e1, doc);
+                            if p1 >= e1 {
+                                return;
+                            }
+                            let second = *d1.add(p1);
+                            if second > doc {
+                                p0 = $geq(d0, p0 + 1, e0, second);
+                                continue 'outer;
+                            }
+                            p2 = $geq(d2, p2, e2, doc);
+                            if p2 >= e2 {
+                                return;
+                            }
+                            let third = *d2.add(p2);
+                            if third > doc {
+                                p0 = $geq(d0, p0 + 1, e0, third);
+                                continue 'outer;
+                            }
+                            docs_out.push(doc);
+                            offs_out.push(p0 as u8);
+                            offs_out.push(p1 as u8);
+                            offs_out.push(p2 as u8);
+                            p0 += 1;
+                        }
+                    }
+                }
             };
         }
-        merge_kernels!(merge_window_2, merge_window_3, find_next_geq_scalar);
+        merge_kernels!(
+            merge_window_2,
+            merge_window_3,
+            merge_window_docs_2,
+            merge_window_docs_3,
+            find_next_geq_scalar
+        );
         #[cfg(target_arch = "x86_64")]
         merge_kernels!(
             merge_window_2_avx2,
             merge_window_3_avx2,
+            merge_window_docs_2_avx2,
+            merge_window_docs_3_avx2,
             find_next_geq_avx2,
             #[target_feature(enable = "avx2")]
         );
@@ -3458,6 +3723,40 @@ impl<'a, S: Scorer, D: WandDocuments> Wand<'a, S, D> {
             }
         }
 
+        #[inline]
+        fn merge_window_docs_n(
+            wins: &[WindowList],
+            cursors: &mut Vec<usize>,
+            docs_out: &mut Vec<u32>,
+            offs_out: &mut Vec<u8>,
+        ) {
+            cursors.clear();
+            cursors.extend(wins.iter().map(|win| win.pos));
+            'outer: while cursors[0] < wins[0].end {
+                let doc = unsafe { *wins[0].docs.add(cursors[0]) };
+                for j in 1..wins.len() {
+                    let win = &wins[j];
+                    let pos = unsafe { find_next_geq(win.docs, cursors[j], win.end, doc) };
+                    cursors[j] = pos;
+                    if pos >= win.end {
+                        return;
+                    }
+                    let clause_doc = unsafe { *win.docs.add(pos) };
+                    if clause_doc > doc {
+                        cursors[0] = unsafe {
+                            find_next_geq(wins[0].docs, cursors[0] + 1, wins[0].end, clause_doc)
+                        };
+                        continue 'outer;
+                    }
+                }
+                docs_out.push(doc);
+                for &pos in cursors.iter() {
+                    offs_out.push(pos as u8);
+                }
+                cursors[0] += 1;
+            }
+        }
+
         let mut candidates = TopKCollector::new(limit, std::cmp::min(limit, BLOCK_SIZE * 10));
         let mut num_comparisons: usize = 0;
         let mut wins: Vec<WindowList> = Vec::with_capacity(num_lists);
@@ -3473,10 +3772,8 @@ impl<'a, S: Scorer, D: WandDocuments> Wand<'a, S, D> {
         let mut cursor_scratch: Vec<usize> = Vec::with_capacity(num_lists);
         // Norm cache: one byte-norm load plus a cached addend replaces the
         // per-clause BM25 denominator recompute in pass B.
-        let norm_k = self.norm_k_cache();
-        let norm_k_ref = norm_k
-            .as_ref()
-            .map(|(norms, cache)| (*norms, cache.as_ref()));
+        let mut norm_k = None;
+        let mut norm_k_initialized = false;
 
         // Per-window prune LUT for the merge kernels: an upper bound of the
         // first (rarest) clause's score by clamped frequency. Lead docs whose
@@ -3488,31 +3785,30 @@ impl<'a, S: Scorer, D: WandDocuments> Wand<'a, S, D> {
         // stays a valid upper bound. Skips only avoid work; every emitted
         // candidate still goes through the exact per-candidate prune below.
         const FREQ_LUT_BUCKETS: usize = 64;
-        let mut freq_bound_lut = [f32::INFINITY; FREQ_LUT_BUCKETS];
-        for (freq, slot) in freq_bound_lut
-            .iter_mut()
-            .enumerate()
-            .take(FREQ_LUT_BUCKETS - 1)
-        {
-            *slot = self.lead[0].score(&self.scorer, freq as u32, 0);
-        }
-        // The clamp bucket must bound every frequency it absorbs; the
-        // clause-wide sup does.
-        freq_bound_lut[FREQ_LUT_BUCKETS - 1] =
-            self.lead[0].frequency_clamp_upper_bound(&self.scorer);
+        let mut freq_bound_lut: Option<[f32; FREQ_LUT_BUCKETS]> = None;
 
         // The conjunction can only start at the max of the clauses' first docs.
         let mut target: u64 = 0;
         for posting in &self.lead {
-            match posting.doc() {
-                Some(doc) => target = target.max(doc.doc_id()),
+            match posting.current_doc_id() {
+                Some(doc) => target = target.max(doc),
                 None => return Ok(vec![]),
             }
         }
 
         'window: loop {
             self.raise_to_shared_floor(params.wand_factor);
-            if self.threshold > 0.0 {
+            let window_started_with_floor = self.threshold > 0.0;
+            if window_started_with_floor {
+                if num_lists >= 2 && freq_bound_lut.is_none() {
+                    let mut lut = [f32::INFINITY; FREQ_LUT_BUCKETS];
+                    for (freq, slot) in lut.iter_mut().enumerate().take(FREQ_LUT_BUCKETS - 1) {
+                        *slot = self.lead[0].score(&self.scorer, freq as u32, 0);
+                    }
+                    lut[FREQ_LUT_BUCKETS - 1] =
+                        self.lead[0].frequency_clamp_upper_bound(&self.scorer);
+                    freq_bound_lut = Some(lut);
+                }
                 let advanced = self.and_advance_target(target);
                 if advanced == TERMINATED_DOC_ID {
                     break;
@@ -3553,7 +3849,7 @@ impl<'a, S: Scorer, D: WandDocuments> Wand<'a, S, D> {
                     unreachable!("bulk AND requires compressed postings");
                 };
                 let block_idx = posting.block_idx;
-                let state = unsafe { &mut *posting.ensure_compressed_block_ptr(list, block_idx) };
+                let state = unsafe { &mut *posting.ensure_compressed_doc_ids_ptr(list, block_idx) };
                 let lo = state.doc_ids.partition_point(|&doc| doc < target32);
                 let hi = if win_end32 == u32::MAX {
                     state.doc_ids.len()
@@ -3575,7 +3871,7 @@ impl<'a, S: Scorer, D: WandDocuments> Wand<'a, S, D> {
                 }
                 wins.push(WindowList {
                     docs: state.doc_ids.as_ptr(),
-                    freqs: state.freqs.as_ptr(),
+                    freqs: std::ptr::null(),
                     pos: lo,
                     end: hi,
                     block_start: block_idx << list.block_shift(),
@@ -3588,21 +3884,38 @@ impl<'a, S: Scorer, D: WandDocuments> Wand<'a, S, D> {
                 // Constant within the window (block-anchored); mirrors
                 // `and_candidate_cannot_beat_threshold`'s remaining-clause
                 // bound of first-clause-exact + rest-block-max.
-                let others_block_max = self.lead[1..]
-                    .iter()
-                    .map(|posting| f64::from(posting.block_max_score(&self.scorer)))
-                    .sum::<f64>();
+                let mut others_block_max = if window_started_with_floor {
+                    Some(
+                        self.lead[1..]
+                            .iter()
+                            .map(|posting| f64::from(posting.block_max_score(&self.scorer)))
+                            .sum::<f64>(),
+                    )
+                } else {
+                    None
+                };
 
                 batch_docs.clear();
                 batch_offs.clear();
                 // Precompute the conservative decision once per frequency
                 // bucket so the scalar and SIMD merge kernels stay
                 // floating-point-free.
-                let freq_cannot_beat = if self.threshold > 0.0 && num_lists >= 2 {
+                let freq_cannot_beat = if window_started_with_floor && num_lists >= 2 {
+                    let posting = &self.lead[0];
+                    let PostingList::Compressed(ref list) = posting.list else {
+                        unreachable!("bulk AND requires compressed postings");
+                    };
+                    let state = unsafe {
+                        &mut *posting.ensure_compressed_block_ptr(list, posting.block_idx)
+                    };
+                    wins[0].freqs = state.freqs.as_ptr();
+                    let freq_bound_lut = freq_bound_lut
+                        .as_ref()
+                        .expect("positive threshold should initialize the frequency bound LUT");
                     std::array::from_fn(|frequency| {
                         score_sum_cannot_compete(
                             freq_bound_lut[frequency],
-                            others_block_max,
+                            others_block_max.expect("positive floor should initialize bounds"),
                             self.threshold,
                             score_sum_upper_bound_factor(num_lists),
                             CompetitiveFloorMode::Exclusive,
@@ -3615,10 +3928,30 @@ impl<'a, S: Scorer, D: WandDocuments> Wand<'a, S, D> {
                 let use_avx2 = *HAS_AVX2;
                 #[cfg(not(target_arch = "x86_64"))]
                 let use_avx2 = false;
-                match (num_lists, use_avx2) {
-                    (1, _) => merge_window_1(&wins, &mut batch_docs, &mut batch_offs),
+                match (num_lists, use_avx2, window_started_with_floor) {
+                    (1, _, _) => merge_window_1(&wins, &mut batch_docs, &mut batch_offs),
                     #[cfg(target_arch = "x86_64")]
-                    (2, true) => unsafe {
+                    (2, true, false) => unsafe {
+                        merge_window_docs_2_avx2(&wins, &mut batch_docs, &mut batch_offs)
+                    },
+                    #[cfg(target_arch = "x86_64")]
+                    (3, true, false) => unsafe {
+                        merge_window_docs_3_avx2(&wins, &mut batch_docs, &mut batch_offs)
+                    },
+                    (2, _, false) => unsafe {
+                        merge_window_docs_2(&wins, &mut batch_docs, &mut batch_offs)
+                    },
+                    (3, _, false) => unsafe {
+                        merge_window_docs_3(&wins, &mut batch_docs, &mut batch_offs)
+                    },
+                    (_, _, false) => merge_window_docs_n(
+                        &wins,
+                        &mut cursor_scratch,
+                        &mut batch_docs,
+                        &mut batch_offs,
+                    ),
+                    #[cfg(target_arch = "x86_64")]
+                    (2, true, true) => unsafe {
                         merge_window_2_avx2(
                             &wins,
                             &freq_cannot_beat,
@@ -3627,7 +3960,7 @@ impl<'a, S: Scorer, D: WandDocuments> Wand<'a, S, D> {
                         )
                     },
                     #[cfg(target_arch = "x86_64")]
-                    (3, true) => unsafe {
+                    (3, true, true) => unsafe {
                         merge_window_3_avx2(
                             &wins,
                             &freq_cannot_beat,
@@ -3635,13 +3968,13 @@ impl<'a, S: Scorer, D: WandDocuments> Wand<'a, S, D> {
                             &mut batch_offs,
                         )
                     },
-                    (2, _) => unsafe {
+                    (2, _, true) => unsafe {
                         merge_window_2(&wins, &freq_cannot_beat, &mut batch_docs, &mut batch_offs)
                     },
-                    (3, _) => unsafe {
+                    (3, _, true) => unsafe {
                         merge_window_3(&wins, &freq_cannot_beat, &mut batch_docs, &mut batch_offs)
                     },
-                    _ => merge_window_n(
+                    (_, _, true) => merge_window_n(
                         &wins,
                         &freq_cannot_beat,
                         &mut cursor_scratch,
@@ -3650,12 +3983,31 @@ impl<'a, S: Scorer, D: WandDocuments> Wand<'a, S, D> {
                     ),
                 }
 
+                if !batch_docs.is_empty() {
+                    for (win, posting) in wins.iter_mut().zip(self.lead.iter()) {
+                        let PostingList::Compressed(ref list) = posting.list else {
+                            unreachable!("bulk AND requires compressed postings");
+                        };
+                        let state = unsafe {
+                            &mut *posting.ensure_compressed_block_ptr(list, posting.block_idx)
+                        };
+                        win.freqs = state.freqs.as_ptr();
+                    }
+                    if !norm_k_initialized {
+                        norm_k = self.norm_k_cache();
+                        norm_k_initialized = true;
+                    }
+                }
+
                 // Pass A: gather doc norms/lengths for the whole batch up
                 // front so the loads issue back-to-back and their cache
                 // misses overlap. With the norm cache, only the byte code is
                 // gathered; the exact length decodes from a tiny LUT.
                 batch_lens.clear();
                 batch_norms.clear();
+                let norm_k_ref = norm_k
+                    .as_ref()
+                    .map(|(norms, cache)| (*norms, cache.as_ref()));
                 match norm_k_ref {
                     Some((norms, _)) => {
                         for &doc in batch_docs.iter() {
@@ -3687,7 +4039,18 @@ impl<'a, S: Scorer, D: WandDocuments> Wand<'a, S, D> {
                         None => (None, batch_lens[index]),
                     };
                     let offs = &batch_offs[index * num_lists..(index + 1) * num_lists];
-                    if self.threshold > 0.0 && num_lists >= 2 {
+                    if self.threshold > 0.0 && num_lists >= 2 && others_block_max.is_none() {
+                        others_block_max = Some(
+                            self.lead[1..]
+                                .iter()
+                                .map(|posting| f64::from(posting.block_max_score(&self.scorer)))
+                                .sum::<f64>(),
+                        );
+                    }
+                    if self.threshold > 0.0
+                        && num_lists >= 2
+                        && let Some(others_block_max) = others_block_max
+                    {
                         let first_freq = unsafe { *wins[0].freqs.add(offs[0] as usize) };
                         let first_score = match norm_addend {
                             Some(addend) => {
@@ -5594,6 +5957,67 @@ mod tests {
         #[case] expected: bool,
     ) {
         assert_eq!(mode.enabled_for(num_clauses), expected);
+    }
+
+    #[test]
+    fn find_next_geq_matches_partition_point_for_full_u32_domain() {
+        let cases = [
+            vec![],
+            vec![7],
+            vec![0, 1, 2, 3, 4, 5, 6, 7],
+            vec![0, 1, 2, 3, 4, 5, 6, 7, 8],
+            (0..32).collect(),
+            vec![
+                0,
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                i32::MAX as u32,
+                i32::MAX as u32 + 1,
+                i32::MAX as u32 + 2,
+                i32::MAX as u32 + 3,
+                i32::MAX as u32 + 4,
+                i32::MAX as u32 + 5,
+                i32::MAX as u32 + 6,
+                u32::MAX - 2,
+                u32::MAX - 1,
+                u32::MAX,
+            ],
+        ];
+        let targets = [
+            0,
+            1,
+            6,
+            7,
+            8,
+            i32::MAX as u32 - 1,
+            i32::MAX as u32,
+            i32::MAX as u32 + 1,
+            u32::MAX - 1,
+            u32::MAX,
+        ];
+
+        for docs in &cases {
+            for pos in 0..=docs.len() {
+                for &target in &targets {
+                    let expected = pos + docs[pos..].partition_point(|&doc_id| doc_id < target);
+                    let actual = unsafe { find_next_geq(docs.as_ptr(), pos, docs.len(), target) };
+                    assert_eq!(
+                        actual, expected,
+                        "docs={docs:?}, pos={pos}, target={target}"
+                    );
+                    assert_eq!(
+                        find_next_geq_in_block(docs, pos, target),
+                        expected,
+                        "block search: docs={docs:?}, pos={pos}, target={target}"
+                    );
+                }
+            }
+        }
     }
 
     struct PanicQueryWeightScorer;
@@ -7625,5 +8049,223 @@ mod tests {
         assert!(!bulk.is_empty(), "test corpus should produce matches");
         assert_eq!(bulk, classic);
         assert_eq!(auto, classic);
+    }
+
+    #[rstest]
+    #[case::bulk_two(BulkAndMode::On, 2)]
+    #[case::classic_four(BulkAndMode::Off, 4)]
+    #[case::classic_five(BulkAndMode::Off, 5)]
+    fn underfilled_disjoint_and_decodes_no_frequencies_or_bounds(
+        #[case] mode: BulkAndMode,
+        #[case] num_clauses: usize,
+    ) {
+        let num_docs = (BLOCK_SIZE * 3) as u32;
+        let mut docs = DocSet::default();
+        for doc_id in 0..num_docs {
+            docs.append(u64::from(doc_id), 1);
+        }
+        let even = (0..num_docs).filter(|doc| doc % 2 == 0).collect::<Vec<_>>();
+        let odd = (0..num_docs).filter(|doc| doc % 2 == 1).collect::<Vec<_>>();
+        let all = (0..num_docs).collect::<Vec<_>>();
+        let postings = (0..num_clauses)
+            .map(|term| {
+                let doc_ids = match term {
+                    0 => even.clone(),
+                    1 => odd.clone(),
+                    _ => all.clone(),
+                };
+                let len = doc_ids.len();
+                PostingIterator::with_query_weight(
+                    format!("t{term}"),
+                    term as u32,
+                    term as u32,
+                    1.0,
+                    generate_impact_posting_list_with_freqs(doc_ids, vec![1; len], vec![1; len]),
+                    docs.len(),
+                )
+            })
+            .collect::<Vec<_>>();
+        let scored = Arc::new(AtomicUsize::new(0));
+        let mut wand = Wand::new(
+            Operator::And,
+            postings.into_iter(),
+            &docs,
+            CountingScorer {
+                scored: scored.clone(),
+            },
+        )
+        .with_bulk_and_mode(mode);
+
+        let hits = wand
+            .search(
+                &FtsSearchParams::default().with_limit(Some(10)),
+                &NoOpMetricsCollector,
+            )
+            .unwrap();
+
+        assert!(hits.is_empty());
+        assert_eq!(scored.load(Ordering::Relaxed), 0);
+        assert_eq!(
+            wand.lead
+                .iter()
+                .map(|posting| posting.frequency_blocks_decoded())
+                .sum::<usize>(),
+            0
+        );
+        assert_eq!(
+            wand.lead
+                .iter()
+                .map(|posting| posting.impact_bound_computations())
+                .sum::<usize>(),
+            0
+        );
+    }
+
+    #[rstest]
+    #[case::legacy_full(crate::scalar::inverted::LEGACY_BLOCK_SIZE, 0)]
+    #[case::legacy_tail(crate::scalar::inverted::LEGACY_BLOCK_SIZE, 7)]
+    #[case::modern_full(MAX_POSTING_BLOCK_SIZE, 0)]
+    #[case::modern_tail(MAX_POSTING_BLOCK_SIZE, 7)]
+    fn underfilled_sparse_and_decodes_only_matching_frequency_blocks(
+        #[values(BulkAndMode::On, BulkAndMode::Off)] mode: BulkAndMode,
+        #[case] block_size: usize,
+        #[case] tail_len: usize,
+    ) {
+        let posting_len = block_size * 2 + tail_len;
+        let first = (0..posting_len)
+            .map(|index| (index * 2) as u32)
+            .collect::<Vec<_>>();
+        let mut second = (0..posting_len)
+            .map(|index| (index * 2 + 1) as u32)
+            .collect::<Vec<_>>();
+        let last_doc = *first.last().unwrap();
+        *second.last_mut().unwrap() = last_doc;
+        let num_docs = posting_len * 2;
+        let mut docs = DocSet::default();
+        for doc_id in 0..num_docs {
+            docs.append(doc_id as u64, 1);
+        }
+        let postings = [first, second]
+            .into_iter()
+            .enumerate()
+            .map(|(term, doc_ids)| {
+                let len = doc_ids.len();
+                PostingIterator::with_query_weight(
+                    format!("t{term}"),
+                    term as u32,
+                    term as u32,
+                    1.0,
+                    generate_impact_posting_list_with_freqs_and_block_size(
+                        doc_ids,
+                        vec![1; len],
+                        vec![1; len],
+                        block_size,
+                    ),
+                    docs.len(),
+                )
+            })
+            .collect::<Vec<_>>();
+        let scored = Arc::new(AtomicUsize::new(0));
+        let mut wand = Wand::new(
+            Operator::And,
+            postings.into_iter(),
+            &docs,
+            CountingScorer {
+                scored: scored.clone(),
+            },
+        )
+        .with_bulk_and_mode(mode);
+
+        let hits = wand
+            .search(
+                &FtsSearchParams::default().with_limit(Some(10)),
+                &NoOpMetricsCollector,
+            )
+            .unwrap();
+
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].document, u64::from(last_doc));
+        assert_eq!(scored.load(Ordering::Relaxed), 2);
+        assert_eq!(
+            wand.lead
+                .iter()
+                .map(|posting| posting.frequency_blocks_decoded())
+                .sum::<usize>(),
+            2,
+            "only the two blocks containing the surviving match need frequencies"
+        );
+        assert_eq!(
+            wand.lead
+                .iter()
+                .map(|posting| posting.impact_bound_computations())
+                .sum::<usize>(),
+            0
+        );
+    }
+
+    #[test]
+    fn bulk_and_activates_frequencies_and_bounds_after_heap_fills() {
+        let num_docs = (BLOCK_SIZE * 2) as u32;
+        let mut docs = DocSet::default();
+        for doc_id in 0..num_docs {
+            docs.append(u64::from(doc_id), 1);
+        }
+        let frequencies = (0..num_docs)
+            .map(|doc| if doc < BLOCK_SIZE as u32 { 1 } else { 10 })
+            .collect::<Vec<_>>();
+        let postings = (0..2)
+            .map(|term| {
+                PostingIterator::with_query_weight(
+                    format!("t{term}"),
+                    term,
+                    term,
+                    1.0,
+                    generate_impact_posting_list_with_freqs(
+                        (0..num_docs).collect(),
+                        frequencies.clone(),
+                        vec![1; num_docs as usize],
+                    ),
+                    docs.len(),
+                )
+            })
+            .collect::<Vec<_>>();
+        let scored = Arc::new(AtomicUsize::new(0));
+        let mut wand = Wand::new(
+            Operator::And,
+            postings.into_iter(),
+            &docs,
+            CountingScorer {
+                scored: scored.clone(),
+            },
+        )
+        .with_bulk_and_mode(BulkAndMode::On);
+
+        let hits = wand
+            .search(
+                &FtsSearchParams::default().with_limit(Some(1)),
+                &NoOpMetricsCollector,
+            )
+            .unwrap();
+
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].document, BLOCK_SIZE as u64);
+        assert!(wand.threshold > 0.0);
+        assert!(
+            wand.lead
+                .iter()
+                .map(|posting| posting.frequency_blocks_decoded())
+                .sum::<usize>()
+                >= 4,
+            "the competitive second window must decode its frequency blocks"
+        );
+        assert!(
+            wand.lead
+                .iter()
+                .map(|posting| posting.impact_bound_computations())
+                .sum::<usize>()
+                > 0,
+            "impact bounds must activate on the first window after the heap fills"
+        );
+        assert!(scored.load(Ordering::Relaxed) > 0);
     }
 }


### PR DESCRIPTION
Before a competitive floor exists, AND queries still decoded frequencies and prepared bounds while looking for intersections. This PR keeps that work lazy, particularly when the final intersection has fewer than `k` matches.

- Split DocID and frequency decoding for full posting blocks and tails, retaining the existing encoded format and combined decoding entry points.
- Advance and intersect DocIDs before decoding frequencies; initialize score bounds when a positive competitive floor makes them useful.
- Avoid loading document lengths for partitions whose dictionaries cannot satisfy all required tokens.
- Use SIMD catch-up for the existing classic 4/5-clause path, with unsigned comparisons covering the full `u32` DocID range and a binary-search fallback without AVX2.

Tests cover empty/underfilled intersections, delayed frequency and bound activation, block/tail transitions, required-token misses, and scalar/SIMD boundary behavior. Code and its regression tests stay together in this PR.

No isolated `main` A/B measurement is claimed for this layer. The later bulk-intersection measurements belong to [#9030](https://github.com/lance-format/lance/pull/9030).

## Validation

- Local inverted-index suite: 530 passed.
- Required all-workspace Clippy: passed.
- CI: pending.

Stack, 1/4: **this PR** → [#9032](https://github.com/lance-format/lance/pull/9032) → [#9033](https://github.com/lance-format/lance/pull/9033) → [#9030](https://github.com/lance-format/lance/pull/9030). Base: `main`.

Merge in stack order; retarget/restack the remaining PRs after their parent merges.
