### PR TITLE
fix(merge_insert): surface a splitter panic as a stream error

### DIFF
--- a/rust/lance/src/dataset/write/merge_insert/exec/write.rs
+++ b/rust/lance/src/dataset/write/merge_insert/exec/write.rs
@@ -633,32 +633,50 @@ impl FullSchemaMergeInsertExec {
         let output_schema_clone = output_schema.clone();
         let merge_state_clone = merge_state;
 
+        // The splitter owns both senders, so a panic inside it drops them and
+        // the receivers would see end-of-stream — a partial merge committed
+        // with no error. Catch the unwind and forward it as a stream error
+        // instead, so the writer fails and the transaction is never stored.
+        // The clones outlive the unwound future; we never resume it, so the
+        // `AssertUnwindSafe` bound is fine.
+        let panic_update_tx = update_tx.clone();
+        let panic_insert_tx = insert_tx.clone();
         tokio::spawn(async move {
-            let mut input_stream = input_stream;
+            let result =
+                futures::FutureExt::catch_unwind(std::panic::AssertUnwindSafe(async move {
+                    let mut input_stream = input_stream;
 
-            while let Some(batch_result) = input_stream.next().await {
-                match batch_result {
-                    Ok(batch) => {
-                        match Self::process_and_split_batch(
-                            &batch,
-                            rowaddr_idx,
-                            rowid_idx,
-                            action_idx,
-                            &data_column_indices,
-                            output_schema_clone.clone(),
-                            merge_state_clone.clone(),
-                        ) {
-                            Ok((update_batch_opt, insert_batch_opt)) => {
-                                if let Some(update_batch) = update_batch_opt
-                                    && update_tx.send(Ok(update_batch)).is_err()
-                                {
-                                    break;
-                                }
+                    while let Some(batch_result) = input_stream.next().await {
+                        match batch_result {
+                            Ok(batch) => {
+                                match Self::process_and_split_batch(
+                                    &batch,
+                                    rowaddr_idx,
+                                    rowid_idx,
+                                    action_idx,
+                                    &data_column_indices,
+                                    output_schema_clone.clone(),
+                                    merge_state_clone.clone(),
+                                ) {
+                                    Ok((update_batch_opt, insert_batch_opt)) => {
+                                        if let Some(update_batch) = update_batch_opt
+                                            && update_tx.send(Ok(update_batch)).is_err()
+                                        {
+                                            break;
+                                        }
 
-                                if let Some(insert_batch) = insert_batch_opt
-                                    && insert_tx.send(Ok(insert_batch)).is_err()
-                                {
-                                    break;
+                                        if let Some(insert_batch) = insert_batch_opt
+                                            && insert_tx.send(Ok(insert_batch)).is_err()
+                                        {
+                                            break;
+                                        }
+                                    }
+                                    Err(e) => {
+                                        Self::handle_stream_processing_error(
+                                            e, &update_tx, &insert_tx,
+                                        );
+                                        break;
+                                    }
                                 }
                             }
                             Err(e) => {
@@ -667,11 +685,24 @@ impl FullSchemaMergeInsertExec {
                             }
                         }
                     }
-                    Err(e) => {
-                        Self::handle_stream_processing_error(e, &update_tx, &insert_tx);
-                        break;
-                    }
-                }
+                }))
+                .await;
+
+            if let Err(panic) = result {
+                let panic_msg = if let Some(msg) = panic.downcast_ref::<&str>() {
+                    (*msg).to_string()
+                } else if let Some(msg) = panic.downcast_ref::<String>() {
+                    msg.clone()
+                } else {
+                    "unknown panic payload".to_string()
+                };
+                Self::handle_stream_processing_error(
+                    datafusion::error::DataFusionError::Execution(format!(
+                        "merge insert stream splitter panicked: {panic_msg}"
+                    )),
+                    &panic_update_tx,
+                    &panic_insert_tx,
+                );
             }
         });
 
@@ -1121,6 +1152,109 @@ impl ExecutionPlan for FullSchemaMergeInsertExec {
 mod tests {
     use super::*;
     use arrow_array::UInt64Array;
+
+    use crate::dataset::write::merge_insert::{MergeInsertBuilder, WhenMatched, WhenNotMatched};
+
+    // A panic in the detached splitter task must surface on the output
+    // streams as an error. The task owns the channel senders, so an unwind
+    // drops them and the receivers cannot distinguish "writer panicked" from
+    // end-of-stream — without a guard, a partial merge is silently committed.
+    // The poisoned `updating_row_ids` mutex stands in for any panic source.
+    #[tokio::test]
+    async fn splitter_panic_surfaces_as_stream_error() {
+        use arrow_array::Int32Array;
+        use datafusion::physical_plan::empty::EmptyExec;
+        use futures::TryStreamExt;
+
+        let schema = Arc::new(arrow_schema::Schema::new(vec![
+            arrow_schema::Field::new("key", arrow_schema::DataType::UInt64, false),
+            arrow_schema::Field::new("value", arrow_schema::DataType::Int32, false),
+        ]));
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(UInt64Array::from(vec![1u64])),
+                Arc::new(Int32Array::from(vec![42])),
+            ],
+        )
+        .unwrap();
+        let dataset = Dataset::write(
+            arrow_array::RecordBatchIterator::new(vec![Ok(batch)], schema.clone()),
+            "memory://splitter-panic",
+            None,
+        )
+        .await
+        .unwrap();
+
+        let job = MergeInsertBuilder::try_new(Arc::new(dataset.clone()), vec!["key".to_string()])
+            .unwrap()
+            .when_matched(WhenMatched::UpdateAll)
+            .when_not_matched(WhenNotMatched::InsertAll)
+            .try_build()
+            .unwrap();
+        let exec = FullSchemaMergeInsertExec::try_new(
+            Arc::new(EmptyExec::new(schema.clone())),
+            Arc::new(dataset),
+            job.params.clone(),
+            Arc::new(std::sync::atomic::AtomicU64::new(0)),
+        )
+        .unwrap();
+
+        let metrics = MergeInsertMetrics::new(&ExecutionPlanMetricsSet::new(), 0);
+        let merge_state = Arc::new(std::sync::Mutex::new(MergeState::new(
+            metrics,
+            true,
+            vec!["key".to_string()],
+            Vec::new(),
+            SourceDedupeBehavior::Fail,
+        )));
+
+        // Poison the captured-row-ids mutex so the splitter task panics when
+        // the UpdateAll row reaches the capture call.
+        {
+            let poison_target = merge_state.lock().unwrap().updating_row_ids.clone();
+            let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                let _guard = poison_target.lock().unwrap();
+                panic!("poison the captured row ids mutex");
+            }));
+        }
+
+        let input_schema = Arc::new(arrow_schema::Schema::new(vec![
+            arrow_schema::Field::new("key", arrow_schema::DataType::UInt64, false),
+            arrow_schema::Field::new("value", arrow_schema::DataType::Int32, false),
+            arrow_schema::Field::new(ROW_ADDR, arrow_schema::DataType::UInt64, true),
+            arrow_schema::Field::new(ROW_ID, arrow_schema::DataType::UInt64, true),
+            arrow_schema::Field::new(MERGE_ACTION_COLUMN, arrow_schema::DataType::UInt8, false),
+        ]));
+        let input_batch = RecordBatch::try_new(
+            input_schema.clone(),
+            vec![
+                Arc::new(UInt64Array::from(vec![1u64])),
+                Arc::new(Int32Array::from(vec![42])),
+                Arc::new(UInt64Array::from(vec![1u64 << 32])),
+                Arc::new(UInt64Array::from(vec![7u64])),
+                Arc::new(arrow_array::UInt8Array::from(vec![1u8])), // UpdateAll
+            ],
+        )
+        .unwrap();
+        let input_stream = Box::pin(RecordBatchStreamAdapter::new(
+            input_schema,
+            futures::stream::iter(vec![Ok(input_batch)]),
+        ));
+
+        let (update_stream, _insert_stream) = exec
+            .split_updates_and_inserts(input_stream, merge_state)
+            .unwrap();
+
+        let result: DFResult<Vec<RecordBatch>> = update_stream.try_collect().await;
+        let err = result.expect_err(
+            "a splitter panic must surface as a stream error, not a silent end-of-stream",
+        );
+        assert!(
+            err.to_string().to_lowercase().contains("panic"),
+            "error should name the panic, got: {err}"
+        );
+    }
 
     #[test]
     fn test_merge_state_duplicate_rowid_detection_fail() {


### PR DESCRIPTION
Closes #9082.

`split_updates_and_inserts` runs its batch loop on a detached tokio task that owns both channel senders. A panic inside it unwinds the task, drops the senders, and the update and insert receivers yield `None`, which is indistinguishable from a source that ended normally. Nothing observes the panic either, since the `JoinHandle` is dropped. Depending on where the panic lands the writer then either commits a partial merge or trips an unrelated unwrap further down, and neither outcome reports what actually happened. The explicit error path already forwards through `handle_stream_processing_error`; only the panic path had no route out.

The loop is now wrapped in `catch_unwind` and a caught panic is forwarded through that same helper, so the writer fails and the transaction is never stored. The sender clones used by the panic path are taken before the move, so they outlive the unwound future and the receivers cannot see end-of-stream before the error is queued.

On `AssertUnwindSafe`: the only shared state the inner future captures is the `Arc<Mutex<MergeState>>`, and nothing reads it after the unwind. The forwarded error makes `write_fragments_internal(...).await?` return early, so the two sites that would `unwrap()` a poisoned guard are unreachable on this path, and the other two lock sites map poison to an error rather than unwrapping.

## Testing

`splitter_panic_surfaces_as_stream_error` poisons the captured-row-ids mutex so the splitter panics when the first `UpdateAll` row reaches the capture call, then asserts the update stream errors. With the forwarding removed the stream returns `Ok([])`, which is the silent end-of-stream this fixes.

## Not in this PR

`execute()` at `write.rs:985` locks the merge state after the splitter has already been spawned, so on a multi-thread runtime a splitter panic under that guard can still poison the mutex and make `execute()` itself panic rather than return an error. That window is pre-existing and unchanged here, and it fails loudly rather than silently, so it belongs in its own change.
