### PR TITLE
ci(python): run pylance Rust tests in a dedicated job

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -77,8 +77,6 @@ jobs:
         uses: taiki-e/install-action@66068bfca13dcb2ea07c3f613ca2836a37c755d5 # protoc
         with:
           tool: protoc
-      - name: Test Rust reader concurrency
-        run: cargo test --profile ci --locked --no-default-features reader::tests
       - name: Lint Rust
         run: |
           ALL_FEATURES=`cargo metadata --format-version=1 --no-deps | jq -r '.packages[] | .features | keys | .[]' | grep -v protoc | sort | uniq | paste -s -d "," -`
@@ -95,6 +93,39 @@ jobs:
         run: |
           source venv/bin/activate
           pytest --doctest-modules python/lance
+
+  rust-tests:
+    timeout-minutes: 30
+    name: Python Rust tests Linux x86_64
+    runs-on: "ubuntu-24.04-4x"
+    defaults:
+      run:
+        shell: bash
+        working-directory: python
+    env:
+      # Need up-to-date compilers for kernels
+      CC: clang-18
+      CXX: clang++-18
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: 3.11
+      - uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2
+        with:
+          workspaces: python
+          prefix-key: ${{ env.CACHE_PREFIX }}
+      - name: Install protoc
+        uses: taiki-e/install-action@66068bfca13dcb2ea07c3f613ca2836a37c755d5 # protoc
+        with:
+          tool: protoc
+      # The default `extension-module` feature leaves libpython unlinked, which the
+      # host interpreter resolves at load time but a test binary cannot. Disabling it
+      # links libpython so these tests run instead of only compiling.
+      - name: Test Rust
+        run: cargo test --profile ci --locked --no-default-features
+
   linux-wheel:
     timeout-minutes: 45
     name: Python Linux x86_64 wheel

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -94,9 +94,9 @@ jobs:
           source venv/bin/activate
           pytest --doctest-modules python/lance
 
-  rust-tests:
+  python-rust-test:
     timeout-minutes: 30
-    name: Python Rust tests Linux x86_64
+    name: pylance crate Rust tests
     runs-on: "ubuntu-24.04-4x"
     defaults:
       run:


### PR DESCRIPTION
The Python lint job has become the slowest job in CI, and part of the reason is that it runs Rust tests. A `Test Rust reader concurrency` step was added to it alongside the reader rewrite in #8714, because those tests live in the `pylance` crate: `python/` is excluded from the top-level Cargo workspace, so no job in `rust.yml` can see them, and they only link and run with `--no-default-features` (the default `extension-module` feature leaves libpython unresolved until the host interpreter loads the extension, which a test binary cannot do).

Putting that step in the lint job meant compiling the pylance dependency tree in a third, incompatible feature configuration beside the `ALL_FEATURES` clippy build and the default-feature `maturin develop` build. The three share almost no artifacts, so it added a full cold compile to the lint job's critical path.

This moves it into its own `rust-tests` job, which gets its own Rust cache entry and runs in parallel with lint.

It also drops the `reader::tests` filter, so the job now runs all of pylance's Rust tests — 22 across `reader`, `otel`, `file`, and `lib`. Only the 8 reader tests were running before; the other 14 were compile-only.

Test time is 0.10s, so the new job's cost is essentially the compile. Whether lint is still the slowest job after this depends on which of its two remaining pylance builds dominates, which needs a real run to tell.
