### PR TITLE
test: use v2.2 for index replacement rewrite

### DIFF
--- a/rust/lance/src/dataset/tests/dataset_index.rs
+++ b/rust/lance/src/dataset/tests/dataset_index.rs
@@ -2804,7 +2804,7 @@ async fn test_partial_compound_hybrid_prunes_same_path_different_base_rewrite() 
         .create(&replacement_path)
         .await
         .unwrap();
-    let mut writer = lance_file::versions::v2_1::create_writer(
+    let mut writer = lance_file::versions::v2_2::create_writer(
         object_writer,
         schema.as_ref().try_into().unwrap(),
         Default::default(),


### PR DESCRIPTION
## Summary

- update the index data-replacement fixture introduced by #8818 to write its replacement with V2.2
- keep the replacement aligned with the dataset's current `Stable` (V2.2) files

## Root cause

#8657 changed `LanceFileVersion::Stable` from V2.1 to V2.2 and migrated the data-replacement tests that existed at the time. #8818 subsequently added this test with a hard-coded `v2_1::create_writer`.

Once both changes were present on `main`, the test wrote its initial dataset with the new V2.2 default but wrote the replacement file as V2.1. The data-replacement commit correctly rejected the mixed file versions:

```text
All data files must have the same version. Detected both 2.2 and 2.1
```

## Why this surfaced now

- August 20: #8657 was opened.
- August 31: #8818 added this test while `main` still defaulted to V2.1, so the fixture was valid at that point.
- September 7: #8657 was merged, promoting the default to V2.2. This was the first time the two changes coexisted on `main`, exposing the stale hard-coded writer.

This is therefore a cross-PR migration gap rather than a three-week-old failure on `main`.

## Validation

- `cargo fmt --all --check`
- repository commit hooks (`fmt`, `typos`)
- all GitHub Actions workflows passed; one unrelated macOS HNSW test was flaky on the first run and passed when its job was rerun
