### PR TITLE
feat: make data file parts serializable

### DIFF
--- a/rust/lance/src/dataset.rs
+++ b/rust/lance/src/dataset.rs
@@ -70,6 +70,7 @@ pub(crate) mod branch_location;
 pub mod builder;
 pub mod cleanup;
 mod data_file;
+mod data_file_part;
 pub mod delta;
 pub mod files;
 pub mod fragment;
@@ -115,7 +116,8 @@ mod utils;
 pub(crate) mod versions;
 pub mod write;
 
-pub use data_file::{DataFilePart, DataFileTarget};
+pub use data_file::DataFileTarget;
+pub use data_file_part::DataFilePart;
 
 pub(crate) use take::row_offsets_to_row_addresses;
 

--- a/rust/lance/src/dataset/data_file.rs
+++ b/rust/lance/src/dataset/data_file.rs
@@ -1,57 +1,50 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright The Lance Authors
 
-//! Stateless writing and concatenation of complete encoded data-file parts.
+use std::{
+    collections::{HashMap, HashSet},
+    io::Cursor,
+    sync::Arc,
+};
 
-use std::{collections::HashSet, num::NonZeroU64, ops::Range, sync::Arc};
-
+use arrow::ipc::{reader::StreamReader, writer::StreamWriter};
 use arrow_array::RecordBatch;
-use futures::{Stream, StreamExt};
-use lance_core::{Error, Result, datatypes::Schema};
-use lance_file::{
-    concat::{
-        BlobTargetId, EncodedFileInput, FileConcatOptions, FileConcatReason, FileConcatResult,
-        FileConcatTarget, concat_data_file_parts as concat_parts,
-    },
-    version::ConcreteFileVersion,
-    versions as file_versions,
-    writer::{FileWriteSummary, FileWriterOptions},
+use arrow_schema::{Field as ArrowField, Schema as ArrowSchema};
+use lance_core::{
+    Error, Result,
+    datatypes::{Field, Schema},
 };
-use lance_io::traits::Writer;
-use lance_table::format::DataFile;
-use object_store::path::Path;
+use lance_file::{concat::BlobTargetId, format::pb, version::ConcreteFileVersion};
+use object_store::path::{Path, PathPart};
+use prost::Message;
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
-pub use lance_file::concat::DataFilePart;
+use super::{Dataset, fragment::write::generate_random_filename};
+use crate::blob::prepared_to_logical_blob_schema;
 
-use super::{
-    Dataset,
-    fragment::{FileFragment, write::generate_random_filename},
-    transaction::DataReplacementGroup,
-};
-use crate::{
-    blob::prepared_to_logical_blob_schema,
-    dataset::{
-        blob::BlobPreprocessor,
-        write::{
-            ExternalBlobMode, WriteParams, blob_v2_external_base_resolver,
-            validate_blob_v2_write_schema,
-        },
-    },
-};
-
-/// Runtime identity and logical schema of a final concatenated data file.
+/// Serializable identity and logical schema of a final concatenated data file.
 ///
-/// Reuse the same live value for every part write and final concatenation. Lance
-/// defines no serialization or recovery contract for this type. The caller must
-/// keep every use associated with the same dataset and resolved base; Lance does
-/// not validate that association across [`Dataset`] instances.
+/// Reuse the same identity for every part write and final concatenation. Callers
+/// serialize and deserialize this value with serde. The representation preserves
+/// field IDs, metadata, and loaded dictionary values. The caller owns checkpoint
+/// state and must keep every use associated with the same dataset and resolved base;
+/// Lance does not validate that association across [`Dataset`] instances.
+///
+/// ```
+/// # use lance::dataset::DataFileTarget;
+/// # fn checkpoint(target: &DataFileTarget) -> Result<(), serde_json::Error> {
+/// let bytes = serde_json::to_vec(target)?;
+/// let restored: DataFileTarget = serde_json::from_slice(&bytes)?;
+/// # let _ = restored;
+/// # Ok(())
+/// # }
+/// ```
 #[derive(Debug, Clone)]
 pub struct DataFileTarget {
-    file_name: String,
-    base_id: Option<u32>,
-    schema: Arc<Schema>,
-    version: ConcreteFileVersion,
-    blob_target_id: Option<BlobTargetId>,
+    pub(super) file_name: String,
+    pub(super) base_id: Option<u32>,
+    pub(super) schema: Arc<Schema>,
+    pub(super) version: ConcreteFileVersion,
 }
 
 impl DataFileTarget {
@@ -109,7 +102,6 @@ impl DataFileTarget {
             }
         }
         let schema = Arc::new(prepared_to_logical_blob_schema(schema.as_ref())?);
-        let has_blob_v2 = schema.fields_pre_order().any(|field| field.is_blob_v2());
         if schema
             .fields_pre_order()
             .any(|field| field.is_blob() && !field.is_blob_v2())
@@ -118,359 +110,258 @@ impl DataFileTarget {
                 "DataFileTarget does not support legacy Blob v1 fields",
             ));
         }
-        let file_name = format!("{}.lance", generate_random_filename());
-        let blob_target_id = has_blob_v2.then(|| {
-            let base = base_id
-                .map(|id| format!("base:{id}"))
-                .unwrap_or_else(|| "primary".to_string());
-            BlobTargetId::new(format!("{base}/{file_name}"))
-        });
         Ok(Self {
-            file_name,
+            file_name: format!("{}.lance", generate_random_filename()),
             base_id,
             schema,
             version,
-            blob_target_id,
         })
     }
 
