### PR TITLE
feat(format): add the MinHash LSH scalar index specification

### DIFF
--- a/docs/src/format/index/scalar/.pages
+++ b/docs/src/format/index/scalar/.pages
@@ -7,5 +7,6 @@ nav:
   - Bloom Filter: bloom_filter.md
   - Full Text Search: fts.md
   - N-gram: ngram.md
+  - MinHash LSH: minhash_lsh.md
   - FM-Index: fmindex.md
   - RTree: rtree.md

--- a/docs/src/format/index/scalar/minhash_lsh.md
+++ b/docs/src/format/index/scalar/minhash_lsh.md
@@ -1,0 +1,174 @@
+# MinHash LSH Index (Near-Duplicate Search)
+
+The MinHash LSH index finds near duplicates of a text: rows whose content is
+essentially the same as the query with a few edits, such as reposts with a
+different footer, mirror pages, or copy-pasted records with small changes. It
+scores rows by the **estimated Jaccard similarity** of their token shingle
+sets, a literal measure of overlap that needs no model. Unlike the Full-Text
+Search index, which ranks rows by term relevance, and unlike a vector index,
+which finds rows that mean the same thing, this index answers "which rows are
+copies of this one".
+
+The index is approximate: candidates are found with locality sensitive hashing
+(LSH) over MinHash signatures and ranked by comparing signatures, so the
+reported similarity is an estimate, and rows whose similarity is below the
+index's threshold are usually not found.
+
+## High-Level Architecture
+
+Every indexed text is turned into a fixed-length **signature** of `num_hashes`
+values, and the signature is split into `num_bands` **bands** whose hashes are
+the lookup keys. Two rows become candidates for each other when they share at
+least one band key; candidates are then ranked by the fraction of equal
+signature values.
+
+```
+              text
+               |  tokenize, shingle, hash
+               v
+   +-----------------------------------------+
+   |   signature: num_hashes 16-bit values   |   1 - (fraction of equal values)
+   +-----------------------------------------+   = Jaccard distance
+       |  split into num_bands bands, hash each
+       v
+   band keys ------------> bands table   (candidate lookup: rows sharing a key)
+   signature ------------> signature table  (ranking the candidates)
+```
+
+The index uses Lance's **Segmented Index** architecture: each segment covers a
+disjoint group of fragments and holds its own bands table and signature table.
+Scores depend only on the two signatures being compared, never on corpus
+statistics, so results from different segments merge exactly.
+
+```
+                     +----------------------------------------+
+                     |            Lance Dataset               |
+                     |   (Disjoint groups of Fragments 0..N)  |
+                     +----------------------------------------+
+                                         |
+                                         v
+                     +----------------------------------------+
+                     |            Segmented Index             |
+                     |  +-----------+ +-----------+ +-------+ |
+                     |  | Segment 1 | | Segment 2 | | ...   | |
+                     |  | bands +   | | bands +   | |       | |
+                     |  | signatures| | signatures| |       | |
+                     |  +-----------+ +-----------+ +-------+ |
+                     +----------------------------------------+
+```
+
+## Index Details
+
+```protobuf
+%%% proto.message.MinHashLshIndexDetails %%%
+```
+
+| Parameter           | Default | Effect                                                                                                                                                                                                         |
+|:--------------------|:--------|:---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `num_hashes`        | 128     | Signature length. More hashes make the similarity estimate more precise (error about `1 / sqrt(num_hashes)`) and the signature table larger (`8 + 2 * num_hashes` bytes per row).                              |
+| `num_bands`         | 16      | Number of bands; `num_hashes` must be a multiple of it. With `num_hashes` it sets the similarity threshold `(1 / num_bands) ^ (num_bands / num_hashes)`. The bands table costs `12 * num_bands` bytes per row. |
+| `shingle_size`      | 3       | Tokens per shingle. Shorter shingles tolerate more edits but let unrelated texts that share common phrases look alike; 5 suits long documents, 2 very short texts.                                             |
+| `tokenizer`         | full text search default, without stemming and stop-word removal | The tokenizer, recorded as the Full-Text Search index records it. Stemming and stop-word removal are off by default because merging different words inflates similarity.                         |
+| `signature_version` | 0       | Version of the signature procedure, including its hash seed. Managed by Lance, not a user parameter.                                                                                                           |
+
+Reference points: the probability that a row with true Jaccard similarity `J`
+becomes a candidate is `1 - (1 - J^r)^b` with `b = num_bands` and
+`r = num_hashes / num_bands`.
+
+| `num_hashes` / `num_bands` | Threshold | Found at J = 0.9 | Found at J = 0.7 | Bytes per row |
+|:---------------------------|:----------|:-----------------|:-----------------|:--------------|
+| 64 / 8                     | 0.77      | 99%              | 38%              | 232           |
+| 128 / 16 (default)         | 0.71      | 99.99%           | 61%              | 456           |
+| 96 / 16                    | 0.63      | 100%             | 87%              | 392           |
+
+Bands of fewer than six values admit a noticeable share of unrelated rows into
+the candidate set on tables of billions of rows and are better left to offline
+use.
+
+## Signature Generation
+
+The build side and the query side run the same procedure, so a query is
+comparable with every stored row:
+
+1. Tokenize the text with the configured tokenizer.
+2. Form shingles of `shingle_size` consecutive tokens (joined with the byte
+   `0x1F`). A text with fewer tokens than `shingle_size` forms one shingle of
+   all its tokens; a text with no tokens (NULL, empty, whitespace only) has no
+   signature, is not indexed, and never appears in results.
+3. Hash every shingle to 64 bits with XXH64 (seed 42).
+4. Apply `num_hashes` permutations of the form `a_i * x + b_i mod 2^64`, with
+   coefficients drawn from a SplitMix64 generator (seed 42, odd `a_i`), and
+   keep the minimum of each permutation over all shingles of the text.
+5. Store each minimum as 16 bits: `(c_i * min mod 2^64) >> 48` with an odd
+   multiplier `c_i` from the same generator. A minimum shrinks as the text
+   grows, so its raw high bits would agree between any two long texts;
+   multiply-shift hashing keeps the chance that two different minima collide
+   below `2^-15`, negligible against the `1 / num_hashes` resolution of the
+   estimate.
+
+The estimated Jaccard similarity of two signatures is the fraction of
+positions whose values are equal; the reported `_distance` is
+`1 - estimated similarity`. Every constant of the procedure is fixed by
+`signature_version`, and every segment of an index must carry identical
+details, so signatures written by different segments or at query time are
+always comparable. Changing a parameter, or upgrading a tokenizer dictionary,
+requires rebuilding the index.
+
+## Storage Layout
+
+Each segment consists of two Lance files:
+
+- `signatures.lance` — one row per indexed document: its `_rowid` and its
+  signature as a fixed-size list of `num_hashes` 16-bit values. The row number
+  is the segment-local document id, so a segment holds at most `2^32`
+  documents; larger tables use several segments. Rows are fixed width, so one
+  document's signature is a single ranged read at a known offset.
+- `bands.lance` — one row per (band key, document id) pair, sorted by band key
+  and then document id. A bucket is the run of rows sharing a key. The file is
+  divided into logical pages of 4096 rows, and a page table holding the
+  largest key of every page is stored in a global buffer of the file and kept
+  in memory when the index is open. The band key puts the band number in its
+  high 8 bits and a hash of the band's values in the low 56 bits, so the keys
+  of one band are contiguous.
+
+Both files also record the index parameters and the index version as schema
+metadata, so a mismatch with the index details is detected when the index is
+opened.
+
+## Segments, Appends and Merging
+
+- **Building**: `create_index` reads the text column, signs every row and
+  writes one segment. Distributed builds create one uncommitted segment per
+  worker over disjoint fragment sets and commit them together; the commit
+  rejects segments whose details differ.
+- **Unindexed appends**: fragments appended after the build are not covered
+  by any segment. `optimize_indices` adds a segment over them. Until then a
+  query still searches those rows, signing them on the fly with the index
+  parameters, unless the scan asks for indexed rows only (`fast_search`).
+- **Segment merging**: merging segments rebuilds one segment from the stored
+  signatures without tokenizing the text again — the signatures of the
+  surviving rows are concatenated, band keys are recomputed and the bands
+  table is rewritten. A merge whose result would exceed `2^32` documents is
+  rejected and the segments stay separate.
+- **Deletes and compaction**: deleted rows are filtered at query time; after a
+  compaction the stored row ids are remapped like those of every other scalar
+  index.
+
+## Query Evaluation
+
+When a search is submitted (`nearest = MinHashQuery(text, column)`):
+
+1. The query text is signed with the parameters recorded in the index, and its
+   band keys are computed.
+2. In every segment, each band key is looked up through the page table: a
+   binary search finds the pages holding the key's bucket, and those pages are
+   fetched in one scattered read. The document ids in the buckets form the
+   candidate set.
+3. The candidates' signatures are read — from memory when resident, otherwise
+   with scattered reads, or with a sequential scan when the candidates cover a
+   large share of the segment — and each candidate's Jaccard distance to the
+   query is computed. Rows removed by filters or deletions are skipped.
+4. Each segment keeps its `limit` closest rows; rows not covered by any
+   segment are scored the same way by the query engine.
+5. The per-segment results are merged by distance, and the `limit` closest
+   rows are returned with their `_distance`.

