### PR TITLE
feat(index): proportional hierarchical k-means for IVF training

### DIFF
--- a/rust/lance-index/examples/kmeans_quality.rs
+++ b/rust/lance-index/examples/kmeans_quality.rs
@@ -1,0 +1,513 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+//! Measure IVF k-means training time against clustering quality on a big-ann
+//! style `.fbin` dataset (`u32` row count, `u32` dimension, then row-major
+//! `f32` vectors), such as the 10M subsets of DEEP1B or Text-to-Image1B.
+//!
+//! Trains on a seeded sample of `sample_rate * k` rows, assigns the whole base
+//! to the trained centroids with the exact flat assignment, and reports:
+//!
+//! - training and assignment wall time,
+//! - WCSS (mean squared L2 distance to the assigned centroid) on the base and
+//!   on the training sample,
+//! - partition-size balance: coefficient of variation, percentiles relative to
+//!   the mean size, empty and oversized (> 4x mean) partitions,
+//! - per-query scan cost (rows in the `nprobes` nearest partitions) and
+//!   recall@10 of the probed partitions against exact ground truth.
+//!
+//! Run:
+//!   cargo run --release -p lance-index --example kmeans_quality -- \
+//!     --base /data/T2I/base.10M.fbin --queries /data/T2I/query.public.100K.fbin \
+//!     --k 2441 --mode hierarchical --hk 16 --refine-iters 2 --seed 1 --out results.jsonl
+
+#![allow(clippy::print_stdout)]
+
+use std::collections::HashSet;
+use std::fs::{File, OpenOptions};
+use std::io::{BufReader, Read, Seek, SeekFrom, Write};
+use std::path::{Path, PathBuf};
+use std::time::Instant;
+
+use arrow_array::Float32Array;
+use arrow_array::cast::AsArray;
+use arrow_array::types::Float32Type;
+use lance_index::vector::kmeans::{
+    KMeansAlgoFloat, KMeansParams, compute_partitions_with_dists, kmeans_find_partitions,
+    train_kmeans,
+};
+use lance_linalg::distance::DistanceType;
+use lance_linalg::distance::l2::l2_distance_batch;
+use rand::SeedableRng;
+use rand::rngs::SmallRng;
+use rayon::prelude::*;
+
+const TOP_K: usize = 10;
+
+struct Args {
+    base: PathBuf,
+    queries: PathBuf,
+    rows: Option<usize>,
+    k: usize,
+    sample_rate: usize,
+    seed: u64,
+    hk: usize,
+    max_iters: u32,
+    mode: String,
+    refine_iters: u32,
+    balance_factor: f32,
+    nprobes: usize,
+    num_queries: usize,
+    threads: Option<usize>,
+    label: String,
+    out: Option<PathBuf>,
+    skip_assign: bool,
+    stream: bool,
+}
+
+fn parse_args() -> Args {
+    let mut args = Args {
+        base: PathBuf::new(),
+        queries: PathBuf::new(),
+        rows: None,
+        k: 2441,
+        sample_rate: 256,
+        seed: 1,
+        hk: 16,
+        max_iters: 50,
+        mode: "hierarchical".to_string(),
+        refine_iters: 0,
+        balance_factor: 1.0,
+        nprobes: 20,
+        num_queries: 1000,
+        threads: None,
+        label: String::new(),
+        out: None,
+        skip_assign: false,
+        stream: false,
+    };
+    let argv: Vec<String> = std::env::args().skip(1).collect();
+    let mut i = 0;
+    while i + 1 < argv.len() {
+        let value = &argv[i + 1];
+        match argv[i].as_str() {
+            "--base" => args.base = PathBuf::from(value),
+            "--queries" => args.queries = PathBuf::from(value),
+            "--rows" => args.rows = Some(value.parse().unwrap()),
+            "--k" => args.k = value.parse().unwrap(),
+            "--sample-rate" => args.sample_rate = value.parse().unwrap(),
+            "--seed" => args.seed = value.parse().unwrap(),
+            "--hk" => args.hk = value.parse().unwrap(),
+            "--max-iters" => args.max_iters = value.parse().unwrap(),
+            "--mode" => args.mode = value.clone(),
+            "--refine-iters" => args.refine_iters = value.parse().unwrap(),
+            "--balance-factor" => args.balance_factor = value.parse().unwrap(),
+            "--nprobes" => args.nprobes = value.parse().unwrap(),
+            "--num-queries" => args.num_queries = value.parse().unwrap(),
+            "--threads" => args.threads = Some(value.parse().unwrap()),
+            "--label" => args.label = value.clone(),
+            "--out" => args.out = Some(PathBuf::from(value)),
+            "--skip-assign" => {
+                args.skip_assign = value == "true";
+            }
+            "--stream" => {
+                args.stream = value == "true";
+            }
+            other => panic!("unknown argument {other}"),
+        }
+        i += 2;
+    }
+    assert!(args.base.exists(), "--base {:?} does not exist", args.base);
+    assert!(
+        args.queries.exists(),
+        "--queries {:?} does not exist",
+        args.queries
+    );
+    args
+}
+
+/// Rows of the base, either held in memory or streamed from the `.fbin` file in
+/// chunks so that a base larger than memory can still be assigned and scored.
+enum Base {
+    Memory {
+        values: Vec<f32>,
+        rows: usize,
+        dim: usize,
+    },
+    File {
+        path: PathBuf,
+        rows: usize,
+        dim: usize,
+    },
+}
+
+const STREAM_CHUNK_ROWS: usize = 200_000;
+
+impl Base {
+    fn rows(&self) -> usize {
+        match self {
+            Self::Memory { rows, .. } | Self::File { rows, .. } => *rows,
+        }
+    }
+    fn dim(&self) -> usize {
+        match self {
+            Self::Memory { dim, .. } | Self::File { dim, .. } => *dim,
+        }
+    }
+    /// Call `f(start_row, values)` for consecutive chunks covering every row.
+    fn for_each_chunk(&self, mut f: impl FnMut(usize, &[f32])) {
+        match self {
+            Self::Memory { values, rows, dim } => {
+                let mut start = 0;
+                while start < *rows {
+                    let take = STREAM_CHUNK_ROWS.min(rows - start);
+                    f(start, &values[start * dim..(start + take) * dim]);
+                    start += take;
+                }
+            }
+            Self::File { path, rows, dim } => {
+                let mut file = BufReader::with_capacity(8 << 20, File::open(path).unwrap());
+                file.seek(SeekFrom::Start(8)).unwrap();
+                let mut bytes = vec![0u8; STREAM_CHUNK_ROWS * dim * 4];
+                let mut values = vec![0f32; STREAM_CHUNK_ROWS * dim];
+                let mut start = 0;
+                while start < *rows {
+                    let take = STREAM_CHUNK_ROWS.min(rows - start);
+                    file.read_exact(&mut bytes[..take * dim * 4]).unwrap();
+                    for (v, b) in values[..take * dim].iter_mut().zip(bytes.chunks_exact(4)) {
+                        *v = f32::from_le_bytes([b[0], b[1], b[2], b[3]]);
+                    }
+                    f(start, &values[..take * dim]);
+                    start += take;
+                }
+            }
+        }
+    }
+    /// Gather the given rows, returned in the order of `rows`.
+    fn gather(&self, rows: &[usize]) -> Vec<f32> {
+        let dim = self.dim();
+        let mut out = vec![0f32; rows.len() * dim];
+        let mut order: Vec<(usize, usize)> = rows
+            .iter()
+            .copied()
+            .enumerate()
+            .map(|(pos, row)| (row, pos))
+            .collect();
+        order.sort_unstable();
+        let mut next = 0;
+        self.for_each_chunk(|start, values| {
+            let end = start + values.len() / dim;
+            while next < order.len() && order[next].0 < end {
+                let (row, pos) = order[next];
+                out[pos * dim..(pos + 1) * dim]
+                    .copy_from_slice(&values[(row - start) * dim..(row - start + 1) * dim]);
+                next += 1;
+            }
+        });
+        out
+    }
+}
+
+fn fbin_header(path: &Path) -> (usize, usize) {
+    let mut file = File::open(path).unwrap();
+    let mut header = [0u8; 8];
+    file.read_exact(&mut header).unwrap();
+    (
+        u32::from_le_bytes(header[0..4].try_into().unwrap()) as usize,
+        u32::from_le_bytes(header[4..8].try_into().unwrap()) as usize,
+    )
+}
+
+/// Read up to `limit` rows of an `.fbin` file. Returns the flat values, the
+/// number of rows read and the dimension.
+fn read_fbin(path: &Path, limit: Option<usize>) -> (Vec<f32>, usize, usize) {
+    let mut file = BufReader::with_capacity(1 << 20, File::open(path).unwrap());
+    let mut header = [0u8; 8];
+    file.read_exact(&mut header).unwrap();
+    let n = u32::from_le_bytes(header[0..4].try_into().unwrap()) as usize;
+    let d = u32::from_le_bytes(header[4..8].try_into().unwrap()) as usize;
+    let rows = limit.map_or(n, |limit| limit.min(n));
+    let mut values = Vec::with_capacity(rows * d);
+    let mut chunk = vec![0u8; 64 << 20];
+    let mut remaining = rows * d * 4;
+    while remaining > 0 {
+        let take = remaining.min(chunk.len());
+        file.read_exact(&mut chunk[..take]).unwrap();
+        values.extend(
+            chunk[..take]
+                .chunks_exact(4)
+                .map(|b| f32::from_le_bytes([b[0], b[1], b[2], b[3]])),
+        );
+        remaining -= take;
+    }
+    (values, rows, d)
+}
+
+/// Exact top-10 neighbours of every query over the base, cached next to the
+/// query file since they do not depend on the clustering.
+fn ground_truth(args: &Args, base: &Base, rows: usize, d: usize, queries: &[f32]) -> Vec<u32> {
+    let cache = args.queries.with_extension(format!(
+        "gt{}.rows{}.top{}.bin",
+        args.num_queries, rows, TOP_K
+    ));
+    if let Ok(mut file) = File::open(&cache) {
+        let mut bytes = Vec::new();
+        file.read_to_end(&mut bytes).unwrap();
+        if bytes.len() == args.num_queries * TOP_K * 4 {
+            return bytes
+                .chunks_exact(4)
+                .map(|b| u32::from_le_bytes([b[0], b[1], b[2], b[3]]))
+                .collect();
+        }
+    }
+    let start = Instant::now();
+    let num_queries = queries.len() / d;
+    let mut best: Vec<Vec<(f32, u32)>> = vec![Vec::with_capacity(TOP_K + 1); num_queries];
+    base.for_each_chunk(|chunk_start, values| {
+        queries
+            .par_chunks(d)
+            .zip(best.par_iter_mut())
+            .for_each(|(query, best)| {
+                for (i, dist) in l2_distance_batch(query, values, d).enumerate() {
+                    if best.len() < TOP_K || dist < best[TOP_K - 1].0 {
+                        let pos = best.partition_point(|(other, _)| *other <= dist);
+                        best.insert(pos, (dist, (chunk_start + i) as u32));
+                        best.truncate(TOP_K);
+                    }
+                }
+            });
+    });
+    let gt: Vec<u32> = best
+        .into_iter()
+        .flat_map(|best| best.into_iter().map(|(_, row)| row))
+        .collect();
+    println!(
+        "ground truth for {} queries over {} rows in {:.1}s",
+        args.num_queries,
+        rows,
+        start.elapsed().as_secs_f64()
+    );
+    let bytes: Vec<u8> = gt.iter().flat_map(|row| row.to_le_bytes()).collect();
+    std::fs::write(&cache, bytes).unwrap();
+    gt
+}
+
+fn percentile(sorted: &[f64], p: f64) -> f64 {
+    if sorted.is_empty() {
+        return 0.0;
+    }
+    let rank = ((sorted.len() as f64 - 1.0) * p).round() as usize;
+    sorted[rank.min(sorted.len() - 1)]
+}
+
+fn main() {
+    let args = parse_args();
+    if let Some(threads) = args.threads {
+        rayon::ThreadPoolBuilder::new()
+            .num_threads(threads)
+            .build_global()
+            .unwrap();
+    }
+
+    let load_start = Instant::now();
+    let base = if args.stream {
+        let (rows, dim) = fbin_header(&args.base);
+        let rows = args.rows.map_or(rows, |limit| limit.min(rows));
+        Base::File {
+            path: args.base.clone(),
+            rows,
+            dim,
+        }
+    } else {
+        let (values, rows, dim) = read_fbin(&args.base, args.rows);
+        Base::Memory { values, rows, dim }
+    };
+    let (rows, d) = (base.rows(), base.dim());
+    let (queries, _, qd) = read_fbin(&args.queries, Some(args.num_queries));
+    assert_eq!(d, qd, "query dimension differs from base dimension");
+    println!(
+        "loaded {} x {} base and {} queries in {:.1}s",
+        rows,
+        d,
+        args.num_queries,
+        load_start.elapsed().as_secs_f64()
+    );
+
+    // Seeded training sample in random order: the trainer takes prefixes of it
+    // when it sub-samples, so the order must not carry structure.
+    let sample_size = (args.sample_rate * args.k).min(rows);
+    let mut rng = SmallRng::seed_from_u64(args.seed);
+    let sample_indices = rand::seq::index::sample(&mut rng, rows, sample_size).into_vec();
+    let sample = Float32Array::from(base.gather(&sample_indices));
+
+    let hierarchical = match args.mode.as_str() {
+        "flat" => false,
+        "hierarchical" => true,
+        other => panic!("unknown --mode {other}"),
+    };
+    let params = KMeansParams::new(None, args.max_iters, 1, DistanceType::L2)
+        .with_balance_factor(args.balance_factor)
+        .with_refine_iters(args.refine_iters)
+        .with_seed(args.seed)
+        .with_hierarchical_k(if hierarchical { args.hk } else { 1 });
+
+    let train_start = Instant::now();
+    let kmeans = train_kmeans::<Float32Type>(&sample, params, d, args.k, args.sample_rate).unwrap();
+    let train_secs = train_start.elapsed().as_secs_f64();
+    let centroids = kmeans.centroids.as_primitive::<Float32Type>().clone();
+    let k = centroids.len() / d;
+    println!(
+        "trained {} centroids ({} {}, hk={}, refine={}) in {:.1}s",
+        k, args.mode, args.k, args.hk, args.refine_iters, train_secs
+    );
+    if args.skip_assign {
+        let result = serde_json::json!({
+            "label": args.label, "k": args.k, "mode": args.mode, "hk": args.hk,
+            "refine_iters": args.refine_iters, "seed": args.seed, "rows": rows, "dim": d,
+            "train_secs": train_secs, "train_only": true,
+        });
+        println!("{}", serde_json::to_string(&result).unwrap());
+        if let Some(out) = &args.out {
+            let mut file = OpenOptions::new()
+                .create(true)
+                .append(true)
+                .open(out)
+                .unwrap();
+            writeln!(file, "{}", serde_json::to_string(&result).unwrap()).unwrap();
+        }
+        return;
+    }
+
+    let assign_start = Instant::now();
+    let mut membership: Vec<Option<u32>> = Vec::with_capacity(rows);
+    let mut dists: Vec<Option<f32>> = Vec::with_capacity(rows);
+    base.for_each_chunk(|_, values| {
+        let chunk = Float32Array::from(values.to_vec());
+        let (chunk_membership, chunk_dists) = compute_partitions_with_dists::<
+            Float32Type,
+            KMeansAlgoFloat<Float32Type>,
+        >(&centroids, &chunk, d, DistanceType::L2);
+        membership.extend(chunk_membership);
+        dists.extend(chunk_dists);
+    });
+    let assign_secs = assign_start.elapsed().as_secs_f64();
+    let centroids = centroids.values();
+
+    let mut sizes = vec![0usize; k];
+    let mut assigned = 0usize;
+    let mut wcss = 0.0f64;
+    for (cluster, dist) in membership.iter().zip(dists.iter()) {
+        if let (Some(cluster), Some(dist)) = (cluster, dist) {
+            sizes[*cluster as usize] += 1;
+            assigned += 1;
+            wcss += *dist as f64;
+        }
+    }
+    let wcss_base = wcss / assigned as f64;
+    let wcss_sample = sample_indices
+        .iter()
+        .filter_map(|&row| dists[row].map(|dist| dist as f64))
+        .sum::<f64>()
+        / sample_indices.len() as f64;
+
+    let mean_size = assigned as f64 / k as f64;
+    let mut sorted: Vec<f64> = sizes.iter().map(|&s| s as f64 / mean_size).collect();
+    sorted.sort_by(|a, b| a.partial_cmp(b).unwrap());
+    let cv = (sorted.iter().map(|s| (s - 1.0).powi(2)).sum::<f64>() / k as f64).sqrt();
+    let empty = sizes.iter().filter(|&&s| s == 0).count();
+    let tiny = sorted.iter().filter(|&&s| s < 0.25).count();
+    let oversized: Vec<usize> = sizes
+        .iter()
+        .copied()
+        .filter(|&s| s as f64 > 4.0 * mean_size)
+        .collect();
+    let rows_in_oversized = oversized.iter().sum::<usize>() as f64 / assigned as f64;
+
+    let gt = ground_truth(&args, &base, rows, d, queries.as_slice());
+    let max_probes = (args.nprobes * 2).min(k);
+    let probed: Vec<Vec<u32>> = queries
+        .as_slice()
+        .par_chunks(d)
+        .map(|query| {
+            let (ids, _) =
+                kmeans_find_partitions(centroids, query, max_probes, DistanceType::L2).unwrap();
+            ids.values().to_vec()
+        })
+        .collect();
+    let mut query_metrics = serde_json::Map::new();
+    for nprobes in [args.nprobes / 2, args.nprobes, args.nprobes * 2] {
+        let nprobes = nprobes.clamp(1, max_probes);
+        let mut scanned: Vec<f64> = Vec::with_capacity(probed.len());
+        let mut recall = 0.0f64;
+        for (q, ids) in probed.iter().enumerate() {
+            let ids = &ids[..nprobes];
+            scanned.push(ids.iter().map(|&id| sizes[id as usize] as f64).sum::<f64>());
+            let probed_set: HashSet<u32> = ids.iter().copied().collect();
+            let hits = gt[q * TOP_K..(q + 1) * TOP_K]
+                .iter()
+                .filter(|&&row| membership[row as usize].is_some_and(|c| probed_set.contains(&c)))
+                .count();
+            recall += hits as f64 / TOP_K as f64;
+        }
+        recall /= probed.len() as f64;
+        scanned.sort_by(|a, b| a.partial_cmp(b).unwrap());
+        let expected = nprobes as f64 * mean_size;
+        query_metrics.insert(
+            format!("nprobes_{nprobes}"),
+            serde_json::json!({
+                "recall_at_10": recall,
+                "scan_rows_mean": scanned.iter().sum::<f64>() / scanned.len() as f64,
+                "scan_rows_p50": percentile(&scanned, 0.5),
+                "scan_rows_p90": percentile(&scanned, 0.9),
+                "scan_rows_p99": percentile(&scanned, 0.99),
+                "scan_rows_max": scanned.last().copied().unwrap_or(0.0),
+                "scan_p99_over_expected": percentile(&scanned, 0.99) / expected,
+                "scan_max_over_expected": scanned.last().copied().unwrap_or(0.0) / expected,
+            }),
+        );
+    }
+
+    let result = serde_json::json!({
+        "label": args.label,
+        "base": args.base,
+        "rows": rows,
+        "dim": d,
+        "k": args.k,
+        "k_trained": k,
+        "sample_rate": args.sample_rate,
+        "sample_size": sample_size,
+        "seed": args.seed,
+        "mode": args.mode,
+        "hk": args.hk,
+        "max_iters": args.max_iters,
+        "refine_iters": args.refine_iters,
+        "balance_factor": args.balance_factor,
+        "threads": args.threads.unwrap_or_else(rayon::current_num_threads),
+        "stream": args.stream,
+        "train_secs": train_secs,
+        "assign_secs": assign_secs,
+        "train_loss": kmeans.loss,
+        "wcss_base": wcss_base,
+        "wcss_sample": wcss_sample,
+        "size_mean": mean_size,
+        "size_cv": cv,
+        "size_p50_over_mean": percentile(&sorted, 0.5),
+        "size_p90_over_mean": percentile(&sorted, 0.9),
+        "size_p99_over_mean": percentile(&sorted, 0.99),
+        "size_max_over_mean": sorted.last().copied().unwrap_or(0.0),
+        "empty": empty,
+        "tiny_under_quarter_mean": tiny,
+        "oversized_over_4x_mean": oversized.len(),
+        "rows_in_oversized": rows_in_oversized,
+        "queries": query_metrics,
+    });
+    println!("{}", serde_json::to_string_pretty(&result).unwrap());
+    if let Some(out) = &args.out {
+        let mut file = OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(out)
+            .unwrap();
+        writeln!(file, "{}", serde_json::to_string(&result).unwrap()).unwrap();
+    }
+}

