### PR TITLE
feat: allow commits without automatic rebasing

### DIFF
--- a/rust/lance/src/dataset.rs
+++ b/rust/lance/src/dataset.rs
@@ -1667,6 +1667,7 @@ impl Dataset {
             DEFAULT_COMMIT_RETRY_TIMEOUT,
             self.manifest_location.naming_scheme,
             None,
+            false,
         )
         .await?;
 

--- a/rust/lance/src/dataset/optimize.rs
+++ b/rust/lance/src/dataset/optimize.rs
@@ -2276,6 +2276,7 @@ async fn reserve_fragment_ids(
         DEFAULT_COMMIT_RETRY_TIMEOUT,
         dataset.manifest_location.naming_scheme,
         None,
+        false,
     )
     .await?;
 

--- a/rust/lance/src/dataset/write/commit.rs
+++ b/rust/lance/src/dataset/write/commit.rs
@@ -48,6 +48,7 @@ pub struct CommitBuilder<'a> {
     session: Option<Arc<Session>>,
     detached: bool,
     commit_config: CommitConfig,
+    disable_rebase: bool,
     retry_timeout: Duration,
     affected_rows: Option<RowAddrTreeMap>,
     transaction_properties: Option<Arc<HashMap<String, String>>>,
@@ -73,6 +74,7 @@ impl<'a> CommitBuilder<'a> {
             session: None,
             detached: false,
             commit_config: Default::default(),
+            disable_rebase: false,
             retry_timeout: DEFAULT_COMMIT_RETRY_TIMEOUT,
             affected_rows: None,
             transaction_properties: None,
@@ -198,6 +200,29 @@ impl<'a> CommitBuilder<'a> {
     /// If a commit operation fails, it will be retried up to `max_retries` times.
     pub fn with_max_retries(mut self, max_retries: u32) -> Self {
         self.commit_config.num_retries = max_retries;
+        self
+    }
+
+    /// Whether an attached transaction may be rebased over concurrent commits.
+    ///
+    /// Enabled by default. When disabled, the transaction can only publish
+    /// version `read_version + 1`, even if a concurrent write would normally be
+    /// compatible. A conflict is returned without rebasing or retrying, after
+    /// checking whether this transaction already committed. This lets a caller
+    /// validate application-specific preconditions against `read_version`
+    /// without a race between validation and publication.
+    ///
+    /// Unlike setting [`Self::with_max_retries`] to zero, this also disables
+    /// rebasing before the first commit attempt. Detached commits and creation
+    /// of a new dataset do not rebase and are unaffected by this option.
+    ///
+    /// ```
+    /// use lance::dataset::CommitBuilder;
+    ///
+    /// let builder = CommitBuilder::new("memory://dataset").with_auto_rebase(false);
+    /// ```
+    pub fn with_auto_rebase(mut self, enabled: bool) -> Self {
+        self.disable_rebase = !enabled;
         self
     }
 
@@ -468,6 +493,7 @@ impl<'a> CommitBuilder<'a> {
                     self.retry_timeout,
                     manifest_naming_scheme,
                     self.affected_rows.as_ref(),
+                    self.disable_rebase,
                 )
                 .await?
             }
@@ -607,6 +633,7 @@ pub struct BatchCommitResult {
 mod tests {
     use arrow::array::{Int32Array, RecordBatch};
     use arrow_schema::{DataType, Field as ArrowField, Schema as ArrowSchema};
+    use lance_datagen::{RowCount, array, gen_batch};
 
     use lance_io::utils::CachedFileSize;
     use lance_io::{assert_io_eq, assert_io_gt};
@@ -1085,6 +1112,67 @@ mod tests {
             matches!(&error, Error::TooMuchWriteContention { message, .. } if message.contains("failed on retry_timeout")),
             "got {error:?}"
         );
+    }
+
+    #[tokio::test]
+    #[rstest::rstest]
+    #[case(false, 20, false)]
+    #[case(true, 0, true)]
+    #[case(true, 20, true)]
+    async fn test_commit_auto_rebase(
+        #[case] auto_rebase: bool,
+        #[case] max_retries: u32,
+        #[case] succeeds: bool,
+    ) {
+        let batch = gen_batch()
+            .col("i", array::step::<arrow_array::types::Int32Type>())
+            .into_batch_rows(RowCount::from(4))
+            .unwrap();
+        let source = Arc::new(
+            InsertBuilder::new("memory://")
+                .execute(vec![batch])
+                .await
+                .unwrap(),
+        );
+        let winner = sample_transaction(source.version().version);
+        let latest = Arc::new(
+            CommitBuilder::new(source.clone())
+                .with_auto_rebase(false)
+                .execute(winner.clone())
+                .await
+                .unwrap(),
+        );
+
+        // Losing a successful response still recovers the original version.
+        let replayed = CommitBuilder::new(source.clone())
+            .with_auto_rebase(false)
+            .execute(winner)
+            .await
+            .unwrap();
+        assert_eq!(replayed.version().version, latest.version().version);
+
+        // A latest destination handle must not bypass the transaction's read version.
+        let result = CommitBuilder::new(latest.clone())
+            .with_auto_rebase(auto_rebase)
+            .with_max_retries(max_retries)
+            .execute(sample_transaction(source.version().version))
+            .await;
+        if succeeds {
+            assert_eq!(
+                result.unwrap().version().version,
+                latest.version().version + 1
+            );
+        } else {
+            let error =
+                result.expect_err("an intervening append invalidates an exact-version commit");
+            assert!(
+                matches!(error, Error::TooMuchWriteContention { .. }),
+                "{error:?}"
+            );
+            let mut unchanged = latest.as_ref().clone();
+            unchanged.checkout_latest().await.unwrap();
+            assert_eq!(unchanged.version().version, latest.version().version);
+        }
     }
 
     #[tokio::test]

--- a/rust/lance/src/dataset/write/commit.rs
+++ b/rust/lance/src/dataset/write/commit.rs
@@ -207,7 +207,7 @@ impl<'a> CommitBuilder<'a> {
     ///
     /// Enabled by default. When disabled, the transaction can only publish
     /// version `read_version + 1`, even if a concurrent write would normally be
-    /// compatible. A conflict is returned without rebasing or retrying, after
+    /// compatible. An [`Error::RetryableCommitConflict`] is returned without rebasing or retrying, after
     /// checking whether this transaction already committed. This lets a caller
     /// validate application-specific preconditions against `read_version`
     /// without a race between validation and publication.
@@ -1166,7 +1166,7 @@ mod tests {
             let error =
                 result.expect_err("an intervening append invalidates an exact-version commit");
             assert!(
-                matches!(error, Error::TooMuchWriteContention { .. }),
+                matches!(error, Error::RetryableCommitConflict { .. }),
                 "{error:?}"
             );
             let mut unchanged = latest.as_ref().clone();

--- a/rust/lance/src/io/commit.rs
+++ b/rust/lance/src/io/commit.rs
@@ -1710,6 +1710,14 @@ pub(crate) async fn commit_transaction(
     }
 
     cleanup_transaction_file(object_store, &dataset.base, &current_transaction_file).await;
+    if disable_rebase {
+        return Err(crate::Error::retryable_commit_conflict_source(
+            target_version,
+            "the transaction's read version was superseded; revalidate before committing"
+                .to_string()
+                .into(),
+        ));
+    }
     Err(crate::Error::commit_conflict_source(
         target_version,
         format!(

--- a/rust/lance/src/io/commit.rs
+++ b/rust/lance/src/io/commit.rs
@@ -1409,15 +1409,16 @@ pub(crate) async fn commit_transaction(
     // Strict overwrites are not subject to any sort of automatic conflict resolution.
     let strict_overwrite = matches!(transaction.operation, Operation::Overwrite { .. })
         && commit_config.num_retries == 0;
-    let mut dataset =
-        if dataset.manifest.version != read_version && (read_version != 0 || strict_overwrite) {
-            // If the dataset version is not the same as the read version, we need to
-            // checkout the read version.
-            dataset.checkout_version(read_version).await?
-        } else {
-            // If the dataset version is the same as the read version, we can use it directly.
-            dataset.clone()
-        };
+    let mut dataset = if dataset.manifest.version != read_version
+        && (read_version != 0 || strict_overwrite || disable_rebase)
+    {
+        // If the dataset version is not the same as the read version, we need to
+        // checkout the read version.
+        dataset.checkout_version(read_version).await?
+    } else {
+        // If the dataset version is the same as the read version, we can use it directly.
+        dataset.clone()
+    };
 
     // The version this transaction read, captured before the retry loop moves
     // `dataset` forward. MemWAL index catch-up is derived from it: an index

--- a/rust/lance/src/io/commit.rs
+++ b/rust/lance/src/io/commit.rs
@@ -1396,6 +1396,7 @@ pub(crate) async fn commit_transaction(
     retry_timeout: Duration,
     manifest_naming_scheme: ManifestNamingScheme,
     affected_rows: Option<&RowAddrTreeMap>,
+    disable_rebase: bool,
 ) -> Result<(Manifest, ManifestLocation)> {
     // Note: object_store has been configured with WriteParams, but dataset.object_store.as_ref()
     // has not necessarily. So for anything involving writing, use `object_store`.
@@ -1434,7 +1435,11 @@ pub(crate) async fn commit_transaction(
 
     let mut transaction = transaction.clone();
 
-    let num_attempts = std::cmp::max(commit_config.num_retries, 1);
+    let num_attempts = if disable_rebase {
+        1
+    } else {
+        std::cmp::max(commit_config.num_retries, 1)
+    };
     let mut backoff = SlotBackoff::default();
     let start = Instant::now();
 
@@ -1453,7 +1458,7 @@ pub(crate) async fn commit_transaction(
         // faster and the slow path slower, which makes performance less predictable
         // for users. So we always check for other transactions.
         // We skip this for strict overwrites, because strict overwrites can't be rebased.
-        if !strict_overwrite {
+        if !strict_overwrite && !disable_rebase {
             (dataset, other_transactions) = load_and_sort_new_transactions(&dataset).await?;
 
             ensure_can_write_manifest(&dataset.manifest)?;

--- a/rust/lance/src/io/commit.rs
+++ b/rust/lance/src/io/commit.rs
@@ -2763,6 +2763,7 @@ mod tests {
             DEFAULT_COMMIT_RETRY_TIMEOUT,
             dataset.manifest_location.naming_scheme,
             None,
+            false,
         )
         .await
         .expect("the inline transaction must identify the landed commit");


### PR DESCRIPTION
Callers that validate application-specific preconditions against a dataset version need publication to remain conditional on that version. Today, even `with_max_retries(0)` can rebase a transaction before its first commit attempt, allowing a compatible concurrent write to bypass the caller's validation.

Add `CommitBuilder::with_auto_rebase(false)` for attached transactions. It attempts only `read_version + 1` and returns `RetryableCommitConflict` when that version is superseded, so the caller can reload, revalidate, and construct another transaction. Readback still recovers an already committed transaction when its successful response was lost. Automatic rebasing remains enabled by default; detached commits and new-dataset creation are unaffected.

This is an opt-in Rust API with no storage-format change. Coverage checks exact-version publication, recovery of an already committed transaction, rejection with a newer destination handle, and the existing auto-rebase behavior with both zero and nonzero retry budgets.