--- a/docs/src/format/index/scalar/minhash_lsh.md
+++ b/docs/src/format/index/scalar/minhash_lsh.md
@@ -161,9 +161,10 @@ When a search is submitted (`nearest = MinHashQuery(text, column)`):
 1. The query text is signed with the parameters recorded in the index, and its
    band keys are computed.
 2. In every segment, each band key is looked up through the page table: a
-   binary search finds the pages holding the key's bucket, and those pages are
-   fetched in one scattered read. The document ids in the buckets form the
-   candidate set.
+   binary search finds the first and the last page of the key's bucket. The
+   boundary pages of all buckets are fetched in one scattered read; the pages
+   in between, when a bucket spans more than two pages, are streamed in
+   bounded windows. The document ids in the buckets form the candidate set.
 3. The candidates' signatures are read — from memory when resident, otherwise
    with scattered reads, or with a sequential scan when the candidates cover a
    large share of the segment — and each candidate's Jaccard distance to the

--- a/docs/src/format/index/scalar/minhash_lsh.md
+++ b/docs/src/format/index/scalar/minhash_lsh.md
@@ -69,8 +69,7 @@ statistics, so results from different segments merge exactly.
 | `num_bands`         | 16                                                               | 1 to 256                                      | Number of bands. With `num_hashes` it sets the similarity threshold `(1 / num_bands) ^ (num_bands / num_hashes)`. The bands table costs `12 * num_bands` bytes per row.                                        |
 | `shingle_size`      | 3                                                                | at least 1                                    | Tokens per shingle. Shorter shingles tolerate more edits but let unrelated texts that share common phrases look alike; 5 suits long documents, 2 very short texts.                                             |
 | `tokenizer`         | full text search default, without stemming and stop-word removal | the subset described under [Tokenizer](#tokenizer) | The tokenizer, recorded as the Full-Text Search index records it. Stemming and stop-word removal are off by default because merging different words inflates similarity.                                  |
-| `signature_version` | 0                                                                | 0                                             | Version of the signature procedure, including its hash seed and the band key hash. Managed by Lance, not a user parameter.                                                                                     |
-| `tokenizer_fingerprint` | absent                                                       | present exactly when the tokenizer loads resources from the language model home | XXH64 fingerprint of those resources, defined under [Tokenizer](#tokenizer). Managed by Lance, not a user parameter.                                                                       |
+| `signature_version` | 0                                                                | 0                                             | Version of the signature procedure, including the token streams of the built-in tokenizers, the hash seed and the band key hash. Managed by Lance, not a user parameter.                                     |
 
 Reference points: the probability that a row with true Jaccard similarity `J`
 becomes a candidate is `1 - (1 - J^r)^b` with `b = num_bands` and
@@ -94,13 +93,7 @@ file, and rejects the index when:
 - a parameter is outside its range above (this includes a `num_hashes` that is
   not a multiple of `num_bands`);
 - `tokenizer` is absent, or asks for a setting outside the supported subset;
-- `signature_version` is not a version the reader implements (only 0 exists);
-- `tokenizer_fingerprint` is present for a tokenizer that loads no resources,
-  or absent for one that does;
-- the tokenizer configuration names a resource outside its directory, or
-  depends on a fallback outside it;
-- the tokenizer loads resources and the reader does not implement the
-  fingerprint.
+- `signature_version` is not a version the reader implements (only 0 exists).
 
 The ranges bound every derived size: a signature row is at most
 `8 + 2 * 4096` bytes, a band at most 4096 values and a query at most 256 band
@@ -111,46 +104,28 @@ an unbounded allocation.
 
 The tokenizer is recorded as a `lance.table.InvertedIndexDetails`, the message
 the Full-Text Search index persists, and is rebuilt from that message alone at
-query time. The supported subset is exactly what the message records:
+query time. The details must identify the tokenizer completely, so the
+supported subset is what the message records about a tokenizer whose data
+ships with Lance:
 
 | Fields                                                                                                                                                                | Role                                                                                    |
 |:----------------------------------------------------------------------------------------------------------------------------------------------------------------------|:----------------------------------------------------------------------------------------|
 | `base_tokenizer`, `language`, `max_token_length`, `lower_case`, `stem`, `remove_stop_words`, `ascii_folding`, `min_ngram_length`, `max_ngram_length`, `prefix_only`, `code_config` | Shape the token stream and are applied by the index.                                    |
 | `with_position`, `block_size`, `document_granularity`, `posting_format_version`                                                                                       | Describe full text search postings; carried unchanged and ignored.                      |
 | custom stop words, document-level text extraction (`lance_tokenizer`)                                                                                                 | Cannot be recorded in the message; a build that asks for them is rejected.              |
+| `jieba`, `jieba/*`, `lindera/*`                                                                                                                                       | Load dictionaries from the deployment (`LANCE_LANGUAGE_MODEL_HOME`), which the message cannot identify; rejected. |
 
 The default is the `simple` tokenizer with `language = English`,
 `max_token_length = 40`, `lower_case = true`, `ascii_folding = true`,
 `stem = false` and `remove_stop_words = false`.
 
-The details identify every input of tokenization, in one of two ways:
-
-- **Tokenizers whose data ships with Lance** (`simple`, `whitespace`, `raw`,
-  `ngram`, `code`, `icu`, `icu/split`; the ICU segmentation data is compiled
-  into Lance): their token stream for a given text and configuration is part
-  of `signature_version`, and `tokenizer_fingerprint` is absent.
-- **Tokenizers that load resources from the language model home**
-  (`jieba`, `jieba/*`, `lindera/*`, which read the directory
-  `LANCE_LANGUAGE_MODEL_HOME/<base_tokenizer>/`): the directory is the
-  complete set of resources. Its configuration file must exist (no
-  environment or built-in fallback, such as `LINDERA_CONFIG_PATH`, is
-  consulted), and every path the configuration names must be relative,
-  contain no `..` component and no URI scheme, and resolve to a regular file
-  below the directory; a configuration that reaches outside the directory is
-  rejected when an index is created or opened. Dictionaries compiled into
-  Lance (Lindera's built-in dictionary kinds) need no files and are part of
-  `signature_version`. The details carry `tokenizer_fingerprint`, the XXH64
-  hash (seed 0) of the directory's contents. The hash consumes, for every
-  regular file below the directory in
-  ascending order of its relative path bytes, following symbolic links: the
-  relative path as UTF-8 bytes with `/` separators, one `0x00` byte, the file
-  length as 8 little-endian bytes, and the file contents. The writer computes
-  it when the index is built; a reader recomputes it from its own deployment
-  when it opens the index and rejects a mismatch, since the query would be
-  tokenized differently from the rows (the index must be rebuilt, or the
-  resources restored). An implementation that does not compute the
-  fingerprint rejects these tokenizers when an index is created and when one
-  is opened.
+Version 0 therefore admits `simple`, `whitespace`, `raw`, `ngram`, `code`,
+`icu` and `icu/split` as `base_tokenizer` (the ICU segmentation data is
+compiled into Lance). The token stream these tokenizers produce for a given
+text and configuration is part of `signature_version`. For CJK text, `ngram`
+or `icu` gives deterministic shingles. A later version may admit
+dictionary-backed tokenizers by storing their resources in the index; a
+reader of this version rejects details that name them.
 
 ## Signature Generation
 
@@ -366,9 +341,7 @@ reading the file.
 A reader opens a segment in this order and treats a failed check as
 corruption of the named file, except where noted:
 
-1. Parse and validate the index details ([Validation](#validation)). When
-   they carry a `tokenizer_fingerprint`, recompute it from the deployment
-   and reject a mismatch as unsupported, not as corruption.
+1. Parse and validate the index details ([Validation](#validation)).
 2. Open both files. In each, the schema must match its definition above
    exactly in field names, types, nullability and list size, which must equal
    `num_hashes`; `minhash_lsh_details` must be

--- a/docs/src/format/index/scalar/minhash_lsh.md
+++ b/docs/src/format/index/scalar/minhash_lsh.md
@@ -70,6 +70,7 @@ statistics, so results from different segments merge exactly.
 | `shingle_size`      | 3                                                                | at least 1                                    | Tokens per shingle. Shorter shingles tolerate more edits but let unrelated texts that share common phrases look alike; 5 suits long documents, 2 very short texts.                                             |
 | `tokenizer`         | full text search default, without stemming and stop-word removal | the subset described under [Tokenizer](#tokenizer) | The tokenizer, recorded as the Full-Text Search index records it. Stemming and stop-word removal are off by default because merging different words inflates similarity.                                  |
 | `signature_version` | 0                                                                | 0                                             | Version of the signature procedure, including its hash seed and the band key hash. Managed by Lance, not a user parameter.                                                                                     |
+| `tokenizer_fingerprint` | absent                                                       | present exactly when the tokenizer loads resources from the language model home | XXH64 fingerprint of those resources, defined under [Tokenizer](#tokenizer). Managed by Lance, not a user parameter.                                                                       |
 
 Reference points: the probability that a row with true Jaccard similarity `J`
 becomes a candidate is `1 - (1 - J^r)^b` with `b = num_bands` and
@@ -93,7 +94,11 @@ file, and rejects the index when:
 - a parameter is outside its range above (this includes a `num_hashes` that is
   not a multiple of `num_bands`);
 - `tokenizer` is absent, or asks for a setting outside the supported subset;
-- `signature_version` is not a version the reader implements (only 0 exists).
+- `signature_version` is not a version the reader implements (only 0 exists);
+- `tokenizer_fingerprint` is present for a tokenizer that loads no resources,
+  or absent for one that does;
+- the tokenizer loads resources and the reader does not implement the
+  fingerprint.
 
 The ranges bound every derived size: a signature row is at most
 `8 + 2 * 4096` bytes, a band at most 4096 values and a query at most 256 band
@@ -114,10 +119,28 @@ query time. The supported subset is exactly what the message records:
 
 The default is the `simple` tokenizer with `language = English`,
 `max_token_length = 40`, `lower_case = true`, `ascii_folding = true`,
-`stem = false` and `remove_stop_words = false`. Dictionary-backed tokenizers
-(`icu`, `jieba/*`, `lindera/*`) are identified by name, as in the Full-Text
-Search index: the dictionary is part of the deployment, and an index must be
-rebuilt when it changes.
+`stem = false` and `remove_stop_words = false`.
+
+The details identify every input of tokenization, in one of two ways:
+
+- **Tokenizers whose data ships with Lance** (`simple`, `whitespace`, `raw`,
+  `ngram`, `code`, `icu`, `icu/split`; the ICU segmentation data is compiled
+  into Lance): their token stream for a given text and configuration is part
+  of `signature_version`, and `tokenizer_fingerprint` is absent.
+- **Tokenizers that load resources from the language model home**
+  (`jieba`, `jieba/*`, `lindera/*`, which read the directory
+  `LANCE_LANGUAGE_MODEL_HOME/<base_tokenizer>/`): the details carry
+  `tokenizer_fingerprint`, the XXH64 hash (seed 0) of the directory's
+  contents. The hash consumes, for every regular file below the directory in
+  ascending order of its relative path bytes, following symbolic links: the
+  relative path as UTF-8 bytes with `/` separators, one `0x00` byte, the file
+  length as 8 little-endian bytes, and the file contents. The writer computes
+  it when the index is built; a reader recomputes it from its own deployment
+  when it opens the index and rejects a mismatch, since the query would be
+  tokenized differently from the rows (the index must be rebuilt, or the
+  resources restored). An implementation that does not compute the
+  fingerprint rejects these tokenizers when an index is created and when one
+  is opened.
 
 ## Signature Generation
 
@@ -224,8 +247,8 @@ The texts `""` and `"  \n"` have no tokens and therefore no signature.
 ## Storage Layout
 
 Each segment consists of two Lance files. The details in the index metadata
-are the authoritative parameters; the files repeat them only so that a file
-that does not belong to the details is detected.
+are authoritative; both files repeat them as schema metadata so that a file
+that does not belong to the details is detected when the segment is opened.
 
 ### Signature File Schema
 
@@ -234,17 +257,35 @@ that does not belong to the details is detected.
 segment holds at most `2^32` documents, and larger tables use several
 segments.
 
-| Column      | Type                                | Nullable | Description                                                                                                                                                                  |
-|:------------|:------------------------------------|:---------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `_rowid`    | UInt64                              | false    | The row id of the indexed row as the dataset hands it to the index: the row address, or the stable row id when the dataset has stable row ids enabled, like every scalar index. |
-| `signature` | FixedSizeList<UInt16, `num_hashes`> | false    | The signature; the list items are not nullable.                                                                                                                              |
+```python
+pa.schema(
+    [
+        pa.field("_rowid", pa.uint64(), nullable=False),
+        pa.field(
+            "signature",
+            pa.list_(pa.field("item", pa.uint16(), nullable=False), num_hashes),
+            nullable=False,
+            metadata={
+                "lance-encoding:structural-encoding": "fullzip",
+                "lance-encoding:compression": "none",
+            },
+        ),
+    ],
+    metadata={
+        "minhash_lsh_details": "<hexadecimal serialized MinHashLshIndexDetails>",
+        "minhash_lsh_index_version": "0",
+    },
+)
+```
 
-The `signature` field carries the field metadata
-`lance-encoding:structural-encoding = fullzip` and
-`lance-encoding:compression = none`, so every row occupies the same
-`2 * num_hashes` bytes and a reader fetches the signature of document `i` by
-row number as one ranged read. Rows are written in document id order and
-never reordered.
+`_rowid` is the row id of the indexed row as the dataset hands it to the
+index: the row address, or the stable row id when the dataset has stable row
+ids enabled, like every scalar index. `signature` is the signature of
+[Signature Generation](#signature-generation). The field metadata of
+`signature` selects the full-zip structural encoding without compression, so
+every row occupies the same `2 * num_hashes` bytes and a reader fetches the
+signature of document `i` by row number as one ranged read. Rows are written
+in document id order and never reordered.
 
 ### Bands File Schema
 
@@ -252,13 +293,36 @@ never reordered.
 `band_key` and then `doc_id`, ascending. A bucket is the run of rows sharing
 a key.
 
-| Column     | Type   | Nullable | Description                                                  |
-|:-----------|:-------|:---------|:-------------------------------------------------------------|
-| `band_key` | UInt64 | false    | The band key of [Band Keys](#band-keys).                     |
-| `doc_id`   | UInt32 | false    | Segment-local document id: the row number in `signatures.lance`. |
+```python
+pa.schema(
+    [
+        pa.field(
+            "band_key",
+            pa.uint64(),
+            nullable=False,
+            metadata={"lance-encoding:compression": "none"},
+        ),
+        pa.field(
+            "doc_id",
+            pa.uint32(),
+            nullable=False,
+            metadata={"lance-encoding:compression": "none"},
+        ),
+    ],
+    metadata={
+        "minhash_lsh_details": "<hexadecimal serialized MinHashLshIndexDetails>",
+        "minhash_lsh_index_version": "0",
+        "minhash_lsh_num_docs": "<decimal document count>",
+        "minhash_lsh_page_rows": "4096",
+        "minhash_lsh_page_table_buffer": "<decimal global buffer index>",
+    },
+)
+```
 
-Both fields carry `lance-encoding:compression = none`, so any run of rows is
-one ranged read per column. The file is divided into logical pages of
+`band_key` is the key of [Band Keys](#band-keys); `doc_id` is the
+segment-local document id, the row number in `signatures.lance`. Both
+columns are stored without compression, so any run of rows is one ranged
+read per column. The file is divided into logical pages of
 `minhash_lsh_page_rows` rows: page `p` holds rows
 `[p * page_rows, (p + 1) * page_rows)`, and the last page may be shorter. A
 bucket may span any number of pages.
@@ -267,7 +331,7 @@ bucket may span any number of pages.
 
 | Key                             | File       | Value                                                                                                                                                                                                |
 |:--------------------------------|:-----------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `minhash_lsh_params`            | both       | JSON object with `num_hashes`, `num_bands`, `shingle_size` and `tokenizer` (the JSON form of the Full-Text Search index parameters). Must describe the same parameters as the index details.        |
+| `minhash_lsh_details`           | both       | Lower-case hexadecimal encoding of the serialized `MinHashLshIndexDetails` the segment was built from. A reader decodes it and requires it to describe, field by field, the same details as the index metadata. |
 | `minhash_lsh_index_version`     | both       | Decimal file layout version; `0` for the layout described here. Independent of `signature_version`.                                                                                                 |
 | `minhash_lsh_num_docs`          | `bands`    | Decimal number of documents of the segment; equals the row count of `signatures.lance`.                                                                                                             |
 | `minhash_lsh_page_rows`         | `bands`    | Decimal number of rows per logical page; positive. Writers use `4096`.                                                                                                                              |
@@ -290,13 +354,17 @@ reading the file.
 A reader opens a segment in this order and treats a failed check as
 corruption of the named file, except where noted:
 
-1. Parse and validate the index details ([Validation](#validation)).
-2. Open `bands.lance` and read its schema metadata. Every key above must be
-   present and parse. A `minhash_lsh_index_version` greater than the version
-   the reader implements is rejected as unsupported, not as corruption.
-   `minhash_lsh_params` must equal the details and `minhash_lsh_page_rows`
-   must be positive.
-3. Open `signatures.lance`; its row count must equal `minhash_lsh_num_docs`.
+1. Parse and validate the index details ([Validation](#validation)). When
+   they carry a `tokenizer_fingerprint`, recompute it from the deployment
+   and reject a mismatch as unsupported, not as corruption.
+2. Open both files. In each, the schema must match its definition above
+   exactly in field names, types, nullability (including the list item) and
+   list size, which must equal `num_hashes`; `minhash_lsh_details` must be
+   present, decode, validate and equal the index details field by field; and
+   `minhash_lsh_index_version` must be present. A version greater than the
+   one the reader implements is rejected as unsupported, not as corruption.
+3. In `bands.lance`, `minhash_lsh_page_rows` must be positive and
+   `minhash_lsh_num_docs` must equal the row count of `signatures.lance`.
 4. Read the page table buffer; its length must be a multiple of 8 and its
    entry count must be `ceil(num_rows / page_rows)` for the row count of
    `bands.lance`.

--- a/docs/src/format/index/scalar/minhash_lsh.md
+++ b/docs/src/format/index/scalar/minhash_lsh.md
@@ -97,6 +97,8 @@ file, and rejects the index when:
 - `signature_version` is not a version the reader implements (only 0 exists);
 - `tokenizer_fingerprint` is present for a tokenizer that loads no resources,
   or absent for one that does;
+- the tokenizer configuration names a resource outside its directory, or
+  depends on a fallback outside it;
 - the tokenizer loads resources and the reader does not implement the
   fingerprint.
 
@@ -129,9 +131,17 @@ The details identify every input of tokenization, in one of two ways:
   of `signature_version`, and `tokenizer_fingerprint` is absent.
 - **Tokenizers that load resources from the language model home**
   (`jieba`, `jieba/*`, `lindera/*`, which read the directory
-  `LANCE_LANGUAGE_MODEL_HOME/<base_tokenizer>/`): the details carry
-  `tokenizer_fingerprint`, the XXH64 hash (seed 0) of the directory's
-  contents. The hash consumes, for every regular file below the directory in
+  `LANCE_LANGUAGE_MODEL_HOME/<base_tokenizer>/`): the directory is the
+  complete set of resources. Its configuration file must exist (no
+  environment or built-in fallback, such as `LINDERA_CONFIG_PATH`, is
+  consulted), and every path the configuration names must be relative,
+  contain no `..` component and no URI scheme, and resolve to a regular file
+  below the directory; a configuration that reaches outside the directory is
+  rejected when an index is created or opened. Dictionaries compiled into
+  Lance (Lindera's built-in dictionary kinds) need no files and are part of
+  `signature_version`. The details carry `tokenizer_fingerprint`, the XXH64
+  hash (seed 0) of the directory's contents. The hash consumes, for every
+  regular file below the directory in
   ascending order of its relative path bytes, following symbolic links: the
   relative path as UTF-8 bytes with `/` separators, one `0x00` byte, the file
   length as 8 little-endian bytes, and the file contents. The writer computes

--- a/docs/src/format/index/scalar/minhash_lsh.md
+++ b/docs/src/format/index/scalar/minhash_lsh.md
@@ -263,7 +263,7 @@ pa.schema(
         pa.field("_rowid", pa.uint64(), nullable=False),
         pa.field(
             "signature",
-            pa.list_(pa.field("item", pa.uint16(), nullable=False), num_hashes),
+            pa.list_(pa.uint16(), num_hashes),
             nullable=False,
             metadata={
                 "lance-encoding:structural-encoding": "fullzip",
@@ -281,7 +281,9 @@ pa.schema(
 `_rowid` is the row id of the indexed row as the dataset hands it to the
 index: the row address, or the stable row id when the dataset has stable row
 ids enabled, like every scalar index. `signature` is the signature of
-[Signature Generation](#signature-generation). The field metadata of
+[Signature Generation](#signature-generation); its values are never null
+(the Lance schema does not record the nullability of a fixed-size list item,
+so a reader treats a null value as corruption of the file). The field metadata of
 `signature` selects the full-zip structural encoding without compression, so
 every row occupies the same `2 * num_hashes` bytes and a reader fetches the
 signature of document `i` by row number as one ranged read. Rows are written
@@ -358,8 +360,8 @@ corruption of the named file, except where noted:
    they carry a `tokenizer_fingerprint`, recompute it from the deployment
    and reject a mismatch as unsupported, not as corruption.
 2. Open both files. In each, the schema must match its definition above
-   exactly in field names, types, nullability (including the list item) and
-   list size, which must equal `num_hashes`; `minhash_lsh_details` must be
+   exactly in field names, types, nullability and list size, which must equal
+   `num_hashes`; `minhash_lsh_details` must be
    present, decode, validate and equal the index details field by field; and
    `minhash_lsh_index_version` must be present. A version greater than the
    one the reader implements is rejected as unsupported, not as corruption.
@@ -371,7 +373,8 @@ corruption of the named file, except where noted:
 
 While answering queries, a page that does not decode to non-null `UInt64`
 and `UInt32` columns, and a `doc_id` that is not below
-`minhash_lsh_num_docs`, are corruption of `bands.lance`.
+`minhash_lsh_num_docs`, are corruption of `bands.lance`; a signature batch
+with a null value is corruption of `signatures.lance`.
 
 The fragments a segment covers are recorded in the index metadata of the
 dataset, never derived from the stored `_rowid` values (which do not identify

--- a/docs/src/format/index/scalar/minhash_lsh.md
+++ b/docs/src/format/index/scalar/minhash_lsh.md
@@ -63,13 +63,13 @@ statistics, so results from different segments merge exactly.
 %%% proto.message.MinHashLshIndexDetails %%%
 ```
 
-| Parameter           | Default | Effect                                                                                                                                                                                                         |
-|:--------------------|:--------|:---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `num_hashes`        | 128     | Signature length. More hashes make the similarity estimate more precise (error about `1 / sqrt(num_hashes)`) and the signature table larger (`8 + 2 * num_hashes` bytes per row).                              |
-| `num_bands`         | 16      | Number of bands; `num_hashes` must be a multiple of it. With `num_hashes` it sets the similarity threshold `(1 / num_bands) ^ (num_bands / num_hashes)`. The bands table costs `12 * num_bands` bytes per row. |
-| `shingle_size`      | 3       | Tokens per shingle. Shorter shingles tolerate more edits but let unrelated texts that share common phrases look alike; 5 suits long documents, 2 very short texts.                                             |
-| `tokenizer`         | full text search default, without stemming and stop-word removal | The tokenizer, recorded as the Full-Text Search index records it. Stemming and stop-word removal are off by default because merging different words inflates similarity.                         |
-| `signature_version` | 0       | Version of the signature procedure, including its hash seed. Managed by Lance, not a user parameter.                                                                                                           |
+| Parameter           | Default                                                          | Range                                         | Effect                                                                                                                                                                                                         |
+|:--------------------|:-----------------------------------------------------------------|:----------------------------------------------|:---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `num_hashes`        | 128                                                              | 1 to 4096, a multiple of `num_bands`          | Signature length. More hashes make the similarity estimate more precise (error about `1 / sqrt(num_hashes)`) and the signature table larger (`8 + 2 * num_hashes` bytes per row).                              |
+| `num_bands`         | 16                                                               | 1 to 256                                      | Number of bands. With `num_hashes` it sets the similarity threshold `(1 / num_bands) ^ (num_bands / num_hashes)`. The bands table costs `12 * num_bands` bytes per row.                                        |
+| `shingle_size`      | 3                                                                | at least 1                                    | Tokens per shingle. Shorter shingles tolerate more edits but let unrelated texts that share common phrases look alike; 5 suits long documents, 2 very short texts.                                             |
+| `tokenizer`         | full text search default, without stemming and stop-word removal | the subset described under [Tokenizer](#tokenizer) | The tokenizer, recorded as the Full-Text Search index records it. Stemming and stop-word removal are off by default because merging different words inflates similarity.                                  |
+| `signature_version` | 0                                                                | 0                                             | Version of the signature procedure, including its hash seed and the band key hash. Managed by Lance, not a user parameter.                                                                                     |
 
 Reference points: the probability that a row with true Jaccard similarity `J`
 becomes a candidate is `1 - (1 - J^r)^b` with `b = num_bands` and
@@ -85,55 +85,229 @@ Bands of fewer than six values admit a noticeable share of unrelated rows into
 the candidate set on tables of billions of rows and are better left to offline
 use.
 
+### Validation
+
+A reader validates the details before it allocates memory or reads an index
+file, and rejects the index when:
+
+- a parameter is outside its range above (this includes a `num_hashes` that is
+  not a multiple of `num_bands`);
+- `tokenizer` is absent, or asks for a setting outside the supported subset;
+- `signature_version` is not a version the reader implements (only 0 exists).
+
+The ranges bound every derived size: a signature row is at most
+`8 + 2 * 4096` bytes, a band at most 4096 values and a query at most 256 band
+keys, so no combination of parameters can overflow a size computation or drive
+an unbounded allocation.
+
+### Tokenizer
+
+The tokenizer is recorded as a `lance.table.InvertedIndexDetails`, the message
+the Full-Text Search index persists, and is rebuilt from that message alone at
+query time. The supported subset is exactly what the message records:
+
+| Fields                                                                                                                                                                | Role                                                                                    |
+|:----------------------------------------------------------------------------------------------------------------------------------------------------------------------|:----------------------------------------------------------------------------------------|
+| `base_tokenizer`, `language`, `max_token_length`, `lower_case`, `stem`, `remove_stop_words`, `ascii_folding`, `min_ngram_length`, `max_ngram_length`, `prefix_only`, `code_config` | Shape the token stream and are applied by the index.                                    |
+| `with_position`, `block_size`, `document_granularity`, `posting_format_version`                                                                                       | Describe full text search postings; carried unchanged and ignored.                      |
+| custom stop words, document-level text extraction (`lance_tokenizer`)                                                                                                 | Cannot be recorded in the message; a build that asks for them is rejected.              |
+
+The default is the `simple` tokenizer with `language = English`,
+`max_token_length = 40`, `lower_case = true`, `ascii_folding = true`,
+`stem = false` and `remove_stop_words = false`. Dictionary-backed tokenizers
+(`icu`, `jieba/*`, `lindera/*`) are identified by name, as in the Full-Text
+Search index: the dictionary is part of the deployment, and an index must be
+rebuilt when it changes.
+
 ## Signature Generation
 
 The build side and the query side run the same procedure, so a query is
-comparable with every stored row:
+comparable with every stored row. All arithmetic below is on unsigned 64-bit
+integers modulo `2^64`, and every multi-byte value is little-endian.
 
-1. Tokenize the text with the configured tokenizer.
-2. Form shingles of `shingle_size` consecutive tokens (joined with the byte
-   `0x1F`). A text with fewer tokens than `shingle_size` forms one shingle of
-   all its tokens; a text with no tokens (NULL, empty, whitespace only) has no
-   signature, is not indexed, and never appears in results.
-3. Hash every shingle to 64 bits with XXH64 (seed 42).
-4. Apply `num_hashes` permutations of the form `a_i * x + b_i mod 2^64`, with
-   coefficients drawn from a SplitMix64 generator (seed 42, odd `a_i`), and
-   keep the minimum of each permutation over all shingles of the text.
-5. Store each minimum as 16 bits: `(c_i * min mod 2^64) >> 48` with an odd
-   multiplier `c_i` from the same generator. A minimum shrinks as the text
-   grows, so its raw high bits would agree between any two long texts;
-   multiply-shift hashing keeps the chance that two different minima collide
-   below `2^-15`, negligible against the `1 / num_hashes` resolution of the
-   estimate.
+1. **Tokenize** the text with the configured tokenizer. A token is the UTF-8
+   bytes of the token text the tokenizer emits, in emission order.
+2. **Shingle**: a shingle is `shingle_size` consecutive tokens joined with the
+   single byte `0x1F`; a text of `n` tokens has `n - shingle_size + 1`
+   shingles, one starting at every token position. A text with fewer tokens
+   than `shingle_size` but at least one token forms one shingle of all its
+   tokens. A text with no tokens (NULL, empty, whitespace only, or every token
+   discarded by the tokenizer) has no signature, is not indexed, and never
+   appears in results.
+3. **Hash** every shingle to 64 bits: `x = XXH64(shingle bytes, seed = 42)`.
+4. **Coefficients** come from a SplitMix64 generator whose state `s` starts at
+   42. One draw is:
+
+    ```
+    s    = s + 0x9E3779B97F4A7C15
+    z    = s
+    z    = (z ^ (z >> 30)) * 0xBF58476D1CE4E5B9
+    z    = (z ^ (z >> 27)) * 0x94D049BB133111EB
+    draw = z ^ (z >> 31)
+    ```
+
+    The draws are consumed in this order: for `i = 0 .. num_hashes - 1`,
+    `a_i = draw() | 1` and then `b_i = draw()`; after all pairs, for
+    `i = 0 .. num_hashes - 1`, `c_i = draw() | 1`. The coefficients depend on
+    `num_hashes` only.
+5. **Permute and take the minima**: `m_i = min over all shingles x of
+   (a_i * x + b_i)`, comparing the full 64-bit values.
+6. **Compress** each minimum to 16 bits: `signature[i] = (c_i * m_i) >> 48`.
+   A minimum shrinks as the text grows, so its raw high bits would agree
+   between any two long texts; multiply-shift hashing keeps the chance that
+   two different minima collide below `2^-15`, negligible against the
+   `1 / num_hashes` resolution of the estimate.
 
 The estimated Jaccard similarity of two signatures is the fraction of
 positions whose values are equal; the reported `_distance` is
-`1 - estimated similarity`. Every constant of the procedure is fixed by
-`signature_version`, and every segment of an index must carry identical
-details, so signatures written by different segments or at query time are
-always comparable. Changing a parameter, or upgrading a tokenizer dictionary,
+`1 - estimated similarity`, and rows at equal distance are ordered by row id.
+Every constant of the procedure, and the band key below, is fixed by
+`signature_version`; every segment of an index must carry identical details,
+so signatures written by different segments or at query time are always
+comparable. Changing a parameter, or upgrading a tokenizer dictionary,
 requires rebuilding the index.
+
+### Band Keys
+
+The signature is split into `num_bands` bands of `r = num_hashes / num_bands`
+consecutive values; band `j` holds `signature[j * r .. (j + 1) * r)`. Its key
+is
+
+```
+band_key_j = (j << 56) | (XXH64(band bytes, seed = 42) & 0x00FFFFFFFFFFFFFF)
+```
+
+where the band bytes are the band's `r` values, each written as 2 little-endian
+bytes, in signature order. The band number in the high byte keeps the keys of
+one band contiguous in the sorted bands table.
+
+### Known-Answer Vectors
+
+An implementation of the procedure must reproduce these values, computed with
+`num_hashes = 4`, `num_bands = 2`, `shingle_size = 2`, the default tokenizer
+and `signature_version = 0`.
+
+Coefficients:
+
+| `i` | `a_i`              | `b_i`              | `c_i`              |
+|:----|:-------------------|:-------------------|:-------------------|
+| 0   | `0xbdd732262feb6e95` | `0x28efe333b266f103` | `0x5705b8770b3d7dd5` |
+| 1   | `0x47526757130f9f53` | `0x581ce1ff0e4ae394` | `0x9e54d738297f77af` |
+| 2   | `0x09bc585a244823f3` | `0xde4431fa3c80db06` | `0x3474724a775b19bf` |
+| 3   | `0x37e9671c45376d5d` | `0xccf635ee9e9e2fa4` | `0x7e348a0e451650bf` |
+
+Text `"The quick brown fox"` tokenizes to `the`, `quick`, `brown`, `fox`:
+
+| Shingle bytes           | `XXH64`            |
+|:------------------------|:-------------------|
+| `the` `0x1F` `quick`    | `0x4c0b0d36203ce55f` |
+| `quick` `0x1F` `brown`  | `0x09c7ae895d82b184` |
+| `brown` `0x1F` `fox`    | `0x68e7f4b1be7b4c1f` |
+
+| `i` | `m_i`              | `signature[i]` |
+|:----|:-------------------|:---------------|
+| 0   | `0x0959767d77eafad7` | `0xb00f`         |
+| 1   | `0x464e4457275cd2a1` | `0x59d6`         |
+| 2   | `0x50f41804abaa5973` | `0x511a`         |
+| 3   | `0x8944bd01067b09e7` | `0xcd2c`         |
+
+Band keys: `0x00f30f3501d458ea` (band 0), `0x01aec5df28d04915` (band 1).
+
+Text `"Fox"` has one token, fewer than `shingle_size`, so its only shingle is
+`fox` with `XXH64` `0x07c0130ab04388d5`; the minima are `0x2bb8ade505081afc`,
+`0x0a273c6ff9a78ba3`, `0x802f20573838dc35`, `0x1ef46a8d372c9605`, the signature is
+`0x2970 0xd6db 0x65f8 0xadfc`, and the band keys are `0x003cf6e803312eca` and
+`0x017c5504fbc83f36`.
+
+The texts `""` and `"  \n"` have no tokens and therefore no signature.
 
 ## Storage Layout
 
-Each segment consists of two Lance files:
+Each segment consists of two Lance files. The details in the index metadata
+are the authoritative parameters; the files repeat them only so that a file
+that does not belong to the details is detected.
 
-- `signatures.lance` — one row per indexed document: its `_rowid` and its
-  signature as a fixed-size list of `num_hashes` 16-bit values. The row number
-  is the segment-local document id, so a segment holds at most `2^32`
-  documents; larger tables use several segments. Rows are fixed width, so one
-  document's signature is a single ranged read at a known offset.
-- `bands.lance` — one row per (band key, document id) pair, sorted by band key
-  and then document id. A bucket is the run of rows sharing a key. The file is
-  divided into logical pages of 4096 rows, and a page table holding the
-  largest key of every page is stored in a global buffer of the file and kept
-  in memory when the index is open. The band key puts the band number in its
-  high 8 bits and a hash of the band's values in the low 56 bits, so the keys
-  of one band are contiguous.
+### Signature File Schema
 
-Both files also record the index parameters and the index version as schema
-metadata, so a mismatch with the index details is detected when the index is
-opened.
+`signatures.lance` holds one row per indexed document. Row `i` is document
+`i` of the segment: the row number is the segment-local document id, so a
+segment holds at most `2^32` documents, and larger tables use several
+segments.
+
+| Column      | Type                                | Nullable | Description                                                                                                                                                                  |
+|:------------|:------------------------------------|:---------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `_rowid`    | UInt64                              | false    | The row id of the indexed row as the dataset hands it to the index: the row address, or the stable row id when the dataset has stable row ids enabled, like every scalar index. |
+| `signature` | FixedSizeList<UInt16, `num_hashes`> | false    | The signature; the list items are not nullable.                                                                                                                              |
+
+The `signature` field carries the field metadata
+`lance-encoding:structural-encoding = fullzip` and
+`lance-encoding:compression = none`, so every row occupies the same
+`2 * num_hashes` bytes and a reader fetches the signature of document `i` by
+row number as one ranged read. Rows are written in document id order and
+never reordered.
+
+### Bands File Schema
+
+`bands.lance` holds one row per (band key, document id) pair, sorted by
+`band_key` and then `doc_id`, ascending. A bucket is the run of rows sharing
+a key.
+
+| Column     | Type   | Nullable | Description                                                  |
+|:-----------|:-------|:---------|:-------------------------------------------------------------|
+| `band_key` | UInt64 | false    | The band key of [Band Keys](#band-keys).                     |
+| `doc_id`   | UInt32 | false    | Segment-local document id: the row number in `signatures.lance`. |
+
+Both fields carry `lance-encoding:compression = none`, so any run of rows is
+one ranged read per column. The file is divided into logical pages of
+`minhash_lsh_page_rows` rows: page `p` holds rows
+`[p * page_rows, (p + 1) * page_rows)`, and the last page may be shorter. A
+bucket may span any number of pages.
+
+### Schema Metadata
+
+| Key                             | File       | Value                                                                                                                                                                                                |
+|:--------------------------------|:-----------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `minhash_lsh_params`            | both       | JSON object with `num_hashes`, `num_bands`, `shingle_size` and `tokenizer` (the JSON form of the Full-Text Search index parameters). Must describe the same parameters as the index details.        |
+| `minhash_lsh_index_version`     | both       | Decimal file layout version; `0` for the layout described here. Independent of `signature_version`.                                                                                                 |
+| `minhash_lsh_num_docs`          | `bands`    | Decimal number of documents of the segment; equals the row count of `signatures.lance`.                                                                                                             |
+| `minhash_lsh_page_rows`         | `bands`    | Decimal number of rows per logical page; positive. Writers use `4096`.                                                                                                                              |
+| `minhash_lsh_page_table_buffer` | `bands`    | Decimal index of the global buffer of `bands.lance` that holds the page table.                                                                                                                      |
+
+### Page Table
+
+The page table is a global buffer of `bands.lance` holding
+`ceil(num_rows / page_rows)` little-endian UInt64 values; entry `p` is the
+largest `band_key` of page `p`, that is the key of its last row. It is read
+when the segment is opened and kept in memory while the index is open. A
+bucket for key `K` starts in the first page whose entry is `>= K` and ends in
+the first page whose entry is `> K` (or the last page when there is none);
+the pages strictly between hold nothing but that bucket. Both positions are
+binary searches over the table, so a bucket's page range is known without
+reading the file.
+
+### Opening a Segment
+
+A reader opens a segment in this order and treats a failed check as
+corruption of the named file, except where noted:
+
+1. Parse and validate the index details ([Validation](#validation)).
+2. Open `bands.lance` and read its schema metadata. Every key above must be
+   present and parse. A `minhash_lsh_index_version` greater than the version
+   the reader implements is rejected as unsupported, not as corruption.
+   `minhash_lsh_params` must equal the details and `minhash_lsh_page_rows`
+   must be positive.
+3. Open `signatures.lance`; its row count must equal `minhash_lsh_num_docs`.
+4. Read the page table buffer; its length must be a multiple of 8 and its
+   entry count must be `ceil(num_rows / page_rows)` for the row count of
+   `bands.lance`.
+
+While answering queries, a page that does not decode to non-null `UInt64`
+and `UInt32` columns, and a `doc_id` that is not below
+`minhash_lsh_num_docs`, are corruption of `bands.lance`.
+
+The fragments a segment covers are recorded in the index metadata of the
+dataset, never derived from the stored `_rowid` values (which do not identify
+fragments once stable row ids are enabled).
 
 ## Segments, Appends and Merging
 
@@ -160,11 +334,12 @@ When a search is submitted (`nearest = MinHashQuery(text, column)`):
 
 1. The query text is signed with the parameters recorded in the index, and its
    band keys are computed.
-2. In every segment, each band key is looked up through the page table: a
-   binary search finds the first and the last page of the key's bucket. The
-   boundary pages of all buckets are fetched in one scattered read; the pages
-   in between, when a bucket spans more than two pages, are streamed in
-   bounded windows. The document ids in the buckets form the candidate set.
+2. In every segment, each band key is looked up through the
+   [page table](#page-table), which yields the first and the last page of the
+   key's bucket. The boundary pages of all buckets are fetched in one
+   scattered read; the pages in between, when a bucket spans more than two
+   pages, are streamed in bounded windows. The document ids in the buckets
+   form the candidate set.
 3. The candidates' signatures are read — from memory when resident, otherwise
    with scattered reads, or with a sequential scan when the candidates cover a
    large share of the segment — and each candidate's Jaccard distance to the

--- a/protos/index.proto
+++ b/protos/index.proto
@@ -6,6 +6,7 @@ syntax = "proto3";
 package lance.index.pb;
 
 import "google/protobuf/any.proto";
+import "index_old.proto";
 
 // The type of an index.
 enum IndexType {
@@ -255,3 +256,41 @@ message BloomFilterIndexDetails {}
 message RTreeIndexDetails {}
 
 message FMIndexDetails {}
+
+/* Details for a MinHash LSH index used for near-duplicate detection
+ * (approximate Jaccard similarity top-k over text).
+ *
+ * Every parameter that shapes a signature lives here and nowhere else. All
+ * segments of one logical index must carry identical parameters so that
+ * signatures written by different segments (and computed on the query side)
+ * are comparable; the index files repeat them as schema metadata only to
+ * detect a details/file mismatch.
+ */
+message MinHashLshIndexDetails {
+  /* Number of MinHash values per signature (k). Must be a positive multiple of
+   * `num_bands`.
+   */
+  uint32 num_hashes = 1;
+
+  /* Number of LSH bands (b). Each band covers `num_hashes / num_bands`
+   * consecutive signature values. Must be in [1, 256].
+   */
+  uint32 num_bands = 2;
+
+  // Number of consecutive tokens joined into one shingle before hashing.
+  uint32 shingle_size = 3;
+
+  /* The tokenizer, recorded exactly like a full text search index records
+   * it. Only the tokenization fields matter here; fields that shape full text
+   * search postings (`with_position`, `block_size`, `posting_format_version`,
+   * `document_granularity`) are carried unchanged and ignored.
+   */
+  lance.table.InvertedIndexDetails tokenizer = 4;
+
+  /* Version of the signature generation behavior (tokenize, shingle, hash,
+   * permute, compress, including the fixed seed the coefficients derive from).
+   * Bumped whenever any step changes in a way that makes old and new
+   * signatures incomparable. Independent of the index file format version.
+   */
+  uint32 signature_version = 5;
+}

--- a/protos/index.proto
+++ b/protos/index.proto
@@ -308,7 +308,9 @@ message MinHashLshIndexDetails {
   /* XXH64 fingerprint of the resources the tokenizer loads from the language
    * model home at build time (the jieba and lindera dictionaries), as
    * defined by the format specification. Present exactly when the tokenizer
-   * loads such resources. A reader recomputes it from its own deployment
+   * loads such resources, which must all lie below the tokenizer's directory:
+   * a configuration that reaches outside it, or relies on a fallback, is
+   * rejected. A reader recomputes the fingerprint from its own deployment
    * before signing a query and rejects a mismatch; a writer or reader that
    * does not implement the fingerprint rejects these tokenizers instead.
    */

--- a/protos/index.proto
+++ b/protos/index.proto
@@ -257,62 +257,49 @@ message RTreeIndexDetails {}
 
 message FMIndexDetails {}
 
-/* Details for a MinHash LSH index used for near-duplicate detection
- * (approximate Jaccard similarity top-k over text).
+/* Details of a MinHash LSH index (near-duplicate search over text).
  *
- * Every input of signature generation is identified here and nowhere else:
- * the parameters, the tokenizer configuration, the fingerprint of tokenizer
- * resources that do not ship with Lance, and the version of the procedure.
- * All segments of one logical index must carry identical details so that
- * signatures written by different segments (and computed on the query side)
- * are comparable; both index files repeat the serialized message as schema
- * metadata so that a file that does not belong to the details is detected. A
- * reader validates every field against the ranges below before it allocates
- * memory or reads an index file, and rejects details outside them.
+ * The message identifies every input of signature generation: the
+ * parameters, the tokenizer and the version of the procedure. All segments
+ * of one logical index carry identical details, so their signatures and the
+ * query signature are comparable; both index files repeat the serialized
+ * message in their schema metadata so that a file which does not belong to
+ * the details is detected. A reader validates every field against the ranges
+ * below before it allocates memory or reads an index file.
  */
 message MinHashLshIndexDetails {
-  /* Number of MinHash values per signature (k). Must be in [1, 4096] and a
-   * multiple of `num_bands`.
+  /* Number of MinHash values per signature (k): in [1, 4096] and a multiple
+   * of `num_bands`.
    */
   uint32 num_hashes = 1;
 
-  /* Number of LSH bands (b). Each band covers `num_hashes / num_bands`
-   * consecutive signature values. Must be in [1, 256].
+  /* Number of LSH bands (b), in [1, 256]. Each band covers
+   * `num_hashes / num_bands` consecutive signature values.
    */
   uint32 num_bands = 2;
 
-  /* Number of consecutive tokens joined into one shingle before hashing. Must
-   * be at least 1; a text with fewer tokens forms one shingle of all of them.
+  /* Number of consecutive tokens joined into one shingle; at least 1. A text
+   * with fewer tokens forms one shingle of all of them.
    */
   uint32 shingle_size = 3;
 
-  /* The tokenizer, recorded exactly like a full text search index records it
-   * and rebuilt from this message alone at query time. Required. Only the
-   * tokenization fields matter here; fields that shape full text search
-   * postings (`with_position`, `block_size`, `posting_format_version`,
-   * `document_granularity`) are carried unchanged and ignored. Settings the
-   * message cannot record (custom stop words, document-level text extraction)
-   * are rejected when the index is created. The token stream of a tokenizer
-   * whose data ships with Lance is fixed by `signature_version`.
+  /* The tokenizer, recorded as a full text search index records it and
+   * rebuilt from this message alone at query time. Required. Fields that only
+   * shape full text search postings (`with_position`, `block_size`,
+   * `posting_format_version`, `document_granularity`) are carried unchanged
+   * and ignored. The details must identify the tokenizer completely, so
+   * settings the message cannot record (custom stop words, document-level
+   * text extraction) and tokenizers that load data from outside Lance (the
+   * jieba and lindera dictionaries) are rejected.
    */
   lance.table.InvertedIndexDetails tokenizer = 4;
 
-  /* Version of the signature generation behavior (tokenize, shingle, hash,
-   * permute, compress and derive band keys, including the fixed seed the
-   * coefficients derive from). Bumped whenever any step changes in a way that
-   * makes old and new signatures incomparable; a reader rejects a version it
-   * does not implement. Independent of the index file format version.
+  /* Version of the signature procedure: the token streams of the tokenizers
+   * that ship with Lance, shingling, hashing, the permutation coefficients
+   * and their seed, compression and band keys. Bumped whenever any of them
+   * changes in a way that makes old and new signatures incomparable; a reader
+   * rejects a version it does not implement. Independent of the index file
+   * format version.
    */
   uint32 signature_version = 5;
-
-  /* XXH64 fingerprint of the resources the tokenizer loads from the language
-   * model home at build time (the jieba and lindera dictionaries), as
-   * defined by the format specification. Present exactly when the tokenizer
-   * loads such resources, which must all lie below the tokenizer's directory:
-   * a configuration that reaches outside it, or relies on a fallback, is
-   * rejected. A reader recomputes the fingerprint from its own deployment
-   * before signing a query and rejects a mismatch; a writer or reader that
-   * does not implement the fingerprint rejects these tokenizers instead.
-   */
-  optional uint64 tokenizer_fingerprint = 6;
 }

--- a/protos/index.proto
+++ b/protos/index.proto
@@ -260,13 +260,15 @@ message FMIndexDetails {}
 /* Details for a MinHash LSH index used for near-duplicate detection
  * (approximate Jaccard similarity top-k over text).
  *
- * Every parameter that shapes a signature lives here and nowhere else. All
- * segments of one logical index must carry identical parameters so that
+ * Every input of signature generation is identified here and nowhere else:
+ * the parameters, the tokenizer configuration, the fingerprint of tokenizer
+ * resources that do not ship with Lance, and the version of the procedure.
+ * All segments of one logical index must carry identical details so that
  * signatures written by different segments (and computed on the query side)
- * are comparable; the index files repeat them as schema metadata only to
- * detect a details/file mismatch. A reader validates every field against the
- * ranges below before it allocates memory or reads an index file, and rejects
- * details outside them.
+ * are comparable; both index files repeat the serialized message as schema
+ * metadata so that a file that does not belong to the details is detected. A
+ * reader validates every field against the ranges below before it allocates
+ * memory or reads an index file, and rejects details outside them.
  */
 message MinHashLshIndexDetails {
   /* Number of MinHash values per signature (k). Must be in [1, 4096] and a
@@ -290,7 +292,8 @@ message MinHashLshIndexDetails {
    * postings (`with_position`, `block_size`, `posting_format_version`,
    * `document_granularity`) are carried unchanged and ignored. Settings the
    * message cannot record (custom stop words, document-level text extraction)
-   * are rejected when the index is created.
+   * are rejected when the index is created. The token stream of a tokenizer
+   * whose data ships with Lance is fixed by `signature_version`.
    */
   lance.table.InvertedIndexDetails tokenizer = 4;
 
@@ -301,4 +304,13 @@ message MinHashLshIndexDetails {
    * does not implement. Independent of the index file format version.
    */
   uint32 signature_version = 5;
+
+  /* XXH64 fingerprint of the resources the tokenizer loads from the language
+   * model home at build time (the jieba and lindera dictionaries), as
+   * defined by the format specification. Present exactly when the tokenizer
+   * loads such resources. A reader recomputes it from its own deployment
+   * before signing a query and rejects a mismatch; a writer or reader that
+   * does not implement the fingerprint rejects these tokenizers instead.
+   */
+  optional uint64 tokenizer_fingerprint = 6;
 }

--- a/protos/index.proto
+++ b/protos/index.proto
@@ -264,11 +264,13 @@ message FMIndexDetails {}
  * segments of one logical index must carry identical parameters so that
  * signatures written by different segments (and computed on the query side)
  * are comparable; the index files repeat them as schema metadata only to
- * detect a details/file mismatch.
+ * detect a details/file mismatch. A reader validates every field against the
+ * ranges below before it allocates memory or reads an index file, and rejects
+ * details outside them.
  */
 message MinHashLshIndexDetails {
-  /* Number of MinHash values per signature (k). Must be a positive multiple of
-   * `num_bands`.
+  /* Number of MinHash values per signature (k). Must be in [1, 4096] and a
+   * multiple of `num_bands`.
    */
   uint32 num_hashes = 1;
 
@@ -277,20 +279,26 @@ message MinHashLshIndexDetails {
    */
   uint32 num_bands = 2;
 
-  // Number of consecutive tokens joined into one shingle before hashing.
+  /* Number of consecutive tokens joined into one shingle before hashing. Must
+   * be at least 1; a text with fewer tokens forms one shingle of all of them.
+   */
   uint32 shingle_size = 3;
 
-  /* The tokenizer, recorded exactly like a full text search index records
-   * it. Only the tokenization fields matter here; fields that shape full text
-   * search postings (`with_position`, `block_size`, `posting_format_version`,
-   * `document_granularity`) are carried unchanged and ignored.
+  /* The tokenizer, recorded exactly like a full text search index records it
+   * and rebuilt from this message alone at query time. Required. Only the
+   * tokenization fields matter here; fields that shape full text search
+   * postings (`with_position`, `block_size`, `posting_format_version`,
+   * `document_granularity`) are carried unchanged and ignored. Settings the
+   * message cannot record (custom stop words, document-level text extraction)
+   * are rejected when the index is created.
    */
   lance.table.InvertedIndexDetails tokenizer = 4;
 
   /* Version of the signature generation behavior (tokenize, shingle, hash,
-   * permute, compress, including the fixed seed the coefficients derive from).
-   * Bumped whenever any step changes in a way that makes old and new
-   * signatures incomparable. Independent of the index file format version.
+   * permute, compress and derive band keys, including the fixed seed the
+   * coefficients derive from). Bumped whenever any step changes in a way that
+   * makes old and new signatures incomparable; a reader rejects a version it
+   * does not implement. Independent of the index file format version.
    */
   uint32 signature_version = 5;
 }

--- a/rust/lance-index/build.rs
+++ b/rust/lance-index/build.rs
@@ -19,12 +19,14 @@ fn main() -> Result<()> {
     let mut prost_build = prost_build::Config::new();
     prost_build.protoc_arg("--experimental_allow_proto3_optional");
     prost_build.enable_type_names();
+    prost_build.compile_protos(&["./protos/index_old.proto"], &["./protos"])?;
+    // `index.proto` references `lance.table.InvertedIndexDetails`. An extern
+    // path resolves the reference to the module that includes the generated
+    // `lance.table` code, but it also stops prost from generating that
+    // package, hence the separate pass above.
+    prost_build.extern_path(".lance.table", "crate::pbold");
     prost_build.compile_protos(
-        &[
-            "./protos/index.proto",
-            "./protos/index_old.proto",
-            "./protos-cache/cache.proto",
-        ],
+        &["./protos/index.proto", "./protos-cache/cache.proto"],
         &["./protos", "./protos-cache"],
     )?;
 


### PR DESCRIPTION
Add MinHashLshIndexDetails, the persisted parameters of the MinHash LSH index (num_hashes, num_bands, shingle_size, the tokenizer recorded as the full text search index records it, and signature_version), and the format specification of its two files: the fixed-width signature table and the sorted band table with its page table, together with the signature procedure, the band key, reader navigation, multi-segment semantics and versioning.

The message references lance.table.InvertedIndexDetails from another proto package, so the build script maps that package to the module that already includes its generated code.