### PR TITLE
perf(fts): reuse resident statistics and prepared scorers

### DIFF
--- a/rust/lance-index/src/scalar/inverted.rs
+++ b/rust/lance-index/src/scalar/inverted.rs
@@ -18,7 +18,7 @@ pub mod tokenizer;
 mod wand;
 
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
-use std::sync::Arc;
+use std::sync::{Arc, LazyLock};
 
 use arrow_schema::{DataType, Field};
 use async_trait::async_trait;
@@ -51,6 +51,7 @@ pub struct PreparedBm25Query {
     tokens: Arc<Tokens>,
     scorer: Arc<MemBM25Scorer>,
     has_all_query_positions: bool,
+    can_reuse_scorer: bool,
 }
 
 impl std::fmt::Debug for PreparedBm25Query {
@@ -59,6 +60,7 @@ impl std::fmt::Debug for PreparedBm25Query {
             .debug_struct("PreparedBm25Query")
             .field("token_count", &self.tokens.len())
             .field("has_all_query_positions", &self.has_all_query_positions)
+            .field("can_reuse_scorer", &self.can_reuse_scorer)
             .field("scorer", &self.scorer)
             .finish()
     }
@@ -74,6 +76,7 @@ impl PreparedBm25Query {
             tokens,
             scorer,
             has_all_query_positions,
+            can_reuse_scorer: false,
         }
     }
 
@@ -85,6 +88,10 @@ impl PreparedBm25Query {
     #[doc(hidden)]
     pub fn scorer(&self) -> &Arc<MemBM25Scorer> {
         &self.scorer
+    }
+
+    pub(crate) fn reusable_scorer(&self) -> Option<&Arc<MemBM25Scorer>> {
+        self.can_reuse_scorer.then_some(&self.scorer)
     }
 
     pub(crate) fn has_all_query_positions(&self) -> bool {
@@ -170,6 +177,104 @@ pub(crate) fn has_all_query_positions(query_tokens: &Tokens, final_tokens: &Toke
     (0..query_tokens.len()).all(|index| surviving_positions.contains(&query_tokens.position(index)))
 }
 
+const LANCE_FTS_SYNC_DF_ENV: &str = "LANCE_FTS_SYNC_DF";
+
+fn sync_df_enabled_from_value(value: Option<&str>) -> bool {
+    !value.is_some_and(|value| {
+        let value = value.trim();
+        value == "0" || value.eq_ignore_ascii_case("off")
+    })
+}
+
+static LANCE_FTS_SYNC_DF_ENABLED: LazyLock<bool> = LazyLock::new(|| {
+    sync_df_enabled_from_value(std::env::var(LANCE_FTS_SYNC_DF_ENV).ok().as_deref())
+});
+
+/// Build the global scorer without futures when a completed full prewarm made
+/// every segment statistic and posting-length table synchronously available.
+/// Returning `None` leaves the existing asynchronous path entirely in charge.
+fn bm25_scorer_from_loaded_stats(
+    indices: &[Arc<InvertedIndex>],
+    terms: &[String],
+) -> Result<Option<Arc<MemBM25Scorer>>> {
+    bm25_scorer_from_loaded_stats_with_enabled(indices, terms, *LANCE_FTS_SYNC_DF_ENABLED)
+}
+
+fn bm25_scorer_from_loaded_stats_with_enabled(
+    indices: &[Arc<InvertedIndex>],
+    terms: &[String],
+    is_enabled: bool,
+) -> Result<Option<Arc<MemBM25Scorer>>> {
+    // Keep the kill switch first so an ablation does not even probe prewarm
+    // state or resident metadata.
+    if !is_enabled {
+        return Ok(None);
+    }
+
+    let mut loaded_stats = Vec::with_capacity(indices.len());
+    for index in indices {
+        let Some(stats) = index.bm25_stats_for_terms_if_loaded(terms)? else {
+            return Ok(None);
+        };
+        loaded_stats.push(stats);
+    }
+
+    merge_loaded_bm25_stats(terms, loaded_stats)
+}
+
+fn merge_loaded_bm25_stats(
+    terms: &[String],
+    loaded_stats: Vec<(u64, usize, Vec<usize>)>,
+) -> Result<Option<Arc<MemBM25Scorer>>> {
+    let mut loaded_stats = loaded_stats.into_iter();
+    let Some((mut total_tokens, mut num_docs, first_token_docs)) = loaded_stats.next() else {
+        return Ok(None);
+    };
+    if first_token_docs.len() != terms.len() {
+        return Err(lance_core::Error::internal(format!(
+            "loaded FTS document-frequency count is {}, expected {}",
+            first_token_docs.len(),
+            terms.len()
+        )));
+    }
+    let mut token_docs = HashMap::with_capacity(terms.len());
+    for (term, count) in terms.iter().cloned().zip(first_token_docs) {
+        token_docs.insert(term, count);
+    }
+    for (segment_total_tokens, segment_num_docs, segment_token_docs) in loaded_stats {
+        if segment_token_docs.len() != terms.len() {
+            return Err(lance_core::Error::internal(format!(
+                "loaded FTS document-frequency count is {}, expected {}",
+                segment_token_docs.len(),
+                terms.len()
+            )));
+        }
+        total_tokens = total_tokens
+            .checked_add(segment_total_tokens)
+            .ok_or_else(|| lance_core::Error::index("FTS corpus token count overflows u64"))?;
+        num_docs = num_docs
+            .checked_add(segment_num_docs)
+            .ok_or_else(|| lance_core::Error::index("FTS corpus document count overflows usize"))?;
+        for (term, count) in terms.iter().zip(segment_token_docs) {
+            let total = token_docs.get_mut(term).ok_or_else(|| {
+                lance_core::Error::internal(format!(
+                    "global scorer term '{term}' was not initialized"
+                ))
+            })?;
+            *total = total.checked_add(count).ok_or_else(|| {
+                lance_core::Error::index(format!(
+                    "FTS document frequency for term '{term}' overflows usize"
+                ))
+            })?;
+        }
+    }
+    Ok(Some(Arc::new(MemBM25Scorer::new(
+        total_tokens,
+        num_docs,
+        token_docs,
+    ))))
+}
+
 /// Expand and score one indexed query leaf exactly once across all segments.
 ///
 /// Expansion consumes one deterministic `max_expansions` budget in query
@@ -199,7 +304,7 @@ pub async fn prepare_bm25_query(
         (Arc::new(query_tokens), true)
     };
     let terms = unique_terms(tokens.as_ref());
-    let scorer = if let Some(scorer) = base_scorer {
+    let (scorer, can_reuse_scorer) = if let Some(scorer) = base_scorer {
         if let Some(missing) = terms
             .iter()
             .find(|term| !scorer.token_docs.contains_key(term.as_str()))
@@ -208,7 +313,9 @@ pub async fn prepare_bm25_query(
                 "injected BM25 scorer is missing compound FTS token '{missing}'"
             )));
         }
-        scorer
+        (scorer, false)
+    } else if let Some(scorer) = bm25_scorer_from_loaded_stats(indices, &terms)? {
+        (scorer, true)
     } else {
         let (mut total_tokens, mut num_docs, first_token_docs) =
             first_index.bm25_stats_for_terms(&terms, metrics).await?;
@@ -239,13 +346,17 @@ pub async fn prepare_bm25_query(
                 })?;
             }
         }