--- a/rust/lance-index/src/vector/kmeans.rs
+++ b/rust/lance-index/src/vector/kmeans.rs
@@ -1346,6 +1346,24 @@ impl KMeans {
             kmeans.centroids.as_primitive::<T>().values(),
             params.distance_type,
         )?;
+        if children.len() < 2 {
+            // The merge handed every vector to one sub-cluster (say 999 duplicates
+            // and one outlier with a quota of 300), which would be this very node
+            // again: recursing could never make progress. Stop here as a leaf;
+            // `fill_missing_leaves` tries the remaining splits with a bounded
+            // loop and reports the shortfall.
+            let indices = children.into_iter().flatten().collect();
+            return Ok(vec![Self::leaf_from_indices::<T, Algo>(
+                data_values,
+                dimension,
+                indices,
+                params.distance_type,
+            )?]);
+        }
+        debug_assert!(
+            children.iter().all(|child| child.len() < n),
+            "every sub-cluster must be smaller than its parent for the recursion to end"
+        );
 
         let leaves = children
             .into_par_iter()
@@ -2595,6 +2613,29 @@ mod tests {
             assert!(!val.is_nan(), "Centroid should not contain NaN values");
             assert!(val != f16::ZERO);
         }
+    }
+
+    #[test]
+    fn test_hierarchical_kmeans_one_outlier_among_duplicates_errors() {
+        // 999 identical rows plus one outlier with a quota of 300: the outlier's
+        // sub-cluster earns no centroid and is merged back, which used to hand the
+        // whole node to itself again and recurse until the stack overflowed. It
+        // must end in the bounded "cannot create" error instead.
+        let mut values = vec![1.0_f32; 999];
+        values.push(100.0);
+        let data = FixedSizeListArray::try_new_from_values(Float32Array::from(values), 1).unwrap();
+        let params = KMeansParams {
+            max_iters: 10,
+            seed: Some(42),
+            ..Default::default()
+        };
+        let err = KMeans::new_with_params(&data, 300, &params)
+            .expect_err("duplicates cannot be split into 300 partitions");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("Cannot create") && msg.contains("300"),
+            "unexpected error message: {msg}"
+        );
     }
 
     #[test]

