### PR TITLE
feat(index): split IVF partitions to target size and join undersized ones in one optimize pass

### DIFF
--- a/rust/lance-index/src/vector/ivf/transform.rs
+++ b/rust/lance-index/src/vector/ivf/transform.rs
@@ -70,36 +70,72 @@ impl PartitionTransformer {
         self.with_distance = with_distance;
         self
     }
-}
-impl Transformer for PartitionTransformer {
-    #[instrument(name = "PartitionTransformer::transform", level = "debug", skip_all)]
-    fn transform(&self, batch: &RecordBatch) -> Result<RecordBatch> {
-        if !(batch.column_by_name(&self.output_column).is_none()
-            || self.with_distance && batch.column_by_name(CENTROID_DIST_COLUMN).is_none())
-        {
-            // If the output columns are already present, we don't need to compute it again.
-            return Ok(batch.clone());
+
+    fn with_distances_to_chosen_partitions(&self, batch: &RecordBatch) -> Result<RecordBatch> {
+        let fsl = self.input_vectors(batch)?;
+        let part_ids = batch
+            .column_by_name(&self.output_column)
+            .expect("checked by the caller")
+            .as_primitive::<UInt32Type>();
+        let mut dists = Vec::with_capacity(fsl.len());
+        for (vector, part_id) in fsl.iter().zip(part_ids.iter()) {
+            let (Some(vector), Some(part_id)) = (vector, part_id) else {
+                dists.push(None);
+                continue;
+            };
+            let centroid = self.centroids.slice(part_id as usize, 1);
+            let dist = self.distance_type.arrow_batch_func()(vector.as_ref(), &centroid)?;
+            dists.push(Some(dist.value(0)));
         }
+        let loss = dists
+            .iter()
+            .map(|d| d.unwrap_or_default() as f64)
+            .sum::<f64>();
+        let batch = batch.drop_column(CENTROID_DIST_COLUMN)?.try_with_column(
+            CENTROID_DIST_FIELD.clone(),
+            Arc::new(Float32Array::from(dists)),
+        )?;
+        Ok(batch.add_metadata(LOSS_METADATA_KEY.to_owned(), loss.to_string())?)
+    }
 
-        // clear the columns if any of them is present
-        let batch = batch
-            .drop_column(PART_ID_COLUMN)?
-            .drop_column(CENTROID_DIST_COLUMN)?;
-
+    fn input_vectors<'a>(&self, batch: &'a RecordBatch) -> Result<&'a FixedSizeListArray> {
         let arr = batch.column_by_name(&self.input_column).ok_or_else(|| {
             lance_core::Error::index(format!(
                 "PartitionTransformer: column {} not found in the RecordBatch",
                 self.input_column
             ))
         })?;
-
-        let fsl = arr.as_fixed_size_list_opt().ok_or_else(|| {
+        arr.as_fixed_size_list_opt().ok_or_else(|| {
             lance_core::Error::index(format!(
                 "PartitionTransformer: column {} is not a FixedSizeListArray: {}",
                 self.input_column,
                 arr.data_type(),
             ))
-        })?;
+        })
+    }
+}
+impl Transformer for PartitionTransformer {
+    #[instrument(name = "PartitionTransformer::transform", level = "debug", skip_all)]
+    fn transform(&self, batch: &RecordBatch) -> Result<RecordBatch> {
+        let has_part_ids = batch.column_by_name(&self.output_column).is_some();
+        let needs_dists =
+            self.with_distance && batch.column_by_name(CENTROID_DIST_COLUMN).is_none();
+        if has_part_ids && !needs_dists {
+            // If the output columns are already present, we don't need to compute it again.
+            return Ok(batch.clone());
+        }
+        if has_part_ids {
+            // The caller chose every row's partition (a join placing rows where
+            // there is room): keep it and measure the distance to that centroid
+            // rather than reassign the row to its nearest one.
+            return self.with_distances_to_chosen_partitions(batch);
+        }
+
+        // clear the columns if any of them is present
+        let batch = batch
+            .drop_column(PART_ID_COLUMN)?
+            .drop_column(CENTROID_DIST_COLUMN)?;
+        let fsl = self.input_vectors(&batch)?;
 
         let (part_ids, dists) = match &self.index {
             Some(index) => fsl
@@ -287,6 +323,26 @@ mod tests {
 
     /// Recomputing over an already-assigned batch would waste the work and could
     /// disagree with the ids the caller already wrote.
+    #[test]
+    fn test_keeps_chosen_partitions_and_measures_their_distance() {
+        // A caller that chose partition 1 for a vector nearest to partition 0
+        // gets the distance to partition 1, not a new assignment.
+        let batch = vector_batch(vec![vec![1.0, 1.0]])
+            .try_with_column(
+                PART_ID_FIELD.clone(),
+                Arc::new(UInt32Array::from(vec![1_u32])),
+            )
+            .unwrap();
+        let output = transformer().with_distance(true).transform(&batch).unwrap();
+        assert_eq!(part_ids_of(&output), vec![Some(1)]);
+        let dists = output
+            .column_by_name(CENTROID_DIST_COLUMN)
+            .unwrap()
+            .as_primitive::<arrow_array::types::Float32Type>();
+        assert!((dists.value(0) - 99.0_f32 * 99.0 * 2.0).abs() < 1e-3);
+        assert!((loss_of(&output) - 99.0_f64 * 99.0 * 2.0).abs() < 1e-3);
+    }
+
     #[test]
     fn test_is_noop_when_partitions_already_present() {
         let assigned = transformer()

--- a/rust/lance/src/index.rs
+++ b/rust/lance/src/index.rs
@@ -4108,7 +4108,11 @@ mod tests {
         ]));
         let first_fragment_rows = 20_000;
         let second_fragment_rows = 100;
-        let first_values = vec![0.0f32; first_fragment_rows * dimension as usize];
+        // A tiny per-row perturbation keeps the rows distinct, so the oversized
+        // partition can actually be split by k-means.
+        let first_values = (0..first_fragment_rows * dimension as usize)
+            .map(|i| (i / dimension as usize) as f32 * 0.0001)
+            .collect::<Vec<f32>>();
         let second_values = vec![100.0f32; second_fragment_rows * dimension as usize];
         let first_vectors =
             FixedSizeListArray::try_new_from_values(Float32Array::from(first_values), dimension)
@@ -4767,7 +4771,12 @@ mod tests {
             .num_partitions_per_segment()
             .into_iter()
             .collect::<HashMap<_, _>>();
-        assert_eq!(partitions_per_segment[&after_by_fragment[&vec![0]]], 3);
+        // The 20_000-row partition is split straight to the target size:
+        // ceil(20_000 / 4096) = 5 pieces, so 2 + 4 partitions.
+        assert_eq!(
+            partitions_per_segment[&after_by_fragment[&vec![0]]],
+            2 + 20_000_usize.div_ceil(IndexType::IvfFlat.target_partition_size()) - 1
+        );
         assert_eq!(partitions_per_segment[&after_by_fragment[&vec![1]]], 2);
     }
 

--- a/rust/lance/src/index/append.rs
+++ b/rust/lance/src/index/append.rs
@@ -29,8 +29,8 @@ use roaring::RoaringBitmap;
 use uuid::Uuid;
 
 use super::vector::ivf::{
-    VectorSegmentCompatibility, index_type_for_segmented_optimize, optimize_vector_indices,
-    select_segment_for_single_rebalance, vector_segment_compatibility,
+    SteadyStateRebalance, VectorSegmentCompatibility, index_type_for_segmented_optimize,
+    optimize_vector_indices, select_steady_state_rebalance, vector_segment_compatibility,
 };
 use super::vector::{LogicalVectorIndex, fresh_vector_segment_params};
 use super::{CreateIndexBuilder, DatasetIndexInternalExt};
@@ -960,22 +960,19 @@ pub async fn merge_indices_with_unindexed_frags<'a>(
             if unindexed.is_empty() && options.num_indices_to_merge == Some(0) {
                 return Ok(None);
             }
-            if unindexed.is_empty()
-                && options.num_indices_to_merge.is_none()
-                && select_segment_for_single_rebalance(&ivf_view)?.is_none()
-            {
-                return Ok(None);
-            }
-
-            let use_single_segment_rebalance = logical_index.num_segments() > 1
-                && options.num_indices_to_merge.is_none()
-                && unindexed.is_empty();
-
-            if use_single_segment_rebalance {
-                let Some(selected_segment_id) = select_segment_for_single_rebalance(&ivf_view)?
-                else {
-                    return Ok(None);
+            let steady_state_rebalance =
+                if unindexed.is_empty() && options.num_indices_to_merge.is_none() {
+                    let Some(rebalance) = select_steady_state_rebalance(&ivf_view)? else {
+                        return Ok(None);
+                    };
+                    Some(rebalance)
+                } else {
+                    None
                 };
+
+            if let Some(SteadyStateRebalance::Segment(selected_segment_id)) = steady_state_rebalance
+                && logical_index.num_segments() > 1
+            {
                 let removed_segment = old_indices
                 .iter()
                 .copied()
@@ -2284,7 +2281,7 @@ mod tests {
     /// vector index used to fall through to `optimize_vector_indices` and write
     /// a new UUID directory + manifest even though nothing had changed. The
     /// no-op gate inside `merge_indices_with_unindexed_frags` should bail out
-    /// once `select_segment_for_single_rebalance` returns `None`.
+    /// once `select_steady_state_rebalance` returns `None`.
     #[tokio::test]
     async fn test_optimize_indices_append_is_noop_on_steady_state() {
         const DIM: usize = 64;

--- a/rust/lance/src/index/append.rs
+++ b/rust/lance/src/index/append.rs
@@ -962,7 +962,8 @@ pub async fn merge_indices_with_unindexed_frags<'a>(
             }
             let steady_state_rebalance =
                 if unindexed.is_empty() && options.num_indices_to_merge.is_none() {
-                    let Some(rebalance) = select_steady_state_rebalance(&ivf_view)? else {
+                    let Some(rebalance) = select_steady_state_rebalance(&ivf_view, compatibility)?
+                    else {
                         return Ok(None);
                     };
                     Some(rebalance)
@@ -1561,7 +1562,10 @@ mod tests {
 
         let initial_fragments = dataset.get_fragments();
         assert_eq!(initial_fragments.len(), 2);
-        let params = VectorIndexParams::ivf_flat(1, MetricType::L2);
+        // Two partitions per segment: summed over the segments they are under
+        // the join threshold, which must not tempt a steady-state merge of
+        // segments whose centroids differ.
+        let params = VectorIndexParams::ivf_flat(2, MetricType::L2);
         let mut initial_segments = Vec::with_capacity(initial_fragments.len());
         for fragment in &initial_fragments {
             initial_segments.push(

--- a/rust/lance/src/index/vector/builder.rs
+++ b/rust/lance/src/index/vector/builder.rs
@@ -78,6 +78,7 @@ use lance_table::format::IndexFile;
 use log::info;
 use object_store::path::Path;
 use prost::Message;
+use rand::{SeedableRng, rngs::SmallRng};
 use roaring::RoaringBitmap;
 use tokio::sync::{OnceCell, OwnedSemaphorePermit, Semaphore};
 use tracing::{Level, instrument, span};
@@ -99,8 +100,30 @@ use super::{
 
 // the number of partitions to evaluate for reassigning
 const REASSIGN_RANGE: usize = 64;
-// sample size for kmeans training when splitting a partition (sample_rate * k = 256 * 2)
-const SPLIT_SAMPLE_SIZE: usize = 512;
+/// Training vectors sampled per centroid when a partition is split.
+const SPLIT_SAMPLE_RATE: usize = 256;
+/// Upper bound on the number of partitions one oversized partition is split into
+/// in a single optimize pass; anything still oversized waits for the next pass.
+const MAX_SPLIT_WAYS: usize = 1024;
+/// Rows sampled from a neighbor partition to decide whether a split can pull any
+/// of its rows away.
+const REASSIGN_SAMPLE_SIZE: usize = 512;
+/// A sampled row counts as movable when a new centroid is within this relative
+/// margin of its own centroid's distance, so near-ties do not prune a neighbor
+/// that unsampled rows would still leave.
+const REASSIGN_MARGIN: f32 = 0.05;
+
+/// Number of partitions the split partitions' rows now belong to.
+fn new_partition_ids_len(split_partitions: &[(usize, Vec<usize>)]) -> usize {
+    split_partitions.iter().map(|(_, ids)| ids.len()).sum()
+}
+
+/// One oversized partition and the number of partitions it is split into.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct PartitionSplit {
+    partition: usize,
+    ways: usize,
+}
 /// Maximum decoded input bytes admitted across active builds and completed
 /// partitions waiting for their turn to be written.
 const PARTITION_BUILD_BUDGET_BYTES: usize = 512 * 1024 * 1024;
@@ -124,20 +147,23 @@ impl Default for FreshPartitionBuildLimits {
 
 /// Build a new centroid array that incorporates the results of partition splits.
 ///
-/// For each `(part_idx, centroid1, centroid2)` in `splits`:
-/// - `original[part_idx]` is replaced by `centroid1`
-/// - `centroid2` is appended after all existing centroids
-///
-/// Unchanged centroids keep their original indices.  The k-th split's second
-/// centroid lands at index `original.len() + k`.
+/// For each `(part_idx, centroids)` in `splits`, `original[part_idx]` is replaced
+/// by the first new centroid and the remaining ones are appended after all
+/// existing centroids, in split order. Unchanged centroids keep their original
+/// indices.
 fn apply_centroid_splits(
     original: &FixedSizeListArray,
-    splits: &[(usize, ArrayRef, ArrayRef)],
+    splits: &[(usize, Vec<ArrayRef>)],
 ) -> Result<FixedSizeListArray> {
     let mut new_centroids: Vec<ArrayRef> = original.iter().map(|v| v.unwrap()).collect();
-    for (part_idx, centroid1, centroid2) in splits {
-        new_centroids[*part_idx] = centroid1.clone();
-        new_centroids.push(centroid2.clone());
+    for (part_idx, centroids) in splits {
+        let (first, rest) = centroids.split_first().ok_or_else(|| {
+            Error::invalid_input(format!(
+                "split of partition {part_idx} produced no centroids"
+            ))
+        })?;
+        new_centroids[*part_idx] = first.clone();
+        new_centroids.extend(rest.iter().cloned());
     }
     let refs: Vec<&dyn Array> = new_centroids.iter().map(|a| a.as_ref()).collect();
     let concatenated = arrow::compute::concat(&refs)?;
@@ -271,6 +297,9 @@ pub struct IvfIndexBuilder<S: IvfSubIndex, Q: Quantization> {
     optimize_options: Option<OptimizeOptions>,
     // number of indices merged
     merged_num: usize,
+    // rows per partition the index was created for; `None` falls back to the
+    // index type's default when deciding splits and joins
+    target_partition_size: Option<usize>,
     // whether to transpose codes when building storage
     transpose_codes: bool,
 
@@ -375,6 +404,7 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
             fragment_filter: None,
             optimize_options: None,
             merged_num: 0,
+            target_partition_size: None,
             transpose_codes: true,
             format_version,
             progress: Arc::new(NoopIndexBuildProgress),
@@ -442,6 +472,7 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
             fragment_filter: None,
             optimize_options: None,
             merged_num: 0,
+            target_partition_size: None,
             transpose_codes: true,
             format_version,
             progress: Arc::new(NoopIndexBuildProgress),
@@ -580,6 +611,16 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
     }
 
     /// Set progress callback for index building
+    /// Rows per partition the index was created for. Split and join thresholds
+    /// are derived from it; without it the index type's default is used.
+    pub fn with_target_partition_size(
+        &mut self,
+        target_partition_size: Option<usize>,
+    ) -> &mut Self {
+        self.target_partition_size = target_partition_size;
+        self
+    }
+
     pub fn with_progress(&mut self, progress: Arc<dyn IndexBuildProgress>) -> &mut Self {
         self.progress = progress;
         self
@@ -996,56 +1037,72 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
             )
         };
 
-        let (assign_batches, merge_indices, partition_adjustment) =
-            if num_indices_to_merge.is_some() || self.optimize_options.is_none() {
-                no_partition_adjustment()
+        let (assign_batches, merge_indices, partition_adjustment) = if num_indices_to_merge
+            .is_some()
+            || self.optimize_options.is_none()
+        {
+            no_partition_adjustment()
+        } else {
+            let target_partition_size = self.effective_target_partition_size()?;
+            let (splits, joins) = Self::check_partition_adjustment(
+                ivf,
+                reader.as_ref(),
+                &self.existing_indices,
+                target_partition_size,
+            )?;
+            let split_result = if splits.is_empty() {
+                None
             } else {
-                let (split_partitions, join_partition) =
-                    Self::check_partition_adjustment(ivf, reader.as_ref(), &self.existing_indices)?;
-                if !split_partitions.is_empty() {
-                    log::info!(
-                        "split partitions {:?}, will merge all {} delta indices",
-                        split_partitions,
-                        self.existing_indices.len()
-                    );
-                    let split_result = self
-                        .split_partitions_streaming(&split_partitions, ivf)
-                        .await?;
-                    let Some(ivf) = self.ivf.as_mut() else {
-                        return Err(Error::invalid_input(
-                            "IVF not set before building partitions",
-                        ));
-                    };
-                    ivf.centroids = Some(split_result.new_centroids);
-                    (
-                        vec![None; ivf.num_partitions()],
-                        Arc::new(self.existing_indices.clone()),
-                        Some(PartitionAdjustment::Split {
-                            affected_partitions: split_result.affected_partitions,
-                            split_shuffle_reader: split_result.shuffle_reader,
-                        }),
-                    )
-                } else {
-                    match join_partition {
-                        Some(partition) => {
-                            log::info!("join partition {}", partition);
-                            let results = self.join_partition(partition, ivf).await?;
-                            let Some(ivf) = self.ivf.as_mut() else {
-                                return Err(Error::invalid_input(
-                                    "IVF model not set before joining partition",
-                                ));
-                            };
-                            ivf.centroids = Some(results.new_centroids);
-                            (
-                                results.assign_batches,
-                                Arc::new(self.existing_indices.clone()),
-                                Some(PartitionAdjustment::Join(partition)),
-                            )
-                        }
-                        None => no_partition_adjustment(),
-                    }
-                }
+                log::info!(
+                    "split partitions {:?} (target partition size {}), will merge all {} delta indices",
+                    splits,
+                    target_partition_size,
+                    self.existing_indices.len()
+                );
+                self.split_partitions_streaming(&splits, ivf)
+                    .boxed()
+                    .await?
             };
+            if let Some(split_result) = split_result {
+                let Some(ivf) = self.ivf.as_mut() else {
+                    return Err(Error::invalid_input(
+                        "IVF not set before building partitions",
+                    ));
+                };
+                ivf.centroids = Some(split_result.new_centroids);
+                (
+                    vec![None; ivf.num_partitions()],
+                    Arc::new(self.existing_indices.clone()),
+                    Some(PartitionAdjustment::Split {
+                        affected_partitions: split_result.affected_partitions,
+                        split_shuffle_reader: split_result.shuffle_reader,
+                    }),
+                )
+            } else if !joins.is_empty() {
+                log::info!(
+                    "join partitions {:?} (target partition size {}), will merge all {} delta indices",
+                    joins,
+                    target_partition_size,
+                    self.existing_indices.len()
+                );
+                let results = self.join_partitions(&joins, ivf).boxed().await?;
+                let Some(ivf) = self.ivf.as_mut() else {
+                    return Err(Error::invalid_input(
+                        "IVF model not set before joining partitions",
+                    ));
+                };
+                ivf.centroids = Some(results.new_centroids);
+                (
+                    results.assign_batches,
+                    Arc::new(self.existing_indices.clone()),
+                    Some(PartitionAdjustment::Join {
+                        kept_partitions: results.kept_partitions,
+                    }),
+                )
+            } else {
+                no_partition_adjustment()
+            }
+        };
         self.merged_num = merge_indices.len();
         log::info!(
             "merge {}/{} delta indices",
@@ -1099,10 +1156,8 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
                             _ => (false, None),
                         };
                         let partition = match partition_adjustment.as_ref() {
-                            Some(PartitionAdjustment::Join(joined_partition))
-                                if partition >= *joined_partition =>
-                            {
-                                partition + 1
+                            Some(PartitionAdjustment::Join { kept_partitions }) => {
+                                kept_partitions[partition]
                             }
                             _ => partition,
                         };
@@ -1814,25 +1869,35 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
     ) -> Result<Vec<RecordBatch>> {
         let projection = Arc::new(dataset.schema().project(&[column])?);
         // arrow uses i32 for index, so we chunk the row ids to avoid large batch causing overflow
-        let mut batches = Vec::new();
         let row_ids = dataset.filter_deleted_ids(row_ids).await?;
-        for chunk in row_ids.chunks(store.block_size()) {
-            let batch = dataset
-                .take_rows(chunk, ProjectionRequest::Schema(projection.clone()))
-                .await?;
-            if batch.num_rows() != chunk.len() {
-                return Err(Error::invalid_input(format!(
-                    "batch.num_rows() != chunk.len() ({} != {})",
-                    batch.num_rows(),
-                    chunk.len()
-                )));
-            }
-            let batch = batch.try_with_column(
-                ROW_ID_FIELD.clone(),
-                Arc::new(UInt64Array::from(chunk.to_vec())),
-            )?;
-            batches.push(batch);
-        }
+        let chunks: Vec<Vec<u64>> = row_ids
+            .chunks(store.block_size())
+            .map(|chunk| chunk.to_vec())
+            .collect();
+        let batches = stream::iter(chunks)
+            .map(|chunk| {
+                let dataset = dataset.clone();
+                let projection = projection.clone();
+                async move {
+                    let batch = dataset
+                        .take_rows(&chunk, ProjectionRequest::Schema(projection))
+                        .await?;
+                    if batch.num_rows() != chunk.len() {
+                        return Err(Error::invalid_input(format!(
+                            "batch.num_rows() != chunk.len() ({} != {})",
+                            batch.num_rows(),
+                            chunk.len()
+                        )));
+                    }
+                    Ok(batch.try_with_column(
+                        ROW_ID_FIELD.clone(),
+                        Arc::new(UInt64Array::from(chunk)),
+                    )?)
+                }
+            })
+            .buffered(store.io_parallelism())
+            .try_collect::<Vec<_>>()
+            .await?;
         Ok(batches)
     }
 
@@ -1875,37 +1940,64 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
         Ok(Some((row_ids, vectors)))
     }
 
-    // check whether need to split or join partition
+    /// Rows per partition that split and join thresholds are derived from: the
+    /// value the index was created with when known, else the type default.
+    fn effective_target_partition_size(&self) -> Result<usize> {
+        if let Some(size) = self.target_partition_size {
+            return Ok(size);
+        }
+        let index_type = IndexType::try_from(
+            index_type_string(S::name().try_into()?, Q::quantization_type()).as_str(),
+        )?;
+        Ok(index_type.target_partition_size())
+    }
+
+    /// Decide which partitions to split and which to join away.
+    ///
+    /// A partition above `MAX_PARTITION_SIZE_FACTOR` times the target is split
+    /// straight to the target size (`ceil(rows / target)` ways, capped at
+    /// `MAX_SPLIT_WAYS`), so one pass leaves nothing above the threshold. Every
+    /// partition below `MIN_PARTITION_SIZE_PERCENT` of the target is joined away,
+    /// except that the largest of them stays when all partitions are undersized.
     fn check_partition_adjustment(
         ivf: &IvfModel,
         reader: &dyn ShuffleReader,
         existing_indices: &[ExistingIndex],
-    ) -> Result<(Vec<usize>, Option<usize>)> {
-        let index_type = IndexType::try_from(
-            index_type_string(S::name().try_into()?, Q::quantization_type()).as_str(),
-        )?;
+        target_partition_size: usize,
+    ) -> Result<(Vec<PartitionSplit>, Vec<usize>)> {
+        let split_threshold = MAX_PARTITION_SIZE_FACTOR * target_partition_size;
+        let join_threshold = MIN_PARTITION_SIZE_PERCENT * target_partition_size / 100;
 
-        let mut split_partitions = Vec::new();
-        let mut join_partition = None;
-        let mut min_partition_size = usize::MAX;
+        let mut splits = Vec::new();
+        let mut joins = Vec::new();
         for partition in 0..ivf.num_partitions() {
             let mut num_rows = reader.partition_size(partition)?;
             for source in existing_indices.iter() {
                 num_rows += source.index.partition_size(partition);
             }
-            if num_rows > MAX_PARTITION_SIZE_FACTOR * index_type.target_partition_size() {
-                split_partitions.push(partition);
-            }
-            if ivf.num_partitions() > 1
-                && num_rows < min_partition_size
-                && num_rows < MIN_PARTITION_SIZE_PERCENT * index_type.target_partition_size() / 100
-            {
-                min_partition_size = num_rows;
-                join_partition = Some(partition);
+            if num_rows > split_threshold {
+                splits.push(PartitionSplit {
+                    partition,
+                    ways: num_rows
+                        .div_ceil(target_partition_size)
+                        .clamp(2, MAX_SPLIT_WAYS),
+                });
+            } else if ivf.num_partitions() > 1 && num_rows < join_threshold {
+                joins.push((num_rows, partition));
             }
         }
+        if joins.len() == ivf.num_partitions() {
+            let largest = joins
+                .iter()
+                .enumerate()
+                .max_by_key(|(_, (num_rows, _))| *num_rows)
+                .map(|(i, _)| i)
+                .expect("joins is not empty");
+            joins.remove(largest);
+        }
+        let joins = joins.into_iter().map(|(_, partition)| partition).collect();
 
-        Ok((split_partitions, join_partition))
+        Ok((splits, joins))
     }
 
     /// Split oversized partitions using a streaming approach.
@@ -1915,13 +2007,13 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
     /// 3. Stream raw vectors for affected partitions through the IVF+quantizer
     ///    transform pipeline, writing to temp files via a shuffler.
     ///
-    /// The returned `SplitResult` contains a `ShuffleReader` with properly
-    /// quantized data for all affected partitions.
+    /// Returns `None` when no partition could be split (none had live rows), so
+    /// the caller does not pay for a merge that changes nothing.
     async fn split_partitions_streaming(
         &self,
-        split_partitions: &[usize],
+        splits: &[PartitionSplit],
         ivf: &IvfModel,
-    ) -> Result<SplitResult> {
+    ) -> Result<Option<SplitResult>> {
         let Some(dataset) = self.dataset.as_ref() else {
             return Err(Error::invalid_input(
                 "dataset not set before split partition",
@@ -1929,21 +2021,21 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
         };
 
         let (_, element_type) = get_vector_type(dataset.schema(), &self.column)?;
-        let (new_centroids, actual_splits) = match element_type {
+        let (new_centroids, split_partitions) = match element_type {
             DataType::Float16 => {
-                self.compute_split_centroids::<Float16Type>(split_partitions, ivf)
+                self.compute_split_centroids::<Float16Type>(splits, ivf)
                     .await?
             }
             DataType::Float32 => {
-                self.compute_split_centroids::<Float32Type>(split_partitions, ivf)
+                self.compute_split_centroids::<Float32Type>(splits, ivf)
                     .await?
             }
             DataType::Float64 => {
-                self.compute_split_centroids::<Float64Type>(split_partitions, ivf)
+                self.compute_split_centroids::<Float64Type>(splits, ivf)
                     .await?
             }
             DataType::UInt8 => {
-                self.compute_split_centroids::<UInt8Type>(split_partitions, ivf)
+                self.compute_split_centroids::<UInt8Type>(splits, ivf)
                     .await?
             }
             dt => {
@@ -1954,40 +2046,52 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
             }
         };
 
-        if actual_splits.is_empty() {
-            let centroids = ivf.centroids_array().unwrap();
-            // Create a dummy empty shuffle reader
-            let empty_reader = Arc::new(IvfShufflerReader::new(
-                Arc::new(self.store.clone()),
-                self.temp_dir.clone().join("split_shuffle"),
-                vec![0; ivf.num_partitions()],
-                0.0,
-            ));
-            return Ok(SplitResult {
-                new_centroids: centroids.clone(),
-                affected_partitions: HashSet::new(),
-                shuffle_reader: empty_reader,
-            });
+        if split_partitions.is_empty() {
+            return Ok(None);
         }
 
-        // Compute affected partitions: split targets + their neighbors
+        // Affected partitions: every partition that received a new centroid plus
+        // those neighbors of the split partitions' old centroids that can lose a
+        // row to a new centroid.
         let mut affected_partitions = HashSet::new();
-        for &part_idx in &actual_splits {
-            affected_partitions.insert(part_idx);
-            let c0 = ivf.centroid(part_idx).ok_or(Error::invalid_input(format!(
+        let mut new_partition_ids = Vec::new();
+        let mut candidates = HashSet::new();
+        for (part_idx, new_partitions) in &split_partitions {
+            affected_partitions.extend(new_partitions.iter().copied());
+            new_partition_ids.extend(new_partitions.iter().map(|id| *id as u32));
+            let c0 = ivf.centroid(*part_idx).ok_or(Error::invalid_input(format!(
                 "centroid not found for partition {part_idx}",
             )))?;
-            let (neighbor_ids, _) =
-                select_reassign_candidates_impl(self.distance_type, ivf, part_idx, &c0)?;
-            for neighbor_id in neighbor_ids.values() {
-                affected_partitions.insert(*neighbor_id as usize);
-            }
+            let (neighbor_ids, _) = select_reassign_candidates_impl(
+                self.distance_type,
+                ivf,
+                *part_idx,
+                &c0,
+                &HashSet::new(),
+            )?;
+            candidates.extend(neighbor_ids.values().iter().map(|id| *id as usize));
         }
+        let mut candidates: Vec<usize> = candidates
+            .difference(&affected_partitions)
+            .copied()
+            .collect();
+        candidates.sort_unstable();
+        let split_centroids =
+            arrow::compute::take(&new_centroids, &UInt32Array::from(new_partition_ids), None)?
+                .as_fixed_size_list()
+                .clone();
+        let kept = self
+            .prune_reassign_candidates(&candidates, &new_centroids, &split_centroids)
+            .await?;
         log::info!(
-            "split {} partitions, {} total affected partitions (including neighbors)",
-            actual_splits.len(),
-            affected_partitions.len(),
+            "split {} partitions into {} partitions; {} of {} neighbor partitions can lose rows to the new centroids and are reassigned, {} total affected partitions",
+            split_partitions.len(),
+            new_partition_ids_len(&split_partitions),
+            kept.len(),
+            candidates.len(),
+            affected_partitions.len() + kept.len(),
         );
+        affected_partitions.extend(kept);
 
         // Stream raw vectors for affected partitions through the IVF+quantizer
         // transform, writing to temp files via a second shuffler.
@@ -1995,50 +2099,99 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
             .reshuffle_partitions(&affected_partitions, &new_centroids)
             .await?;
 
-        Ok(SplitResult {
+        Ok(Some(SplitResult {
             new_centroids,
             affected_partitions,
             shuffle_reader: split_shuffle_reader.into(),
-        })
+        }))
+    }
+
+    /// Of the neighbor partitions of a split, keep those where a sampled row is
+    /// now closer to one of the new centroids than to its own centroid, within
+    /// `REASSIGN_MARGIN` (SPFresh's necessary condition for a row to move). The
+    /// others keep their rows and codes untouched, which is what saves the
+    /// raw-vector reads: most neighbors of a split cannot lose a row.
+    async fn prune_reassign_candidates(
+        &self,
+        candidates: &[usize],
+        centroids: &FixedSizeListArray,
+        split_centroids: &FixedSizeListArray,
+    ) -> Result<Vec<usize>> {
+        let checks = stream::iter(candidates.iter().copied())
+            .map(|candidate| async move {
+                let Some(sample) = self
+                    .sample_partition_raw_vectors(candidate, REASSIGN_SAMPLE_SIZE)
+                    .await?
+                else {
+                    return Ok::<_, Error>(None);
+                };
+                let dist_fn = self.distance_type.arrow_batch_func();
+                let own_centroid = centroids.slice(candidate, 1);
+                for i in 0..sample.len() {
+                    let vector = sample.value(i);
+                    let own_dist = dist_fn(&vector, &own_centroid)?.value(0);
+                    let new_dist = dist_fn(&vector, split_centroids)?
+                        .values()
+                        .iter()
+                        .copied()
+                        .fold(f32::INFINITY, f32::min);
+                    if new_dist < own_dist + REASSIGN_MARGIN * own_dist.abs() {
+                        return Ok(Some(candidate));
+                    }
+                }
+                Ok(None)
+            })
+            .buffered(get_num_compute_intensive_cpus())
+            .try_collect::<Vec<_>>()
+            .await?;
+        Ok(checks.into_iter().flatten().collect())
     }
 
     /// Train new centroids for partitions that need splitting.
-    /// Returns the full updated centroids array and the list of partition IDs
-    /// that were actually split (empty partitions are skipped).
+    ///
+    /// Returns the full updated centroids array and, for every partition that was
+    /// actually split (partitions without live rows are skipped), the ids of the
+    /// partitions its rows now belong to: the original id followed by the appended
+    /// ones.
     async fn compute_split_centroids<T: ArrowPrimitiveType>(
         &self,
-        split_partitions: &[usize],
+        splits: &[PartitionSplit],
         ivf: &IvfModel,
-    ) -> Result<(FixedSizeListArray, Vec<usize>)>
+    ) -> Result<(FixedSizeListArray, Vec<(usize, Vec<usize>)>)>
     where
         T::Native: Dot + L2 + Normalize,
         PrimitiveArray<T>: From<Vec<T::Native>>,
     {
         let centroids = ivf.centroids_array().unwrap();
 
-        // Train split centroids in parallel (low memory — only samples).
-        let trained_centroids = stream::iter(split_partitions.iter().copied())
-            .map(|part_idx| async move { self.train_split_centroids::<T>(part_idx).await })
+        // Train split centroids in parallel (low memory: only samples).
+        let trained_centroids = stream::iter(splits.iter().copied())
+            .map(|split| async move { self.train_split_centroids::<T>(split).await })
             .buffered(get_num_compute_intensive_cpus())
             .try_collect::<Vec<_>>()
             .await?;
 
-        let mut splits = Vec::new();
-        for (&part_idx, centroids_opt) in split_partitions.iter().zip(trained_centroids) {
-            let Some((centroid1, centroid2)) = centroids_opt else {
+        let mut applied = Vec::new();
+        let mut split_partitions = Vec::new();
+        let mut next_partition = centroids.len();
+        for (split, trained) in splits.iter().zip(trained_centroids) {
+            let Some(trained) = trained else {
                 continue;
             };
-            splits.push((part_idx, centroid1, centroid2));
+            let appended = next_partition..next_partition + trained.len() - 1;
+            next_partition = appended.end;
+            let mut partitions = vec![split.partition];
+            partitions.extend(appended);
+            split_partitions.push((split.partition, partitions));
+            applied.push((split.partition, trained));
         }
 
-        if splits.is_empty() {
+        if applied.is_empty() {
             return Ok((centroids.clone(), vec![]));
         }
 
-        let actual_splits: Vec<usize> = splits.iter().map(|(idx, _, _)| *idx).collect();
-        let new_centroids = apply_centroid_splits(centroids, &splits)?;
-
-        Ok((new_centroids, actual_splits))
+        let new_centroids = apply_centroid_splits(centroids, &applied)?;
+        Ok((new_centroids, split_partitions))
     }
 
     /// Stream raw vectors for the given partitions through the IVF+quantizer
@@ -2068,6 +2221,7 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
         let projection = Arc::new(dataset.schema().project(&[self.column.as_str()])?);
         let row_ids = dataset.filter_deleted_ids(&all_row_ids).await?;
         let block_size = self.store.block_size();
+        let io_parallelism = self.store.io_parallelism();
         let column = self.column.clone();
 
         let dataset_clone = dataset.clone();
@@ -2078,7 +2232,7 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
                 .map(|c| c.to_vec())
                 .collect::<Vec<_>>(),
         )
-        .then(move |chunk| {
+        .map(move |chunk| {
             let dataset = dataset_clone.clone();
             let projection = projection_clone.clone();
             let column = column.clone();
@@ -2092,6 +2246,7 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
                 Flatten::new(&column).transform(&batch)
             }
         })
+        .buffered(io_parallelism)
         .boxed();
 
         let transformer = Arc::new(
@@ -2168,10 +2323,15 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
             return Ok(None);
         }
 
-        // Sample row IDs with stride before loading any vectors
+        // Sample row ids before loading any vectors. Uniform rather than strided:
+        // row ids follow insertion order, so a stride would favour old rows.
+        // Seeded per partition so a rerun trains the same split.
         if row_ids.len() > sample_size {
-            let stride = row_ids.len() / sample_size;
-            row_ids = (0..sample_size).map(|i| row_ids[i * stride]).collect();
+            let mut rng = SmallRng::seed_from_u64(part_idx as u64);
+            let mut chosen =
+                rand::seq::index::sample(&mut rng, row_ids.len(), sample_size).into_vec();
+            chosen.sort_unstable();
+            row_ids = chosen.into_iter().map(|i| row_ids[i]).collect();
         }
 
         let batches = Self::take_vectors(dataset, &self.column, &self.store, &row_ids).await?;
@@ -2191,22 +2351,30 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
         Ok(Some(vectors))
     }
 
-    /// Train kmeans centroids for splitting a partition. This only needs a
-    /// small sample of vectors and is cheap enough to run in parallel.
+    /// Train the centroids that split one partition `split.ways` ways. Only a
+    /// sample of `SPLIT_SAMPLE_RATE` vectors per centroid is read, so this is
+    /// cheap enough to run in parallel.
+    ///
+    /// Returns `None` when the partition has no live rows, and fewer centroids
+    /// than requested when it has fewer distinct rows than that.
     async fn train_split_centroids<T: ArrowPrimitiveType>(
         &self,
-        part_idx: usize,
-    ) -> Result<Option<(ArrayRef, ArrayRef)>>
+        split: PartitionSplit,
+    ) -> Result<Option<Vec<ArrayRef>>>
     where
         T::Native: Dot + L2 + Normalize,
         PrimitiveArray<T>: From<Vec<T::Native>>,
     {
         let Some(vectors) = self
-            .sample_partition_raw_vectors(part_idx, SPLIT_SAMPLE_SIZE)
+            .sample_partition_raw_vectors(split.partition, SPLIT_SAMPLE_RATE * split.ways)
             .await?
         else {
             return Ok(None);
         };
+        let ways = split.ways.min(vectors.len());
+        if ways < 2 {
+            return Ok(None);
+        }
 
         let dimension = infer_vector_dim(vectors.data_type())?;
         let (normalized_dist_type, normalized_vectors) = match self.distance_type {
@@ -2216,150 +2384,167 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
             }
             _ => (self.distance_type, vectors),
         };
-        let params = KMeansParams::new(None, 50, 1, normalized_dist_type);
+        // Balanced like IVF training itself, so the pieces come out even.
+        let params = KMeansParams::new(None, 50, 1, normalized_dist_type).with_balance_factor(1.0);
         let kmeans = lance_index::vector::kmeans::train_kmeans::<T>(
             normalized_vectors.values().as_primitive::<T>(),
             params,
             dimension,
-            2,
-            256,
+            ways,
+            SPLIT_SAMPLE_RATE,
         )?;
 
-        let centroid1 = kmeans.centroids.slice(0, dimension);
-        let centroid2 = kmeans.centroids.slice(dimension, dimension);
-        Ok(Some((centroid1, centroid2)))
+        // A centroid no sampled row is nearest to would only produce an empty
+        // partition (near-duplicate rows collapse onto one centroid). Keep the
+        // centroids that attract rows, and leave the partition alone when fewer
+        // than two do: it cannot be split by clustering.
+        let (membership, _) = kmeans.compute_membership_and_distances(&normalized_vectors)?;
+        let mut attracts_rows = vec![false; ways];
+        for cluster in membership.into_iter().flatten() {
+            attracts_rows[cluster as usize] = true;
+        }
+        let centroids: Vec<ArrayRef> = (0..ways)
+            .filter(|&i| attracts_rows[i])
+            .map(|i| kmeans.centroids.slice(i * dimension, dimension))
+            .collect();
+        if centroids.len() < 2 {
+            log::warn!(
+                "partition {} is oversized but its sampled rows are too alike to split; leaving it as is",
+                split.partition
+            );
+            return Ok(None);
+        }
+        Ok(Some(centroids))
     }
 
-    // join the given partition:
-    // 1. delete the original parttion
-    // 2. reasign all vectors of the original partitions
-    async fn join_partition(&self, part_idx: usize, ivf: &IvfModel) -> Result<AssignResult> {
+    /// Join undersized partitions away in one pass: their centroids are removed
+    /// and every one of their vectors is reassigned to the nearest remaining
+    /// partition among the `REASSIGN_RANGE` nearest neighbors of its old centroid.
+    async fn join_partitions(&self, partitions: &[usize], ivf: &IvfModel) -> Result<JoinResult> {
+        let removed: HashSet<usize> = partitions.iter().copied().collect();
+        let kept_partitions: Vec<usize> = (0..ivf.num_partitions())
+            .filter(|partition| !removed.contains(partition))
+            .collect();
         let centroids = ivf.centroids_array().unwrap();
-        let mut new_centroids: Vec<ArrayRef> = Vec::with_capacity(ivf.num_partitions() - 1);
-        new_centroids.extend(centroids.iter().enumerate().filter_map(|(i, vec)| {
-            if i == part_idx {
-                None
-            } else {
-                Some(vec.unwrap())
-            }
-        }));
-        let new_centroids = new_centroids
-            .iter()
-            .map(|vec| vec.as_ref())
-            .collect::<Vec<_>>();
-        let new_centroids = arrow::compute::concat(&new_centroids)?;
-        let new_centroids =
-            FixedSizeListArray::try_new_from_values(new_centroids, centroids.value_length())?;
+        let kept_ids = UInt32Array::from(
+            kept_partitions
+                .iter()
+                .map(|partition| *partition as u32)
+                .collect::<Vec<_>>(),
+        );
+        let new_centroids = arrow::compute::take(centroids, &kept_ids, None)?
+            .as_fixed_size_list()
+            .clone();
 
-        // take the raw vectors from dataset
-        let Some((row_ids, vectors)) = self.load_partition_raw_vectors(part_idx).await? else {
-            return Ok(AssignResult {
-                assign_batches: vec![None; ivf.num_partitions() - 1],
-                new_centroids,
-            });
+        let Some(dataset) = self.dataset.as_ref() else {
+            return Err(Error::invalid_input(
+                "dataset not set before joining partitions",
+            ));
         };
-
-        match vectors.value_type() {
+        let (_, element_type) = get_vector_type(dataset.schema(), &self.column)?;
+        let assign_batches = match element_type {
             DataType::Float16 => {
-                self.join_partition_impl::<Float16Type>(
-                    part_idx,
+                self.join_partitions_impl::<Float16Type>(
+                    partitions,
+                    &kept_partitions,
                     ivf,
-                    &row_ids,
-                    &vectors,
-                    new_centroids,
+                    &new_centroids,
                 )
-                .await
+                .await?
             }
             DataType::Float32 => {
-                self.join_partition_impl::<Float32Type>(
-                    part_idx,
+                self.join_partitions_impl::<Float32Type>(
+                    partitions,
+                    &kept_partitions,
                     ivf,
-                    &row_ids,
-                    &vectors,
-                    new_centroids,
+                    &new_centroids,
                 )
-                .await
+                .await?
             }
             DataType::Float64 => {
-                self.join_partition_impl::<Float64Type>(
-                    part_idx,
+                self.join_partitions_impl::<Float64Type>(
+                    partitions,
+                    &kept_partitions,
                     ivf,
-                    &row_ids,
-                    &vectors,
-                    new_centroids,
+                    &new_centroids,
                 )
-                .await
+                .await?
             }
             DataType::UInt8 => {
-                self.join_partition_impl::<UInt8Type>(
-                    part_idx,
+                self.join_partitions_impl::<UInt8Type>(
+                    partitions,
+                    &kept_partitions,
                     ivf,
-                    &row_ids,
-                    &vectors,
-                    new_centroids,
+                    &new_centroids,
                 )
-                .await
+                .await?
             }
-            dt => Err(Error::invalid_input(format!(
-                "vectors must be float16, float32, float64 or uint8, but got {:?}",
-                dt
-            ))),
-        }
+            dt => {
+                return Err(Error::invalid_input(format!(
+                    "vectors must be float16, float32, float64 or uint8, but got {:?}",
+                    dt
+                )));
+            }
+        };
+
+        Ok(JoinResult {
+            assign_batches,
+            new_centroids,
+            kept_partitions,
+        })
     }
 
-    async fn join_partition_impl<T: ArrowPrimitiveType>(
+    async fn join_partitions_impl<T: ArrowPrimitiveType>(
         &self,
-        part_idx: usize,
+        partitions: &[usize],
+        kept_partitions: &[usize],
         ivf: &IvfModel,
-        row_ids: &UInt64Array,
-        vectors: &FixedSizeListArray,
-        new_centroids: FixedSizeListArray,
-    ) -> Result<AssignResult>
+        new_centroids: &FixedSizeListArray,
+    ) -> Result<Vec<Option<(RecordBatch, UInt64Array)>>>
     where
         T::Native: Dot + L2 + Normalize,
         PrimitiveArray<T>: From<Vec<T::Native>>,
     {
-        assert_eq!(row_ids.len(), vectors.len());
+        let removed: HashSet<usize> = partitions.iter().copied().collect();
+        // old partition id -> output partition id
+        let mut output_partition = vec![None; ivf.num_partitions()];
+        for (output, &old) in kept_partitions.iter().enumerate() {
+            output_partition[old] = Some(output);
+        }
 
-        // the original centroid
-        let c0 = ivf
-            .centroid(part_idx)
-            .ok_or(Error::invalid_input("original centroid not found"))?;
-
-        // get top REASSIGN_RANGE centroids from c0
-        let (reassign_part_ids, reassign_part_centroids) =
-            self.select_reassign_candidates(ivf, part_idx, &c0)?;
-
-        let new_part_id = |idx: usize| -> usize {
-            if idx < part_idx {
-                idx
-            } else {
-                // part_idx has been deleted, so any part id after it should be decremented by 1
-                idx - 1
-            }
-        };
-        let mut assign_ops = vec![Vec::new(); ivf.num_partitions() - 1];
-        // reassign the vectors in the original partition
-        for (i, &row_id) in row_ids.values().iter().enumerate() {
-            let ReassignPartition::ReassignCandidate(idx) = self.reassign_vectors(
-                vectors.value(i).as_primitive::<T>(),
-                None,
-                &reassign_part_ids,
-                &reassign_part_centroids,
-            )?
-            else {
-                log::warn!("this is a bug, the vector is not reassigned");
+        let mut assign_ops = vec![Vec::new(); kept_partitions.len()];
+        for &part_idx in partitions {
+            let Some((row_ids, vectors)) = self.load_partition_raw_vectors(part_idx).await? else {
                 continue;
             };
+            assert_eq!(row_ids.len(), vectors.len());
+            let c0 = ivf
+                .centroid(part_idx)
+                .ok_or(Error::invalid_input("original centroid not found"))?;
+            let (reassign_part_ids, reassign_part_centroids) =
+                self.select_reassign_candidates(ivf, part_idx, &c0, &removed)?;
 
-            assign_ops[new_part_id(idx as usize)].push(AssignOp::Add((row_id, vectors.value(i))));
+            for (i, &row_id) in row_ids.values().iter().enumerate() {
+                let ReassignPartition::ReassignCandidate(target) = self.reassign_vectors(
+                    vectors.value(i).as_primitive::<T>(),
+                    None,
+                    &reassign_part_ids,
+                    &reassign_part_centroids,
+                )?
+                else {
+                    log::warn!("this is a bug, the vector is not reassigned");
+                    continue;
+                };
+                let output = output_partition[target as usize].ok_or_else(|| {
+                    Error::internal(format!(
+                        "partition {target} is being joined away but was selected to receive vectors of partition {part_idx}"
+                    ))
+                })?;
+                assign_ops[output].push(AssignOp::Add((row_id, vectors.value(i))));
+            }
         }
-        let assign_batches = self.build_assign_batch::<T>(&new_centroids, &assign_ops)?;
 
-        Ok(AssignResult {
-            assign_batches,
-            new_centroids,
-        })
+        self.build_assign_batch::<T>(new_centroids, &assign_ops)
     }
 
     // Build the assign batch form assign ops for each partition
@@ -2511,8 +2696,9 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
         ivf: &IvfModel,
         part_idx: usize,
         c0: &ArrayRef,
+        excluded: &HashSet<usize>,
     ) -> Result<(UInt32Array, FixedSizeListArray)> {
-        select_reassign_candidates_impl(self.distance_type, ivf, part_idx, c0)
+        select_reassign_candidates_impl(self.distance_type, ivf, part_idx, c0, excluded)
     }
     // assign a vector to the closest partition among:
     // 1. the 2 new centroids
@@ -2570,24 +2756,27 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
     }
 }
 
+/// The nearest `REASSIGN_RANGE` partitions to `c0`, skipping `part_idx` itself and
+/// every partition in `excluded` (partitions being joined away cannot receive
+/// vectors). Non-empty whenever a partition outside `excluded` exists.
 fn select_reassign_candidates_impl(
     distance_type: DistanceType,
     ivf: &IvfModel,
     part_idx: usize,
     c0: &ArrayRef,
+    excluded: &HashSet<usize>,
 ) -> Result<(UInt32Array, FixedSizeListArray)> {
-    let reassign_range = std::cmp::min(REASSIGN_RANGE + 1, ivf.num_partitions());
     let centroids = ivf.centroids_array().unwrap();
-    let centroid_dists = distance_type.arrow_batch_func()(&c0, centroids)?;
-    let reassign_range_candidates =
-        sort_to_indices(centroid_dists.as_ref(), None, Some(reassign_range))?;
-    let selection_len = reassign_range.saturating_sub(1);
-    let filtered_ids = reassign_range_candidates
+    let centroid_dists = distance_type.arrow_batch_func()(c0, centroids)?;
+    // Fetch enough neighbors that the exclusions cannot empty the candidate set.
+    let fetch = (REASSIGN_RANGE + excluded.len() + 1).min(ivf.num_partitions());
+    let nearest = sort_to_indices(centroid_dists.as_ref(), None, Some(fetch))?;
+    let filtered_ids = nearest
         .values()
         .iter()
         .copied()
-        .filter(|&idx| idx as usize != part_idx)
-        .take(selection_len)
+        .filter(|&idx| idx as usize != part_idx && !excluded.contains(&(idx as usize)))
+        .take(REASSIGN_RANGE)
         .collect::<Vec<_>>();
     let reassign_candidate_ids = UInt32Array::from(filtered_ids);
     let reassign_candidate_centroids =
@@ -2598,9 +2787,11 @@ fn select_reassign_candidates_impl(
     ))
 }
 
-struct AssignResult {
+struct JoinResult {
     assign_batches: Vec<Option<(RecordBatch, UInt64Array)>>,
     new_centroids: FixedSizeListArray,
+    /// Old ids of the partitions that survive, in output order.
+    kept_partitions: Vec<usize>,
 }
 
 struct SplitResult {
@@ -2623,13 +2814,15 @@ enum ReassignPartition {
 
 enum PartitionAdjustment {
     /// Split partitions. Carries the set of all affected partitions (split
-    /// targets + neighbors) and a shuffle reader with re-quantized data.
+    /// targets, the partitions appended for them and their neighbors) and a
+    /// shuffle reader with re-quantized data.
     Split {
         affected_partitions: HashSet<usize>,
         split_shuffle_reader: Arc<dyn ShuffleReader>,
     },
-    /// Join partition at given id
-    Join(usize),
+    /// Join partitions away; `kept_partitions[i]` is the old id of output
+    /// partition `i`.
+    Join { kept_partitions: Vec<usize> },
 }
 
 impl std::fmt::Debug for PartitionAdjustment {
@@ -2642,7 +2835,10 @@ impl std::fmt::Debug for PartitionAdjustment {
                 .debug_struct("Split")
                 .field("affected_partitions", affected_partitions)
                 .finish(),
-            Self::Join(id) => f.debug_tuple("Join").field(id).finish(),
+            Self::Join { kept_partitions } => f
+                .debug_struct("Join")
+                .field("kept_partitions", &kept_partitions.len())
+                .finish(),
         }
     }
 }
@@ -2944,22 +3140,28 @@ mod tests {
 
         let c1_for_1: ArrayRef = Arc::new(Float32Array::from(vec![1.1_f32, 1.1]));
         let c2_for_1: ArrayRef = Arc::new(Float32Array::from(vec![0.9_f32, 0.9]));
+        let c3_for_1: ArrayRef = Arc::new(Float32Array::from(vec![1.2_f32, 1.2]));
         let c1_for_3: ArrayRef = Arc::new(Float32Array::from(vec![3.1_f32, 3.1]));
         let c2_for_3: ArrayRef = Arc::new(Float32Array::from(vec![2.9_f32, 2.9]));
 
-        let splits = vec![(1_usize, c1_for_1, c2_for_1), (3_usize, c1_for_3, c2_for_3)];
+        // Partition 1 splits three ways, partition 3 two ways.
+        let splits = vec![
+            (1_usize, vec![c1_for_1, c2_for_1, c3_for_1]),
+            (3_usize, vec![c1_for_3, c2_for_3]),
+        ];
         let result = apply_centroid_splits(&original, &splits).unwrap();
 
-        assert_eq!(result.len(), 6);
+        assert_eq!(result.len(), 7);
         // Unchanged partitions
         assert_eq!(centroid_values(&result, 0), [0.0, 0.0]);
         assert_eq!(centroid_values(&result, 2), [2.0, 2.0]);
-        // Replaced centroids (centroid1 for each split partition)
+        // Replaced centroids (first new centroid of each split partition)
         assert_eq!(centroid_values(&result, 1), [1.1, 1.1]);
         assert_eq!(centroid_values(&result, 3), [3.1, 3.1]);
-        // Appended centroid2s, in split order
+        // Appended centroids, in split order
         assert_eq!(centroid_values(&result, 4), [0.9, 0.9]);
-        assert_eq!(centroid_values(&result, 5), [2.9, 2.9]);
+        assert_eq!(centroid_values(&result, 5), [1.2, 1.2]);
+        assert_eq!(centroid_values(&result, 6), [2.9, 2.9]);
     }
 
     #[test]
@@ -2974,7 +3176,8 @@ mod tests {
 
         let c0 = ivf.centroid(1).unwrap();
         let (reassign_ids, reassign_centroids) =
-            select_reassign_candidates_impl(DistanceType::L2, &ivf, 1, &c0).unwrap();
+            select_reassign_candidates_impl(DistanceType::L2, &ivf, 1, &c0, &HashSet::new())
+                .unwrap();
 
         assert_eq!(reassign_ids.len(), 1);
         assert_eq!(reassign_ids.value(0), 0);
@@ -3079,15 +3282,301 @@ mod tests {
             .unwrap();
         let ivf = optimized.ivf_model();
 
+        // 18k rows split ceil(18_000 / 4096) = 5 ways: 2 original + 4 new.
         assert_eq!(
             ivf.num_partitions(),
-            3,
-            "expected one split: 2 original + 1 new = 3 partitions",
+            6,
+            "expected one 5-way split: 2 original + 4 new = 6 partitions",
         );
         let total_rows: usize = (0..ivf.num_partitions())
             .map(|p| optimized.partition_size(p))
             .sum();
         assert_eq!(total_rows, 19_500, "all vectors preserved across split");
+    }
+
+    /// Rows of the vector column of the `k` nearest rows to `[center; 4]`,
+    /// probing one partition, so a wrongly placed row shows up as a miss.
+    async fn nearest_first_components(dataset: &crate::Dataset, center: f32, k: usize) -> Vec<f32> {
+        let query = Float32Array::from(vec![center; 4]);
+        let batch = dataset
+            .scan()
+            .nearest("vec", &query, k)
+            .unwrap()
+            .minimum_nprobes(1)
+            .try_into_batch()
+            .await
+            .unwrap();
+        let vectors = batch["vec"].as_fixed_size_list();
+        (0..vectors.len())
+            .map(|i| vectors.value(i).as_primitive::<Float32Type>().value(0))
+            .collect()
+    }
+
+    fn cluster_batch(
+        schema: &Arc<arrow_schema::Schema>,
+        num_rows: usize,
+        center: f32,
+    ) -> RecordBatch {
+        // Tiny per-row perturbation gives kmeans something to fit while keeping
+        // within-cluster variance negligible relative to the 1000-unit cluster
+        // separation.
+        let mut values = Vec::with_capacity(num_rows * 4);
+        for i in 0..num_rows {
+            let p = center + (i as f32) * 0.0001;
+            values.extend_from_slice(&[p, p, p, p]);
+        }
+        let fsl = FixedSizeListArray::try_new_from_values(Float32Array::from(values), 4).unwrap();
+        RecordBatch::try_new(schema.clone(), vec![Arc::new(fsl)]).unwrap()
+    }
+
+    fn cluster_schema() -> Arc<arrow_schema::Schema> {
+        let item_field = Arc::new(Field::new("item", DataType::Float32, true));
+        Arc::new(arrow_schema::Schema::new(vec![Field::new(
+            "vec",
+            DataType::FixedSizeList(item_field, 4),
+            false,
+        )]))
+    }
+
+    async fn write_clusters(uri: &str, clusters: &[(usize, f32)]) -> crate::Dataset {
+        use arrow_array::RecordBatchIterator;
+        let schema = cluster_schema();
+        let batches = clusters
+            .iter()
+            .map(|(rows, center)| Ok(cluster_batch(&schema, *rows, *center)))
+            .collect::<Vec<_>>();
+        let reader = RecordBatchIterator::new(batches, schema);
+        crate::Dataset::write(reader, uri, None).await.unwrap()
+    }
+
+    async fn append_cluster(dataset: crate::Dataset, rows: usize, center: f32) -> crate::Dataset {
+        use crate::dataset::{InsertBuilder, WriteMode, WriteParams};
+        let batch = cluster_batch(&cluster_schema(), rows, center);
+        InsertBuilder::new(Arc::new(dataset))
+            .with_params(&WriteParams {
+                mode: WriteMode::Append,
+                ..Default::default()
+            })
+            .execute(vec![batch])
+            .await
+            .unwrap()
+    }
+
+    async fn open_single_segment(dataset: &crate::Dataset) -> Arc<dyn VectorIndex> {
+        use crate::index::{DatasetIndexExt, DatasetIndexInternalExt};
+        let indices = dataset.load_indices_by_name("idx").await.unwrap();
+        assert_eq!(
+            indices.len(),
+            1,
+            "expected the rebalance to merge into one segment"
+        );
+        dataset
+            .open_vector_index("vec", &indices[0].uuid, &NoOpMetricsCollector)
+            .await
+            .unwrap()
+    }
+
+    #[tokio::test]
+    async fn optimize_splits_oversized_partition_to_target_in_one_pass() {
+        use crate::index::DatasetIndexExt;
+        use crate::index::vector::VectorIndexParams;
+        use lance_index::optimize::OptimizeOptions;
+        use lance_linalg::distance::MetricType;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let uri = tmp.path().to_str().unwrap();
+        let mut dataset = write_clusters(uri, &[(15_000, 0.0), (1_500, 1000.0)]).await;
+        let params = VectorIndexParams::ivf_flat(2, MetricType::L2);
+        dataset
+            .create_index(
+                &["vec"],
+                IndexType::Vector,
+                Some("idx".into()),
+                &params,
+                false,
+            )
+            .await
+            .unwrap();
+
+        // 36k rows in partition 0: ceil(36_000 / 4096) = 9 pieces of the target
+        // size, produced by one optimize instead of one halving per call.
+        let mut dataset = append_cluster(dataset, 21_000, 0.0).await;
+        dataset
+            .optimize_indices(&OptimizeOptions::default())
+            .await
+            .unwrap();
+
+        let optimized = open_single_segment(&dataset).await;
+        let ivf = optimized.ivf_model();
+        assert_eq!(ivf.num_partitions(), 2 + 8, "one 9-way split");
+        let sizes: Vec<usize> = (0..ivf.num_partitions())
+            .map(|p| optimized.partition_size(p))
+            .collect();
+        assert_eq!(
+            sizes.iter().sum::<usize>(),
+            37_500,
+            "all vectors preserved across split"
+        );
+        let max_size = *sizes.iter().max().unwrap();
+        assert!(
+            max_size <= 4 * 4096,
+            "no partition may stay above the split threshold after one pass, got {max_size}"
+        );
+        // Every piece is findable through its own centroid.
+        let found = nearest_first_components(&dataset, 3.0, 5).await;
+        assert_eq!(found.len(), 5);
+        assert!(found.iter().all(|v| (0.0..=3.6).contains(v)), "{found:?}");
+    }
+
+    #[tokio::test]
+    async fn optimize_joins_all_undersized_partitions_in_one_pass() {
+        use crate::index::DatasetIndexExt;
+        use crate::index::vector::VectorIndexParams;
+        use lance_index::optimize::OptimizeOptions;
+        use lance_linalg::distance::MetricType;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let uri = tmp.path().to_str().unwrap();
+        // Three partitions under the join threshold (25% of 4096 = 1024 rows).
+        let mut dataset = write_clusters(
+            uri,
+            &[(2_000, 0.0), (100, 1000.0), (100, 2000.0), (100, 3000.0)],
+        )
+        .await;
+        let params = VectorIndexParams::ivf_flat(4, MetricType::L2);
+        dataset
+            .create_index(
+                &["vec"],
+                IndexType::Vector,
+                Some("idx".into()),
+                &params,
+                false,
+            )
+            .await
+            .unwrap();
+
+        let mut dataset = append_cluster(dataset, 10, 0.0).await;
+        dataset
+            .optimize_indices(&OptimizeOptions::default())
+            .await
+            .unwrap();
+
+        let optimized = open_single_segment(&dataset).await;
+        let ivf = optimized.ivf_model();
+        assert_eq!(
+            ivf.num_partitions(),
+            1,
+            "all three undersized partitions joined in one pass"
+        );
+        assert_eq!(optimized.partition_size(0), 2_310);
+        // Rows of a joined partition are still indexed.
+        let found = nearest_first_components(&dataset, 3000.0, 3).await;
+        assert!(
+            found.iter().all(|v| (3000.0..=3000.1).contains(v)),
+            "{found:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn optimize_steady_state_keeps_small_delta_partitions() {
+        use crate::index::DatasetIndexExt;
+        use crate::index::vector::VectorIndexParams;
+        use lance_index::optimize::OptimizeOptions;
+        use lance_linalg::distance::MetricType;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let uri = tmp.path().to_str().unwrap();
+        // Two partitions of 1_500 rows, above the join threshold (25% of 4096).
+        let mut dataset = write_clusters(uri, &[(1_500, 0.0), (1_500, 1000.0)]).await;
+        let params = VectorIndexParams::ivf_flat(2, MetricType::L2);
+        dataset
+            .create_index(
+                &["vec"],
+                IndexType::Vector,
+                Some("idx".into()),
+                &params,
+                false,
+            )
+            .await
+            .unwrap();
+
+        // A small append becomes a delta segment whose partitions hold ~100 rows.
+        let dataset = append_cluster(dataset, 100, 0.0).await;
+        let mut dataset = append_cluster(dataset, 100, 1000.0).await;
+        dataset
+            .optimize_indices(&OptimizeOptions::default())
+            .await
+            .unwrap();
+        let indices = dataset.load_indices_by_name("idx").await.unwrap();
+        assert_eq!(indices.len(), 2, "the append is a delta segment");
+
+        // Summed over both segments every partition is normal-sized, so a
+        // steady-state optimize must leave the delta's small partitions alone.
+        dataset
+            .optimize_indices(&OptimizeOptions::default())
+            .await
+            .unwrap();
+        let indices = dataset.load_indices_by_name("idx").await.unwrap();
+        assert_eq!(indices.len(), 2, "steady state is a no-op");
+        for index in &indices {
+            use crate::index::DatasetIndexInternalExt;
+            let opened = dataset
+                .open_vector_index("vec", &index.uuid, &NoOpMetricsCollector)
+                .await
+                .unwrap();
+            assert_eq!(
+                opened.ivf_model().num_partitions(),
+                2,
+                "no partition was joined away"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn optimize_split_threshold_honors_persisted_target_partition_size() {
+        use crate::index::DatasetIndexExt;
+        use crate::index::vector::{StageParams, VectorIndexParams};
+        use lance_index::optimize::OptimizeOptions;
+        use lance_linalg::distance::MetricType;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let uri = tmp.path().to_str().unwrap();
+        let mut dataset = write_clusters(uri, &[(5_000, 0.0), (500, 1000.0)]).await;
+        // 5_000 rows exceed 4 x 1024 but not 4 x 4096 (the IVF_FLAT default), so
+        // the split only happens when the recorded target is used.
+        let mut params = VectorIndexParams::ivf_flat(2, MetricType::L2);
+        let StageParams::Ivf(ivf_params) = &mut params.stages[0] else {
+            panic!("ivf_flat params start with the IVF stage");
+        };
+        ivf_params.target_partition_size = Some(1024);
+        dataset
+            .create_index(
+                &["vec"],
+                IndexType::Vector,
+                Some("idx".into()),
+                &params,
+                false,
+            )
+            .await
+            .unwrap();
+
+        let mut dataset = append_cluster(dataset, 10, 0.0).await;
+        dataset
+            .optimize_indices(&OptimizeOptions::default())
+            .await
+            .unwrap();
+
+        let optimized = open_single_segment(&dataset).await;
+        let ivf = optimized.ivf_model();
+        assert_eq!(
+            ivf.num_partitions(),
+            2 + 4,
+            "5_010 rows split ceil(5010 / 1024) = 5 ways"
+        );
+        let total: usize = (0..ivf.num_partitions())
+            .map(|p| optimized.partition_size(p))
+            .sum();
+        assert_eq!(total, 5_510);
     }
 
     #[tokio::test]

--- a/rust/lance/src/index/vector/builder.rs
+++ b/rust/lance/src/index/vector/builder.rs
@@ -1050,6 +1050,7 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
             let target_partition_size = self.effective_target_partition_size()?;
             let (splits, joins) = Self::check_partition_adjustment(
                 ivf,
+                self.distance_type,
                 reader.as_ref(),
                 &self.existing_indices,
                 target_partition_size,
@@ -1985,6 +1986,7 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
     /// See [`plan_partition_adjustment`] for the rules.
     fn check_partition_adjustment(
         ivf: &IvfModel,
+        distance_type: DistanceType,
         reader: &dyn ShuffleReader,
         existing_indices: &[ExistingIndex],
         target_partition_size: usize,
@@ -1998,11 +2000,13 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
             }
             partition_sizes.push(num_rows);
         }
-        Ok(plan_partition_adjustment(
+        plan_partition_adjustment(
+            ivf,
+            distance_type,
             &partition_sizes,
             target_partition_size,
             join_bytes_per_row,
-        ))
+        )
     }
 
     /// Split oversized partitions using a streaming approach.
@@ -2171,7 +2175,7 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
 
         // Train split centroids in parallel (low memory: only samples).
         let trained_centroids = stream::iter(splits.iter().copied())
-            .map(|split| async move { self.train_split_centroids::<T>(split).await })
+            .map(|split| async move { self.train_split_centroids::<T>(split, ivf).await })
             .buffered(get_num_compute_intensive_cpus())
             .try_collect::<Vec<_>>()
             .await?;
@@ -2365,6 +2369,7 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
     async fn train_split_centroids<T: ArrowPrimitiveType>(
         &self,
         split: PartitionSplit,
+        ivf: &IvfModel,
     ) -> Result<Option<Vec<ArrayRef>>>
     where
         T::Native: Dot + L2 + Normalize,
@@ -2420,14 +2425,43 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
             }
         };
 
-        // A centroid no sampled row is nearest to would only produce an empty
-        // partition (near-duplicate rows collapse onto one centroid). Keep the
-        // centroids that attract rows, and leave the partition alone when fewer
-        // than two do: it cannot be split by clustering.
-        let (membership, _) = kmeans.compute_membership_and_distances(&normalized_vectors)?;
+        // The split partition's rows are reassigned among every centroid, so a
+        // new centroid only fills a partition if some sampled row is nearer to
+        // it than to its siblings and to the old centroids around the partition
+        // (the `REASSIGN_RANGE` nearest, the only ones its rows can reach). The
+        // others would produce empty partitions: near-duplicate rows collapse
+        // onto one centroid, and rows that k-means saw but a neighbor already
+        // holds stay there. Keep the centroids that win rows, and leave the
+        // partition alone when fewer than two do: it cannot be split by
+        // clustering. Same assignment routine as the IVF transformer that
+        // places the rows, and an exact tie goes to the old centroid, so the
+        // check never keeps a centroid the transformer would leave empty.
+        let trained_centroids =
+            FixedSizeListArray::try_new_from_values(kmeans.centroids.clone(), dimension as i32)?;
+        let (membership, new_dists) = lance_index::vector::kmeans::compute_partitions_arrow_array(
+            &trained_centroids,
+            &normalized_vectors,
+            normalized_dist_type,
+        )?;
+        let c0 = ivf
+            .centroid(split.partition)
+            .ok_or(Error::invalid_input("original centroid not found"))?;
+        let (_, neighbor_centroids) =
+            self.select_reassign_candidates(ivf, split.partition, &c0, &HashSet::new())?;
+        let (_, old_dists) = lance_index::vector::kmeans::compute_partitions_arrow_array(
+            &neighbor_centroids,
+            &normalized_vectors,
+            normalized_dist_type,
+        )?;
         let mut attracts_rows = vec![false; ways];
-        for cluster in membership.into_iter().flatten() {
-            attracts_rows[cluster as usize] = true;
+        for ((cluster, new_dist), old_dist) in membership.into_iter().zip(new_dists).zip(old_dists)
+        {
+            let (Some(cluster), Some(new_dist)) = (cluster, new_dist) else {
+                continue;
+            };
+            if old_dist.is_none_or(|old_dist| new_dist < old_dist) {
+                attracts_rows[cluster as usize] = true;
+            }
         }
         let centroids: Vec<ArrayRef> = (0..ways)
             .filter(|&i| attracts_rows[i])
@@ -2807,64 +2841,134 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
     }
 }
 
-/// The nearest `REASSIGN_RANGE` partitions to `c0`, skipping `part_idx` itself and
-/// every partition in `excluded` (partitions being joined away cannot receive
-/// vectors). Non-empty whenever a partition outside `excluded` exists.
 /// Split every partition above `MAX_PARTITION_SIZE_FACTOR` times the target
 /// straight to the target size (`ceil(rows / target)` ways, capped at
 /// `MAX_SPLIT_WAYS`), so one pass leaves nothing above the threshold. Join away
 /// partitions below `MIN_PARTITION_SIZE_PERCENT` of the target, smallest first,
 /// within two limits:
 ///
-/// * Enough partitions stay for all rows to average the target size. Joined
-///   rows move to the nearest kept centroid, so joining every undersized
-///   partition into the largest one would rebuild the very oversized partition
-///   the split threshold exists to prevent.
+/// * A joined partition's rows go to the nearest surviving centroid, so each
+///   candidate is projected onto that destination and skipped when the
+///   destination would end up above the split threshold. Without that, many
+///   small partitions around one survivor would rebuild the very oversized
+///   partition the split threshold exists to prevent. A destination that is
+///   still undersized may be joined away in a later round, its received rows
+///   re-projected onto their new nearest survivor, so a handful of tiny
+///   partitions converges to one instead of stopping at pairs.
 /// * The joined rows fit in `JOIN_BYTES_BUDGET` at `join_bytes_per_row`, since
 ///   they stay in memory until the merge writes them out. The rest wait for
 ///   the next optimize.
 fn plan_partition_adjustment(
+    ivf: &IvfModel,
+    distance_type: DistanceType,
     partition_sizes: &[usize],
     target_partition_size: usize,
     join_bytes_per_row: usize,
-) -> (Vec<PartitionSplit>, Vec<usize>) {
+) -> Result<(Vec<PartitionSplit>, Vec<usize>)> {
     let split_threshold = MAX_PARTITION_SIZE_FACTOR * target_partition_size;
     let join_threshold = MIN_PARTITION_SIZE_PERCENT * target_partition_size / 100;
     let num_partitions = partition_sizes.len();
 
-    let mut splits = Vec::new();
-    let mut joins = Vec::new();
-    for (partition, &num_rows) in partition_sizes.iter().enumerate() {
-        if num_rows > split_threshold {
-            splits.push(PartitionSplit {
-                partition,
-                ways: num_rows
-                    .div_ceil(target_partition_size)
-                    .clamp(2, MAX_SPLIT_WAYS),
-            });
-        } else if num_partitions > 1 && num_rows < join_threshold {
-            joins.push((num_rows, partition));
-        }
+    let splits = partition_sizes
+        .iter()
+        .enumerate()
+        .filter(|&(_, &num_rows)| num_rows > split_threshold)
+        .map(|(partition, &num_rows)| PartitionSplit {
+            partition,
+            ways: num_rows
+                .div_ceil(target_partition_size)
+                .clamp(2, MAX_SPLIT_WAYS),
+        })
+        .collect();
+    if num_partitions < 2 {
+        return Ok((splits, Vec::new()));
     }
 
-    let total_rows: usize = partition_sizes.iter().sum();
-    let min_kept = total_rows.div_ceil(target_partition_size).max(1);
-    let max_joins = num_partitions.saturating_sub(min_kept);
-    joins.sort_unstable();
+    let centroids = ivf
+        .centroids_array()
+        .ok_or_else(|| Error::invalid_input("IVF model has no centroids to plan joins"))?;
+    let nearest_survivor = |partition: usize, removed: &[bool]| -> Result<Option<usize>> {
+        let c0 = ivf
+            .centroid(partition)
+            .ok_or(Error::invalid_input("original centroid not found"))?;
+        let dists = distance_type.arrow_batch_func()(&c0, centroids)?;
+        Ok(dists
+            .values()
+            .iter()
+            .enumerate()
+            .filter(|&(other, _)| other != partition && !removed[other])
+            .min_by(|(_, a), (_, b)| a.total_cmp(b))
+            .map(|(other, _)| other))
+    };
+
+    // Sizes once the joins so far are applied, and which joined partitions'
+    // rows each survivor is projected to hold.
+    let mut projected_sizes = partition_sizes.to_vec();
+    let mut contributors: Vec<Vec<usize>> = vec![Vec::new(); num_partitions];
+    let mut removed = vec![false; num_partitions];
     let mut joined_bytes = 0usize;
-    let joins = joins
-        .into_iter()
-        .take(max_joins)
-        .take_while(|(num_rows, _)| {
-            let first = joined_bytes == 0;
+    let mut joins = Vec::new();
+    'rounds: loop {
+        let mut candidates: Vec<(usize, usize)> = (0..num_partitions)
+            .filter(|&partition| !removed[partition] && projected_sizes[partition] < join_threshold)
+            .map(|partition| (projected_sizes[partition], partition))
+            .collect();
+        candidates.sort_unstable();
+        let mut progress = false;
+        for (_, partition) in candidates {
+            if projected_sizes[partition] >= join_threshold {
+                // Grew past the threshold from joins earlier in this round.
+                continue;
+            }
+            let num_rows = partition_sizes[partition];
+            if !joins.is_empty() && joined_bytes + num_rows * join_bytes_per_row > JOIN_BYTES_BUDGET
+            {
+                break 'rounds;
+            }
+            // Its own rows and those projected onto it each go to their nearest
+            // surviving centroid; every such destination must stay below the
+            // split threshold.
+            removed[partition] = true;
+            let mut moves = Vec::with_capacity(contributors[partition].len() + 1);
+            for &source in std::iter::once(&partition).chain(contributors[partition].iter()) {
+                match nearest_survivor(source, &removed)? {
+                    Some(destination) => moves.push((source, destination)),
+                    None => break,
+                }
+            }
+            let mut increments: HashMap<usize, usize> = HashMap::new();
+            for &(source, destination) in &moves {
+                *increments.entry(destination).or_default() += partition_sizes[source];
+            }
+            let fits = moves.len() == contributors[partition].len() + 1
+                && increments.iter().all(|(&destination, &rows)| {
+                    projected_sizes[destination] + rows <= split_threshold
+                });
+            if !fits {
+                removed[partition] = false;
+                continue;
+            }
+            for (source, destination) in moves {
+                projected_sizes[destination] += partition_sizes[source];
+                contributors[destination].push(source);
+            }
+            projected_sizes[partition] = 0;
+            contributors[partition].clear();
             joined_bytes += num_rows * join_bytes_per_row;
-            first || joined_bytes <= JOIN_BYTES_BUDGET
-        })
-        .map(|(_, partition)| partition)
-        .collect();
-    (splits, joins)
+            joins.push(partition);
+            progress = true;
+        }
+        if !progress {
+            break;
+        }
+    }
+    joins.sort_unstable();
+    Ok((splits, joins))
 }
 
+/// The nearest `REASSIGN_RANGE` partitions to `c0`, skipping `part_idx` itself and
+/// every partition in `excluded` (partitions being joined away cannot receive
+/// vectors). Non-empty whenever a partition outside `excluded` exists.
 fn select_reassign_candidates_impl(
     distance_type: DistanceType,
     ivf: &IvfModel,
@@ -3435,6 +3539,23 @@ mod tests {
         RecordBatch::try_new(schema.clone(), vec![Arc::new(fsl)]).unwrap()
     }
 
+    /// IVF_FLAT params with one fixed 4-d centroid `[c; 4]` per center, so the
+    /// partition layout does not depend on how k-means is seeded.
+    fn ivf_flat_at_centers(
+        centers: &[f32],
+        target_partition_size: Option<usize>,
+    ) -> crate::index::vector::VectorIndexParams {
+        use crate::index::vector::VectorIndexParams;
+        use lance_linalg::distance::MetricType;
+        let values: Vec<f32> = centers.iter().flat_map(|&c| [c; 4]).collect();
+        let centroids =
+            FixedSizeListArray::try_new_from_values(Float32Array::from(values), 4).unwrap();
+        let mut ivf_params =
+            IvfBuildParams::try_with_centroids(centers.len(), Arc::new(centroids)).unwrap();
+        ivf_params.target_partition_size = target_partition_size;
+        VectorIndexParams::with_ivf_flat_params(MetricType::L2, ivf_params)
+    }
+
     fn cluster_schema() -> Arc<arrow_schema::Schema> {
         let item_field = Arc::new(Field::new("item", DataType::Float32, true));
         Arc::new(arrow_schema::Schema::new(vec![Field::new(
@@ -3537,9 +3658,7 @@ mod tests {
     #[tokio::test]
     async fn optimize_joins_all_undersized_partitions_in_one_pass() {
         use crate::index::DatasetIndexExt;
-        use crate::index::vector::VectorIndexParams;
         use lance_index::optimize::OptimizeOptions;
-        use lance_linalg::distance::MetricType;
 
         let tmp = tempfile::tempdir().unwrap();
         let uri = tmp.path().to_str().unwrap();
@@ -3549,7 +3668,7 @@ mod tests {
             &[(2_000, 0.0), (100, 1000.0), (100, 2000.0), (100, 3000.0)],
         )
         .await;
-        let params = VectorIndexParams::ivf_flat(4, MetricType::L2);
+        let params = ivf_flat_at_centers(&[0.0, 1000.0, 2000.0, 3000.0], None);
         dataset
             .create_index(
                 &["vec"],
@@ -3569,12 +3688,14 @@ mod tests {
 
         let optimized = open_single_segment(&dataset).await;
         let ivf = optimized.ivf_model();
+        let sizes: Vec<usize> = (0..ivf.num_partitions())
+            .map(|p| optimized.partition_size(p))
+            .collect();
         assert_eq!(
-            ivf.num_partitions(),
-            1,
+            sizes,
+            vec![2_310],
             "all three undersized partitions joined in one pass"
         );
-        assert_eq!(optimized.partition_size(0), 2_310);
         // Rows of a joined partition are still indexed.
         let found = nearest_first_components(&dataset, 3000.0, 3).await;
         assert!(
@@ -3685,47 +3806,98 @@ mod tests {
         assert_eq!(total, 5_510);
     }
 
+    /// Partitions of `sizes` rows with one-dimensional centroids at `positions`.
+    fn ivf_on_a_line(positions: &[f32]) -> IvfModel {
+        let centroids =
+            FixedSizeListArray::try_new_from_values(Float32Array::from(positions.to_vec()), 1)
+                .unwrap();
+        IvfModel::new(centroids, None)
+    }
+
+    /// Where the rows of every joined partition land: the nearest centroid that
+    /// is not joined away, as `join_partitions` assigns them.
+    fn projected_sizes_after_joins(ivf: &IvfModel, sizes: &[usize], joins: &[usize]) -> Vec<usize> {
+        let excluded: HashSet<usize> = joins.iter().copied().collect();
+        let mut projected = sizes.to_vec();
+        for &partition in joins {
+            let c0 = ivf.centroid(partition).unwrap();
+            let (targets, _) =
+                select_reassign_candidates_impl(DistanceType::L2, ivf, partition, &c0, &excluded)
+                    .unwrap();
+            projected[targets.value(0) as usize] += sizes[partition];
+        }
+        projected
+    }
+
     #[test]
-    fn plan_partition_adjustment_keeps_enough_partitions_for_the_target() {
-        // Twenty partitions of 24 rows at target 100 are all under the join
-        // threshold (25 rows). Joined into one they would make 480 rows, above
-        // the split threshold of 400, so five of them stay.
-        let (splits, joins) = plan_partition_adjustment(&[24; 20], 100, 1);
+    fn plan_partition_adjustment_bounds_each_join_destination() {
+        // Forty partitions of 24 rows at target 100 are all under the join
+        // threshold (25 rows). Thirty centroids coincide next to a thirty-first,
+        // so joined naively they would all land on that one partition (744 rows,
+        // above the split threshold of 400).
+        let sizes = [24; 40];
+        let mut positions = vec![0.0_f32; 30];
+        positions.push(0.1);
+        positions.extend((1..10).map(|i| i as f32 * 1000.0));
+        let ivf = ivf_on_a_line(&positions);
+        let (splits, joins) =
+            plan_partition_adjustment(&ivf, DistanceType::L2, &sizes, 100, 1).unwrap();
         assert!(splits.is_empty());
-        assert_eq!(joins, (0..15).collect::<Vec<_>>());
+        assert!(joins.len() >= 20, "{joins:?}");
+        let projected = projected_sizes_after_joins(&ivf, &sizes, &joins);
+        assert!(
+            projected.iter().all(|&rows| rows <= 400),
+            "a join destination exceeds the split threshold: {projected:?}"
+        );
+    }
+
+    #[test]
+    fn plan_partition_adjustment_joins_all_undersized_partitions_but_one() {
+        // Four partitions of 66 rows at target 4096: each one's nearest centroid
+        // is another undersized partition, and they still end up as one.
+        let ivf = ivf_on_a_line(&[0.0, 1000.0, 2000.0, 3000.0]);
+        let (_, joins) =
+            plan_partition_adjustment(&ivf, DistanceType::L2, &[66; 4], 4096, 1).unwrap();
+        assert_eq!(joins.len(), 3, "{joins:?}");
     }
 
     #[test]
     fn plan_partition_adjustment_bounds_joined_bytes_per_pass() {
+        let ivf = ivf_on_a_line(&[0.0, 1000.0, 2000.0, 3000.0, 4000.0]);
         // Each 10-row partition costs 40% of the budget: two fit, the rest wait.
         let bytes_per_row = JOIN_BYTES_BUDGET / 25;
-        let (splits, joins) = plan_partition_adjustment(&[50, 10, 10, 10, 10], 100, bytes_per_row);
+        let (splits, joins) = plan_partition_adjustment(
+            &ivf,
+            DistanceType::L2,
+            &[50, 10, 10, 10, 10],
+            100,
+            bytes_per_row,
+        )
+        .unwrap();
         assert!(splits.is_empty());
-        assert_eq!(joins, vec![1, 2]);
+        assert_eq!(joins.len(), 2, "{joins:?}");
         // A single partition over the budget is still joined, or it never would be.
-        let (_, joins) = plan_partition_adjustment(&[50, 10], 100, JOIN_BYTES_BUDGET);
+        let ivf = ivf_on_a_line(&[0.0, 1000.0]);
+        let (_, joins) =
+            plan_partition_adjustment(&ivf, DistanceType::L2, &[50, 10], 100, JOIN_BYTES_BUDGET)
+                .unwrap();
         assert_eq!(joins, vec![1]);
     }
 
     #[tokio::test]
     async fn optimize_join_leaves_no_partition_above_the_split_threshold() {
         use crate::index::DatasetIndexExt;
-        use crate::index::vector::{StageParams, VectorIndexParams};
         use lance_index::optimize::OptimizeOptions;
-        use lance_linalg::distance::MetricType;
 
         let tmp = tempfile::tempdir().unwrap();
         let uri = tmp.path().to_str().unwrap();
         // Twenty clusters of 24 rows: at target 100 every partition is under
         // the join threshold (25 rows), while all of them together (480 rows)
         // are above the split threshold (400 rows).
-        let clusters: Vec<(usize, f32)> = (0..20).map(|i| (24, i as f32 * 1000.0)).collect();
+        let centers: Vec<f32> = (0..20).map(|i| i as f32 * 1000.0).collect();
+        let clusters: Vec<(usize, f32)> = centers.iter().map(|&c| (24, c)).collect();
         let mut dataset = write_clusters(uri, &clusters).await;
-        let mut params = VectorIndexParams::ivf_flat(20, MetricType::L2);
-        let StageParams::Ivf(ivf_params) = &mut params.stages[0] else {
-            panic!("ivf_flat params start with the IVF stage");
-        };
-        ivf_params.target_partition_size = Some(100);
+        let params = ivf_flat_at_centers(&centers, Some(100));
         dataset
             .create_index(
                 &["vec"],
@@ -3749,8 +3921,10 @@ mod tests {
             .map(|p| optimized.partition_size(p))
             .collect();
         assert_eq!(sizes.iter().sum::<usize>(), 481, "all rows preserved");
-        // 481 rows need at least five partitions to average the target size.
-        assert!(ivf.num_partitions() >= 5, "{sizes:?}");
+        assert!(
+            ivf.num_partitions() < 20,
+            "some partitions were joined: {sizes:?}"
+        );
         let max_size = *sizes.iter().max().unwrap();
         assert!(
             max_size <= 4 * 100,
@@ -3780,10 +3954,8 @@ mod tests {
     async fn optimize_splits_duplicate_heavy_partition_as_far_as_its_distinct_rows_allow() {
         use crate::dataset::{InsertBuilder, WriteMode, WriteParams};
         use crate::index::DatasetIndexExt;
-        use crate::index::vector::{StageParams, VectorIndexParams};
         use arrow_array::RecordBatchIterator;
         use lance_index::optimize::OptimizeOptions;
-        use lance_linalg::distance::MetricType;
 
         let tmp = tempfile::tempdir().unwrap();
         let uri = tmp.path().to_str().unwrap();
@@ -3798,11 +3970,9 @@ mod tests {
         ];
         let reader = RecordBatchIterator::new(batches, schema.clone());
         let mut dataset = crate::Dataset::write(reader, uri, None).await.unwrap();
-        let mut params = VectorIndexParams::ivf_flat(2, MetricType::L2);
-        let StageParams::Ivf(ivf_params) = &mut params.stages[0] else {
-            panic!("ivf_flat params start with the IVF stage");
-        };
-        ivf_params.target_partition_size = Some(4);
+        // Fixed centroids: k-means seeded with two identical duplicate rows would
+        // leave one partition empty, which is not what this test is about.
+        let params = ivf_flat_at_centers(&[2.0, 1000.0], Some(4));
         dataset
             .create_index(
                 &["vec"],

--- a/rust/lance/src/index/vector/builder.rs
+++ b/rust/lance/src/index/vector/builder.rs
@@ -50,7 +50,7 @@ use lance_index::vector::v3::shuffler::{
 };
 use lance_index::vector::v3::subindex::SubIndexType;
 use lance_index::vector::{LOSS_METADATA_KEY, PART_ID_COLUMN, PQ_CODE_COLUMN, VectorIndex};
-use lance_index::vector::{PART_ID_FIELD, ivf::storage::IvfModel};
+use lance_index::vector::{PART_ID_FIELD, ivf::IvfTransformer, ivf::storage::IvfModel};
 use lance_index::{
     INDEX_AUXILIARY_FILE_NAME, INDEX_FILE_NAME, pb,
     vector::{
@@ -112,6 +112,10 @@ const REASSIGN_SAMPLE_SIZE: usize = 512;
 /// margin of its own centroid's distance, so near-ties do not prune a neighbor
 /// that unsampled rows would still leave.
 const REASSIGN_MARGIN: f32 = 0.05;
+/// Bytes of quantized rows one join pass may keep in memory until the merge
+/// writes them out. Undersized partitions that do not fit wait for the next
+/// optimize, so joining every one of them at once cannot exhaust memory.
+const JOIN_BYTES_BUDGET: usize = 512 * 1024 * 1024;
 
 /// Number of partitions the split partitions' rows now belong to.
 fn new_partition_ids_len(split_partitions: &[(usize, Vec<usize>)]) -> usize {
@@ -1049,6 +1053,7 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
                 reader.as_ref(),
                 &self.existing_indices,
                 target_partition_size,
+                self.join_bytes_per_row()?,
             )?;
             let split_result = if splits.is_empty() {
                 None
@@ -1952,52 +1957,52 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
         Ok(index_type.target_partition_size())
     }
 
-    /// Decide which partitions to split and which to join away.
-    ///
-    /// A partition above `MAX_PARTITION_SIZE_FACTOR` times the target is split
-    /// straight to the target size (`ceil(rows / target)` ways, capped at
-    /// `MAX_SPLIT_WAYS`), so one pass leaves nothing above the threshold. Every
-    /// partition below `MIN_PARTITION_SIZE_PERCENT` of the target is joined away,
-    /// except that the largest of them stays when all partitions are undersized.
+    /// Bytes one reassigned row occupies while a join runs: its row id, its
+    /// partition id and its code (the raw vector for a flat index).
+    fn join_bytes_per_row(&self) -> Result<usize> {
+        let Some(quantizer) = self.quantizer.as_ref() else {
+            return Err(Error::invalid_input(
+                "quantizer not set before planning partition joins",
+            ));
+        };
+        let code_bytes = match Q::quantization_type() {
+            QuantizationType::Flat => {
+                let Some(dataset) = self.dataset.as_ref() else {
+                    return Err(Error::invalid_input(
+                        "dataset not set before planning partition joins",
+                    ));
+                };
+                let (_, element_type) = get_vector_type(dataset.schema(), &self.column)?;
+                quantizer.code_dim() * element_type.primitive_width().unwrap_or(size_of::<f32>())
+            }
+            _ => quantizer.code_dim(),
+        };
+        Ok(code_bytes + size_of::<u64>() + size_of::<u32>())
+    }
+
+    /// Decide which partitions to split and which to join away, from the
+    /// partition sizes summed over the new rows and every existing segment.
+    /// See [`plan_partition_adjustment`] for the rules.
     fn check_partition_adjustment(
         ivf: &IvfModel,
         reader: &dyn ShuffleReader,
         existing_indices: &[ExistingIndex],
         target_partition_size: usize,
+        join_bytes_per_row: usize,
     ) -> Result<(Vec<PartitionSplit>, Vec<usize>)> {
-        let split_threshold = MAX_PARTITION_SIZE_FACTOR * target_partition_size;
-        let join_threshold = MIN_PARTITION_SIZE_PERCENT * target_partition_size / 100;
-
-        let mut splits = Vec::new();
-        let mut joins = Vec::new();
+        let mut partition_sizes = Vec::with_capacity(ivf.num_partitions());
         for partition in 0..ivf.num_partitions() {
             let mut num_rows = reader.partition_size(partition)?;
             for source in existing_indices.iter() {
                 num_rows += source.index.partition_size(partition);
             }
-            if num_rows > split_threshold {
-                splits.push(PartitionSplit {
-                    partition,
-                    ways: num_rows
-                        .div_ceil(target_partition_size)
-                        .clamp(2, MAX_SPLIT_WAYS),
-                });
-            } else if ivf.num_partitions() > 1 && num_rows < join_threshold {
-                joins.push((num_rows, partition));
-            }
+            partition_sizes.push(num_rows);
         }
-        if joins.len() == ivf.num_partitions() {
-            let largest = joins
-                .iter()
-                .enumerate()
-                .max_by_key(|(_, (num_rows, _))| *num_rows)
-                .map(|(i, _)| i)
-                .expect("joins is not empty");
-            joins.remove(largest);
-        }
-        let joins = joins.into_iter().map(|(_, partition)| partition).collect();
-
-        Ok((splits, joins))
+        Ok(plan_partition_adjustment(
+            &partition_sizes,
+            target_partition_size,
+            join_bytes_per_row,
+        ))
     }
 
     /// Split oversized partitions using a streaming approach.
@@ -2386,13 +2391,34 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
         };
         // Balanced like IVF training itself, so the pieces come out even.
         let params = KMeansParams::new(None, 50, 1, normalized_dist_type).with_balance_factor(1.0);
-        let kmeans = lance_index::vector::kmeans::train_kmeans::<T>(
-            normalized_vectors.values().as_primitive::<T>(),
-            params,
+        let values = normalized_vectors.values().as_primitive::<T>();
+        let kmeans = match lance_index::vector::kmeans::train_kmeans::<T>(
+            values,
+            params.clone(),
             dimension,
             ways,
             SPLIT_SAMPLE_RATE,
-        )?;
+        ) {
+            Ok(kmeans) => kmeans,
+            Err(err) => {
+                // Above 256 ways the trainer goes hierarchical, which refuses a
+                // sample with fewer distinct rows than pieces rather than return
+                // fewer centroids. Flat k-means leaves the surplus centroids
+                // empty instead, and those are dropped below, so the partition
+                // still splits as far as its distinct rows allow.
+                log::info!(
+                    "retrying the {ways}-way split of partition {} with flat k-means: {err}",
+                    split.partition
+                );
+                lance_index::vector::kmeans::train_kmeans::<T>(
+                    values,
+                    params.with_hierarchical_k(1),
+                    dimension,
+                    ways,
+                    SPLIT_SAMPLE_RATE,
+                )?
+            }
+        };
 
         // A centroid no sampled row is nearest to would only produce an empty
         // partition (near-duplicate rows collapse onto one centroid). Keep the
@@ -2420,6 +2446,8 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
     /// Join undersized partitions away in one pass: their centroids are removed
     /// and every one of their vectors is reassigned to the nearest remaining
     /// partition among the `REASSIGN_RANGE` nearest neighbors of its old centroid.
+    /// Partitions are loaded one at a time and their rows quantized right away,
+    /// so only one partition's raw vectors are in memory at once.
     async fn join_partitions(&self, partitions: &[usize], ivf: &IvfModel) -> Result<JoinResult> {
         let removed: HashSet<usize> = partitions.iter().copied().collect();
         let kept_partitions: Vec<usize> = (0..ivf.num_partitions())
@@ -2512,7 +2540,9 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
             output_partition[old] = Some(output);
         }
 
-        let mut assign_ops = vec![Vec::new(); kept_partitions.len()];
+        let (transformer, vector_field) = self.assign_transformer(new_centroids)?;
+
+        let mut assigned: Vec<Vec<RecordBatch>> = vec![Vec::new(); kept_partitions.len()];
         for &part_idx in partitions {
             let Some((row_ids, vectors)) = self.load_partition_raw_vectors(part_idx).await? else {
                 continue;
@@ -2524,6 +2554,7 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
             let (reassign_part_ids, reassign_part_centroids) =
                 self.select_reassign_candidates(ivf, part_idx, &c0, &removed)?;
 
+            let mut assign_ops = vec![Vec::new(); kept_partitions.len()];
             for (i, &row_id) in row_ids.values().iter().enumerate() {
                 let ReassignPartition::ReassignCandidate(target) = self.reassign_vectors(
                     vectors.value(i).as_primitive::<T>(),
@@ -2542,18 +2573,34 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
                 })?;
                 assign_ops[output].push(AssignOp::Add((row_id, vectors.value(i))));
             }
+            let batches = Self::build_assign_batch::<T>(&transformer, &vector_field, &assign_ops)?;
+            for (output, batch) in batches.into_iter().enumerate() {
+                if let Some(batch) = batch {
+                    assigned[output].push(batch);
+                }
+            }
         }
 
-        self.build_assign_batch::<T>(new_centroids, &assign_ops)
+        let empty_deleted = UInt64Array::from(Vec::<u64>::new());
+        assigned
+            .into_iter()
+            .map(|mut batches| {
+                let batch = match batches.len() {
+                    0 => return Ok(None),
+                    1 => batches.pop().unwrap(),
+                    _ => arrow::compute::concat_batches(&batches[0].schema(), &batches)?,
+                };
+                Ok(Some((batch, empty_deleted.clone())))
+            })
+            .collect()
     }
 
-    // Build the assign batch form assign ops for each partition
-    // returns the assign batch and the deleted row ids
-    fn build_assign_batch<T: ArrowPrimitiveType>(
+    /// The IVF + quantizer transform that turns reassigned rows into index rows
+    /// of `centroids`, with the vector field its input batches use.
+    fn assign_transformer(
         &self,
         centroids: &FixedSizeListArray,
-        assign_ops: &[Vec<AssignOp>],
-    ) -> Result<Vec<Option<(RecordBatch, UInt64Array)>>> {
+    ) -> Result<(IvfTransformer, Field)> {
         let Some(dataset) = self.dataset.as_ref() else {
             return Err(Error::invalid_input(
                 "dataset not set before building assign batch",
@@ -2581,22 +2628,29 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
             ));
         };
 
-        let transformer = Arc::new(
-            lance_index::vector::ivf::new_ivf_transformer_with_quantizer(
-                centroids.clone(),
-                self.distance_type,
-                vector_field.name().as_str(),
-                quantizer.into(),
-                None,
-            )?,
-        );
+        let transformer = lance_index::vector::ivf::new_ivf_transformer_with_quantizer(
+            centroids.clone(),
+            self.distance_type,
+            vector_field.name().as_str(),
+            quantizer.into(),
+            None,
+        )?;
+        Ok((transformer, vector_field))
+    }
 
+    /// Quantize the rows of `assign_ops` into one batch per output partition,
+    /// `None` where a partition receives no rows.
+    fn build_assign_batch<T: ArrowPrimitiveType>(
+        transformer: &IvfTransformer,
+        vector_field: &Field,
+        assign_ops: &[Vec<AssignOp>],
+    ) -> Result<Vec<Option<RecordBatch>>> {
+        let dimension = infer_vector_dim(vector_field.data_type())?;
         let num_rows: usize = assign_ops.iter().map(|ops| ops.len()).sum();
 
         // build the input batch with schema | row_id | vector | part_id |
         let mut row_ids_builder = UInt64Builder::with_capacity(num_rows);
-        let mut vector_builder =
-            PrimitiveBuilder::<T>::with_capacity(num_rows * centroids.value_length() as usize);
+        let mut vector_builder = PrimitiveBuilder::<T>::with_capacity(num_rows * dimension);
         let mut part_ids_builder = UInt32Builder::with_capacity(num_rows);
 
         let mut counts = Vec::with_capacity(assign_ops.len());
@@ -2610,14 +2664,12 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
         }
 
         let row_ids = row_ids_builder.finish();
-        let vector = FixedSizeListArray::try_new_from_values(
-            vector_builder.finish(),
-            centroids.value_length(),
-        )?;
+        let vector =
+            FixedSizeListArray::try_new_from_values(vector_builder.finish(), dimension as i32)?;
         let part_ids = part_ids_builder.finish();
         let schema = arrow_schema::Schema::new(vec![
             ROW_ID_FIELD.clone(),
-            vector_field,
+            vector_field.clone(),
             PART_ID_FIELD.clone(),
         ]);
         let batch = RecordBatch::try_new(
@@ -2626,14 +2678,13 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
         )?;
         let batch = transformer.transform(&batch)?;
 
-        let empty_deleted = UInt64Array::from(Vec::<u64>::new());
         let mut results = Vec::with_capacity(assign_ops.len());
         let mut offset = 0;
         for count in counts {
             if count == 0 {
                 results.push(None);
             } else {
-                results.push(Some((batch.slice(offset, count), empty_deleted.clone())));
+                results.push(Some(batch.slice(offset, count)));
                 offset += count;
             }
         }
@@ -2759,6 +2810,61 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
 /// The nearest `REASSIGN_RANGE` partitions to `c0`, skipping `part_idx` itself and
 /// every partition in `excluded` (partitions being joined away cannot receive
 /// vectors). Non-empty whenever a partition outside `excluded` exists.
+/// Split every partition above `MAX_PARTITION_SIZE_FACTOR` times the target
+/// straight to the target size (`ceil(rows / target)` ways, capped at
+/// `MAX_SPLIT_WAYS`), so one pass leaves nothing above the threshold. Join away
+/// partitions below `MIN_PARTITION_SIZE_PERCENT` of the target, smallest first,
+/// within two limits:
+///
+/// * Enough partitions stay for all rows to average the target size. Joined
+///   rows move to the nearest kept centroid, so joining every undersized
+///   partition into the largest one would rebuild the very oversized partition
+///   the split threshold exists to prevent.
+/// * The joined rows fit in `JOIN_BYTES_BUDGET` at `join_bytes_per_row`, since
+///   they stay in memory until the merge writes them out. The rest wait for
+///   the next optimize.
+fn plan_partition_adjustment(
+    partition_sizes: &[usize],
+    target_partition_size: usize,
+    join_bytes_per_row: usize,
+) -> (Vec<PartitionSplit>, Vec<usize>) {
+    let split_threshold = MAX_PARTITION_SIZE_FACTOR * target_partition_size;
+    let join_threshold = MIN_PARTITION_SIZE_PERCENT * target_partition_size / 100;
+    let num_partitions = partition_sizes.len();
+
+    let mut splits = Vec::new();
+    let mut joins = Vec::new();
+    for (partition, &num_rows) in partition_sizes.iter().enumerate() {
+        if num_rows > split_threshold {
+            splits.push(PartitionSplit {
+                partition,
+                ways: num_rows
+                    .div_ceil(target_partition_size)
+                    .clamp(2, MAX_SPLIT_WAYS),
+            });
+        } else if num_partitions > 1 && num_rows < join_threshold {
+            joins.push((num_rows, partition));
+        }
+    }
+
+    let total_rows: usize = partition_sizes.iter().sum();
+    let min_kept = total_rows.div_ceil(target_partition_size).max(1);
+    let max_joins = num_partitions.saturating_sub(min_kept);
+    joins.sort_unstable();
+    let mut joined_bytes = 0usize;
+    let joins = joins
+        .into_iter()
+        .take(max_joins)
+        .take_while(|(num_rows, _)| {
+            let first = joined_bytes == 0;
+            joined_bytes += num_rows * join_bytes_per_row;
+            first || joined_bytes <= JOIN_BYTES_BUDGET
+        })
+        .map(|(_, partition)| partition)
+        .collect();
+    (splits, joins)
+}
+
 fn select_reassign_candidates_impl(
     distance_type: DistanceType,
     ivf: &IvfModel,
@@ -3577,6 +3683,162 @@ mod tests {
             .map(|p| optimized.partition_size(p))
             .sum();
         assert_eq!(total, 5_510);
+    }
+
+    #[test]
+    fn plan_partition_adjustment_keeps_enough_partitions_for_the_target() {
+        // Twenty partitions of 24 rows at target 100 are all under the join
+        // threshold (25 rows). Joined into one they would make 480 rows, above
+        // the split threshold of 400, so five of them stay.
+        let (splits, joins) = plan_partition_adjustment(&[24; 20], 100, 1);
+        assert!(splits.is_empty());
+        assert_eq!(joins, (0..15).collect::<Vec<_>>());
+    }
+
+    #[test]
+    fn plan_partition_adjustment_bounds_joined_bytes_per_pass() {
+        // Each 10-row partition costs 40% of the budget: two fit, the rest wait.
+        let bytes_per_row = JOIN_BYTES_BUDGET / 25;
+        let (splits, joins) = plan_partition_adjustment(&[50, 10, 10, 10, 10], 100, bytes_per_row);
+        assert!(splits.is_empty());
+        assert_eq!(joins, vec![1, 2]);
+        // A single partition over the budget is still joined, or it never would be.
+        let (_, joins) = plan_partition_adjustment(&[50, 10], 100, JOIN_BYTES_BUDGET);
+        assert_eq!(joins, vec![1]);
+    }
+
+    #[tokio::test]
+    async fn optimize_join_leaves_no_partition_above_the_split_threshold() {
+        use crate::index::DatasetIndexExt;
+        use crate::index::vector::{StageParams, VectorIndexParams};
+        use lance_index::optimize::OptimizeOptions;
+        use lance_linalg::distance::MetricType;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let uri = tmp.path().to_str().unwrap();
+        // Twenty clusters of 24 rows: at target 100 every partition is under
+        // the join threshold (25 rows), while all of them together (480 rows)
+        // are above the split threshold (400 rows).
+        let clusters: Vec<(usize, f32)> = (0..20).map(|i| (24, i as f32 * 1000.0)).collect();
+        let mut dataset = write_clusters(uri, &clusters).await;
+        let mut params = VectorIndexParams::ivf_flat(20, MetricType::L2);
+        let StageParams::Ivf(ivf_params) = &mut params.stages[0] else {
+            panic!("ivf_flat params start with the IVF stage");
+        };
+        ivf_params.target_partition_size = Some(100);
+        dataset
+            .create_index(
+                &["vec"],
+                IndexType::Vector,
+                Some("idx".into()),
+                &params,
+                false,
+            )
+            .await
+            .unwrap();
+
+        let mut dataset = append_cluster(dataset, 1, 0.0).await;
+        dataset
+            .optimize_indices(&OptimizeOptions::default())
+            .await
+            .unwrap();
+
+        let optimized = open_single_segment(&dataset).await;
+        let ivf = optimized.ivf_model();
+        let sizes: Vec<usize> = (0..ivf.num_partitions())
+            .map(|p| optimized.partition_size(p))
+            .collect();
+        assert_eq!(sizes.iter().sum::<usize>(), 481, "all rows preserved");
+        // 481 rows need at least five partitions to average the target size.
+        assert!(ivf.num_partitions() >= 5, "{sizes:?}");
+        let max_size = *sizes.iter().max().unwrap();
+        assert!(
+            max_size <= 4 * 100,
+            "a join must not create a partition above the split threshold, got {sizes:?}"
+        );
+    }
+
+    /// `distinct` vectors, each repeated `repeats` times, at `center + i`.
+    fn duplicate_batch(
+        schema: &Arc<arrow_schema::Schema>,
+        distinct: usize,
+        repeats: usize,
+        center: f32,
+    ) -> RecordBatch {
+        let mut values = Vec::with_capacity(distinct * repeats * 4);
+        for i in 0..distinct {
+            let p = center + i as f32;
+            for _ in 0..repeats {
+                values.extend_from_slice(&[p, p, p, p]);
+            }
+        }
+        let fsl = FixedSizeListArray::try_new_from_values(Float32Array::from(values), 4).unwrap();
+        RecordBatch::try_new(schema.clone(), vec![Arc::new(fsl)]).unwrap()
+    }
+
+    #[tokio::test]
+    async fn optimize_splits_duplicate_heavy_partition_as_far_as_its_distinct_rows_allow() {
+        use crate::dataset::{InsertBuilder, WriteMode, WriteParams};
+        use crate::index::DatasetIndexExt;
+        use crate::index::vector::{StageParams, VectorIndexParams};
+        use arrow_array::RecordBatchIterator;
+        use lance_index::optimize::OptimizeOptions;
+        use lance_linalg::distance::MetricType;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let uri = tmp.path().to_str().unwrap();
+        // Five distinct vectors repeated 240 times each. At target 4 the
+        // partition asks for a ceil(1210 / 4) = 303-way split, which is more
+        // than 256 pieces and therefore trained hierarchically. The other
+        // partition stays under the split threshold of 16 rows.
+        let schema = cluster_schema();
+        let batches = vec![
+            Ok(duplicate_batch(&schema, 5, 240, 0.0)),
+            Ok(duplicate_batch(&schema, 1, 10, 1000.0)),
+        ];
+        let reader = RecordBatchIterator::new(batches, schema.clone());
+        let mut dataset = crate::Dataset::write(reader, uri, None).await.unwrap();
+        let mut params = VectorIndexParams::ivf_flat(2, MetricType::L2);
+        let StageParams::Ivf(ivf_params) = &mut params.stages[0] else {
+            panic!("ivf_flat params start with the IVF stage");
+        };
+        ivf_params.target_partition_size = Some(4);
+        dataset
+            .create_index(
+                &["vec"],
+                IndexType::Vector,
+                Some("idx".into()),
+                &params,
+                false,
+            )
+            .await
+            .unwrap();
+
+        let append = duplicate_batch(&schema, 1, 10, 0.0);
+        let mut dataset = InsertBuilder::new(Arc::new(dataset))
+            .with_params(&WriteParams {
+                mode: WriteMode::Append,
+                ..Default::default()
+            })
+            .execute(vec![append])
+            .await
+            .unwrap();
+        dataset
+            .optimize_indices(&OptimizeOptions::default())
+            .await
+            .unwrap();
+
+        let optimized = open_single_segment(&dataset).await;
+        let ivf = optimized.ivf_model();
+        let mut sizes: Vec<usize> = (0..ivf.num_partitions())
+            .map(|p| optimized.partition_size(p))
+            .collect();
+        // The five duplicate groups come apart, one partition each, even
+        // though 303 pieces were asked for.
+        sizes.sort_unstable();
+        assert_eq!(sizes, vec![10, 240, 240, 240, 240, 250]);
+        let found = nearest_first_components(&dataset, 3.0, 5).await;
+        assert!(found.iter().all(|v| *v == 3.0), "{found:?}");
     }
 
     #[tokio::test]

--- a/rust/lance/src/index/vector/builder.rs
+++ b/rust/lance/src/index/vector/builder.rs
@@ -19,7 +19,7 @@ use arrow_array::{
     RecordBatch, UInt32Array, UInt64Array,
 };
 use arrow_schema::{DataType, Field, Fields};
-use futures::{FutureExt, stream};
+use futures::{FutureExt, SinkExt, stream};
 use futures::{
     Stream,
     prelude::stream::{StreamExt, TryStreamExt},
@@ -115,13 +115,6 @@ const REASSIGN_SAMPLE_SIZE: usize = 512;
 /// margin of its own centroid's distance, so near-ties do not prune a neighbor
 /// that unsampled rows would still leave.
 const REASSIGN_MARGIN: f32 = 0.05;
-/// Bytes of quantized rows one join pass may keep in memory until the merge
-/// writes them out. The planner estimates it from the quantizer's output
-/// width to pick the join set, and the join measures what it actually retains
-/// and stops early when it is reached; undersized partitions that do not fit
-/// wait for the next optimize, so joining every one of them at once cannot
-/// exhaust memory.
-const JOIN_BYTES_BUDGET: usize = 512 * 1024 * 1024;
 
 /// Number of partitions the split partitions' rows now belong to.
 fn new_partition_ids_len(split_partitions: &[(usize, Vec<usize>)]) -> usize {
@@ -1040,14 +1033,10 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
                 [self.existing_indices.len().saturating_sub(num_to_merge)..]
                 .to_vec();
 
-            (
-                vec![None; ivf.num_partitions()],
-                Arc::new(indices_to_merge),
-                None,
-            )
+            (ivf.num_partitions(), Arc::new(indices_to_merge), None)
         };
 
-        let (assign_batches, merge_indices, partition_adjustment) = if num_indices_to_merge
+        let (num_partitions, merge_indices, partition_adjustment) = if num_indices_to_merge
             .is_some()
             || self.optimize_options.is_none()
         {
@@ -1064,7 +1053,6 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
                 reader.as_ref(),
                 &self.existing_indices,
                 target_partition_size,
-                self.join_bytes_per_row()?,
             )?;
             let split_result = if splits.is_empty() {
                 None
@@ -1087,7 +1075,7 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
                 };
                 ivf.centroids = Some(split_result.new_centroids);
                 (
-                    vec![None; ivf.num_partitions()],
+                    ivf.num_partitions(),
                     Arc::new(self.existing_indices.clone()),
                     Some(PartitionAdjustment::Split {
                         affected_partitions: split_result.affected_partitions,
@@ -1117,11 +1105,12 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
                 };
                 ivf.centroids = Some(results.new_centroids);
                 (
-                    results.assign_batches,
+                    results.kept_partitions.len(),
                     Arc::new(self.existing_indices.clone()),
                     Some(PartitionAdjustment::Join {
                         kept_partitions: results.kept_partitions,
                         reindexed_row_ids: results.reindexed_row_ids,
+                        join_shuffle_reader: results.join_shuffle_reader,
                     }),
                 )
             } else {
@@ -1142,7 +1131,6 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
             && self.existing_indices.is_empty()
             && partition_adjustment.is_none()
         {
-            let num_partitions = assign_batches.len();
             return Self::build_fresh_partitions_windowed(
                 reader,
                 num_partitions,
@@ -1155,119 +1143,111 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
             );
         }
         let partition_adjustment = Arc::new(partition_adjustment);
-        let build_iter =
-            assign_batches
-                .into_iter()
-                .enumerate()
-                .map(move |(partition, assign_batch)| {
-                    let output_partition_id = partition;
-                    let reader = reader.clone();
-                    let indices = merge_indices.clone();
-                    let distance_type = distance_type;
-                    let quantizer = quantizer.clone();
-                    let sub_index_params = sub_index_params.clone();
-                    let column = column.clone();
-                    let frag_reuse_index = frag_reuse_index.clone();
-                    let partition_adjustment = partition_adjustment.clone();
-                    async move {
-                        let (is_affected, split_reader) = match partition_adjustment.as_ref() {
-                            Some(PartitionAdjustment::Split {
-                                affected_partitions,
-                                split_shuffle_reader,
-                            }) => (
-                                affected_partitions.contains(&partition),
-                                Some(split_shuffle_reader.clone()),
-                            ),
-                            _ => (false, None),
-                        };
-                        let partition = match partition_adjustment.as_ref() {
-                            Some(PartitionAdjustment::Join {
-                                kept_partitions, ..
-                            }) => kept_partitions[partition],
-                            _ => partition,
-                        };
+        let build_iter = (0..num_partitions).map(move |partition| {
+            let output_partition_id = partition;
+            let reader = reader.clone();
+            let indices = merge_indices.clone();
+            let distance_type = distance_type;
+            let quantizer = quantizer.clone();
+            let sub_index_params = sub_index_params.clone();
+            let column = column.clone();
+            let frag_reuse_index = frag_reuse_index.clone();
+            let partition_adjustment = partition_adjustment.clone();
+            async move {
+                let (is_affected, split_reader) = match partition_adjustment.as_ref() {
+                    Some(PartitionAdjustment::Split {
+                        affected_partitions,
+                        split_shuffle_reader,
+                    }) => (
+                        affected_partitions.contains(&partition),
+                        Some(split_shuffle_reader.clone()),
+                    ),
+                    _ => (false, None),
+                };
+                let partition = match partition_adjustment.as_ref() {
+                    Some(PartitionAdjustment::Join {
+                        kept_partitions, ..
+                    }) => kept_partitions[partition],
+                    _ => partition,
+                };
 
-                        // For affected partitions, the split shuffle reader has
-                        // all data (existing + new), re-assigned with updated
-                        // centroids. For other partitions, read from existing
-                        // indices + original shuffle reader as normal.
-                        let (mut batches, mut loss) = if is_affected {
-                            Self::take_partition_batches(
-                                partition,
-                                &[],
-                                Some(split_reader.as_ref().unwrap().as_ref()),
-                            )
-                            .await?
-                        } else {
-                            Self::take_partition_batches(
-                                partition,
-                                indices.as_ref(),
-                                Some(reader.as_ref()),
-                            )
-                            .await?
-                        };
+                // For affected partitions, the split shuffle reader has
+                // all data (existing + new), re-assigned with updated
+                // centroids. For other partitions, read from existing
+                // indices + original shuffle reader as normal.
+                let (mut batches, mut loss) = if is_affected {
+                    Self::take_partition_batches(
+                        partition,
+                        &[],
+                        Some(split_reader.as_ref().unwrap().as_ref()),
+                    )
+                    .await?
+                } else {
+                    Self::take_partition_batches(partition, indices.as_ref(), Some(reader.as_ref()))
+                        .await?
+                };
 
-                        // For unaffected partitions during a split, vectors from
-                        // affected partitions may have been reassigned here.
-                        if !is_affected && let Some(sr) = split_reader.as_ref() {
-                            let (extra, extra_loss) =
-                                Self::take_partition_batches(partition, &[], Some(sr.as_ref()))
-                                    .await?;
-                            batches.extend(extra);
-                            loss += extra_loss;
+                // For unaffected partitions during a split, vectors from
+                // affected partitions may have been reassigned here.
+                if !is_affected && let Some(sr) = split_reader.as_ref() {
+                    let (extra, extra_loss) =
+                        Self::take_partition_batches(partition, &[], Some(sr.as_ref())).await?;
+                    batches.extend(extra);
+                    loss += extra_loss;
+                }
+                // A join reindexes whole logical rows: their old entries
+                // leave every partition, and their new ones come from the
+                // join shuffler.
+                if let Some(PartitionAdjustment::Join {
+                    reindexed_row_ids,
+                    join_shuffle_reader,
+                    ..
+                }) = partition_adjustment.as_ref()
+                {
+                    if !reindexed_row_ids.is_empty() {
+                        for batch in batches.iter_mut() {
+                            let row_ids = batch[ROW_ID].as_primitive::<UInt64Type>();
+                            let mask = BooleanArray::from_iter(row_ids.iter().map(|row_id| {
+                                row_id.map(|row_id| !reindexed_row_ids.contains(&row_id))
+                            }));
+                            *batch = arrow::compute::filter_record_batch(batch, &mask)?;
                         }
-
-                        spawn_cpu(move || {
-                            // A join reindexes whole logical rows: their old
-                            // entries leave every partition before the assign
-                            // batches add the new ones.
-                            if let Some(PartitionAdjustment::Join {
-                                reindexed_row_ids, ..
-                            }) = partition_adjustment.as_ref()
-                                && !reindexed_row_ids.is_empty()
-                            {
-                                for batch in batches.iter_mut() {
-                                    let row_ids = batch[ROW_ID].as_primitive::<UInt64Type>();
-                                    let mask =
-                                        BooleanArray::from_iter(row_ids.iter().map(|row_id| {
-                                            row_id
-                                                .map(|row_id| !reindexed_row_ids.contains(&row_id))
-                                        }));
-                                    *batch = arrow::compute::filter_record_batch(batch, &mask)?;
-                                }
-                            }
-                            if let Some(assign_batch) = assign_batch
-                                && assign_batch.num_rows() > 0
-                            {
-                                // Drop PART_ID column from assign_batch to match schema of existing batches
-                                let assign_batch = assign_batch.drop_column(PART_ID_COLUMN)?;
-                                batches.push(assign_batch);
-                            }
-
-                            let num_rows = batches.iter().map(|b| b.num_rows()).sum::<usize>();
-                            if num_rows == 0 {
-                                return Ok(Budgeted::untracked(PartitionBuildResult {
-                                    partition_id: output_partition_id,
-                                    built: None,
-                                }));
-                            }
-
-                            let (storage, sub_index) = Self::build_index(
-                                distance_type,
-                                quantizer,
-                                sub_index_params,
-                                batches,
-                                column,
-                                frag_reuse_index,
-                            )?;
-                            Ok(Budgeted::untracked(PartitionBuildResult {
-                                partition_id: output_partition_id,
-                                built: Some((storage, sub_index, loss)),
-                            }))
-                        })
-                        .await
                     }
-                });
+                    let (extra, extra_loss) = Self::take_partition_batches(
+                        partition,
+                        &[],
+                        Some(join_shuffle_reader.as_ref()),
+                    )
+                    .await?;
+                    batches.extend(extra);
+                    loss += extra_loss;
+                }
+
+                spawn_cpu(move || {
+                    let num_rows = batches.iter().map(|b| b.num_rows()).sum::<usize>();
+                    if num_rows == 0 {
+                        return Ok(Budgeted::untracked(PartitionBuildResult {
+                            partition_id: output_partition_id,
+                            built: None,
+                        }));
+                    }
+
+                    let (storage, sub_index) = Self::build_index(
+                        distance_type,
+                        quantizer,
+                        sub_index_params,
+                        batches,
+                        column,
+                        frag_reuse_index,
+                    )?;
+                    Ok(Budgeted::untracked(PartitionBuildResult {
+                        partition_id: output_partition_id,
+                        built: Some((storage, sub_index, loss)),
+                    }))
+                })
+                .await
+            }
+        });
         Ok(stream::iter(build_iter)
             .buffered(get_num_compute_intensive_cpus())
             .boxed())
@@ -1892,6 +1872,20 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
         store: &ObjectStore,
         row_ids: &[u64],
     ) -> Result<Vec<RecordBatch>> {
+        Self::take_vectors_stream(dataset, column, store, row_ids)
+            .await?
+            .try_collect()
+            .await
+    }
+
+    /// The raw vectors of `row_ids` in chunks of `store.block_size()` rows,
+    /// each batch with schema | row_id | vector |, loaded as they are read.
+    async fn take_vectors_stream(
+        dataset: &Dataset,
+        column: &str,
+        store: &ObjectStore,
+        row_ids: &[u64],
+    ) -> Result<impl Stream<Item = Result<RecordBatch>> + Send + 'static> {
         let projection = Arc::new(dataset.schema().project(&[column])?);
         // arrow uses i32 for index, so we chunk the row ids to avoid large batch causing overflow
         let row_ids = dataset.filter_deleted_ids(row_ids).await?;
@@ -1899,8 +1893,10 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
             .chunks(store.block_size())
             .map(|chunk| chunk.to_vec())
             .collect();
-        let batches = stream::iter(chunks)
-            .map(|chunk| {
+        let dataset = dataset.clone();
+        let io_parallelism = store.io_parallelism();
+        Ok(stream::iter(chunks)
+            .map(move |chunk| {
                 let dataset = dataset.clone();
                 let projection = projection.clone();
                 async move {
@@ -1920,31 +1916,16 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
                     )?)
                 }
             })
-            .buffered(store.io_parallelism())
-            .try_collect::<Vec<_>>()
-            .await?;
-        Ok(batches)
+            .buffered(io_parallelism))
     }
 
-    /// The raw vectors of the logical rows `row_ids`, flattened to one row id
-    /// per vector (a multivector row contributes every one of its vectors).
-    async fn load_raw_vectors(
+    /// A chunk of raw vectors flattened to one row id per vector (a multivector
+    /// row contributes every one of its vectors).
+    fn flatten_raw_vectors(
         &self,
-        row_ids: &[u64],
-    ) -> Result<Option<(UInt64Array, FixedSizeListArray)>> {
-        let Some(dataset) = self.dataset.as_ref() else {
-            return Err(Error::invalid_input(
-                "dataset not set before loading raw vectors",
-            ));
-        };
-        let batches = Self::take_vectors(dataset, &self.column, &self.store, row_ids).await?;
-        if batches.is_empty() {
-            return Ok(None);
-        }
-        let batch = arrow::compute::concat_batches(&batches[0].schema(), batches.iter())?;
-        // for multivector, we need to flatten the vectors
-        let batch = Flatten::new(&self.column).transform(&batch)?;
-        // need to retrieve the row ids from the batch because some rows may have been deleted
+        batch: &RecordBatch,
+    ) -> Result<(UInt64Array, FixedSizeListArray)> {
+        let batch = Flatten::new(&self.column).transform(batch)?;
         let row_ids = batch[ROW_ID].as_primitive::<UInt64Type>().clone();
         let vectors = batch
             .column_by_qualified_name(&self.column)
@@ -1955,7 +1936,7 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
             )))?
             .as_fixed_size_list()
             .clone();
-        Ok(Some((row_ids, vectors)))
+        Ok((row_ids, vectors))
     }
 
     /// Rows per partition that split and join thresholds are derived from: the
@@ -1970,21 +1951,6 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
         Ok(index_type.target_partition_size())
     }
 
-    /// Bytes one reindexed row occupies while a join runs: the quantizer's
-    /// output columns (its code and, for RaBitQ, the factor and extra-code
-    /// columns) plus the row id and the partition id.
-    fn join_bytes_per_row(&self) -> Result<usize> {
-        let Some(quantizer) = self.quantizer.as_ref() else {
-            return Err(Error::invalid_input(
-                "quantizer not set before planning partition joins",
-            ));
-        };
-        let fields: Vec<Field> = std::iter::once(quantizer.field())
-            .chain(quantizer.extra_fields())
-            .collect();
-        retained_bytes_per_row(&fields)
-    }
-
     /// Decide which partitions to split and which to join away, from the
     /// partition sizes summed over the new rows and every existing segment.
     /// See [`plan_partition_adjustment`] for the rules.
@@ -1994,7 +1960,6 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
         reader: &dyn ShuffleReader,
         existing_indices: &[ExistingIndex],
         target_partition_size: usize,
-        join_bytes_per_row: usize,
     ) -> Result<PartitionAdjustmentPlan> {
         let mut partition_sizes = Vec::with_capacity(ivf.num_partitions());
         for partition in 0..ivf.num_partitions() {
@@ -2004,13 +1969,8 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
             }
             partition_sizes.push(num_rows);
         }
-        let (splits, joins) = plan_partition_adjustment(
-            ivf,
-            distance_type,
-            &partition_sizes,
-            target_partition_size,
-            join_bytes_per_row,
-        )?;
+        let (splits, joins) =
+            plan_partition_adjustment(ivf, distance_type, &partition_sizes, target_partition_size)?;
         Ok(PartitionAdjustmentPlan {
             splits,
             joins,
@@ -2487,17 +2447,16 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
     }
 
     /// Join undersized partitions away in one pass. Every logical row with an
-    /// entry in a joined partition is reindexed once: all of its vectors go to
-    /// their nearest surviving partition with room below `split_threshold`
-    /// (given `partition_sizes`), the `REASSIGN_RANGE` nearest neighbors of
-    /// the old centroid first, and its old entries are dropped from every
-    /// partition through `reindexed_row_ids`. That conserves both the count
-    /// and the identity of a multivector row's vectors wherever they were.
-    /// Partitions are loaded one at a time and their rows quantized right
-    /// away, so only one partition's raw vectors are in memory at once, and
-    /// the pass stops joining once the quantized rows it retains reach
-    /// `JOIN_BYTES_BUDGET`; the remaining planned joins wait for the next
-    /// optimize.
+    /// entry in a joined partition is reindexed once: its old entries leave
+    /// every partition through `reindexed_row_ids`, and all of its vectors are
+    /// placed anew in their nearest surviving partition with room below
+    /// `split_threshold`, the `REASSIGN_RANGE` nearest neighbors of the old
+    /// centroid first. Room is counted on the survivors' sizes after those
+    /// entries are gone, so the bound holds wherever a multivector row's
+    /// vectors were. The reindexed rows are quantized for their chosen
+    /// partition (old numbering) and streamed to `join_shuffle_reader` chunk by
+    /// chunk, so memory does not grow with the number of joined partitions or
+    /// with the vectors a reindexed row has elsewhere.
     async fn join_partitions(
         &self,
         partitions: &[usize],
@@ -2510,48 +2469,22 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
                 "dataset not set before joining partitions",
             ));
         };
-        // Rows each partition can still take before it reaches the split threshold.
-        let mut room: Vec<usize> = partition_sizes
-            .iter()
-            .map(|&size| split_threshold.saturating_sub(size))
-            .collect();
-        let (_, element_type) = get_vector_type(dataset.schema(), &self.column)?;
-        let execution = match element_type {
-            DataType::Float16 => {
-                self.join_partitions_impl::<Float16Type>(partitions, ivf, &mut room)
-                    .await?
-            }
-            DataType::Float32 => {
-                self.join_partitions_impl::<Float32Type>(partitions, ivf, &mut room)
-                    .await?
-            }
-            DataType::Float64 => {
-                self.join_partitions_impl::<Float64Type>(partitions, ivf, &mut room)
-                    .await?
-            }
-            DataType::UInt8 => {
-                self.join_partitions_impl::<UInt8Type>(partitions, ivf, &mut room)
-                    .await?
-            }
-            dt => {
-                return Err(Error::invalid_input(format!(
-                    "vectors must be float16, float32, float64 or uint8, but got {:?}",
-                    dt
-                )));
-            }
-        };
-        if execution.joined.len() < partitions.len() {
-            log::info!(
-                "joined {} of {} planned partitions; the retained rows reached the {} byte budget",
-                execution.joined.len(),
-                partitions.len(),
-                JOIN_BYTES_BUDGET
-            );
-        }
 
-        let joined: HashSet<usize> = execution.joined.iter().copied().collect();
+        // The rows to reindex, each under the first joined partition holding it.
+        let mut reindexed_row_ids = HashSet::new();
+        let mut rows_per_partition = Vec::with_capacity(partitions.len());
+        for &partition in partitions {
+            let mut row_ids = self.partition_row_ids(partition).await?;
+            row_ids.sort_unstable();
+            row_ids.dedup();
+            row_ids.retain(|row_id| reindexed_row_ids.insert(*row_id));
+            rows_per_partition.push(row_ids);
+        }
+        let reindexed_row_ids = Arc::new(reindexed_row_ids);
+
+        let removed: HashSet<usize> = partitions.iter().copied().collect();
         let kept_partitions: Vec<usize> = (0..ivf.num_partitions())
-            .filter(|partition| !joined.contains(partition))
+            .filter(|partition| !removed.contains(partition))
             .collect();
         let centroids = ivf
             .centroids_array()
@@ -2562,111 +2495,196 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
         let new_centroids = arrow::compute::take(centroids, &kept_ids, None)?
             .as_fixed_size_list()
             .clone();
-        let mut assigned = execution.assigned;
-        let assign_batches = kept_partitions
-            .iter()
-            .map(|old| -> Result<Option<RecordBatch>> {
-                let Some(mut batches) = assigned.remove(old) else {
-                    return Ok(None);
-                };
-                Ok(Some(match batches.len() {
-                    1 => batches.pop().unwrap(),
-                    _ => arrow::compute::concat_batches(&batches[0].schema(), &batches)?,
-                }))
-            })
-            .collect::<Result<Vec<_>>>()?;
+
+        // Rows each survivor can still take below the split threshold once the
+        // reindexed rows' entries are gone. Only a multivector row has entries
+        // outside the joined partitions, so only then are the survivors read.
+        let column_type = dataset
+            .schema()
+            .field(&self.column)
+            .map(|field| field.data_type())
+            .ok_or_else(|| Error::invalid_input(format!("column {} not found", self.column)))?;
+        let multivector = matches!(column_type, DataType::List(_) | DataType::LargeList(_));
+        let mut room = vec![0usize; ivf.num_partitions()];
+        for &partition in &kept_partitions {
+            let mut load = partition_sizes[partition];
+            if multivector {
+                load -= self
+                    .partition_row_ids(partition)
+                    .await?
+                    .iter()
+                    .filter(|row_id| reindexed_row_ids.contains(row_id))
+                    .count();
+            }
+            room[partition] = split_threshold.saturating_sub(load);
+        }
+
+        let (_, element_type) = get_vector_type(dataset.schema(), &self.column)?;
+        let join_shuffle_reader = match element_type {
+            DataType::Float16 => {
+                self.join_partitions_impl::<Float16Type>(
+                    partitions,
+                    &rows_per_partition,
+                    ivf,
+                    &removed,
+                    &mut room,
+                )
+                .await?
+            }
+            DataType::Float32 => {
+                self.join_partitions_impl::<Float32Type>(
+                    partitions,
+                    &rows_per_partition,
+                    ivf,
+                    &removed,
+                    &mut room,
+                )
+                .await?
+            }
+            DataType::Float64 => {
+                self.join_partitions_impl::<Float64Type>(
+                    partitions,
+                    &rows_per_partition,
+                    ivf,
+                    &removed,
+                    &mut room,
+                )
+                .await?
+            }
+            DataType::UInt8 => {
+                self.join_partitions_impl::<UInt8Type>(
+                    partitions,
+                    &rows_per_partition,
+                    ivf,
+                    &removed,
+                    &mut room,
+                )
+                .await?
+            }
+            dt => {
+                return Err(Error::invalid_input(format!(
+                    "vectors must be float16, float32, float64 or uint8, but got {:?}",
+                    dt
+                )));
+            }
+        };
         Ok(JoinResult {
-            assign_batches,
             new_centroids,
             kept_partitions,
-            reindexed_row_ids: Arc::new(execution.reindexed_row_ids),
+            reindexed_row_ids,
+            join_shuffle_reader,
         })
     }
 
+    /// Route and quantize the rows of each joined partition chunk by chunk,
+    /// writing them through a shuffler keyed by old partition id.
     async fn join_partitions_impl<T: ArrowPrimitiveType>(
         &self,
         partitions: &[usize],
+        rows_per_partition: &[Vec<u64>],
         ivf: &IvfModel,
+        removed: &HashSet<usize>,
         room: &mut [usize],
-    ) -> Result<JoinExecution>
+    ) -> Result<Arc<dyn ShuffleReader>>
     where
         T::Native: Dot + L2 + Normalize,
         PrimitiveArray<T>: From<Vec<T::Native>>,
     {
-        // Rows go to partitions the plan keeps. If the budget stops the pass
-        // early the remaining planned partitions stay as well; they just
-        // receive nothing.
-        let removed: HashSet<usize> = partitions.iter().copied().collect();
+        let Some(dataset) = self.dataset.as_ref() else {
+            return Err(Error::invalid_input(
+                "dataset not set before joining partitions",
+            ));
+        };
         let old_centroids = ivf
             .centroids_array()
             .ok_or_else(|| Error::invalid_input("IVF model has no centroids"))?;
         let (transformer, vector_field) = self.assign_transformer(old_centroids)?;
 
-        let mut execution = JoinExecution::default();
-        let mut retained_bytes = 0usize;
-        for &part_idx in partitions {
-            if !execution.joined.is_empty() && retained_bytes >= JOIN_BYTES_BUDGET {
-                break;
-            }
-            let mut row_ids = self.partition_row_ids(part_idx).await?;
-            row_ids.sort_unstable();
-            row_ids.dedup();
-            // A row that straddles two joined partitions is reindexed by the first.
-            row_ids.retain(|row_id| !execution.reindexed_row_ids.contains(row_id));
-            execution.joined.push(part_idx);
-            execution.reindexed_row_ids.extend(row_ids.iter().copied());
-            let Some((row_ids, vectors)) = self.load_raw_vectors(&row_ids).await? else {
-                continue;
+        let num_partitions = ivf.num_partitions();
+        let shuffle_dir = self.temp_dir.clone().join("join_shuffle");
+        let shuffler = create_ivf_shuffler(
+            shuffle_dir.clone(),
+            num_partitions,
+            self.format_version,
+            None,
+        );
+        let store = Arc::new(self.store.clone());
+        let (mut sender, mut receiver) = futures::channel::mpsc::channel::<RecordBatch>(2);
+        let shuffle = async move {
+            let Some(first) = receiver.next().await else {
+                let empty: Box<dyn ShuffleReader> = Box::new(IvfShufflerReader::new(
+                    store,
+                    shuffle_dir,
+                    vec![0; num_partitions],
+                    0.0,
+                ));
+                return Ok(empty);
             };
-            assert_eq!(row_ids.len(), vectors.len());
-            let c0 = ivf
-                .centroid(part_idx)
-                .ok_or(Error::invalid_input("original centroid not found"))?;
-            let (window_ids, window_centroids) =
-                self.select_reassign_candidates(ivf, part_idx, &c0, &removed)?;
-
-            let mut assign_ops: BTreeMap<u32, Vec<AssignOp>> = BTreeMap::new();
-            let mut overflowed = 0usize;
-            for i in 0..row_ids.len() {
-                let (target, had_room) = choose_join_destination(
-                    self.distance_type,
-                    vectors.value(i).as_primitive::<T>(),
-                    &window_ids,
-                    &window_centroids,
-                    ivf,
-                    &removed,
-                    room,
-                )?;
-                if had_room {
-                    room[target as usize] -= 1;
-                } else {
-                    overflowed += 1;
+            let schema = first.schema();
+            let batches = stream::iter(std::iter::once(Ok(first))).chain(receiver.map(Ok));
+            shuffler
+                .shuffle(Box::new(RecordBatchStreamAdapter::new(schema, batches)))
+                .await
+        };
+        let route = async move {
+            for (&part_idx, row_ids) in partitions.iter().zip(rows_per_partition) {
+                if row_ids.is_empty() {
+                    continue;
                 }
-                assign_ops
-                    .entry(target)
-                    .or_default()
-                    .push(AssignOp::Add((row_ids.value(i), vectors.value(i))));
+                let c0 = ivf
+                    .centroid(part_idx)
+                    .ok_or(Error::invalid_input("original centroid not found"))?;
+                let (window_ids, window_centroids) =
+                    self.select_reassign_candidates(ivf, part_idx, &c0, removed)?;
+                let mut overflowed = 0usize;
+                let mut chunks =
+                    Self::take_vectors_stream(dataset, &self.column, &self.store, row_ids).await?;
+                while let Some(chunk) = chunks.try_next().await? {
+                    let (row_ids, vectors) = self.flatten_raw_vectors(&chunk)?;
+                    let mut assign_ops: BTreeMap<u32, Vec<AssignOp>> = BTreeMap::new();
+                    for i in 0..row_ids.len() {
+                        let (target, had_room) = choose_join_destination(
+                            self.distance_type,
+                            vectors.value(i).as_primitive::<T>(),
+                            &window_ids,
+                            &window_centroids,
+                            ivf,
+                            removed,
+                            room,
+                        )?;
+                        if had_room {
+                            room[target as usize] -= 1;
+                        } else {
+                            overflowed += 1;
+                        }
+                        assign_ops
+                            .entry(target)
+                            .or_default()
+                            .push(AssignOp::Add((row_ids.value(i), vectors.value(i))));
+                    }
+                    for (target, ops) in assign_ops {
+                        let batch = Self::build_assign_batch::<T>(
+                            &transformer,
+                            &vector_field,
+                            target,
+                            &ops,
+                        )?;
+                        sender.send(batch).await.map_err(|_| {
+                            Error::internal("the join shuffler stopped taking batches")
+                        })?;
+                    }
+                }
+                if overflowed > 0 {
+                    log::warn!(
+                        "{overflowed} rows of joined partition {part_idx} found no partition below the split threshold and went to the nearest full one"
+                    );
+                }
             }
-            if overflowed > 0 {
-                log::warn!(
-                    "{overflowed} rows of joined partition {part_idx} found no partition below the split threshold and went to the nearest full one"
-                );
-            }
-            // Quantize now, under the old centroid numbering (a code depends on
-            // the centroid, not on its index), so only this partition's raw
-            // vectors are in memory and the retained size is what it will be.
-            for (target, ops) in assign_ops {
-                let batch =
-                    Self::build_assign_batch::<T>(&transformer, &vector_field, target, &ops)?;
-                retained_bytes = retained_bytes.saturating_add(batch.get_array_memory_size());
-                execution
-                    .assigned
-                    .entry(target as usize)
-                    .or_default()
-                    .push(batch);
-            }
-        }
-        Ok(execution)
+            drop(sender);
+            Ok(())
+        };
+        let (reader, ()) = futures::try_join!(shuffle, route)?;
+        Ok(reader.into())
     }
 
     /// The IVF + quantizer transform that turns reassigned rows into index rows
@@ -2825,15 +2843,13 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
 ///   itself places every row in its nearest partition with room below the
 ///   threshold ([`choose_join_destination`]), and enough survivors are kept
 ///   for their room to hold every joined row.
-/// * The joined rows fit in `JOIN_BYTES_BUDGET` at `join_bytes_per_row`, since
-///   they stay in memory until the merge writes them out. The rest wait for
-///   the next optimize.
+/// * Enough partitions survive for their room below the threshold to hold
+///   every joined row.
 fn plan_partition_adjustment(
     ivf: &IvfModel,
     distance_type: DistanceType,
     partition_sizes: &[usize],
     target_partition_size: usize,
-    join_bytes_per_row: usize,
 ) -> Result<(Vec<PartitionSplit>, Vec<usize>)> {
     let split_threshold = MAX_PARTITION_SIZE_FACTOR * target_partition_size;
     let join_threshold = MIN_PARTITION_SIZE_PERCENT * target_partition_size / 100;
@@ -2861,7 +2877,6 @@ fn plan_partition_adjustment(
     let mut projected_sizes = partition_sizes.to_vec();
     let mut neighbors: Vec<Option<Vec<u32>>> = vec![None; num_partitions];
     let mut removed = vec![false; num_partitions];
-    let mut joined_bytes = 0usize;
     let mut joins = Vec::new();
     // Every join removes one partition's room below the threshold and adds its
     // rows to the rest, so the survivors can take every joined row only while
@@ -2880,11 +2895,7 @@ fn plan_partition_adjustment(
                 // Grew past the threshold from joins earlier in this round.
                 continue;
             }
-            let num_rows = partition_sizes[partition];
-            let row_bytes = num_rows.saturating_mul(join_bytes_per_row);
-            if joins.len() == max_joins
-                || (!joins.is_empty() && joined_bytes.saturating_add(row_bytes) > JOIN_BYTES_BUDGET)
-            {
+            if joins.len() == max_joins {
                 break 'rounds;
             }
             let Some(destination) = nearest_surviving_neighbor(
@@ -2903,7 +2914,6 @@ fn plan_partition_adjustment(
             projected_sizes[destination] += projected_sizes[partition];
             projected_sizes[partition] = 0;
             removed[partition] = true;
-            joined_bytes = joined_bytes.saturating_add(row_bytes);
             joins.push(partition);
             progress = true;
         }
@@ -3059,38 +3069,6 @@ fn select_reassign_candidates_impl(
     ))
 }
 
-/// What a join pass produced, in old partition ids.
-#[derive(Default)]
-struct JoinExecution {
-    /// Quantized rows per destination partition.
-    assigned: HashMap<usize, Vec<RecordBatch>>,
-    /// Partitions actually joined away, in plan order.
-    joined: Vec<usize>,
-    /// Logical rows whose vectors were all reindexed.
-    reindexed_row_ids: HashSet<u64>,
-}
-
-/// Bytes per row of an index batch with these quantizer output `fields`, plus
-/// the row id and the partition id.
-fn retained_bytes_per_row(fields: &[Field]) -> Result<usize> {
-    fn width(data_type: &DataType) -> Result<usize> {
-        match data_type {
-            DataType::FixedSizeList(inner, len) => {
-                Ok(width(inner.data_type())?.saturating_mul(usize::try_from(*len).unwrap_or(0)))
-            }
-            DataType::Boolean => Ok(1),
-            other => other.primitive_width().ok_or_else(|| {
-                Error::invalid_input(format!("cannot size a {other} column for the join budget"))
-            }),
-        }
-    }
-    fields
-        .iter()
-        .try_fold(size_of::<u64>() + size_of::<u32>(), |bytes, field| {
-            Ok(bytes.saturating_add(width(field.data_type())?))
-        })
-}
-
 /// What one optimize pass does to the partitions, from the sizes it saw.
 struct PartitionAdjustmentPlan {
     splits: Vec<PartitionSplit>,
@@ -3099,12 +3077,13 @@ struct PartitionAdjustmentPlan {
 }
 
 struct JoinResult {
-    assign_batches: Vec<Option<RecordBatch>>,
     new_centroids: FixedSizeListArray,
     /// Old ids of the partitions that survive, in output order.
     kept_partitions: Vec<usize>,
     /// Logical rows the join reindexed; their old entries leave every partition.
     reindexed_row_ids: Arc<HashSet<u64>>,
+    /// The reindexed rows, quantized, keyed by old partition id.
+    join_shuffle_reader: Arc<dyn ShuffleReader>,
 }
 
 struct SplitResult {
@@ -3127,11 +3106,13 @@ enum PartitionAdjustment {
         split_shuffle_reader: Arc<dyn ShuffleReader>,
     },
     /// Join partitions away; `kept_partitions[i]` is the old id of output
-    /// partition `i`, and every entry of a row in `reindexed_row_ids` is
-    /// dropped from the existing partitions before the assign batches are added.
+    /// partition `i`. Every entry of a row in `reindexed_row_ids` is dropped
+    /// from the existing partitions, and the rows' new entries come from
+    /// `join_shuffle_reader`, keyed by old partition id.
     Join {
         kept_partitions: Vec<usize>,
         reindexed_row_ids: Arc<HashSet<u64>>,
+        join_shuffle_reader: Arc<dyn ShuffleReader>,
     },
 }
 
@@ -3148,6 +3129,7 @@ impl std::fmt::Debug for PartitionAdjustment {
             Self::Join {
                 kept_partitions,
                 reindexed_row_ids,
+                ..
             } => f
                 .debug_struct("Join")
                 .field("kept_partitions", &kept_partitions.len())
@@ -3945,7 +3927,7 @@ mod tests {
         positions.extend((1..10).map(|i| i as f32 * 1000.0));
         let ivf = ivf_on_a_line(&positions);
         let (splits, joins) =
-            plan_partition_adjustment(&ivf, DistanceType::L2, &sizes, 100, 1).unwrap();
+            plan_partition_adjustment(&ivf, DistanceType::L2, &sizes, 100).unwrap();
         assert!(splits.is_empty());
         assert!(joins.len() >= 20, "{joins:?}");
         let projected = projected_sizes_after_joins(&ivf, &sizes, &joins);
@@ -3965,8 +3947,7 @@ mod tests {
         let ivf = ivf_on_a_line(&positions);
         let started = std::time::Instant::now();
         let (_, joins) =
-            plan_partition_adjustment(&ivf, DistanceType::L2, &[0; NUM_PARTITIONS], 4096, 1)
-                .unwrap();
+            plan_partition_adjustment(&ivf, DistanceType::L2, &[0; NUM_PARTITIONS], 4096).unwrap();
         let elapsed = started.elapsed();
         assert_eq!(joins.len(), NUM_PARTITIONS - 1);
         // Recomputing every distance at each step took about 8 s here; the
@@ -4033,7 +4014,7 @@ mod tests {
         let mut sizes = vec![24, 10, 376, 390];
         sizes.extend([400; 63]);
         let ivf = ivf_on_a_line(&positions);
-        let (_, joins) = plan_partition_adjustment(&ivf, DistanceType::L2, &sizes, 100, 1).unwrap();
+        let (_, joins) = plan_partition_adjustment(&ivf, DistanceType::L2, &sizes, 100).unwrap();
         assert_eq!(joins, vec![0, 1]);
         let actual = execute_joins_on_a_line(&ivf, &sizes, &[(0, 4.0), (1, 10.05)], 400);
         assert!(actual.iter().all(|&size| size <= 400), "{actual:?}");
@@ -4046,8 +4027,7 @@ mod tests {
         // need two survivors, so at most three may be joined even though each
         // one alone would fit next to its neighbor.
         let ivf = ivf_on_a_line(&[0.0, 1.0, 2.0, 3.0, 4.0]);
-        let (_, joins) =
-            plan_partition_adjustment(&ivf, DistanceType::L2, &[90; 5], 100, 1).unwrap();
+        let (_, joins) = plan_partition_adjustment(&ivf, DistanceType::L2, &[90; 5], 100).unwrap();
         assert!(joins.len() <= 3, "{joins:?}");
     }
 
@@ -4089,62 +4069,116 @@ mod tests {
         assert_eq!(sizes, vec![115, 400]);
     }
 
+    /// Rows of 4-d vectors, each row a list with one vector per given center,
+    /// nudged apart along the last dimension so no two rows are identical.
+    fn multivector_batch(rows: &[Vec<[f32; 4]>], first_id: usize) -> RecordBatch {
+        let mut values = Vec::new();
+        for (i, row) in rows.iter().enumerate() {
+            for center in row {
+                let mut vector = *center;
+                vector[3] += (first_id + i) as f32 * 0.0001;
+                values.extend_from_slice(&vector);
+            }
+        }
+        let vectors =
+            FixedSizeListArray::try_new_from_values(Float32Array::from(values), 4).unwrap();
+        let item_field = Arc::new(Field::new("item", vectors.data_type().clone(), true));
+        let offsets = arrow::buffer::OffsetBuffer::from_lengths(rows.iter().map(|row| row.len()));
+        let list = arrow_array::ListArray::new(item_field, offsets, Arc::new(vectors), None);
+        let schema = Arc::new(arrow_schema::Schema::new(vec![Field::new(
+            "vec",
+            list.data_type().clone(),
+            false,
+        )]));
+        RecordBatch::try_new(schema, vec![Arc::new(list)]).unwrap()
+    }
+
+    #[tokio::test]
+    async fn optimize_join_counts_room_after_the_reindexed_rows_leave() {
+        use crate::dataset::{InsertBuilder, WriteMode, WriteParams};
+        use crate::index::DatasetIndexExt;
+        use crate::index::vector::VectorIndexParams;
+        use arrow_array::RecordBatchIterator;
+        use lance_index::optimize::OptimizeOptions;
+        use lance_linalg::distance::MetricType;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let uri = tmp.path().to_str().unwrap();
+        const C0: [f32; 4] = [1.0, 0.0, 0.0, 0.0];
+        const C1: [f32; 4] = [0.0, 1.0, 0.0, 0.0];
+        const C2: [f32; 4] = [0.0, 0.0, 1.0, 0.0];
+        // Twenty rows with one vector at c0 and eighteen at c1 make up all but
+        // one of partition 1's 361 entries; 380 single-vector rows sit at c2.
+        // At target 100 partition 0 (20 entries) is joined away, which reindexes
+        // those twenty rows: their 360 entries leave partition 1 first, so all
+        // 380 of their vectors fit below the split threshold of 400, where the
+        // 39 rows of room partition 1 had before could not hold them.
+        let mut rows: Vec<Vec<[f32; 4]>> = (0..20)
+            .map(|_| {
+                std::iter::once(C0)
+                    .chain(std::iter::repeat_n(C1, 18))
+                    .collect()
+            })
+            .collect();
+        rows.extend((0..380).map(|_| vec![C2]));
+        let batch = multivector_batch(&rows, 0);
+        let reader = RecordBatchIterator::new(vec![Ok(batch.clone())], batch.schema());
+        let mut dataset = crate::Dataset::write(reader, uri, None).await.unwrap();
+        let centroids =
+            FixedSizeListArray::try_new_from_values(Float32Array::from([C0, C1, C2].concat()), 4)
+                .unwrap();
+        let mut ivf_params = IvfBuildParams::try_with_centroids(3, Arc::new(centroids)).unwrap();
+        ivf_params.target_partition_size = Some(100);
+        let params = VectorIndexParams::with_ivf_flat_params(MetricType::Cosine, ivf_params);
+        dataset
+            .create_index(
+                &["vec"],
+                IndexType::Vector,
+                Some("idx".into()),
+                &params,
+                false,
+            )
+            .await
+            .unwrap();
+
+        let append = multivector_batch(&[vec![C1]], rows.len());
+        let mut dataset = InsertBuilder::new(Arc::new(dataset))
+            .with_params(&WriteParams {
+                mode: WriteMode::Append,
+                ..Default::default()
+            })
+            .execute(vec![append])
+            .await
+            .unwrap();
+        dataset
+            .optimize_indices(&OptimizeOptions::default())
+            .await
+            .unwrap();
+
+        let optimized = open_single_segment(&dataset).await;
+        let ivf = optimized.ivf_model();
+        let sizes: Vec<usize> = (0..ivf.num_partitions())
+            .map(|p| optimized.partition_size(p))
+            .collect();
+        assert_eq!(ivf.num_partitions(), 2, "{sizes:?}");
+        assert_eq!(
+            sizes.iter().sum::<usize>(),
+            761,
+            "every vector indexed once"
+        );
+        assert!(
+            sizes.iter().all(|&rows| rows <= 400),
+            "a join destination exceeds the split threshold: {sizes:?}"
+        );
+    }
+
     #[test]
     fn plan_partition_adjustment_joins_all_undersized_partitions_but_one() {
         // Four partitions of 66 rows at target 4096: each one's nearest centroid
         // is another undersized partition, and they still end up as one.
         let ivf = ivf_on_a_line(&[0.0, 1000.0, 2000.0, 3000.0]);
-        let (_, joins) =
-            plan_partition_adjustment(&ivf, DistanceType::L2, &[66; 4], 4096, 1).unwrap();
+        let (_, joins) = plan_partition_adjustment(&ivf, DistanceType::L2, &[66; 4], 4096).unwrap();
         assert_eq!(joins.len(), 3, "{joins:?}");
-    }
-
-    #[test]
-    fn retained_bytes_per_row_counts_every_quantizer_column() {
-        // The columns RaBitQ emits for an 8-dimensional 5-bit index: one
-        // binary-code byte, five f32 factors and 32 extra-code bytes, plus the
-        // row id and the partition id.
-        let u8_list = |name: &str, len: i32| {
-            Field::new(
-                name,
-                DataType::FixedSizeList(Arc::new(Field::new("item", DataType::UInt8, true)), len),
-                true,
-            )
-        };
-        let f32_field = |name: &str| Field::new(name, DataType::Float32, true);
-        let fields = vec![
-            u8_list("code", 1),
-            f32_field("add"),
-            f32_field("scale"),
-            f32_field("error"),
-            u8_list("ex_code", 32),
-            f32_field("ex_add"),
-            f32_field("ex_scale"),
-        ];
-        assert_eq!(retained_bytes_per_row(&fields).unwrap(), 65);
-    }
-
-    #[test]
-    fn plan_partition_adjustment_bounds_joined_bytes_per_pass() {
-        let ivf = ivf_on_a_line(&[0.0, 1000.0, 2000.0, 3000.0, 4000.0]);
-        // Each 10-row partition costs 40% of the budget: two fit, the rest wait.
-        let bytes_per_row = JOIN_BYTES_BUDGET / 25;
-        let (splits, joins) = plan_partition_adjustment(
-            &ivf,
-            DistanceType::L2,
-            &[50, 10, 10, 10, 10],
-            100,
-            bytes_per_row,
-        )
-        .unwrap();
-        assert!(splits.is_empty());
-        assert_eq!(joins.len(), 2, "{joins:?}");
-        // A single partition over the budget is still joined, or it never would be.
-        let ivf = ivf_on_a_line(&[0.0, 1000.0]);
-        let (_, joins) =
-            plan_partition_adjustment(&ivf, DistanceType::L2, &[50, 10], 100, JOIN_BYTES_BUDGET)
-                .unwrap();
-        assert_eq!(joins, vec![1]);
     }
 
     #[tokio::test]

--- a/rust/lance/src/index/vector/builder.rs
+++ b/rust/lance/src/index/vector/builder.rs
@@ -115,10 +115,14 @@ const REASSIGN_SAMPLE_SIZE: usize = 512;
 /// margin of its own centroid's distance, so near-ties do not prune a neighbor
 /// that unsampled rows would still leave.
 const REASSIGN_MARGIN: f32 = 0.05;
-/// Logical rows a join fetches at a time from a multivector column, where a
-/// row can expand to many vectors; a single oversized row is the one working
-/// set that cannot be split further.
-const JOIN_MULTIVECTOR_ROWS_PER_FETCH: usize = 64;
+/// Decoded bytes of raw vectors a join holds at a time: rows are fetched and
+/// regrouped until a batch reaches this size, so the working set does not
+/// depend on how many vectors the rows hold. A single row larger than this is
+/// the one batch that cannot be split further.
+const JOIN_FETCH_BYTES: usize = 32 * 1024 * 1024;
+/// Single-row fetches in flight while a join reads a multivector column, whose
+/// row sizes are unknown until read.
+const JOIN_MULTIVECTOR_FETCHES_IN_FLIGHT: usize = 4;
 /// Vectors a join routes and quantizes at a time before handing them to the
 /// shuffler, whatever the fetched rows expanded to.
 const JOIN_VECTORS_PER_BATCH: usize = 1024;
@@ -2647,10 +2651,17 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
                 .shuffle(Box::new(RecordBatchStreamAdapter::new(schema, batches)))
                 .await
         };
+        // A fixed-size vector row has a known size, so a chunk is sized to the
+        // budget up front; a multivector row does not, so those are fetched one
+        // at a time and regrouped by measured size.
         let (rows_per_fetch, prefetch) = if multivector {
-            (JOIN_MULTIVECTOR_ROWS_PER_FETCH, 1)
+            (1, JOIN_MULTIVECTOR_FETCHES_IN_FLIGHT)
         } else {
-            (self.store.block_size(), 2)
+            let row_bytes = ivf.dimension() * vector_field_element_width(&vector_field);
+            (
+                (JOIN_FETCH_BYTES / row_bytes.max(1)).clamp(1, self.store.block_size()),
+                2,
+            )
         };
         let route = async move {
             for (&part_idx, row_ids) in partitions.iter().zip(rows_per_partition) {
@@ -2663,7 +2674,7 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
                 let partition_window =
                     self.select_reassign_candidates(ivf, part_idx, &c0, removed)?;
                 let mut overflowed = 0usize;
-                let mut chunks = Self::take_vectors_stream(
+                let fetched = Self::take_vectors_stream(
                     dataset,
                     &self.column,
                     row_ids,
@@ -2671,6 +2682,7 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
                     prefetch,
                 )
                 .await?;
+                let mut chunks = Box::pin(regroup_by_bytes(fetched, JOIN_FETCH_BYTES));
                 while let Some(chunk) = chunks.try_next().await? {
                     let (row_ids, vectors) = self.flatten_raw_vectors(&chunk)?;
                     for start in (0..row_ids.len()).step_by(JOIN_VECTORS_PER_BATCH) {
@@ -3080,6 +3092,44 @@ where
     })?
     .ok_or_else(|| Error::internal("a joined partition has no neighbor to receive its rows"))?;
     Ok((target, false))
+}
+
+/// Regroup `batches` so that each yielded batch holds up to `budget` bytes of
+/// decoded rows; a single batch larger than that passes through alone. This
+/// bounds the working set of a consumer that expands every row it holds.
+fn regroup_by_bytes<S>(batches: S, budget: usize) -> impl Stream<Item = Result<RecordBatch>>
+where
+    S: Stream<Item = Result<RecordBatch>> + Unpin,
+{
+    stream::try_unfold(
+        (batches, Vec::<RecordBatch>::new(), 0usize),
+        move |(mut batches, mut pending, mut pending_bytes)| async move {
+            loop {
+                let Some(batch) = batches.try_next().await? else {
+                    if pending.is_empty() {
+                        return Ok(None);
+                    }
+                    let grouped = arrow::compute::concat_batches(&pending[0].schema(), &pending)?;
+                    return Ok(Some((grouped, (batches, Vec::new(), 0))));
+                };
+                let bytes = batch.get_array_memory_size();
+                if !pending.is_empty() && pending_bytes + bytes > budget {
+                    let grouped = arrow::compute::concat_batches(&pending[0].schema(), &pending)?;
+                    return Ok(Some((grouped, (batches, vec![batch], bytes))));
+                }
+                pending.push(batch);
+                pending_bytes += bytes;
+            }
+        },
+    )
+}
+
+/// Bytes of one element of a fixed-size vector field.
+fn vector_field_element_width(field: &Field) -> usize {
+    match field.data_type() {
+        DataType::FixedSizeList(item, _) => item.data_type().primitive_width().unwrap_or(4),
+        _ => 4,
+    }
 }
 
 /// The `REASSIGN_RANGE` nearest surviving partitions to `vector` itself, for a
@@ -4227,6 +4277,42 @@ mod tests {
             sizes.iter().all(|&rows| rows <= 400),
             "a join destination exceeds the split threshold: {sizes:?}"
         );
+    }
+
+    #[tokio::test]
+    async fn regroup_by_bytes_bounds_each_batch_to_the_budget() {
+        let one_row = |value: f32| {
+            let vectors =
+                FixedSizeListArray::try_new_from_values(Float32Array::from(vec![value; 4]), 4)
+                    .unwrap();
+            let schema = Arc::new(arrow_schema::Schema::new(vec![Field::new(
+                "vec",
+                vectors.data_type().clone(),
+                false,
+            )]));
+            RecordBatch::try_new(schema, vec![Arc::new(vectors)]).unwrap()
+        };
+        let rows: Vec<RecordBatch> = (0..5).map(|i| one_row(i as f32)).collect();
+        let row_bytes = rows[0].get_array_memory_size();
+        // Two rows fit the budget, a third would not.
+        let grouped: Vec<RecordBatch> = regroup_by_bytes(
+            stream::iter(rows.clone().into_iter().map(Ok)),
+            2 * row_bytes,
+        )
+        .try_collect()
+        .await
+        .unwrap();
+        assert_eq!(
+            grouped.iter().map(|b| b.num_rows()).collect::<Vec<_>>(),
+            vec![2, 2, 1]
+        );
+        // A single row over the budget still comes through, on its own.
+        let grouped: Vec<RecordBatch> =
+            regroup_by_bytes(stream::iter(rows.into_iter().map(Ok)), row_bytes / 2)
+                .try_collect()
+                .await
+                .unwrap();
+        assert_eq!(grouped.len(), 5);
     }
 
     #[test]

--- a/rust/lance/src/index/vector/builder.rs
+++ b/rust/lance/src/index/vector/builder.rs
@@ -4,9 +4,12 @@
 use lance_core::utils::row_addr_remap::RowAddrRemap;
 use std::collections::HashSet;
 use std::sync::{Arc, Mutex};
-use std::{collections::HashMap, pin::Pin};
+use std::{
+    collections::{BTreeMap, HashMap},
+    pin::Pin,
+};
 
-use arrow::array::{AsArray as _, PrimitiveBuilder, UInt32Builder, UInt64Builder};
+use arrow::array::{AsArray as _, PrimitiveBuilder, UInt64Builder};
 use arrow::compute::sort_to_indices;
 use arrow::datatypes::{self};
 use arrow::datatypes::{Float16Type, Float64Type, UInt8Type, UInt64Type};
@@ -113,8 +116,11 @@ const REASSIGN_SAMPLE_SIZE: usize = 512;
 /// that unsampled rows would still leave.
 const REASSIGN_MARGIN: f32 = 0.05;
 /// Bytes of quantized rows one join pass may keep in memory until the merge
-/// writes them out. Undersized partitions that do not fit wait for the next
-/// optimize, so joining every one of them at once cannot exhaust memory.
+/// writes them out. The planner estimates it from the quantizer's output
+/// width to pick the join set, and the join measures what it actually retains
+/// and stops early when it is reached; undersized partitions that do not fit
+/// wait for the next optimize, so joining every one of them at once cannot
+/// exhaust memory.
 const JOIN_BYTES_BUDGET: usize = 512 * 1024 * 1024;
 
 /// Number of partitions the split partitions' rows now belong to.
@@ -1115,6 +1121,7 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
                     Arc::new(self.existing_indices.clone()),
                     Some(PartitionAdjustment::Join {
                         kept_partitions: results.kept_partitions,
+                        reindexed_row_ids: results.reindexed_row_ids,
                     }),
                 )
             } else {
@@ -1174,9 +1181,9 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
                             _ => (false, None),
                         };
                         let partition = match partition_adjustment.as_ref() {
-                            Some(PartitionAdjustment::Join { kept_partitions }) => {
-                                kept_partitions[partition]
-                            }
+                            Some(PartitionAdjustment::Join {
+                                kept_partitions, ..
+                            }) => kept_partitions[partition],
                             _ => partition,
                         };
 
@@ -1211,30 +1218,30 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
                         }
 
                         spawn_cpu(move || {
-                            // Apply assign_batch for join operations (splits no
-                            // longer use assign_batches)
-                            if let Some((assign_batch, deleted_row_ids)) = assign_batch {
-                                if !deleted_row_ids.is_empty() {
-                                    let deleted_row_ids = HashSet::<u64>::from_iter(
-                                        deleted_row_ids.values().iter().copied(),
-                                    );
-                                    for batch in batches.iter_mut() {
-                                        let row_ids = batch[ROW_ID].as_primitive::<UInt64Type>();
-                                        let mask =
-                                            BooleanArray::from_iter(row_ids.iter().map(|row_id| {
-                                                row_id.map(|row_id| {
-                                                    !deleted_row_ids.contains(&row_id)
-                                                })
-                                            }));
-                                        *batch = arrow::compute::filter_record_batch(batch, &mask)?;
-                                    }
+                            // A join reindexes whole logical rows: their old
+                            // entries leave every partition before the assign
+                            // batches add the new ones.
+                            if let Some(PartitionAdjustment::Join {
+                                reindexed_row_ids, ..
+                            }) = partition_adjustment.as_ref()
+                                && !reindexed_row_ids.is_empty()
+                            {
+                                for batch in batches.iter_mut() {
+                                    let row_ids = batch[ROW_ID].as_primitive::<UInt64Type>();
+                                    let mask =
+                                        BooleanArray::from_iter(row_ids.iter().map(|row_id| {
+                                            row_id
+                                                .map(|row_id| !reindexed_row_ids.contains(&row_id))
+                                        }));
+                                    *batch = arrow::compute::filter_record_batch(batch, &mask)?;
                                 }
-
-                                if assign_batch.num_rows() > 0 {
-                                    // Drop PART_ID column from assign_batch to match schema of existing batches
-                                    let assign_batch = assign_batch.drop_column(PART_ID_COLUMN)?;
-                                    batches.push(assign_batch);
-                                }
+                            }
+                            if let Some(assign_batch) = assign_batch
+                                && assign_batch.num_rows() > 0
+                            {
+                                // Drop PART_ID column from assign_batch to match schema of existing batches
+                                let assign_batch = assign_batch.drop_column(PART_ID_COLUMN)?;
+                                batches.push(assign_batch);
                             }
 
                             let num_rows = batches.iter().map(|b| b.num_rows()).sum::<usize>();
@@ -1919,29 +1926,18 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
         Ok(batches)
     }
 
-    /// The raw vectors of every logical row with an entry in a partition,
-    /// flattened to one row id per vector, plus how many entries of each row the
-    /// partition held (a multivector row's vectors can be spread over several
-    /// partitions, and the dataset returns all of them).
-    async fn load_partition_raw_vectors(&self, part_idx: usize) -> Result<Option<PartitionRows>> {
+    /// The raw vectors of the logical rows `row_ids`, flattened to one row id
+    /// per vector (a multivector row contributes every one of its vectors).
+    async fn load_raw_vectors(
+        &self,
+        row_ids: &[u64],
+    ) -> Result<Option<(UInt64Array, FixedSizeListArray)>> {
         let Some(dataset) = self.dataset.as_ref() else {
             return Err(Error::invalid_input(
-                "dataset not set before split partition",
+                "dataset not set before loading raw vectors",
             ));
         };
-
-        let mut row_ids = self.partition_row_ids(part_idx).await?;
-        if !row_ids.is_sorted() {
-            row_ids.sort();
-        }
-        let mut entries_per_row: HashMap<u64, usize> = HashMap::new();
-        for &row_id in &row_ids {
-            *entries_per_row.entry(row_id).or_default() += 1;
-        }
-        // dedup is needed if it's multivector
-        row_ids.dedup();
-
-        let batches = Self::take_vectors(dataset, &self.column, &self.store, &row_ids).await?;
+        let batches = Self::take_vectors(dataset, &self.column, &self.store, row_ids).await?;
         if batches.is_empty() {
             return Ok(None);
         }
@@ -1959,35 +1955,7 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
             )))?
             .as_fixed_size_list()
             .clone();
-        Ok(Some(PartitionRows {
-            row_ids,
-            vectors,
-            entries_per_row,
-        }))
-    }
-
-    /// This partition's centroid followed by its `REASSIGN_RANGE` nearest
-    /// neighbors in the old model, for [`vectors_held_by_partition`].
-    fn provenance_centroids(&self, ivf: &IvfModel, part_idx: usize) -> Result<FixedSizeListArray> {
-        let c0 = ivf
-            .centroid(part_idx)
-            .ok_or(Error::invalid_input("original centroid not found"))?;
-        let (neighbor_ids, _) = select_reassign_candidates_impl(
-            self.distance_type,
-            ivf,
-            part_idx,
-            &c0,
-            &HashSet::new(),
-        )?;
-        let ids = UInt32Array::from_iter_values(
-            std::iter::once(part_idx as u32).chain(neighbor_ids.values().iter().copied()),
-        );
-        let centroids = ivf
-            .centroids_array()
-            .ok_or_else(|| Error::invalid_input("IVF model has no centroids"))?;
-        Ok(arrow::compute::take(centroids, &ids, None)?
-            .as_fixed_size_list()
-            .clone())
+        Ok(Some((row_ids, vectors)))
     }
 
     /// Rows per partition that split and join thresholds are derived from: the
@@ -2002,27 +1970,19 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
         Ok(index_type.target_partition_size())
     }
 
-    /// Bytes one reassigned row occupies while a join runs: its row id, its
-    /// partition id and its code (the raw vector for a flat index).
+    /// Bytes one reindexed row occupies while a join runs: the quantizer's
+    /// output columns (its code and, for RaBitQ, the factor and extra-code
+    /// columns) plus the row id and the partition id.
     fn join_bytes_per_row(&self) -> Result<usize> {
         let Some(quantizer) = self.quantizer.as_ref() else {
             return Err(Error::invalid_input(
                 "quantizer not set before planning partition joins",
             ));
         };
-        let code_bytes = match Q::quantization_type() {
-            QuantizationType::Flat => {
-                let Some(dataset) = self.dataset.as_ref() else {
-                    return Err(Error::invalid_input(
-                        "dataset not set before planning partition joins",
-                    ));
-                };
-                let (_, element_type) = get_vector_type(dataset.schema(), &self.column)?;
-                quantizer.code_dim() * element_type.primitive_width().unwrap_or(size_of::<f32>())
-            }
-            _ => quantizer.code_dim(),
-        };
-        Ok(code_bytes + size_of::<u64>() + size_of::<u32>())
+        let fields: Vec<Field> = std::iter::once(quantizer.field())
+            .chain(quantizer.extra_fields())
+            .collect();
+        retained_bytes_per_row(&fields)
     }
 
     /// Decide which partitions to split and which to join away, from the
@@ -2526,12 +2486,18 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
         Ok(Some(centroids))
     }
 
-    /// Join undersized partitions away in one pass: their centroids are removed
-    /// and every one of their vectors is reassigned to the nearest remaining
-    /// partition with room below `split_threshold` (given `partition_sizes`),
-    /// among the `REASSIGN_RANGE` nearest neighbors of its old centroid first.
-    /// Partitions are loaded one at a time and their rows quantized right away,
-    /// so only one partition's raw vectors are in memory at once.
+    /// Join undersized partitions away in one pass. Every logical row with an
+    /// entry in a joined partition is reindexed once: all of its vectors go to
+    /// their nearest surviving partition with room below `split_threshold`
+    /// (given `partition_sizes`), the `REASSIGN_RANGE` nearest neighbors of
+    /// the old centroid first, and its old entries are dropped from every
+    /// partition through `reindexed_row_ids`. That conserves both the count
+    /// and the identity of a multivector row's vectors wherever they were.
+    /// Partitions are loaded one at a time and their rows quantized right
+    /// away, so only one partition's raw vectors are in memory at once, and
+    /// the pass stops joining once the quantized rows it retains reach
+    /// `JOIN_BYTES_BUDGET`; the remaining planned joins wait for the next
+    /// optimize.
     async fn join_partitions(
         &self,
         partitions: &[usize],
@@ -2539,21 +2505,6 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
         partition_sizes: &[usize],
         split_threshold: usize,
     ) -> Result<JoinResult> {
-        let removed: HashSet<usize> = partitions.iter().copied().collect();
-        let kept_partitions: Vec<usize> = (0..ivf.num_partitions())
-            .filter(|partition| !removed.contains(partition))
-            .collect();
-        let centroids = ivf.centroids_array().unwrap();
-        let kept_ids = UInt32Array::from(
-            kept_partitions
-                .iter()
-                .map(|partition| *partition as u32)
-                .collect::<Vec<_>>(),
-        );
-        let new_centroids = arrow::compute::take(centroids, &kept_ids, None)?
-            .as_fixed_size_list()
-            .clone();
-
         let Some(dataset) = self.dataset.as_ref() else {
             return Err(Error::invalid_input(
                 "dataset not set before joining partitions",
@@ -2565,46 +2516,22 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
             .map(|&size| split_threshold.saturating_sub(size))
             .collect();
         let (_, element_type) = get_vector_type(dataset.schema(), &self.column)?;
-        let assign_batches = match element_type {
+        let execution = match element_type {
             DataType::Float16 => {
-                self.join_partitions_impl::<Float16Type>(
-                    partitions,
-                    &kept_partitions,
-                    ivf,
-                    &new_centroids,
-                    &mut room,
-                )
-                .await?
+                self.join_partitions_impl::<Float16Type>(partitions, ivf, &mut room)
+                    .await?
             }
             DataType::Float32 => {
-                self.join_partitions_impl::<Float32Type>(
-                    partitions,
-                    &kept_partitions,
-                    ivf,
-                    &new_centroids,
-                    &mut room,
-                )
-                .await?
+                self.join_partitions_impl::<Float32Type>(partitions, ivf, &mut room)
+                    .await?
             }
             DataType::Float64 => {
-                self.join_partitions_impl::<Float64Type>(
-                    partitions,
-                    &kept_partitions,
-                    ivf,
-                    &new_centroids,
-                    &mut room,
-                )
-                .await?
+                self.join_partitions_impl::<Float64Type>(partitions, ivf, &mut room)
+                    .await?
             }
             DataType::UInt8 => {
-                self.join_partitions_impl::<UInt8Type>(
-                    partitions,
-                    &kept_partitions,
-                    ivf,
-                    &new_centroids,
-                    &mut room,
-                )
-                .await?
+                self.join_partitions_impl::<UInt8Type>(partitions, ivf, &mut room)
+                    .await?
             }
             dt => {
                 return Err(Error::invalid_input(format!(
@@ -2613,94 +2540,99 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
                 )));
             }
         };
+        if execution.joined.len() < partitions.len() {
+            log::info!(
+                "joined {} of {} planned partitions; the retained rows reached the {} byte budget",
+                execution.joined.len(),
+                partitions.len(),
+                JOIN_BYTES_BUDGET
+            );
+        }
 
+        let joined: HashSet<usize> = execution.joined.iter().copied().collect();
+        let kept_partitions: Vec<usize> = (0..ivf.num_partitions())
+            .filter(|partition| !joined.contains(partition))
+            .collect();
+        let centroids = ivf
+            .centroids_array()
+            .ok_or_else(|| Error::invalid_input("IVF model has no centroids"))?;
+        let kept_ids = UInt32Array::from_iter_values(
+            kept_partitions.iter().map(|&partition| partition as u32),
+        );
+        let new_centroids = arrow::compute::take(centroids, &kept_ids, None)?
+            .as_fixed_size_list()
+            .clone();
+        let mut assigned = execution.assigned;
+        let assign_batches = kept_partitions
+            .iter()
+            .map(|old| -> Result<Option<RecordBatch>> {
+                let Some(mut batches) = assigned.remove(old) else {
+                    return Ok(None);
+                };
+                Ok(Some(match batches.len() {
+                    1 => batches.pop().unwrap(),
+                    _ => arrow::compute::concat_batches(&batches[0].schema(), &batches)?,
+                }))
+            })
+            .collect::<Result<Vec<_>>>()?;
         Ok(JoinResult {
             assign_batches,
             new_centroids,
             kept_partitions,
+            reindexed_row_ids: Arc::new(execution.reindexed_row_ids),
         })
     }
 
     async fn join_partitions_impl<T: ArrowPrimitiveType>(
         &self,
         partitions: &[usize],
-        kept_partitions: &[usize],
         ivf: &IvfModel,
-        new_centroids: &FixedSizeListArray,
         room: &mut [usize],
-    ) -> Result<Vec<Option<(RecordBatch, UInt64Array)>>>
+    ) -> Result<JoinExecution>
     where
         T::Native: Dot + L2 + Normalize,
         PrimitiveArray<T>: From<Vec<T::Native>>,
     {
+        // Rows go to partitions the plan keeps. If the budget stops the pass
+        // early the remaining planned partitions stay as well; they just
+        // receive nothing.
         let removed: HashSet<usize> = partitions.iter().copied().collect();
-        // old partition id -> output partition id
-        let mut output_partition = vec![None; ivf.num_partitions()];
-        for (output, &old) in kept_partitions.iter().enumerate() {
-            output_partition[old] = Some(output);
-        }
+        let old_centroids = ivf
+            .centroids_array()
+            .ok_or_else(|| Error::invalid_input("IVF model has no centroids"))?;
+        let (transformer, vector_field) = self.assign_transformer(old_centroids)?;
 
-        let (transformer, vector_field) = self.assign_transformer(new_centroids)?;
-
-        let mut assigned: Vec<Vec<RecordBatch>> = vec![Vec::new(); kept_partitions.len()];
+        let mut execution = JoinExecution::default();
+        let mut retained_bytes = 0usize;
         for &part_idx in partitions {
-            let Some(PartitionRows {
-                row_ids,
-                vectors,
-                entries_per_row,
-            }) = self.load_partition_raw_vectors(part_idx).await?
-            else {
+            if !execution.joined.is_empty() && retained_bytes >= JOIN_BYTES_BUDGET {
+                break;
+            }
+            let mut row_ids = self.partition_row_ids(part_idx).await?;
+            row_ids.sort_unstable();
+            row_ids.dedup();
+            // A row that straddles two joined partitions is reindexed by the first.
+            row_ids.retain(|row_id| !execution.reindexed_row_ids.contains(row_id));
+            execution.joined.push(part_idx);
+            execution.reindexed_row_ids.extend(row_ids.iter().copied());
+            let Some((row_ids, vectors)) = self.load_raw_vectors(&row_ids).await? else {
                 continue;
             };
             assert_eq!(row_ids.len(), vectors.len());
             let c0 = ivf
                 .centroid(part_idx)
                 .ok_or(Error::invalid_input("original centroid not found"))?;
-            let (reassign_part_ids, reassign_part_centroids) =
+            let (window_ids, window_centroids) =
                 self.select_reassign_candidates(ivf, part_idx, &c0, &removed)?;
 
-            // Only the vectors this partition held move; the rest of a
-            // multivector row stays where it is, so entries are conserved and
-            // the room and byte accounting see the same units as the planner.
-            let mut provenance_centroids = None;
-            let mut held = Vec::with_capacity(row_ids.len());
-            let mut start = 0;
-            while start < row_ids.len() {
-                let row_id = row_ids.value(start);
-                let mut end = start + 1;
-                while end < row_ids.len() && row_ids.value(end) == row_id {
-                    end += 1;
-                }
-                let count = entries_per_row.get(&row_id).copied().unwrap_or(0);
-                if end - start <= count {
-                    held.extend(start..end);
-                } else {
-                    let centroids = match &provenance_centroids {
-                        Some(centroids) => centroids,
-                        None => {
-                            provenance_centroids.insert(self.provenance_centroids(ivf, part_idx)?)
-                        }
-                    };
-                    held.extend(vectors_held_by_partition::<T>(
-                        self.distance_type,
-                        &vectors,
-                        start..end,
-                        centroids,
-                        count,
-                    )?);
-                }
-                start = end;
-            }
-
-            let mut assign_ops = vec![Vec::new(); kept_partitions.len()];
+            let mut assign_ops: BTreeMap<u32, Vec<AssignOp>> = BTreeMap::new();
             let mut overflowed = 0usize;
-            for i in held {
-                let row_id = row_ids.value(i);
+            for i in 0..row_ids.len() {
                 let (target, had_room) = choose_join_destination(
                     self.distance_type,
                     vectors.value(i).as_primitive::<T>(),
-                    &reassign_part_ids,
-                    &reassign_part_centroids,
+                    &window_ids,
+                    &window_centroids,
                     ivf,
                     &removed,
                     room,
@@ -2710,38 +2642,31 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
                 } else {
                     overflowed += 1;
                 }
-                let output = output_partition[target as usize].ok_or_else(|| {
-                    Error::internal(format!(
-                        "partition {target} is being joined away but was selected to receive vectors of partition {part_idx}"
-                    ))
-                })?;
-                assign_ops[output].push(AssignOp::Add((row_id, vectors.value(i))));
+                assign_ops
+                    .entry(target)
+                    .or_default()
+                    .push(AssignOp::Add((row_ids.value(i), vectors.value(i))));
             }
             if overflowed > 0 {
                 log::warn!(
                     "{overflowed} rows of joined partition {part_idx} found no partition below the split threshold and went to the nearest full one"
                 );
             }
-            let batches = Self::build_assign_batch::<T>(&transformer, &vector_field, &assign_ops)?;
-            for (output, batch) in batches.into_iter().enumerate() {
-                if let Some(batch) = batch {
-                    assigned[output].push(batch);
-                }
+            // Quantize now, under the old centroid numbering (a code depends on
+            // the centroid, not on its index), so only this partition's raw
+            // vectors are in memory and the retained size is what it will be.
+            for (target, ops) in assign_ops {
+                let batch =
+                    Self::build_assign_batch::<T>(&transformer, &vector_field, target, &ops)?;
+                retained_bytes = retained_bytes.saturating_add(batch.get_array_memory_size());
+                execution
+                    .assigned
+                    .entry(target as usize)
+                    .or_default()
+                    .push(batch);
             }
         }
-
-        let empty_deleted = UInt64Array::from(Vec::<u64>::new());
-        assigned
-            .into_iter()
-            .map(|mut batches| {
-                let batch = match batches.len() {
-                    0 => return Ok(None),
-                    1 => batches.pop().unwrap(),
-                    _ => arrow::compute::concat_batches(&batches[0].schema(), &batches)?,
-                };
-                Ok(Some((batch, empty_deleted.clone())))
-            })
-            .collect()
+        Ok(execution)
     }
 
     /// The IVF + quantizer transform that turns reassigned rows into index rows
@@ -2787,35 +2712,28 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
         Ok((transformer, vector_field))
     }
 
-    /// Quantize the rows of `assign_ops` into one batch per output partition,
-    /// `None` where a partition receives no rows.
+    /// Quantize `ops`, all bound for partition `part_id` of the transformer's
+    /// centroids, into one index batch.
     fn build_assign_batch<T: ArrowPrimitiveType>(
         transformer: &IvfTransformer,
         vector_field: &Field,
-        assign_ops: &[Vec<AssignOp>],
-    ) -> Result<Vec<Option<RecordBatch>>> {
+        part_id: u32,
+        ops: &[AssignOp],
+    ) -> Result<RecordBatch> {
         let dimension = infer_vector_dim(vector_field.data_type())?;
-        let num_rows: usize = assign_ops.iter().map(|ops| ops.len()).sum();
+        let num_rows = ops.len();
 
         // build the input batch with schema | row_id | vector | part_id |
         let mut row_ids_builder = UInt64Builder::with_capacity(num_rows);
         let mut vector_builder = PrimitiveBuilder::<T>::with_capacity(num_rows * dimension);
-        let mut part_ids_builder = UInt32Builder::with_capacity(num_rows);
-
-        let mut counts = Vec::with_capacity(assign_ops.len());
-        for (part_idx, ops) in assign_ops.iter().enumerate() {
-            for AssignOp::Add((row_id, vector)) in ops {
-                row_ids_builder.append_value(*row_id);
-                vector_builder.append_array(vector.as_primitive::<T>());
-                part_ids_builder.append_value(part_idx as u32);
-            }
-            counts.push(ops.len());
+        for AssignOp::Add((row_id, vector)) in ops {
+            row_ids_builder.append_value(*row_id);
+            vector_builder.append_array(vector.as_primitive::<T>());
         }
-
         let row_ids = row_ids_builder.finish();
         let vector =
             FixedSizeListArray::try_new_from_values(vector_builder.finish(), dimension as i32)?;
-        let part_ids = part_ids_builder.finish();
+        let part_ids = UInt32Array::from(vec![part_id; num_rows]);
         let schema = arrow_schema::Schema::new(vec![
             ROW_ID_FIELD.clone(),
             vector_field.clone(),
@@ -2825,19 +2743,7 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
             Arc::new(schema),
             vec![Arc::new(row_ids), Arc::new(vector), Arc::new(part_ids)],
         )?;
-        let batch = transformer.transform(&batch)?;
-
-        let mut results = Vec::with_capacity(assign_ops.len());
-        let mut offset = 0;
-        for count in counts {
-            if count == 0 {
-                results.push(None);
-            } else {
-                results.push(Some(batch.slice(offset, count)));
-                offset += count;
-            }
-        }
-        Ok(results)
+        transformer.transform(&batch)
     }
 
     async fn partition_row_ids(&self, part_idx: usize) -> Result<Vec<u64>> {
@@ -2975,9 +2881,9 @@ fn plan_partition_adjustment(
                 continue;
             }
             let num_rows = partition_sizes[partition];
+            let row_bytes = num_rows.saturating_mul(join_bytes_per_row);
             if joins.len() == max_joins
-                || (!joins.is_empty()
-                    && joined_bytes + num_rows * join_bytes_per_row > JOIN_BYTES_BUDGET)
+                || (!joins.is_empty() && joined_bytes.saturating_add(row_bytes) > JOIN_BYTES_BUDGET)
             {
                 break 'rounds;
             }
@@ -2997,7 +2903,7 @@ fn plan_partition_adjustment(
             projected_sizes[destination] += projected_sizes[partition];
             projected_sizes[partition] = 0;
             removed[partition] = true;
-            joined_bytes += num_rows * join_bytes_per_row;
+            joined_bytes = joined_bytes.saturating_add(row_bytes);
             joins.push(partition);
             progress = true;
         }
@@ -3039,39 +2945,6 @@ fn nearest_surviving_neighbor(
     let nearest = ids.first().map(|&id| id as usize);
     *cache = Some(ids);
     Ok(nearest)
-}
-
-/// Which `count` of a multivector row's `vectors[range]` a partition held.
-/// The index placed every vector with its nearest centroid, so they are the
-/// ones for which this centroid (first in `provenance_centroids`) beats the
-/// nearest neighbors (the rest) by the largest margin.
-fn vectors_held_by_partition<T: ArrowPrimitiveType>(
-    distance_type: DistanceType,
-    vectors: &FixedSizeListArray,
-    range: std::ops::Range<usize>,
-    provenance_centroids: &FixedSizeListArray,
-    count: usize,
-) -> Result<Vec<usize>>
-where
-    T::Native: Dot + L2 + Normalize,
-{
-    let mut margins = Vec::with_capacity(range.len());
-    for i in range {
-        let dists = distance_type.arrow_batch_func()(
-            vectors.value(i).as_primitive::<T>(),
-            provenance_centroids,
-        )?;
-        let own = dists.value(0);
-        let nearest_neighbor = dists.values()[1..]
-            .iter()
-            .copied()
-            .fold(f32::INFINITY, f32::min);
-        margins.push((own - nearest_neighbor, i));
-    }
-    margins.sort_by(|(a, i), (b, j)| a.total_cmp(b).then(i.cmp(j)));
-    let mut held: Vec<usize> = margins.into_iter().take(count).map(|(_, i)| i).collect();
-    held.sort_unstable();
-    Ok(held)
 }
 
 /// The candidate nearest to `vector` among those `accept` allows.
@@ -3186,12 +3059,36 @@ fn select_reassign_candidates_impl(
     ))
 }
 
-/// The rows of one partition, flattened to one row id per vector, with the
-/// number of entries the partition held for each row.
-struct PartitionRows {
-    row_ids: UInt64Array,
-    vectors: FixedSizeListArray,
-    entries_per_row: HashMap<u64, usize>,
+/// What a join pass produced, in old partition ids.
+#[derive(Default)]
+struct JoinExecution {
+    /// Quantized rows per destination partition.
+    assigned: HashMap<usize, Vec<RecordBatch>>,
+    /// Partitions actually joined away, in plan order.
+    joined: Vec<usize>,
+    /// Logical rows whose vectors were all reindexed.
+    reindexed_row_ids: HashSet<u64>,
+}
+
+/// Bytes per row of an index batch with these quantizer output `fields`, plus
+/// the row id and the partition id.
+fn retained_bytes_per_row(fields: &[Field]) -> Result<usize> {
+    fn width(data_type: &DataType) -> Result<usize> {
+        match data_type {
+            DataType::FixedSizeList(inner, len) => {
+                Ok(width(inner.data_type())?.saturating_mul(usize::try_from(*len).unwrap_or(0)))
+            }
+            DataType::Boolean => Ok(1),
+            other => other.primitive_width().ok_or_else(|| {
+                Error::invalid_input(format!("cannot size a {other} column for the join budget"))
+            }),
+        }
+    }
+    fields
+        .iter()
+        .try_fold(size_of::<u64>() + size_of::<u32>(), |bytes, field| {
+            Ok(bytes.saturating_add(width(field.data_type())?))
+        })
 }
 
 /// What one optimize pass does to the partitions, from the sizes it saw.
@@ -3202,10 +3099,12 @@ struct PartitionAdjustmentPlan {
 }
 
 struct JoinResult {
-    assign_batches: Vec<Option<(RecordBatch, UInt64Array)>>,
+    assign_batches: Vec<Option<RecordBatch>>,
     new_centroids: FixedSizeListArray,
     /// Old ids of the partitions that survive, in output order.
     kept_partitions: Vec<usize>,
+    /// Logical rows the join reindexed; their old entries leave every partition.
+    reindexed_row_ids: Arc<HashSet<u64>>,
 }
 
 struct SplitResult {
@@ -3228,8 +3127,12 @@ enum PartitionAdjustment {
         split_shuffle_reader: Arc<dyn ShuffleReader>,
     },
     /// Join partitions away; `kept_partitions[i]` is the old id of output
-    /// partition `i`.
-    Join { kept_partitions: Vec<usize> },
+    /// partition `i`, and every entry of a row in `reindexed_row_ids` is
+    /// dropped from the existing partitions before the assign batches are added.
+    Join {
+        kept_partitions: Vec<usize>,
+        reindexed_row_ids: Arc<HashSet<u64>>,
+    },
 }
 
 impl std::fmt::Debug for PartitionAdjustment {
@@ -3242,9 +3145,13 @@ impl std::fmt::Debug for PartitionAdjustment {
                 .debug_struct("Split")
                 .field("affected_partitions", affected_partitions)
                 .finish(),
-            Self::Join { kept_partitions } => f
+            Self::Join {
+                kept_partitions,
+                reindexed_row_ids,
+            } => f
                 .debug_struct("Join")
                 .field("kept_partitions", &kept_partitions.len())
+                .field("reindexed_rows", &reindexed_row_ids.len())
                 .finish(),
         }
     }
@@ -4190,6 +4097,31 @@ mod tests {
         let (_, joins) =
             plan_partition_adjustment(&ivf, DistanceType::L2, &[66; 4], 4096, 1).unwrap();
         assert_eq!(joins.len(), 3, "{joins:?}");
+    }
+
+    #[test]
+    fn retained_bytes_per_row_counts_every_quantizer_column() {
+        // The columns RaBitQ emits for an 8-dimensional 5-bit index: one
+        // binary-code byte, five f32 factors and 32 extra-code bytes, plus the
+        // row id and the partition id.
+        let u8_list = |name: &str, len: i32| {
+            Field::new(
+                name,
+                DataType::FixedSizeList(Arc::new(Field::new("item", DataType::UInt8, true)), len),
+                true,
+            )
+        };
+        let f32_field = |name: &str| Field::new(name, DataType::Float32, true);
+        let fields = vec![
+            u8_list("code", 1),
+            f32_field("add"),
+            f32_field("scale"),
+            f32_field("error"),
+            u8_list("ex_code", 32),
+            f32_field("ex_add"),
+            f32_field("ex_scale"),
+        ];
+        assert_eq!(retained_bytes_per_row(&fields).unwrap(), 65);
     }
 
     #[test]

--- a/rust/lance/src/index/vector/builder.rs
+++ b/rust/lance/src/index/vector/builder.rs
@@ -1919,11 +1919,11 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
         Ok(batches)
     }
 
-    // helper to load row ids and vectors for a partition
-    async fn load_partition_raw_vectors(
-        &self,
-        part_idx: usize,
-    ) -> Result<Option<(UInt64Array, FixedSizeListArray)>> {
+    /// The raw vectors of every logical row with an entry in a partition,
+    /// flattened to one row id per vector, plus how many entries of each row the
+    /// partition held (a multivector row's vectors can be spread over several
+    /// partitions, and the dataset returns all of them).
+    async fn load_partition_raw_vectors(&self, part_idx: usize) -> Result<Option<PartitionRows>> {
         let Some(dataset) = self.dataset.as_ref() else {
             return Err(Error::invalid_input(
                 "dataset not set before split partition",
@@ -1933,6 +1933,10 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
         let mut row_ids = self.partition_row_ids(part_idx).await?;
         if !row_ids.is_sorted() {
             row_ids.sort();
+        }
+        let mut entries_per_row: HashMap<u64, usize> = HashMap::new();
+        for &row_id in &row_ids {
+            *entries_per_row.entry(row_id).or_default() += 1;
         }
         // dedup is needed if it's multivector
         row_ids.dedup();
@@ -1955,7 +1959,35 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
             )))?
             .as_fixed_size_list()
             .clone();
-        Ok(Some((row_ids, vectors)))
+        Ok(Some(PartitionRows {
+            row_ids,
+            vectors,
+            entries_per_row,
+        }))
+    }
+
+    /// This partition's centroid followed by its `REASSIGN_RANGE` nearest
+    /// neighbors in the old model, for [`vectors_held_by_partition`].
+    fn provenance_centroids(&self, ivf: &IvfModel, part_idx: usize) -> Result<FixedSizeListArray> {
+        let c0 = ivf
+            .centroid(part_idx)
+            .ok_or(Error::invalid_input("original centroid not found"))?;
+        let (neighbor_ids, _) = select_reassign_candidates_impl(
+            self.distance_type,
+            ivf,
+            part_idx,
+            &c0,
+            &HashSet::new(),
+        )?;
+        let ids = UInt32Array::from_iter_values(
+            std::iter::once(part_idx as u32).chain(neighbor_ids.values().iter().copied()),
+        );
+        let centroids = ivf
+            .centroids_array()
+            .ok_or_else(|| Error::invalid_input("IVF model has no centroids"))?;
+        Ok(arrow::compute::take(centroids, &ids, None)?
+            .as_fixed_size_list()
+            .clone())
     }
 
     /// Rows per partition that split and join thresholds are derived from: the
@@ -2612,7 +2644,12 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
 
         let mut assigned: Vec<Vec<RecordBatch>> = vec![Vec::new(); kept_partitions.len()];
         for &part_idx in partitions {
-            let Some((row_ids, vectors)) = self.load_partition_raw_vectors(part_idx).await? else {
+            let Some(PartitionRows {
+                row_ids,
+                vectors,
+                entries_per_row,
+            }) = self.load_partition_raw_vectors(part_idx).await?
+            else {
                 continue;
             };
             assert_eq!(row_ids.len(), vectors.len());
@@ -2622,9 +2659,43 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
             let (reassign_part_ids, reassign_part_centroids) =
                 self.select_reassign_candidates(ivf, part_idx, &c0, &removed)?;
 
+            // Only the vectors this partition held move; the rest of a
+            // multivector row stays where it is, so entries are conserved and
+            // the room and byte accounting see the same units as the planner.
+            let mut provenance_centroids = None;
+            let mut held = Vec::with_capacity(row_ids.len());
+            let mut start = 0;
+            while start < row_ids.len() {
+                let row_id = row_ids.value(start);
+                let mut end = start + 1;
+                while end < row_ids.len() && row_ids.value(end) == row_id {
+                    end += 1;
+                }
+                let count = entries_per_row.get(&row_id).copied().unwrap_or(0);
+                if end - start <= count {
+                    held.extend(start..end);
+                } else {
+                    let centroids = match &provenance_centroids {
+                        Some(centroids) => centroids,
+                        None => {
+                            provenance_centroids.insert(self.provenance_centroids(ivf, part_idx)?)
+                        }
+                    };
+                    held.extend(vectors_held_by_partition::<T>(
+                        self.distance_type,
+                        &vectors,
+                        start..end,
+                        centroids,
+                        count,
+                    )?);
+                }
+                start = end;
+            }
+
             let mut assign_ops = vec![Vec::new(); kept_partitions.len()];
             let mut overflowed = 0usize;
-            for (i, &row_id) in row_ids.values().iter().enumerate() {
+            for i in held {
+                let row_id = row_ids.value(i);
                 let (target, had_room) = choose_join_destination(
                     self.distance_type,
                     vectors.value(i).as_primitive::<T>(),
@@ -2970,6 +3041,39 @@ fn nearest_surviving_neighbor(
     Ok(nearest)
 }
 
+/// Which `count` of a multivector row's `vectors[range]` a partition held.
+/// The index placed every vector with its nearest centroid, so they are the
+/// ones for which this centroid (first in `provenance_centroids`) beats the
+/// nearest neighbors (the rest) by the largest margin.
+fn vectors_held_by_partition<T: ArrowPrimitiveType>(
+    distance_type: DistanceType,
+    vectors: &FixedSizeListArray,
+    range: std::ops::Range<usize>,
+    provenance_centroids: &FixedSizeListArray,
+    count: usize,
+) -> Result<Vec<usize>>
+where
+    T::Native: Dot + L2 + Normalize,
+{
+    let mut margins = Vec::with_capacity(range.len());
+    for i in range {
+        let dists = distance_type.arrow_batch_func()(
+            vectors.value(i).as_primitive::<T>(),
+            provenance_centroids,
+        )?;
+        let own = dists.value(0);
+        let nearest_neighbor = dists.values()[1..]
+            .iter()
+            .copied()
+            .fold(f32::INFINITY, f32::min);
+        margins.push((own - nearest_neighbor, i));
+    }
+    margins.sort_by(|(a, i), (b, j)| a.total_cmp(b).then(i.cmp(j)));
+    let mut held: Vec<usize> = margins.into_iter().take(count).map(|(_, i)| i).collect();
+    held.sort_unstable();
+    Ok(held)
+}
+
 /// The candidate nearest to `vector` among those `accept` allows.
 fn nearest_candidate<T: ArrowPrimitiveType>(
     distance_type: DistanceType,
@@ -3080,6 +3184,14 @@ fn select_reassign_candidates_impl(
         reassign_candidate_ids,
         reassign_candidate_centroids.as_fixed_size_list().clone(),
     ))
+}
+
+/// The rows of one partition, flattened to one row id per vector, with the
+/// number of entries the partition held for each row.
+struct PartitionRows {
+    row_ids: UInt64Array,
+    vectors: FixedSizeListArray,
+    entries_per_row: HashMap<u64, usize>,
 }
 
 /// What one optimize pass does to the partitions, from the sizes it saw.
@@ -3950,7 +4062,9 @@ mod tests {
                 .unwrap();
         let elapsed = started.elapsed();
         assert_eq!(joins.len(), NUM_PARTITIONS - 1);
-        assert!(elapsed < std::time::Duration::from_secs(1), "{elapsed:?}");
+        // Recomputing every distance at each step took about 8 s here; the
+        // cached orderings take well under a second even in a loaded debug run.
+        assert!(elapsed < std::time::Duration::from_secs(5), "{elapsed:?}");
     }
 
     /// Send `sizes[partition]` rows at `value` of each joined partition to the

--- a/rust/lance/src/index/vector/builder.rs
+++ b/rust/lance/src/index/vector/builder.rs
@@ -81,7 +81,6 @@ use lance_table::format::IndexFile;
 use log::info;
 use object_store::path::Path;
 use prost::Message;
-use rand::{SeedableRng, rngs::SmallRng};
 use roaring::RoaringBitmap;
 use tokio::sync::{OnceCell, OwnedSemaphorePermit, Semaphore};
 use tracing::{Level, instrument, span};
@@ -108,13 +107,6 @@ const SPLIT_SAMPLE_RATE: usize = 256;
 /// Upper bound on the number of partitions one oversized partition is split into
 /// in a single optimize pass; anything still oversized waits for the next pass.
 const MAX_SPLIT_WAYS: usize = 1024;
-/// Rows sampled from a neighbor partition to decide whether a split can pull any
-/// of its rows away.
-const REASSIGN_SAMPLE_SIZE: usize = 512;
-/// A sampled row counts as movable when a new centroid is within this relative
-/// margin of its own centroid's distance, so near-ties do not prune a neighbor
-/// that unsampled rows would still leave.
-const REASSIGN_MARGIN: f32 = 0.05;
 /// Decoded bytes of raw vectors a join holds at a time: rows are fetched and
 /// regrouped until a batch reaches this size, so the working set does not
 /// depend on how many vectors the rows hold. A single row larger than this is
@@ -1060,7 +1052,6 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
                 partition_sizes,
             } = Self::check_partition_adjustment(
                 ivf,
-                self.distance_type,
                 reader.as_ref(),
                 &self.existing_indices,
                 target_partition_size,
@@ -1973,7 +1964,6 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
     /// See [`plan_partition_adjustment`] for the rules.
     fn check_partition_adjustment(
         ivf: &IvfModel,
-        distance_type: DistanceType,
         reader: &dyn ShuffleReader,
         existing_indices: &[ExistingIndex],
         target_partition_size: usize,
@@ -1986,8 +1976,7 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
             }
             partition_sizes.push(num_rows);
         }
-        let (splits, joins) =
-            plan_partition_adjustment(ivf, distance_type, &partition_sizes, target_partition_size)?;
+        let (splits, joins) = plan_partition_adjustment(&partition_sizes, target_partition_size);
         Ok(PartitionAdjustmentPlan {
             splits,
             joins,
@@ -2046,14 +2035,12 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
         }
 
         // Affected partitions: every partition that received a new centroid plus
-        // those neighbors of the split partitions' old centroids that can lose a
-        // row to a new centroid.
+        // the `REASSIGN_RANGE` neighbors of each split partition's old centroid,
+        // whose rows may now be nearer to a new centroid.
         let mut affected_partitions = HashSet::new();
-        let mut new_partition_ids = Vec::new();
-        let mut candidates = HashSet::new();
+        let mut neighbors = 0usize;
         for (part_idx, new_partitions) in &split_partitions {
             affected_partitions.extend(new_partitions.iter().copied());
-            new_partition_ids.extend(new_partitions.iter().map(|id| *id as u32));
             let c0 = ivf.centroid(*part_idx).ok_or(Error::invalid_input(format!(
                 "centroid not found for partition {part_idx}",
             )))?;
@@ -2064,29 +2051,19 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
                 &c0,
                 &HashSet::new(),
             )?;
-            candidates.extend(neighbor_ids.values().iter().map(|id| *id as usize));
+            for id in neighbor_ids.values() {
+                if affected_partitions.insert(*id as usize) {
+                    neighbors += 1;
+                }
+            }
         }
-        let mut candidates: Vec<usize> = candidates
-            .difference(&affected_partitions)
-            .copied()
-            .collect();
-        candidates.sort_unstable();
-        let split_centroids =
-            arrow::compute::take(&new_centroids, &UInt32Array::from(new_partition_ids), None)?
-                .as_fixed_size_list()
-                .clone();
-        let kept = self
-            .prune_reassign_candidates(&candidates, &new_centroids, &split_centroids)
-            .await?;
         log::info!(
-            "split {} partitions into {} partitions; {} of {} neighbor partitions can lose rows to the new centroids and are reassigned, {} total affected partitions",
+            "split {} partitions into {} partitions; {} neighbor partitions reassigned, {} total affected partitions",
             split_partitions.len(),
             new_partition_ids_len(&split_partitions),
-            kept.len(),
-            candidates.len(),
-            affected_partitions.len() + kept.len(),
+            neighbors,
+            affected_partitions.len(),
         );
-        affected_partitions.extend(kept);
 
         // Stream raw vectors for affected partitions through the IVF+quantizer
         // transform, writing to temp files via a second shuffler.
@@ -2099,47 +2076,6 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
             affected_partitions,
             shuffle_reader: split_shuffle_reader.into(),
         }))
-    }
-
-    /// Of the neighbor partitions of a split, keep those where a sampled row is
-    /// now closer to one of the new centroids than to its own centroid, within
-    /// `REASSIGN_MARGIN` (SPFresh's necessary condition for a row to move). The
-    /// others keep their rows and codes untouched, which is what saves the
-    /// raw-vector reads: most neighbors of a split cannot lose a row.
-    async fn prune_reassign_candidates(
-        &self,
-        candidates: &[usize],
-        centroids: &FixedSizeListArray,
-        split_centroids: &FixedSizeListArray,
-    ) -> Result<Vec<usize>> {
-        let checks = stream::iter(candidates.iter().copied())
-            .map(|candidate| async move {
-                let Some(sample) = self
-                    .sample_partition_raw_vectors(candidate, REASSIGN_SAMPLE_SIZE)
-                    .await?
-                else {
-                    return Ok::<_, Error>(None);
-                };
-                let dist_fn = self.distance_type.arrow_batch_func();
-                let own_centroid = centroids.slice(candidate, 1);
-                for i in 0..sample.len() {
-                    let vector = sample.value(i);
-                    let own_dist = dist_fn(&vector, &own_centroid)?.value(0);
-                    let new_dist = dist_fn(&vector, split_centroids)?
-                        .values()
-                        .iter()
-                        .copied()
-                        .fold(f32::INFINITY, f32::min);
-                    if new_dist < own_dist + REASSIGN_MARGIN * own_dist.abs() {
-                        return Ok(Some(candidate));
-                    }
-                }
-                Ok(None)
-            })
-            .buffered(get_num_compute_intensive_cpus())
-            .try_collect::<Vec<_>>()
-            .await?;
-        Ok(checks.into_iter().flatten().collect())
     }
 
     /// Train new centroids for partitions that need splitting.
@@ -2318,15 +2254,15 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
             return Ok(None);
         }
 
-        // Sample row ids before loading any vectors. Uniform rather than strided:
-        // row ids follow insertion order, so a stride would favour old rows.
-        // Seeded per partition so a rerun trains the same split.
+        // Sample row ids before loading any vectors.
         if row_ids.len() > sample_size {
-            let mut rng = SmallRng::seed_from_u64(part_idx as u64);
-            let mut chosen =
-                rand::seq::index::sample(&mut rng, row_ids.len(), sample_size).into_vec();
-            chosen.sort_unstable();
-            row_ids = chosen.into_iter().map(|i| row_ids[i]).collect();
+            let step = row_ids.len() / sample_size;
+            row_ids = row_ids
+                .iter()
+                .copied()
+                .step_by(step.max(1))
+                .take(sample_size)
+                .collect();
         }
 
         let batches = Self::take_vectors(dataset, &self.column, &self.store, &row_ids).await?;
@@ -2380,8 +2316,9 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
             }
             _ => (self.distance_type, vectors),
         };
-        // Balanced like IVF training itself, so the pieces come out even.
-        let params = KMeansParams::new(None, 50, 1, normalized_dist_type).with_balance_factor(1.0);
+        // Seeded per partition so a rerun trains the same split.
+        let params =
+            KMeansParams::new(None, 50, 1, normalized_dist_type).with_seed(split.partition as u64);
         let values = normalized_vectors.values().as_primitive::<T>();
         let kmeans = match lance_index::vector::kmeans::train_kmeans::<T>(
             values,
@@ -2886,27 +2823,13 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
 /// straight to the target size (`ceil(rows / target)` ways, capped at
 /// `MAX_SPLIT_WAYS`), so one pass leaves nothing above the threshold. Join away
 /// partitions below `MIN_PARTITION_SIZE_PERCENT` of the target, smallest first,
-/// within two limits:
-///
-/// * A joined partition's rows go to its nearest surviving neighbor, so each
-///   candidate is projected onto that destination and skipped when the
-///   destination would end up above the split threshold. Without that, many
-///   small partitions around one survivor would rebuild the very oversized
-///   partition the split threshold exists to prevent. A destination that is
-///   still undersized may be joined away in a later round, taking the rows
-///   projected onto it along, so a handful of tiny partitions converges to one
-///   instead of stopping at pairs. The projection is an estimate: the join
-///   itself places every row in its nearest partition with room below the
-///   threshold ([`choose_join_destination`]), and enough survivors are kept
-///   for their room to hold every joined row.
-/// * Enough partitions survive for their room below the threshold to hold
-///   every joined row.
+/// as long as enough partitions survive for their room below the threshold to
+/// hold every joined row; where each row lands is decided when the join runs
+/// ([`choose_join_destination`]).
 fn plan_partition_adjustment(
-    ivf: &IvfModel,
-    distance_type: DistanceType,
     partition_sizes: &[usize],
     target_partition_size: usize,
-) -> Result<(Vec<PartitionSplit>, Vec<usize>)> {
+) -> (Vec<PartitionSplit>, Vec<usize>) {
     let split_threshold = MAX_PARTITION_SIZE_FACTOR * target_partition_size;
     let join_threshold = MIN_PARTITION_SIZE_PERCENT * target_partition_size / 100;
     let num_partitions = partition_sizes.len();
@@ -2923,94 +2846,28 @@ fn plan_partition_adjustment(
         })
         .collect();
     if num_partitions < 2 {
-        return Ok((splits, Vec::new()));
+        return (splits, Vec::new());
     }
 
-    // Sizes once the joins so far are applied. A joined partition's rows are
-    // projected onto its nearest surviving neighbor, and the rows projected
-    // onto it move on with it: an estimate, since the join itself sends every
-    // row to its own nearest neighbor with room below the split threshold.
-    let mut projected_sizes = partition_sizes.to_vec();
-    let mut neighbors: Vec<Option<Vec<u32>>> = vec![None; num_partitions];
-    let mut removed = vec![false; num_partitions];
-    let mut joins = Vec::new();
     // Every join removes one partition's room below the threshold and adds its
     // rows to the rest, so the survivors can take every joined row only while
     // at least `ceil(total_rows / split_threshold)` of them remain.
     let total_rows: usize = partition_sizes.iter().sum();
     let max_joins = num_partitions.saturating_sub(total_rows.div_ceil(split_threshold).max(1));
-    'rounds: loop {
-        let mut candidates: Vec<(usize, usize)> = (0..num_partitions)
-            .filter(|&partition| !removed[partition] && projected_sizes[partition] < join_threshold)
-            .map(|partition| (projected_sizes[partition], partition))
-            .collect();
-        candidates.sort_unstable();
-        let mut progress = false;
-        for (_, partition) in candidates {
-            if projected_sizes[partition] >= join_threshold {
-                // Grew past the threshold from joins earlier in this round.
-                continue;
-            }
-            if joins.len() == max_joins {
-                break 'rounds;
-            }
-            let Some(destination) = nearest_surviving_neighbor(
-                ivf,
-                distance_type,
-                partition,
-                &removed,
-                &mut neighbors[partition],
-            )?
-            else {
-                continue;
-            };
-            if projected_sizes[destination] + projected_sizes[partition] > split_threshold {
-                continue;
-            }
-            projected_sizes[destination] += projected_sizes[partition];
-            projected_sizes[partition] = 0;
-            removed[partition] = true;
-            joins.push(partition);
-            progress = true;
-        }
-        if !progress {
-            break;
-        }
-    }
-    joins.sort_unstable();
-    Ok((splits, joins))
-}
-
-/// The nearest partition to `partition` that is not joined away. `cache` holds
-/// its `REASSIGN_RANGE` nearest neighbors from the last lookup and is refetched
-/// past the removed partitions only once every cached one is gone, so a chain
-/// of joins does not recompute the distances to every centroid at each step.
-fn nearest_surviving_neighbor(
-    ivf: &IvfModel,
-    distance_type: DistanceType,
-    partition: usize,
-    removed: &[bool],
-    cache: &mut Option<Vec<u32>>,
-) -> Result<Option<usize>> {
-    if let Some(ids) = cache
-        && let Some(&id) = ids.iter().find(|&&id| !removed[id as usize])
-    {
-        return Ok(Some(id as usize));
-    }
-    let c0 = ivf
-        .centroid(partition)
-        .ok_or(Error::invalid_input("original centroid not found"))?;
-    let excluded: HashSet<usize> = removed
+    let mut candidates: Vec<(usize, usize)> = partition_sizes
         .iter()
         .enumerate()
-        .filter(|(_, gone)| **gone)
-        .map(|(other, _)| other)
+        .filter(|&(_, &num_rows)| num_rows < join_threshold)
+        .map(|(partition, &num_rows)| (num_rows, partition))
         .collect();
-    let (ids, _) = select_reassign_candidates_impl(distance_type, ivf, partition, &c0, &excluded)?;
-    let ids = ids.values().to_vec();
-    let nearest = ids.first().map(|&id| id as usize);
-    *cache = Some(ids);
-    Ok(nearest)
+    candidates.sort_unstable();
+    let mut joins: Vec<usize> = candidates
+        .into_iter()
+        .take(max_joins)
+        .map(|(_, partition)| partition)
+        .collect();
+    joins.sort_unstable();
+    (splits, joins)
 }
 
 /// The candidate nearest to `vector` among those `accept` allows.
@@ -4007,135 +3864,16 @@ mod tests {
         IvfModel::new(centroids, None)
     }
 
-    /// Where the rows of every joined partition land: the nearest centroid that
-    /// is not joined away, as `join_partitions` assigns them.
-    fn projected_sizes_after_joins(ivf: &IvfModel, sizes: &[usize], joins: &[usize]) -> Vec<usize> {
-        let excluded: HashSet<usize> = joins.iter().copied().collect();
-        let mut projected = sizes.to_vec();
-        for &partition in joins {
-            let c0 = ivf.centroid(partition).unwrap();
-            let (targets, _) =
-                select_reassign_candidates_impl(DistanceType::L2, ivf, partition, &c0, &excluded)
-                    .unwrap();
-            projected[targets.value(0) as usize] += sizes[partition];
-        }
-        projected
-    }
-
-    #[test]
-    fn plan_partition_adjustment_bounds_each_join_destination() {
-        // Forty partitions of 24 rows at target 100 are all under the join
-        // threshold (25 rows). Thirty centroids coincide next to a thirty-first,
-        // so joined naively they would all land on that one partition (744 rows,
-        // above the split threshold of 400).
-        let sizes = [24; 40];
-        let mut positions = vec![0.0_f32; 30];
-        positions.push(0.1);
-        positions.extend((1..10).map(|i| i as f32 * 1000.0));
-        let ivf = ivf_on_a_line(&positions);
-        let (splits, joins) =
-            plan_partition_adjustment(&ivf, DistanceType::L2, &sizes, 100).unwrap();
-        assert!(splits.is_empty());
-        assert!(joins.len() >= 20, "{joins:?}");
-        let projected = projected_sizes_after_joins(&ivf, &sizes, &joins);
-        assert!(
-            projected.iter().all(|&rows| rows <= 400),
-            "a join destination exceeds the split threshold: {projected:?}"
-        );
-    }
-
-    #[test]
-    fn plan_partition_adjustment_handles_a_chain_of_empty_partitions_quickly() {
-        // Every partition is empty and each one's nearest neighbor is the next:
-        // one long chain of joins, which must not recompute the distances to
-        // every centroid at each step.
-        const NUM_PARTITIONS: usize = 512;
-        let positions: Vec<f32> = (0..NUM_PARTITIONS).map(|i| i as f32).collect();
-        let ivf = ivf_on_a_line(&positions);
-        let started = std::time::Instant::now();
-        let (_, joins) =
-            plan_partition_adjustment(&ivf, DistanceType::L2, &[0; NUM_PARTITIONS], 4096).unwrap();
-        let elapsed = started.elapsed();
-        assert_eq!(joins.len(), NUM_PARTITIONS - 1);
-        // Recomputing every distance at each step took about 8 s here; the
-        // cached orderings take well under a second even in a loaded debug run.
-        assert!(elapsed < std::time::Duration::from_secs(5), "{elapsed:?}");
-    }
-
-    /// Send `sizes[partition]` rows at `value` of each joined partition to the
-    /// destinations `join_partitions` would pick, returning the final sizes.
-    fn execute_joins_on_a_line(
-        ivf: &IvfModel,
-        sizes: &[usize],
-        joins: &[(usize, f32)],
-        split_threshold: usize,
-    ) -> Vec<usize> {
-        let removed: HashSet<usize> = joins.iter().map(|&(partition, _)| partition).collect();
-        let mut actual = sizes.to_vec();
-        let mut room: Vec<usize> = sizes
-            .iter()
-            .map(|&size| split_threshold.saturating_sub(size))
-            .collect();
-        for &(partition, value) in joins {
-            let c0 = ivf.centroid(partition).unwrap();
-            let (window_ids, window_centroids) =
-                select_reassign_candidates_impl(DistanceType::L2, ivf, partition, &c0, &removed)
-                    .unwrap();
-            let vector = Float32Array::from(vec![value]);
-            for _ in 0..sizes[partition] {
-                let (target, had_room) = choose_join_destination(
-                    DistanceType::L2,
-                    &vector,
-                    &window_ids,
-                    &window_centroids,
-                    ivf,
-                    &removed,
-                    &room,
-                )
-                .unwrap();
-                assert!(had_room, "{actual:?}");
-                room[target as usize] -= 1;
-                actual[target as usize] += 1;
-            }
-            actual[partition] = 0;
-        }
-        actual
-    }
-
-    #[test]
-    fn join_destination_spills_to_the_next_neighbor() {
-        // Rows at 4.0 are nearest to the centroid at 10.0, which has room for
-        // ten more; the rest go to the centroid at -9.0.
-        let ivf = ivf_on_a_line(&[0.0, -9.0, 10.0]);
-        let actual = execute_joins_on_a_line(&ivf, &[24, 100, 390], &[(0, 4.0)], 400);
-        assert_eq!(actual, vec![0, 114, 400]);
-    }
-
-    #[test]
-    fn join_destination_searches_beyond_a_full_window() {
-        // The second joined partition's 64 nearest survivors are all full once
-        // the first one has taken the room at 10.01; its rows must reach the
-        // partition at -9.0 outside that window instead of overflowing.
-        let mut positions = vec![0.0_f32, 10.05, -9.0, 10.01];
-        positions.extend((0..63).map(|i| 10.2 + i as f32 * 0.01));
-        let mut sizes = vec![24, 10, 376, 390];
-        sizes.extend([400; 63]);
-        let ivf = ivf_on_a_line(&positions);
-        let (_, joins) = plan_partition_adjustment(&ivf, DistanceType::L2, &sizes, 100).unwrap();
-        assert_eq!(joins, vec![0, 1]);
-        let actual = execute_joins_on_a_line(&ivf, &sizes, &[(0, 4.0), (1, 10.05)], 400);
-        assert!(actual.iter().all(|&size| size <= 400), "{actual:?}");
-        assert_eq!(&actual[..4], &[0, 0, 400, 400]);
-    }
-
     #[test]
     fn plan_partition_adjustment_keeps_room_for_every_joined_row() {
-        // Five partitions of 90 rows at target 100 (threshold 400): 450 rows
-        // need two survivors, so at most three may be joined even though each
-        // one alone would fit next to its neighbor.
-        let ivf = ivf_on_a_line(&[0.0, 1.0, 2.0, 3.0, 4.0]);
-        let (_, joins) = plan_partition_adjustment(&ivf, DistanceType::L2, &[90; 5], 100).unwrap();
-        assert!(joins.len() <= 3, "{joins:?}");
+        // Forty partitions of 24 rows at target 100 (threshold 400): 960 rows
+        // need three survivors, so at most 37 may be joined even though every
+        // one is under the join threshold of 25.
+        let (_, joins) = plan_partition_adjustment(&[24; 40], 100);
+        assert_eq!(joins.len(), 37, "{joins:?}");
+        // Five partitions of 20 rows fit in one survivor.
+        let (_, joins) = plan_partition_adjustment(&[20; 5], 100);
+        assert_eq!(joins.len(), 4, "{joins:?}");
     }
 
     #[tokio::test]
@@ -4349,11 +4087,11 @@ mod tests {
 
     #[test]
     fn plan_partition_adjustment_joins_all_undersized_partitions_but_one() {
-        // Four partitions of 66 rows at target 4096: each one's nearest centroid
-        // is another undersized partition, and they still end up as one.
-        let ivf = ivf_on_a_line(&[0.0, 1000.0, 2000.0, 3000.0]);
-        let (_, joins) = plan_partition_adjustment(&ivf, DistanceType::L2, &[66; 4], 4096).unwrap();
-        assert_eq!(joins.len(), 3, "{joins:?}");
+        // Four partitions of 66 rows at target 4096 fit in one survivor, and the
+        // smallest ones go first.
+        let (_, joins) = plan_partition_adjustment(&[66, 65, 66, 66], 4096);
+        assert_eq!(joins, vec![0, 1, 2]);
+        assert!(plan_partition_adjustment(&[66], 4096).1.is_empty());
     }
 
     #[tokio::test]

--- a/rust/lance/src/index/vector/builder.rs
+++ b/rust/lance/src/index/vector/builder.rs
@@ -2496,8 +2496,8 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
 
     /// Join undersized partitions away in one pass: their centroids are removed
     /// and every one of their vectors is reassigned to the nearest remaining
-    /// partition among the `REASSIGN_RANGE` nearest neighbors of its old centroid
-    /// that still has room below `split_threshold`, given `partition_sizes`.
+    /// partition with room below `split_threshold` (given `partition_sizes`),
+    /// among the `REASSIGN_RANGE` nearest neighbors of its old centroid first.
     /// Partitions are loaded one at a time and their rows quantized right away,
     /// so only one partition's raw vectors are in memory at once.
     async fn join_partitions(
@@ -2625,11 +2625,13 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
             let mut assign_ops = vec![Vec::new(); kept_partitions.len()];
             let mut overflowed = 0usize;
             for (i, &row_id) in row_ids.values().iter().enumerate() {
-                let (target, had_room) = reassign_with_room(
+                let (target, had_room) = choose_join_destination(
                     self.distance_type,
                     vectors.value(i).as_primitive::<T>(),
                     &reassign_part_ids,
                     &reassign_part_centroids,
+                    ivf,
+                    &removed,
                     room,
                 )?;
                 if had_room {
@@ -2646,7 +2648,7 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
             }
             if overflowed > 0 {
                 log::warn!(
-                    "{overflowed} rows of joined partition {part_idx} found no neighbor below the split threshold and went to the nearest full one"
+                    "{overflowed} rows of joined partition {part_idx} found no partition below the split threshold and went to the nearest full one"
                 );
             }
             let batches = Self::build_assign_batch::<T>(&transformer, &vector_field, &assign_ops)?;
@@ -2843,8 +2845,9 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
 ///   still undersized may be joined away in a later round, taking the rows
 ///   projected onto it along, so a handful of tiny partitions converges to one
 ///   instead of stopping at pairs. The projection is an estimate: the join
-///   itself places every row in its nearest neighbor with room below the
-///   threshold ([`reassign_with_room`]).
+///   itself places every row in its nearest partition with room below the
+///   threshold ([`choose_join_destination`]), and enough survivors are kept
+///   for their room to hold every joined row.
 /// * The joined rows fit in `JOIN_BYTES_BUDGET` at `join_bytes_per_row`, since
 ///   they stay in memory until the merge writes them out. The rest wait for
 ///   the next optimize.
@@ -2883,6 +2886,11 @@ fn plan_partition_adjustment(
     let mut removed = vec![false; num_partitions];
     let mut joined_bytes = 0usize;
     let mut joins = Vec::new();
+    // Every join removes one partition's room below the threshold and adds its
+    // rows to the rest, so the survivors can take every joined row only while
+    // at least `ceil(total_rows / split_threshold)` of them remain.
+    let total_rows: usize = partition_sizes.iter().sum();
+    let max_joins = num_partitions.saturating_sub(total_rows.div_ceil(split_threshold).max(1));
     'rounds: loop {
         let mut candidates: Vec<(usize, usize)> = (0..num_partitions)
             .filter(|&partition| !removed[partition] && projected_sizes[partition] < join_threshold)
@@ -2896,7 +2904,9 @@ fn plan_partition_adjustment(
                 continue;
             }
             let num_rows = partition_sizes[partition];
-            if !joins.is_empty() && joined_bytes + num_rows * join_bytes_per_row > JOIN_BYTES_BUDGET
+            if joins.len() == max_joins
+                || (!joins.is_empty()
+                    && joined_bytes + num_rows * join_bytes_per_row > JOIN_BYTES_BUDGET)
             {
                 break 'rounds;
             }
@@ -2960,34 +2970,84 @@ fn nearest_surviving_neighbor(
     Ok(nearest)
 }
 
-/// The candidate partition nearest to `vector` among those with `room` for
-/// another row, so a join cannot push a partition above the split threshold.
-/// Only when every candidate is full does the row go to the nearest one.
-fn reassign_with_room<T: ArrowPrimitiveType>(
+/// The candidate nearest to `vector` among those `accept` allows.
+fn nearest_candidate<T: ArrowPrimitiveType>(
     distance_type: DistanceType,
     vector: &PrimitiveArray<T>,
     candidate_ids: &UInt32Array,
     candidate_centroids: &FixedSizeListArray,
+    accept: impl Fn(u32) -> bool,
+) -> Result<Option<u32>>
+where
+    T::Native: Dot + L2 + Normalize,
+{
+    let dists = distance_type.arrow_batch_func()(vector, candidate_centroids)?;
+    Ok(dists
+        .values()
+        .iter()
+        .enumerate()
+        .filter(|&(i, _)| accept(candidate_ids.value(i)))
+        .min_by(|(_, a), (_, b)| a.total_cmp(b))
+        .map(|(i, _)| candidate_ids.value(i)))
+}
+
+/// Where a row of a joined partition goes: the nearest of the `window` (the
+/// `REASSIGN_RANGE` nearest surviving partitions of its old centroid) that
+/// has `room` below the split threshold. When the whole window is full, the
+/// nearest surviving partition anywhere with room, so a join never rebuilds
+/// an oversized partition while any partition has room. The planner keeps
+/// enough total room for every joined row, so only an index that is already
+/// at the threshold everywhere lands a row in a full partition (`false`),
+/// which the next optimize splits.
+fn choose_join_destination<T: ArrowPrimitiveType>(
+    distance_type: DistanceType,
+    vector: &PrimitiveArray<T>,
+    window_ids: &UInt32Array,
+    window_centroids: &FixedSizeListArray,
+    ivf: &IvfModel,
+    removed: &HashSet<usize>,
     room: &[usize],
 ) -> Result<(u32, bool)>
 where
     T::Native: Dot + L2 + Normalize,
 {
-    let dists = distance_type.arrow_batch_func()(vector, candidate_centroids)?;
-    let nearest = |with_room: bool| {
-        dists
-            .values()
-            .iter()
-            .enumerate()
-            .filter(|&(i, _)| !with_room || room[candidate_ids.value(i) as usize] > 0)
-            .min_by(|(_, a), (_, b)| a.total_cmp(b))
-            .map(|(i, _)| candidate_ids.value(i))
-    };
-    if let Some(target) = nearest(true) {
+    let has_room = |id: u32| room[id as usize] > 0;
+    if let Some(target) = nearest_candidate(
+        distance_type,
+        vector,
+        window_ids,
+        window_centroids,
+        has_room,
+    )? {
         return Ok((target, true));
     }
-    let target = nearest(false)
-        .ok_or_else(|| Error::internal("a joined partition has no neighbor to receive its rows"))?;
+    let anywhere_ids = UInt32Array::from(
+        (0..ivf.num_partitions())
+            .filter(|&id| !removed.contains(&id) && room[id] > 0)
+            .map(|id| id as u32)
+            .collect::<Vec<_>>(),
+    );
+    if !anywhere_ids.is_empty() {
+        let centroids = ivf
+            .centroids_array()
+            .ok_or_else(|| Error::invalid_input("IVF model has no centroids"))?;
+        let anywhere_centroids = arrow::compute::take(centroids, &anywhere_ids, None)?
+            .as_fixed_size_list()
+            .clone();
+        if let Some(target) = nearest_candidate(
+            distance_type,
+            vector,
+            &anywhere_ids,
+            &anywhere_centroids,
+            |_| true,
+        )? {
+            return Ok((target, true));
+        }
+    }
+    let target = nearest_candidate(distance_type, vector, window_ids, window_centroids, |_| {
+        true
+    })?
+    .ok_or_else(|| Error::internal("a joined partition has no neighbor to receive its rows"))?;
     Ok((target, false))
 }
 
@@ -3893,41 +3953,81 @@ mod tests {
         assert!(elapsed < std::time::Duration::from_secs(1), "{elapsed:?}");
     }
 
+    /// Send `sizes[partition]` rows at `value` of each joined partition to the
+    /// destinations `join_partitions` would pick, returning the final sizes.
+    fn execute_joins_on_a_line(
+        ivf: &IvfModel,
+        sizes: &[usize],
+        joins: &[(usize, f32)],
+        split_threshold: usize,
+    ) -> Vec<usize> {
+        let removed: HashSet<usize> = joins.iter().map(|&(partition, _)| partition).collect();
+        let mut actual = sizes.to_vec();
+        let mut room: Vec<usize> = sizes
+            .iter()
+            .map(|&size| split_threshold.saturating_sub(size))
+            .collect();
+        for &(partition, value) in joins {
+            let c0 = ivf.centroid(partition).unwrap();
+            let (window_ids, window_centroids) =
+                select_reassign_candidates_impl(DistanceType::L2, ivf, partition, &c0, &removed)
+                    .unwrap();
+            let vector = Float32Array::from(vec![value]);
+            for _ in 0..sizes[partition] {
+                let (target, had_room) = choose_join_destination(
+                    DistanceType::L2,
+                    &vector,
+                    &window_ids,
+                    &window_centroids,
+                    ivf,
+                    &removed,
+                    &room,
+                )
+                .unwrap();
+                assert!(had_room, "{actual:?}");
+                room[target as usize] -= 1;
+                actual[target as usize] += 1;
+            }
+            actual[partition] = 0;
+        }
+        actual
+    }
+
     #[test]
-    fn reassign_with_room_spills_to_the_next_neighbor() {
+    fn join_destination_spills_to_the_next_neighbor() {
         // Rows at 4.0 are nearest to the centroid at 10.0, which has room for
         // ten more; the rest go to the centroid at -9.0.
-        let candidate_ids = UInt32Array::from(vec![1_u32, 2]);
-        let candidate_centroids =
-            FixedSizeListArray::try_new_from_values(Float32Array::from(vec![-9.0_f32, 10.0]), 1)
-                .unwrap();
-        let mut room = vec![0, 300, 10];
-        let vector = Float32Array::from(vec![4.0_f32]);
-        let mut targets = vec![0usize; 3];
-        for _ in 0..24 {
-            let (target, had_room) = reassign_with_room(
-                DistanceType::L2,
-                &vector,
-                &candidate_ids,
-                &candidate_centroids,
-                &room,
-            )
-            .unwrap();
-            assert!(had_room);
-            room[target as usize] -= 1;
-            targets[target as usize] += 1;
-        }
-        assert_eq!(targets, vec![0, 14, 10]);
-        // With every candidate full the nearest one takes the row anyway.
-        let (target, had_room) = reassign_with_room(
-            DistanceType::L2,
-            &vector,
-            &candidate_ids,
-            &candidate_centroids,
-            &[0, 0, 0],
-        )
-        .unwrap();
-        assert_eq!((target, had_room), (2, false));
+        let ivf = ivf_on_a_line(&[0.0, -9.0, 10.0]);
+        let actual = execute_joins_on_a_line(&ivf, &[24, 100, 390], &[(0, 4.0)], 400);
+        assert_eq!(actual, vec![0, 114, 400]);
+    }
+
+    #[test]
+    fn join_destination_searches_beyond_a_full_window() {
+        // The second joined partition's 64 nearest survivors are all full once
+        // the first one has taken the room at 10.01; its rows must reach the
+        // partition at -9.0 outside that window instead of overflowing.
+        let mut positions = vec![0.0_f32, 10.05, -9.0, 10.01];
+        positions.extend((0..63).map(|i| 10.2 + i as f32 * 0.01));
+        let mut sizes = vec![24, 10, 376, 390];
+        sizes.extend([400; 63]);
+        let ivf = ivf_on_a_line(&positions);
+        let (_, joins) = plan_partition_adjustment(&ivf, DistanceType::L2, &sizes, 100, 1).unwrap();
+        assert_eq!(joins, vec![0, 1]);
+        let actual = execute_joins_on_a_line(&ivf, &sizes, &[(0, 4.0), (1, 10.05)], 400);
+        assert!(actual.iter().all(|&size| size <= 400), "{actual:?}");
+        assert_eq!(&actual[..4], &[0, 0, 400, 400]);
+    }
+
+    #[test]
+    fn plan_partition_adjustment_keeps_room_for_every_joined_row() {
+        // Five partitions of 90 rows at target 100 (threshold 400): 450 rows
+        // need two survivors, so at most three may be joined even though each
+        // one alone would fit next to its neighbor.
+        let ivf = ivf_on_a_line(&[0.0, 1.0, 2.0, 3.0, 4.0]);
+        let (_, joins) =
+            plan_partition_adjustment(&ivf, DistanceType::L2, &[90; 5], 100, 1).unwrap();
+        assert!(joins.len() <= 3, "{joins:?}");
     }
 
     #[tokio::test]

--- a/rust/lance/src/index/vector/builder.rs
+++ b/rust/lance/src/index/vector/builder.rs
@@ -1048,7 +1048,11 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
             no_partition_adjustment()
         } else {
             let target_partition_size = self.effective_target_partition_size()?;
-            let (splits, joins) = Self::check_partition_adjustment(
+            let PartitionAdjustmentPlan {
+                splits,
+                joins,
+                partition_sizes,
+            } = Self::check_partition_adjustment(
                 ivf,
                 self.distance_type,
                 reader.as_ref(),
@@ -1091,7 +1095,15 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
                     target_partition_size,
                     self.existing_indices.len()
                 );
-                let results = self.join_partitions(&joins, ivf).boxed().await?;
+                let results = self
+                    .join_partitions(
+                        &joins,
+                        ivf,
+                        &partition_sizes,
+                        MAX_PARTITION_SIZE_FACTOR * target_partition_size,
+                    )
+                    .boxed()
+                    .await?;
                 let Some(ivf) = self.ivf.as_mut() else {
                     return Err(Error::invalid_input(
                         "IVF model not set before joining partitions",
@@ -1991,7 +2003,7 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
         existing_indices: &[ExistingIndex],
         target_partition_size: usize,
         join_bytes_per_row: usize,
-    ) -> Result<(Vec<PartitionSplit>, Vec<usize>)> {
+    ) -> Result<PartitionAdjustmentPlan> {
         let mut partition_sizes = Vec::with_capacity(ivf.num_partitions());
         for partition in 0..ivf.num_partitions() {
             let mut num_rows = reader.partition_size(partition)?;
@@ -2000,13 +2012,18 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
             }
             partition_sizes.push(num_rows);
         }
-        plan_partition_adjustment(
+        let (splits, joins) = plan_partition_adjustment(
             ivf,
             distance_type,
             &partition_sizes,
             target_partition_size,
             join_bytes_per_row,
-        )
+        )?;
+        Ok(PartitionAdjustmentPlan {
+            splits,
+            joins,
+            partition_sizes,
+        })
     }
 
     /// Split oversized partitions using a streaming approach.
@@ -2479,10 +2496,17 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
 
     /// Join undersized partitions away in one pass: their centroids are removed
     /// and every one of their vectors is reassigned to the nearest remaining
-    /// partition among the `REASSIGN_RANGE` nearest neighbors of its old centroid.
+    /// partition among the `REASSIGN_RANGE` nearest neighbors of its old centroid
+    /// that still has room below `split_threshold`, given `partition_sizes`.
     /// Partitions are loaded one at a time and their rows quantized right away,
     /// so only one partition's raw vectors are in memory at once.
-    async fn join_partitions(&self, partitions: &[usize], ivf: &IvfModel) -> Result<JoinResult> {
+    async fn join_partitions(
+        &self,
+        partitions: &[usize],
+        ivf: &IvfModel,
+        partition_sizes: &[usize],
+        split_threshold: usize,
+    ) -> Result<JoinResult> {
         let removed: HashSet<usize> = partitions.iter().copied().collect();
         let kept_partitions: Vec<usize> = (0..ivf.num_partitions())
             .filter(|partition| !removed.contains(partition))
@@ -2503,6 +2527,11 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
                 "dataset not set before joining partitions",
             ));
         };
+        // Rows each partition can still take before it reaches the split threshold.
+        let mut room: Vec<usize> = partition_sizes
+            .iter()
+            .map(|&size| split_threshold.saturating_sub(size))
+            .collect();
         let (_, element_type) = get_vector_type(dataset.schema(), &self.column)?;
         let assign_batches = match element_type {
             DataType::Float16 => {
@@ -2511,6 +2540,7 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
                     &kept_partitions,
                     ivf,
                     &new_centroids,
+                    &mut room,
                 )
                 .await?
             }
@@ -2520,6 +2550,7 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
                     &kept_partitions,
                     ivf,
                     &new_centroids,
+                    &mut room,
                 )
                 .await?
             }
@@ -2529,6 +2560,7 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
                     &kept_partitions,
                     ivf,
                     &new_centroids,
+                    &mut room,
                 )
                 .await?
             }
@@ -2538,6 +2570,7 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
                     &kept_partitions,
                     ivf,
                     &new_centroids,
+                    &mut room,
                 )
                 .await?
             }
@@ -2562,6 +2595,7 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
         kept_partitions: &[usize],
         ivf: &IvfModel,
         new_centroids: &FixedSizeListArray,
+        room: &mut [usize],
     ) -> Result<Vec<Option<(RecordBatch, UInt64Array)>>>
     where
         T::Native: Dot + L2 + Normalize,
@@ -2589,23 +2623,31 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
                 self.select_reassign_candidates(ivf, part_idx, &c0, &removed)?;
 
             let mut assign_ops = vec![Vec::new(); kept_partitions.len()];
+            let mut overflowed = 0usize;
             for (i, &row_id) in row_ids.values().iter().enumerate() {
-                let ReassignPartition::ReassignCandidate(target) = self.reassign_vectors(
+                let (target, had_room) = reassign_with_room(
+                    self.distance_type,
                     vectors.value(i).as_primitive::<T>(),
-                    None,
                     &reassign_part_ids,
                     &reassign_part_centroids,
-                )?
-                else {
-                    log::warn!("this is a bug, the vector is not reassigned");
-                    continue;
-                };
+                    room,
+                )?;
+                if had_room {
+                    room[target as usize] -= 1;
+                } else {
+                    overflowed += 1;
+                }
                 let output = output_partition[target as usize].ok_or_else(|| {
                     Error::internal(format!(
                         "partition {target} is being joined away but was selected to receive vectors of partition {part_idx}"
                     ))
                 })?;
                 assign_ops[output].push(AssignOp::Add((row_id, vectors.value(i))));
+            }
+            if overflowed > 0 {
+                log::warn!(
+                    "{overflowed} rows of joined partition {part_idx} found no neighbor below the split threshold and went to the nearest full one"
+                );
             }
             let batches = Self::build_assign_batch::<T>(&transformer, &vector_field, &assign_ops)?;
             for (output, batch) in batches.into_iter().enumerate() {
@@ -2785,60 +2827,6 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
     ) -> Result<(UInt32Array, FixedSizeListArray)> {
         select_reassign_candidates_impl(self.distance_type, ivf, part_idx, c0, excluded)
     }
-    // assign a vector to the closest partition among:
-    // 1. the 2 new centroids
-    // 2. the closest REASSIGN_RANGE partitions from the original centroid
-    fn reassign_vectors<T: ArrowPrimitiveType>(
-        &self,
-        vector: &PrimitiveArray<T>,
-        // the dists to the 2 new centroids
-        split_centroids_dists: Option<(f32, f32)>,
-        reassign_candidate_ids: &UInt32Array,
-        reassign_candidate_centroids: &FixedSizeListArray,
-    ) -> Result<ReassignPartition> {
-        Self::reassign_vectors_impl(
-            self.distance_type,
-            vector,
-            split_centroids_dists,
-            reassign_candidate_ids,
-            reassign_candidate_centroids,
-        )
-    }
-
-    fn reassign_vectors_impl<T: ArrowPrimitiveType>(
-        distance_type: DistanceType,
-        vector: &PrimitiveArray<T>,
-        split_centroids_dists: Option<(f32, f32)>,
-        reassign_candidate_ids: &UInt32Array,
-        reassign_candidate_centroids: &FixedSizeListArray,
-    ) -> Result<ReassignPartition> {
-        let dists = distance_type.arrow_batch_func()(vector, reassign_candidate_centroids)?;
-        let min_dist_idx = dists
-            .values()
-            .iter()
-            .enumerate()
-            .min_by(|(_, a), (_, b)| a.total_cmp(b))
-            .map(|(i, _)| i);
-        let min_dist = min_dist_idx
-            .map(|idx| dists.value(idx))
-            .unwrap_or(f32::INFINITY);
-        match split_centroids_dists {
-            Some((d1, d2)) => {
-                if min_dist <= d1 && min_dist <= d2 {
-                    Ok(ReassignPartition::ReassignCandidate(
-                        reassign_candidate_ids.value(min_dist_idx.unwrap()),
-                    ))
-                } else if d1 <= d2 {
-                    Ok(ReassignPartition::NewCentroid1)
-                } else {
-                    Ok(ReassignPartition::NewCentroid2)
-                }
-            }
-            None => Ok(ReassignPartition::ReassignCandidate(
-                reassign_candidate_ids.value(min_dist_idx.unwrap()),
-            )),
-        }
-    }
 }
 
 /// Split every partition above `MAX_PARTITION_SIZE_FACTOR` times the target
@@ -2847,14 +2835,16 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
 /// partitions below `MIN_PARTITION_SIZE_PERCENT` of the target, smallest first,
 /// within two limits:
 ///
-/// * A joined partition's rows go to the nearest surviving centroid, so each
+/// * A joined partition's rows go to its nearest surviving neighbor, so each
 ///   candidate is projected onto that destination and skipped when the
 ///   destination would end up above the split threshold. Without that, many
 ///   small partitions around one survivor would rebuild the very oversized
 ///   partition the split threshold exists to prevent. A destination that is
-///   still undersized may be joined away in a later round, its received rows
-///   re-projected onto their new nearest survivor, so a handful of tiny
-///   partitions converges to one instead of stopping at pairs.
+///   still undersized may be joined away in a later round, taking the rows
+///   projected onto it along, so a handful of tiny partitions converges to one
+///   instead of stopping at pairs. The projection is an estimate: the join
+///   itself places every row in its nearest neighbor with room below the
+///   threshold ([`reassign_with_room`]).
 /// * The joined rows fit in `JOIN_BYTES_BUDGET` at `join_bytes_per_row`, since
 ///   they stay in memory until the merge writes them out. The rest wait for
 ///   the next optimize.
@@ -2884,27 +2874,12 @@ fn plan_partition_adjustment(
         return Ok((splits, Vec::new()));
     }
 
-    let centroids = ivf
-        .centroids_array()
-        .ok_or_else(|| Error::invalid_input("IVF model has no centroids to plan joins"))?;
-    let nearest_survivor = |partition: usize, removed: &[bool]| -> Result<Option<usize>> {
-        let c0 = ivf
-            .centroid(partition)
-            .ok_or(Error::invalid_input("original centroid not found"))?;
-        let dists = distance_type.arrow_batch_func()(&c0, centroids)?;
-        Ok(dists
-            .values()
-            .iter()
-            .enumerate()
-            .filter(|&(other, _)| other != partition && !removed[other])
-            .min_by(|(_, a), (_, b)| a.total_cmp(b))
-            .map(|(other, _)| other))
-    };
-
-    // Sizes once the joins so far are applied, and which joined partitions'
-    // rows each survivor is projected to hold.
+    // Sizes once the joins so far are applied. A joined partition's rows are
+    // projected onto its nearest surviving neighbor, and the rows projected
+    // onto it move on with it: an estimate, since the join itself sends every
+    // row to its own nearest neighbor with room below the split threshold.
     let mut projected_sizes = partition_sizes.to_vec();
-    let mut contributors: Vec<Vec<usize>> = vec![Vec::new(); num_partitions];
+    let mut neighbors: Vec<Option<Vec<u32>>> = vec![None; num_partitions];
     let mut removed = vec![false; num_partitions];
     let mut joined_bytes = 0usize;
     let mut joins = Vec::new();
@@ -2925,35 +2900,22 @@ fn plan_partition_adjustment(
             {
                 break 'rounds;
             }
-            // Its own rows and those projected onto it each go to their nearest
-            // surviving centroid; every such destination must stay below the
-            // split threshold.
-            removed[partition] = true;
-            let mut moves = Vec::with_capacity(contributors[partition].len() + 1);
-            for &source in std::iter::once(&partition).chain(contributors[partition].iter()) {
-                match nearest_survivor(source, &removed)? {
-                    Some(destination) => moves.push((source, destination)),
-                    None => break,
-                }
-            }
-            let mut increments: HashMap<usize, usize> = HashMap::new();
-            for &(source, destination) in &moves {
-                *increments.entry(destination).or_default() += partition_sizes[source];
-            }
-            let fits = moves.len() == contributors[partition].len() + 1
-                && increments.iter().all(|(&destination, &rows)| {
-                    projected_sizes[destination] + rows <= split_threshold
-                });
-            if !fits {
-                removed[partition] = false;
+            let Some(destination) = nearest_surviving_neighbor(
+                ivf,
+                distance_type,
+                partition,
+                &removed,
+                &mut neighbors[partition],
+            )?
+            else {
+                continue;
+            };
+            if projected_sizes[destination] + projected_sizes[partition] > split_threshold {
                 continue;
             }
-            for (source, destination) in moves {
-                projected_sizes[destination] += partition_sizes[source];
-                contributors[destination].push(source);
-            }
+            projected_sizes[destination] += projected_sizes[partition];
             projected_sizes[partition] = 0;
-            contributors[partition].clear();
+            removed[partition] = true;
             joined_bytes += num_rows * join_bytes_per_row;
             joins.push(partition);
             progress = true;
@@ -2964,6 +2926,69 @@ fn plan_partition_adjustment(
     }
     joins.sort_unstable();
     Ok((splits, joins))
+}
+
+/// The nearest partition to `partition` that is not joined away. `cache` holds
+/// its `REASSIGN_RANGE` nearest neighbors from the last lookup and is refetched
+/// past the removed partitions only once every cached one is gone, so a chain
+/// of joins does not recompute the distances to every centroid at each step.
+fn nearest_surviving_neighbor(
+    ivf: &IvfModel,
+    distance_type: DistanceType,
+    partition: usize,
+    removed: &[bool],
+    cache: &mut Option<Vec<u32>>,
+) -> Result<Option<usize>> {
+    if let Some(ids) = cache
+        && let Some(&id) = ids.iter().find(|&&id| !removed[id as usize])
+    {
+        return Ok(Some(id as usize));
+    }
+    let c0 = ivf
+        .centroid(partition)
+        .ok_or(Error::invalid_input("original centroid not found"))?;
+    let excluded: HashSet<usize> = removed
+        .iter()
+        .enumerate()
+        .filter(|(_, gone)| **gone)
+        .map(|(other, _)| other)
+        .collect();
+    let (ids, _) = select_reassign_candidates_impl(distance_type, ivf, partition, &c0, &excluded)?;
+    let ids = ids.values().to_vec();
+    let nearest = ids.first().map(|&id| id as usize);
+    *cache = Some(ids);
+    Ok(nearest)
+}
+
+/// The candidate partition nearest to `vector` among those with `room` for
+/// another row, so a join cannot push a partition above the split threshold.
+/// Only when every candidate is full does the row go to the nearest one.
+fn reassign_with_room<T: ArrowPrimitiveType>(
+    distance_type: DistanceType,
+    vector: &PrimitiveArray<T>,
+    candidate_ids: &UInt32Array,
+    candidate_centroids: &FixedSizeListArray,
+    room: &[usize],
+) -> Result<(u32, bool)>
+where
+    T::Native: Dot + L2 + Normalize,
+{
+    let dists = distance_type.arrow_batch_func()(vector, candidate_centroids)?;
+    let nearest = |with_room: bool| {
+        dists
+            .values()
+            .iter()
+            .enumerate()
+            .filter(|&(i, _)| !with_room || room[candidate_ids.value(i) as usize] > 0)
+            .min_by(|(_, a), (_, b)| a.total_cmp(b))
+            .map(|(i, _)| candidate_ids.value(i))
+    };
+    if let Some(target) = nearest(true) {
+        return Ok((target, true));
+    }
+    let target = nearest(false)
+        .ok_or_else(|| Error::internal("a joined partition has no neighbor to receive its rows"))?;
+    Ok((target, false))
 }
 
 /// The nearest `REASSIGN_RANGE` partitions to `c0`, skipping `part_idx` itself and
@@ -2997,6 +3022,13 @@ fn select_reassign_candidates_impl(
     ))
 }
 
+/// What one optimize pass does to the partitions, from the sizes it saw.
+struct PartitionAdjustmentPlan {
+    splits: Vec<PartitionSplit>,
+    joins: Vec<usize>,
+    partition_sizes: Vec<usize>,
+}
+
 struct JoinResult {
     assign_batches: Vec<Option<(RecordBatch, UInt64Array)>>,
     new_centroids: FixedSizeListArray,
@@ -3013,13 +3045,6 @@ struct SplitResult {
 #[derive(Debug, Clone)]
 enum AssignOp {
     Add((u64, ArrayRef)),
-}
-
-#[derive(Debug, Copy, Clone)]
-enum ReassignPartition {
-    NewCentroid1,
-    NewCentroid2,
-    ReassignCandidate(u32),
 }
 
 enum PartitionAdjustment {
@@ -3849,6 +3874,98 @@ mod tests {
             projected.iter().all(|&rows| rows <= 400),
             "a join destination exceeds the split threshold: {projected:?}"
         );
+    }
+
+    #[test]
+    fn plan_partition_adjustment_handles_a_chain_of_empty_partitions_quickly() {
+        // Every partition is empty and each one's nearest neighbor is the next:
+        // one long chain of joins, which must not recompute the distances to
+        // every centroid at each step.
+        const NUM_PARTITIONS: usize = 512;
+        let positions: Vec<f32> = (0..NUM_PARTITIONS).map(|i| i as f32).collect();
+        let ivf = ivf_on_a_line(&positions);
+        let started = std::time::Instant::now();
+        let (_, joins) =
+            plan_partition_adjustment(&ivf, DistanceType::L2, &[0; NUM_PARTITIONS], 4096, 1)
+                .unwrap();
+        let elapsed = started.elapsed();
+        assert_eq!(joins.len(), NUM_PARTITIONS - 1);
+        assert!(elapsed < std::time::Duration::from_secs(1), "{elapsed:?}");
+    }
+
+    #[test]
+    fn reassign_with_room_spills_to_the_next_neighbor() {
+        // Rows at 4.0 are nearest to the centroid at 10.0, which has room for
+        // ten more; the rest go to the centroid at -9.0.
+        let candidate_ids = UInt32Array::from(vec![1_u32, 2]);
+        let candidate_centroids =
+            FixedSizeListArray::try_new_from_values(Float32Array::from(vec![-9.0_f32, 10.0]), 1)
+                .unwrap();
+        let mut room = vec![0, 300, 10];
+        let vector = Float32Array::from(vec![4.0_f32]);
+        let mut targets = vec![0usize; 3];
+        for _ in 0..24 {
+            let (target, had_room) = reassign_with_room(
+                DistanceType::L2,
+                &vector,
+                &candidate_ids,
+                &candidate_centroids,
+                &room,
+            )
+            .unwrap();
+            assert!(had_room);
+            room[target as usize] -= 1;
+            targets[target as usize] += 1;
+        }
+        assert_eq!(targets, vec![0, 14, 10]);
+        // With every candidate full the nearest one takes the row anyway.
+        let (target, had_room) = reassign_with_room(
+            DistanceType::L2,
+            &vector,
+            &candidate_ids,
+            &candidate_centroids,
+            &[0, 0, 0],
+        )
+        .unwrap();
+        assert_eq!((target, had_room), (2, false));
+    }
+
+    #[tokio::test]
+    async fn optimize_join_keeps_every_destination_below_the_split_threshold() {
+        use crate::index::DatasetIndexExt;
+        use lance_index::optimize::OptimizeOptions;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let uri = tmp.path().to_str().unwrap();
+        // The 24 rows of the partition at 0 sit at 4.0, nearer to the 390-row
+        // partition at 10 than to the 100-row one at -9. Only ten fit below the
+        // split threshold of 400; the other fourteen must go to -9.
+        let mut dataset = write_clusters(uri, &[(24, 4.0), (100, -9.0), (390, 10.0)]).await;
+        let params = ivf_flat_at_centers(&[0.0, -9.0, 10.0], Some(100));
+        dataset
+            .create_index(
+                &["vec"],
+                IndexType::Vector,
+                Some("idx".into()),
+                &params,
+                false,
+            )
+            .await
+            .unwrap();
+
+        let mut dataset = append_cluster(dataset, 1, -9.0).await;
+        dataset
+            .optimize_indices(&OptimizeOptions::default())
+            .await
+            .unwrap();
+
+        let optimized = open_single_segment(&dataset).await;
+        let ivf = optimized.ivf_model();
+        let mut sizes: Vec<usize> = (0..ivf.num_partitions())
+            .map(|p| optimized.partition_size(p))
+            .collect();
+        sizes.sort_unstable();
+        assert_eq!(sizes, vec![115, 400]);
     }
 
     #[test]

--- a/rust/lance/src/index/vector/builder.rs
+++ b/rust/lance/src/index/vector/builder.rs
@@ -115,6 +115,13 @@ const REASSIGN_SAMPLE_SIZE: usize = 512;
 /// margin of its own centroid's distance, so near-ties do not prune a neighbor
 /// that unsampled rows would still leave.
 const REASSIGN_MARGIN: f32 = 0.05;
+/// Logical rows a join fetches at a time from a multivector column, where a
+/// row can expand to many vectors; a single oversized row is the one working
+/// set that cannot be split further.
+const JOIN_MULTIVECTOR_ROWS_PER_FETCH: usize = 64;
+/// Vectors a join routes and quantizes at a time before handing them to the
+/// shuffler, whatever the fetched rows expanded to.
+const JOIN_VECTORS_PER_BATCH: usize = 1024;
 
 /// Number of partitions the split partitions' rows now belong to.
 fn new_partition_ids_len(split_partitions: &[(usize, Vec<usize>)]) -> usize {
@@ -1872,29 +1879,35 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
         store: &ObjectStore,
         row_ids: &[u64],
     ) -> Result<Vec<RecordBatch>> {
-        Self::take_vectors_stream(dataset, column, store, row_ids)
-            .await?
-            .try_collect()
-            .await
+        Self::take_vectors_stream(
+            dataset,
+            column,
+            row_ids,
+            store.block_size(),
+            store.io_parallelism(),
+        )
+        .await?
+        .try_collect()
+        .await
     }
 
-    /// The raw vectors of `row_ids` in chunks of `store.block_size()` rows,
-    /// each batch with schema | row_id | vector |, loaded as they are read.
+    /// The raw vectors of `row_ids` in chunks of `rows_per_chunk` rows with up
+    /// to `prefetch` chunks in flight, each batch with schema | row_id | vector |.
     async fn take_vectors_stream(
         dataset: &Dataset,
         column: &str,
-        store: &ObjectStore,
         row_ids: &[u64],
+        rows_per_chunk: usize,
+        prefetch: usize,
     ) -> Result<impl Stream<Item = Result<RecordBatch>> + Send + 'static> {
         let projection = Arc::new(dataset.schema().project(&[column])?);
         // arrow uses i32 for index, so we chunk the row ids to avoid large batch causing overflow
         let row_ids = dataset.filter_deleted_ids(row_ids).await?;
         let chunks: Vec<Vec<u64>> = row_ids
-            .chunks(store.block_size())
+            .chunks(rows_per_chunk.max(1))
             .map(|chunk| chunk.to_vec())
             .collect();
         let dataset = dataset.clone();
-        let io_parallelism = store.io_parallelism();
         Ok(stream::iter(chunks)
             .map(move |chunk| {
                 let dataset = dataset.clone();
@@ -1916,7 +1929,7 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
                     )?)
                 }
             })
-            .buffered(io_parallelism))
+            .buffered(prefetch.max(1)))
     }
 
     /// A chunk of raw vectors flattened to one row id per vector (a multivector
@@ -2528,6 +2541,7 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
                     ivf,
                     &removed,
                     &mut room,
+                    multivector,
                 )
                 .await?
             }
@@ -2538,6 +2552,7 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
                     ivf,
                     &removed,
                     &mut room,
+                    multivector,
                 )
                 .await?
             }
@@ -2548,6 +2563,7 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
                     ivf,
                     &removed,
                     &mut room,
+                    multivector,
                 )
                 .await?
             }
@@ -2558,6 +2574,7 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
                     ivf,
                     &removed,
                     &mut room,
+                    multivector,
                 )
                 .await?
             }
@@ -2577,7 +2594,10 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
     }
 
     /// Route and quantize the rows of each joined partition chunk by chunk,
-    /// writing them through a shuffler keyed by old partition id.
+    /// writing them through a shuffler keyed by old partition id. A single
+    /// vector row is routed within its partition's window; every vector of a
+    /// multivector row gets its own, since it may lie far from the joined
+    /// partition the row was found under.
     async fn join_partitions_impl<T: ArrowPrimitiveType>(
         &self,
         partitions: &[usize],
@@ -2585,6 +2605,7 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
         ivf: &IvfModel,
         removed: &HashSet<usize>,
         room: &mut [usize],
+        multivector: bool,
     ) -> Result<Arc<dyn ShuffleReader>>
     where
         T::Native: Dot + L2 + Normalize,
@@ -2626,6 +2647,11 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
                 .shuffle(Box::new(RecordBatchStreamAdapter::new(schema, batches)))
                 .await
         };
+        let (rows_per_fetch, prefetch) = if multivector {
+            (JOIN_MULTIVECTOR_ROWS_PER_FETCH, 1)
+        } else {
+            (self.store.block_size(), 2)
+        };
         let route = async move {
             for (&part_idx, row_ids) in partitions.iter().zip(rows_per_partition) {
                 if row_ids.is_empty() {
@@ -2634,44 +2660,62 @@ impl<S: IvfSubIndex + 'static, Q: Quantization + 'static> IvfIndexBuilder<S, Q> 
                 let c0 = ivf
                     .centroid(part_idx)
                     .ok_or(Error::invalid_input("original centroid not found"))?;
-                let (window_ids, window_centroids) =
+                let partition_window =
                     self.select_reassign_candidates(ivf, part_idx, &c0, removed)?;
                 let mut overflowed = 0usize;
-                let mut chunks =
-                    Self::take_vectors_stream(dataset, &self.column, &self.store, row_ids).await?;
+                let mut chunks = Self::take_vectors_stream(
+                    dataset,
+                    &self.column,
+                    row_ids,
+                    rows_per_fetch,
+                    prefetch,
+                )
+                .await?;
                 while let Some(chunk) = chunks.try_next().await? {
                     let (row_ids, vectors) = self.flatten_raw_vectors(&chunk)?;
-                    let mut assign_ops: BTreeMap<u32, Vec<AssignOp>> = BTreeMap::new();
-                    for i in 0..row_ids.len() {
-                        let (target, had_room) = choose_join_destination(
-                            self.distance_type,
-                            vectors.value(i).as_primitive::<T>(),
-                            &window_ids,
-                            &window_centroids,
-                            ivf,
-                            removed,
-                            room,
-                        )?;
-                        if had_room {
-                            room[target as usize] -= 1;
-                        } else {
-                            overflowed += 1;
+                    for start in (0..row_ids.len()).step_by(JOIN_VECTORS_PER_BATCH) {
+                        let end = (start + JOIN_VECTORS_PER_BATCH).min(row_ids.len());
+                        let mut assign_ops: BTreeMap<u32, Vec<AssignOp>> = BTreeMap::new();
+                        for i in start..end {
+                            let vector = vectors.value(i);
+                            let vector_window;
+                            let (window_ids, window_centroids) = if multivector {
+                                vector_window =
+                                    window_for_vector(self.distance_type, ivf, &vector, removed)?;
+                                &vector_window
+                            } else {
+                                &partition_window
+                            };
+                            let (target, had_room) = choose_join_destination(
+                                self.distance_type,
+                                vector.as_primitive::<T>(),
+                                window_ids,
+                                window_centroids,
+                                ivf,
+                                removed,
+                                room,
+                            )?;
+                            if had_room {
+                                room[target as usize] -= 1;
+                            } else {
+                                overflowed += 1;
+                            }
+                            assign_ops
+                                .entry(target)
+                                .or_default()
+                                .push(AssignOp::Add((row_ids.value(i), vector)));
                         }
-                        assign_ops
-                            .entry(target)
-                            .or_default()
-                            .push(AssignOp::Add((row_ids.value(i), vectors.value(i))));
-                    }
-                    for (target, ops) in assign_ops {
-                        let batch = Self::build_assign_batch::<T>(
-                            &transformer,
-                            &vector_field,
-                            target,
-                            &ops,
-                        )?;
-                        sender.send(batch).await.map_err(|_| {
-                            Error::internal("the join shuffler stopped taking batches")
-                        })?;
+                        for (target, ops) in assign_ops {
+                            let batch = Self::build_assign_batch::<T>(
+                                &transformer,
+                                &vector_field,
+                                target,
+                                &ops,
+                            )?;
+                            sender.send(batch).await.map_err(|_| {
+                                Error::internal("the join shuffler stopped taking batches")
+                            })?;
+                        }
                     }
                 }
                 if overflowed > 0 {
@@ -3036,6 +3080,19 @@ where
     })?
     .ok_or_else(|| Error::internal("a joined partition has no neighbor to receive its rows"))?;
     Ok((target, false))
+}
+
+/// The `REASSIGN_RANGE` nearest surviving partitions to `vector` itself, for a
+/// vector of a reindexed multivector row: it may belong to a region far from
+/// the joined partition the row was found under, so that partition's window
+/// would place it wrongly.
+fn window_for_vector(
+    distance_type: DistanceType,
+    ivf: &IvfModel,
+    vector: &ArrayRef,
+    removed: &HashSet<usize>,
+) -> Result<(UInt32Array, FixedSizeListArray)> {
+    select_reassign_candidates_impl(distance_type, ivf, usize::MAX, vector, removed)
 }
 
 /// The nearest `REASSIGN_RANGE` partitions to `c0`, skipping `part_idx` itself and
@@ -4170,6 +4227,38 @@ mod tests {
             sizes.iter().all(|&rows| rows <= 400),
             "a join destination exceeds the split threshold: {sizes:?}"
         );
+    }
+
+    #[test]
+    fn join_window_follows_each_vector_of_a_multivector_row() {
+        // A row found under joined partition 0 has a vector at 100, whose exact
+        // surviving centroid (66) lies outside partition 0's 64-neighbor window
+        // of centroids near 0; routed by its own window it goes to 66.
+        let mut positions: Vec<f32> = (0..65).map(|i| i as f32 * 0.001).collect();
+        positions.extend([100.0, 100.0]);
+        let ivf = ivf_on_a_line(&positions);
+        let removed: HashSet<usize> = [0, 65].into_iter().collect();
+        let vector: ArrayRef = Arc::new(Float32Array::from(vec![100.0_f32]));
+        let (window_ids, window_centroids) =
+            window_for_vector(DistanceType::L2, &ivf, &vector, &removed).unwrap();
+        assert_eq!(window_ids.value(0), 66);
+        let room = vec![1; positions.len()];
+        let (target, had_room) = choose_join_destination(
+            DistanceType::L2,
+            vector.as_primitive::<Float32Type>(),
+            &window_ids,
+            &window_centroids,
+            &ivf,
+            &removed,
+            &room,
+        )
+        .unwrap();
+        assert_eq!((target, had_room), (66, true));
+        // Partition 0's own window would have kept it near 0.
+        let c0 = ivf.centroid(0).unwrap();
+        let (partition_window, _) =
+            select_reassign_candidates_impl(DistanceType::L2, &ivf, 0, &c0, &removed).unwrap();
+        assert!(!partition_window.values().contains(&66));
     }
 
     #[test]

--- a/rust/lance/src/index/vector/details.rs
+++ b/rust/lance/src/index/vector/details.rs
@@ -237,6 +237,12 @@ pub fn apply_runtime_hints(hints: &HashMap<String, String>, params: &mut VectorI
 /// Reconstruct `VectorIndexParams` from a stored `VectorIndexDetails` proto.
 ///
 /// Returns `None` for legacy indices (empty details) or if the proto is malformed.
+/// The rows-per-partition target the index was created with, if it was recorded.
+pub fn target_partition_size_from_details(details: &prost_types::Any) -> Option<usize> {
+    let details = details.to_msg::<VectorIndexDetails>().ok()?;
+    (details.target_partition_size > 0).then_some(details.target_partition_size as usize)
+}
+
 /// Runtime hints are applied on top of the reconstructed spec.
 // TODO: wire into a general `Dataset::rebuild_index` method so users can
 // regenerate an index from its stored details (e.g. after file corruption).

--- a/rust/lance/src/index/vector/ivf.rs
+++ b/rust/lance/src/index/vector/ivf.rs
@@ -3,6 +3,7 @@
 
 //! IVF - Inverted File index.
 
+use super::details::target_partition_size_from_details;
 use super::{
     LogicalIvfView, derive_hnsw_params,
     pq::{PQIndex, build_pq_model},
@@ -384,30 +385,55 @@ pub(crate) fn index_type_for_segmented_optimize(index: &dyn VectorIndex) -> Resu
     IndexType::try_from(index_type_string(sub_index_type, quantization_type).as_str())
 }
 
-pub(crate) fn select_segment_for_single_rebalance(
+/// What a steady-state optimize (no new rows) should do to a logical IVF index.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum SteadyStateRebalance {
+    /// Rewrite this one segment alone: it holds oversized partitions.
+    Segment(Uuid),
+    /// Merge every segment: some partitions are undersized across the whole
+    /// logical index, which only a merge can repair.
+    MergeAll,
+}
+
+/// Pick the steady-state rebalance for a logical IVF index.
+///
+/// Splits are decided per segment, since an oversized partition lives in one
+/// segment's file. Joins are decided on the partition sizes summed over all
+/// segments: a delta segment's partitions are small on their own but normal
+/// once merged with the base segment, so joining them per segment would
+/// collapse every delta into a handful of partitions.
+pub(crate) fn select_steady_state_rebalance(
     logical_index: &LogicalIvfView<'_>,
-) -> Result<Option<Uuid>> {
+) -> Result<Option<SteadyStateRebalance>> {
     let mut best_split = None;
-    let mut best_join = None;
+    let mut summed_sizes: Vec<usize> = Vec::new();
+    let mut join_threshold = None;
 
     for (metadata, index) in logical_index.segments() {
         let index_type = index_type_for_segmented_optimize(index.as_ref())?;
-        let split_threshold = MAX_PARTITION_SIZE_FACTOR * index_type.target_partition_size();
-        let join_threshold = MIN_PARTITION_SIZE_PERCENT * index_type.target_partition_size() / 100;
+        let target_partition_size = metadata
+            .index_details
+            .as_deref()
+            .and_then(target_partition_size_from_details)
+            .unwrap_or_else(|| index_type.target_partition_size());
+        let split_threshold = MAX_PARTITION_SIZE_FACTOR * target_partition_size;
+        // The builder derives its thresholds from the first segment's target.
+        join_threshold.get_or_insert(MIN_PARTITION_SIZE_PERCENT * target_partition_size / 100);
         let num_partitions = index.ivf_model().num_partitions();
         if num_partitions == 0 {
             continue;
         }
+        if summed_sizes.len() < num_partitions {
+            summed_sizes.resize(num_partitions, 0);
+        }
 
         let mut split_partition_count = 0usize;
-        let mut join_partition_count = 0usize;
-        for partition_id in 0..num_partitions {
+        for (partition_id, summed_size) in summed_sizes.iter_mut().enumerate().take(num_partitions)
+        {
             let partition_size = index.partition_size(partition_id);
+            *summed_size += partition_size;
             if partition_size > split_threshold {
                 split_partition_count += 1;
-            }
-            if num_partitions > 1 && partition_size < join_threshold {
-                join_partition_count += 1;
             }
         }
 
@@ -426,21 +452,17 @@ pub(crate) fn select_segment_for_single_rebalance(
         {
             best_split = Some(candidate);
         }
-
-        let join_candidate = (join_partition_count > 0).then_some(SegmentRebalanceCandidate {
-            segment_id: metadata.uuid,
-            score: join_partition_count,
-            created_at_ms,
-        });
-        if let Some(candidate) = join_candidate
-            && candidate_is_better(candidate, best_join)
-        {
-            best_join = Some(candidate);
-        }
     }
 
-    let selected = best_split.or(best_join);
-    Ok(selected.map(|candidate| candidate.segment_id))
+    if let Some(candidate) = best_split {
+        return Ok(Some(SteadyStateRebalance::Segment(candidate.segment_id)));
+    }
+    let Some(join_threshold) = join_threshold else {
+        return Ok(None);
+    };
+    let has_join_candidate =
+        summed_sizes.len() > 1 && summed_sizes.iter().any(|&size| size < join_threshold);
+    Ok(has_join_candidate.then_some(SteadyStateRebalance::MergeAll))
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -663,8 +685,20 @@ pub(crate) async fn optimize_vector_indices(
     // fallback to v2 IVFIndex if it's not v1 IVFIndex
     if !existing_indices[0].as_any().is::<IVFIndex>() {
         let sources = existing_index_sources(&dataset, logical_index);
-        return optimize_vector_indices_v2(&dataset, unindexed, vector_column, &sources, options)
-            .await;
+        let target_partition_size = logical_index
+            .segments()
+            .next()
+            .and_then(|(metadata, _)| metadata.index_details.as_deref())
+            .and_then(target_partition_size_from_details);
+        return optimize_vector_indices_v2(
+            &dataset,
+            unindexed,
+            vector_column,
+            &sources,
+            options,
+            target_partition_size,
+        )
+        .await;
     }
 
     let new_uuid = Uuid::new_v4();
@@ -735,6 +769,7 @@ pub(crate) async fn optimize_vector_indices_v2(
     vector_column: &str,
     existing_indices: &[ExistingIndex],
     options: &OptimizeOptions,
+    target_partition_size: Option<usize>,
 ) -> Result<(Uuid, usize, Vec<IndexFile>)> {
     // Sanity check the indices
     if existing_indices.is_empty() {
@@ -779,6 +814,7 @@ pub(crate) async fn optimize_vector_indices_v2(
                 .with_quantizer(quantizer.try_into()?)
                 .with_existing_index_sources(existing_indices.clone())
                 .with_progress(options.progress.clone())
+                .with_target_partition_size(target_partition_size)
                 .shuffle_data_input(unindexed)
                 .build()
                 .await?
@@ -797,6 +833,7 @@ pub(crate) async fn optimize_vector_indices_v2(
                 .with_quantizer(quantizer.try_into()?)
                 .with_existing_index_sources(existing_indices.clone())
                 .with_progress(options.progress.clone())
+                .with_target_partition_size(target_partition_size)
                 .shuffle_data_input(unindexed)
                 .build()
                 .await?
@@ -818,6 +855,7 @@ pub(crate) async fn optimize_vector_indices_v2(
             .with_quantizer(quantizer.try_into()?)
             .with_existing_index_sources(existing_indices.clone())
             .with_progress(options.progress.clone())
+            .with_target_partition_size(target_partition_size)
             .shuffle_data_input(unindexed)
             .build()
             .await?
@@ -838,6 +876,7 @@ pub(crate) async fn optimize_vector_indices_v2(
             .with_quantizer(quantizer.try_into()?)
             .with_existing_index_sources(existing_indices.clone())
             .with_progress(options.progress.clone())
+            .with_target_partition_size(target_partition_size)
             .shuffle_data_input(unindexed)
             .build()
             .await?
@@ -858,6 +897,7 @@ pub(crate) async fn optimize_vector_indices_v2(
             .with_quantizer(quantizer.try_into()?)
             .with_existing_index_sources(existing_indices.clone())
             .with_progress(options.progress.clone())
+            .with_target_partition_size(target_partition_size)
             .shuffle_data_input(unindexed)
             .build()
             .await?
@@ -877,6 +917,7 @@ pub(crate) async fn optimize_vector_indices_v2(
             .with_quantizer(quantizer.try_into()?)
             .with_existing_index_sources(existing_indices.clone())
             .with_progress(options.progress.clone())
+            .with_target_partition_size(target_partition_size)
             .shuffle_data_input(unindexed)
             .build()
             .await?
@@ -898,6 +939,7 @@ pub(crate) async fn optimize_vector_indices_v2(
                 .with_quantizer(quantizer.try_into()?)
                 .with_existing_index_sources(existing_indices.clone())
                 .with_progress(options.progress.clone())
+                .with_target_partition_size(target_partition_size)
                 .shuffle_data_input(unindexed)
                 .build()
                 .await?
@@ -916,6 +958,7 @@ pub(crate) async fn optimize_vector_indices_v2(
                 .with_quantizer(quantizer.try_into()?)
                 .with_existing_index_sources(existing_indices.clone())
                 .with_progress(options.progress.clone())
+                .with_target_partition_size(target_partition_size)
                 .shuffle_data_input(unindexed)
                 .build()
                 .await?
@@ -937,6 +980,7 @@ pub(crate) async fn optimize_vector_indices_v2(
             .with_quantizer(quantizer.try_into()?)
             .with_existing_index_sources(existing_indices.clone())
             .with_progress(options.progress.clone())
+            .with_target_partition_size(target_partition_size)
             .shuffle_data_input(unindexed)
             .build()
             .await?
@@ -957,6 +1001,7 @@ pub(crate) async fn optimize_vector_indices_v2(
             .with_quantizer(quantizer.try_into()?)
             .with_existing_index_sources(existing_indices.clone())
             .with_progress(options.progress.clone())
+            .with_target_partition_size(target_partition_size)
             .shuffle_data_input(unindexed)
             .build()
             .await?
@@ -5051,6 +5096,7 @@ mod tests {
             "vector",
             &sources,
             &OptimizeOptions::new(),
+            None,
         )
         .await
         .unwrap();
@@ -5066,6 +5112,7 @@ mod tests {
             "vector",
             &sources,
             &OptimizeOptions::merge(1),
+            None,
         )
         .await
         .unwrap();

--- a/rust/lance/src/index/vector/ivf.rs
+++ b/rust/lance/src/index/vector/ivf.rs
@@ -401,9 +401,12 @@ pub(crate) enum SteadyStateRebalance {
 /// segment's file. Joins are decided on the partition sizes summed over all
 /// segments: a delta segment's partitions are small on their own but normal
 /// once merged with the base segment, so joining them per segment would
-/// collapse every delta into a handful of partitions.
+/// collapse every delta into a handful of partitions. That merge needs the
+/// segments to share one model, so segments with different centroids (whose
+/// partition ids do not even correspond) are never joined.
 pub(crate) fn select_steady_state_rebalance(
     logical_index: &LogicalIvfView<'_>,
+    compatibility: VectorSegmentCompatibility,
 ) -> Result<Option<SteadyStateRebalance>> {
     let mut best_split = None;
     let mut summed_sizes: Vec<usize> = Vec::new();
@@ -456,6 +459,9 @@ pub(crate) fn select_steady_state_rebalance(
 
     if let Some(candidate) = best_split {
         return Ok(Some(SteadyStateRebalance::Segment(candidate.segment_id)));
+    }
+    if compatibility != VectorSegmentCompatibility::SharedModel {
+        return Ok(None);
     }
     let Some(join_threshold) = join_threshold else {
         return Ok(None);

--- a/rust/lance/src/index/vector/ivf/v2.rs
+++ b/rust/lance/src/index/vector/ivf/v2.rs
@@ -3052,10 +3052,15 @@ mod tests {
         let ids = Arc::new(UInt64Array::from_iter_values(
             start_id..start_id + total_rows as u64,
         ));
+        // A tiny per-row drift keeps the appended rows distinct (identical rows
+        // cannot be split by clustering) without moving them off their template's
+        // partition.
         let mut appended_values = Vec::with_capacity(total_rows * DIM);
         for template in templates {
-            for _ in 0..rows_per_template {
-                appended_values.extend_from_slice(template);
+            for row in 0..rows_per_template {
+                let mut values = template.clone();
+                values[0] += row as f32 * 0.0001;
+                appended_values.extend_from_slice(&values);
             }
         }
         let vectors = Arc::new(
@@ -6570,14 +6575,17 @@ mod tests {
         .await;
         expected_rows += NO_SPLIT_APPEND_ROWS;
 
+        // The oversized partition is split straight to the target size in one
+        // optimize: ceil(rows / target) pieces instead of a single halving.
+        let split_rows = expected_rows + SPLIT_APPEND_ROWS;
         append_and_verify_append_phase(
             &mut dataset,
             INDEX_NAME,
             &template_values,
             &mut next_id,
             SPLIT_APPEND_ROWS,
-            2,
-            expected_rows + SPLIT_APPEND_ROWS,
+            split_rows.div_ceil(IndexType::IvfPq.target_partition_size()),
+            split_rows,
             1,
             true,
         )
@@ -6623,17 +6631,21 @@ mod tests {
             .unwrap();
 
         let expected_rows = NUM_ROWS + APPEND_ROWS;
+        // Every vector of a row counts towards the partition size, and the split
+        // goes straight to the target size: ceil(vectors / target) pieces.
+        let expected_partitions =
+            (expected_rows * VECTORS_PER_ROW).div_ceil(IndexType::IvfPq.target_partition_size());
         let final_ctx = load_vector_index_context(&dataset, "vector", INDEX_NAME).await;
         assert_eq!(
             final_ctx.num_partitions(),
-            2,
-            "Expected one oversized multivector partition to split, stats: {}",
+            expected_partitions,
+            "Expected the oversized multivector partition to split into {expected_partitions}, stats: {}",
             final_ctx.stats_json()
         );
         let partitions = final_ctx.stats()["indices"][0]["partitions"]
             .as_array()
             .expect("partitions should be present");
-        assert_eq!(partitions.len(), 2);
+        assert_eq!(partitions.len(), expected_partitions);
         assert_eq!(
             partitions
                 .iter()
@@ -6724,10 +6736,14 @@ mod tests {
             .unwrap();
         dataset.validate().await.unwrap();
 
+        // Both partitions hold BASE + APPEND rows and are split straight to the
+        // target size in one optimize: ceil(rows / target) pieces each.
+        let pieces_per_partition = (BASE_ROWS_PER_PARTITION + APPEND_ROWS_PER_PARTITION)
+            .div_ceil(IndexType::IvfFlat.target_partition_size());
         let final_ctx = load_vector_index_context(&dataset, "vector", INDEX_NAME).await;
         assert_eq!(
             final_ctx.num_partitions(),
-            4,
+            2 * pieces_per_partition,
             "Expected both original partitions to split in one optimize, stats: {}",
             final_ctx.stats_json()
         );
@@ -6745,7 +6761,7 @@ mod tests {
         let partitions = indices[0]["partitions"]
             .as_array()
             .expect("partitions should be present");
-        assert_eq!(partitions.len(), 4);
+        assert_eq!(partitions.len(), 2 * pieces_per_partition);
         let expected_rows = 2 * BASE_ROWS_PER_PARTITION + 2 * APPEND_ROWS_PER_PARTITION;
         let total_partition_rows = partitions
             .iter()
@@ -7053,12 +7069,12 @@ mod tests {
     async fn test_optimize_join_after_delete_with_stable_row_ids() {
         // Regression test for https://github.com/lance-format/lance/issues/7701:
         // every partition (400 rows / 4) is under the IVF_FLAT join threshold,
-        // so optimize joins the smallest after a scattered delete.
+        // so one optimize joins all of them but the largest after a scattered delete.
         let run = optimize_after_delete(400, 4, "id % 3 = 0", "id % 3 != 0").await;
 
         assert_eq!(
-            run.num_partitions_after, 3,
-            "optimize should have joined the smallest partition, got stats: {}",
+            run.num_partitions_after, 1,
+            "optimize should have joined every undersized partition but one, got stats: {}",
             run.stats_json
         );
 

--- a/rust/lance/src/index/vector/ivf/v2.rs
+++ b/rust/lance/src/index/vector/ivf/v2.rs
@@ -2987,7 +2987,7 @@ mod tests {
         delete_ids(dataset, &ids[1..]).await;
         compact_after_deletions(dataset).await;
 
-        append_constant_vector_with_start_id(
+        append_template_vector_with_start_id(
             dataset,
             ROWS_TO_APPEND_FOR_JOIN,
             &template_values,
@@ -3019,13 +3019,13 @@ mod tests {
         (deleted_rows, ROWS_TO_APPEND_FOR_JOIN, post_partitions)
     }
 
-    async fn append_constant_vector_with_start_id(
+    async fn append_template_vector_with_start_id(
         dataset: &mut Dataset,
         rows: usize,
         template: &[f32],
         next_id: &mut u64,
     ) {
-        append_constant_vector_batch(dataset, rows, template, *next_id, None).await;
+        append_template_vector_batch(dataset, rows, template, *next_id, None).await;
         *next_id += rows as u64;
     }
 
@@ -3079,17 +3079,17 @@ mod tests {
         dataset.append(batches, None).await.unwrap();
     }
 
-    async fn append_constant_vector_with_params(
+    async fn append_template_vector_with_params(
         dataset: &mut Dataset,
         rows: usize,
         template: &[f32],
         write_params: Option<WriteParams>,
     ) {
         let start_id = dataset.count_all_rows().await.unwrap() as u64;
-        append_constant_vector_batch(dataset, rows, template, start_id, write_params).await;
+        append_template_vector_batch(dataset, rows, template, start_id, write_params).await;
     }
 
-    async fn append_constant_vector_batch(
+    async fn append_template_vector_batch(
         dataset: &mut Dataset,
         rows: usize,
         template: &[f32],
@@ -3106,9 +3106,14 @@ mod tests {
         let ids = Arc::new(UInt64Array::from_iter_values(
             start_id..start_id + rows as u64,
         ));
+        // The same tiny per-row drift as `append_partition_templates`: a split
+        // into `ceil(rows / target)` pieces needs that many distinct rows, and
+        // identical rows would leave some pieces empty at random.
         let mut appended_values = Vec::with_capacity(rows * DIM);
-        for _ in 0..rows {
-            appended_values.extend_from_slice(template);
+        for row in 0..rows {
+            let mut values = template.to_vec();
+            values[0] += row as f32 * 0.0001;
+            appended_values.extend_from_slice(&values);
         }
         let vectors = Arc::new(
             FixedSizeListArray::try_new_from_values(
@@ -3142,7 +3147,7 @@ mod tests {
         expected_index_count: usize,
         expect_split: bool,
     ) {
-        append_constant_vector_with_start_id(dataset, rows_to_append, template, next_id).await;
+        append_template_vector_with_start_id(dataset, rows_to_append, template, next_id).await;
         dataset
             .optimize_indices(&OptimizeOptions::new())
             .await
@@ -6382,7 +6387,7 @@ mod tests {
             ..Default::default()
         };
         append_params.mode = WriteMode::Append;
-        append_constant_vector_with_params(
+        append_template_vector_with_params(
             &mut dataset,
             SMALL_APPEND_ROWS,
             &template_values,

--- a/rust/lance/src/index/vector/ivf/v2.rs
+++ b/rust/lance/src/index/vector/ivf/v2.rs
@@ -2566,11 +2566,15 @@ mod tests {
         (batch, schema)
     }
 
+    /// Rows of `vectors_per_row` vectors around their cluster's centroid. The
+    /// `straddling_row`, if any, spreads its vectors over the centroids instead,
+    /// one per vector, so it belongs to several partitions at once.
     fn generate_clustered_multivec_batch(
         cluster_sizes: &[usize],
         centroids: &[(f32, f32)],
         vectors_per_row: usize,
         start_id: u64,
+        straddling_row: Option<u64>,
     ) -> (RecordBatch, SchemaRef) {
         assert_eq!(
             cluster_sizes.len(),
@@ -2585,9 +2589,14 @@ mod tests {
         let mut current_id = start_id;
         for (&rows, &(x, y)) in cluster_sizes.iter().zip(centroids.iter()) {
             for _ in 0..rows {
-                ids.push(current_id);
+                let row_id = current_id;
+                ids.push(row_id);
                 current_id += 1;
-                for _ in 0..vectors_per_row {
+                for vector_idx in 0..vectors_per_row {
+                    let (x, y) = match straddling_row {
+                        Some(id) if id == row_id => centroids[vector_idx % centroids.len()],
+                        _ => (x, y),
+                    };
                     for dim in 0..DIM {
                         let base = match dim {
                             0 => x,
@@ -6821,9 +6830,17 @@ mod tests {
         // distinct directions avoid the collinear assignment in the old fixture.
         let centroids = [(-1.0, 0.0), (0.0, 1.0), (1.0, 0.0)];
         let total_rows = cluster_sizes.iter().sum::<usize>();
+        // Row 1600, the one retained below, has one vector in each partition.
+        // Joining the partition that holds one of them must reassign only that
+        // vector, not re-add the two the other partitions keep.
         let mut dataset = {
-            let (batch, schema) =
-                generate_clustered_multivec_batch(&cluster_sizes, &centroids, MULTIVEC_PER_ROW, 0);
+            let (batch, schema) = generate_clustered_multivec_batch(
+                &cluster_sizes,
+                &centroids,
+                MULTIVEC_PER_ROW,
+                0,
+                Some(1600),
+            );
             let batches = RecordBatchIterator::new(vec![batch].into_iter().map(Ok), schema);
             Dataset::write(
                 batches,
@@ -6895,6 +6912,7 @@ mod tests {
             &centroids[2..],
             MULTIVEC_PER_ROW,
             total_rows as u64,
+            None,
         );
         dataset
             .append(


### PR DESCRIPTION
## What changed?

Incremental IVF maintenance (`optimize_indices` on an IVF_FLAT/SQ/PQ/RQ index, the SPFresh-style split / join / reassign pass in `rust/lance/src/index/vector/builder.rs`) now converges in one pass and reads far fewer raw vectors:

- **Split straight to the target size.** A partition above `4 x target` is split `ceil(rows / target)` ways (capped at 1024) by one k-means on `256 x ways` sampled rows (seeded per partition, so a rerun trains the same split), instead of one 2-way split per optimize call. A 1.5M-row partition with a 4096-row target needed ~7 optimize passes (each re-reading raw vectors); it now needs one. Above 256 ways the trainer is hierarchical, which refuses a sample with fewer distinct rows than pieces; the split then retries with flat k-means and keeps only the centroids that win sampled rows against their siblings and the 64 nearest old centroids (the same assignment the IVF transformer makes, ties to the old centroid), so a duplicate-heavy hub still splits as far as its distinct rows allow (or is left alone when fewer than two centroids win rows) and no new partition comes out empty.
- **Undersized partitions are joined in one pass** (`join_partitions`, `PartitionAdjustment::Join { kept_partitions }`), smallest first, each vector going to the nearest of the 64 nearest remaining partitions, instead of one join per optimize call. The join is executed against one finalized state. The rows to reindex are gathered first from every joined partition, their old entries are dropped from every partition through a shared set carried by the join adjustment (`reindexed_row_ids`), and survivor room below the split threshold is counted after those entries are gone (survivors are read for that only on multivector indexes, the only ones where a joined row has entries elsewhere). Each vector then goes to its nearest neighbor with room (`choose_join_destination`) among the 64 nearest survivors of the joined partition's centroid for a single-vector row, or of the vector itself for a multivector row (whose vectors may lie far from the partition the row was found under), or to the nearest surviving partition anywhere with room when all 64 are full; the planner keeps at least `ceil(rows / threshold)` survivors so that room always exists, and only an index already at the threshold everywhere lands a row in a full partition (logged, and split by the next optimize). Rows are fetched in batches admitted by decoded size (`regroup_by_bytes`, 32 MiB): a fixed-size vector column is chunked to that budget from its known row size, a multivector column is fetched one row at a time with four fetches in flight and regrouped by measured bytes, and only a single row larger than the budget ever exceeds it; each batch is then routed and quantized 1,024 vectors at a time with the chosen partition forced (the partition transformer now keeps a supplied partition id and measures the distance to it instead of reassigning, which RaBitQ's residual needs) and streamed through a shuffler to temp files like the split path, so memory is bounded by one chunk regardless of how many partitions are joined or how many vectors a reindexed row has elsewhere; there is no byte budget. The planner joins the smallest undersized partitions first, as many as leave `ceil(rows / threshold)` survivors; where each row lands is decided when the join runs.
- **The recorded `target_partition_size` drives the thresholds.** Split and join thresholds used the index type's default (8192 / 4096 rows) even when the index was created with another target; the persisted value is now read from the index details (`target_partition_size_from_details`) both in the builder and in the steady-state segment selector. In steady state, joins are decided on sizes summed over all segments and only when the segments share one IVF model; segments with different centroids are left alone.
- **Cheaper reads.** Raw vectors for the sample and the reassignment are fetched with `io_parallelism` concurrent `take_rows` chunks instead of one at a time; an optimize whose split candidates turned out empty no longer forces a full merge.

## Why?

Partition skew is the direct cause of IVF query tail latency, and repairing it was expensive: every optimize halved one oversized partition, re-read the raw vectors of it and its 64 neighbors, and re-quantized all of them, so a hub partition took many passes and each pass cost O(65 partitions) of dataset reads. Joins were one per pass as well.

## Results

Measured with the ablation harness (`ablate.py`: every optimize and every recall evaluation runs in its own process). Dataset: the first 6M rows of DEEP-10M (96-d, L2) with an IVF_PQ index of 1024 partitions and 32 sub-vectors (target partition size 8192, so the split threshold is 32,768 rows and the join threshold 2,048), built once and copied for every run. Two scenarios append near-duplicate hubs on top of it and then call `optimize_indices` until it is a no-op (at most 6 calls): `hub` = 8 hubs x 150k rows (18x the target), `smallhub` = 8 hubs x 30k rows. Machine: Mac mini M4 (10 cores, 26 GB), local NVMe, `maturin develop --release` builds of `main` (415776603) and this PR's head; every number is the mean over three runs (the branch is deterministic across them, std 0). Optimize time, partitions re-read and largest partition: lower is better; recall@10 (1,000 DEEP queries, nprobes 16, refine 10, against exact ground truth over the live rows): higher is better.

| Scenario / metric | Baseline (main) | This PR | Benefit |
| --- | ---: | ---: | ---: |
| hub: optimize calls until nothing is left to do | not converged after 6 calls | 2 calls | converges |
| hub: largest partition after one call | 150,339 rows | 20,874 rows | 7.2x smaller |
| hub: largest partition after the last call | 150,181 rows (6 calls) | 21,558 rows (2 calls) | 7.0x smaller |
| hub: undersized partitions after the last call | 47 (6 calls) | 0 (2 calls) | converges |
| hub: total optimize wall time | 60.7 s (6 calls) | 14.2 s (2 calls) | 4.3x faster |
| hub: partitions re-read from the dataset | 2,633 (6 calls) | 597 (2 calls) | 4.4x fewer |
| hub: recall@10 after the last call | 0.9499 | 0.9501 | unchanged |
| smallhub: optimize calls until nothing is left to do | 4 calls | 2 calls | 2x fewer |
| smallhub: total optimize wall time | 8.1 s | 7.7 s | 1.05x faster |
| smallhub: partitions re-read from the dataset | 365 | 396 | 0.92x (slightly more: every split reassigns all 64 neighbors once) |
| smallhub: recall@10 after the last call | 0.9505 | 0.9503 | unchanged |

On the near-duplicate hubs `main`'s 2-way splits peel a few hundred rows off each hub per call, so the hubs stay at ~150k rows while undersized pieces pile up (47 after six calls); the k-way split takes each hub to the target size in one call and the batched join removes the pieces in the next.

### Ablation

Each optimization in the PR was switched off on its own (an env-gated build that is not part of the PR) and measured on both scenarios, three seeds of the split's k-means each. Only the two core changes move the outcome; the rest were removed from the PR.

| Variant | hub: calls / total s / partitions read / undersized after call 1 | smallhub: calls / total s / partitions read / undersized after call 1 | Decision |
| --- | --- | --- | --- |
| 2-way splits instead of k-way (main's split) | >4, not converged: largest partition still 155,221 after 4 calls | - | keep k-way split |
| one join per call instead of all undersized (main's join) | >4, not converged: 17 undersized left after 4 calls | - | keep batched join |
| neighbor pruning by a 512-row sample (SPFresh necessary condition) | 2 / 15.5 s / 552 / 18.3 with pruning vs 2 / 14.5 s / 604 / 18.3 without | 2 / 8.4 s / 338 / 10.0 vs 2 / 8.0 s / 400 / 10.0 | removed: skips 9-16% of re-reads but the sampling costs more time than it saves on local disk |
| planner projecting join destinations (nearest surviving neighbor, cached, multi-round) | identical to the plain planner in every run | identical | removed: the row-level room check in the join already guarantees the bound |
| seeded uniform split sample instead of a stride | 18.3 ± 2.9 undersized vs 16.0 ± 0.8 with a stride | 10.0 ± 0.8 vs 7.0 ± 1.6 | removed: no measurable benefit |
| balanced k-means for the split centroids | 18.3 ± 2.9 undersized vs 15.0 ± 1.6 without | 10.0 ± 0.8 vs 6.0 ± 1.4 | removed: leaves more undersized pieces, not fewer |
| parallel `take_rows` chunks | 15.1 s vs 15.1 s sequential | 8.0 s vs 7.9 s | kept (no cost; only matters on high-latency storage, not measured here) |

## Tests

- New in `builder.rs`: `optimize_splits_oversized_partition_to_target_in_one_pass`, `optimize_joins_all_undersized_partitions_in_one_pass`, `optimize_split_threshold_honors_persisted_target_partition_size`, `optimize_join_leaves_no_partition_above_the_split_threshold` (20 x 24-row partitions at target 100; the optimize tests build their index on fixed centroids so the layout does not depend on k-means seeding), `optimize_splits_duplicate_heavy_partition_as_far_as_its_distinct_rows_allow` (a 303-way split of five duplicate groups, built on fixed centroids), `optimize_join_keeps_every_destination_below_the_split_threshold` (24 rows nearest to a 390-row partition at threshold 400: ten fit, fourteen spill to the next neighbor), `join_destination_spills_to_the_next_neighbor`, `join_destination_searches_beyond_a_full_window` (a source whose 64-neighbor window is full after an earlier join reaches a partition outside it), `plan_partition_adjustment_keeps_room_for_every_joined_row`, `plan_partition_adjustment_joins_all_undersized_partitions_but_one`, `optimize_join_counts_room_after_the_reindexed_rows_leave` (multivector rows whose 360 entries leave a survivor before their 380 vectors are placed), `join_window_follows_each_vector_of_a_multivector_row` (a vector at 100 found under a partition near 0 reaches its own surviving centroid), `regroup_by_bytes_bounds_each_batch_to_the_budget`; `apply_centroid_splits_correct_count_and_ordering` covers a 3-way split; `select_reassign_candidates_skips_deleted_partition` covers the exclusion set.
- `test_join_partition_on_delete_multivec` now retains a row with one vector in each partition and checks the joined index holds exactly three entries per row. `test_keeps_chosen_partitions_and_measures_their_distance` in `lance-index` covers the forced-partition path of the partition transformer.
- Existing split/join tests in `ivf/v2.rs` and `index.rs` updated to the new granularity (`ceil(rows / target)` pieces, batched joins); two fixtures that appended identical rows now add a tiny per-row drift, since identical rows cannot be split by clustering (the split is skipped instead of producing empty partitions).
- `optimize_steady_state_keeps_small_delta_partitions` guards the steady-state rule that joins are decided on sizes summed over all segments; `test_vector_append_is_segment_set_native_with_distinct_models` now uses two partitions per segment so a steady-state optimize of segments with different models is exercised as a no-op.
- `cargo test -p lance --lib -- index::`: 870 passed, 1 failed once (`dataset::index::frag_reuse::tests::test_cleanup_frag_reuse_index`, a scalar-index compaction cleanup test); it passed on three reruns (twice on this branch, once on a tree without these changes) and does not touch the vector rebalance path, so it is classified as flaky under the parallel run. `cargo clippy -p lance --tests --benches -- -D warnings` and `cargo fmt --all` are clean.

## Limitations / follow-ups

- A split or join still rewrites every segment (the merged index is one new segment); a partition-scoped rewrite needs a format addition and is left for a follow-up.
- Row ids of candidate partitions are still obtained by loading the whole partition; a row-id-only projection would cut that further.
- A join reindexes every logical row that had an entry in a joined partition exactly once, whichever partitions held its vectors; the split path still reassigns every vector of the rows it streams, as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


