### PR TITLE
fix(lance-table): reject out-of-range created_at in IndexMetadata

### DIFF
--- a/rust/lance-table/src/format/index.rs
+++ b/rust/lance-table/src/format/index.rs
@@ -79,6 +79,8 @@ pub struct IndexMetadata {
     ///
     /// This field is optional for backward compatibility. For existing indices created before
     /// this field was added, this will be None.
+    ///
+    /// An out-of-range value fails the conversion with [`Error::CorruptFile`] rather than defaulting.
     pub created_at: Option<DateTime<Utc>>,
 
     /// The base path index of the index files. Used when the index is imported or referred from another dataset.
@@ -285,6 +287,23 @@ impl TryFrom<pb::IndexMetadata> for IndexMetadata {
             )
         };
 
+        let out_of_range = |ts: u64| {
+            Error::corrupt_file_named(
+                "index metadata",
+                format!(
+                    "index {} created_at timestamp out of range: {ts}",
+                    proto.name
+                ),
+            )
+        };
+        let created_at = proto
+            .created_at
+            .map(|ts| {
+                DateTime::from_timestamp_millis(i64::try_from(ts).map_err(|_| out_of_range(ts))?)
+                    .ok_or_else(|| out_of_range(ts))
+            })
+            .transpose()?;
+
         let metadata = Self {
             uuid: proto.uuid.as_ref().map(Uuid::try_from).ok_or_else(|| {
                 Error::invalid_input("uuid field does not exist in Index metadata".to_string())
@@ -296,10 +315,7 @@ impl TryFrom<pb::IndexMetadata> for IndexMetadata {
             fragment_bitmap,
             index_details: proto.index_details.map(Arc::new),
             index_version: proto.index_version.unwrap_or_default(),
-            created_at: proto.created_at.map(|ts| {
-                DateTime::from_timestamp_millis(ts as i64)
-                    .expect("Invalid timestamp in index metadata")
-            }),
+            created_at,
             base_id: proto.base_id,
             files,
         };
@@ -477,6 +493,28 @@ mod tests {
 
         let recovered = IndexMetadata::try_from(proto).unwrap();
         assert_eq!(recovered.fragment_bitmap, Some(bitmap));
+    }
+
+    #[rstest]
+    #[case::above_chrono_max(9_000_000_000_000_000)]
+    #[case::negative_wrap_u64_max(u64::MAX)]
+    #[case::negative_wrap_i64_boundary(i64::MAX as u64 + 1)]
+    fn test_index_metadata_rejects_out_of_range_created_at(#[case] created_at: u64) {
+        let mut proto = pb::IndexMetadata::from(&index_metadata_with(vec![0], vec![]));
+        proto.created_at = Some(created_at);
+
+        let err = IndexMetadata::try_from(proto).unwrap_err();
+        assert!(matches!(err, Error::CorruptFile { .. }), "got: {err:?}");
+        assert!(err.to_string().contains("created_at"), "got: {err}");
+    }
+
+    #[test]
+    fn test_index_metadata_created_at_roundtrip() {
+        let mut metadata = index_metadata_with(vec![0], vec![]);
+        metadata.created_at = Some(DateTime::from_timestamp_millis(1_700_000_000_000).unwrap());
+
+        let recovered = IndexMetadata::try_from(pb::IndexMetadata::from(&metadata)).unwrap();
+        assert_eq!(recovered.created_at, metadata.created_at);
     }
 
     /// Demonstrates the pattern a disk-backed cache backend would use:


### PR DESCRIPTION
## Summary

`IndexMetadata::try_from` panicked (`.expect`) when a manifest carried a file-controlled `created_at` outside chrono's range, failing every dataset open; `u64` values above `i64::MAX` additionally wrapped negative and decoded as valid 1969 dates. Both now return `Error::corrupt_file_named` naming the offending index.

## Test plan

rstest over the positive-overflow and both wraparound values (variant + message asserted), plus a valid-value roundtrip; fmt and clippy `-D warnings` clean.