### PR TITLE
perf(index): floor the default HNSW search ef at 256

### DIFF
--- a/docs/src/examples/rust/hnsw.md
+++ b/docs/src/examples/rust/hnsw.md
@@ -8,6 +8,11 @@ This example will show how to:
 2. Build a hierarchical graph structure for efficient vector search using Lance API
 3. Perform vector search with different parameters and compute the ground truth using L2 distance search
 
+The example sets the search beam width `ef` explicitly. A query that leaves it
+unset gets `1.5 * k * refine_factor`, floored at 256; the floor is what keeps
+recall usable on a single large partition, which is the layout
+`IVF_HNSW_*` builds by default.
+
 ## Complete Example
 
 ```rust

--- a/java/src/main/java/org/lance/ipc/Query.java
+++ b/java/src/main/java/org/lance/ipc/Query.java
@@ -223,7 +223,7 @@ public class Query {
 
     /**
      * Sets the number of candidates to reserve while searching. This is an optional parameter for
-     * HNSW related index types.
+     * HNSW related index types. Defaults to {@code 1.5 * k * refineFactor}, floored at 256.
      *
      * @param ef The number of candidates to reserve.
      * @return The Builder instance for method chaining.

--- a/python/python/lance/dataset.py
+++ b/python/python/lance/dataset.py
@@ -6976,6 +6976,9 @@ class ScannerBuilder:
             When ``use_index`` is true and a vector index is available, each query
             vector is searched through the index path; otherwise the flat batch path
             is used.
+        ef: int, optional
+            Beam width for HNSW search. Defaults to ``1.5 * k * refine_factor``,
+            floored at 256.
         query_parallelism: int, optional
             Maximum partition-search concurrency for a single vector query.
             The default is 0. Value 0 uses the automatic policy, which
@@ -8226,7 +8229,8 @@ def _build_vector_search_query(
     use_index: bool, default True
         Whether to use the index for the search.
     ef: int, optional
-        The ef parameter for HNSW search.
+        Beam width for HNSW search. Defaults to ``1.5 * k * refine_factor``,
+        floored at 256.
     query_parallelism: int, optional
         Maximum partition-search concurrency for a single vector query.
         The default is 0. Value 0 uses the automatic policy, which currently

--- a/rust/lance-index/src/vector.rs
+++ b/rust/lance-index/src/vector.rs
@@ -133,6 +133,8 @@ pub struct Query {
 
     /// The number of candidates to reserve while searching.
     /// this is an optional parameter for HNSW related index types.
+    /// Unset defaults to `1.5 * k * refine_factor`, floored at
+    /// [`crate::vector::hnsw::builder::DEFAULT_MIN_EF`].
     pub ef: Option<usize>,
 
     /// If presented, apply a refine step.

--- a/rust/lance-index/src/vector/hnsw/builder.rs
+++ b/rust/lance-index/src/vector/hnsw/builder.rs
@@ -1411,6 +1411,9 @@ impl DeepSizeOf for HnswGraph {
     }
 }
 
+/// Lower bound for the search-time `ef` when the caller does not set one.
+pub const DEFAULT_MIN_EF: usize = 256;
+
 #[derive(Debug, Clone, Copy)]
 pub struct HnswQueryParams {
     pub ef: usize,
@@ -1424,7 +1427,7 @@ impl From<&Query> for HnswQueryParams {
     fn from(query: &Query) -> Self {
         let k = query.k * query.refine_factor.unwrap_or(1) as usize;
         Self {
-            ef: query.ef.unwrap_or(k + k / 2),
+            ef: query.ef.unwrap_or_else(|| (k + k / 2).max(DEFAULT_MIN_EF)),
             lower_bound: query.lower_bound,
             upper_bound: query.upper_bound,
             dist_q_c: query.dist_q_c,
@@ -1848,6 +1851,7 @@ mod tests {
     };
     use crate::metrics::NoOpMetricsCollector;
     use crate::prefilter::PreFilter;
+    use crate::vector::Query;
     use crate::vector::graph::builder::GraphBuilderNode;
     use crate::vector::storage::{DistCalculator, VectorStore};
     use crate::vector::v3::subindex::IvfSubIndex;
@@ -1856,7 +1860,7 @@ mod tests {
         graph::{DISTS_FIELD, NEIGHBORS_FIELD, OrderedNode, VisitedGenerator},
         hnsw::{
             HNSW, HnswMetadata, VECTOR_ID_FIELD,
-            builder::{HnswBuildParams, HnswQueryParams},
+            builder::{DEFAULT_MIN_EF, HnswBuildParams, HnswQueryParams},
         },
     };
 
@@ -2629,7 +2633,7 @@ mod tests {
         }
         assert_eq!(all_results[0], all_results[1]);
 
-        // default ef (k + k/2) and a deletion-style mask (all but a few rows)
+        // the pre-floor default and a deletion-style mask
         let default_ef_params = HnswQueryParams {
             ef: k + k / 2,
             ..params
@@ -3360,5 +3364,40 @@ mod tests {
             loaded.deep_size_of(),
             builder.deep_size_of(),
         );
+    }
+
+    fn query_with(k: usize, ef: Option<usize>, refine_factor: Option<u32>) -> Query {
+        Query {
+            column: "vector".to_string(),
+            key: Arc::new(Float32Array::from(vec![0.0; 8])),
+            k,
+            lower_bound: None,
+            upper_bound: None,
+            minimum_nprobes: 1,
+            maximum_nprobes: None,
+            ef,
+            refine_factor,
+            metric_type: Some(DistanceType::L2),
+            use_index: true,
+            query_parallelism: 0,
+            dist_q_c: 0.0,
+            approx_mode: Default::default(),
+        }
+    }
+
+    #[rstest]
+    #[case::floor_binds_at_search_shaped_k(10, None, None, DEFAULT_MIN_EF)]
+    #[case::floor_stops_binding_by_k(1000, None, None, 1500)]
+    #[case::floor_stops_binding_by_refine(10, None, Some(100), 1500)]
+    #[case::explicit_ef_wins_below_the_floor(10, Some(15), None, 15)]
+    #[case::explicit_ef_wins_above_the_floor(10, Some(4096), None, 4096)]
+    fn default_ef_is_floored_but_never_overrides_the_caller(
+        #[case] k: usize,
+        #[case] ef: Option<usize>,
+        #[case] refine_factor: Option<u32>,
+        #[case] expected: usize,
+    ) {
+        let params = HnswQueryParams::from(&query_with(k, ef, refine_factor));
+        assert_eq!(params.ef, expected);
     }
 }

--- a/rust/lance/src/dataset/scanner.rs
+++ b/rust/lance/src/dataset/scanner.rs
@@ -2110,9 +2110,15 @@ impl Scanner {
         self
     }
 
+    /// Set the beam width used when searching an HNSW graph.
+    ///
+    /// Defaults to `1.5 * k * refine_factor`, floored at
+    /// [`lance_index::vector::hnsw::builder::DEFAULT_MIN_EF`].
     pub fn ef(&mut self, ef: usize) -> &mut Self {
         if let Some(q) = self.nearest.as_mut() {
             q.ef = Some(ef);
+        } else {
+            log::warn!("ef is not set because nearest has not been called yet");
         }
         self
     }


### PR DESCRIPTION
`IVF_HNSW_*` indexes default to `target_partition_size = 1 << 20`, so any table below roughly two million rows resolves to a single partition and IVF routing is inert. The graph is then the only thing pruning the search, and it runs at `ef = 1.5 * k`, which is 15 at `k = 10`.

The reference below is `IVF_SQ` over the same quantizer, the same partition layout and the same code bytes, differing only in that it scans the partition exhaustively instead of walking a graph through it. The gap between the two rows is therefore what the graph itself loses, with the quantizer and the data held constant.

| `ef` | GIST1M recall@10 (d=960) | SIFT1M recall@10 (d=128) | GIST1M p50 | SIFT1M p50 |
|---|---|---|---|---|
| 15 (today) | 0.567 ± 0.003 | 0.828 | 1.0 ms | 0.8 ms |
| 256 (this PR) | 0.925 ± 0.002 | 0.980 | 3.5 ms | 1.7 ms |
| 1024 | 0.952 ± 0.003 | 0.982 | 7.0 ms | 3.3 ms |
| exhaustive scan of the same codes | 0.953 ± 0.003 | 0.981 | 76.4 ms | 18.3 ms |

At the shipped default the graph returns 0.567 on GIST1M where an exhaustive scan of its own codes returns 0.953, a recall@10 deficit of 0.386. The floor takes that deficit to 0.027, and on SIFT1M from 0.154 to 0.001.

It reads nothing extra. At a single partition the query loads the whole partition whatever `ef` is, so bytes per query move by 144 out of 220,694,062 across the entire ladder from 15 to 1024; only distance comparisons grow, and even at the proposed floor the graph does an order of magnitude less work than the scan it approximates. Queries whose `k * refine_factor` already exceeds 171 are unaffected, since `1.5 * k_eff` clears the floor on its own.

256 rather than 1024, which closes the gap outright, because a fixed floor also applies to small partitions. At 8192 rows per partition the graph at `ef = 256` already spends 2997 distance comparisons against an exhaustive 10597, so a wider beam there would cost more than scanning. Making the default scale with the graph it searches is the better answer and needs a measurement of its own.

The knob is unchanged and keeps precedence: `Scanner::ef` in Rust, `ef=` in Python's `nearest`, `Query.Builder.setEf` in Java. This PR also documents the default on all three, which none of them stated before, and makes `Scanner::ef` warn when `nearest` has not been called yet: today it silently drops the value, leaving the caller on the very default this PR is changing.

Setup: SIFT1M (1,000,000 vectors of 128 dimensions, 5,000 official queries) and GIST1M (1,000,000 vectors of 960 dimensions, 1,000 official queries), official ground truth, L2, `k = 10`, one partition. GIST figures are the mean over four independent builds per arm; the control arm alone moves 0.008 between builds, so the deficit is formed inside each build and then averaged. Latencies are per-query p50 with the index resident, comparable across `ef` within this table rather than against a cold cache.
