### PR TITLE
fix(index): keep every HNSW node reachable after a parallel build

### DIFF
--- a/rust/lance-index/src/vector/hnsw/builder.rs
+++ b/rust/lance-index/src/vector/hnsw/builder.rs
@@ -918,22 +918,41 @@ impl HnswBuilder {
     /// Nothing inserted afterwards can rediscover such a node, since discovery
     /// only happens by traversal.
     ///
-    /// The level-0 graph is therefore walked once from the entry point after
-    /// the parallel phase, and every stranded node is linked from the nearest
-    /// node the walk did reach. The anchor is allowed to exceed `2 * m` by that
-    /// one edge: evicting one of its neighbors instead could strand that
-    /// neighbor in turn, and a far anchor with spare room would leave the node
-    /// findable only by queries far away from it. The extra work is bounded by
-    /// one beam search per stranded node, so it never exceeds the build itself.
+    /// The level-0 graph is walked once from the entry point after the
+    /// parallel phase, and every stranded node is linked from a reachable node
+    /// near it. The work is bounded explicitly, because degenerate data (many
+    /// identical vectors) can strand most of the graph and an unbounded
+    /// per-node search would then cost more than the build itself:
+    ///
+    /// - The audit and the bookkeeping are `O(N + E)`: a stranded node is
+    ///   anchored on its nearest reachable out-neighbor, and a node whose
+    ///   out-neighbors are all stranded waits until one of them is linked.
+    /// - The anchor is refined by a greedy walk over reachable nodes of at
+    ///   most `ef_construction` hops, so a node costs at most
+    ///   `ef_construction * 2 * m` distance computations.
+    /// - Every node anchors at most one stranded node, so a level-0 list never
+    ///   exceeds `2 * m + 1`. Once the candidates near a node are all taken, it
+    ///   chains onto the most recently linked node instead, which has room by
+    ///   construction.
+    ///
+    /// The anchor is allowed that one extra edge rather than evicting a
+    /// neighbor, which could strand that neighbor in turn.
     fn connect_stranded_nodes(&self, storage: &impl VectorStore) {
         let nodes = self.nodes.as_slice();
         let level0 = HnswLevelView::new(0, nodes);
         let mut reachable = vec![false; nodes.len()];
         let mut queue = VecDeque::new();
-        let mut mark_reachable = |start: u32, reachable: &mut Vec<bool>| {
+        // Marks everything the walk reaches from `start` and returns the nodes
+        // that were not reachable before.
+        let mut mark_reachable = |start: u32, reachable: &mut Vec<bool>| -> Vec<u32> {
+            let mut newly_reachable = Vec::new();
+            if reachable[start as usize] {
+                return newly_reachable;
+            }
             reachable[start as usize] = true;
             queue.push_back(start);
             while let Some(current) = queue.pop_front() {
+                newly_reachable.push(current);
                 for &neighbor in level0.neighbors(current).iter() {
                     if !reachable[neighbor as usize] {
                         reachable[neighbor as usize] = true;
@@ -941,59 +960,109 @@ impl HnswBuilder {
                     }
                 }
             }
+            newly_reachable
         };
         mark_reachable(self.entry_point, &mut reachable);
 
-        let mut visited_generator = VisitedGenerator::new(nodes.len());
-        let mut stranded = 0;
-        for node in 0..nodes.len() as u32 {
+        let stranded: Vec<u32> = (0..nodes.len() as u32)
+            .filter(|node| !reachable[*node as usize])
+            .collect();
+        if stranded.is_empty() {
+            return;
+        }
+
+        // Stranded nodes keyed by the stranded out-neighbors they wait on.
+        let mut waiting_on: HashMap<u32, Vec<u32>> = HashMap::new();
+        for &node in &stranded {
+            for &neighbor in level0.neighbors(node).iter() {
+                if !reachable[neighbor as usize] {
+                    waiting_on.entry(neighbor).or_default().push(node);
+                }
+            }
+        }
+
+        let mut anchored = vec![false; nodes.len()];
+        // The most recently linked node that has not anchored anything yet.
+        let mut chain_tail: Option<u32> = None;
+        let link = |anchor: OrderedNode,
+                    node: u32,
+                    anchored: &mut [bool],
+                    chain_tail: &mut Option<u32>| {
+            let mut anchor_node = nodes[anchor.id as usize].write().unwrap();
+            anchor_node.add_neighbor(node, anchor.dist, 0);
+            anchor_node.update_from_ranked_neighbors(0);
+            anchored[anchor.id as usize] = true;
+            *chain_tail = Some(node);
+        };
+
+        let mut isolated = Vec::new();
+        let mut ready: VecDeque<u32> = stranded.iter().copied().collect();
+        while let Some(node) = ready.pop_front() {
             if reachable[node as usize] {
                 continue;
             }
-            stranded += 1;
             let dist_calc = storage.dist_calculator_from_id(node);
-            let ep = OrderedNode::new(
-                self.entry_point,
-                dist_calc.distance(self.entry_point).into(),
-            );
-            let anchor = {
-                let mut visited = visited_generator.generate(nodes.len());
-                // The beam starts at the entry point, so it only visits nodes
-                // that are reachable, and the closest of them comes first. The
-                // entry point itself is always in the result and always a
-                // valid anchor.
-                beam_search(
-                    &level0,
-                    &ep,
-                    &HnswQueryParams {
-                        ef: self.params.ef_construction,
-                        lower_bound: None,
-                        upper_bound: None,
-                        dist_q_c: 0.0,
-                        use_acorn: false,
-                    },
-                    &dist_calc,
-                    None,
-                    self.params.prefetch_distance,
-                    &mut visited,
-                )
-                .into_iter()
-                .next()
-                .unwrap_or(ep)
+            let mut candidates: Vec<OrderedNode> =
+                nodes[node as usize].read().unwrap().level_neighbors_ranked[0]
+                    .iter()
+                    .filter(|neighbor| reachable[neighbor.id as usize])
+                    .cloned()
+                    .collect();
+            let Some(nearest) = candidates.iter().min().cloned() else {
+                isolated.push(node);
+                continue;
             };
-            {
-                let mut anchor_node = nodes[anchor.id as usize].write().unwrap();
-                anchor_node.add_neighbor(node, anchor.dist, 0);
-                anchor_node.update_from_ranked_neighbors(0);
+
+            // Walk toward the node over reachable nodes only; the walk is
+            // capped so that it cannot degenerate into a graph-wide search.
+            let mut closest = nearest.clone();
+            for _ in 0..self.params.ef_construction {
+                let step = level0
+                    .neighbors(closest.id)
+                    .iter()
+                    .filter(|neighbor| reachable[**neighbor as usize])
+                    .map(|&neighbor| {
+                        OrderedNode::new(neighbor, dist_calc.distance(neighbor).into())
+                    })
+                    .min();
+                match step {
+                    Some(step) if step.dist < closest.dist => closest = step,
+                    _ => break,
+                }
             }
-            // The node's own edges may lead to other stranded nodes.
+
+            candidates.sort_unstable();
+            let anchor = std::iter::once(closest)
+                .chain(candidates)
+                .find(|candidate| !anchored[candidate.id as usize])
+                .or_else(|| {
+                    chain_tail.map(|tail| OrderedNode::new(tail, dist_calc.distance(tail).into()))
+                })
+                .unwrap_or(nearest);
+            link(anchor, node, &mut anchored, &mut chain_tail);
+            for newly_reachable in mark_reachable(node, &mut reachable) {
+                if let Some(waiting) = waiting_on.remove(&newly_reachable) {
+                    ready.extend(waiting);
+                }
+            }
+        }
+
+        // Nodes whose out-edges never lead back to the entry point have no
+        // nearby anchor to offer; chain them onto the last linked node.
+        for node in isolated {
+            if reachable[node as usize] {
+                continue;
+            }
+            let anchor = chain_tail.unwrap_or(self.entry_point);
+            let anchor = OrderedNode::new(anchor, storage.dist_between(anchor, node).into());
+            link(anchor, node, &mut anchored, &mut chain_tail);
             mark_reachable(node, &mut reachable);
         }
-        if stranded > 0 {
-            log::debug!(
-                "Linked {stranded} HNSW node(s) that parallel construction left unreachable on level 0"
-            );
-        }
+
+        log::debug!(
+            "Linked {} HNSW node(s) that parallel construction left unreachable on level 0",
+            stranded.len()
+        );
     }
 
     fn prune(
@@ -2024,15 +2093,30 @@ mod tests {
         );
     }
 
+    /// Every level-0 list stays within `2 * m` plus the one edge a repair may
+    /// add, which is what bounds the degree of repaired graphs.
+    fn assert_level0_degree_bound(hnsw: &HNSW, m: usize) {
+        for (id, node) in hnsw.nodes().unwrap().iter().enumerate() {
+            let degree = node.level_neighbors[0].len();
+            assert!(
+                degree <= 2 * m + 1,
+                "node {id} has {degree} level-0 neighbors, more than 2 * {m} + 1"
+            );
+        }
+    }
+
     /// A node that parallel construction left without any inbound level-0
-    /// edge is linked from its nearest reachable node, whether or not that
-    /// node is already full, and the walk it enables covers the nodes behind
-    /// it without further links.
+    /// edge is linked from a reachable node near it: its nearest reachable
+    /// out-neighbor, refined by walking toward the node. A full anchor takes
+    /// the one extra edge. Nodes that only become reachable through a repaired
+    /// node need no link of their own, and a node whose out-edges all lead to
+    /// stranded nodes waits for one of them to be linked, or is chained onto
+    /// the last repaired node when none ever is.
     #[test]
-    fn test_connect_stranded_nodes_links_from_nearest_reachable() {
+    fn test_connect_stranded_nodes_links_from_nearby_reachable_node() {
         // Points on a line at x = id, except node 4 sits at 4.5 so that node 2
         // is strictly the nearest reachable node to node 3.
-        let mut xs: Vec<f32> = (0..12).map(|id| id as f32).collect();
+        let mut xs: Vec<f32> = (0..16).map(|id| id as f32).collect();
         xs[4] = 4.5;
         let values = Float32Array::from(xs.into_iter().flat_map(|x| [x, 0.0]).collect::<Vec<_>>());
         let fsl = FixedSizeListArray::try_new_from_values(values, 2).unwrap();
@@ -2049,33 +2133,119 @@ mod tests {
             }
             node.update_from_ranked_neighbors(0);
         };
-        // Node 2 is full (2 * MIN_HNSW_M edges) and is the nearest node to the
-        // stranded node 3. Node 9 has room and is the nearest to the stranded
-        // node 10, which is the only way into node 11.
+        // Reachable: 0, 1, 2 and 4..=9. Node 2 is full (2 * MIN_HNSW_M edges).
         set_neighbors(0, &[1]);
         set_neighbors(1, &[0, 2]);
         set_neighbors(2, &[1, 0, 4, 5, 6, 7, 8, 9]);
         for id in 4..=9 {
             set_neighbors(id, &[2]);
         }
+        // Stranded, nearest reachable node is the full node 2.
         set_neighbors(3, &[2]);
+        // Stranded pair: 10 is anchored on 9, 11 is reached through 10.
         set_neighbors(10, &[9, 11]);
         set_neighbors(11, &[10]);
+        // Stranded, only out-neighbor is 9, but walking from 9 reaches 11.
+        set_neighbors(12, &[9]);
+        // Stranded pair whose out-edges never lead back to the entry point.
+        set_neighbors(13, &[14]);
+        set_neighbors(14, &[13]);
+        // Stranded, only out-neighbor is the entry point, far away.
+        set_neighbors(15, &[0]);
+
+        builder.connect_stranded_nodes(&store);
+
+        let hnsw = builder.finish();
+        assert_all_reachable_on_level0(&hnsw);
+        assert_level0_degree_bound(&hnsw, MIN_HNSW_M);
+        let nodes = hnsw.nodes().unwrap();
+        let level0 = |id: usize| nodes[id].level_neighbors[0].as_slice().to_vec();
+        let inbound = |id: u32| -> Vec<usize> {
+            (0..nodes.len())
+                .filter(|other| nodes[*other].level_neighbors[0].contains(&id))
+                .collect()
+        };
+        // 3: the full node 2 takes the extra edge.
+        assert_eq!(level0(2), vec![1, 0, 4, 5, 6, 7, 8, 9, 3]);
+        // 10: anchored on 9; 11 becomes reachable through 10 with no new edge.
+        assert_eq!(level0(9), vec![2, 10]);
+        assert_eq!(inbound(11), vec![10]);
+        // 12: the walk from 9 continues through 10 to 11.
+        assert_eq!(level0(11), vec![10, 12]);
+        // 15: the walk from the entry point ends at 12, the closest reachable node.
+        assert_eq!(level0(12), vec![9, 15]);
+        // 13: never reachable through its own edges, chained onto the last
+        // repaired node; 14 becomes reachable through 13 with no new edge.
+        assert_eq!(level0(15), vec![0, 13]);
+        assert_eq!(inbound(14), vec![13]);
+    }
+
+    /// Every node anchors at most one stranded node. When the nodes near a
+    /// stranded node have all anchored one already, it chains onto the most
+    /// recently repaired node instead of growing an anchor further.
+    #[test]
+    fn test_connect_stranded_nodes_anchors_each_node_once() {
+        let values = Float32Array::from(vec![
+            0.0, 0.0, // entry point
+            1.0, 0.0, // reachable
+            0.0, 5.0, // stranded, anchored on 0
+            5.0, 0.0, // stranded, anchored on 1
+            0.0, -5.0, // stranded, 0 is the closest node but already an anchor
+        ]);
+        let fsl = FixedSizeListArray::try_new_from_values(values, 2).unwrap();
+        let store = FlatFloatStorage::new(fsl, DistanceType::L2);
+        let params = HnswBuildParams::default()
+            .num_edges(MIN_HNSW_M)
+            .max_level(1);
+        let builder = HnswBuilder::with_params(params, &store);
+        assert_eq!(builder.entry_point, 0);
+        let set_neighbors = |id: u32, neighbors: &[u32]| {
+            let mut node = builder.nodes[id as usize].write().unwrap();
+            for &neighbor in neighbors {
+                node.add_neighbor(neighbor, store.dist_between(id, neighbor).into(), 0);
+            }
+            node.update_from_ranked_neighbors(0);
+        };
+        set_neighbors(0, &[1]);
+        set_neighbors(1, &[0]);
+        for id in 2..=4 {
+            set_neighbors(id, &[0]);
+        }
 
         builder.connect_stranded_nodes(&store);
 
         let hnsw = builder.finish();
         assert_all_reachable_on_level0(&hnsw);
         let nodes = hnsw.nodes().unwrap();
-        assert_eq!(
-            *nodes[2].level_neighbors[0],
-            vec![1, 0, 4, 5, 6, 7, 8, 9, 3]
+        assert_eq!(*nodes[0].level_neighbors[0], vec![1, 2]);
+        assert_eq!(*nodes[1].level_neighbors[0], vec![0, 3]);
+        assert_eq!(*nodes[3].level_neighbors[0], vec![0, 4]);
+    }
+
+    /// Identical or nearly identical vectors strand most of the graph, since
+    /// pruning keeps the same few ids everywhere. The repair still has to
+    /// finish in linear time and keep every level-0 list within `2 * m + 1`.
+    #[rstest]
+    #[case::identical(1)]
+    #[case::few_distinct(3)]
+    fn test_degenerate_vectors_stay_reachable_within_degree_bound(#[case] distinct: usize) {
+        const TOTAL: usize = 2000;
+        let values = Float32Array::from(
+            (0..TOTAL)
+                .flat_map(|id| [(id % distinct) as f32, 0.0])
+                .collect::<Vec<_>>(),
         );
-        assert_eq!(*nodes[9].level_neighbors[0], vec![2, 10]);
-        let inbound_to_11: Vec<usize> = (0..nodes.len())
-            .filter(|id| nodes[*id].level_neighbors[0].contains(&11))
-            .collect();
-        assert_eq!(inbound_to_11, vec![10]);
+        let fsl = FixedSizeListArray::try_new_from_values(values, 2).unwrap();
+        let store = FlatFloatStorage::new(fsl, DistanceType::L2);
+        let hnsw = HNSW::index_vectors(
+            &store,
+            HnswBuildParams::default()
+                .num_edges(MIN_HNSW_M)
+                .ef_construction(MIN_HNSW_M),
+        )
+        .unwrap();
+        assert_all_reachable_on_level0(&hnsw);
+        assert_level0_degree_bound(&hnsw, MIN_HNSW_M);
     }
 
     /// The lowest accepted construction settings keep every node reachable on

--- a/rust/lance-index/src/vector/hnsw/builder.rs
+++ b/rust/lance-index/src/vector/hnsw/builder.rs
@@ -905,6 +905,97 @@ impl HnswBuilder {
         )
     }
 
+    /// Give every node an inbound path from the entry point on level 0.
+    ///
+    /// A query only ever enumerates level 0, so a node without a level-0 path
+    /// from the entry point can never be returned by a graph traversal.
+    /// Parallel insertion cannot rule that out: a node picks its neighbors
+    /// from the graph it searched, and by the time its reciprocal edges are
+    /// written those neighbors may have filled up with closer nodes and pruned
+    /// it straight back out, leaving it with no inbound edge at all. A node
+    /// inserted while the graph was still nearly empty is the usual victim:
+    /// its only neighbors are the first few hubs, and hubs fill up first.
+    /// Nothing inserted afterwards can rediscover such a node, since discovery
+    /// only happens by traversal.
+    ///
+    /// The level-0 graph is therefore walked once from the entry point after
+    /// the parallel phase, and every stranded node is linked from the nearest
+    /// node the walk did reach. The anchor is allowed to exceed `2 * m` by that
+    /// one edge: evicting one of its neighbors instead could strand that
+    /// neighbor in turn, and a far anchor with spare room would leave the node
+    /// findable only by queries far away from it. The extra work is bounded by
+    /// one beam search per stranded node, so it never exceeds the build itself.
+    fn connect_stranded_nodes(&self, storage: &impl VectorStore) {
+        let nodes = self.nodes.as_slice();
+        let level0 = HnswLevelView::new(0, nodes);
+        let mut reachable = vec![false; nodes.len()];
+        let mut queue = VecDeque::new();
+        let mut mark_reachable = |start: u32, reachable: &mut Vec<bool>| {
+            reachable[start as usize] = true;
+            queue.push_back(start);
+            while let Some(current) = queue.pop_front() {
+                for &neighbor in level0.neighbors(current).iter() {
+                    if !reachable[neighbor as usize] {
+                        reachable[neighbor as usize] = true;
+                        queue.push_back(neighbor);
+                    }
+                }
+            }
+        };
+        mark_reachable(self.entry_point, &mut reachable);
+
+        let mut visited_generator = VisitedGenerator::new(nodes.len());
+        let mut stranded = 0;
+        for node in 0..nodes.len() as u32 {
+            if reachable[node as usize] {
+                continue;
+            }
+            stranded += 1;
+            let dist_calc = storage.dist_calculator_from_id(node);
+            let ep = OrderedNode::new(
+                self.entry_point,
+                dist_calc.distance(self.entry_point).into(),
+            );
+            let anchor = {
+                let mut visited = visited_generator.generate(nodes.len());
+                // The beam starts at the entry point, so it only visits nodes
+                // that are reachable, and the closest of them comes first. The
+                // entry point itself is always in the result and always a
+                // valid anchor.
+                beam_search(
+                    &level0,
+                    &ep,
+                    &HnswQueryParams {
+                        ef: self.params.ef_construction,
+                        lower_bound: None,
+                        upper_bound: None,
+                        dist_q_c: 0.0,
+                        use_acorn: false,
+                    },
+                    &dist_calc,
+                    None,
+                    self.params.prefetch_distance,
+                    &mut visited,
+                )
+                .into_iter()
+                .next()
+                .unwrap_or(ep)
+            };
+            {
+                let mut anchor_node = nodes[anchor.id as usize].write().unwrap();
+                anchor_node.add_neighbor(node, anchor.dist, 0);
+                anchor_node.update_from_ranked_neighbors(0);
+            }
+            // The node's own edges may lead to other stranded nodes.
+            mark_reachable(node, &mut reachable);
+        }
+        if stranded > 0 {
+            log::debug!(
+                "Linked {stranded} HNSW node(s) that parallel construction left unreachable on level 0"
+            );
+        }
+    }
+
     fn prune(
         &self,
         storage: &impl VectorStore,
@@ -1565,6 +1656,7 @@ impl IvfSubIndex for HNSW {
             );
 
         assert_eq!(builder.level_count[0].load(Ordering::Relaxed), len);
+        builder.connect_stranded_nodes(storage);
         Ok(builder.finish())
     }
 
@@ -1910,9 +2002,85 @@ mod tests {
         );
     }
 
-    /// The lowest accepted construction settings retain a useful graph, but
-    /// do not promise full reachability. This seeded floor makes that quality
-    /// trade-off explicit and guards against catastrophic fragmentation.
+    /// Every node must have a level-0 path from the entry point, which is what
+    /// [HnswBuilder::connect_stranded_nodes] guarantees after a build.
+    fn assert_all_reachable_on_level0(hnsw: &HNSW) {
+        let nodes = hnsw.nodes().unwrap();
+        let mut reachable = vec![false; nodes.len()];
+        let mut queue = std::collections::VecDeque::from([hnsw.metadata().entry_point]);
+        reachable[hnsw.metadata().entry_point as usize] = true;
+        while let Some(current) = queue.pop_front() {
+            for &neighbor in nodes[current as usize].bottom_neighbors.iter() {
+                if !reachable[neighbor as usize] {
+                    reachable[neighbor as usize] = true;
+                    queue.push_back(neighbor);
+                }
+            }
+        }
+        let stranded: Vec<usize> = (0..nodes.len()).filter(|id| !reachable[*id]).collect();
+        assert!(
+            stranded.is_empty(),
+            "nodes {stranded:?} are unreachable from the entry point on level 0"
+        );
+    }
+
+    /// A node that parallel construction left without any inbound level-0
+    /// edge is linked from its nearest reachable node, whether or not that
+    /// node is already full, and the walk it enables covers the nodes behind
+    /// it without further links.
+    #[test]
+    fn test_connect_stranded_nodes_links_from_nearest_reachable() {
+        // Points on a line at x = id, except node 4 sits at 4.5 so that node 2
+        // is strictly the nearest reachable node to node 3.
+        let mut xs: Vec<f32> = (0..12).map(|id| id as f32).collect();
+        xs[4] = 4.5;
+        let values = Float32Array::from(xs.into_iter().flat_map(|x| [x, 0.0]).collect::<Vec<_>>());
+        let fsl = FixedSizeListArray::try_new_from_values(values, 2).unwrap();
+        let store = FlatFloatStorage::new(fsl, DistanceType::L2);
+        let params = HnswBuildParams::default()
+            .num_edges(MIN_HNSW_M)
+            .max_level(1);
+        let builder = HnswBuilder::with_params(params, &store);
+        assert_eq!(builder.entry_point, 0);
+        let set_neighbors = |id: u32, neighbors: &[u32]| {
+            let mut node = builder.nodes[id as usize].write().unwrap();
+            for &neighbor in neighbors {
+                node.add_neighbor(neighbor, store.dist_between(id, neighbor).into(), 0);
+            }
+            node.update_from_ranked_neighbors(0);
+        };
+        // Node 2 is full (2 * MIN_HNSW_M edges) and is the nearest node to the
+        // stranded node 3. Node 9 has room and is the nearest to the stranded
+        // node 10, which is the only way into node 11.
+        set_neighbors(0, &[1]);
+        set_neighbors(1, &[0, 2]);
+        set_neighbors(2, &[1, 0, 4, 5, 6, 7, 8, 9]);
+        for id in 4..=9 {
+            set_neighbors(id, &[2]);
+        }
+        set_neighbors(3, &[2]);
+        set_neighbors(10, &[9, 11]);
+        set_neighbors(11, &[10]);
+
+        builder.connect_stranded_nodes(&store);
+
+        let hnsw = builder.finish();
+        assert_all_reachable_on_level0(&hnsw);
+        let nodes = hnsw.nodes().unwrap();
+        assert_eq!(
+            *nodes[2].level_neighbors[0],
+            vec![1, 0, 4, 5, 6, 7, 8, 9, 3]
+        );
+        assert_eq!(*nodes[9].level_neighbors[0], vec![2, 10]);
+        let inbound_to_11: Vec<usize> = (0..nodes.len())
+            .filter(|id| nodes[*id].level_neighbors[0].contains(&11))
+            .collect();
+        assert_eq!(inbound_to_11, vec![10]);
+    }
+
+    /// The lowest accepted construction settings keep every node reachable on
+    /// level 0, and the greedy descent still lands close enough for a full
+    /// enumeration to cover nearly all of them.
     #[test]
     fn test_minimum_params_reachability() {
         const DIM: usize = 32;
@@ -1932,6 +2100,7 @@ mod tests {
                 .ef_construction(MIN_HNSW_M),
         )
         .unwrap();
+        assert_all_reachable_on_level0(&hnsw);
         let results = hnsw
             .search_basic(
                 vectors.value(0),


### PR DESCRIPTION
## Bug Fix

### What is the bug?

`vector::hnsw::builder::tests::test_distance_range_prefilter_dispatch` is flaky (~1 failure in 200–300 runs locally). The dense-mask assertion, which traverses the graph, sometimes returns `[]` instead of `[0]`.

The underlying cause is in parallel HNSW construction. A node picks its neighbors from the graph it searched, but its reciprocal edges are written afterwards. When that thread is delayed between the two steps (write-lock contention on the entry point hub, or scheduling), the chosen neighbors fill up with closer nodes in the meantime and prune the new node straight back out. The node ends up with no inbound level-0 edge, and nothing inserted afterwards can rediscover it, because discovery only happens by traversal.

Instrumenting the build with an insertion sequence number shows it directly. In one failing build node 0 searched at step 6 and found only `[44, 50]` (the entry point and one hub), but no node inserted between steps 7 and 46 saw node 0 at all. By the time its reciprocal edges landed, 44 and 50 were full and evicted it, and the few far nodes that did see it did not select it.

### What issues or incorrect behavior does the bug cause?

A stranded node can never be returned by a graph traversal. It is only found by the sparse-prefilter flat scan. On the 100-point line dataset used by the test, roughly 0.7% of builds (14 of 2000, debug) strand a node, usually row 0.

### How does this PR fix the problem?

After the parallel insert phase, walk level 0 from the entry point once and link every stranded node from a reachable node near it. The work is bounded explicitly, since degenerate data (many identical vectors) strands most of the graph:

- The audit and bookkeeping are O(N + E). A stranded node is anchored on its nearest reachable out-neighbor; a node whose out-neighbors are all stranded waits until one of them is linked.
- The anchor is refined by a greedy walk over reachable nodes, capped at `ef_construction` hops, so a node costs at most `ef_construction * 2m` distance computations.
- Every node anchors at most one stranded node, so a level-0 list never exceeds `2m + 1`. When the candidates near a node are all taken, it chains onto the most recently linked node, which has room by construction.

The anchor takes that one extra edge rather than evicting a neighbor, which could strand that neighbor in turn.

### Validation

- `test_distance_range_prefilter_dispatch`: before the fix, `case_1_prefetch` failed 1/200 and `case_2_no_prefetch` 1/300; after, 0/300 for each.
- New `test_connect_stranded_nodes_links_from_nearby_reachable_node` and `test_connect_stranded_nodes_anchors_each_node_once` build stranded graphs by hand and check the anchor choice, the walk, the extra edge on a full anchor, the wait on stranded out-neighbors, the chain fallback, and that nodes reached through a repaired node get no edge of their own.
- New `test_degenerate_vectors_stay_reachable_within_degree_bound` builds 2000 identical and few-distinct vectors through `index_vectors` and asserts full reachability and the `2m + 1` degree bound.
- `test_minimum_params_reachability` now also asserts full level-0 reachability from the entry point.
- Repair cost on identical vectors (debug, `m = ef_construction = 4`), where nearly every node is stranded:

  | Nodes | Build | Repair | Max level-0 degree |
  | ---: | ---: | ---: | ---: |
  | 500 | 10.6 ms | 3.2 ms | 9 |
  | 2000 | 34.9 ms | 11.0 ms | 9 |
  | 8000 | 114.0 ms | 36.5 ms | 9 |

- Stranded-node rate and repair cost on random data (release, `HnswBuildParams::default()`, 10 cores), where the repair is just the audit:

  | Dataset | Builds | Builds with stranded nodes | Avg build | Avg repair |
  | --- | ---: | ---: | ---: | ---: |
  | line 100×32 (test data) | 500 | 2 | 1.6 ms | 0.01 ms |
  | random 4096×32 | 10 | 0 | 97 ms | 0.41 ms |
  | random 16384×32 | 5 | 0 | 484 ms | 1.6 ms |
  | random 65536×32 | 2 | 0 | 3022 ms | 32 ms |

- `cargo fmt --all`, `cargo clippy --all --tests --benches -- -D warnings`, `cargo test -p lance-index --lib vector::hnsw` (49 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
