### PR TITLE
fix(cache): bypass Moka single-flight for zero-capacity caches

### DIFF
--- a/rust/lance-core/src/cache/backend.rs
+++ b/rust/lance-core/src/cache/backend.rs
@@ -78,7 +78,8 @@ pub trait CacheBackend: Send + Sync + std::fmt::Debug {
     /// Get an existing entry or compute it from `loader`.
     ///
     /// Implementations should deduplicate concurrent loads for the same key
-    /// so the loader runs at most once.
+    /// so the loader runs at most once, unless caching is disabled. Disabled
+    /// caches may invoke each caller's loader independently.
     ///
     /// Returns `(entry, was_cached)` where `was_cached` is `true` if the entry
     /// was already present in the cache (the loader was not invoked).

--- a/rust/lance-core/src/cache/moka.rs
+++ b/rust/lance-core/src/cache/moka.rs
@@ -48,8 +48,8 @@ fn entry_weight(key: &InternalCacheKey, size_bytes: usize, weight_unit: usize) -
 
 /// Default [`CacheBackend`] backed by a [moka](https://crates.io/crates/moka) cache.
 ///
-/// Provides weighted-capacity eviction and concurrent-load deduplication
-/// via moka's built-in `optionally_get_with`.
+/// Nonzero capacities provide weighted eviction and concurrent-load deduplication.
+/// A zero capacity invokes each loader independently without caching.
 pub struct MokaCacheBackend {
     cache: moka::future::Cache<InternalCacheKey, MokaCacheEntry>,
     capacity: usize,
@@ -127,6 +127,11 @@ impl CacheBackend for MokaCacheBackend {
         loader: Pin<Box<dyn Future<Output = Result<(CacheEntry, usize)>> + Send + 'a>>,
         _codec: Option<CacheCodec>,
     ) -> Result<(CacheEntry, bool)> {
+        // Avoid Moka's single-flight waiters when nothing can be cached.
+        if self.capacity == 0 {
+            return loader.await.map(|(entry, _)| (entry, false));
+        }
+
         // Track whether the loader actually ran (= cache miss).
         let was_miss = Arc::new(AtomicBool::new(false));
         let was_miss_clone = was_miss.clone();
@@ -193,7 +198,71 @@ impl CacheBackend for MokaCacheBackend {
 
 #[cfg(test)]
 mod tests {
+    use std::pin::pin;
+
+    use futures::{FutureExt, poll};
+    use tokio::sync::oneshot;
+
     use super::*;
+
+    #[rstest::rstest]
+    #[case::zero_capacity_success(MokaCacheBackend::with_capacity(0), false)]
+    #[case::zero_capacity_error(MokaCacheBackend::with_capacity(0), true)]
+    #[case::no_cache_success(MokaCacheBackend::no_cache(), false)]
+    #[case::no_cache_error(MokaCacheBackend::no_cache(), true)]
+    #[tokio::test]
+    async fn zero_capacity_loaders_run_independently(
+        #[case] backend: MokaCacheBackend,
+        #[case] loader_fails: bool,
+    ) {
+        let key = InternalCacheKey::from_bytes([0; 16]);
+        let first_entry: CacheEntry = Arc::new(1_u64);
+        let second_entry: CacheEntry = Arc::new(2_u64);
+        let (release_tx, release_rx) = oneshot::channel();
+        let entry = first_entry.clone();
+        let mut first = pin!(backend.get_or_insert(
+            &key,
+            Box::pin(async move {
+                release_rx.await.unwrap();
+                Ok((entry, 8))
+            }),
+            None,
+        ));
+        assert!(poll!(first.as_mut()).is_pending());
+
+        let entry = second_entry.clone();
+        let second = backend
+            .get_or_insert(
+                &key,
+                Box::pin(async move {
+                    if loader_fails {
+                        Err(crate::Error::invalid_input("independent loader failed"))
+                    } else {
+                        Ok((entry, 8))
+                    }
+                }),
+                None,
+            )
+            .now_or_never()
+            .expect("a disabled cache must not wait for another loader on the same key");
+        if loader_fails {
+            let error = second.unwrap_err();
+            assert!(matches!(&error, crate::Error::InvalidInput { .. }));
+            assert!(error.to_string().contains("independent loader failed"));
+        } else {
+            let (entry, was_cached) = second.unwrap();
+            assert!(Arc::ptr_eq(&entry, &second_entry));
+            assert!(!was_cached);
+        }
+
+        release_tx.send(()).unwrap();
+        let (entry, was_cached) = first.await.unwrap();
+        assert!(Arc::ptr_eq(&entry, &first_entry));
+        assert!(!was_cached);
+        assert!(backend.get(&key, None).await.is_none());
+        assert_eq!(backend.num_entries().await, 0);
+        assert_eq!(backend.size_bytes().await, 0);
+    }
 
     #[test]
     fn entry_weights_are_exact_at_byte_granularity() {


### PR DESCRIPTION
Zero capacity prevents Moka from retaining entries but still enters its per-key initialization path. Concurrent uncached loads can therefore wait on one another and allocate the waiters involved in fragment-open leaks.

Await each loader directly when capacity is zero, preserving its value or error and reporting a cache miss. Keep nonzero-capacity caching unchanged and document that disabled caches may load the same key independently.

Cover with_capacity(0) and no_cache with a pending same-key loader and an independent successful or failing loader, and verify that no entries are retained. All four cases fail without the fast path and pass with it.

Validation:
- cargo test --locked -p lance-core
- cargo clippy --locked -p lance-core --all-targets -- -D warnings
- cargo fmt --all -- --check