-    /// Relative path of the final data file within its selected base.
-    pub fn file_name(&self) -> &str {
-        &self.file_name
+    pub(super) fn blob_target_id(&self) -> Option<BlobTargetId> {
+        self.schema
+            .fields_pre_order()
+            .any(|field| field.is_blob_v2())
+            .then(|| {
+                let base = self
+                    .base_id
+                    .map(|id| format!("base:{id}"))
+                    .unwrap_or_else(|| "primary".to_string());
+                BlobTargetId::new(format!("{base}/{}", self.file_name))
+            })
     }
 
-    /// Optional registered dataset base that owns the final data file.
-    pub fn base_id(&self) -> Option<u32> {
-        self.base_id
+    pub(super) fn data_file_key(&self) -> &str {
+        self.file_name
+            .strip_suffix(".lance")
+            .unwrap_or(&self.file_name)
     }
 
-    /// Caller-visible logical schema encoded by every part.
-    pub fn schema(&self) -> &Arc<Schema> {
-        &self.schema
-    }
-
-    /// Exact Lance file grammar used by parts and final output.
-    pub fn version(&self) -> ConcreteFileVersion {
-        self.version
-    }
-
-    /// Open one caller-provided part and associate its managed Blob descriptors
-    /// with this runtime target.
-    ///
-    /// The caller must ensure that Blob payloads were written through this target
-    /// using the same dataset and resolved base that will assemble the part.
-    pub async fn open_part(
-        &self,
-        input: EncodedFileInput,
-        blob_ids: Option<Range<u32>>,
-    ) -> Result<DataFilePart> {
-        DataFilePart::open(input, blob_ids, self.blob_target_id.clone()).await
-    }
-
-    fn object_path(&self, data_dir: &Path) -> Path {
+    pub(super) fn object_path(&self, data_dir: &Path) -> Path {
         data_dir.clone().join(self.file_name.as_str())
     }
-}
 
-impl Dataset {
-    fn validate_data_file_target(&self, target: &DataFileTarget) -> Result<()> {
-        let dataset_version = self.manifest.data_storage_format.lance_file_format();
-        if target.version != dataset_version {
-            return Err(Error::invalid_input(format!(
-                "DataFileTarget.version is {}, but dataset version {} uses {}",
-                target.version,
-                self.version_id(),
-                dataset_version
-            )));
-        }
-        self.data_file_dir_for_base(target.base_id)?;
+    pub(super) fn parts_dir(&self, data_dir: &Path) -> Path {
+        data_dir
+            .clone()
+            .join("_parts")
+            .join(self.file_name.as_str())
+    }
 
-        if target.schema.metadata != self.schema().metadata {
-            return Err(Error::invalid_input(
-                "DataFileTarget.schema metadata differs from the dataset schema metadata",
-            ));
+    /// Release staging parts after a successful commit, keeping the final file
+    /// and its managed Blob payloads. Stop all writers and assemblers first.
+    ///
+    /// This also removes incomplete parts. Missing files are OK; storage failures
+    /// may leave partial cleanup and can be retried. Use the same dataset and
+    /// resolved base as the original write. This does not commit the target.
+    ///
+    /// ```
+    /// # use lance::{Dataset, dataset::DataFileTarget};
+    /// # async fn release(dataset: &Dataset, target: &DataFileTarget) -> lance_core::Result<()> {
+    /// // After committing the assembled file and releasing all part users:
+    /// target.finish(dataset).await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn finish(&self, dataset: &Dataset) -> Result<()> {
+        let data_dir = dataset.data_file_dir_for_base(self.base_id)?;
+        let store = dataset.object_store(self.base_id).await?;
+        if let Err(error) = store.remove_dir_all(self.parts_dir(&data_dir)).await
+            && !error.is_not_found()
+        {
+            return Err(error);
         }
-        for target_field in &target.schema.fields {
-            let Some(dataset_field) = self
-                .schema()
-                .fields
-                .iter()
-                .find(|field| field.id == target_field.id)
-            else {
-                return Err(Error::invalid_input(format!(
-                    "DataFileTarget.schema field ID {} is not a top-level dataset field",
-                    target_field.id
-                )));
-            };
-            if dataset_field != target_field {
-                return Err(Error::invalid_input(format!(
-                    "DataFileTarget.schema field ID {} differs from the current dataset field",
-                    target_field.id
-                )));
-            }
-        }
-
         Ok(())
     }
 
-    /// Encode one independently persisted part for a future data file.
+    /// Delete an abandoned target's staging parts, final file, and managed Blob
+    /// payloads, including objects left by failed writes or assembly.
     ///
-    /// The caller owns `output` and its storage path. Managed Blob payloads are
-    /// written directly beneath the sidecar directory selected by the final
-    /// target using IDs from `blob_ids`; every non-empty logical Inline value is
-    /// spilled to Packed or Dedicated storage so final concatenation never copies
-    /// Blob payload bytes.
-    /// Every use of `target` must refer to the same dataset and resolved base;
-    /// associating a runtime target with that storage context is the caller's
-    /// responsibility.
-    ///
-    /// # Example
+    /// The caller must stop all users and ensure no current or retained dataset
+    /// version, checkpoint, or future commit needs this target. Lance does not
+    /// track task liveness or check historical references. Use the original
+    /// dataset/base mapping. Missing objects are OK; retry on storage failures.
     ///
     /// ```
-    /// use arrow_array::RecordBatch;
-    /// use futures::stream;
-    /// use lance::{Dataset, dataset::DataFileTarget};
-    /// use lance_io::traits::Writer;
-    ///
-    /// # async fn write_part(
-    /// #     dataset: &Dataset,
-    /// #     target: &DataFileTarget,
-    /// #     output: Box<dyn Writer>,
-    /// #     batch: RecordBatch,
-    /// # ) -> lance_core::Result<()> {
-    /// dataset
-    ///     .write_data_file_part(target, output, None, stream::iter([Ok(batch)]))
-    ///     .await?;
+    /// # use lance::{Dataset, dataset::DataFileTarget};
+    /// # async fn abandon(dataset: &Dataset, target: &DataFileTarget) -> lance_core::Result<()> {
+    /// // After abandoning the target and stopping all its users:
+    /// target.cleanup(dataset).await?;
     /// # Ok(())
     /// # }
     /// ```
-    pub async fn write_data_file_part(
-        &self,
-        target: &DataFileTarget,
-        output: Box<dyn Writer>,
-        blob_ids: Option<Range<u32>>,
-        data: impl Stream<Item = Result<RecordBatch>> + Send,
-    ) -> Result<FileWriteSummary> {
-        self.validate_data_file_target(target)?;
-        validate_blob_v2_write_schema(target.schema.as_ref())?;
-        let has_blob = target
-            .schema
-            .fields_pre_order()
-            .any(|field| field.is_blob_v2());
-        if has_blob && blob_ids.is_none() {
-            return Err(Error::invalid_input(
-                "write_data_file_part requires a non-empty Blob ID range for a schema containing Blob v2 fields",
-            ));
+    pub async fn cleanup(&self, dataset: &Dataset) -> Result<()> {
+        self.finish(dataset).await?;
+        let data_dir = dataset.data_file_dir_for_base(self.base_id)?;
+        let store = dataset.object_store(self.base_id).await?;
+        if let Err(error) = store.delete(&self.object_path(&data_dir)).await
+            && !error.is_not_found()
+        {
+            return Err(error);
         }
-
-        let mut preprocessor = if let Some(blob_ids) = blob_ids {
-            let data_dir = self.data_file_dir_for_base(target.base_id)?;
-            let data_file_key = target.file_name.strip_suffix(".lance").ok_or_else(|| {
-                Error::invalid_input("DataFileTarget.file_name must end in '.lance'")
-            })?;
-            let object_store = self.object_store(target.base_id).await?;
-            let external_base_resolver = blob_v2_external_base_resolver(
-                Some(self),
-                &WriteParams::default(),
-                target.schema.as_ref(),
-            )
-            .await?;
-            Some(
-                BlobPreprocessor::new(
-                    object_store.as_ref().clone(),
-                    data_dir,
-                    data_file_key.to_string(),
-                    target.schema.as_ref(),
-                    external_base_resolver,
-                    false,
-                    ExternalBlobMode::Reference,
-                    self.session().store_registry(),
-                    self.store_params().cloned().unwrap_or_default(),
-                    None,
-                )?
-                .with_part_blob_ids(blob_ids)?,
-            )
-        } else {
-            None
-        };
-
-        let mut writer = file_versions::create_writer(
-            target.version,
-            output,
-            target.schema.as_ref().clone(),
-            FileWriterOptions::default(),
-        )?;
-        let mut data = Box::pin(data);
-        let write_result = async {
-            while let Some(batch) = data.next().await {
-                let batch = batch?;
-                if let Some(preprocessor) = preprocessor.as_mut() {
-                    let batch = preprocessor.preprocess_batch(&batch).await?;
-                    writer.write_batch(&batch).await?;
-                } else {
-                    writer.write_batch(&batch).await?;
-                }
-            }
-            if let Some(preprocessor) = preprocessor.as_mut() {
-                preprocessor.finish().await?;
-            }
-            writer.finish().await
+        if let Err(error) = store
+            .remove_dir_all(data_dir.join(self.data_file_key()))
+            .await
+            && !error.is_not_found()
+        {
+            return Err(error);
         }
-        .await;
-
-        match write_result {
-            Ok(summary) => Ok(summary),
-            Err(error) => {
-                writer.abort().await;
-                if let Some(preprocessor) = preprocessor.as_mut() {
-                    preprocessor.abort();
-                }
-                Err(error)
-            }
-        }
-    }
-
-    /// Concatenate validated parts into the Lance-generated final data file.
-    ///
-    /// Part order is the final physical row order. The operation copies
-    /// encoded page buffers and regenerates metadata and the footer; incompatible
-    /// inputs fail without a decode/re-encode fallback or dataset commit. The
-    /// caller owns cleanup of all durable part, Blob, and final-file objects.
-    /// The caller must also assemble the target through the same dataset and
-    /// resolved base used to write managed Blob payloads.
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// use lance::{Dataset, dataset::{DataFilePart, DataFileTarget}};
-    ///
-    /// # async fn concat(
-    /// #     dataset: &Dataset,
-    /// #     target: &DataFileTarget,
-    /// #     ordered_parts: &[DataFilePart],
-    /// # ) -> lance_core::Result<()> {
-    /// let data_file = dataset.concat_data_file_parts(target, ordered_parts).await?;
-    /// // The caller decides when and how to commit `data_file`.
-    /// # let _ = data_file;
-    /// # Ok(())
-    /// # }
-    /// ```
-    pub async fn concat_data_file_parts(
-        &self,
-        target: &DataFileTarget,
-        ordered_parts: &[DataFilePart],
-    ) -> Result<DataFile> {
-        self.validate_data_file_target(target)?;
-        if ordered_parts.is_empty() {
-            return Err(Error::invalid_input(
-                "concat_data_file_parts requires at least one part",
-            ));
-        }
-        let data_dir = self.data_file_dir_for_base(target.base_id)?;
-        let output_path = target.object_path(&data_dir);
-        let object_store = self.object_store(target.base_id).await?;
-        let mut concat_target = FileConcatTarget::new(target.version, target.schema.clone());
-        if let Some(blob_target_id) = target.blob_target_id.clone() {
-            concat_target = concat_target.with_blob_target_id(blob_target_id);
-        }
-        let result = concat_parts(
-            &concat_target,
-            ordered_parts,
-            {
-                let object_store = object_store.clone();
-                let output_path = output_path.clone();
-                move || async move { object_store.create(&output_path).await }
-            },
-            FileConcatOptions::default(),
-        )
-        .await;
-
-        let output = match result {
-            Ok(FileConcatResult::Written(output)) => output,
-            Ok(FileConcatResult::Reused(_, _)) => {
-                return Err(Error::internal(
-                    "data-file part concatenation unexpectedly reused an input".to_string(),
-                ));
-            }
-            Ok(FileConcatResult::Unsupported(reason)) => {
-                let message = format!(
-                    "parts cannot be concatenated into target {:?}: {reason}",
-                    target.file_name
-                );
-                return Err(match reason {
-                    FileConcatReason::VersionMismatch { actual, .. } => {
-                        let (major, minor) = actual.to_standard_footer_numbers();
-                        Error::version_conflict(message, major, minor)
-                    }
-                    FileConcatReason::SchemaMismatch { .. } => Error::schema_mismatch(message),
-                    FileConcatReason::LegacyVersion
-                    | FileConcatReason::ColumnLayoutMismatch { .. }
-                    | FileConcatReason::ColumnEncodingMismatch { .. }
-                    | FileConcatReason::ColumnBuffers { .. }
-                    | FileConcatReason::ExtraGlobalBuffers { .. }
-                    | FileConcatReason::BlobColumns => Error::not_supported(message),
-                });
-            }
-            Err(error) => return Err(error),
-        };
-        let (fields, column_indices) =
-            file_versions::data_file_columns(target.version, target.schema.as_ref());
-        Ok(DataFile::new(
-            target.file_name.clone(),
-            fields,
-            column_indices,
-            target.version,
-            NonZeroU64::new(output.size_bytes),
-            target.base_id,
-        ))
+        Ok(())
     }
 }
 
-impl FileFragment {
-    /// Write parts as a complete replacement for existing top-level columns.
-    ///
-    /// The target schema must name current top-level fields, and the sum of
-    /// part footer row counts must equal this fragment's physical row count.
-    /// The returned group is uncommitted; the caller retains snapshot fencing.
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// use lance::dataset::{DataFilePart, DataFileTarget};
-    /// use lance::dataset::fragment::FileFragment;
-    ///
-    /// # async fn replace(
-    /// #     fragment: &FileFragment,
-    /// #     target: &DataFileTarget,
-    /// #     ordered_parts: &[DataFilePart],
-    /// # ) -> lance_core::Result<()> {
-    /// let replacement = fragment.write_columns_from_parts(target, ordered_parts).await?;
-    /// // The caller includes `replacement` in its fenced transaction.
-    /// # let _ = replacement;
-    /// # Ok(())
-    /// # }
-    /// ```
-    pub async fn write_columns_from_parts(
-        &self,
-        target: &DataFileTarget,
-        ordered_parts: &[DataFilePart],
-    ) -> Result<DataReplacementGroup> {
-        let expected_rows = self.physical_rows().await? as u64;
-        let actual_rows = ordered_parts.iter().try_fold(0u64, |total, part| {
-            total
-                .checked_add(part.num_rows())
-                .ok_or_else(|| Error::invalid_input("part physical row count overflows u64"))
-        })?;
-        if actual_rows != expected_rows {
-            return Err(Error::invalid_input(format!(
-                "parts contain {actual_rows} physical rows, but fragment {} contains {expected_rows}",
-                self.id()
+#[derive(Serialize, Deserialize)]
+struct TargetData {
+    format_version: u32,
+    file_name: String,
+    base_id: Option<u32>,
+    file_version: String,
+    fields: Vec<FieldData>,
+    metadata: HashMap<String, String>,
+}
+
+// Keep the tree explicit: logical Blob children can carry unassigned field IDs,
+// so reconstructing parent/child relationships from IDs alone is ambiguous.
+#[derive(Serialize, Deserialize)]
+struct FieldData {
+    field: Vec<u8>,
+    children: Vec<Self>,
+    dictionary_values: Option<Vec<u8>>,
+}
+
+impl TryFrom<&Field> for FieldData {
+    type Error = Error;
+
+    fn try_from(field: &Field) -> Result<Self> {
+        let dictionary_values = field
+            .dictionary
+            .as_ref()
+            .and_then(|dictionary| dictionary.values.as_ref())
+            .map(|values| -> Result<Vec<u8>> {
+                let schema = Arc::new(ArrowSchema::new(vec![ArrowField::new(
+                    "values",
+                    values.data_type().clone(),
+                    true,
+                )]));
+                let batch = RecordBatch::try_new(schema.clone(), vec![values.clone()])?;
+                let mut bytes = Vec::new();
+                let mut writer = StreamWriter::try_new(&mut bytes, schema.as_ref())?;
+                writer.write(&batch)?;
+                writer.finish()?;
+                drop(writer);
+                Ok(bytes)
+            })
+            .transpose()?;
+        Ok(Self {
+            field: pb::Field::from(field).encode_to_vec(),
+            children: field
+                .children
+                .iter()
+                .map(Self::try_from)
+                .collect::<Result<_>>()?,
+            dictionary_values,
+        })
+    }
+}
+
+impl TryFrom<FieldData> for Field {
+    type Error = Error;
+
+    fn try_from(data: FieldData) -> Result<Self> {
+        let mut field = Self::from(&pb::Field::decode(data.field.as_slice())?);
+        field.children = data
+            .children
+            .into_iter()
+            .map(Self::try_from)
+            .collect::<Result<_>>()?;
+        if let Some(bytes) = data.dictionary_values {
+            let dictionary = field.dictionary.as_mut().ok_or_else(|| {
+                Error::invalid_input(format!(
+                    "field '{}' has values without dictionary metadata",
+                    field.name
+                ))
+            })?;
+            let mut reader = StreamReader::try_new(Cursor::new(bytes), None)?;
+            let batch = reader.next().transpose()?.ok_or_else(|| {
+                Error::invalid_input(format!(
+                    "field '{}' has an empty dictionary stream",
+                    field.name
+                ))
+            })?;
+            if batch.num_columns() != 1 || reader.next().transpose()?.is_some() {
+                return Err(Error::invalid_input(format!(
+                    "field '{}' dictionary stream must contain one column and one batch",
+                    field.name
+                )));
+            }
+            dictionary.values = Some(batch.column(0).clone());
+        }
+        Ok(field)
+    }
+}
+
+impl Serialize for DataFileTarget {
+    fn serialize<S: Serializer>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error> {
+        let fields = self
+            .schema
+            .fields
+            .iter()
+            .map(FieldData::try_from)
+            .collect::<Result<Vec<_>>>()
+            .map_err(serde::ser::Error::custom)?;
+        TargetData {
+            format_version: 1,
+            file_name: self.file_name.clone(),
+            base_id: self.base_id,
+            file_version: self.version.to_string(),
+            fields,
+            metadata: self.schema.metadata.clone(),
+        }
+        .serialize(serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for DataFileTarget {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> std::result::Result<Self, D::Error> {
+        let data = TargetData::deserialize(deserializer)?;
+        if data.format_version != 1 {
+            return Err(serde::de::Error::custom(format!(
+                "unsupported data-file target checkpoint version {}",
+                data.format_version
             )));
         }
-        let data_file = self
-            .dataset()
-            .concat_data_file_parts(target, ordered_parts)
-            .await?;
-        Ok(DataReplacementGroup(self.id() as u64, data_file))
+        let fields = data
+            .fields
+            .into_iter()
+            .map(Field::try_from)
+            .collect::<Result<Vec<_>>>()
+            .map_err(serde::de::Error::custom)?;
+        let version = ConcreteFileVersion::from_manifest_string(&data.file_version)
+            .map_err(serde::de::Error::custom)?;
+        // The identity must select a child object, never a parent directory.
+        PathPart::parse(&data.file_name).map_err(|error| {
+            serde::de::Error::custom(format!("invalid target identity: {error}"))
+        })?;
+        if data
+            .file_name
+            .strip_suffix(".lance")
+            .unwrap_or(&data.file_name)
+            .is_empty()
+        {
+            return Err(serde::de::Error::custom(
+                "target identity must not be empty",
+            ));
+        }
+        let mut target = Self::new(
+            data.base_id,
+            Arc::new(Schema {
+                fields,
+                metadata: data.metadata,
+            }),
+            version,
+        )
+        .map_err(serde::de::Error::custom)?;
+        target.file_name = data.file_name;
+        Ok(target)
     }
 }

--- a/rust/lance/src/dataset/data_file.rs
+++ b/rust/lance/src/dataset/data_file.rs
@@ -29,6 +29,10 @@ use crate::blob::prepared_to_logical_blob_schema;
 /// field IDs, metadata, and loaded dictionary values. The caller owns checkpoint
 /// state and must keep every use associated with the same dataset and resolved base;
 /// Lance does not validate that association across [`Dataset`] instances.
+/// Checkpoints must come from trusted application state. Deserialization does not
+/// prove artifact ownership or establish whether a target has been committed.
+/// Callers must fence stale workers and never resume writes or assembly for a
+/// committed target; only staging cleanup via [`Self::finish`] remains valid.
 ///
 /// ```
 /// # use lance::dataset::DataFileTarget;
@@ -154,6 +158,10 @@ impl DataFileTarget {
     /// This also removes incomplete parts. Missing files are OK; storage failures
     /// may leave partial cleanup and can be retried. Use the same dataset and
     /// resolved base as the original write. This does not commit the target.
+    /// All Blob payloads in the target's namespace are retained, including those
+    /// from failed or unused retry leases. Ordinary dataset GC also retains these
+    /// payloads while the parent data file is referenced; this operation does not
+    /// perform per-Blob reachability collection.
     ///
     /// ```
     /// # use lance::{Dataset, dataset::DataFileTarget};

--- a/rust/lance/src/dataset/data_file_part.rs
+++ b/rust/lance/src/dataset/data_file_part.rs
@@ -1,0 +1,131 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+use std::{collections::HashSet, num::NonZeroU64, ops::Range};
+
+use lance_core::{Error, Result};
+use lance_file::concat::{DataFilePart as OpenedDataFilePart, EncodedFileInput};
+use lance_io::{
+    scheduler::{ScanScheduler, SchedulerConfig},
+    utils::CachedFileSize,
+};
+use object_store::path::PathPart;
+use serde::{Deserialize, Serialize};
+
+use super::{DataFileTarget, Dataset};
+
+/// Serializable description of a completed staging part, containing its identity
+/// and expected metadata rather than file contents or open readers.
+///
+/// Assembly reopens and validates the actual file. Keep staging files until no
+/// worker or checkpoint needs them, then call [`DataFileTarget::finish`] after
+/// commit or [`DataFileTarget::cleanup`] when abandoning the target.
+///
+/// ```
+/// # use lance::dataset::DataFilePart;
+/// # fn checkpoint(part: &DataFilePart) -> Result<(), serde_json::Error> {
+/// let bytes = serde_json::to_vec(part)?;
+/// let restored: DataFilePart = serde_json::from_slice(&bytes)?;
+/// # let _ = restored;
+/// # Ok(())
+/// # }
+/// ```
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct DataFilePart {
+    pub(super) target_file_name: String,
+    pub(super) base_id: Option<u32>,
+    pub(super) file_name: String,
+    pub(super) blob_ids: Option<Range<u32>>,
+    pub(super) num_rows: u64,
+    pub(super) size_bytes: NonZeroU64,
+}
+
+impl DataFilePart {
+    /// Expected physical row count, verified against the footer during assembly.
+    pub fn num_rows(&self) -> u64 {
+        self.num_rows
+    }
+
+    /// Expected complete file size, verified during assembly.
+    pub fn size_bytes(&self) -> u64 {
+        self.size_bytes.get()
+    }
+
+    pub(super) async fn open_all(
+        dataset: &Dataset,
+        target: &DataFileTarget,
+        parts: &[Self],
+    ) -> Result<Vec<OpenedDataFilePart>> {
+        dataset.validate_data_file_target(target)?;
+        if parts.is_empty() {
+            return Err(Error::invalid_input(
+                "concat_data_file_parts requires at least one part",
+            ));
+        }
+        let mut names = HashSet::with_capacity(parts.len());
+        let mut ranges = Vec::with_capacity(parts.len());
+        for part in parts {
+            PathPart::parse(&part.file_name)
+                .map_err(|error| Error::invalid_input(format!("invalid part identity: {error}")))?;
+            if part.file_name.is_empty() {
+                return Err(Error::invalid_input(
+                    "part file_name must select a child object",
+                ));
+            }
+            if part.target_file_name != target.file_name || part.base_id != target.base_id {
+                return Err(Error::invalid_input(format!(
+                    "part '{}' belongs to target {:?} in base {:?}, not {:?} in base {:?}",
+                    part.file_name.as_str(),
+                    part.target_file_name,
+                    part.base_id,
+                    target.file_name,
+                    target.base_id
+                )));
+            }
+            if !names.insert(part.file_name.as_str()) {
+                return Err(Error::invalid_input(format!(
+                    "duplicate part '{}'",
+                    part.file_name.as_str()
+                )));
+            }
+            if let Some(ids) = &part.blob_ids {
+                ranges.push(ids);
+            }
+        }
+        ranges.sort_unstable_by_key(|range| range.start);
+        for pair in ranges.windows(2) {
+            if pair[1].start < pair[0].end {
+                return Err(Error::invalid_input(format!(
+                    "part Blob ID ranges overlap: {:?} and {:?}",
+                    pair[0], pair[1]
+                )));
+            }
+        }
+        let store = dataset.object_store(target.base_id).await?;
+        let dir = target.parts_dir(&dataset.data_file_dir_for_base(target.base_id)?);
+        let scheduler = ScanScheduler::new(store.clone(), SchedulerConfig::max_bandwidth(&store));
+        let mut opened = Vec::with_capacity(parts.len());
+        for part in parts {
+            let path = dir.clone().join(part.file_name.as_str());
+            let size = store.size(&path).await?;
+            if size != part.size_bytes() {
+                return Err(Error::invalid_input(format!(
+                    "part at '{path}' has {size} bytes, checkpoint expects {}",
+                    part.size_bytes()
+                )));
+            }
+            let file = scheduler
+                .open_file(&path, &CachedFileSize::new(size))
+                .await?;
+            opened.push(
+                OpenedDataFilePart::open(
+                    EncodedFileInput::new(file).with_expected_num_rows(part.num_rows()),
+                    part.blob_ids.clone(),
+                    target.blob_target_id(),
+                )
+                .await?,
+            );
+        }
+        Ok(opened)
+    }
+}

--- a/rust/lance/src/dataset/tests/data_file_part.rs
+++ b/rust/lance/src/dataset/tests/data_file_part.rs
@@ -10,19 +10,18 @@ use arrow_array::{
 };
 use arrow_schema::{DataType, Field, Schema as ArrowSchema};
 use bytes::Bytes;
-use futures::stream;
+use futures::{TryStreamExt, stream};
 use lance_arrow::{ARROW_EXT_NAME_KEY, BLOB_V2_EXT_NAME};
 use lance_core::{
+    Error,
     datatypes::{BLOB_V2_LOGICAL_FIELDS, BlobHandling},
-    utils::tempfile::TempDir,
+    utils::{blob::blob_path, tempfile::TempDir},
 };
 use lance_file::concat::EncodedFileInput;
-use lance_file::version::LanceFileVersion;
-use lance_io::{
-    scheduler::{ScanScheduler, SchedulerConfig},
-    utils::CachedFileSize,
-};
+use lance_file::version::{ConcreteFileVersion, LanceFileVersion};
+use lance_io::scheduler::{ScanScheduler, SchedulerConfig};
 use lance_table::format::BasePath;
+use rstest::rstest;
 
 use crate::blob::{BlobArrayBuilder, BlobDescriptorArrayBuilder, blob_field};
 use crate::dataset::fragment::FileFragment;
@@ -80,29 +79,11 @@ fn only_fragment(dataset: &Dataset) -> FileFragment {
 async fn write_part(
     dataset: &Dataset,
     target: &DataFileTarget,
-    staging_name: &str,
     blob_ids: Option<Range<u32>>,
     batch: RecordBatch,
 ) -> DataFilePart {
-    let path = dataset.data_dir().join(staging_name);
-    let output = dataset.object_store.create(&path).await.unwrap();
-    let summary = dataset
-        .write_data_file_part(target, output, blob_ids.clone(), stream::iter([Ok(batch)]))
-        .await
-        .unwrap();
-    let scheduler = ScanScheduler::new(
-        dataset.object_store.clone(),
-        SchedulerConfig::default_for_testing(),
-    );
-    let file = scheduler
-        .open_file(&path, &CachedFileSize::new(summary.size_bytes))
-        .await
-        .unwrap();
-    target
-        .open_part(
-            EncodedFileInput::new(file).with_expected_num_rows(summary.num_rows),
-            blob_ids,
-        )
+    dataset
+        .write_data_file_part(target, blob_ids, stream::iter([Ok(batch)]))
         .await
         .unwrap()
 }
@@ -135,7 +116,6 @@ async fn concatenates_parts_in_caller_order_without_reusing_staging_files() {
     let first = write_part(
         &dataset,
         &target,
-        "part-1.lance",
         None,
         arrow_array::record_batch!(("id", Int32, [10, 11])).unwrap(),
     )
@@ -143,49 +123,32 @@ async fn concatenates_parts_in_caller_order_without_reusing_staging_files() {
     let second = write_part(
         &dataset,
         &target,
-        "part-2.lance",
         None,
         arrow_array::record_batch!(("id", Int32, [12, 13])).unwrap(),
     )
     .await;
 
-    let replacement = only_fragment(&dataset)
-        .write_columns_from_parts(&target, &[second, first])
+    let ordered_parts = [second, first];
+    // The caller checks fragment coverage before assembling its replacement.
+    assert_eq!(
+        ordered_parts
+            .iter()
+            .map(DataFilePart::num_rows)
+            .sum::<u64>(),
+        only_fragment(&dataset).physical_rows().await.unwrap() as u64,
+    );
+    let data_file = dataset
+        .concat_data_file_parts(&target, &ordered_parts)
         .await
         .unwrap();
-    assert_eq!(replacement.1.path, target.file_name());
+    let replacement = DataReplacementGroup(only_fragment(&dataset).id() as u64, data_file);
+    assert_eq!(replacement.1.path, target.file_name.as_str());
     let dataset = commit(&dataset, replacement).await.unwrap();
     let batch = dataset.scan().try_into_batch().await.unwrap();
     assert_eq!(
         batch["id"].as_primitive::<Int32Type>().values(),
         &[12, 13, 10, 11]
     );
-}
-
-#[tokio::test]
-async fn fragment_adapter_rejects_incomplete_physical_coverage() {
-    let original = arrow_array::record_batch!(("id", Int32, [0, 1, 2])).unwrap();
-    let dataset = dataset_of(original, LanceFileVersion::V2_1).await;
-    let target = DataFileTarget::new(
-        None,
-        Arc::new(dataset.schema().clone()),
-        dataset.manifest.data_storage_format.lance_file_format(),
-    )
-    .unwrap();
-    let part = write_part(
-        &dataset,
-        &target,
-        "short-part.lance",
-        None,
-        arrow_array::record_batch!(("id", Int32, [10, 11])).unwrap(),
-    )
-    .await;
-    let error = only_fragment(&dataset)
-        .write_columns_from_parts(&target, &[part])
-        .await
-        .unwrap_err();
-    assert!(error.to_string().contains("2 physical rows"), "{error}");
-    assert!(error.to_string().contains("contains 3"), "{error}");
 }
 
 #[tokio::test]
@@ -205,10 +168,494 @@ async fn target_uses_an_ordinary_generated_data_file_name() {
     )
     .unwrap();
 
-    assert_ne!(first.file_name(), second.file_name());
-    assert_eq!(first.file_name().len(), 56);
-    assert!(first.file_name().ends_with(".lance"));
-    assert!(!first.file_name().contains('/'));
+    assert_ne!(first.file_name.as_str(), second.file_name.as_str());
+    assert_eq!(first.file_name.len(), 56);
+    assert!(first.file_name.ends_with(".lance"));
+    assert!(!first.file_name.contains('/'));
+
+    let restored =
+        serde_json::from_slice::<DataFileTarget>(&serde_json::to_vec(&first).unwrap()).unwrap();
+    assert_eq!(restored.file_name.as_str(), first.file_name.as_str());
+    assert_eq!(restored.base_id, first.base_id);
+    assert_eq!(restored.schema, first.schema);
+    assert_eq!(restored.version, first.version);
+}
+
+#[test]
+fn target_serialization_preserves_schema_and_rejects_invalid_identity() {
+    let arrow_schema = ArrowSchema::new(vec![
+        Field::new(
+            "nested",
+            DataType::Struct(vec![Field::new("value", DataType::Int32, true)].into()),
+            true,
+        ),
+        Field::new(
+            "category",
+            DataType::Dictionary(Box::new(DataType::UInt32), Box::new(DataType::Utf8)),
+            true,
+        ),
+    ]);
+    let mut schema = lance_core::datatypes::Schema::try_from(&arrow_schema).unwrap();
+    schema
+        .metadata
+        .insert("owner".to_string(), "test".to_string());
+    schema.fields[0].id = 10;
+    schema.fields[0].children[0].id = 11;
+    schema.fields[0].children[0].parent_id = 10;
+    schema.fields[0].children[0]
+        .metadata
+        .insert("unit".to_string(), "count".to_string());
+    schema.fields[1].id = 20;
+    schema.fields[1].dictionary = Some(lance_core::datatypes::Dictionary {
+        offset: 12,
+        length: 2,
+        values: Some(Arc::new(StringArray::from(vec!["a", "b"]))),
+    });
+    let target = DataFileTarget::new(Some(7), Arc::new(schema), ConcreteFileVersion::V2_2).unwrap();
+    let value = serde_json::to_value(&target).unwrap();
+    let restored: DataFileTarget = serde_json::from_value(value.clone()).unwrap();
+    assert_eq!(restored.schema, target.schema);
+    assert_eq!(restored.file_name.as_str(), target.file_name.as_str());
+    assert_eq!(restored.base_id, target.base_id);
+    let dictionary = restored.schema.fields[1].dictionary.as_ref().unwrap();
+    assert_eq!((dictionary.offset, dictionary.length), (12, 2));
+    for (key, replacement, message) in [
+        (
+            "format_version",
+            serde_json::json!(99),
+            "checkpoint version",
+        ),
+        ("file_version", serde_json::json!("stable"), "version"),
+        (
+            "file_name",
+            serde_json::json!("../outside.lance"),
+            "target identity",
+        ),
+        ("file_name", serde_json::json!(""), "target identity"),
+        ("file_name", serde_json::json!(".lance"), "target identity"),
+        ("file_name", serde_json::json!(".."), "target identity"),
+        ("base_id", serde_json::json!(0), "base_id"),
+    ] {
+        let mut invalid = value.clone();
+        invalid[key] = replacement;
+        let error = serde_json::from_value::<DataFileTarget>(invalid).unwrap_err();
+        assert!(error.to_string().contains(message), "{error}");
+    }
+}
+
+#[rstest]
+#[case::rows("num_rows", serde_json::json!(3), "physical rows")]
+#[case::size("size_bytes", serde_json::json!(1), "bytes")]
+#[case::missing("file_name", serde_json::json!("missing.part"), "missing.part")]
+#[tokio::test]
+async fn managed_part_checks_real_file_before_creating_output(
+    #[case] field: &str,
+    #[case] value: serde_json::Value,
+    #[case] message: &str,
+) {
+    let batch = arrow_array::record_batch!(("id", Int32, [1, 2])).unwrap();
+    let dataset = dataset_of(batch.clone(), LanceFileVersion::V2_2).await;
+    let target = DataFileTarget::new(
+        None,
+        Arc::new(dataset.schema().clone()),
+        ConcreteFileVersion::V2_2,
+    )
+    .unwrap();
+    let part = write_part(&dataset, &target, None, batch).await;
+    let mut description = serde_json::to_value(&part).unwrap();
+    description[field] = value;
+    let invalid = serde_json::from_value::<DataFilePart>(description).unwrap();
+    let error = dataset
+        .concat_data_file_parts(&target, &[invalid])
+        .await
+        .unwrap_err();
+    if field == "file_name" {
+        assert!(matches!(error, Error::NotFound { .. }), "{error}");
+    } else {
+        assert!(matches!(error, Error::InvalidInput { .. }), "{error}");
+    }
+    assert!(error.to_string().contains(message), "{error}");
+    assert!(
+        !dataset
+            .object_store
+            .exists(&dataset.data_dir().join(target.file_name.as_str()))
+            .await
+            .unwrap()
+    );
+}
+
+#[tokio::test]
+async fn managed_part_rejects_invalid_descriptions_and_duplicate_inputs() {
+    let batch = arrow_array::record_batch!(("id", Int32, [1])).unwrap();
+    let dataset = dataset_of(batch.clone(), LanceFileVersion::V2_2).await;
+    let target = DataFileTarget::new(
+        None,
+        Arc::new(dataset.schema().clone()),
+        ConcreteFileVersion::V2_2,
+    )
+    .unwrap();
+    let part = write_part(&dataset, &target, None, batch).await;
+    let description = serde_json::to_value(&part).unwrap();
+    let mut zero_size = description.clone();
+    zero_size["size_bytes"] = serde_json::json!(0);
+    let error = serde_json::from_value::<DataFilePart>(zero_size).unwrap_err();
+    assert!(error.to_string().contains("nonzero"), "{error}");
+    for (key, replacement, message) in [
+        (
+            "file_name",
+            serde_json::json!("../outside.part"),
+            "part identity",
+        ),
+        ("file_name", serde_json::json!(""), "child object"),
+        (
+            "target_file_name",
+            serde_json::json!("../outside.lance"),
+            "belongs to target",
+        ),
+        (
+            "blob_ids",
+            serde_json::json!({"start": 0, "end": 1}),
+            "Blob ID range",
+        ),
+        (
+            "blob_ids",
+            serde_json::json!({"start": 2, "end": 2}),
+            "Blob ID range",
+        ),
+        ("base_id", serde_json::json!(0), "belongs to target"),
+    ] {
+        let mut invalid = description.clone();
+        invalid[key] = replacement;
+        let part = serde_json::from_value::<DataFilePart>(invalid).unwrap();
+        let error = dataset
+            .concat_data_file_parts(&target, &[part])
+            .await
+            .unwrap_err();
+        assert!(matches!(error, Error::InvalidInput { .. }), "{error}");
+        assert!(error.to_string().contains(message), "{error}");
+    }
+    let error = dataset
+        .concat_data_file_parts(&target, &[part.clone(), part])
+        .await
+        .unwrap_err();
+    assert!(matches!(error, Error::InvalidInput { .. }));
+    assert!(error.to_string().contains("duplicate part"), "{error}");
+    assert!(
+        !dataset
+            .object_store
+            .exists(&dataset.data_dir().join(target.file_name.as_str()))
+            .await
+            .unwrap()
+    );
+}
+
+#[rstest]
+#[case::plain_primary(false, None)]
+#[case::plain_registered(false, Some(7))]
+#[case::blob_primary(true, None)]
+#[case::blob_registered(true, Some(7))]
+#[tokio::test]
+async fn abandoned_target_cleanup_includes_failed_writes_and_preserves_other_targets(
+    #[case] has_blob: bool,
+    #[case] base_id: Option<u32>,
+) {
+    let dir = TempDir::default();
+    let batch = if has_blob {
+        let schema = Arc::new(ArrowSchema::new(vec![blob_field("blob", true)]));
+        let mut values = BlobArrayBuilder::new(1);
+        values.push_bytes(b"payload").unwrap();
+        RecordBatch::try_new(schema, vec![values.finish().unwrap()]).unwrap()
+    } else {
+        arrow_array::record_batch!(("id", Int32, [1])).unwrap()
+    };
+    let lease = |start| has_blob.then_some(start..start + 10);
+    let dataset = Dataset::write(
+        RecordBatchIterator::new([Ok(batch.clone())], batch.schema()),
+        format!("{}/dataset", dir.path_str()).as_str(),
+        Some(WriteParams {
+            data_storage_version: Some(LanceFileVersion::V2_2),
+            initial_bases: base_id.map(|id| {
+                vec![BasePath {
+                    id,
+                    name: Some("output".to_string()),
+                    path: format!("{}/output", dir.path_str()),
+                    is_dataset_root: false,
+                }]
+            }),
+            ..Default::default()
+        }),
+    )
+    .await
+    .unwrap();
+    let target = DataFileTarget::new(
+        base_id,
+        Arc::new(dataset.schema().clone()),
+        ConcreteFileVersion::V2_2,
+    )
+    .unwrap();
+    let mut neighbor = serde_json::to_value(&target).unwrap();
+    neighbor["file_name"] = serde_json::json!(format!("{}.neighbor.lance", target.file_name));
+    let neighbor: DataFileTarget = serde_json::from_value(neighbor).unwrap();
+    let first = write_part(&dataset, &target, lease(1), batch.clone()).await;
+    let assembled = dataset
+        .concat_data_file_parts(&target, std::slice::from_ref(&first))
+        .await
+        .unwrap();
+    let assembled_path = dataset
+        .data_file_dir_for_base(base_id)
+        .unwrap()
+        .join(assembled.path.as_str());
+    assert!(
+        dataset
+            .object_store(base_id)
+            .await
+            .unwrap()
+            .exists(&assembled_path)
+            .await
+            .unwrap()
+    );
+    let other = write_part(&dataset, &neighbor, lease(1), batch.clone()).await;
+    let error = dataset
+        .write_data_file_part(
+            &target,
+            lease(20),
+            stream::iter([
+                Ok(batch),
+                Err(Error::invalid_input("injected input failure")),
+            ]),
+        )
+        .await
+        .unwrap_err();
+    assert!(matches!(error, Error::InvalidInput { .. }));
+    assert!(error.to_string().contains("injected input failure"));
+    let store = dataset.object_store(base_id).await.unwrap();
+    let data_dir = dataset.data_file_dir_for_base(base_id).unwrap();
+    let staging = data_dir
+        .clone()
+        .join("_parts")
+        .join(target.file_name.as_str());
+    // Simulate durable objects left when a worker exits without returning a part.
+    store
+        .put(&staging.clone().join("incomplete.part"), b"incomplete")
+        .await
+        .unwrap();
+    let blob_dir = data_dir
+        .clone()
+        .join(target.file_name.strip_suffix(".lance").unwrap());
+    if has_blob {
+        let orphan = blob_path(&data_dir, target.data_file_key(), 99);
+        store.put(&orphan, b"orphan").await.unwrap();
+    }
+    assert!(
+        store
+            .exists(&staging.clone().join(first.file_name.as_str()))
+            .await
+            .unwrap()
+    );
+    assert_eq!(
+        !store
+            .list(Some(blob_dir.clone()))
+            .try_collect::<Vec<_>>()
+            .await
+            .unwrap()
+            .is_empty(),
+        has_blob,
+    );
+    let restored: DataFileTarget =
+        serde_json::from_slice(&serde_json::to_vec(&target).unwrap()).unwrap();
+    restored.cleanup(&dataset).await.unwrap();
+    assert!(!store.exists(&assembled_path).await.unwrap());
+    restored.cleanup(&dataset).await.unwrap();
+    assert!(
+        store
+            .list(Some(staging))
+            .try_collect::<Vec<_>>()
+            .await
+            .unwrap()
+            .is_empty()
+    );
+    let prefix = format!("{blob_dir}/");
+    assert!(
+        !store
+            .list(Some(blob_dir))
+            .try_collect::<Vec<_>>()
+            .await
+            .unwrap()
+            .iter()
+            .any(|object| object.location.as_ref().starts_with(&prefix))
+    );
+    let data_file = dataset
+        .concat_data_file_parts(&neighbor, &[other])
+        .await
+        .unwrap();
+    let replacement = DataReplacementGroup(only_fragment(&dataset).id() as u64, data_file);
+    let dataset = commit(&dataset, replacement).await.unwrap();
+    let mut scanner = dataset.scan();
+    scanner.blob_handling(BlobHandling::AllBinary);
+    let result = scanner.try_into_batch().await.unwrap();
+    if has_blob {
+        assert_eq!(result["blob"].as_binary::<i64>().value(0), b"payload");
+    } else {
+        assert_eq!(result["id"].as_primitive::<Int32Type>().value(0), 1);
+    }
+}
+
+#[rstest]
+#[case::plain_primary(false, None)]
+#[case::plain_registered(false, Some(7))]
+#[case::blob_primary(true, None)]
+#[case::blob_registered(true, Some(7))]
+#[tokio::test]
+async fn restores_target_and_completed_parts_from_checkpoint(
+    #[case] has_blob: bool,
+    #[case] base_id: Option<u32>,
+) {
+    let dir = TempDir::default();
+    let dataset_uri = format!("{}/dataset", dir.path_str());
+    let make_batch = |ids: Vec<i32>| {
+        let batch = arrow_array::record_batch!(("id", Int32, ids.clone())).unwrap();
+        if !has_blob {
+            return batch;
+        }
+        let mut blobs = BlobArrayBuilder::new(ids.len());
+        for id in ids {
+            blobs.push_bytes(format!("blob-{id}").as_bytes()).unwrap();
+        }
+        RecordBatch::try_new(
+            Arc::new(ArrowSchema::new(vec![
+                batch.schema().field(0).clone(),
+                blob_field("blob", true),
+            ])),
+            vec![batch["id"].clone(), blobs.finish().unwrap()],
+        )
+        .unwrap()
+    };
+    let lease = |start| has_blob.then_some(start..start + 10);
+
+    let checkpoint = {
+        let original = make_batch(vec![0, 1, 2, 3]);
+        let dataset = Dataset::write(
+            RecordBatchIterator::new([Ok(original.clone())], original.schema()),
+            dataset_uri.as_str(),
+            Some(WriteParams {
+                data_storage_version: Some(LanceFileVersion::V2_2),
+                max_rows_per_file: 2,
+                initial_bases: base_id.map(|id| {
+                    vec![BasePath {
+                        id,
+                        name: Some("output".to_string()),
+                        path: format!("{}/output", dir.path_str()),
+                        is_dataset_root: false,
+                    }]
+                }),
+                ..Default::default()
+            }),
+        )
+        .await
+        .unwrap();
+        assert_eq!(dataset.get_fragments().len(), 2);
+        let target = DataFileTarget::new(
+            base_id,
+            Arc::new(dataset.schema().clone()),
+            dataset.manifest.data_storage_format.lance_file_format(),
+        )
+        .unwrap();
+        let part = write_part(&dataset, &target, lease(1), make_batch(vec![10])).await;
+        serde_json::to_vec(&(target, part, dataset.version_id())).unwrap()
+    };
+
+    let (target, first, snapshot): (DataFileTarget, DataFilePart, u64) =
+        serde_json::from_slice(&checkpoint).unwrap();
+    let dataset = Dataset::open(&dataset_uri)
+        .await
+        .unwrap()
+        .checkout_version(snapshot)
+        .await
+        .unwrap();
+    assert_eq!(target.schema.as_ref(), dataset.schema());
+    assert_eq!(target.base_id, base_id);
+    let data_dir = dataset.data_file_dir_for_base(base_id).unwrap();
+    let store = dataset.object_store(base_id).await.unwrap();
+    assert!(
+        !store
+            .exists(&data_dir.clone().join(target.file_name.as_str()))
+            .await
+            .unwrap()
+    );
+    let second = write_part(&dataset, &target, lease(11), make_batch(vec![11])).await;
+    assert_ne!(first.file_name.as_str(), second.file_name.as_str());
+    let checkpoint = serde_json::to_vec(&(target, vec![first, second], snapshot)).unwrap();
+    drop(store);
+    drop(dataset);
+
+    // Assembly reconstructs its own target and opens files only from descriptors.
+    let (target, parts, snapshot): (DataFileTarget, Vec<DataFilePart>, u64) =
+        serde_json::from_slice(&checkpoint).unwrap();
+    let dataset = Dataset::open(&dataset_uri)
+        .await
+        .unwrap()
+        .checkout_version(snapshot)
+        .await
+        .unwrap();
+    let store = dataset.object_store(base_id).await.unwrap();
+    let blob_dir = data_dir
+        .clone()
+        .join(target.file_name.strip_suffix(".lance").unwrap());
+    let blobs_before = store
+        .list(Some(blob_dir.clone()))
+        .try_collect::<Vec<_>>()
+        .await
+        .unwrap();
+    let data_file = dataset
+        .concat_data_file_parts(&target, &parts)
+        .await
+        .unwrap();
+    let replacement = DataReplacementGroup(dataset.get_fragments()[0].id() as u64, data_file);
+    assert_eq!(replacement.1.path, target.file_name.as_str());
+    assert_eq!(replacement.1.base_id, base_id);
+    assert_eq!(
+        blobs_before,
+        store
+            .list(Some(blob_dir))
+            .try_collect::<Vec<_>>()
+            .await
+            .unwrap()
+    );
+    let dataset = commit(&dataset, replacement).await.unwrap();
+    target.finish(&dataset).await.unwrap();
+    target.finish(&dataset).await.unwrap();
+    let staging_dir = data_dir
+        .clone()
+        .join("_parts")
+        .join(target.file_name.as_str());
+    assert!(
+        store
+            .list(Some(staging_dir))
+            .try_collect::<Vec<_>>()
+            .await
+            .unwrap()
+            .is_empty()
+    );
+
+    let mut scanner = dataset.scan();
+    scanner.blob_handling(BlobHandling::AllBinary);
+    let batch = scanner.try_into_batch().await.unwrap();
+    assert_eq!(
+        batch["id"].as_primitive::<Int32Type>().values(),
+        &[10, 11, 2, 3]
+    );
+    if has_blob {
+        let values = batch["blob"].as_binary::<i64>();
+        assert_eq!(
+            values.iter().collect::<Vec<_>>(),
+            vec![
+                Some(b"blob-10".as_slice()),
+                Some(b"blob-11".as_slice()),
+                Some(b"blob-2".as_slice()),
+                Some(b"blob-3".as_slice()),
+            ]
+        );
+    }
 }
 
 #[tokio::test]
@@ -224,17 +671,12 @@ async fn blob_part_requires_an_id_lease_before_writing() {
         dataset.manifest.data_storage_format.lance_file_format(),
     )
     .unwrap();
-    let output = dataset
-        .object_store
-        .create(&dataset.data_dir().join("missing-lease-part.lance"))
-        .await
-        .unwrap();
     let mut replacement = BlobArrayBuilder::new(1);
     replacement.push_bytes(b"new").unwrap();
     let batch = RecordBatch::try_new(schema, vec![replacement.finish().unwrap()]).unwrap();
 
     let error = dataset
-        .write_data_file_part(&target, output, None, stream::iter([Ok(batch)]))
+        .write_data_file_part(&target, None, stream::iter([Ok(batch)]))
         .await
         .unwrap_err();
     assert!(
@@ -265,7 +707,7 @@ async fn data_file_part_rejects_non_empty_file_relative_inline_blob() {
         .await
         .unwrap();
 
-    let error = DataFilePart::open(EncodedFileInput::new(file), None, None)
+    let error = lance_file::concat::DataFilePart::open(EncodedFileInput::new(file), None, None)
         .await
         .unwrap_err();
     assert!(error.to_string().contains("non-empty Inline"), "{error}");
@@ -307,7 +749,7 @@ async fn complete_logical_blob_schema_and_external_range_survive_assembly() {
     )
     .unwrap();
     assert_eq!(
-        target.schema().fields[0]
+        target.schema.fields[0]
             .children
             .iter()
             .map(|child| child.name.as_str())
@@ -318,16 +760,16 @@ async fn complete_logical_blob_schema_and_external_range_survive_assembly() {
     let part = write_part(
         &dataset,
         &target,
-        "complete-logical-part.lance",
         Some(1..10),
         complete_logical_blob_batch(&external_uri, 7, 8),
     )
     .await;
     assert_eq!(part.num_rows(), 1);
-    let replacement = only_fragment(&dataset)
-        .write_columns_from_parts(&target, &[part])
+    let data_file = dataset
+        .concat_data_file_parts(&target, &[part])
         .await
         .unwrap();
+    let replacement = DataReplacementGroup(only_fragment(&dataset).id() as u64, data_file);
     let dataset = commit(&dataset, replacement).await.unwrap();
     assert_eq!(dataset.schema().fields[0].children.len(), 4);
 
@@ -388,24 +830,15 @@ async fn blob_parts_write_sidecars_in_final_namespace_and_concat_descriptors() {
     let first = write_part(
         &dataset,
         &target,
-        "blob-part-1.lance",
         Some(1..10),
         make_prepared_batch(10, b"replacement-0"),
     )
     .await;
-    let scheduler = ScanScheduler::new(
-        dataset.object_store.clone(),
-        SchedulerConfig::default_for_testing(),
-    );
-    let file = scheduler
-        .open_file(
-            &dataset.data_dir().join("blob-part-1.lance"),
-            &CachedFileSize::unknown(),
-        )
-        .await
-        .unwrap();
-    let error = target
-        .open_part(EncodedFileInput::new(file), Some(20..30))
+    let mut invalid = serde_json::to_value(&first).unwrap();
+    invalid["blob_ids"] = serde_json::json!({"start": 20, "end": 30});
+    let invalid: DataFilePart = serde_json::from_value(invalid).unwrap();
+    let error = dataset
+        .concat_data_file_parts(&target, &[invalid])
         .await
         .unwrap_err();
     assert!(
@@ -415,7 +848,6 @@ async fn blob_parts_write_sidecars_in_final_namespace_and_concat_descriptors() {
     let second = write_part(
         &dataset,
         &target,
-        "blob-part-2.lance",
         Some(10..20),
         make_batch(vec![11], vec![b"replacement-1"]),
     )
@@ -431,19 +863,22 @@ async fn blob_parts_write_sidecars_in_final_namespace_and_concat_descriptors() {
         .concat_data_file_parts(&other_target, &[first.clone(), second.clone()])
         .await
         .unwrap_err();
-    assert!(error.to_string().contains("Blob target ID"), "{error}");
+    assert!(error.to_string().contains("belongs to target"), "{error}");
     assert!(
         !dataset
             .object_store
-            .exists(&dataset.data_dir().join(other_target.file_name()))
+            .exists(&dataset.data_dir().join(other_target.file_name.as_str()))
             .await
             .unwrap()
     );
 
-    let replacement = only_fragment(&dataset)
-        .write_columns_from_parts(&target, &[first, second])
+    let target =
+        serde_json::from_slice::<DataFileTarget>(&serde_json::to_vec(&target).unwrap()).unwrap();
+    let data_file = dataset
+        .concat_data_file_parts(&target, &[first, second])
         .await
         .unwrap();
+    let replacement = DataReplacementGroup(only_fragment(&dataset).id() as u64, data_file);
     let dataset = commit(&dataset, replacement).await.unwrap();
     let mut scanner = dataset.scan();
     scanner.blob_handling(BlobHandling::AllBinary);

--- a/rust/lance/src/dataset/write.rs
+++ b/rust/lance/src/dataset/write.rs
@@ -256,6 +256,9 @@ impl Dataset {
     /// caller owns cleanup of all durable part, Blob, and final-file objects.
     /// The caller must also assemble the target through the same dataset and
     /// resolved base used to write managed Blob payloads.
+    /// The target must still be uncommitted and have no concurrent assembler.
+    /// Assembly can overwrite a previous uncommitted output for the same target;
+    /// it does not check current or historical manifests for references.
     ///
     /// To replace a fragment's columns, wrap the returned file in a
     /// [`DataReplacementGroup`](super::transaction::DataReplacementGroup).

--- a/rust/lance/src/dataset/write.rs
+++ b/rust/lance/src/dataset/write.rs
@@ -5,7 +5,7 @@ use arrow_array::RecordBatch;
 use bytes::Bytes;
 use chrono::TimeDelta;
 use datafusion::physical_plan::SendableRecordBatchStream;
-use futures::StreamExt;
+use futures::{Stream, StreamExt};
 use lance_arrow::{
     ARROW_EXT_NAME_KEY, BLOB_DEDICATED_SIZE_THRESHOLD_META_KEY,
     BLOB_INLINE_SIZE_THRESHOLD_META_KEY, BLOB_META_KEY, BLOB_PACK_FILE_SIZE_THRESHOLD_META_KEY,
@@ -17,11 +17,16 @@ use lance_core::utils::tracing::{
 };
 use lance_core::{Error, Result, datatypes::Schema};
 use lance_datafusion::utils::StreamingWriteSource;
+use lance_file::concat::{
+    FileConcatOptions, FileConcatReason, FileConcatResult, FileConcatTarget,
+    concat_data_file_parts as concat_parts,
+};
 use lance_file::version::{ConcreteFileVersion, LanceFileVersion};
 use lance_file::versions::v1::writer::{
     FileWriter as V1FileWriter, ManifestProvider as V1ManifestProvider,
 };
 use lance_file::writer::{self as current_writer};
+use lance_file::{versions as file_versions, writer::FileWriterOptions};
 use lance_io::object_store::{
     ObjectStore, ObjectStoreParams, ObjectStoreRegistry, parse_base_scoped_key,
 };
@@ -33,7 +38,8 @@ use object_store::path::Path;
 use std::borrow::Cow;
 use std::collections::{BTreeSet, HashMap, HashSet, VecDeque};
 use std::future::Future;
-use std::num::NonZero;
+use std::num::{NonZero, NonZeroU64};
+use std::ops::Range;
 use std::sync::Arc;
 use std::sync::atomic::AtomicUsize;
 use tracing::{info, instrument};
@@ -49,12 +55,12 @@ use crate::index::DatasetIndexExt;
 use crate::index::scalar::{IndexDetails, fetch_index_details};
 use crate::session::Session;
 
-use super::DATA_DIR;
 use super::fragment::write::generate_random_filename;
 use super::progress::{NoopFragmentWriteProgress, WriteFragmentProgress};
 use super::transaction::Transaction;
 use super::utils::SchemaAdapter;
 use super::versions;
+use super::{DATA_DIR, DataFilePart, DataFileTarget};
 
 mod commit;
 pub mod delete;
@@ -67,6 +73,277 @@ pub use super::progress::{WriteProgressFn, WriteStats};
 pub use commit::{CommitBuilder, DEFAULT_COMMIT_TIMEOUT};
 pub use delete::{DeleteBuilder, DeleteResult, UncommittedDelete};
 pub use insert::InsertBuilder;
+
+impl Dataset {
+    pub(super) fn validate_data_file_target(&self, target: &DataFileTarget) -> Result<()> {
+        let dataset_version = self.manifest.data_storage_format.lance_file_format();
+        if target.version != dataset_version {
+            return Err(Error::invalid_input(format!(
+                "DataFileTarget.version is {}, but dataset version {} uses {}",
+                target.version,
+                self.version_id(),
+                dataset_version
+            )));
+        }
+        self.data_file_dir_for_base(target.base_id)?;
+
+        if target.schema.metadata != self.schema().metadata {
+            return Err(Error::invalid_input(
+                "DataFileTarget.schema metadata differs from the dataset schema metadata",
+            ));
+        }
+        for target_field in &target.schema.fields {
+            let Some(dataset_field) = self
+                .schema()
+                .fields
+                .iter()
+                .find(|field| field.id == target_field.id)
+            else {
+                return Err(Error::invalid_input(format!(
+                    "DataFileTarget.schema field ID {} is not a top-level dataset field",
+                    target_field.id
+                )));
+            };
+            if dataset_field != target_field {
+                return Err(Error::invalid_input(format!(
+                    "DataFileTarget.schema field ID {} differs from the current dataset field",
+                    target_field.id
+                )));
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Encode one managed part and return its serializable description.
+    ///
+    /// Lance generates a unique staging name in the target's base. Managed Blob
+    /// payloads are written directly beneath the sidecar directory selected by the final
+    /// target using IDs from `blob_ids`; every non-empty logical Inline value is
+    /// spilled to Packed or Dedicated storage so final concatenation never copies
+    /// Blob payload bytes.
+    /// Every use of `target` must refer to the same dataset and resolved base;
+    /// associating a target with that storage context is the caller's
+    /// responsibility.
+    /// Persist the target before writing. A failed write may leave files; after
+    /// stopping all users of the target, [`DataFileTarget::cleanup`] can
+    /// remove them without a completed part description. Retries must use fresh,
+    /// disjoint Blob ID ranges, including ranges from failed writes. Staging
+    /// `.part` files are only explicitly cleaned; ordinary dataset GC rules still
+    /// apply to uncommitted Blob sidecars and must be coordinated with checkpoints.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use arrow_array::RecordBatch;
+    /// use futures::stream;
+    /// use lance::{Dataset, dataset::DataFileTarget};
+    ///
+    /// # async fn write_part(
+    /// #     dataset: &Dataset,
+    /// #     target: &DataFileTarget,
+    /// #     batch: RecordBatch,
+    /// # ) -> lance_core::Result<()> {
+    /// let part = dataset
+    ///     .write_data_file_part(target, None, stream::iter([Ok(batch)]))
+    ///     .await?;
+    /// // Serialize part into the caller's checkpoint.
+    /// # let _ = part;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn write_data_file_part(
+        &self,
+        target: &DataFileTarget,
+        blob_ids: Option<Range<u32>>,
+        data: impl Stream<Item = Result<RecordBatch>> + Send,
+    ) -> Result<DataFilePart> {
+        self.validate_data_file_target(target)?;
+        validate_blob_v2_write_schema(target.schema.as_ref())?;
+        let part_blob_ids = blob_ids.clone();
+        let has_blob = target
+            .schema
+            .fields_pre_order()
+            .any(|field| field.is_blob_v2());
+        if has_blob && blob_ids.is_none() {
+            return Err(Error::invalid_input(
+                "write_data_file_part requires a non-empty Blob ID range for a schema containing Blob v2 fields",
+            ));
+        }
+
+        let mut preprocessor = if let Some(blob_ids) = blob_ids {
+            let data_dir = self.data_file_dir_for_base(target.base_id)?;
+            let object_store = self.object_store(target.base_id).await?;
+            let external_base_resolver = blob_v2_external_base_resolver(
+                Some(self),
+                &WriteParams::default(),
+                target.schema.as_ref(),
+            )
+            .await?;
+            Some(
+                BlobPreprocessor::new(
+                    object_store.as_ref().clone(),
+                    data_dir,
+                    target.data_file_key().to_string(),
+                    target.schema.as_ref(),
+                    external_base_resolver,
+                    false,
+                    ExternalBlobMode::Reference,
+                    self.session().store_registry(),
+                    self.store_params().cloned().unwrap_or_default(),
+                    None,
+                )?
+                .with_part_blob_ids(blob_ids)?,
+            )
+        } else {
+            None
+        };
+
+        let file_name = format!("{}.part", generate_random_filename());
+        let path = target
+            .parts_dir(&self.data_file_dir_for_base(target.base_id)?)
+            .join(file_name.as_str());
+        let store = self.object_store(target.base_id).await?;
+        let mut writer = file_versions::create_writer(
+            target.version,
+            store.create(&path).await?,
+            target.schema.as_ref().clone(),
+            FileWriterOptions::default(),
+        )?;
+        let mut data = Box::pin(data);
+        let write_result = async {
+            while let Some(batch) = data.next().await {
+                let batch = batch?;
+                if let Some(preprocessor) = preprocessor.as_mut() {
+                    let batch = preprocessor.preprocess_batch(&batch).await?;
+                    writer.write_batch(&batch).await?;
+                } else {
+                    writer.write_batch(&batch).await?;
+                }
+            }
+            if let Some(preprocessor) = preprocessor.as_mut() {
+                preprocessor.finish().await?;
+            }
+            writer.finish().await
+        }
+        .await;
+
+        match write_result {
+            Ok(summary) => Ok(DataFilePart {
+                target_file_name: target.file_name.clone(),
+                base_id: target.base_id,
+                file_name,
+                blob_ids: part_blob_ids,
+                num_rows: summary.num_rows,
+                size_bytes: NonZeroU64::new(summary.size_bytes)
+                    .ok_or_else(|| Error::internal("completed part has zero file size"))?,
+            }),
+            Err(error) => {
+                writer.abort().await;
+                if let Some(preprocessor) = preprocessor.as_mut() {
+                    preprocessor.abort();
+                }
+                Err(error)
+            }
+        }
+    }
+
+    /// Reopen, validate, and concatenate parts into the final data file.
+    ///
+    /// Part order is the final physical row order. The operation copies
+    /// encoded page buffers and regenerates metadata and the footer; incompatible
+    /// inputs fail without a decode/re-encode fallback or dataset commit. The
+    /// caller owns cleanup of all durable part, Blob, and final-file objects.
+    /// The caller must also assemble the target through the same dataset and
+    /// resolved base used to write managed Blob payloads.
+    ///
+    /// To replace a fragment's columns, wrap the returned file in a
+    /// [`DataReplacementGroup`](super::transaction::DataReplacementGroup).
+    /// The caller must check that the ordered parts cover the fragment's physical
+    /// rows exactly, including deleted rows; this operation does not check
+    /// fragment coverage or commit the replacement.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use lance::{Dataset, dataset::{DataFilePart, DataFileTarget}};
+    ///
+    /// # async fn concat(
+    /// #     dataset: &Dataset,
+    /// #     target: &DataFileTarget,
+    /// #     ordered_parts: &[DataFilePart],
+    /// # ) -> lance_core::Result<()> {
+    /// let data_file = dataset.concat_data_file_parts(target, ordered_parts).await?;
+    /// // The caller decides when and how to commit `data_file`.
+    /// # let _ = data_file;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn concat_data_file_parts(
+        &self,
+        target: &DataFileTarget,
+        ordered_parts: &[DataFilePart],
+    ) -> Result<DataFile> {
+        let opened = DataFilePart::open_all(self, target, ordered_parts).await?;
+        let data_dir = self.data_file_dir_for_base(target.base_id)?;
+        let output_path = target.object_path(&data_dir);
+        let object_store = self.object_store(target.base_id).await?;
+        let mut concat_target = FileConcatTarget::new(target.version, target.schema.clone());
+        if let Some(blob_target_id) = target.blob_target_id() {
+            concat_target = concat_target.with_blob_target_id(blob_target_id);
+        }
+        let result = concat_parts(
+            &concat_target,
+            &opened,
+            {
+                let object_store = object_store.clone();
+                let output_path = output_path.clone();
+                move || async move { object_store.create(&output_path).await }
+            },
+            FileConcatOptions::default(),
+        )
+        .await;
+
+        let output = match result {
+            Ok(FileConcatResult::Written(output)) => output,
+            Ok(FileConcatResult::Reused(_, _)) => {
+                return Err(Error::internal(
+                    "data-file part concatenation unexpectedly reused an input".to_string(),
+                ));
+            }
+            Ok(FileConcatResult::Unsupported(reason)) => {
+                let message = format!(
+                    "parts cannot be concatenated into target {:?}: {reason}",
+                    target.file_name
+                );
+                return Err(match reason {
+                    FileConcatReason::VersionMismatch { actual, .. } => {
+                        let (major, minor) = actual.to_standard_footer_numbers();
+                        Error::version_conflict(message, major, minor)
+                    }
+                    FileConcatReason::SchemaMismatch { .. } => Error::schema_mismatch(message),
+                    FileConcatReason::LegacyVersion
+                    | FileConcatReason::ColumnLayoutMismatch { .. }
+                    | FileConcatReason::ColumnEncodingMismatch { .. }
+                    | FileConcatReason::ColumnBuffers { .. }
+                    | FileConcatReason::ExtraGlobalBuffers { .. }
+                    | FileConcatReason::BlobColumns => Error::not_supported(message),
+                });
+            }
+            Err(error) => return Err(error),
+        };
+        let (fields, column_indices) =
+            file_versions::data_file_columns(target.version, target.schema.as_ref());
+        Ok(DataFile::new(
+            target.file_name.clone(),
+            fields,
+            column_indices,
+            target.version,
+            NonZeroU64::new(output.size_bytes),
+            target.base_id,
+        ))
+    }
+}
 
 /// The destination to write data to.
 #[derive(Debug, Clone)]


### PR DESCRIPTION
Distributed writers need to persist a target and completed parts so another process can resume writing or assemble the final file. `DataFileTarget` and `DataFilePart` now support serde, and Lance creates staging files when writing parts. Assembly reopens and validates the referenced files before producing the final `DataFile`.

Managed Blob payloads are written directly into the final target's sidecar namespace and are not copied during assembly. Callers explicitly invoke `target.finish(dataset)` after commit to remove staging parts, or `target.cleanup(dataset)` after abandoning the target to remove staging parts, the final file, and Blob payloads. Both operations tolerate missing objects and can be retried after partial cleanup. Callers remain responsible for stopping users of the target, retaining the same dataset/base mapping, allocating disjoint Blob ID ranges across retries, and coordinating checkpoints with dataset GC.

This replaces the high-level caller-provided Writer and `open_part` flow with serializable part descriptions. Callers use `Dataset::concat_data_file_parts` and construct `DataReplacementGroup` themselves; fragment row coverage and commit fencing remain their responsibility. No separate `FileFragment::write_columns_from_parts` entry point is retained.

Checkpoint contents must be trusted, and callers must fence stale workers so they cannot resume writes or assembly after a target is committed. These descriptors do not prove ownership or consult retained manifests. `finish` retains all Blob payloads under the target, including unused retry leases; ordinary dataset GC also preserves them while the parent file is referenced. Per-Blob reachability collection is outside this change.

Follow-up to #8923.