--- a/rust/lance-index/src/vector/kmeans.rs
+++ b/rust/lance-index/src/vector/kmeans.rs
@@ -10,8 +10,7 @@
 //!
 
 use core::f32;
-use std::cmp::Ordering;
-use std::collections::BinaryHeap;
+use std::cmp::Reverse;
 use std::ops::{AddAssign, DivAssign};
 use std::sync::Arc;
 use std::vec;
@@ -52,13 +51,14 @@ use crate::vector::utils::SimpleIndex;
 use lance_core::{Error, Result};
 
 /// KMean initialization method.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum KMeanInit {
     Random,
     Incremental(Arc<FixedSizeListArray>),
 }
 
 /// KMean Training Parameters
+#[derive(Clone)]
 pub struct KMeansParams {
     /// Max number of iterations.
     pub max_iters: u32,
@@ -83,12 +83,27 @@ pub struct KMeansParams {
     /// which is the same as normal kmeans clustering.
     pub balance_factor: f32,
 
-    /// The number of clusters to train in each hierarchical level.
+    /// The number of sub-clusters each node of the hierarchy is split into.
     ///
-    /// Default is 16, which performs the best performance in our experiments.
-    /// Higher would split the clusters more aggressively, which would be more accurate but slower.
-    /// hierarchical kmeans is enabled only if hierarchical_k > 1 and k > 256.
+    /// Default is 16. A larger fan-out makes a shallower tree with fewer
+    /// sub-tree boundaries, which improves the clustering a little at a higher
+    /// training cost; a smaller one is faster but loses recall.
+    /// Hierarchical k-means is enabled only if hierarchical_k > 1 and k > 256.
     pub hierarchical_k: usize,
+
+    /// Number of global Lloyd iterations run over the whole training sample after
+    /// the hierarchical tree is built, with every centroid competing for every
+    /// vector. The tree fits each centroid only against its own sub-tree's
+    /// vectors, so this pass repairs the boundaries between sub-trees. Each
+    /// iteration costs about as much as assigning the training sample to the
+    /// centroids once. Off by default (`0`); two iterations typically recover
+    /// most of the gap to flat k-means in WCSS and recall. Non-hierarchical
+    /// training already iterates globally and ignores it.
+    pub refine_iters: u32,
+
+    /// Seed for centroid initialization. `None` draws a seed from the OS, so two
+    /// trainings of the same data may pick different initial centroids.
+    pub seed: Option<u64>,
 
     /// Optional sync callback for iteration progress: (current_iteration, max_iterations).
     pub on_progress: Option<Arc<dyn Fn(u32, u32) + Send + Sync>>,
@@ -104,6 +119,8 @@ impl std::fmt::Debug for KMeansParams {
             .field("distance_type", &self.distance_type)
             .field("balance_factor", &self.balance_factor)
             .field("hierarchical_k", &self.hierarchical_k)
+            .field("refine_iters", &self.refine_iters)
+            .field("seed", &self.seed)
             .field("on_progress", &self.on_progress.as_ref().map(|_| "..."))
             .finish()
     }
@@ -119,6 +136,8 @@ impl Default for KMeansParams {
             distance_type: DistanceType::L2,
             balance_factor: 0.0,
             hierarchical_k: 16,
+            refine_iters: 0,
+            seed: None,
             on_progress: None,
         }
     }
@@ -159,13 +178,42 @@ impl KMeansParams {
         self
     }
 
-    /// Set the number of clusters to train in each hierarchical level.
-    ///
-    /// Higher would split the clusters more aggressively, which would be more accurate but slower.
-    /// hierarchical kmeans is enabled only if hierarchical_k > 1 and k > 256.
+    /// Set the number of sub-clusters each node of the hierarchy is split into.
+    /// See [`KMeansParams::hierarchical_k`].
     pub fn with_hierarchical_k(mut self, hierarchical_k: usize) -> Self {
         self.hierarchical_k = hierarchical_k;
         self
+    }
+
+    /// Set the number of global refinement iterations run after hierarchical
+    /// training. See [`KMeansParams::refine_iters`].
+    pub fn with_refine_iters(mut self, refine_iters: u32) -> Self {
+        self.refine_iters = refine_iters;
+        self
+    }
+
+    /// Seed centroid initialization, making training reproducible.
+    pub fn with_seed(mut self, seed: u64) -> Self {
+        self.seed = Some(seed);
+        self
+    }
+
+    fn rng(&self) -> SmallRng {
+        match self.seed {
+            Some(seed) => SmallRng::seed_from_u64(seed),
+            None => SmallRng::from_os_rng(),
+        }
+    }
+
+    /// The same parameters with a seed derived for one sub-problem, so sibling
+    /// sub-trees of a hierarchical training do not share initial centroids.
+    /// Unseeded parameters stay unseeded.
+    fn derive(&self, salt: u64) -> Self {
+        let mut params = self.clone();
+        params.seed = self
+            .seed
+            .map(|seed| seed ^ salt.wrapping_mul(0x9E37_79B9_7F4A_7C15).rotate_left(17));
+        params
     }
 }
 
@@ -195,26 +243,21 @@ fn kmeans_random_init<T: ArrowPrimitiveType>(
     }
 }
 
