### PR TITLE
fix: copy sliced arrays from logical offsets

### DIFF
--- a/rust/lance-arrow/src/deepcopy.rs
+++ b/rust/lance-arrow/src/deepcopy.rs
@@ -89,54 +89,24 @@ pub fn deep_copy_batch(batch: &RecordBatch) -> crate::Result<RecordBatch> {
 /// Deep copy array data, extracting only the sliced portion using MutableArrayData
 /// This is the most efficient and correct way to copy just the sliced data
 pub fn deep_copy_array_data_sliced(data: &ArrayData) -> ArrayData {
-    // Arrow's extenders disagree about who applies a parent offset, so no one
-    // index convention is right for every layout: the bit-packed extender adds
-    // `ArrayData::offset()` to the raw buffer itself, while the `FixedSizeList`
-    // one forwards `start * size` to a child that `ArrayData::slice` left
-    // whole. Resolving the offset into the children first settles it, after
-    // which logical indices are correct everywhere -- the convention arrow's
-    // own `concat` relies on.
-    let resolved;
-    let data = if data.offset() == 0 {
-        data
-    } else {
-        resolved = offset_resolved(data);
-        &resolved
-    };
-
+    // Use MutableArrayData to efficiently copy just the slice
     let mut mutable = MutableArrayData::new(vec![data], false, data.len());
-    mutable.extend(0, 0, data.len());
+
+    // Which index this takes depends on the layout, because arrow's extenders
+    // disagree about who applies `ArrayData::offset()`. The bit-packed one adds
+    // it to the raw values buffer itself, so an offset-applied index there
+    // reads from twice the offset and runs off the end of the buffer. Every
+    // other layout either reads through an already-offset-applied view or
+    // forwards the index to children carrying their own offsets, and takes the
+    // absolute index it has always been given.
+    let start = match data.data_type() {
+        DataType::Boolean => 0,
+        _ => data.offset(),
+    };
+    mutable.extend(0, start, start + data.len());
 
     // Freeze into immutable ArrayData
     mutable.freeze()
-}
-
-/// Push a parent offset down to wherever each layout expects to find it.
-///
-/// Rebuilding through the array API does this, and recursively: constructing a
-/// `FixedSizeListArray` slices its child by `offset * size`, and constructing a
-/// `StructArray` slices each of its children in turn.
-///
-/// The one shape that cannot be rebuilt as it stands is a struct, because
-/// `ArrayData::slice` both slices a struct's children and records the offset --
-/// double-counting, so applying it again slices past the end of the children it
-/// already produced. Dropping that now-redundant offset is what makes the
-/// struct rebuildable, and it is the reading arrow's own extender takes.
-fn offset_resolved(data: &ArrayData) -> ArrayData {
-    if matches!(data.data_type(), DataType::Struct(_)) {
-        // SAFETY: `build_unchecked` inherits `ArrayData::new_unchecked`'s
-        // contract. Only the offset changes, and only to zero; the buffers,
-        // nulls and child data are the ones `ArrayData::slice` already narrowed
-        // to this window, so every value-level invariant they upheld still
-        // holds and the payload described is the same one.
-        let data = unsafe {
-            ArrayDataBuilder::from(data.clone())
-                .offset(0)
-                .build_unchecked()
-        };
-        return make_array(data).to_data();
-    }
-    make_array(data.clone()).to_data()
 }
 
 /// Deep copy an array, extracting only the sliced portion using MutableArrayData
@@ -169,9 +139,9 @@ mod tests {
         // `ArrayData::slice` records the offset on the parent and leaves the
         // child whole -- a shape `FixedSizeListArray::slice` never produces,
         // but a legal one this public helper can be handed directly. Arrow's
-        // extender forwards `start * size` to that unsliced child, so the
-        // parent offset has to be resolved before the copy or the wrong rows
-        // come back.
+        // extender forwards `start * size` to that unsliced child and adds
+        // nothing, so the index it gets has to be the absolute one; this is
+        // here to stop the boolean fix from being generalised over it.
         let child = Int32Array::from(vec![10, 11, 20, 21]).to_data();
         let field = Arc::new(Field::new_list_field(DataType::Int32, false));
         let data = ArrayDataBuilder::new(DataType::FixedSizeList(field, 2))
@@ -187,11 +157,11 @@ mod tests {
     }
 
     #[test]
-    fn raw_sliced_struct_of_fixed_size_list_resolves_both_levels() {
+    fn raw_sliced_struct_of_fixed_size_list_reaches_the_right_values() {
         // Slicing raw struct data pushes the window into the struct's children,
         // and a fixed-size-list child takes it as its own parent offset with
-        // its values left whole -- so the offset has to be resolved at both
-        // levels, not just the outer one.
+        // its values left whole. Two levels of offset, and the absolute index
+        // has to remain right through both of them.
         let values = Int32Array::from(vec![10, 11, 20, 21, 30, 31]).to_data();
         let item = Arc::new(Field::new_list_field(DataType::Int32, false));
         let list = ArrayDataBuilder::new(DataType::FixedSizeList(item, 2))
@@ -213,19 +183,21 @@ mod tests {
     }
 
     #[test]
-    fn raw_sliced_struct_data_keeps_its_child_offset() {
-        let child = Int32Array::from(vec![10, 11, 20, 21]).to_data();
+    fn raw_parent_offset_struct_keeps_the_selected_child_row() {
+        // A struct whose children are whole and whose window is the parent
+        // offset: arrow's struct extender forwards the index to those children
+        // untouched, so it has to be the absolute one.
         let field = Arc::new(Field::new("a", DataType::Int32, false));
         let data = ArrayDataBuilder::new(DataType::Struct(vec![field].into()))
-            .len(4)
-            .add_child_data(child)
+            .len(1)
+            .offset(1)
+            .add_child_data(Int32Array::from(vec![10, 20]).to_data())
             .build()
             .unwrap();
-        let sliced = data.slice(2, 2);
 
-        let copied = super::deep_copy_array_data_sliced(&sliced);
+        let copied = super::deep_copy_array_data_sliced(&data);
         let copied_child = Int32Array::from(copied.child_data()[0].clone());
-        assert_eq!(copied_child.values().as_ref(), &[20, 21]);
+        assert_eq!(copied_child.values().as_ref(), &[20]);
     }
 
     #[test]

--- a/rust/lance-arrow/src/deepcopy.rs
+++ b/rust/lance-arrow/src/deepcopy.rs
@@ -91,8 +91,12 @@ pub fn deep_copy_array_data_sliced(data: &ArrayData) -> ArrayData {
     // Use MutableArrayData to efficiently copy just the slice
     let mut mutable = MutableArrayData::new(vec![data], false, data.len());
 
-    // Copy from offset to offset+len (the visible slice)
-    mutable.extend(0, data.offset(), data.offset() + data.len());
+    // Logical indices: `MutableArrayData` applies the source's own offset, so
+    // adding it here applies it twice. Only a layout that keeps a non-zero
+    // `ArrayData::offset()` after slicing is affected -- a primitive slice
+    // advances its buffer instead -- which in practice means the bit-packed
+    // ones, where the doubled offset runs off the end of the values buffer.
+    mutable.extend(0, 0, data.len());
 
     // Freeze into immutable ArrayData
     mutable.freeze()
@@ -119,8 +123,47 @@ pub fn deep_copy_batch_sliced(batch: &RecordBatch) -> crate::Result<RecordBatch>
 mod tests {
     use std::sync::Arc;
 
-    use arrow_array::{Array, Int32Array, RecordBatch, StringArray};
+    use arrow_array::{Array, BooleanArray, Int32Array, RecordBatch, StringArray};
     use arrow_schema::{DataType, Field, Schema};
+
+    #[test]
+    fn sliced_boolean_deep_copy_reads_from_the_slice() {
+        // A boolean slice keeps its `ArrayData::offset()` -- the buffer cannot
+        // advance by a fraction of a byte -- so a copy that adds the offset on
+        // top of what `MutableArrayData` already applies reads past the end of
+        // the values buffer and panics.
+        let array = BooleanArray::from(vec![true, false, true, false, true, false, true, false]);
+        for (offset, len) in [(0usize, 8usize), (1, 7), (3, 5), (7, 1)] {
+            let sliced = array.slice(offset, len);
+            let copied = super::deep_copy_array_sliced(&sliced);
+            let copied = copied.as_any().downcast_ref::<BooleanArray>().unwrap();
+            let expected: Vec<bool> = (0..len).map(|i| sliced.value(i)).collect();
+            let actual: Vec<bool> = (0..len).map(|i| copied.value(i)).collect();
+            assert_eq!(actual, expected, "offset={offset} len={len}");
+        }
+    }
+
+    #[test]
+    fn sliced_boolean_deep_copy_keeps_its_nulls() {
+        let array = BooleanArray::from(vec![
+            Some(true),
+            None,
+            Some(false),
+            Some(true),
+            None,
+            Some(false),
+        ]);
+        let sliced = array.slice(1, 4);
+        let copied = super::deep_copy_array_sliced(&sliced);
+        let copied = copied.as_any().downcast_ref::<BooleanArray>().unwrap();
+        let expected: Vec<Option<bool>> = (0..sliced.len())
+            .map(|i| (!sliced.is_null(i)).then(|| sliced.value(i)))
+            .collect();
+        let actual: Vec<Option<bool>> = (0..copied.len())
+            .map(|i| (!copied.is_null(i)).then(|| copied.value(i)))
+            .collect();
+        assert_eq!(actual, expected);
+    }
 
     #[test]
     fn test_deep_copy_sliced_array_with_nulls() {

--- a/rust/lance-arrow/src/deepcopy.rs
+++ b/rust/lance-arrow/src/deepcopy.rs
@@ -6,6 +6,7 @@ use std::sync::Arc;
 use arrow_array::{Array, RecordBatch, make_array};
 use arrow_buffer::{BooleanBuffer, Buffer, NullBuffer};
 use arrow_data::{ArrayData, ArrayDataBuilder, transform::MutableArrayData};
+use arrow_schema::DataType;
 
 pub fn deep_copy_buffer(buffer: &Buffer) -> Buffer {
     Buffer::from(buffer.as_slice())
@@ -88,18 +89,54 @@ pub fn deep_copy_batch(batch: &RecordBatch) -> crate::Result<RecordBatch> {
 /// Deep copy array data, extracting only the sliced portion using MutableArrayData
 /// This is the most efficient and correct way to copy just the sliced data
 pub fn deep_copy_array_data_sliced(data: &ArrayData) -> ArrayData {
-    // Use MutableArrayData to efficiently copy just the slice
-    let mut mutable = MutableArrayData::new(vec![data], false, data.len());
+    // Arrow's extenders disagree about who applies a parent offset, so no one
+    // index convention is right for every layout: the bit-packed extender adds
+    // `ArrayData::offset()` to the raw buffer itself, while the `FixedSizeList`
+    // one forwards `start * size` to a child that `ArrayData::slice` left
+    // whole. Resolving the offset into the children first settles it, after
+    // which logical indices are correct everywhere -- the convention arrow's
+    // own `concat` relies on.
+    let resolved;
+    let data = if data.offset() == 0 {
+        data
+    } else {
+        resolved = offset_resolved(data);
+        &resolved
+    };
 
-    // Logical indices: `MutableArrayData` applies the source's own offset, so
-    // adding it here applies it twice. Only a layout that keeps a non-zero
-    // `ArrayData::offset()` after slicing is affected -- a primitive slice
-    // advances its buffer instead -- which in practice means the bit-packed
-    // ones, where the doubled offset runs off the end of the values buffer.
+    let mut mutable = MutableArrayData::new(vec![data], false, data.len());
     mutable.extend(0, 0, data.len());
 
     // Freeze into immutable ArrayData
     mutable.freeze()
+}
+
+/// Push a parent offset down to wherever each layout expects to find it.
+///
+/// Rebuilding through the array API does this, and recursively: constructing a
+/// `FixedSizeListArray` slices its child by `offset * size`, and constructing a
+/// `StructArray` slices each of its children in turn.
+///
+/// The one shape that cannot be rebuilt as it stands is a struct, because
+/// `ArrayData::slice` both slices a struct's children and records the offset --
+/// double-counting, so applying it again slices past the end of the children it
+/// already produced. Dropping that now-redundant offset is what makes the
+/// struct rebuildable, and it is the reading arrow's own extender takes.
+fn offset_resolved(data: &ArrayData) -> ArrayData {
+    if matches!(data.data_type(), DataType::Struct(_)) {
+        // SAFETY: `build_unchecked` inherits `ArrayData::new_unchecked`'s
+        // contract. Only the offset changes, and only to zero; the buffers,
+        // nulls and child data are the ones `ArrayData::slice` already narrowed
+        // to this window, so every value-level invariant they upheld still
+        // holds and the payload described is the same one.
+        let data = unsafe {
+            ArrayDataBuilder::from(data.clone())
+                .offset(0)
+                .build_unchecked()
+        };
+        return make_array(data).to_data();
+    }
+    make_array(data.clone()).to_data()
 }
 
 /// Deep copy an array, extracting only the sliced portion using MutableArrayData
@@ -124,7 +161,72 @@ mod tests {
     use std::sync::Arc;
 
     use arrow_array::{Array, BooleanArray, Int32Array, RecordBatch, StringArray};
+    use arrow_data::ArrayDataBuilder;
     use arrow_schema::{DataType, Field, Schema};
+
+    #[test]
+    fn raw_sliced_fixed_size_list_data_keeps_its_child_offset() {
+        // `ArrayData::slice` records the offset on the parent and leaves the
+        // child whole -- a shape `FixedSizeListArray::slice` never produces,
+        // but a legal one this public helper can be handed directly. Arrow's
+        // extender forwards `start * size` to that unsliced child, so the
+        // parent offset has to be resolved before the copy or the wrong rows
+        // come back.
+        let child = Int32Array::from(vec![10, 11, 20, 21]).to_data();
+        let field = Arc::new(Field::new_list_field(DataType::Int32, false));
+        let data = ArrayDataBuilder::new(DataType::FixedSizeList(field, 2))
+            .len(2)
+            .add_child_data(child)
+            .build()
+            .unwrap();
+        let sliced = data.slice(1, 1);
+
+        let copied = super::deep_copy_array_data_sliced(&sliced);
+        let copied_child = Int32Array::from(copied.child_data()[0].clone());
+        assert_eq!(copied_child.values().as_ref(), &[20, 21]);
+    }
+
+    #[test]
+    fn raw_sliced_struct_of_fixed_size_list_resolves_both_levels() {
+        // Slicing raw struct data pushes the window into the struct's children,
+        // and a fixed-size-list child takes it as its own parent offset with
+        // its values left whole -- so the offset has to be resolved at both
+        // levels, not just the outer one.
+        let values = Int32Array::from(vec![10, 11, 20, 21, 30, 31]).to_data();
+        let item = Arc::new(Field::new_list_field(DataType::Int32, false));
+        let list = ArrayDataBuilder::new(DataType::FixedSizeList(item, 2))
+            .len(3)
+            .add_child_data(values)
+            .build()
+            .unwrap();
+        let field = Arc::new(Field::new("l", list.data_type().clone(), false));
+        let data = ArrayDataBuilder::new(DataType::Struct(vec![field].into()))
+            .len(3)
+            .add_child_data(list)
+            .build()
+            .unwrap();
+        let sliced = data.slice(2, 1);
+
+        let copied = super::deep_copy_array_data_sliced(&sliced);
+        let copied_values = Int32Array::from(copied.child_data()[0].child_data()[0].clone());
+        assert_eq!(copied_values.values().as_ref(), &[30, 31]);
+    }
+
+    #[test]
+    fn raw_sliced_struct_data_keeps_its_child_offset() {
+        let child = Int32Array::from(vec![10, 11, 20, 21]).to_data();
+        let field = Arc::new(Field::new("a", DataType::Int32, false));
+        let data = ArrayDataBuilder::new(DataType::Struct(vec![field].into()))
+            .len(4)
+            .add_child_data(child)
+            .build()
+            .unwrap();
+        let sliced = data.slice(2, 2);
+
+        let copied = super::deep_copy_array_data_sliced(&sliced);
+        let copied_child = Int32Array::from(copied.child_data()[0].clone());
+        assert_eq!(copied_child.values().as_ref(), &[20, 21]);
+    }
 
     #[test]
     fn sliced_boolean_deep_copy_reads_from_the_slice() {

--- a/rust/lance-arrow/src/stream.rs
+++ b/rust/lance-arrow/src/stream.rs
@@ -167,7 +167,20 @@ fn slice_batch(
     let batch_bytes = batch.get_array_memory_size();
     let num_rows = batch.num_rows();
 
-    if batch_bytes <= max_bytes || num_rows <= 1 {
+    if batch_bytes <= max_bytes {
+        return Ok(vec![batch]);
+    }
+
+    if num_rows <= 1 {
+        // A single row cannot be split further, but the size just measured may
+        // belong to its source buffer rather than to the row:
+        // `get_array_memory_size` reports whole buffers, and a slice shares
+        // them. Returning it uncopied hands the caller that inflated figure --
+        // a 100 KB row inside a 200 MB buffer measures as 200 MB, and a caller
+        // budgeting on it concludes the row cannot fit anywhere.
+        if deep_copy {
+            return Ok(vec![deep_copy_batch_sliced(&batch)?]);
+        }
         return Ok(vec![batch]);
     }
 
@@ -215,6 +228,42 @@ mod tests {
     use arrow_array::Int32Array;
     use arrow_schema::{DataType, Field, Schema};
     use futures::executor::block_on;
+
+    /// A single row that shares a large source buffer must report its own
+    /// size, not the buffer's. Callers budget on this figure, and an inflated
+    /// one makes a small row look impossible to place.
+    #[test]
+    fn a_single_row_slice_reports_its_own_size() {
+        use arrow_array::LargeStringArray;
+
+        let row = "x".repeat(100 * 1024);
+        let values: Vec<&str> = (0..2000).map(|_| row.as_str()).collect();
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "text",
+            DataType::LargeUtf8,
+            false,
+        )]));
+        let batch =
+            RecordBatch::try_new(schema, vec![Arc::new(LargeStringArray::from(values))]).unwrap();
+        let whole = batch.get_array_memory_size();
+
+        let one_row = batch.slice(7, 1);
+        assert_eq!(
+            one_row.get_array_memory_size(),
+            whole,
+            "a slice shares its source buffer, which is the reason this test exists"
+        );
+
+        // Budget far below the row so the split recurses to the single-row floor.
+        let chunks = slice_batch(one_row, 1024, true).unwrap();
+        assert_eq!(chunks.len(), 1);
+        let measured = chunks[0].get_array_memory_size();
+        assert_eq!(chunks[0].num_rows(), 1);
+        assert!(
+            measured < whole / 100,
+            "single row still measured as {measured} bytes against a {whole} byte source"
+        );
+    }
 
     fn make_batch(num_rows: usize) -> RecordBatch {
         let schema = test_schema();


### PR DESCRIPTION
`deep_copy_array_data_sliced` passes absolute buffer indices to `MutableArrayData::extend`, which takes logical ones — arrow applies the source's `ArrayData::offset()` itself. `transform/boolean.rs` adds it to the raw values buffer; `transform/primitive.rs` reads through `ArrayData::buffer`, which is already offset-applied. So the offset is applied twice.

Slicing a primitive advances its buffer and leaves `offset()` at zero, which is why this stayed hidden. A bit-packed layout cannot advance by a fraction of a byte and keeps the offset, so a sliced boolean reads from `2 * offset` and runs off the end of its values buffer:

```
assertion failed: offset_read.checked_add(len).expect("operation will overflow read buffer") <= data.len() * 8
  arrow-buffer/src/util/bit_mask.rs:41
  arrow_data::transform::boolean::build_extend
  arrow_data::transform::MutableArrayData::extend
  lance_arrow::deepcopy::deep_copy_array_data_sliced
  lance_arrow::stream::slice_batch
  lance_arrow::stream::rechunk_stream_by_size_inner
  lance::dataset::fragment::FileFragment::write_columns
```

Any writer whose batches get rechunked and whose schema carries a boolean column hits it. We ran into it writing a column of ~100 KB strings, where the rechunker slices often enough to land on a non-zero offset.

The line dates from #4513. The same one-line fix was written on the `gatekeeper/fix-3393-1` branch as part of #8182, which was closed without merging.

Two regression tests cover it, over several offsets and with nulls; both fail on the previous line and pass on this one.