-        Arc::new(MemBM25Scorer::new(total_tokens, num_docs, token_docs))
+        (
+            Arc::new(MemBM25Scorer::new(total_tokens, num_docs, token_docs)),
+            true,
+        )
     };
 
     Ok(PreparedBm25Query {
         tokens,
         scorer,
         has_all_query_positions,
+        can_reuse_scorer,
     })
 }
 
@@ -506,6 +617,70 @@ impl ScalarIndexPlugin for InvertedIndexPlugin {
 mod tests {
     use super::*;
     use crate::scalar::{BuiltinIndexType, ScalarIndexParams};
+
+    #[test]
+    fn test_sync_df_kill_switch_parser() {
+        for value in [None, Some(""), Some("1"), Some("on"), Some("false")] {
+            assert!(
+                sync_df_enabled_from_value(value),
+                "unexpected disable: {value:?}"
+            );
+        }
+        for value in [Some("0"), Some("off"), Some("OFF"), Some(" off ")] {
+            assert!(
+                !sync_df_enabled_from_value(value),
+                "unexpected enable: {value:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_prepared_query_from_parts_keeps_scorer_ineligible_for_reuse() {
+        let tokens = Arc::new(Tokens::new(
+            vec!["term".to_owned()],
+            crate::scalar::inverted::document_tokenizer::DocType::Text,
+        ));
+        let scorer = Arc::new(MemBM25Scorer::new(1, 1, HashMap::new()));
+        let prepared = PreparedBm25Query::from_parts(tokens, scorer.clone(), true);
+
+        assert!(Arc::ptr_eq(prepared.scorer(), &scorer));
+        assert!(prepared.reusable_scorer().is_none());
+        assert_eq!(Arc::strong_count(&scorer), 2);
+    }
+
+    #[test]
+    fn test_sync_df_merge_reports_checked_overflow_and_invalid_shape() {
+        let terms = vec!["term".to_string()];
+        for (stats, expected) in [
+            (
+                vec![(u64::MAX, 1, vec![1]), (1, 1, vec![1])],
+                "corpus token count overflows u64",
+            ),
+            (
+                vec![(1, usize::MAX, vec![1]), (1, 1, vec![1])],
+                "corpus document count overflows usize",
+            ),
+            (
+                vec![(1, 1, vec![usize::MAX]), (1, 1, vec![1])],
+                "document frequency for term 'term' overflows usize",
+            ),
+        ] {
+            let error = merge_loaded_bm25_stats(&terms, stats).unwrap_err();
+            assert!(
+                error.to_string().contains(expected),
+                "unexpected error: {error}"
+            );
+        }
+
+        let error = merge_loaded_bm25_stats(&terms, vec![(1, 1, Vec::new())]).unwrap_err();
+        assert!(matches!(error, lance_core::Error::Internal { .. }));
+        assert!(
+            error
+                .to_string()
+                .contains("document-frequency count is 0, expected 1"),
+            "unexpected error: {error}"
+        );
+    }
 
     #[test]
     fn test_plugin_version_tracks_v3_capability_gate() {

--- a/rust/lance-index/src/scalar/inverted/index/posting_reader.rs
+++ b/rust/lance-index/src/scalar/inverted/index/posting_reader.rs
@@ -247,6 +247,39 @@ impl PostingListReader {
         }
     }
 
+    /// Return a posting-list length only when its metadata is already resident.
+    ///
+    /// Legacy offsets are loaded with the schema. Modern lengths remain absent
+    /// until an explicit bulk metadata load, so this probe never starts I/O or
+    /// relies on the scoring path's stronger [`Self::posting_len`] contract.
+    pub(crate) fn loaded_posting_len(&self, token_id: u32) -> Option<usize> {
+        let token_id = token_id as usize;
+        match &self.metadata {
+            PostingMetadata::LegacyV1 { offsets, .. } => {
+                let offset = offsets.get(token_id).copied()?;
+                let next_offset = offsets
+                    .get(token_id.checked_add(1)?)
+                    .copied()
+                    .unwrap_or(self.reader.num_rows());
+                next_offset.checked_sub(offset)
+            }
+            PostingMetadata::V2 { metadata } => metadata
+                .get()?
+                .lengths
+                .get(token_id)
+                .copied()
+                .map(|length| length as usize),
+        }
+    }
+
+    /// Whether every posting length can be read synchronously without I/O.
+    pub(crate) fn posting_lengths_loaded(&self) -> bool {
+        match &self.metadata {
+            PostingMetadata::LegacyV1 { .. } => true,
+            PostingMetadata::V2 { metadata } => self.is_empty() || metadata.get().is_some(),
+        }
+    }
+
     /// Async access to a single token's posting list length. For v2
     /// indexes this reads one row of posting metadata if the bulk metadata has
     /// not been loaded yet, and never triggers the bulk load itself. The stats

--- a/rust/lance-index/src/scalar/inverted/index/search.rs
+++ b/rust/lance-index/src/scalar/inverted/index/search.rs
@@ -4,6 +4,42 @@
 use super::partition::FuzzyAutomaton;
 use super::*;
 
+const LANCE_FTS_REUSE_PREPARED_SCORER_ENV: &str = "LANCE_FTS_REUSE_PREPARED_SCORER";
+
+fn reuse_prepared_scorer_enabled_from_value(value: Option<&str>) -> bool {
+    !value.is_some_and(|value| {
+        let value = value.trim();
+        value == "0" || value.eq_ignore_ascii_case("off")
+    })
+}
+
+static LANCE_FTS_REUSE_PREPARED_SCORER_ENABLED: LazyLock<bool> = LazyLock::new(|| {
+    reuse_prepared_scorer_enabled_from_value(
+        std::env::var(LANCE_FTS_REUSE_PREPARED_SCORER_ENV)
+            .ok()
+            .as_deref(),
+    )
+});
+
+fn select_impact_scorer(
+    scorer: &MemBM25Scorer,
+    prepared_scorer: Option<&Arc<MemBM25Scorer>>,
+    is_legacy: impl FnOnce() -> bool,
+    reuse_prepared_scorer_enabled: impl FnOnce() -> bool,
+) -> Arc<MemBM25Scorer> {
+    let Some(prepared_scorer) = prepared_scorer else {
+        return Arc::new(scorer.clone());
+    };
+    if is_legacy() || !reuse_prepared_scorer_enabled() {
+        return Arc::new(scorer.clone());
+    }
+    debug_assert!(
+        std::ptr::eq(scorer, prepared_scorer.as_ref()),
+        "prepared BM25 scorer must be the canonical final scorer"
+    );
+    Arc::clone(prepared_scorer)
+}
+
 impl InvertedIndex {
     /// Add this segment's lexicographically smallest fuzzy candidates for one
     /// compiled query-token automaton to a caller-owned cross-segment merge
@@ -90,6 +126,57 @@ impl InvertedIndex {
             futures::future::try_join_all(terms.iter().map(|term| self.df_for_term(term, metrics)))
                 .await?;
         Ok((total_tokens, num_docs, token_docs))
+    }
+
+    /// Return BM25 statistics synchronously when every required value is loaded.
+    ///
+    /// This is an all-or-nothing probe for the full-prewarm query path. It never
+    /// starts I/O: an absent segment corpus statistic or one absent modern
+    /// posting-length table returns `None` for the entire segment.
+    pub(in crate::scalar::inverted) fn bm25_stats_for_terms_if_loaded(
+        &self,
+        terms: &[String],
+    ) -> Result<Option<(u64, usize, Vec<usize>)>> {
+        // Keep the legacy reader on its frozen asynchronous compatibility
+        // path; this optimization targets current partitioned formats.
+        if self.is_legacy() {
+            return Ok(None);
+        }
+        let Some(&(total_tokens, num_docs)) = self.corpus_stats.get() else {
+            return Ok(None);
+        };
+        if self
+            .partitions
+            .iter()
+            .any(|partition| !partition.inverted_list.posting_lengths_loaded())
+        {
+            return Ok(None);
+        }
+        let mut token_docs = Vec::with_capacity(terms.len());
+        for term in terms {
+            let mut term_docs = 0_usize;
+            for partition in &self.partitions {
+                let Some(token_id) = partition.tokens.get(term) else {
+                    continue;
+                };
+                let posting_len = partition
+                    .inverted_list
+                    .loaded_posting_len(token_id)
+                    .ok_or_else(|| {
+                        Error::index(format!(
+                            "FTS token '{term}' maps to invalid posting token id {token_id} in partition {}",
+                            partition.id()
+                        ))
+                    })?;
+                term_docs = term_docs.checked_add(posting_len).ok_or_else(|| {
+                    Error::index(format!(
+                        "FTS document frequency for term '{term}' overflows usize"
+                    ))
+                })?;
+            }
+            token_docs.push(term_docs);
+        }
+        Ok(Some((total_tokens, num_docs, token_docs)))
     }
 
     /// Aggregate immutable per-partition corpus statistics.  New modern files
@@ -366,6 +453,7 @@ impl InvertedIndex {
             prefilter,
             metrics,
             scorer,
+            None,
             initial_score_floor,
         )
         .await
@@ -458,13 +546,16 @@ impl InvertedIndex {
         {
             return Ok(Vec::new());
         }
+        let scorer = prepared.scorer();
+        let reusable_scorer = prepared.reusable_scorer();
         self.bm25_search_final_documents(
             prepared.tokens().clone(),
             params,
             operator,
             prefilter,
             metrics,
-            prepared.scorer().as_ref(),
+            scorer.as_ref(),
+            reusable_scorer,
             initial_score_floor,
         )
         .await
@@ -482,13 +573,19 @@ impl InvertedIndex {
         prefilter: Arc<dyn PreFilter>,
         metrics: Arc<dyn MetricsCollector>,
         scorer: &MemBM25Scorer,
+        prepared_scorer: Option<&Arc<MemBM25Scorer>>,
         initial_score_floor: Option<f32>,
     ) -> Result<Vec<ScoredDoc>> {
         // The wand only consults `scorer.doc_weight`, which is metadata-free.
         // The outer aggregation below consults `scorer.query_weight`; pairing
         // final tokens with precomputed per-term IDFs avoids the v2 bulk
         // metadata pull and keeps scoring aligned with the rewrite.
-        let impact_scorer = Arc::new(scorer.clone());
+        let impact_scorer = select_impact_scorer(
+            scorer,
+            prepared_scorer,
+            || self.is_legacy(),
+            || *LANCE_FTS_REUSE_PREPARED_SCORER_ENABLED,
+        );
 
         let limit = params.limit.unwrap_or(usize::MAX);
         if limit == 0 {
@@ -1068,5 +1165,83 @@ impl InvertedIndex {
             }
         }
         Ok(resolved_documents)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn scorer() -> Arc<MemBM25Scorer> {
+        Arc::new(MemBM25Scorer::new(10, 2, HashMap::new()))
+    }
+
+    #[test]
+    fn test_reuse_prepared_scorer_kill_switch_parser() {
+        for value in [None, Some(""), Some("1"), Some("on"), Some("false")] {
+            assert!(
+                reuse_prepared_scorer_enabled_from_value(value),
+                "unexpected disable: {value:?}"
+            );
+        }
+        for value in [Some("0"), Some("off"), Some("OFF"), Some(" off ")] {
+            assert!(
+                !reuse_prepared_scorer_enabled_from_value(value),
+                "unexpected enable: {value:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_select_impact_scorer_reuses_enabled_prepared_arc() {
+        let prepared = scorer();
+        let impact = select_impact_scorer(prepared.as_ref(), Some(&prepared), || false, || true);
+
+        assert!(Arc::ptr_eq(&impact, &prepared));
+        assert_eq!(Arc::strong_count(&prepared), 2);
+    }
+
+    #[test]
+    fn test_select_impact_scorer_clones_when_disabled() {
+        let prepared = scorer();
+        let unrelated = scorer();
+        let impact = select_impact_scorer(unrelated.as_ref(), Some(&prepared), || false, || false);
+
+        assert!(!Arc::ptr_eq(&impact, &unrelated));
+        assert_eq!(Arc::strong_count(&prepared), 1);
+        assert_eq!(Arc::strong_count(&unrelated), 1);
+        assert_eq!(Arc::strong_count(&impact), 1);
+    }
+
+    #[test]
+    fn test_select_impact_scorer_clones_legacy_without_reading_switch() {
+        let prepared = scorer();
+        let unrelated = scorer();
+        let impact = select_impact_scorer(
+            unrelated.as_ref(),
+            Some(&prepared),
+            || true,
+            || panic!("legacy search must not read the reuse switch"),
+        );
+
+        assert!(!Arc::ptr_eq(&impact, &unrelated));
+        assert_eq!(Arc::strong_count(&prepared), 1);
+        assert_eq!(Arc::strong_count(&unrelated), 1);
+        assert_eq!(Arc::strong_count(&impact), 1);
+    }
+
+    #[test]
+    fn test_select_impact_scorer_clones_nonprepared_without_reading_switch() {
+        let scorer = scorer();
+        let impact = select_impact_scorer(
+            scorer.as_ref(),
+            None,
+            || panic!("nonprepared search must not inspect the index format"),
+            || panic!("nonprepared search must not read the reuse switch"),
+        );
+
+        assert!(!Arc::ptr_eq(&impact, &scorer));
+        assert_eq!(Arc::strong_count(&scorer), 1);
+        assert_eq!(Arc::strong_count(&impact), 1);
     }
 }

--- a/rust/lance-index/src/scalar/inverted/index/tests/query.rs
+++ b/rust/lance-index/src/scalar/inverted/index/tests/query.rs
@@ -368,6 +368,152 @@ async fn prepared_results(
 }
 
 #[tokio::test]
+async fn test_sync_df_requires_all_segments_and_preserves_scorer_bits() {
+    let first_dir = TempObjDir::default();
+    let first_store = Arc::new(LanceIndexStore::new(
+        ObjectStore::local().into(),
+        first_dir.clone(),
+        Arc::new(LanceCache::no_cache()),
+    ));
+    write_pair_partition(
+        &first_store,
+        0,
+        &[("alpha", "beta", 100), ("alpha", "gamma", 101)],
+    )
+    .await;
+    write_test_metadata(&first_store, vec![0], InvertedIndexParams::default()).await;
+    let first_cache = Arc::new(LanceCache::with_capacity(4096));
+    let first = InvertedIndex::load(first_store, None, first_cache.as_ref())
+        .await
+        .unwrap();
+
+    let second_dir = TempObjDir::default();
+    let second_store = Arc::new(LanceIndexStore::new(
+        ObjectStore::local().into(),
+        second_dir.clone(),
+        Arc::new(LanceCache::no_cache()),
+    ));
+    write_pair_partition(&second_store, 0, &[("alpha", "beta", 200)]).await;
+    write_test_metadata(&second_store, vec![0], InvertedIndexParams::default()).await;
+    let second_cache = Arc::new(LanceCache::with_capacity(4096));
+    let second = InvertedIndex::load(second_store, None, second_cache.as_ref())
+        .await
+        .unwrap();
+
+    let indices = vec![first.clone(), second.clone()];
+    let terms = vec!["alpha".to_string(), "beta".to_string()];
+    assert!(
+        crate::scalar::inverted::bm25_scorer_from_loaded_stats_with_enabled(
+            &indices, &terms, false
+        )
+        .unwrap()
+        .is_none(),
+        "the kill switch must return before any readiness-dependent work"
+    );
+    assert!(first.corpus_stats.get().is_none());
+    assert!(second.corpus_stats.get().is_none());
+    assert!(
+        crate::scalar::inverted::bm25_scorer_from_loaded_stats_with_enabled(&indices, &terms, true)
+            .unwrap()
+            .is_none(),
+        "non-prewarmed segments must use the asynchronous path"
+    );
+
+    first
+        .prewarm_with_options(&FtsPrewarmOptions::default())
+        .await
+        .unwrap();
+    assert!(
+        crate::scalar::inverted::bm25_scorer_from_loaded_stats_with_enabled(&indices, &terms, true)
+            .unwrap()
+            .is_none(),
+        "one ready and one cold segment must fall back as one query"
+    );
+
+    second.aggregate_corpus_stats().await.unwrap();
+    assert!(second.corpus_stats.get().is_some());
+    assert!(!second.partitions[0].inverted_list.posting_lengths_loaded());
+    assert!(
+        crate::scalar::inverted::bm25_scorer_from_loaded_stats_with_enabled(&indices, &terms, true)
+            .unwrap()
+            .is_none(),
+        "loaded corpus stats with stale posting metadata must still fall back atomically"
+    );
+
+    second
+        .prewarm_with_options(&FtsPrewarmOptions::default())
+        .await
+        .unwrap();
+    let fast =
+        crate::scalar::inverted::bm25_scorer_from_loaded_stats_with_enabled(&indices, &terms, true)
+            .unwrap()
+            .unwrap();
+    let mut async_stats = Vec::with_capacity(indices.len());
+    for index in &indices {
+        async_stats.push(index.bm25_stats_for_terms(&terms, None).await.unwrap());
+    }
+    let slow = crate::scalar::inverted::merge_loaded_bm25_stats(&terms, async_stats)
+        .unwrap()
+        .unwrap();
+    assert_eq!(fast.total_tokens, slow.total_tokens);
+    assert_eq!(fast.num_docs, slow.num_docs);
+    assert_eq!(fast.token_docs, slow.token_docs);
+    assert_eq!(fast.total_tokens, 6);
+    assert_eq!(fast.num_docs, 3);
+    assert_eq!(
+        fast.token_docs,
+        HashMap::from([("alpha".to_string(), 3), ("beta".to_string(), 2)])
+    );
+    for term in &terms {
+        assert_eq!(
+            fast.query_weight(term).to_bits(),
+            slow.query_weight(term).to_bits(),
+            "query weight changed for {term}"
+        );
+    }
+    for (frequency, doc_tokens) in [(1, 1), (1, 2), (3, 7)] {
+        assert_eq!(
+            fast.doc_weight(frequency, doc_tokens).to_bits(),
+            slow.doc_weight(frequency, doc_tokens).to_bits()
+        );
+    }
+
+    let tokens = Arc::new(Tokens::new(
+        vec!["alpha".to_string(), "beta".to_string()],
+        DocType::Text,
+    ));
+    let params = Arc::new(FtsSearchParams::new().with_limit(Some(10)));
+    let fast_prepared = Arc::new(
+        crate::scalar::inverted::prepare_bm25_query(
+            &indices,
+            tokens.as_ref().clone(),
+            params.as_ref(),
+            None,
+            None,
+        )
+        .await
+        .unwrap(),
+    );
+    assert_eq!(fast_prepared.scorer().token_docs, fast.token_docs);
+    let slow_prepared = Arc::new(
+        crate::scalar::inverted::prepare_bm25_query(
+            &indices,
+            tokens.as_ref().clone(),
+            params.as_ref(),
+            None,
+            Some(slow),
+        )
+        .await
+        .unwrap(),
+    );
+    assert_eq!(
+        prepared_results(&indices, fast_prepared, params.clone()).await,
+        prepared_results(&indices, slow_prepared, params).await,
+        "the synchronous scorer must preserve final score bits"
+    );
+}
+
+#[tokio::test]
 async fn test_canonical_fuzzy_rewrite_is_independent_of_segment_and_partition_shape() {
     let documents = [
         ("alpha", "beta", 100),

--- a/rust/lance-index/src/scalar/inverted/index/tests/scoring.rs
+++ b/rust/lance-index/src/scalar/inverted/index/tests/scoring.rs
@@ -250,6 +250,84 @@ async fn load_global_scoring_test_index(
     (tmpdir, cache, index)
 }
 
+fn scored_document_bits(documents: Vec<ScoredDoc>) -> Vec<(u64, u32)> {
+    let mut results = documents
+        .into_iter()
+        .map(|document| (document.row_id, document.score.0.to_bits()))
+        .collect::<Vec<_>>();
+    results.sort_unstable();
+    results
+}
+
+#[tokio::test]
+async fn test_prepared_scorer_reuse_preserves_deferred_and_resident_results() {
+    let (_tmpdir, _cache, index) = load_global_scoring_test_index(true, true).await;
+    let tokens = Arc::new(Tokens::new(vec!["alpha".to_owned()], DocType::Text));
+    let params = Arc::new(FtsSearchParams::new().with_limit(Some(2)));
+    let prepared = Arc::new(
+        crate::scalar::inverted::prepare_bm25_query(
+            std::slice::from_ref(&index),
+            tokens.as_ref().clone(),
+            params.as_ref(),
+            None,
+            None,
+        )
+        .await
+        .unwrap(),
+    );
+    assert!(Arc::ptr_eq(
+        prepared.reusable_scorer().unwrap(),
+        prepared.scorer()
+    ));
+    let injected_scorer = Arc::new(prepared.scorer().as_ref().clone());
+    let injected_prepared = Arc::new(
+        crate::scalar::inverted::prepare_bm25_query(
+            std::slice::from_ref(&index),
+            tokens.as_ref().clone(),
+            params.as_ref(),
+            None,
+            Some(injected_scorer.clone()),
+        )
+        .await
+        .unwrap(),
+    );
+    assert!(Arc::ptr_eq(injected_prepared.scorer(), &injected_scorer));
+    assert!(injected_prepared.reusable_scorer().is_none());
+    assert_eq!(Arc::strong_count(&injected_scorer), 2);
+
+    let mut expected = None;
+    for is_resident in [false, true] {
+        if is_resident {
+            index
+                .prewarm_with_options(&FtsPrewarmOptions::default())
+                .await
+                .unwrap();
+        }
+        assert_eq!(index.has_resident_document_projections(), is_resident);
+        for query in [&prepared, &injected_prepared] {
+            let actual = scored_document_bits(
+                index
+                    .bm25_search_prepared_documents(
+                        query.clone(),
+                        params.clone(),
+                        Operator::Or,
+                        Arc::new(NoFilter),
+                        Arc::new(NoOpMetricsCollector),
+                    )
+                    .await
+                    .unwrap(),
+            );
+            if let Some(expected) = &expected {
+                assert_eq!(&actual, expected, "resident={is_resident}");
+            } else {
+                expected = Some(actual);
+            }
+            assert_eq!(Arc::strong_count(&injected_scorer), 2);
+            assert_eq!(index.has_resident_document_projections(), is_resident);
+        }
+    }
+}
+
 #[tokio::test]
 async fn test_wand_exactness_certificate_support_requires_all_impact_postings() {
     let (_tmpdir, _cache, mixed_impact_index) = load_global_scoring_test_index(true, false).await;

--- a/rust/lance-index/src/scalar/inverted/index/tests/stats.rs
+++ b/rust/lance-index/src/scalar/inverted/index/tests/stats.rs
@@ -374,6 +374,91 @@ async fn test_aggregate_corpus_stats_reuses_cached_value() {
 }
 
 #[tokio::test]
+async fn test_loaded_bm25_stats_are_all_or_nothing_and_preserve_oov() {
+    let (index, counter, _tmpdir) = load_counted_v2_index(10, LanceCache::no_cache()).await;
+    let posting_reader = &index.partitions[0].inverted_list;
+    let terms = ["t0".to_string(), "missing".to_string(), "t9".to_string()];
+
+    assert!(!posting_reader.posting_lengths_loaded());
+    assert_eq!(posting_reader.loaded_posting_len(0), None);
+    assert_eq!(
+        index.bm25_stats_for_terms_if_loaded(&terms).unwrap(),
+        None,
+        "absent corpus statistics must reject the synchronous path"
+    );
+
+    assert_eq!(index.aggregate_corpus_stats().await.unwrap(), (10, 10));
+    assert_eq!(
+        index.bm25_stats_for_terms_if_loaded(&terms).unwrap(),
+        None,
+        "an OOV term must not hide an unloaded modern length table"
+    );
+    assert_eq!(counter.metadata_rows_read(), 0);
+
+    posting_reader.ensure_metadata_loaded().await.unwrap();
+    assert!(posting_reader.posting_lengths_loaded());
+    assert_eq!(posting_reader.loaded_posting_len(0), Some(1));
+    assert_eq!(posting_reader.loaded_posting_len(9), Some(1));
+    assert_eq!(posting_reader.loaded_posting_len(10), None);
+
+    let loaded = index
+        .bm25_stats_for_terms_if_loaded(&terms)
+        .unwrap()
+        .unwrap();
+    let asynchronous = index.bm25_stats_for_terms(&terms, None).await.unwrap();
+    assert_eq!(loaded, (10, 10, vec![1, 0, 1]));
+    assert_eq!(loaded, asynchronous);
+}
+
+#[tokio::test]
+async fn test_loaded_bm25_stats_reports_invalid_loaded_token_id() {
+    let (mut index, _counter, _tmpdir) = load_counted_v2_index(1, LanceCache::no_cache()).await;
+    index.aggregate_corpus_stats().await.unwrap();
+    index.partitions[0]
+        .inverted_list
+        .ensure_metadata_loaded()
+        .await
+        .unwrap();
+
+    {
+        let index = Arc::get_mut(&mut index).expect("test index should have one owner");
+        let partition =
+            Arc::get_mut(&mut index.partitions[0]).expect("test partition should have one owner");
+        let posting_reader = Arc::get_mut(&mut partition.inverted_list)
+            .expect("test posting reader should have one owner");
+        let PostingMetadata::V2 { metadata } = &mut posting_reader.metadata else {
+            panic!("test requires modern posting metadata");
+        };
+        metadata
+            .get_mut()
+            .expect("metadata was loaded above")
+            .lengths
+            .clear();
+    }
+
+    let terms = ["t0".to_string()];
+    assert!(
+        crate::scalar::inverted::bm25_scorer_from_loaded_stats_with_enabled(
+            std::slice::from_ref(&index),
+            &terms,
+            false,
+        )
+        .unwrap()
+        .is_none(),
+        "the kill switch must short-circuit before loaded-metadata validation"
+    );
+
+    let error = index.bm25_stats_for_terms_if_loaded(&terms).unwrap_err();
+    assert!(matches!(error, Error::Index { .. }));
+    assert!(
+        error
+            .to_string()
+            .contains("token 't0' maps to invalid posting token id 0 in partition 0"),
+        "unexpected error: {error}"
+    );
+}
+
+#[tokio::test]
 async fn test_persisted_stats_do_not_load_document_columns() {
     let (index, _counter, _tmpdir) = load_counted_v2_index(100, LanceCache::no_cache()).await;
     assert!(!index.is_legacy());


### PR DESCRIPTION
Fully prewarmed FTS queries still pay asynchronous document-frequency aggregation overhead, and segment searches clone an already prepared canonical scorer. This PR reuses the resident metadata and scorer.

- Aggregate corpus statistics and posting lengths synchronously only when every required value is already loaded. The probe never starts I/O; incomplete residency uses the existing asynchronous path.
- Reuse the canonical prepared `Arc<MemBM25Scorer>` across modern segments. Legacy and externally supplied scorers retain their existing fallback behavior.
- Check statistic shapes and integer overflow while merging global counts.
- Provide `LANCE_FTS_SYNC_DF=off` and `LANCE_FTS_REUSE_PREPARED_SCORER=off` switches.

The accompanying tests cover cold/partial/full residency, multiple segments, missing terms, overflow, injected scorers, fuzzy preparation, and exact result parity. Shared fixtures remove repetition while retaining the relevant execution modes and assertions.

This layer does not change the query API or persistent format. No isolated `main` A/B performance result is claimed.

## Validation

- Local inverted-index suite: 542 passed.
- Required all-workspace Clippy and formatting: passed.
- PR metadata/gatekeeper checks: pending. Full hosted test workflows only run for `main`/`release/**` bases; this intermediate layer has been tested and linted locally. The full hosted matrix will run after its base is retargeted to `main` following the parent merge.

Stack, 2/4: [#9031](https://github.com/lance-format/lance/pull/9031) → **this PR** → [#9033](https://github.com/lance-format/lance/pull/9033) → [#9030](https://github.com/lance-format/lance/pull/9030). Base: [#9031](https://github.com/lance-format/lance/pull/9031); this diff contains only resident-statistic and prepared-scorer changes with their tests.

Merge in stack order; retarget/restack the remaining PRs after their parent merges.