-/// Split one big cluster into two smaller clusters. After split, each
-/// cluster has approximately half of the vectors.
-fn split_clusters<T: Float + MulAssign>(
-    n: usize,
-    cnts: &mut [usize],
-    centroids: &mut [T],
-    dim: usize,
-) {
+/// Give every empty cluster half of the currently largest cluster. After the
+/// split each of the two has approximately half of the vectors.
+///
+/// Draining the largest cluster first keeps the result independent of a random
+/// draw, so seeded trainings stay reproducible.
+fn split_clusters<T: Float + MulAssign>(cnts: &mut [usize], centroids: &mut [T], dim: usize) {
     let eps = T::from(1.0 / 1024.0).unwrap();
-    let mut rng = SmallRng::from_os_rng();
     for i in 0..cnts.len() {
         if cnts[i] == 0 {
-            let mut j = 0;
-            loop {
-                let p = (cnts[j] as f32 - 1.0) / (n - cnts.len()) as f32;
-                if rng.random::<f32>() < p {
-                    break;
-                }
-                j += 1;
-                j %= cnts.len();
+            let Some(j) = (0..cnts.len()).max_by_key(|&j| cnts[j]) else {
+                break;
+            };
+            if cnts[j] < 2 {
+                // Nothing left to split.
+                break;
             }
 
             cnts[i] = cnts[j] / 2;
@@ -587,12 +630,7 @@ where
             }
         }
 
-        split_clusters(
-            data.len() / dimension,
-            cluster_sizes,
-            &mut centroids,
-            dimension,
-        );
+        split_clusters(cluster_sizes, &mut centroids, dimension);
 
         KMeans {
             centroids: Arc::new(PrimitiveArray::<T>::from(centroids)),
@@ -706,6 +744,60 @@ pub type KMeansMembershipAndLoss = (KMeansMembership, KMeansClusterRadii, KMeans
 
 /// Batch assignment results with per-vector distances.
 pub type KMeansMembershipAndDistances = (KMeansMembership, KMeansDistances);
+
+/// Rows gathered per centroid to train one node of the hierarchy; the same
+/// prefix `train_kmeans` keeps for itself.
+const TRAINING_ROWS_PER_CENTROID: usize = 512;
+/// Bytes of vectors gathered at a time when assigning a node's rows to its
+/// sub-clusters. One such chunk is held per worker thread, so this is sized in
+/// bytes rather than rows: a row-count budget would hold a multiple of it on
+/// high-dimensional data.
+const MEMBERSHIP_CHUNK_BYTES: usize = 4 * 1024 * 1024;
+
+/// One leaf of the proportional hierarchy: a centroid and the training vectors
+/// it was fitted on.
+struct Leaf<N> {
+    centroid: Vec<N>,
+    indices: Vec<usize>,
+}
+
+/// Apportion `quota` centroids over sub-clusters of the given sizes so that each
+/// sub-cluster's share follows its share of the vectors (largest-remainder
+/// rounding). A sub-cluster never gets more centroids than it has vectors, and
+/// one whose share rounds to zero gets none.
+fn allocate_quotas(sizes: &[usize], quota: usize) -> Vec<usize> {
+    let total: usize = sizes.iter().sum();
+    debug_assert!(
+        total > 0,
+        "cannot apportion centroids over empty sub-clusters"
+    );
+    let mut quotas: Vec<usize> = sizes
+        .iter()
+        .map(|&size| (quota * size / total).min(size))
+        .collect();
+    let mut remaining = quota.saturating_sub(quotas.iter().sum::<usize>());
+    let mut order: Vec<usize> = (0..sizes.len()).collect();
+    order.sort_by_key(|&i| (Reverse(quota * sizes[i] % total), Reverse(sizes[i])));
+    // Hand out the remainder by fractional share, going around again while some
+    // sub-cluster still has room for another centroid.
+    while remaining > 0 {
+        let mut handed = 0;
+        for &i in &order {
+            if remaining == 0 {
+                break;
+            }
+            if quotas[i] < sizes[i] {
+                quotas[i] += 1;
+                remaining -= 1;
+                handed += 1;
+            }
+        }
+        if handed == 0 {
+            break;
+        }
+    }
+    quotas
+}
 
 /// KMeans implementation for Apache Arrow Arrays.
 #[derive(Debug, Clone)]
@@ -927,8 +1019,7 @@ impl KMeans {
         let mut cluster_sizes = vec![0; k];
         let mut adjusted_balance_factor = f32::MAX;
 
-        // TODO: use seed for Rng.
-        let mut rng = SmallRng::from_os_rng();
+        let mut rng = params.rng();
         for redo in 1..=params.redos {
             let mut kmeans: Self = match &params.init {
                 KMeanInit::Random => Self::init_random::<T>(
@@ -1012,6 +1103,40 @@ impl KMeans {
     }
 
     /// Helper function to create a FixedSizeListArray from indices
+    /// Nearest centroid of every row in `indices`, computed over gathered chunks
+    /// so that no copy of the whole node is ever held.
+    fn membership_of_rows<T: ArrowNumericType, Algo: KMeansAlgo<T::Native>>(
+        centroids: &[T::Native],
+        data_values: &[T::Native],
+        dimension: usize,
+        indices: &[usize],
+        distance_type: DistanceType,
+    ) -> Vec<Option<u32>>
+    where
+        T::Native: Num,
+    {
+        let chunk_rows = (MEMBERSHIP_CHUNK_BYTES / (dimension * size_of::<T::Native>())).max(1);
+        indices
+            .par_chunks(chunk_rows)
+            .flat_map_iter(|chunk| {
+                let mut rows = Vec::with_capacity(chunk.len() * dimension);
+                for &idx in chunk {
+                    rows.extend_from_slice(&data_values[idx * dimension..(idx + 1) * dimension]);
+                }
+                let (membership, _) = Algo::compute_membership_and_dist(
+                    centroids,
+                    &rows,
+                    dimension,
+                    distance_type,
+                    0.0,
+                    None,
+                    None,
+                );
+                membership
+            })
+            .collect()
+    }
+
     fn create_array_from_indices<T: ArrowNumericType>(
         indices: &[usize],
         data_values: &[T::Native],
@@ -1031,11 +1156,11 @@ impl KMeans {
         FixedSizeListArray::try_new_from_values(array, dimension as i32)
     }
 
-    /// Train a hierarchical KMeans model when k > 256
+    /// Train a hierarchical KMeans model when k > 256.
     ///
-    /// This function implements a hierarchical clustering approach:
-    /// 1. Start with k'=256 initial clusters
-    /// 2. Iteratively split the largest cluster until we have k clusters
+    /// Grows the centroid tree with size-proportional quotas
+    /// ([`Self::train_hierarchical_proportional`]), then optionally refines every
+    /// centroid against the whole sample ([`KMeansParams::refine_iters`]).
     fn train_hierarchical_kmeans<T: ArrowNumericType, Algo: KMeansAlgo<T::Native>>(
         data: &FixedSizeListArray,
         target_k: usize,
@@ -1045,46 +1170,46 @@ impl KMeans {
         T::Native: Num,
         PrimitiveArray<T>: From<Vec<T::Native>>,
     {
-        // Cluster structure for the heap
-        #[derive(Clone, Debug)]
-        struct Cluster<N> {
-            id: usize,
-            indices: Vec<usize>,
-            centroid: Vec<N>,
-            finalized: bool,
+        let tree = Self::train_hierarchical_proportional::<T, Algo>(data, target_k, params)?;
+        if params.refine_iters == 0 {
+            return Ok(tree);
         }
+        info!(
+            "Hierarchical clustering: refining {} centroids for {} iterations",
+            target_k, params.refine_iters
+        );
+        let centroids =
+            FixedSizeListArray::try_new_from_values(tree.centroids.clone(), tree.dimension as i32)?;
+        let refine_params = KMeansParams {
+            init: KMeanInit::Incremental(Arc::new(centroids)),
+            max_iters: params.refine_iters,
+            redos: 1,
+            ..params.clone()
+        };
+        Self::train_kmeans::<T, Algo>(data, target_k, &refine_params)
+    }
 
-        impl<N> Eq for Cluster<N> {}
-
-        impl<N> PartialEq for Cluster<N> {
-            fn eq(&self, other: &Self) -> bool {
-                self.indices.len() == other.indices.len()
-            }
-        }
-
-        impl<N> Ord for Cluster<N> {
-            fn cmp(&self, other: &Self) -> Ordering {
-                // Non-finalized clusters should always have higher priority than finalized ones
-                match (self.finalized, other.finalized) {
-                    (false, true) => Ordering::Greater,
-                    (true, false) => Ordering::Less,
-                    _ => {
-                        // Max heap: larger clusters first
-                        self.indices.len().cmp(&other.indices.len())
-                    }
-                }
-            }
-        }
-
-        impl<N> PartialOrd for Cluster<N> {
-            fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-                Some(self.cmp(other))
-            }
-        }
-
+    /// Hierarchical training that gives every sub-cluster a centroid quota
+    /// proportional to its share of the vectors and grows the sub-trees in
+    /// parallel.
+    ///
+    /// Every node holds `n` vectors and owes `quota` centroids. It runs one small
+    /// k-means with `min(hierarchical_k, quota)` centroids over its vectors and
+    /// hands each sub-cluster `quota * n_i / n` of the quota, so a leaf ends up
+    /// with roughly `n / k` training vectors however skewed the data is. The
+    /// recursion bottoms out where a node's quota fits one k-means run; there the
+    /// sub-clusters become the leaves, each centroid the mean of its vectors.
+    fn train_hierarchical_proportional<T: ArrowNumericType, Algo: KMeansAlgo<T::Native>>(
+        data: &FixedSizeListArray,
+        target_k: usize,
+        params: &KMeansParams,
+    ) -> arrow::error::Result<Self>
+    where
+        T::Native: Num,
+        PrimitiveArray<T>: From<Vec<T::Native>>,
+    {
         let n = data.len();
         let dimension = data.value_length() as usize;
-
         let data_values = data
             .values()
             .as_primitive_opt::<T>()
@@ -1094,223 +1219,287 @@ impl KMeans {
                 data.value_type()
             )))?
             .values();
-
-        // Initial clustering with k'=16
-        let initial_k = params.hierarchical_k.min(target_k).min(n);
         info!(
-            "Hierarchical clustering: initial k={}, target k={}",
-            initial_k, target_k
+            "Hierarchical clustering (proportional): branching {}, target k={}",
+            params.hierarchical_k.max(2),
+            target_k
         );
 
-        let initial_kmeans = Self::train_kmeans::<T, Algo>(data, initial_k, params)?;
-
-        // Get membership for all data points
-        let (membership, _, _) = Algo::compute_membership_and_loss(
-            initial_kmeans.centroids.as_primitive::<T>().values(),
+        let indices: Vec<usize> = (0..n).collect();
+        let mut leaves = Self::grow_proportional_subtree::<T, Algo>(
             data_values,
             dimension,
-            params.distance_type,
-            0.0, // No balance factor for membership computation
-            None,
-            None,
-        );
+            indices,
+            target_k,
+            params,
+            1,
+        )?;
+        Self::fill_missing_leaves::<T, Algo>(
+            data_values,
+            dimension,
+            &mut leaves,
+            target_k,
+            params,
+        )?;
 
-        // Build initial clusters and add to heap
-        let mut heap: BinaryHeap<Cluster<T::Native>> = BinaryHeap::new();
-        let mut next_cluster_id = 0;
-        let initial_centroids = initial_kmeans.centroids.as_primitive::<T>().values();
-
-        for i in 0..initial_k {
-            let mut cluster_indices = Vec::new();
-            for (idx, &cluster_id) in membership.iter().enumerate() {
-                if let Some(cid) = cluster_id
-                    && cid as usize == i
-                {
-                    cluster_indices.push(idx);
-                }
-            }
-
-            if !cluster_indices.is_empty() {
-                let centroid_start = i * dimension;
-                let centroid_end = centroid_start + dimension;
-                let centroid = initial_centroids[centroid_start..centroid_end].to_vec();
-
-                heap.push(Cluster {
-                    id: next_cluster_id,
-                    indices: cluster_indices,
-                    centroid,
-                    finalized: false,
-                });
-                next_cluster_id += 1;
-            }
-        }
-
-        // Iteratively split largest clusters until we have target_k clusters
-        while heap.len() < target_k {
-            // Get the largest cluster
-            let mut largest_cluster = heap.pop().ok_or(ArrowError::InvalidArgumentError(
-                "No cluster can be further split".to_string(),
-            ))?;
-
-            // If this cluster is already finalized, no further split is possible; stop splitting
-            if largest_cluster.finalized {
-                log::warn!(
-                    "Cluster {} is already finalized, no further split is possible, finish with {} clusters",
-                    largest_cluster.id,
-                    heap.len() + 1
-                );
-                heap.push(largest_cluster);
-                break;
-            }
-
-            // Because the clusters are sorted by size, if the cluster has only 1 point, no further split is possible; stop splitting
-            if largest_cluster.indices.len() <= 1 {
-                log::warn!(
-                    "Cluster {} has only 1 point, no further split is possible, finish with {} clusters",
-                    largest_cluster.id,
-                    heap.len() + 1
-                );
-                heap.push(largest_cluster);
-                break;
-            }
-
-            let cluster_size = largest_cluster.indices.len();
-            log::debug!(
-                "Splitting cluster {} with {} points (current total clusters: {})",
-                largest_cluster.id,
-                cluster_size,
-                heap.len() + 1 // +1 for the cluster we just popped
-            );
-
-            // Determine k' for this cluster based on its size
-            let remaining_k = target_k - heap.len(); // Spaces left to fill
-            let cluster_k = if cluster_size <= params.hierarchical_k {
-                2.min(remaining_k).min(cluster_size)
-            } else {
-                // For larger clusters, split more aggressively
-                let suggested_k = cluster_size / params.hierarchical_k;
-                suggested_k
-                    .min(remaining_k)
-                    .min(params.hierarchical_k)
-                    .max(2)
-            };
-
-            // Create sub-dataset for this cluster using indices
-            let sub_data = Self::create_array_from_indices::<T>(
-                &largest_cluster.indices,
-                data_values,
-                dimension,
-            )?;
-
-            // Run kmeans on this cluster
-            let sub_kmeans = Self::train_kmeans::<T, Algo>(&sub_data, cluster_k, params)?;
-
-            // Get membership for points in the sub-cluster
-            let sub_data = sub_data.values().as_primitive::<T>().values();
-            let (sub_membership, _, _) = Algo::compute_membership_and_loss(
-                sub_kmeans.centroids.as_primitive::<T>().values(),
-                sub_data,
-                dimension,
-                params.distance_type,
-                0.0,
-                None,
-                None,
-            );
-
-            // Build per-cluster membership while checking whether the split is effective
-            let approx_cluster_capacity = if cluster_k > 0 {
-                largest_cluster.indices.len().div_ceil(cluster_k)
-            } else {
-                0
-            };
-            let mut cluster_assignments: Vec<Vec<usize>> = (0..cluster_k)
-                .map(|_| Vec::with_capacity(approx_cluster_capacity))
-                .collect();
-
-            let mut first_sid: Option<u32> = None;
-            let mut all_same = true;
-            for (local_idx, &membership) in sub_membership.iter().enumerate() {
-                let Some(sub_cluster_id) = membership else {
-                    continue;
-                };
-
-                if let Some(first) = first_sid {
-                    if sub_cluster_id != first {
-                        all_same = false;
-                    }
-                } else {
-                    first_sid = Some(sub_cluster_id);
-                }
-
-                let sub_cluster_id = sub_cluster_id as usize;
-                if let Some(indices) = cluster_assignments.get_mut(sub_cluster_id) {
-                    indices.push(largest_cluster.indices[local_idx]);
-                } else {
-                    // Unexpected assignment outside [0, cluster_k); treat as ineffective split.
-                    all_same = false;
-                }
-            }
-
-            // If all memberships are identical, the split is ineffective; finalize the original cluster
-            if all_same {
-                largest_cluster.finalized = true;
-                heap.push(largest_cluster);
-                continue;
-            }
-
-            // Create new sub-clusters and add to heap
-            let sub_centroids = sub_kmeans.centroids.as_primitive::<T>().values();
-            for (i, new_cluster_indices) in cluster_assignments.into_iter().enumerate() {
-                if new_cluster_indices.is_empty() {
-                    continue;
-                }
-
-                let centroid_start = i * dimension;
-                let centroid_end = centroid_start + dimension;
-                let centroid = sub_centroids[centroid_start..centroid_end].to_vec();
-
-                heap.push(Cluster {
-                    id: next_cluster_id,
-                    indices: new_cluster_indices,
-                    centroid,
-                    finalized: false,
-                });
-                next_cluster_id += 1;
-            }
-
-            log::debug!(
-                "Split complete: now have {} clusters (target: {})",
-                heap.len(),
-                target_k
-            );
-        }
-        if heap.len() < target_k {
-            return Err(ArrowError::InvalidArgumentError(format!(
-                "Cannot create {target_k} IVF partitions: k-means could only form {} non-empty \
-                 clusters from {n} training vectors. The dataset is likely too small or has too \
-                 many (near-)duplicate vectors for this many partitions. Reduce num_partitions to \
-                 <= {} or provide more diverse data.",
-                heap.len(),
-                heap.len()
-            )));
-        }
-
-        // Construct final KMeans model with all centroids
-        let mut all_clusters: Vec<Cluster<T::Native>> = heap.into_vec();
-
-        // Sort by ID to ensure consistent ordering
-        all_clusters.sort_by_key(|c| c.id);
-
-        let flat_centroids: Vec<T::Native> =
-            all_clusters.into_iter().flat_map(|c| c.centroid).collect();
-        let centroids_array = PrimitiveArray::<T>::from(flat_centroids);
-
+        let centroids: Vec<T::Native> = leaves.into_iter().flat_map(|leaf| leaf.centroid).collect();
         Ok(Self {
-            centroids: Arc::new(centroids_array),
+            centroids: Arc::new(PrimitiveArray::<T>::from(centroids)),
             dimension,
             distance_type: params.distance_type,
             loss: 0.0, // Loss is not meaningful for hierarchical clustering
         })
+    }
+
+    /// Grow the sub-tree under one node of the proportional hierarchy.
+    ///
+    /// `indices` are the node's training vectors and `quota` the number of leaf
+    /// centroids it owes. `salt` derives per-node seeds from a seeded training,
+    /// so sibling sub-trees do not repeat each other's initialization.
+    fn grow_proportional_subtree<T: ArrowNumericType, Algo: KMeansAlgo<T::Native>>(
+        data_values: &[T::Native],
+        dimension: usize,
+        indices: Vec<usize>,
+        quota: usize,
+        params: &KMeansParams,
+        salt: u64,
+    ) -> arrow::error::Result<Vec<Leaf<T::Native>>>
+    where
+        T::Native: Num,
+        PrimitiveArray<T>: From<Vec<T::Native>>,
+    {
+        let n = indices.len();
+        if quota <= 1 || n <= 1 {
+            return Ok(vec![Self::leaf_from_indices::<T, Algo>(
+                data_values,
+                dimension,
+                indices,
+                params.distance_type,
+            )?]);
+        }
+
+        let branching = params.hierarchical_k.max(2);
+        let k = branching.min(quota).min(n);
+        // Train on a prefix of the node's rows, which is a uniform subsample
+        // because the sample is in random order (`train_kmeans` would take the
+        // same prefix itself). Gathering only the prefix, and assigning the rest
+        // in chunks, keeps memory at the sample plus one chunk instead of a copy
+        // of every level of the tree.
+        let training_rows = indices.len().min(k * TRAINING_ROWS_PER_CENTROID);
+        let training = Self::create_array_from_indices::<T>(
+            &indices[..training_rows],
+            data_values,
+            dimension,
+        )?;
+        let kmeans = Self::train_kmeans::<T, Algo>(&training, k, &params.derive(salt))?;
+        drop(training);
+        let membership = Self::membership_of_rows::<T, Algo>(
+            kmeans.centroids.as_primitive::<T>().values(),
+            data_values,
+            dimension,
+            &indices,
+            params.distance_type,
+        );
+        let mut children: Vec<(usize, Vec<usize>)> =
+            (0..k).map(|centroid| (centroid, Vec::new())).collect();
+        for (local, cluster) in membership.iter().enumerate() {
+            if let Some(cluster) = cluster {
+                children[*cluster as usize].1.push(indices[local]);
+            }
+        }
+        children.retain(|(_, child)| !child.is_empty());
+
+        if children.len() <= 1 {
+            // Every vector landed in the same sub-cluster (duplicates): the node
+            // cannot be split. It becomes one leaf; the centroids it still owes
+            // are filled from other leaves afterwards.
+            return Ok(vec![Self::leaf_from_indices::<T, Algo>(
+                data_values,
+                dimension,
+                indices,
+                params.distance_type,
+            )?]);
+        }
+
+        if quota <= k {
+            // Bottom of the tree: the sub-clusters are the leaves.
+            return children
+                .into_iter()
+                .map(|(_, child)| {
+                    Self::leaf_from_indices::<T, Algo>(
+                        data_values,
+                        dimension,
+                        child,
+                        params.distance_type,
+                    )
+                })
+                .collect();
+        }
+
+        let sizes: Vec<usize> = children.iter().map(|(_, child)| child.len()).collect();
+        let quotas = allocate_quotas(&sizes, quota);
+        let (children, quotas) = Self::merge_unfunded_children::<T, Algo>(
+            data_values,
+            dimension,
+            children,
+            quotas,
+            kmeans.centroids.as_primitive::<T>().values(),
+            params.distance_type,
+        )?;
+
+        let leaves = children
+            .into_par_iter()
+            .zip(quotas.into_par_iter())
+            .enumerate()
+            .map(|(child_id, (child, child_quota))| {
+                Self::grow_proportional_subtree::<T, Algo>(
+                    data_values,
+                    dimension,
+                    child,
+                    child_quota,
+                    params,
+                    salt.wrapping_mul(branching as u64 + 1)
+                        .wrapping_add(child_id as u64 + 1),
+                )
+            })
+            .collect::<arrow::error::Result<Vec<_>>>()?;
+        Ok(leaves.into_iter().flatten().collect())
+    }
+
+    /// Hand the vectors of sub-clusters whose quota rounded to zero to the
+    /// nearest sibling that did earn centroids, and drop those sub-clusters.
+    fn merge_unfunded_children<T: ArrowNumericType, Algo: KMeansAlgo<T::Native>>(
+        data_values: &[T::Native],
+        dimension: usize,
+        children: Vec<(usize, Vec<usize>)>,
+        quotas: Vec<usize>,
+        centroids: &[T::Native],
+        distance_type: DistanceType,
+    ) -> arrow::error::Result<(Vec<Vec<usize>>, Vec<usize>)>
+    where
+        T::Native: Num,
+        PrimitiveArray<T>: From<Vec<T::Native>>,
+    {
+        let (mut funded, unfunded): (Vec<_>, Vec<_>) = children
+            .into_iter()
+            .zip(quotas)
+            .partition(|(_, quota)| *quota > 0);
+        if !unfunded.is_empty() {
+            let funded_centroids: Vec<T::Native> = funded
+                .iter()
+                .flat_map(|((centroid, _), _)| {
+                    centroids[centroid * dimension..(centroid + 1) * dimension]
+                        .iter()
+                        .copied()
+                })
+                .collect();
+            let orphans: Vec<usize> = unfunded
+                .into_iter()
+                .flat_map(|((_, child), _)| child)
+                .collect();
+            let orphan_data =
+                Self::create_array_from_indices::<T>(&orphans, data_values, dimension)?;
+            let (membership, _) = Algo::compute_membership_and_dist(
+                &funded_centroids,
+                orphan_data.values().as_primitive::<T>().values(),
+                dimension,
+                distance_type,
+                0.0,
+                None,
+                None,
+            );
+            for (orphan, cluster) in orphans.into_iter().zip(membership) {
+                if let Some(cluster) = cluster {
+                    funded[cluster as usize].0.1.push(orphan);
+                }
+            }
+        }
+        Ok(funded
+            .into_iter()
+            .map(|((_, child), quota)| (child, quota))
+            .unzip())
+    }
+
+    /// One leaf from the given vectors: its centroid is their mean (or mode).
+    fn leaf_from_indices<T: ArrowNumericType, Algo: KMeansAlgo<T::Native>>(
+        data_values: &[T::Native],
+        dimension: usize,
+        indices: Vec<usize>,
+        distance_type: DistanceType,
+    ) -> arrow::error::Result<Leaf<T::Native>>
+    where
+        T::Native: Num,
+        PrimitiveArray<T>: From<Vec<T::Native>>,
+    {
+        let sub_data = Self::create_array_from_indices::<T>(&indices, data_values, dimension)?;
+        let membership = vec![Some(0); indices.len()];
+        let mut sizes = vec![indices.len()];
+        let kmeans = Algo::to_kmeans(
+            sub_data.values().as_primitive::<T>().values(),
+            dimension,
+            1,
+            &membership,
+            &mut sizes,
+            distance_type,
+            0.0,
+        );
+        Ok(Leaf {
+            centroid: kmeans.centroids.as_primitive::<T>().values().to_vec(),
+            indices,
+        })
+    }
+
+    /// Split the largest leaves in two until `target_k` leaves exist, for the
+    /// rare tree that came up short because nodes of duplicate vectors could not
+    /// be split.
+    fn fill_missing_leaves<T: ArrowNumericType, Algo: KMeansAlgo<T::Native>>(
+        data_values: &[T::Native],
+        dimension: usize,
+        leaves: &mut Vec<Leaf<T::Native>>,
+        target_k: usize,
+        params: &KMeansParams,
+    ) -> arrow::error::Result<()>
+    where
+        T::Native: Num,
+        PrimitiveArray<T>: From<Vec<T::Native>>,
+    {
+        let n = data_values.len() / dimension;
+        let mut unsplittable = vec![false; leaves.len()];
+        let mut salt = u64::MAX / 2;
+        while leaves.len() < target_k {
+            let largest = (0..leaves.len())
+                .filter(|&i| !unsplittable[i] && leaves[i].indices.len() >= 2)
+                .max_by_key(|&i| leaves[i].indices.len());
+            let Some(largest) = largest else {
+                return Err(ArrowError::InvalidArgumentError(format!(
+                    "Cannot create {target_k} IVF partitions: k-means could only form {} non-empty \
+                     clusters from {n} training vectors. The dataset is likely too small or has too \
+                     many (near-)duplicate vectors for this many partitions. Reduce num_partitions to \
+                     <= {} or provide more diverse data.",
+                    leaves.len(),
+                    leaves.len()
+                )));
+            };
+            salt += 1;
+            let indices = std::mem::take(&mut leaves[largest].indices);
+            let mut halves = Self::grow_proportional_subtree::<T, Algo>(
+                data_values,
+                dimension,
+                indices.clone(),
+                2,
+                params,
+                salt,
+            )?;
+            if halves.len() < 2 {
+                leaves[largest].indices = indices;
+                unsplittable[largest] = true;
+                continue;
+            }
+            leaves[largest] = halves.pop().unwrap();
+            leaves.push(halves.pop().unwrap());
+            unsplittable.push(false);
+        }
+        Ok(())
     }
 
     /// Train a [`KMeans`] model with full parameters.
@@ -2406,5 +2595,135 @@ mod tests {
             assert!(!val.is_nan(), "Centroid should not contain NaN values");
             assert!(val != f16::ZERO);
         }
+    }
+
+    #[test]
+    fn test_allocate_quotas_follows_sizes() {
+        // Exact shares.
+        assert_eq!(allocate_quotas(&[100, 100, 100, 100], 8), vec![2, 2, 2, 2]);
+        assert_eq!(allocate_quotas(&[700, 200, 100], 10), vec![7, 2, 1]);
+        // Equal fractional parts: the remainder still adds up to the quota.
+        let quotas = allocate_quotas(&[1000, 1000, 1000], 10);
+        assert_eq!(quotas.iter().sum::<usize>(), 10);
+        assert!(quotas.iter().all(|&q| (3..=4).contains(&q)));
+        // Sub-clusters whose share rounds to zero get nothing; the remainder
+        // goes to the largest fractional share.
+        assert_eq!(allocate_quotas(&[1, 1, 1000], 20), vec![0, 0, 20]);
+        assert_eq!(allocate_quotas(&[1, 10_000], 10), vec![0, 10]);
+        // A sub-cluster never gets more centroids than vectors.
+        assert_eq!(allocate_quotas(&[2, 2], 10), vec![2, 2]);
+    }
+
+    #[test]
+    fn test_split_clusters_takes_half_of_the_largest() {
+        let mut cnts = vec![0, 10, 4];
+        let mut centroids = vec![0.0f32, 0.0, 1.0, 2.0, 3.0, 4.0];
+        split_clusters(&mut cnts, &mut centroids, 2);
+        assert_eq!(cnts, vec![5, 5, 4]);
+        // The empty cluster's centroid is a perturbed copy of the largest one.
+        assert!((centroids[0] - 1.0).abs() < 0.01 && centroids[0] != centroids[2]);
+        assert!((centroids[1] - 2.0).abs() < 0.01 && centroids[1] != centroids[3]);
+    }
+
+    fn skewed_training_data(rows: usize, dim: usize) -> FixedSizeListArray {
+        // 80% of the vectors sit in one dense blob near the origin, the rest
+        // spread over the unit cube, so a fixed fan-out would starve the blob
+        // of centroids.
+        let mut values = generate_random_array(rows * dim).values().to_vec();
+        for value in values.iter_mut().take(rows * 8 / 10 * dim) {
+            *value *= 0.05;
+        }
+        FixedSizeListArray::try_new_from_values(Float32Array::from(values), dim as i32).unwrap()
+    }
+
+    fn assigned_sizes(kmeans: &KMeans, data: &FixedSizeListArray) -> Vec<usize> {
+        let (membership, _) =
+            compute_partitions_with_dists::<Float32Type, KMeansAlgoFloat<Float32Type>>(
+                kmeans.centroids.as_primitive(),
+                data.values().as_primitive(),
+                kmeans.dimension,
+                kmeans.distance_type,
+            );
+        let mut sizes = vec![0; kmeans.centroids.len() / kmeans.dimension];
+        for cluster in membership.into_iter().flatten() {
+            sizes[cluster as usize] += 1;
+        }
+        sizes
+    }
+
+    #[test]
+    fn test_hierarchical_kmeans_is_seeded_and_balanced() {
+        const DIM: usize = 16;
+        const K: usize = 300;
+        let data = skewed_training_data(K * 32, DIM);
+        let params = KMeansParams {
+            max_iters: 10,
+            hierarchical_k: 16,
+            seed: Some(42),
+            ..Default::default()
+        };
+
+        let kmeans = KMeans::new_with_params(&data, K, &params).unwrap();
+        assert_eq!(kmeans.centroids.len(), K * DIM);
+        let again = KMeans::new_with_params(&data, K, &params).unwrap();
+        assert_eq!(
+            kmeans.centroids.as_primitive::<Float32Type>().values(),
+            again.centroids.as_primitive::<Float32Type>().values(),
+            "seeded training must be reproducible"
+        );
+
+        let sizes = assigned_sizes(&kmeans, &data);
+        let mean = data.len() as f64 / K as f64;
+        let max = *sizes.iter().max().unwrap() as f64;
+        assert_eq!(
+            sizes.iter().filter(|&&s| s == 0).count(),
+            0,
+            "no empty partition"
+        );
+        assert!(max <= 4.0 * mean, "largest partition {max} vs mean {mean}");
+    }
+
+    #[test]
+    fn test_hierarchical_refinement_lowers_loss() {
+        const DIM: usize = 16;
+        const K: usize = 300;
+        let data = skewed_training_data(K * 16, DIM);
+        let loss_of = |refine_iters: u32| {
+            let params = KMeansParams {
+                max_iters: 5,
+                hierarchical_k: 8,
+                refine_iters,
+                seed: Some(7),
+                ..Default::default()
+            };
+            KMeans::new_with_params(&data, K, &params)
+                .unwrap()
+                .compute_loss(&data)
+                .unwrap()
+        };
+        let unrefined = loss_of(0);
+        let refined = loss_of(3);
+        assert!(
+            refined <= unrefined * 1.001,
+            "refinement raised the loss from {unrefined} to {refined}"
+        );
+    }
+
+    #[test]
+    fn test_flat_kmeans_seed_is_reproducible() {
+        const DIM: usize = 8;
+        let data = generate_random_array(4096 * DIM);
+        let data = FixedSizeListArray::try_new_from_values(data, DIM as i32).unwrap();
+        let params = KMeansParams {
+            max_iters: 5,
+            seed: Some(3),
+            ..Default::default()
+        };
+        let first = KMeans::new_with_params(&data, 16, &params).unwrap();
+        let second = KMeans::new_with_params(&data, 16, &params).unwrap();
+        assert_eq!(
+            first.centroids.as_primitive::<Float32Type>().values(),
+            second.centroids.as_primitive::<Float32Type>().values()
+        );
     }
 }


### PR DESCRIPTION
## What is the new feature?

Hierarchical k-means (IVF training with more than 256 partitions) now builds its centroid tree with size-proportional quotas, and can optionally refine the leaves globally and be seeded.

- **Proportional tree.** Every node runs one k-means with `hierarchical_k` sub-clusters and hands each sub-cluster a centroid quota proportional to its share of the vectors (largest-remainder rounding, `allocate_quotas`), so every leaf ends up with about `n / k` training vectors however skewed the data is. Sub-trees are built in parallel with rayon. Sub-clusters whose quota rounds to zero are merged into the nearest sibling; nodes of duplicate vectors that cannot be split are filled from the largest leaves. Nodes are assigned in gathered chunks (`membership_of_rows`), so training holds the sample plus one chunk instead of one copy of the data per tree level.
- **Global refinement (opt-in).** `KMeansParams::refine_iters` (default 0) runs Lloyd iterations over the whole sample after the tree is built, with every centroid competing for every vector, through the existing flat or HNSW-assisted assignment. Each iteration costs about one assignment of the training sample; two iterations recover most of the remaining gap to flat k-means (see the sweep below).
- **Seeds.** `KMeansParams::seed` makes initialization reproducible; `split_clusters` now takes half of the largest cluster instead of a random one.
- `examples/kmeans_quality.rs` is the harness used below (seeded sample, exact assignment of the whole base, WCSS, size balance, scan cost, recall).

The previous largest-first tree (split the biggest cluster, one at a time, fixed fan-out) is removed: it lost on every metric in every configuration measured.

## Why do we need this feature?

The largest-first tree fits each sub-tree's centroids only against its own vectors and splits with a fixed fan-out, so the final partitions come out badly skewed: on 10M-row datasets 4-14% of the rows sat in partitions more than 4x the mean size, and the 99th percentile of rows scanned per query at `nprobes = 20` was 2-3x the expected amount. Skewed partitions are the direct cause of IVF tail latency, and they also drive the split/join work `optimize_indices` has to do afterwards.

## How does it work?

`train_hierarchical_kmeans` grows the tree with `grow_proportional_subtree` (quota allocation, parallel recursion, chunked assignment), fills any missing leaves, then runs `refine_iters` iterations of the flat trainer initialised from the leaf centroids. See the doc comments in `rust/lance-index/src/vector/kmeans.rs`.

## Results

All numbers below are from `examples/kmeans_quality.rs` on a Mac mini M4 (10 cores, 26 GB), big-ann DEEP-10M (96-d) and Text-to-Image-10M (200-d), L2. Training uses a seeded sample of `256 x K` rows; every one of the 10M rows is then assigned to its exact nearest centroid. Baseline = `main` (largest-first tree, `hierarchical_k = 16`, no refinement); "this PR" = proportional tree with `hierarchical_k = 16` (the default); `refine_iters = 2` is the opt-in refinement. Three seeds where shown as mean (spread). Lower is better for train s, WCSS, size CV/p99/max, >4x and scan p99; higher is better for R@10.

Headline (K = 2441, 4096 rows per partition, three seeds):

| Scenario / metric | Baseline (main) | This PR (refine 0) | This PR + refine 2 (opt-in) | Benefit |
| --- | ---: | ---: | ---: | ---: |
| DEEP train time (s, lower is better) | 1.1 s | 0.7 s | 5.7 s | 1.6x faster tree; refinement costs 12.5% of one full assignment |
| DEEP partition size CV (lower is better) | 0.583 | 0.209 | 0.216 | 2.8x more balanced |
| DEEP partitions above 4x mean (count) | 24 | 0 | 0 | none left |
| DEEP scan p99 / expected at nprobes 20 (lower is better) | 2.53x | 1.16x | 1.25x | 2.2x lower tail scan |
| DEEP recall@10 at equal scan budget (higher is better) | 0.932 | 0.946 | 0.950 | +1.8 pt |
| T2I train time (s) | 2.3 s | 1.5 s | 14.5 s | 1.5x faster tree |
| T2I partition size CV | 0.662 | 0.260 | 0.255 | 2.5x more balanced |
| T2I partitions above 4x mean (count) | 34 | 0 | 0 | none left |
| T2I scan p99 / expected at nprobes 20 | 2.09x | 1.07x | 1.08x | 1.9x lower tail scan |
| T2I recall@10 at equal scan budget | 0.741 | 0.765 | 0.806 | +6.5 pt |

Training time at the largest K after the chunked-assignment change (train only, same seed, `/usr/bin/time -l`):

| Scenario / metric | Baseline (main) | This PR (refine 0) | This PR + refine 2 (opt-in) | Benefit |
| --- | ---: | ---: | ---: | ---: |
| DEEP K = 39062, 10M training rows, train time | 22.1 s | 12.3 s | 49.0 s | 1.8x faster tree |
| T2I K = 39062, 10M training rows, train time | 54.0 s | 27.9 s | 102.9 s | 1.9x faster tree |
| T2I K = 39062 peak RSS of the harness (8 GB of it is the dataset held by the harness) | not measured | 11.5 GB | 11.0 GB | no per-level copies of the sample |


High-dimensional check at the production partition target (`target_partition_size = 4096`), added after the first review round:

| Scenario / metric | Baseline (main) | This PR (refine 0, default) | Benefit |
| --- | ---: | ---: | ---: |
| MS MARCO 10M rows x 1024-d, K = 2441: train time (s) | 5.2 s | 6.5 s | 1.25x slower tree (train only, isolated: 4.2 s vs 5.0 s) |
| Same: peak RSS while training | 4.47 GB | 4.61 GB | +3% |
| Same: partition size CV | 0.657 | 0.299 | 2.2x more balanced |
| Same: partitions above 4x the mean | 31 | 0 | none left |
| Same: rows scanned p99 / expected at nprobes 20 | 2.38x | 1.13x | 2.1x lower tail scan |
| Same: recall@10 at equal scan budget | 0.845 | 0.863 | +1.8 pt |
| arXiv abstracts 2.25M rows x 768-d, K = 549: train time (s) | 1.1 s | 0.9 s | 1.2x faster |
| Same: partition size CV | 0.823 | 0.214 | 3.8x more balanced |
| Same: rows scanned p99 / expected at nprobes 20 | 2.20x | 1.11x | 2.0x lower tail scan |
| Same: recall@10 at equal scan budget | 0.943 | 0.964 | +2.1 pt |

With the opt-in `refine_iters = 2` the 1024-d recall at equal scan budget rises further to 0.887 and WCSS from 0.6160 to 0.6088, at 12.3 s of training.

Full tables (all K, fan-out and refinement sweeps, plus the high-dimensional runs):

Machine: Mac mini M4 (10 cores, 26 GB). Training sample = 256 x K rows (seeded); assignment of all 10M rows is exact. Metrics: train s (lower is better), WCSS = mean squared L2 distance to the assigned centroid (lower is better), size CV / p99 / max relative to the mean partition size (1.0 = balanced, lower is better), >4x = partitions above 4x the mean (Lance's split threshold), R@10 = recall@10 of the 1,000 queries at an equal scan budget of 20 x mean partition size (higher is better), scan p99 = rows scanned at nprobes=20, p99 over queries, relative to the expected 20 x mean (lower is better). Where three seeds exist the mean is shown with the spread in parentheses.

| dataset | K (rows/partition) | variant | train s | WCSS | size CV | size p99/mean | size max/mean | >4x mean | R@10 @ equal scan | scan p99/expected | seeds |
|---|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| DEEP | 2441 (4096) | main: largest-first hk16 | 1.1 (±0.1) | 0.4518 (±0.0012) | 0.583 (±0.025) | 4.01 (±0.16) | 7.1 (±0.8) | 24 (±2) | 0.932 (±0.003) | 2.53 (±0.19) | 3 |
| DEEP | 2441 (4096) | branch: proportional hk16, refine 0 | 0.7 (±0.1) | 0.4450 (±0.0001) | 0.209 (±0.003) | 1.60 (±0.01) | 2.1 (±0.0) | 0 (±0) | 0.946 (±0.001) | 1.16 (±0.01) | 3 |
| DEEP | 2441 (4096) | branch default: proportional hk16, refine 2 | 5.7 | 0.4399 | 0.216 | 1.67 | 2.1 | 0 | 0.950 | 1.25 | 1 |
| DEEP | 2441 (4096) | branch: proportional hk16, refine 5 | 13.8 (±0.5) | 0.4382 (±0.0002) | 0.221 (±0.003) | 1.67 (±0.01) | 2.2 (±0.1) | 0 (±0) | 0.950 (±0.001) | 1.29 (±0.00) | 3 |
| DEEP | 2441 (4096) | flat k-means, 50 iterations (reference) | 88.2 | 0.4365 | 0.349 | 2.19 | 3.6 | 0 | 0.946 | 1.70 | 1 |
| DEEP | 9766 (1023) | main: largest-first hk16 | 4.4 | 0.4066 | 0.692 | 2.95 | 4.1 | 1 | 0.852 | 2.55 | 1 |
| DEEP | 9766 (1023) | branch: proportional hk16, refine 0 | 3.9 | 0.3994 | 0.185 | 1.51 | 2.5 | 0 | 0.891 | 1.15 | 1 |
| DEEP | 9766 (1023) | branch default: proportional hk16, refine 2 | 81.7 | 0.3931 | 0.187 | 1.53 | 2.6 | 0 | 0.898 | 1.23 | 1 |
| DEEP | 9766 (1023) | branch: proportional hk16, refine 5 | 192.6 | 0.3912 | 0.197 | 1.57 | 2.9 | 0 | 0.902 | 1.31 | 1 |
| DEEP | 39062 (256) | main: largest-first hk16 | 22.1 | 0.3602 | 0.465 | 3.13 | 7.9 | 122 | 0.783 | 2.64 | 1 |
| DEEP | 39062 (256) | branch: proportional hk16, refine 0 | 18.6 | 0.3573 | 0.206 | 1.56 | 3.5 | 0 | 0.802 | 1.20 | 1 |
| DEEP | 39062 (256) | branch default: proportional hk16, refine 2 | 57.2 | 0.3508 | 0.207 | 1.57 | 2.6 | 0 | 0.813 | 1.30 | 1 |
| T2I | 2441 (4096) | main: largest-first hk16 | 2.3 (±0.4) | 0.4476 (±0.0014) | 0.662 (±0.032) | 4.34 (±0.15) | 7.3 (±0.9) | 34 (±6) | 0.741 (±0.005) | 2.09 (±0.42) | 3 |
| T2I | 2441 (4096) | branch: proportional hk16, refine 0 | 1.5 (±0.3) | 0.4351 (±0.0003) | 0.260 (±0.001) | 1.74 (±0.02) | 2.8 (±0.1) | 0 (±0) | 0.765 (±0.003) | 1.07 (±0.00) | 3 |
| T2I | 2441 (4096) | branch default: proportional hk16, refine 2 | 14.5 | 0.4282 | 0.255 | 1.76 | 2.5 | 0 | 0.806 | 1.08 | 1 |
| T2I | 2441 (4096) | branch: proportional hk16, refine 5 | 29.6 (±2.5) | 0.4259 (±0.0001) | 0.259 (±0.001) | 1.84 (±0.04) | 2.7 (±0.2) | 0 (±0) | 0.814 (±0.002) | 1.10 (±0.00) | 3 |
| T2I | 2441 (4096) | flat k-means, 50 iterations (reference) | 162.9 | 0.4231 | 0.388 | 2.49 | 4.6 | 3 | 0.828 | 1.41 | 1 |
| T2I | 9766 (1023) | main: largest-first hk16 | 8.3 | 0.3891 | 0.731 | 3.17 | 4.1 | 2 | 0.642 | 2.19 | 1 |
| T2I | 9766 (1023) | branch: proportional hk16, refine 0 | 8.5 | 0.3775 | 0.230 | 1.61 | 2.4 | 0 | 0.680 | 1.05 | 1 |
| T2I | 9766 (1023) | branch default: proportional hk16, refine 2 | 17.6 | 0.3706 | 0.228 | 1.63 | 2.5 | 0 | 0.717 | 1.03 | 1 |
| T2I | 9766 (1023) | branch: proportional hk16, refine 5 | 31.1 | 0.3682 | 0.235 | 1.72 | 2.5 | 0 | 0.731 | 1.06 | 1 |
| T2I | 39062 (256) | main: largest-first hk16 | 54.0 | 0.3326 | 0.587 | 3.58 | 7.4 | 283 | 0.553 | 2.85 | 1 |
| T2I | 39062 (256) | branch: proportional hk16, refine 0 | 121.4 | 0.3284 | 0.260 | 1.72 | 3.9 | 0 | 0.571 | 1.04 | 1 |
| T2I | 39062 (256) | branch default: proportional hk16, refine 2 | 159.3 | 0.3222 | 0.259 | 1.75 | 3.2 | 0 | 0.626 | 1.04 | 1 |

## Fan-out sweep (K=2441, seed 1, no refinement)

| dataset | variant | hk | train s | WCSS | size CV | size max/mean | R@10 @ equal scan |
|---|---|---:|---:|---:|---:|---:|---:|
| DEEP | largest-first | 8 | 1.1 | 0.4498 | 0.395 | 3.7 | 0.933 |
| DEEP | largest-first | 16 | 1.2 | 0.4502 | 0.566 | 6.0 | 0.932 |
| DEEP | largest-first | 32 | 1.3 | 0.4624 | 0.879 | 3.9 | 0.905 |
| DEEP | largest-first | 64 | 1.9 | 0.4640 | 1.062 | 18.6 | 0.925 |
| DEEP | proportional | 4 | 0.4 | 0.4507 | 0.209 | 2.2 | 0.936 |
| DEEP | proportional | 8 | 0.5 | 0.4472 | 0.206 | 2.1 | 0.940 |
| DEEP | proportional | 16 | 0.7 | 0.4451 | 0.211 | 2.1 | 0.947 |
| DEEP | proportional | 32 | 1.6 | 0.4444 | 0.171 | 1.9 | 0.947 |
| DEEP | proportional | 64 | 1.6 | 0.4411 | 0.236 | 2.5 | 0.950 |
| T2I | largest-first | 8 | 2.2 | 0.4424 | 0.460 | 3.4 | 0.735 |
| T2I | largest-first | 16 | 2.9 | 0.4481 | 0.682 | 8.2 | 0.747 |
| T2I | largest-first | 32 | 3.5 | 0.4593 | 0.948 | 4.2 | 0.715 |
| T2I | largest-first | 64 | 3.5 | 0.4590 | 1.391 | 24.8 | 0.689 |
| T2I | proportional | 4 | 1.0 | 0.4423 | 0.258 | 2.5 | 0.728 |
| T2I | proportional | 8 | 1.0 | 0.4385 | 0.255 | 2.4 | 0.743 |
| T2I | proportional | 16 | 1.9 | 0.4352 | 0.258 | 2.7 | 0.768 |
| T2I | proportional | 32 | 2.6 | 0.4336 | 0.220 | 2.5 | 0.782 |
| T2I | proportional | 64 | 5.0 | 0.4304 | 0.280 | 3.3 | 0.790 |

## Refinement sweep (proportional hk16, K=2441, seed 1)

| dataset | refine iters | train s | WCSS | size CV | R@10 @ equal scan | R@10 nprobes 20 |
|---|---:|---:|---:|---:|---:|---:|
| DEEP | 0 | 0.7 | 0.4451 | 0.211 | 0.947 | 0.947 |
| DEEP | 2 | 5.7 | 0.4399 | 0.216 | 0.950 | 0.951 |
| DEEP | 5 | 13.3 | 0.4382 | 0.225 | 0.952 | 0.954 |
| DEEP | 10 | 25.8 | 0.4372 | 0.232 | 0.954 | 0.957 |
| T2I | 0 | 1.9 | 0.4352 | 0.258 | 0.768 | 0.760 |
| T2I | 2 | 14.5 | 0.4282 | 0.255 | 0.806 | 0.803 |
| T2I | 5 | 33.1 | 0.4258 | 0.258 | 0.812 | 0.810 |
| T2I | 10 | 62.5 | 0.4244 | 0.264 | 0.823 | 0.822 |

## 768-d follow-up (Qdrant arXiv abstracts instructor-xl, 2.25M rows, target_partition_size = 4096 -> K = 549); main = 3 unseeded runs, branch = seeds 1-3

| dataset (rows, dim, K) | variant | runs | train s | WCSS | size CV | size p99/mean | size max/mean | >4x mean | empty | R@10 @ equal scan | scan p99/expected |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| arxiv-abstracts-k549 (2,253,000 rows, 768-d, K=549) | branch (proportional hk16, refine 0) | 3 | 0.9 (±0.0) | 0.2008 (±0.0001) | 0.214 (±0.008) | 1.49 (±0.05) | 1.8 (±0.1) | 0 (±0) | 0 (±0) | 0.964 (±0.002) | 1.11 (±0.02) |
| arxiv-abstracts-k549 (2,253,000 rows, 768-d, K=549) | branch (proportional hk16, refine 2) | 3 | 3.1 (±0.1) | 0.1994 (±0.0001) | 0.222 (±0.008) | 1.55 (±0.03) | 1.9 (±0.2) | 0 (±0) | 0 (±0) | 0.967 (±0.002) | 1.14 (±0.02) |
| arxiv-abstracts-k549 (2,253,000 rows, 768-d, K=549) | main (largest-first hk16) | 3 | 1.1 (±0.1) | 0.2045 (±0.0003) | 0.823 (±0.018) | 2.84 (±0.06) | 3.2 (±0.1) | 0 (±0) | 0 (±0) | 0.943 (±0.002) | 2.20 (±0.06) |

## 1024-d, 10M rows (CohereLabs msmarco-v2-embed-english-v3 first 10M passages, target_partition_size = 4096 -> K = 2441); main = 3 unseeded runs, branch = seeds 1-3

| dataset (rows, dim, K) | variant | runs | train s | WCSS | size CV | size p99/mean | size max/mean | >4x mean | empty | R@10 @ equal scan | scan p99/expected |
|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| msmarco-10m-k2441 (10,000,000 rows, 1024-d, K=2441) | branch (proportional hk16, refine 0) | 3 | 6.5 (±1.1) | 0.6160 (±0.0002) | 0.299 (±0.004) | 1.86 (±0.02) | 2.6 (±0.1) | 0 (±0) | 0 (±0) | 0.863 (±0.006) | 1.13 (±0.01) |
| msmarco-10m-k2441 (10,000,000 rows, 1024-d, K=2441) | branch (proportional hk16, refine 2) | 3 | 12.3 (±1.6) | 0.6088 (±0.0001) | 0.291 (±0.002) | 1.81 (±0.01) | 2.6 (±0.2) | 0 (±0) | 0 (±0) | 0.887 (±0.002) | 1.16 (±0.01) |
| msmarco-10m-k2441 (10,000,000 rows, 1024-d, K=2441) | main (largest-first hk16) | 3 | 5.2 (±0.3) | 0.6223 (±0.0002) | 0.657 (±0.022) | 4.27 (±0.15) | 6.6 (±0.3) | 31 (±4) | 0 (±0) | 0.845 (±0.010) | 2.38 (±0.17) |

Training time and peak RSS, train only, same machine, , base streamed from disk (the 2.56 GB training sample dominates):

| variant | train s | peak RSS |
|---|---:|---:|
| main (largest-first hk16) | 4.2 | 4.47 GB |
| branch (proportional hk16, refine 0) | 5.0 | 4.61 GB |
| branch + refine 2 (opt-in) | 10.5 | 4.70 GB |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
