### PR TITLE
fix(fts): preserve prewarmed state across request store wrappers

### DIFF
--- a/rust/lance-index/Cargo.toml
+++ b/rust/lance-index/Cargo.toml
@@ -176,3 +176,7 @@ harness = false
 
 [lints]
 workspace = true
+
+[[bench]]
+name = "inverted_request_cache"
+harness = false

--- a/rust/lance-index/benches/inverted_request_cache.rs
+++ b/rust/lance-index/benches/inverted_request_cache.rs
@@ -1,0 +1,211 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+//! Isolate warm FTS request-open overhead from query scoring and cloud latency.
+
+use std::{
+    collections::HashMap,
+    hint::black_box,
+    sync::{Arc, Mutex},
+    time::Duration,
+};
+
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use futures::{FutureExt, future::try_join_all};
+use lance_core::cache::LanceCache;
+use lance_core::utils::address::RowAddress;
+use lance_core::utils::testing::{ProxyObjectStore, ProxyObjectStorePolicy};
+use lance_index::Index;
+use lance_index::scalar::inverted::{
+    DocSet, FTS_FORMAT_VERSION_KEY, InvertedIndex, InvertedIndexParams, InvertedIndexPlugin,
+    METADATA_FILE, POSTING_BLOCK_SIZE_KEY, PostingListBuilder, TOKEN_SET_FORMAT_KEY, TokenSet,
+    TokenSetFormat,
+    builder::{InnerBuilder, PositionRecorder},
+};
+use lance_index::scalar::lance_format::LanceIndexStore;
+use lance_index::scalar::{IndexStore, registry::ScalarIndexPlugin};
+use lance_io::object_store::{ObjectStore, WrappingObjectStore};
+use object_store::{list::PaginatedListStore, path::Path};
+
+#[derive(Debug)]
+struct RequestWrapper;
+
+impl WrappingObjectStore for RequestWrapper {
+    fn wrap(
+        &self,
+        _prefix: &str,
+        original: Arc<dyn object_store::ObjectStore>,
+    ) -> Arc<dyn object_store::ObjectStore> {
+        Arc::new(ProxyObjectStore::new(
+            original,
+            Arc::new(Mutex::new(ProxyObjectStorePolicy::new())),
+        ))
+    }
+
+    fn wrap_paginated(
+        &self,
+        _prefix: &str,
+        _original: Arc<dyn PaginatedListStore>,
+    ) -> Option<Arc<dyn PaginatedListStore>> {
+        None
+    }
+}
+
+struct Fixture {
+    object_store: ObjectStore,
+    metadata_cache: Arc<LanceCache>,
+    index_cache: LanceCache,
+    file_sizes: HashMap<String, u64>,
+}
+
+impl Fixture {
+    async fn new(partitions: u64, with_file_sizes: bool) -> Self {
+        let object_store = ObjectStore::memory();
+        let metadata_cache = Arc::new(LanceCache::with_capacity(64 * 1024 * 1024));
+        let index_cache = LanceCache::with_capacity(64 * 1024 * 1024);
+        let store = Arc::new(LanceIndexStore::new(
+            Arc::new(object_store.clone()),
+            Path::from("index"),
+            metadata_cache.clone(),
+        ));
+        let params = InvertedIndexParams::default();
+        let format = params.resolved_format_version();
+        let mut file_sizes = HashMap::new();
+        for id in 0..partitions {
+            let mut builder = InnerBuilder::new_with_format_version_and_block_size(
+                id,
+                false,
+                TokenSetFormat::default(),
+                format,
+                params.posting_block_size(),
+            );
+            let mut tokens = TokenSet::default();
+            tokens.add("alpha".to_owned());
+            let mut docs = DocSet::default();
+            let mut posting = PostingListBuilder::new_with_posting_tail_codec_and_block_size(
+                false,
+                format.posting_tail_codec(),
+                params.posting_block_size(),
+            );
+            for row in 0..32 {
+                let doc = docs.append(RowAddress::new_from_parts(id as u32, row).into(), 1);
+                posting.add(doc, PositionRecorder::Count(1));
+            }
+            builder.set_tokens(tokens);
+            builder.set_docs(docs);
+            builder.set_posting_lists(vec![posting]);
+            for file in builder.write(store.as_ref()).await.unwrap() {
+                file_sizes.insert(file.path, file.size_bytes);
+            }
+        }
+        let mut writer = store
+            .new_index_file(METADATA_FILE, Arc::new(arrow_schema::Schema::empty()))
+            .await
+            .unwrap();
+        let file = writer
+            .finish_with_metadata(HashMap::from([
+                ("params".to_owned(), serde_json::to_string(&params).unwrap()),
+                (
+                    "partitions".to_owned(),
+                    serde_json::to_string(&(0..partitions).collect::<Vec<_>>()).unwrap(),
+                ),
+                (
+                    TOKEN_SET_FORMAT_KEY.to_owned(),
+                    TokenSetFormat::default().to_string(),
+                ),
+                (
+                    FTS_FORMAT_VERSION_KEY.to_owned(),
+                    format.index_version().to_string(),
+                ),
+                (
+                    POSTING_BLOCK_SIZE_KEY.to_owned(),
+                    params.posting_block_size().to_string(),
+                ),
+            ]))
+            .await
+            .unwrap();
+        file_sizes.insert(file.path, file.size_bytes);
+        let index = InvertedIndex::load(store.clone(), None, &index_cache)
+            .await
+            .unwrap();
+        index.prewarm().await.unwrap();
+        InvertedIndexPlugin
+            .put_in_cache(store, &index_cache, index)
+            .await
+            .unwrap();
+        if !with_file_sizes {
+            file_sizes.clear();
+        }
+        Self {
+            object_store,
+            metadata_cache,
+            index_cache,
+            file_sizes,
+        }
+    }
+
+    async fn open_request(&self) {
+        let mut object_store = self.object_store.clone();
+        object_store.apply_wrapper(&RequestWrapper);
+        let store = Arc::new(
+            LanceIndexStore::new(
+                Arc::new(object_store),
+                Path::from("index"),
+                self.metadata_cache.clone(),
+            )
+            .with_file_sizes(self.file_sizes.clone()),
+        );
+        let index = InvertedIndexPlugin
+            .get_or_insert_in_cache(
+                store,
+                None,
+                &self.index_cache,
+                async { panic!("prewarmed index metadata should remain cached") }.boxed(),
+            )
+            .await
+            .unwrap();
+        black_box(index);
+    }
+}
+
+fn request_cache(c: &mut Criterion) {
+    let runtime = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(8)
+        .enable_all()
+        .build()
+        .unwrap();
+    let mut group = c.benchmark_group("inverted_request_open");
+    group
+        .sample_size(20)
+        .warm_up_time(Duration::from_secs(1))
+        .measurement_time(Duration::from_secs(2));
+    for partitions in [1, 32, 256] {
+        for file_sizes in [false, true] {
+            let fixture = Arc::new(runtime.block_on(Fixture::new(partitions, file_sizes)));
+            for concurrency in [1, 64] {
+                group.throughput(Throughput::Elements(concurrency));
+                let scenario = format!("p{partitions}_sizes{file_sizes}");
+                group.bench_with_input(
+                    BenchmarkId::new(scenario, concurrency),
+                    &concurrency,
+                    |b, &concurrency| {
+                        b.to_async(&runtime).iter(|| async {
+                            let tasks = (0..concurrency).map(|_| {
+                                let fixture = fixture.clone();
+                                tokio::spawn(async move { fixture.open_request().await })
+                            });
+                            try_join_all(tasks).await.unwrap();
+                            // Test-util builds retain individual I/O records. Bound
+                            // their lifetime to a batch on both compared revisions.
+                            black_box(fixture.object_store.io_stats_incremental());
+                        });
+                    },
+                );
+            }
+        }
+    }
+    group.finish();
+}
+
+criterion_group!(benches, request_cache);
+criterion_main!(benches);

--- a/rust/lance-index/src/scalar/inverted.rs
+++ b/rust/lance-index/src/scalar/inverted.rs
@@ -611,7 +611,6 @@ impl ScalarIndexPlugin for InvertedIndexPlugin {
                 .ok_or_else(|| Error::internal("cached FTS index has an unexpected type"))?;
             index
                 .with_store(rebind_store, frag_reuse_index)
-                .await
                 .map(|index| index.map(|index| Arc::new(index) as Arc<dyn ScalarIndex>))
         })
         .await

--- a/rust/lance-index/src/scalar/inverted.rs
+++ b/rust/lance-index/src/scalar/inverted.rs
@@ -599,11 +599,22 @@ impl ScalarIndexPlugin for InvertedIndexPlugin {
     async fn get_or_insert_in_cache(
         &self,
         index_store: Arc<dyn IndexStore>,
-        _frag_reuse_index: Option<Arc<dyn RowIdRemapper>>,
+        frag_reuse_index: Option<Arc<dyn RowIdRemapper>>,
         cache: &LanceCache,
         load: ScalarIndexLoad<'_>,
     ) -> Result<Arc<dyn ScalarIndex>> {
-        single_flight_store_bound_open(index_store, cache, load).await
+        let rebind_store = index_store.clone();
+        single_flight_store_bound_open(index_store, cache, load, move |index| async move {
+            let index = index
+                .as_any()
+                .downcast_ref::<InvertedIndex>()
+                .ok_or_else(|| Error::internal("cached FTS index has an unexpected type"))?;
+            index
+                .with_store(rebind_store, frag_reuse_index)
+                .await
+                .map(|index| index.map(|index| Arc::new(index) as Arc<dyn ScalarIndex>))
+        })
+        .await
     }
 
     fn details_as_json(&self, details: &prost_types::Any) -> Result<serde_json::Value> {

--- a/rust/lance-index/src/scalar/inverted/documents.rs
+++ b/rust/lance-index/src/scalar/inverted/documents.rs
@@ -1092,10 +1092,10 @@ pub(super) struct PartitionDocuments {
     persisted_total_tokens: Option<u64>,
     quantized_scoring: bool,
     remapper: Option<Arc<dyn RowIdRemapper>>,
-    lengths: OnceCell<Arc<DocLengths>>,
-    projection: OnceCell<Arc<VersionAddressProjection>>,
-    shared_addresses: ArcSwapWeak<UInt64Array>,
-    prewarm_complete: OnceCell<()>,
+    lengths: Arc<OnceCell<Arc<DocLengths>>>,
+    projection: Arc<OnceCell<Arc<VersionAddressProjection>>>,
+    shared_addresses: Arc<ArcSwapWeak<UInt64Array>>,
+    prewarm_complete: Arc<OnceCell<()>>,
 }
 
 /// Load-boundary discriminator between the read-only legacy representation and
@@ -1269,11 +1269,36 @@ impl PartitionDocuments {
             persisted_total_tokens,
             quantized_scoring,
             remapper,
-            lengths: OnceCell::new(),
-            projection: OnceCell::new(),
-            shared_addresses: ArcSwapWeak::from(Weak::new()),
-            prewarm_complete: OnceCell::new(),
+            lengths: Arc::new(OnceCell::new()),
+            projection: Arc::new(OnceCell::new()),
+            shared_addresses: Arc::new(ArcSwapWeak::from(Weak::new())),
+            prewarm_complete: Arc::new(OnceCell::new()),
         })
+    }
+
+    /// Share reader-free state within the same index and fragment-reuse namespace.
+    /// Cache misses use the current store and remapper; no previous request's
+    /// readers or storage credentials are retained by the shared cells.
+    pub(crate) fn with_store(
+        &self,
+        store: Arc<dyn IndexStore>,
+        remapper: Option<Arc<dyn RowIdRemapper>>,
+    ) -> Self {
+        Self {
+            store,
+            path: self.path.clone(),
+            partition_id: self.partition_id,
+            index_cache: self.index_cache.clone(),
+            num_docs: self.num_docs,
+            coordinate_rank: self.coordinate_rank,
+            persisted_total_tokens: self.persisted_total_tokens,
+            quantized_scoring: self.quantized_scoring,
+            remapper,
+            lengths: self.lengths.clone(),
+            projection: self.projection.clone(),
+            shared_addresses: self.shared_addresses.clone(),
+            prewarm_complete: self.prewarm_complete.clone(),
+        }
     }
 
     pub(crate) fn len(&self) -> usize {

--- a/rust/lance-index/src/scalar/inverted/index/inverted_index.rs
+++ b/rust/lance-index/src/scalar/inverted/index/inverted_index.rs
@@ -204,7 +204,7 @@ impl InvertedIndex {
     /// Rebind a modern index within its immutable index/fragment-reuse cache
     /// namespace. Only reader-free state crosses the request boundary; all
     /// future posting and document I/O uses the supplied store and remapper.
-    pub(in super::super) async fn with_store(
+    pub(in super::super) fn with_store(
         &self,
         store: Arc<dyn IndexStore>,
         frag_reuse_index: Option<Arc<dyn RowIdRemapper>>,
@@ -212,31 +212,26 @@ impl InvertedIndex {
         if self.is_legacy() || self.partitions.iter().any(|part| part.is_legacy()) {
             return Ok(None);
         }
-        let partitions = stream::iter(self.partitions.clone().into_iter().enumerate().map(
-            |(priority, part)| {
-                let store = store.with_io_priority(priority as u64);
-                let frag_reuse_index = frag_reuse_index.clone();
-                async move {
-                    let Some(docs) = part.docs.modern() else {
-                        return Err(Error::internal("modern FTS partition has legacy documents"));
-                    };
-                    let reader = store.open_index_file(&posting_file_path(part.id)).await?;
-                    Ok(Arc::new(InvertedPartition {
-                        id: part.id,
-                        store: store.clone(),
-                        tokens: part.tokens.clone(),
-                        inverted_list: Arc::new(part.inverted_list.with_reader(reader)?),
-                        docs: PartitionDocumentStore::Modern(Arc::new(
-                            docs.with_store(store, frag_reuse_index),
-                        )),
-                        token_set_format: part.token_set_format,
-                    }))
-                }
-            },
-        ))
-        .buffered(store.io_parallelism().max(1))
-        .try_collect::<Vec<_>>()
-        .await?;
+        let mut partitions = Vec::with_capacity(self.partitions.len());
+        for (priority, part) in self.partitions.iter().enumerate() {
+            let store = store.with_io_priority(priority as u64);
+            let Some(docs) = part.docs.modern() else {
+                return Err(Error::internal("modern FTS partition has legacy documents"));
+            };
+            partitions.push(Arc::new(InvertedPartition {
+                id: part.id,
+                store: store.clone(),
+                tokens: part.tokens.clone(),
+                inverted_list: Arc::new(
+                    part.inverted_list
+                        .with_store(store.clone(), posting_file_path(part.id))?,
+                ),
+                docs: PartitionDocumentStore::Modern(Arc::new(
+                    docs.with_store(store, frag_reuse_index.clone()),
+                )),
+                token_set_format: part.token_set_format,
+            }));
+        }
         Ok(Some(Self {
             params: self.params.clone(),
             store,

--- a/rust/lance-index/src/scalar/inverted/index/inverted_index.rs
+++ b/rust/lance-index/src/scalar/inverted/index/inverted_index.rs
@@ -201,6 +201,56 @@ impl InvertedIndex {
 }
 
 impl InvertedIndex {
+    /// Rebind a modern index within its immutable index/fragment-reuse cache
+    /// namespace. Only reader-free state crosses the request boundary; all
+    /// future posting and document I/O uses the supplied store and remapper.
+    pub(in super::super) async fn with_store(
+        &self,
+        store: Arc<dyn IndexStore>,
+        frag_reuse_index: Option<Arc<dyn RowIdRemapper>>,
+    ) -> Result<Option<Self>> {
+        if self.is_legacy() || self.partitions.iter().any(|part| part.is_legacy()) {
+            return Ok(None);
+        }
+        let partitions = stream::iter(self.partitions.clone().into_iter().enumerate().map(
+            |(priority, part)| {
+                let store = store.with_io_priority(priority as u64);
+                let frag_reuse_index = frag_reuse_index.clone();
+                async move {
+                    let Some(docs) = part.docs.modern() else {
+                        return Err(Error::internal("modern FTS partition has legacy documents"));
+                    };
+                    let reader = store.open_index_file(&posting_file_path(part.id)).await?;
+                    Ok(Arc::new(InvertedPartition {
+                        id: part.id,
+                        store: store.clone(),
+                        tokens: part.tokens.clone(),
+                        inverted_list: Arc::new(part.inverted_list.with_reader(reader)?),
+                        docs: PartitionDocumentStore::Modern(Arc::new(
+                            docs.with_store(store, frag_reuse_index),
+                        )),
+                        token_set_format: part.token_set_format,
+                    }))
+                }
+            },
+        ))
+        .buffered(store.io_parallelism().max(1))
+        .try_collect::<Vec<_>>()
+        .await?;
+        Ok(Some(Self {
+            params: self.params.clone(),
+            store,
+            tokenizer: self.tokenizer.clone(),
+            token_set_format: self.token_set_format,
+            format_version: self.format_version,
+            partitions,
+            corpus_stats: self.corpus_stats.clone(),
+            prewarm_state: self.prewarm_state.clone(),
+            document_projections_resident: self.document_projections_resident.clone(),
+            deleted_fragments: self.deleted_fragments.clone(),
+        }))
+    }
+
     async fn load_legacy_index(
         store: Arc<dyn IndexStore>,
         frag_reuse_index: Option<Arc<dyn RowIdRemapper>>,
@@ -256,7 +306,7 @@ impl InvertedIndex {
             partitions: vec![Arc::new(InvertedPartition {
                 id: 0,
                 store,
-                tokens,
+                tokens: Arc::new(tokens),
                 inverted_list,
                 docs: PartitionDocumentStore::Legacy(Arc::new(docs)),
                 token_set_format: TokenSetFormat::Arrow,
@@ -473,6 +523,23 @@ impl Index for InvertedIndex {
 }
 
 impl InvertedIndex {
+    /// Return whether both handles share the same runtime prewarm state.
+    ///
+    /// Cloning or rebinding readers preserves this identity; independently
+    /// loading the same index does not. This checks neither cache residency nor
+    /// whether the handles' storage bindings are interchangeable.
+    ///
+    /// ```
+    /// use lance_index::scalar::inverted::InvertedIndex;
+    ///
+    /// fn cloned_handle_shares_state(index: &InvertedIndex) -> bool {
+    ///     index.shares_prewarm_state(&index.clone())
+    /// }
+    /// ```
+    pub fn shares_prewarm_state(&self, other: &Self) -> bool {
+        Arc::ptr_eq(&self.prewarm_state, &other.prewarm_state)
+    }
+
     /// Return whether an explicit prewarm prepared everything this query needs.
     ///
     /// This is an O(1) routing hint for query planning. It never starts I/O or

--- a/rust/lance-index/src/scalar/inverted/index/partition.rs
+++ b/rust/lance-index/src/scalar/inverted/index/partition.rs
@@ -657,7 +657,7 @@ pub struct InvertedPartition {
     // 0 for legacy format
     pub(super) id: u64,
     pub(super) store: Arc<dyn IndexStore>,
-    pub(crate) tokens: TokenSet,
+    pub(crate) tokens: Arc<TokenSet>,
     pub(crate) inverted_list: Arc<PostingListReader>,
     /// Legacy documents stay in their original complete `DocSet`; modern
     /// documents use typed, independently-loaded lengths and addresses.
@@ -720,7 +720,7 @@ impl InvertedPartition {
         Ok(Self {
             id,
             store,
-            tokens,
+            tokens: Arc::new(tokens),
             inverted_list: Arc::new(inverted_list),
             docs: PartitionDocumentStore::Modern(Arc::new(docs)),
             token_set_format,
@@ -1511,7 +1511,7 @@ impl InvertedPartition {
             self.inverted_list.posting_tail_codec(),
             self.inverted_list.block_size(),
         );
-        builder.tokens = self.tokens.into_mutable();
+        builder.tokens = Arc::unwrap_or_clone(self.tokens).into_mutable();
         builder.docs = self.docs.load_build_docset().await?;
 
         builder

--- a/rust/lance-index/src/scalar/inverted/index/posting_prewarm.rs
+++ b/rust/lance-index/src/scalar/inverted/index/posting_prewarm.rs
@@ -130,7 +130,12 @@ impl PostingListReader {
             }
             PostingMetadata::V2 { .. } => tok_start..tok_end,
         };
-        let batch = self.reader.read_range(row_range, Some(&columns)).await?;
+        let batch = self
+            .reader
+            .get()
+            .await?
+            .read_range(row_range, Some(&columns))
+            .await?;
         Ok(batch)
     }
 
@@ -735,6 +740,7 @@ impl PostingListReader {
                 PositionsLayout::LegacyPerDoc => {
                     let batch = self
                         .reader
+                        .get().await?
                         .read_range(self.posting_list_range(token_id), Some(&[POSITION_COL]))
                         .await
                         .map_err(|e| match e {
@@ -748,6 +754,7 @@ impl PostingListReader {
                 PositionsLayout::SharedStream(codec) => {
                     let batch = self
                         .reader
+                        .get().await?
                         .read_range(
                             self.posting_list_range(token_id),
                             Some(&[COMPRESSED_POSITION_COL, POSITION_BLOCK_OFFSET_COL]),

--- a/rust/lance-index/src/scalar/inverted/index/posting_reader.rs
+++ b/rust/lance-index/src/scalar/inverted/index/posting_reader.rs
@@ -27,7 +27,7 @@ pub struct PostingListReader {
     /// queries do not decode the final posting block again.
     pub(super) modern_doc_id_validations: Option<Arc<[OnceCell<()>]>>,
     /// Skips per-token readiness checks once the whole immutable table is validated.
-    pub(super) modern_postings_validated: AtomicBool,
+    pub(super) modern_postings_validated: Arc<AtomicBool>,
     pub(super) modern_num_docs: Option<usize>,
 
     pub(super) index_cache: WeakLanceCache,
@@ -50,7 +50,7 @@ pub(super) enum PostingMetadata {
     /// `ensure_metadata_loaded`, and the stats path can also fetch a single
     /// token via `posting_len_for_token` without forcing the bulk load.
     V2 {
-        metadata: OnceCell<LoadedPostingMetadata>,
+        metadata: Arc<OnceCell<LoadedPostingMetadata>>,
     },
 }
 
@@ -148,7 +148,7 @@ impl PostingListReader {
             }
         } else {
             PostingMetadata::V2 {
-                metadata: OnceCell::new(),
+                metadata: Arc::new(OnceCell::new()),
             }
         };
 
@@ -171,9 +171,44 @@ impl PostingListReader {
             positions_layout,
             grouping,
             modern_doc_id_validations,
-            modern_postings_validated: AtomicBool::new(false),
+            modern_postings_validated: Arc::new(AtomicBool::new(false)),
             modern_num_docs: None,
             index_cache: WeakLanceCache::from(index_cache),
+        })
+    }
+
+    /// Reuse immutable posting state with a reader opened through the current store.
+    /// The caller must preserve the index cache namespace: these cells describe
+    /// one immutable posting file, not an arbitrary reader with the same schema.
+    pub(super) fn with_reader(&self, reader: Arc<dyn IndexReader>) -> Result<Self> {
+        let PostingMetadata::V2 { metadata } = &self.metadata else {
+            return Err(Error::not_supported(
+                "rebinding legacy FTS posting readers requires a full index load",
+            ));
+        };
+        if reader.num_rows() != self.reader.num_rows()
+            || reader.schema() != self.reader.schema()
+            || reader.schema().metadata != self.reader.schema().metadata
+        {
+            return Err(Error::index(
+                "FTS posting file changed while rebinding an immutable index",
+            ));
+        }
+        Ok(Self {
+            reader,
+            metadata: PostingMetadata::V2 {
+                metadata: metadata.clone(),
+            },
+            has_position: self.has_position,
+            has_impacts: self.has_impacts,
+            posting_tail_codec: self.posting_tail_codec,
+            block_size: self.block_size,
+            positions_layout: self.positions_layout,
+            grouping: self.grouping.clone(),
+            modern_doc_id_validations: self.modern_doc_id_validations.clone(),
+            modern_postings_validated: self.modern_postings_validated.clone(),
+            modern_num_docs: self.modern_num_docs,
+            index_cache: self.index_cache.clone(),
         })
     }
 

--- a/rust/lance-index/src/scalar/inverted/index/posting_reader.rs
+++ b/rust/lance-index/src/scalar/inverted/index/posting_reader.rs
@@ -3,8 +3,85 @@
 
 use super::*;
 
+pub(super) struct PostingFileMetadata {
+    schema: lance_core::datatypes::Schema,
+    num_rows: usize,
+    file_size: Option<u64>,
+}
+
+/// A request's reader is opened only when decoded posting data is missing.
+/// Shared metadata never retains the reader or store that supplied it.
+pub(super) enum PostingReader {
+    Opened {
+        reader: Arc<dyn IndexReader>,
+        metadata: OnceLock<Arc<PostingFileMetadata>>,
+    },
+    Deferred {
+        metadata: Arc<PostingFileMetadata>,
+        store: Arc<dyn IndexStore>,
+        path: String,
+        reader: OnceCell<Arc<dyn IndexReader>>,
+    },
+}
+
+impl PostingReader {
+    fn with_store(&self, store: Arc<dyn IndexStore>, path: String) -> Self {
+        let metadata = match self {
+            Self::Opened { reader, metadata } => metadata
+                .get_or_init(|| {
+                    Arc::new(PostingFileMetadata {
+                        schema: reader.schema().clone(),
+                        num_rows: reader.num_rows(),
+                        file_size: reader.file_size_bytes(),
+                    })
+                })
+                .clone(),
+            Self::Deferred { metadata, .. } => metadata.clone(),
+        };
+        Self::Deferred {
+            metadata,
+            store,
+            path,
+            reader: OnceCell::new(),
+        }
+    }
+
+    pub(super) async fn get(&self) -> Result<&Arc<dyn IndexReader>> {
+        match self {
+            Self::Opened { reader, .. } => Ok(reader),
+            Self::Deferred { metadata, store, path, reader } => reader.get_or_try_init(|| async {
+                let opened = store.open_index_file(path).await?;
+                if opened.num_rows() != metadata.num_rows
+                    || opened.schema() != &metadata.schema
+                    || opened.schema().metadata != metadata.schema.metadata
+                {
+                    return Err(Error::index(format!(
+                        "FTS posting file {path} changed while reopening an immutable index: expected {} rows, got {}",
+                        metadata.num_rows, opened.num_rows()
+                    )));
+                }
+                Ok(opened)
+            }).await,
+        }
+    }
+
+    pub(super) fn num_rows(&self) -> usize {
+        match self {
+            Self::Opened { reader, .. } => reader.num_rows(),
+            Self::Deferred { metadata, .. } => metadata.num_rows,
+        }
+    }
+
+    pub(super) fn file_size_bytes(&self) -> Option<u64> {
+        match self {
+            Self::Opened { reader, .. } => reader.file_size_bytes(),
+            Self::Deferred { metadata, .. } => metadata.file_size,
+        }
+    }
+}
+
 pub struct PostingListReader {
-    pub(super) reader: Arc<dyn IndexReader>,
+    pub(super) reader: PostingReader,
 
     /// Layout-specific metadata. V2 keeps its per-token max-score and
     /// length columns lazy so opening a partition doesn't drag O(num_tokens)
@@ -162,7 +239,10 @@ impl PostingListReader {
         });
 
         Ok(Self {
-            reader,
+            reader: PostingReader::Opened {
+                reader,
+                metadata: OnceLock::new(),
+            },
             metadata,
             has_position,
             has_impacts,
@@ -177,25 +257,17 @@ impl PostingListReader {
         })
     }
 
-    /// Reuse immutable posting state with a reader opened through the current store.
+    /// Reuse immutable posting state with deferred I/O through the current store.
     /// The caller must preserve the index cache namespace: these cells describe
     /// one immutable posting file, not an arbitrary reader with the same schema.
-    pub(super) fn with_reader(&self, reader: Arc<dyn IndexReader>) -> Result<Self> {
+    pub(super) fn with_store(&self, store: Arc<dyn IndexStore>, path: String) -> Result<Self> {
         let PostingMetadata::V2 { metadata } = &self.metadata else {
             return Err(Error::not_supported(
                 "rebinding legacy FTS posting readers requires a full index load",
             ));
         };
-        if reader.num_rows() != self.reader.num_rows()
-            || reader.schema() != self.reader.schema()
-            || reader.schema().metadata != self.reader.schema().metadata
-        {
-            return Err(Error::index(
-                "FTS posting file changed while rebinding an immutable index",
-            ));
-        }
         Ok(Self {
-            reader,
+            reader: self.reader.with_store(store, path),
             metadata: PostingMetadata::V2 {
                 metadata: metadata.clone(),
             },
@@ -367,6 +439,8 @@ impl PostingListReader {
                         let token_id = token_id as usize;
                         let batch = self
                             .reader
+                            .get()
+                            .await?
                             .read_range(token_id..token_id + 1, Some(&[MAX_SCORE_COL, LENGTH_COL]))
                             .await?;
                         let max_score = batch[MAX_SCORE_COL].as_primitive::<Float32Type>().value(0);
@@ -397,6 +471,8 @@ impl PostingListReader {
             .get_or_try_init(|| async {
                 let batch = self
                     .reader
+                    .get()
+                    .await?
                     .read_range(
                         0..self.reader.num_rows(),
                         Some(&[MAX_SCORE_COL, LENGTH_COL]),
@@ -448,6 +524,8 @@ impl PostingListReader {
             }
             let batch = self
                 .reader
+                .get()
+                .await?
                 .read_range(token_id..token_id + 1, Some(&columns))
                 .await?;
             Ok(batch)
@@ -472,6 +550,8 @@ impl PostingListReader {
         let offset = offsets[token_id];
         let batch = self
             .reader
+            .get()
+            .await?
             .read_range(offset..offset + length, Some(&columns))
             .await?;
         Ok(batch)
@@ -723,6 +803,8 @@ impl PostingListReader {
         }
         let batch = self
             .reader
+            .get()
+            .await?
             .read_range(start as usize..end as usize, Some(&columns))
             .await?;
         PostingListGroup::new_packed_with_block_size(

--- a/rust/lance-index/src/scalar/inverted/index/tests/position_cache.rs
+++ b/rust/lance-index/src/scalar/inverted/index/tests/position_cache.rs
@@ -145,6 +145,18 @@ async fn test_prewarm_with_positions_populates_separate_position_cache() {
         .await
         .unwrap();
 
+    let rebound_store = Arc::new(LanceIndexStore::new(
+        ObjectStore::local().into(),
+        tmpdir.clone(),
+        Arc::new(LanceCache::no_cache()),
+    ));
+    let index = index
+        .with_store(rebound_store, None)
+        .await
+        .unwrap()
+        .unwrap();
+    assert!(index.prewarmed_query_state_ready(true));
+
     let inverted_list = &index.partitions[0].inverted_list;
     // The posting cache entry is grouped (issue #7040); the group holds
     // positions-free lists while positions live in their own per-token

--- a/rust/lance-index/src/scalar/inverted/index/tests/position_cache.rs
+++ b/rust/lance-index/src/scalar/inverted/index/tests/position_cache.rs
@@ -150,11 +150,7 @@ async fn test_prewarm_with_positions_populates_separate_position_cache() {
         tmpdir.clone(),
         Arc::new(LanceCache::no_cache()),
     ));
-    let index = index
-        .with_store(rebound_store, None)
-        .await
-        .unwrap()
-        .unwrap();
+    let index = index.with_store(rebound_store, None).unwrap().unwrap();
     assert!(index.prewarmed_query_state_ready(true));
 
     let inverted_list = &index.partitions[0].inverted_list;

--- a/rust/lance-index/src/scalar/inverted/index/tests/query.rs
+++ b/rust/lance-index/src/scalar/inverted/index/tests/query.rs
@@ -2,6 +2,112 @@
 // SPDX-FileCopyrightText: Copyright The Lance Authors
 
 use super::*;
+use crate::scalar::inverted::InvertedIndexPlugin;
+use crate::scalar::registry::ScalarIndexPlugin;
+use lance_core::utils::testing::{ProxyObjectStore, ProxyObjectStorePolicy};
+use lance_io::object_store::WrappingObjectStore;
+use object_store::list::PaginatedListStore;
+
+#[derive(Debug, Default)]
+struct RequestWrapper {
+    policy: Arc<std::sync::Mutex<ProxyObjectStorePolicy>>,
+}
+
+impl WrappingObjectStore for RequestWrapper {
+    fn wrap(
+        &self,
+        _store_prefix: &str,
+        original: Arc<dyn object_store::ObjectStore>,
+    ) -> Arc<dyn object_store::ObjectStore> {
+        Arc::new(ProxyObjectStore::new(original, self.policy.clone()))
+    }
+
+    fn wrap_paginated(
+        &self,
+        _store_prefix: &str,
+        _original: Arc<dyn PaginatedListStore>,
+    ) -> Option<Arc<dyn PaginatedListStore>> {
+        None
+    }
+}
+
+#[tokio::test]
+async fn test_request_wrappers_preserve_prewarmed_index_state() {
+    let object_store = ObjectStore::memory();
+    let directory = object_store::path::Path::from("index");
+    let metadata_cache = Arc::new(LanceCache::with_capacity(1024 * 1024));
+    let store = Arc::new(LanceIndexStore::new(
+        Arc::new(object_store.clone()),
+        directory.clone(),
+        metadata_cache.clone(),
+    ));
+    write_pair_partition(&store, 0, &[("alpha", "beta", 0)]).await;
+    write_pair_partition(&store, 1 << 32, &[("alpha", "gamma", 1 << 32)]).await;
+    write_test_metadata(&store, vec![0, 1 << 32], InvertedIndexParams::default()).await;
+    let cache = LanceCache::with_capacity(1024 * 1024);
+    let terms = vec!["alpha".to_owned(), "beta".to_owned()];
+    let mut first = None;
+    for request in 0..3 {
+        let mut wrapped = object_store.clone();
+        wrapped.apply_wrapper(&RequestWrapper::default());
+        let request_store: Arc<dyn IndexStore> = Arc::new(LanceIndexStore::new(
+            Arc::new(wrapped),
+            directory.clone(),
+            metadata_cache.clone(),
+        ));
+        let load_store = request_store.clone();
+        let load_cache = cache.clone();
+        let index = InvertedIndexPlugin
+            .get_or_insert_in_cache(
+                request_store.clone(),
+                None,
+                &cache,
+                async move {
+                    Ok(InvertedIndex::load(load_store, None, &load_cache).await?
+                        as Arc<dyn ScalarIndex>)
+                }
+                .boxed(),
+            )
+            .await
+            .unwrap();
+        let inverted = index.as_any().downcast_ref::<InvertedIndex>().unwrap();
+        assert!(request_store.is_same_storage_binding(inverted.store.as_ref()));
+        if request == 0 {
+            inverted.prewarm().await.unwrap();
+            first = Some(index.clone());
+        } else {
+            assert!(!Arc::ptr_eq(first.as_ref().unwrap(), &index));
+            assert!(
+                first
+                    .as_ref()
+                    .unwrap()
+                    .as_any()
+                    .downcast_ref::<InvertedIndex>()
+                    .unwrap()
+                    .shares_prewarm_state(inverted)
+            );
+            assert!(
+                inverted.corpus_stats.initialized(),
+                "request {request} discarded immutable prewarmed corpus statistics"
+            );
+        }
+        assert!(inverted.prewarmed_query_state_ready(false));
+        assert_eq!(
+            inverted.bm25_stats_for_terms_if_loaded(&terms).unwrap(),
+            Some((4, 2, vec![2, 1]))
+        );
+    }
+    let independently_loaded = InvertedIndex::load(store, None, &cache).await.unwrap();
+    assert!(
+        !first
+            .unwrap()
+            .as_any()
+            .downcast_ref::<InvertedIndex>()
+            .unwrap()
+            .shares_prewarm_state(&independently_loaded),
+        "loading the same index into a new container must not claim shared prewarm state"
+    );
+}
 
 // Enough distinct tokens that `write_posting_lists` emits several posting-list
 // batches (the default batch size is 256 rows), exercising the restructured

--- a/rust/lance-index/src/scalar/inverted/index/tests/query.rs
+++ b/rust/lance-index/src/scalar/inverted/index/tests/query.rs
@@ -49,7 +49,17 @@ async fn test_request_wrappers_preserve_prewarmed_index_state() {
     let mut first = None;
     for request in 0..3 {
         let mut wrapped = object_store.clone();
-        wrapped.apply_wrapper(&RequestWrapper::default());
+        let wrapper = RequestWrapper::default();
+        let requests = Arc::new(AtomicU32::new(0));
+        let counted_requests = requests.clone();
+        wrapper.policy.lock().unwrap().set_before_policy(
+            "count_request_io",
+            Arc::new(move |_, _| {
+                counted_requests.fetch_add(1, Ordering::Relaxed);
+                Ok(())
+            }),
+        );
+        wrapped.apply_wrapper(&wrapper);
         let request_store: Arc<dyn IndexStore> = Arc::new(LanceIndexStore::new(
             Arc::new(wrapped),
             directory.clone(),
@@ -76,6 +86,11 @@ async fn test_request_wrappers_preserve_prewarmed_index_state() {
             inverted.prewarm().await.unwrap();
             first = Some(index.clone());
         } else {
+            assert_eq!(
+                requests.load(Ordering::Relaxed),
+                0,
+                "a prewarmed request must not reopen partition files, even without file sizes"
+            );
             assert!(!Arc::ptr_eq(first.as_ref().unwrap(), &index));
             assert!(
                 first
@@ -106,6 +121,77 @@ async fn test_request_wrappers_preserve_prewarmed_index_state() {
             .unwrap()
             .shares_prewarm_state(&independently_loaded),
         "loading the same index into a new container must not claim shared prewarm state"
+    );
+}
+
+#[tokio::test]
+async fn test_deferred_posting_reader_retries_current_credentials_and_validates_metadata() {
+    let object_store = ObjectStore::memory();
+    let metadata_cache = Arc::new(LanceCache::with_capacity(1024 * 1024));
+    let store = Arc::new(LanceIndexStore::new(
+        Arc::new(object_store.clone()),
+        "index".into(),
+        metadata_cache.clone(),
+    ));
+    write_pair_partition(&store, 0, &[("alpha", "beta", 0)]).await;
+    let index = load_test_index(store, vec![0]).await;
+    let wrapper = RequestWrapper::default();
+    let revoked = Arc::new(AtomicBool::new(true));
+    let requests = Arc::new(AtomicU32::new(0));
+    let policy_revoked = revoked.clone();
+    let policy_requests = requests.clone();
+    wrapper.policy.lock().unwrap().set_before_policy(
+        "credentials",
+        Arc::new(move |_, _| {
+            policy_requests.fetch_add(1, Ordering::Relaxed);
+            if policy_revoked.load(Ordering::Relaxed) {
+                Err(Error::io("request credentials revoked"))
+            } else {
+                Ok(())
+            }
+        }),
+    );
+    let mut wrapped = object_store;
+    wrapped.apply_wrapper(&wrapper);
+    let store = Arc::new(LanceIndexStore::new(
+        Arc::new(wrapped),
+        "index".into(),
+        metadata_cache,
+    ));
+    let rebound = index.with_store(store, None).unwrap().unwrap();
+    assert_eq!(requests.load(Ordering::Relaxed), 0);
+    let reader = &rebound.partitions[0].inverted_list.reader;
+    let Err(error) = reader.get().await else {
+        panic!("revoked credentials must fail when the request needs a reader");
+    };
+    assert!(matches!(error, Error::IO { .. }), "{error:?}");
+    assert!(error.to_string().contains("request credentials revoked"));
+    revoked.store(false, Ordering::Relaxed);
+    let readers = futures::future::try_join_all((0..8).map(|_| reader.get()))
+        .await
+        .unwrap();
+    assert!(readers.iter().all(|reader| Arc::ptr_eq(reader, readers[0])));
+    assert!(requests.load(Ordering::Relaxed) > 0);
+
+    let changed_store = Arc::new(LanceIndexStore::new(
+        ObjectStore::memory().into(),
+        "index".into(),
+        Arc::new(LanceCache::no_cache()),
+    ));
+    let mut writer = changed_store
+        .new_index_file(&posting_file_path(0), Arc::new(Schema::empty()))
+        .await
+        .unwrap();
+    writer.finish().await.unwrap();
+    let changed = rebound.with_store(changed_store, None).unwrap().unwrap();
+    let Err(error) = changed.partitions[0].inverted_list.reader.get().await else {
+        panic!("changed posting metadata must be rejected before reading data");
+    };
+    assert!(matches!(error, Error::Index { .. }), "{error:?}");
+    assert!(
+        error
+            .to_string()
+            .contains("changed while reopening an immutable index")
     );
 }
 

--- a/rust/lance-index/src/scalar/inverted/index/tests/stats.rs
+++ b/rust/lance-index/src/scalar/inverted/index/tests/stats.rs
@@ -429,7 +429,8 @@ async fn test_loaded_bm25_stats_reports_invalid_loaded_token_id() {
         let PostingMetadata::V2 { metadata } = &mut posting_reader.metadata else {
             panic!("test requires modern posting metadata");
         };
-        metadata
+        Arc::get_mut(metadata)
+            .expect("test metadata should have one owner")
             .get_mut()
             .expect("metadata was loaded above")
             .lengths

--- a/rust/lance-index/src/scalar/lance_format.rs
+++ b/rust/lance-index/src/scalar/lance_format.rs
@@ -41,7 +41,9 @@ pub struct LanceIndexStore {
     scheduler: Arc<ScanScheduler>,
     /// Cached file sizes (filename -> size in bytes)
     /// When set, used to avoid HEAD calls when opening files
-    file_sizes: HashMap<String, u64>,
+    // Partition priority views share this immutable map. Cloning all file names
+    // for every partition would make request rebinding quadratic in partitions.
+    file_sizes: Arc<HashMap<String, u64>>,
     format_version: ConcreteFileVersion,
     /// Base I/O priority for all requests this store submits to `scheduler`.
     io_priority: u64,
@@ -89,7 +91,7 @@ impl LanceIndexStore {
             index_dir,
             metadata_cache,
             scheduler,
-            file_sizes: HashMap::new(),
+            file_sizes: Arc::default(),
             format_version,
             io_priority: 0,
         }
@@ -100,7 +102,7 @@ impl LanceIndexStore {
     /// The map should contain relative paths (e.g., "index.idx") as keys
     /// and file sizes in bytes as values.
     pub fn with_file_sizes(mut self, file_sizes: HashMap<String, u64>) -> Self {
-        self.file_sizes = file_sizes;
+        self.file_sizes = Arc::new(file_sizes);
         self
     }
 

--- a/rust/lance-index/src/scalar/registry.rs
+++ b/rust/lance-index/src/scalar/registry.rs
@@ -387,7 +387,28 @@ where
         return Ok(index.clone());
     }
 
-    if let Some(index) = entry.index_for_store(&index_store) {
+    let binding = entry.binding.load_full();
+    if index_store.is_same_storage_binding(binding.index_store.as_ref()) {
+        return Ok(binding.index.clone());
+    }
+
+    // Reader-free state can be rebound independently for each request. Do not
+    // let a slow or cancelled binding delay unrelated requests. Publish only
+    // if the source binding is still current, so a delayed caller cannot roll
+    // the cache back after another request has replaced it.
+    if let Some(index) = rebind(binding.index.clone()).await? {
+        let previous = entry.binding.compare_and_swap(
+            &binding,
+            Arc::new(StoreBoundScalarIndexBinding {
+                index_store: index_store.clone(),
+                index: index.clone(),
+            }),
+        );
+        if !Arc::ptr_eq(&previous, &binding)
+            && index_store.is_same_storage_binding(previous.index_store.as_ref())
+        {
+            return Ok(previous.index.clone());
+        }
         return Ok(index);
     }
 
@@ -401,13 +422,7 @@ where
     let load = take_scalar_index_load(&pending_load)?.ok_or_else(|| {
         lance_core::Error::internal("store-bound scalar index load has no retained result")
     })?;
-    // The namespace identifies immutable index contents. A plugin may reuse
-    // reader-free state, but must rebuild every storage-bound handle through
-    // the current store before publishing the replacement.
-    let index = match rebind(entry.index()).await? {
-        Some(index) => index,
-        None => load.await?,
-    };
+    let index = load.await?;
     entry.replace(index_store, index.clone());
     Ok(index)
 }
@@ -655,6 +670,59 @@ mod tests {
             .await
             .unwrap();
         assert!(Arc::ptr_eq(&cached.index(), &index_b));
+    }
+
+    #[tokio::test]
+    async fn test_independent_scalar_rebinds_do_not_wait_for_each_other() {
+        let [(store_a, index_a), (store_b, index_b)] = empty_index_bindings().await;
+        let [(store_c, index_c), _] = empty_index_bindings().await;
+        let cache = LanceCache::with_capacity(1024 * 1024);
+        let entry = Arc::new(StoreBoundScalarIndexCacheEntry::new(store_a, index_a));
+        cache
+            .insert_unsized_with_key(&ScalarIndexCacheKey, entry.clone())
+            .await;
+        let started = Arc::new(Notify::new());
+        let resume = Arc::new(Notify::new());
+        let slow_started = started.clone();
+        let slow_resume = resume.clone();
+        let slow_cache = cache.clone();
+        let slow_index = index_b.clone();
+        let slow = tokio::spawn(async move {
+            single_flight_store_bound_open(
+                store_b,
+                &slow_cache,
+                async { panic!("warm request must not reload metadata") }.boxed(),
+                |_| async move {
+                    slow_started.notify_one();
+                    slow_resume.notified().await;
+                    Ok(Some(slow_index))
+                },
+            )
+            .await
+        });
+        started.notified().await;
+        let fast_index = index_c.clone();
+        let fast = tokio::time::timeout(
+            std::time::Duration::from_millis(500),
+            single_flight_store_bound_open(
+                store_c,
+                &cache,
+                async { panic!("warm request must not reload metadata") }.boxed(),
+                |_| async move { Ok(Some(fast_index)) },
+            ),
+        )
+        .await;
+        resume.notify_one();
+        let slow = slow.await.unwrap().unwrap();
+        let fast = fast
+            .expect("an independent request waited for another binding's rebind")
+            .unwrap();
+        assert!(Arc::ptr_eq(&slow, &index_b));
+        assert!(Arc::ptr_eq(&fast, &index_c));
+        assert!(
+            Arc::ptr_eq(&entry.index(), &index_c),
+            "a delayed rebind must not overwrite the newer cache binding"
+        );
     }
 
     #[tokio::test]

--- a/rust/lance-index/src/scalar/registry.rs
+++ b/rust/lance-index/src/scalar/registry.rs
@@ -2,7 +2,8 @@
 // SPDX-FileCopyrightText: Copyright The Lance Authors
 
 use std::borrow::Cow;
-use std::sync::{Arc, Mutex};
+use std::future::Future;
+use std::sync::{Arc, Mutex, OnceLock};
 
 use arc_swap::ArcSwap;
 use arrow_schema::{DataType, Field};
@@ -348,13 +349,20 @@ where
     from_state(state)
 }
 
-pub(crate) async fn single_flight_store_bound_open(
+pub(crate) async fn single_flight_store_bound_open<Rebind, RebindFuture>(
     index_store: Arc<dyn IndexStore>,
     cache: &LanceCache,
     load: ScalarIndexLoad<'_>,
-) -> Result<Arc<dyn ScalarIndex>> {
+    rebind: Rebind,
+) -> Result<Arc<dyn ScalarIndex>>
+where
+    Rebind: FnOnce(Arc<dyn ScalarIndex>) -> RebindFuture + Send,
+    RebindFuture: Future<Output = Result<Option<Arc<dyn ScalarIndex>>>> + Send,
+{
     let pending_load = Arc::new(Mutex::new(Some(load)));
     let cache_load = pending_load.clone();
+    let loaded_index = Arc::new(OnceLock::new());
+    let cache_loaded_index = loaded_index.clone();
     let cache_index_store = index_store.clone();
     let entry = cache
         .get_or_insert_unsized_with_key(ScalarIndexCacheKey, move || async move {
@@ -364,12 +372,20 @@ pub(crate) async fn single_flight_store_bound_open(
                 )
             })?;
             let index = load.await?;
+            cache_loaded_index.get_or_init(|| index.clone());
             Ok(Arc::new(StoreBoundScalarIndexCacheEntry::new(
                 cache_index_store,
                 index,
             )))
         })
         .await?;
+
+    // Another request can replace the shared slot after our load is published
+    // but before this caller resumes. Keep the result of our own load so that
+    // this request always receives the storage binding it opened.
+    if let Some(index) = loaded_index.get() {
+        return Ok(index.clone());
+    }
 
     if let Some(index) = entry.index_for_store(&index_store) {
         return Ok(index);
@@ -382,13 +398,16 @@ pub(crate) async fn single_flight_store_bound_open(
         return Ok(index);
     }
 
-    let Some(load) = take_scalar_index_load(&pending_load)? else {
-        // The cache loader ran, so this entry was opened through `index_store`.
-        // A custom store may conservatively report no binding equivalence even
-        // when compared with the same instance.
-        return Ok(entry.index());
+    let load = take_scalar_index_load(&pending_load)?.ok_or_else(|| {
+        lance_core::Error::internal("store-bound scalar index load has no retained result")
+    })?;
+    // The namespace identifies immutable index contents. A plugin may reuse
+    // reader-free state, but must rebuild every storage-bound handle through
+    // the current store before publishing the replacement.
+    let index = match rebind(entry.index()).await? {
+        Some(index) => index,
+        None => load.await?,
     };
-    let index = load.await?;
     entry.replace(index_store, index.clone());
     Ok(index)
 }
@@ -478,5 +497,224 @@ impl UnsizedCacheKey for ScalarIndexCacheKey {
 
     fn write_key(&self, builder: &mut KeyBuilder) {
         builder.write_variant(0);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::{collections::HashMap, pin::Pin};
+
+    use arrow_schema::Schema;
+    use futures::FutureExt;
+    use lance_core::cache::{
+        CacheBackend, CacheCodec, CacheEntry, InternalCacheKey, MokaCacheBackend,
+    };
+    use lance_io::object_store::ObjectStore;
+    use tokio::sync::Notify;
+
+    use crate::scalar::inverted::{
+        InvertedIndex, InvertedIndexParams, METADATA_FILE, TOKEN_SET_FORMAT_KEY, TokenSetFormat,
+    };
+    use crate::scalar::lance_format::LanceIndexStore;
+
+    /// Pause the cold caller after publication, allowing a warm caller to rotate
+    /// the same entry before the cold caller receives its result.
+    #[derive(Debug)]
+    struct PauseColdReturn {
+        inner: MokaCacheBackend,
+        published: Notify,
+        resume: Notify,
+    }
+
+    #[async_trait]
+    impl CacheBackend for PauseColdReturn {
+        async fn get(
+            &self,
+            key: &InternalCacheKey,
+            codec: Option<CacheCodec>,
+        ) -> Option<CacheEntry> {
+            self.inner.get(key, codec).await
+        }
+
+        async fn insert(
+            &self,
+            key: &InternalCacheKey,
+            entry: CacheEntry,
+            size_bytes: usize,
+            codec: Option<CacheCodec>,
+        ) {
+            self.inner.insert(key, entry, size_bytes, codec).await;
+        }
+
+        async fn get_or_insert<'a>(
+            &self,
+            key: &InternalCacheKey,
+            loader: Pin<Box<dyn Future<Output = Result<(CacheEntry, usize)>> + Send + 'a>>,
+            codec: Option<CacheCodec>,
+        ) -> Result<(CacheEntry, bool)> {
+            let result = self.inner.get_or_insert(key, loader, codec).await?;
+            if !result.1 {
+                self.published.notify_one();
+                self.resume.notified().await;
+            }
+            Ok(result)
+        }
+
+        async fn clear(&self) {
+            self.inner.clear().await;
+        }
+
+        async fn num_entries(&self) -> usize {
+            self.inner.num_entries().await
+        }
+
+        async fn size_bytes(&self) -> usize {
+            self.inner.size_bytes().await
+        }
+    }
+
+    async fn empty_index_bindings() -> [(Arc<dyn IndexStore>, Arc<dyn ScalarIndex>); 2] {
+        let object_store = ObjectStore::memory();
+        let metadata_cache = Arc::new(LanceCache::with_capacity(1024 * 1024));
+        let store_a: Arc<dyn IndexStore> = Arc::new(LanceIndexStore::new(
+            Arc::new(object_store.clone()),
+            "index".into(),
+            metadata_cache.clone(),
+        ));
+        let store_b: Arc<dyn IndexStore> = Arc::new(LanceIndexStore::new(
+            Arc::new(object_store),
+            "index".into(),
+            metadata_cache,
+        ));
+        assert!(!store_a.is_same_storage_binding(store_b.as_ref()));
+        let mut writer = store_a
+            .new_index_file(METADATA_FILE, Arc::new(Schema::empty()))
+            .await
+            .unwrap();
+        writer
+            .finish_with_metadata(HashMap::from([
+                ("partitions".to_owned(), "[]".to_owned()),
+                (
+                    "params".to_owned(),
+                    serde_json::to_string(&InvertedIndexParams::default()).unwrap(),
+                ),
+                (
+                    TOKEN_SET_FORMAT_KEY.to_owned(),
+                    TokenSetFormat::default().to_string(),
+                ),
+            ]))
+            .await
+            .unwrap();
+        let index_cache = LanceCache::no_cache();
+        let index_a = InvertedIndex::load(store_a.clone(), None, &index_cache)
+            .await
+            .unwrap();
+        let index_b = InvertedIndex::load(store_b.clone(), None, &index_cache)
+            .await
+            .unwrap();
+        [(store_a, index_a), (store_b, index_b)]
+    }
+
+    #[tokio::test]
+    async fn test_cold_scalar_open_keeps_its_binding_after_concurrent_rotation() {
+        let [(store_a, index_a), (store_b, index_b)] = empty_index_bindings().await;
+        let backend = Arc::new(PauseColdReturn {
+            inner: MokaCacheBackend::with_capacity(1024 * 1024),
+            published: Notify::new(),
+            resume: Notify::new(),
+        });
+        let cache = LanceCache::with_backend(backend.clone());
+        let cold_cache = cache.clone();
+        let cold_index = index_a.clone();
+        let cold = tokio::spawn(async move {
+            single_flight_store_bound_open(
+                store_a,
+                &cold_cache,
+                async move { Ok(cold_index) }.boxed(),
+                |_| async { panic!("cold caller must keep its own loaded index") },
+            )
+            .await
+        });
+        backend.published.notified().await;
+        let replacement = index_b.clone();
+        let warm = single_flight_store_bound_open(
+            store_b,
+            &cache,
+            async { panic!("warm caller must rebind the cached index") }.boxed(),
+            |_| async move { Ok(Some(replacement)) },
+        )
+        .await
+        .unwrap();
+        assert!(Arc::ptr_eq(&warm, &index_b));
+        backend.resume.notify_one();
+        let cold = cold.await.unwrap().unwrap();
+        assert!(Arc::ptr_eq(&cold, &index_a));
+        let cached = cache
+            .get_unsized_with_key(&ScalarIndexCacheKey)
+            .await
+            .unwrap();
+        assert!(Arc::ptr_eq(&cached.index(), &index_b));
+    }
+
+    #[tokio::test]
+    async fn test_failed_or_cancelled_scalar_rebind_preserves_cached_binding() {
+        let [(store_a, index_a), (store_b, index_b)] = empty_index_bindings().await;
+        let cache = LanceCache::with_capacity(1024 * 1024);
+        let entry = Arc::new(StoreBoundScalarIndexCacheEntry::new(
+            store_a,
+            index_a.clone(),
+        ));
+        cache
+            .insert_unsized_with_key(&ScalarIndexCacheKey, entry.clone())
+            .await;
+        let error = single_flight_store_bound_open(
+            store_b.clone(),
+            &cache,
+            async { panic!("failed rebind must not fall back to loading") }.boxed(),
+            |_| async { Err(lance_core::Error::io("replacement credentials revoked")) },
+        )
+        .await
+        .unwrap_err();
+        assert!(matches!(error, lance_core::Error::IO { .. }));
+        assert!(
+            error
+                .to_string()
+                .contains("replacement credentials revoked")
+        );
+        assert!(Arc::ptr_eq(&entry.index(), &index_a));
+
+        let started = Arc::new(Notify::new());
+        let cancel_started = started.clone();
+        let cancel_cache = cache.clone();
+        let cancel_store = store_b.clone();
+        let cancelled = tokio::spawn(async move {
+            single_flight_store_bound_open(
+                cancel_store,
+                &cancel_cache,
+                async { panic!("cancelled rebind must not fall back to loading") }.boxed(),
+                |_| async move {
+                    cancel_started.notify_one();
+                    futures::future::pending().await
+                },
+            )
+            .await
+        });
+        started.notified().await;
+        cancelled.abort();
+        assert!(cancelled.await.unwrap_err().is_cancelled());
+        assert!(Arc::ptr_eq(&entry.index(), &index_a));
+
+        let replacement = index_b.clone();
+        let reopened = single_flight_store_bound_open(
+            store_b,
+            &cache,
+            async { panic!("retry must rebind the cached index") }.boxed(),
+            |_| async move { Ok(Some(replacement)) },
+        )
+        .await
+        .unwrap();
+        assert!(Arc::ptr_eq(&reopened, &index_b));
+        assert!(Arc::ptr_eq(&entry.index(), &index_b));
     }
 }

--- a/rust/lance-index/src/traits.rs
+++ b/rust/lance-index/src/traits.rs
@@ -188,6 +188,8 @@ impl Display for FtsPrewarmDiagnostics {
 pub struct FtsPrewarmSegmentStatus {
     pub segment_id: String,
     pub scalar_index_container_resident: bool,
+    /// Whether the cached container shares the opened segment's prewarm state,
+    /// including when its storage readers have been rebound to another request.
     pub scalar_index_container_matches_prewarmed: bool,
 }
 
@@ -204,7 +206,7 @@ impl Display for FtsPrewarmSegmentStatus {
             missing.push("resident scalar index container");
         }
         if !self.scalar_index_container_matches_prewarmed {
-            missing.push("stable scalar index container identity");
+            missing.push("shared scalar index prewarm state");
         }
         write!(
             f,

--- a/rust/lance/src/index.rs
+++ b/rust/lance/src/index.rs
@@ -545,7 +545,7 @@ async fn aggregate_fts_prewarm_results(
             .and_then(|index| index.as_any().downcast_ref::<InvertedIndex>());
         let container_resident = cached_inverted.is_some();
         let container_matches_prewarmed = match (prewarmed_inverted, cached_inverted) {
-            (Some(prewarmed), Some(cached)) => std::ptr::addr_eq(prewarmed, cached),
+            (Some(prewarmed), Some(cached)) => prewarmed.shares_prewarm_state(cached),
             _ => false,
         };
 
@@ -3754,6 +3754,7 @@ mod tests {
     use futures::{future::try_join_all, stream::TryStreamExt};
     use lance_arrow::*;
     use lance_core::utils::tempfile::TempStrDir;
+    use lance_core::utils::testing::{ProxyObjectStore, ProxyObjectStorePolicy};
     use lance_datagen::gen_batch;
     use lance_datagen::{BatchCount, ByteCount, Dimension, RowCount, array};
     use lance_index::metrics::LocalMetricsCollector;
@@ -3775,7 +3776,9 @@ mod tests {
     };
     use lance_io::{
         assert_io_eq, assert_io_lt,
-        object_store::{ObjectStore, ObjectStoreParams, StorageOptionsAccessor},
+        object_store::{
+            ObjectStore, ObjectStoreParams, StorageOptionsAccessor, WrappingObjectStore,
+        },
         utils::tracking_store::IoStats,
     };
     use lance_linalg::distance::{DistanceType, MetricType};
@@ -3784,7 +3787,10 @@ mod tests {
     use rstest::rstest;
     use std::{
         collections::{HashMap, HashSet},
-        sync::atomic::Ordering,
+        sync::{
+            Mutex,
+            atomic::{AtomicBool, Ordering},
+        },
     };
 
     async fn write_vector_segment_metadata(
@@ -3823,8 +3829,67 @@ mod tests {
         }
     }
 
+    #[derive(Debug)]
+    struct RequestIndexStoreWrapper {
+        policy: Arc<Mutex<ProxyObjectStorePolicy>>,
+        revoked: Arc<AtomicBool>,
+        requests: Arc<Mutex<Vec<String>>>,
+    }
+
+    impl RequestIndexStoreWrapper {
+        fn new(index_path: String) -> Self {
+            let revoked = Arc::new(AtomicBool::new(false));
+            let requests = Arc::new(Mutex::new(Vec::new()));
+            let mut policy = ProxyObjectStorePolicy::new();
+            let policy_revoked = revoked.clone();
+            let policy_requests = requests.clone();
+            policy.set_before_policy(
+                "observe_index_reads",
+                Arc::new(move |method, path| {
+                    if path.as_ref().contains(&index_path) {
+                        policy_requests.lock().unwrap().push(method.to_owned());
+                        if policy_revoked.load(Ordering::Relaxed) {
+                            return Err(object_store::Error::Generic {
+                                store: "RequestIndexStoreWrapper",
+                                source: "request credentials have been revoked".into(),
+                            }
+                            .into());
+                        }
+                    }
+                    Ok(())
+                }),
+            );
+            Self {
+                policy: Arc::new(Mutex::new(policy)),
+                revoked,
+                requests,
+            }
+        }
+    }
+
+    impl WrappingObjectStore for RequestIndexStoreWrapper {
+        fn wrap(
+            &self,
+            _storage_prefix: &str,
+            original: Arc<dyn object_store::ObjectStore>,
+        ) -> Arc<dyn object_store::ObjectStore> {
+            Arc::new(ProxyObjectStore::new(original, self.policy.clone()))
+        }
+
+        fn wrap_paginated(
+            &self,
+            _store_prefix: &str,
+            _original: Arc<dyn object_store::list::PaginatedListStore>,
+        ) -> Option<Arc<dyn object_store::list::PaginatedListStore>> {
+            None
+        }
+    }
+
+    #[rstest]
+    #[case::credential_stores(false)]
+    #[case::request_wrappers(true)]
     #[tokio::test]
-    async fn test_scalar_cache_uses_current_object_store() {
+    async fn test_scalar_cache_uses_current_object_store(#[case] request_wrappers: bool) {
         async fn search_ids(dataset: &Dataset, term: &str) -> Vec<i32> {
             let result = dataset
                 .scan()
@@ -3907,67 +3972,76 @@ mod tests {
             .await
             .unwrap();
 
-        let store_params_a = ObjectStoreParams {
-            storage_options_accessor: Some(Arc::new(StorageOptionsAccessor::with_static_options(
-                HashMap::from([(
-                    "credential_generation".to_owned(),
-                    "secret-generation-a".to_owned(),
-                )]),
-            ))),
-            ..Default::default()
-        };
-        let (store_a, _) = ObjectStore::from_uri_and_params(
-            dataset.session().store_registry(),
-            dataset.uri(),
-            &store_params_a,
-        )
-        .await
-        .unwrap();
-        let dataset_a = dataset.with_object_store(store_a.clone(), Some(store_params_a));
-
-        let store_params_b = ObjectStoreParams {
-            storage_options_accessor: Some(Arc::new(StorageOptionsAccessor::with_static_options(
-                HashMap::from([(
-                    "credential_generation".to_owned(),
-                    "secret-generation-b".to_owned(),
-                )]),
-            ))),
-            ..Default::default()
-        };
-        let (store_b, _) = ObjectStore::from_uri_and_params(
-            dataset.session().store_registry(),
-            dataset.uri(),
-            &store_params_b,
-        )
-        .await
-        .unwrap();
-        assert!(!Arc::ptr_eq(&store_a, &store_b));
-        let dataset_b = dataset.with_object_store(store_b.clone(), Some(store_params_b));
         let index_path_fragment = format!("_indices/{}", index_meta.uuid);
+        let wrapper_a = Arc::new(RequestIndexStoreWrapper::new(index_path_fragment.clone()));
+        let wrapper_b = Arc::new(RequestIndexStoreWrapper::new(index_path_fragment));
+        let mut requests = Vec::with_capacity(2);
+        for (generation, wrapper) in [("a", &wrapper_a), ("b", &wrapper_b)] {
+            let request = if request_wrappers {
+                dataset
+                    .with_object_store_wrappers([wrapper.clone() as Arc<dyn WrappingObjectStore>])
+            } else {
+                let store_params = ObjectStoreParams {
+                    storage_options_accessor: Some(Arc::new(
+                        StorageOptionsAccessor::with_static_options(HashMap::from([(
+                            "credential_generation".to_owned(),
+                            format!("secret-generation-{generation}"),
+                        )])),
+                    )),
+                    object_store_wrapper: Some(wrapper.clone()),
+                    ..Default::default()
+                };
+                let (store, _) = ObjectStore::from_uri_and_params(
+                    dataset.session().store_registry(),
+                    dataset.uri(),
+                    &store_params,
+                )
+                .await
+                .unwrap();
+                dataset.with_object_store(store, Some(store_params))
+            };
+            requests.push(request);
+        }
+        let dataset_a = &requests[0];
+        let dataset_b = &requests[1];
+        assert!(!Arc::ptr_eq(
+            &dataset_a.object_store,
+            &dataset_b.object_store
+        ));
+        assert!(!Arc::ptr_eq(
+            &dataset_a.object_store.inner,
+            &dataset_b.object_store.inner
+        ));
 
-        let _ = store_a.io_stats_incremental();
-        let _ = store_b.io_stats_incremental();
-        assert_eq!(search_ids(&dataset_a, "alpha").await, vec![0, 3, 6]);
-        let first_store_stats = store_a.io_stats_incremental();
+        let initial_metrics = LocalMetricsCollector::default();
+        let initial = dataset_a
+            .open_scalar_index("text", &index_meta.uuid, &initial_metrics)
+            .await
+            .unwrap();
+        assert_eq!(initial_metrics.index_loads.load(Ordering::Relaxed), 1);
+        initial.prewarm().await.unwrap();
+        assert_eq!(search_ids(dataset_a, "alpha").await, vec![0, 3, 6]);
         assert!(
-            first_store_stats
-                .requests
-                .iter()
-                .any(|request| request.path.as_ref().contains(&index_path_fragment)),
-            "the first query should read the FTS index through store A: {first_store_stats:#?}"
+            !wrapper_a.requests.lock().unwrap().is_empty(),
+            "the first request must read the FTS index through store A"
         );
-        let _ = store_b.io_stats_incremental();
+        wrapper_a.requests.lock().unwrap().clear();
+        wrapper_b.requests.lock().unwrap().clear();
 
-        assert_eq!(search_ids(&dataset_a, "alpha").await, vec![0, 3, 6]);
-        let warm_store_stats = store_a.io_stats_incremental();
+        let same_binding_metrics = LocalMetricsCollector::default();
+        let same_binding = dataset_a
+            .open_scalar_index("text", &index_meta.uuid, &same_binding_metrics)
+            .await
+            .unwrap();
+        assert!(Arc::ptr_eq(&initial, &same_binding));
+        assert_eq!(same_binding_metrics.index_loads.load(Ordering::Relaxed), 0);
+        assert_eq!(search_ids(dataset_a, "alpha").await, vec![0, 3, 6]);
         assert!(
-            !warm_store_stats
-                .requests
-                .iter()
-                .any(|request| request.path.as_ref().contains(&index_path_fragment)),
-            "the same store binding should reuse the live scalar index: {warm_store_stats:#?}"
+            wrapper_a.requests.lock().unwrap().is_empty(),
+            "the same store binding should reuse the prewarmed scalar index"
         );
 
+        wrapper_a.revoked.store(true, Ordering::Relaxed);
         let rotation_metrics = LocalMetricsCollector::default();
         let opened = try_join_all(
             (0..8)
@@ -3976,58 +4050,143 @@ mod tests {
         .await
         .unwrap();
         assert_eq!(opened.len(), 8);
+        assert!(opened.iter().all(|index| Arc::ptr_eq(index, &opened[0])));
+        assert!(!Arc::ptr_eq(&initial, &opened[0]));
         assert_eq!(
             rotation_metrics.index_loads.load(Ordering::Relaxed),
-            1,
-            "concurrent opens after rotation should coalesce onto one store-B load"
-        );
-
-        assert_eq!(search_ids(&dataset_b, "beta").await, vec![1, 4, 7]);
-        let old_store_stats = store_a.io_stats_incremental();
-        let new_store_stats = store_b.io_stats_incremental();
-        assert!(
-            !old_store_stats
-                .requests
-                .iter()
-                .any(|request| request.path.as_ref().contains(&index_path_fragment)),
-            "the second dataset must not use the scalar index bound to store A: {old_store_stats:#?}"
+            0,
+            "concurrent opens after rotation should reuse metadata without a full index load"
         );
         assert!(
-            new_store_stats
-                .requests
-                .iter()
-                .any(|request| request.path.as_ref().contains(&index_path_fragment)),
-            "the second dataset should read the scalar index through store B: {new_store_stats:#?}"
+            opened[0]
+                .as_any()
+                .downcast_ref::<InvertedIndex>()
+                .unwrap()
+                .prewarm_residency_result(false)
+                .await
+                .fully_resident,
+            "request B must retain the prewarmed query state before another prewarm"
         );
+        // A request can rebind the cached shell between prewarming and the
+        // final residency check. B still owns the runtime state prepared by A.
+        let result = aggregate_fts_prewarm_results(
+            dataset_a,
+            vec![OpenedSegmentPrewarmResult {
+                index_uuid: index_meta.uuid,
+                partition_count: initial
+                    .as_any()
+                    .downcast_ref::<InvertedIndex>()
+                    .unwrap()
+                    .partition_count(),
+                index: initial.clone(),
+            }],
+            None,
+        )
+        .await
+        .unwrap();
+        assert!(result.fully_resident);
+        assert_eq!(search_ids(dataset_b, "beta").await, vec![1, 4, 7]);
+        assert!(wrapper_a.requests.lock().unwrap().is_empty());
 
         let scalar_cache = dataset.index_cache.for_index(&index_meta.uuid, None);
+        let cached = scalar_cache
+            .get_unsized_with_key(&ScalarIndexCacheKey)
+            .await
+            .expect("the live scalar index should be cached with store B's binding");
+        assert!(Arc::ptr_eq(&cached.index(), &opened[0]));
+
+        // Evict decoded values while retaining the live shell. A fully warm query
+        // cannot prove that cache misses use the current request's credentials.
+        scalar_cache.clear().await;
+        scalar_cache
+            .insert_unsized_with_key(&ScalarIndexCacheKey, cached.clone())
+            .await;
+        wrapper_b.requests.lock().unwrap().clear();
+        assert_eq!(search_ids(dataset_b, "beta").await, vec![1, 4, 7]);
         assert!(
-            scalar_cache
-                .get_unsized_with_key(&ScalarIndexCacheKey)
-                .await
-                .is_some(),
-            "the live scalar index should be cached with store B's binding"
+            wrapper_a.requests.lock().unwrap().is_empty(),
+            "request B must not issue index I/O through revoked store A"
+        );
+        assert!(
+            wrapper_b
+                .requests
+                .lock()
+                .unwrap()
+                .iter()
+                .any(|method| matches!(method.as_str(), "get_opts" | "get_ranges")),
+            "request B must read uncached index data through store B"
         );
 
-        let _ = store_a.io_stats_incremental();
-        let _ = store_b.io_stats_incremental();
-        assert_eq!(search_ids(&dataset_a, "gamma").await, vec![2, 5]);
-        let reopened_store_stats = store_a.io_stats_incremental();
-        let untouched_store_stats = store_b.io_stats_incremental();
+        scalar_cache.clear().await;
+        scalar_cache
+            .insert_unsized_with_key(&ScalarIndexCacheKey, cached)
+            .await;
+        wrapper_a.revoked.store(false, Ordering::Relaxed);
+        wrapper_b.revoked.store(true, Ordering::Relaxed);
+        wrapper_a.requests.lock().unwrap().clear();
+        wrapper_b.requests.lock().unwrap().clear();
+        assert_eq!(search_ids(dataset_a, "gamma").await, vec![2, 5]);
         assert!(
-            reopened_store_stats
+            wrapper_a
                 .requests
+                .lock()
+                .unwrap()
                 .iter()
-                .any(|request| request.path.as_ref().contains(&index_path_fragment)),
-            "re-querying dataset A should replace store B's binding and read through store A: {reopened_store_stats:#?}"
+                .any(|method| matches!(method.as_str(), "get_opts" | "get_ranges")),
+            "re-querying dataset A must read uncached index data through store A"
         );
         assert!(
-            !untouched_store_stats
-                .requests
-                .iter()
-                .any(|request| request.path.as_ref().contains(&index_path_fragment)),
-            "re-querying dataset A must not use store B: {untouched_store_stats:#?}"
+            wrapper_b.requests.lock().unwrap().is_empty(),
+            "re-querying dataset A must not issue index I/O through revoked store B"
         );
+    }
+
+    #[tokio::test]
+    async fn test_request_wrappers_reload_legacy_fts_fixture() {
+        let test_dir = copy_test_data_to_tmp("0.27.0/legacy_fts_index").unwrap();
+        let dataset = Dataset::open(&test_dir.path_str()).await.unwrap();
+        let indices = dataset.load_indices().await.unwrap();
+        assert_eq!(indices.len(), 1);
+        let uuid = indices[0].uuid;
+
+        for _ in 0..2 {
+            let wrapper = Arc::new(RequestIndexStoreWrapper::new(format!("_indices/{uuid}")));
+            let request = dataset
+                .with_object_store_wrappers([wrapper.clone() as Arc<dyn WrappingObjectStore>]);
+            let metrics = LocalMetricsCollector::default();
+            let index = request
+                .open_scalar_index("text", &uuid, &metrics)
+                .await
+                .unwrap();
+            assert!(
+                index
+                    .as_any()
+                    .downcast_ref::<InvertedIndex>()
+                    .unwrap()
+                    .is_legacy()
+            );
+            assert_eq!(
+                metrics.index_loads.load(Ordering::Relaxed),
+                1,
+                "legacy readers must still be reloaded through each request's store"
+            );
+            let result = request
+                .scan()
+                .project(&["text"])
+                .unwrap()
+                .full_text_search(FullTextSearchQuery::new("happy".to_owned()))
+                .unwrap()
+                .try_into_batch()
+                .await
+                .unwrap();
+            assert_eq!(result.num_rows(), 1);
+            assert_eq!(
+                result["text"].as_string::<i32>().value(0),
+                "frodo was a happy puppy"
+            );
+            assert!(!wrapper.requests.lock().unwrap().is_empty());
+            wrapper.revoked.store(true, Ordering::Relaxed);
+        }
     }
 
     fn list_io_stats(stats: &IoStats) -> IoStats {
@@ -5455,6 +5614,34 @@ mod tests {
         )
         .await;
         assert_eq!(phrase_ids, (0..300).step_by(3).collect::<Vec<_>>());
+
+        for _ in 0..2 {
+            let wrapper = Arc::new(RequestIndexStoreWrapper::new(format!(
+                "_indices/{}",
+                indices[0].uuid
+            )));
+            let request = dataset
+                .with_object_store_wrappers([wrapper.clone() as Arc<dyn WrappingObjectStore>]);
+            assert_eq!(
+                search_ids(
+                    &request,
+                    FullTextSearchQuery::new("compatibility".to_owned())
+                )
+                .await,
+                match_ids
+            );
+            let phrase =
+                PhraseQuery::new("lance database".to_owned()).with_column(Some("text".to_owned()));
+            assert_eq!(
+                search_ids(
+                    &request,
+                    FullTextSearchQuery::new_query(FtsQuery::Phrase(phrase))
+                )
+                .await,
+                phrase_ids
+            );
+            wrapper.revoked.store(true, Ordering::Relaxed);
+        }
     }
 
     #[rstest]

--- a/rust/lance/src/index.rs
+++ b/rust/lance/src/index.rs
@@ -4087,6 +4087,10 @@ mod tests {
         assert!(result.fully_resident);
         assert_eq!(search_ids(dataset_b, "beta").await, vec![1, 4, 7]);
         assert!(wrapper_a.requests.lock().unwrap().is_empty());
+        assert!(
+            wrapper_b.requests.lock().unwrap().is_empty(),
+            "a new request must serve the prewarmed index without opening partition files"
+        );
 
         let scalar_cache = dataset.index_cache.for_index(&index_meta.uuid, None);
         let cached = scalar_cache


### PR DESCRIPTION
Request-scoped object-store wrappers create a new storage binding on every request. After #7962, this fully reloads the cached FTS index and discards its prewarmed state even though the index contents have not changed. Reusing the old live index would violate the credential and wrapper isolation required by #7959.

This PR shares reader-free FTS state while keeping storage handles bound to the current request. A prewarmed query can cross a wrapper boundary without opening partition files; cache misses still read through the current store.

### Changes

- Share token dictionaries, corpus statistics, posting metadata/validation, and document/prewarm state within the existing index UUID and fragment-reuse UUID cache namespace.
- Defer posting-reader creation until a decoded-cache miss, then validate the reopened file's metadata. Failed initialization can retry with the current store.
- Rebind warm handles outside the replacement mutex and publish with compare-and-swap. Preserve each cold caller's own result and prevent delayed rebinds from overwriting newer bindings.
- Share file-size maps across partition priority views, avoiding quadratic copying of the complete file list.
- Check shared prewarm-state identity when auditing completion, so a concurrent reader rebind does not produce a false failure.

Strict live binding equality is unchanged. Legacy FTS readers retain the full-reload path. There are no persisted-format, dependency, or breaking API changes; `InvertedIndex::shares_prewarm_state` is additive. No Sophon wrapper-lifetime change is required.

### Validation

- `ulimit -n 4096; cargo test -p lance-index --lib`: **1276 passed**, 3 existing ignored tests.
- Targeted Lance tests: **14 passed**, covering the actual Dataset wrapper API, A/B/A store rotation with revoked old wrappers, cache-miss I/O ownership, prewarm completion/residency, and released FTS fixtures from 0.27.0, 3.0.1, and 4.0.1.
- Regression tests reproduce lost prewarm state, unnecessary warm file opens, and head-of-line blocking before the fixes; they also cover concurrent publication, cancellation, deferred-open retries, and metadata mismatch rejection.
- `cargo fmt --all` and `cargo clippy --all --tests --benches -- -D warnings`: passed on the PR head.

One full-suite run at macOS's default 256-file descriptor limit hit `EMFILE` in the unchanged vector shuffler test. Its isolated retry and the complete suite with a process-local limit of 4096 passed; no vector code or global system setting was changed.

### Warm request-open benchmark

**This measures incremental improvements within this PR, not improvement against `main` or production query QPS.** The baseline is the intermediate state-sharing implementation at `9ca53d1d712e2b877c5a30cb948fd67f88dcf2e8` (the first commit); the measured final head is `1a4795e7e8e5e7d02e915203c84b809d82904b46`.

Apple M4 / 10 cores, 8 Tokio workers, Rust 1.97.0, repository `release-with-debug` profile. Both revisions use the identical `inverted_request_cache` Criterion harness, an in-memory store, 32 documents per partition with one token per document, and prewarmed 64 MiB metadata/index caches. Measurement includes request wrapper/store construction, task spawning, and per-batch I/O-accounting drain; it excludes query scoring, cold-data I/O, and network latency.

Two sequential A/B pairs, 20 samples per scenario per run, 1 s warmup, and a requested 2 s measurement window (automatically extended for slow scenarios). Values below are the median of 40 samples normalized as `sample time / iterations`; each iteration completes a batch of 64 request opens. No samples were removed. Agent builds and validation jobs finished before measurement; the development host was not CPU-pinned.

| Scenario / metric: 64-request batch latency (lower is better) | Baseline `9ca53d1d7` | This PR `1a4795e7e` | Benefit |
| --- | ---: | ---: | ---: |
| 32 partitions, file sizes absent | 30.91 ms/batch | 0.7392 ms/batch | 41.8x speedup |
| 32 partitions, file sizes known | 36.40 ms/batch | 0.7963 ms/batch | 45.7x speedup |
| 256 partitions, file sizes absent | 380.73 ms/batch | 4.7478 ms/batch | 80.2x speedup |
| 256 partitions, file sizes known | 867.85 ms/batch | 4.5079 ms/batch | 192.5x speedup |

The paired speedups were respectively 40.5x/45.0x, 43.9x/47.2x, 76.4x/83.7x, and 194.6x/191.2x. All 12 tested combinations of 1/32/256 partitions, known/absent file sizes, and batches of 1/64 improved. The single-request, 256-partition, known-size case was noisy (current run medians 0.2598 ms and 0.09275 ms), so it is not used as primary evidence above.

Reproduce with the checked-in benchmark source and Cargo bench declaration on both revisions:

```sh
ulimit -n 4096
cargo bench --locked -p lance-index --bench inverted_request_cache \
  --profile release-with-debug -- --save-baseline <name>
```

Requests still construct O(partitions) lightweight binding descriptors. Cold misses still perform current-store I/O, with file-open errors and validation deferred to the first read. End-to-end Sophon QPS and attribution of the reported production regression remain unverified by this microbenchmark.
