### PR TITLE
fix(index): key the row-address mask cache by dataset generation

### DIFF
--- a/rust/lance/src/index/prefilter.rs
+++ b/rust/lance/src/index/prefilter.rs
@@ -197,44 +197,55 @@ impl DatasetPreFilter {
 
         let dataset_clone = dataset.clone();
         let restrict_for_load = restrict_to.clone();
-        let key = crate::session::caches::RowAddrMaskKey {
-            version: dataset.manifest().version,
-            restrict_hash,
+        let load_mask = move || {
+            async move {
+                let row_ids_and_deletions =
+                    load_row_ids_and_deletions(&dataset_clone, restrict_for_load.as_ref()).await?;
+
+                // The process of computing the final mask is CPU-bound, so we spawn it
+                // on a blocking thread.
+                let allow_list = spawn_cpu(move || {
+                    Result::Ok(row_ids_and_deletions.into_iter().fold(
+                        RowAddrTreeMap::new(),
+                        |mut allow_list, (row_ids, deletion_vector)| {
+                            let seq = if let Some(deletion_vector) = deletion_vector {
+                                let mut row_ids = row_ids.as_ref().clone();
+                                row_ids.mask(deletion_vector.to_sorted_iter()).unwrap();
+                                Cow::<RowIdSequence>::Owned(row_ids)
+                            } else {
+                                Cow::<RowIdSequence>::Borrowed(row_ids.as_ref())
+                            };
+                            let treemap = RowAddrTreeMap::from(seq.as_ref());
+                            allow_list |= treemap;
+                            allow_list
+                        },
+                    ))
+                })
+                .await?;
+
+                Ok(RowAddrMask::from_allowed(allow_list))
+            }
         };
-        dataset
-            .metadata_cache
-            .as_ref()
-            .get_or_insert_with_key(key, move || {
-                async move {
-                    let row_ids_and_deletions =
-                        load_row_ids_and_deletions(&dataset_clone, restrict_for_load.as_ref())
-                            .await?;
 
-                    // The process of computing the final mask is CPU-bound, so we spawn it
-                    // on a blocking thread.
-                    let allow_list = spawn_cpu(move || {
-                        Result::Ok(row_ids_and_deletions.into_iter().fold(
-                            RowAddrTreeMap::new(),
-                            |mut allow_list, (row_ids, deletion_vector)| {
-                                let seq = if let Some(deletion_vector) = deletion_vector {
-                                    let mut row_ids = row_ids.as_ref().clone();
-                                    row_ids.mask(deletion_vector.to_sorted_iter()).unwrap();
-                                    Cow::<RowIdSequence>::Owned(row_ids)
-                                } else {
-                                    Cow::<RowIdSequence>::Borrowed(row_ids.as_ref())
-                                };
-                                let treemap = RowAddrTreeMap::from(seq.as_ref());
-                                allow_list |= treemap;
-                                allow_list
-                            },
-                        ))
-                    })
-                    .await?;
-
-                    Ok(RowAddrMask::from_allowed(allow_list))
-                }
-            })
-            .await
+        // The metadata cache is namespaced by dataset URI only, and a dataset
+        // dropped and recreated at the same URI restarts its version history
+        // at 1, so the mask key must carry the manifest e-tag to keep
+        // generations apart. Without one the entry must not be shared at all,
+        // mirroring how `get_row_id_index` treats `RowIdIndexKey`.
+        if let Some(e_tag) = dataset.manifest_location.e_tag.as_deref() {
+            let key = crate::session::caches::RowAddrMaskKey {
+                version: dataset.manifest().version,
+                restrict_hash,
+                e_tag: Some(e_tag),
+            };
+            dataset
+                .metadata_cache
+                .as_ref()
+                .get_or_insert_with_key(key, load_mask)
+                .await
+        } else {
+            load_mask().await.map(Arc::new)
+        }
     }
 
     /// Sets the deleted fragment IDs to block during search.
@@ -680,5 +691,89 @@ mod test {
                 .await
                 .unwrap();
         assert_eq!(mask.allow_list().and_then(|x| x.len()), Some(0));
+    }
+
+    // Regression test: `RowAddrMaskKey` is scoped by `{version, restrict_hash}`
+    // alone, but the metadata cache it lives in is namespaced by dataset URI
+    // only. A dataset dropped and recreated at the same URI restarts its
+    // version history at 1, so the new incarnation reaches the old
+    // incarnation's cached key and is served the previous generation's
+    // allow-list. Stable row ids restart near 0 in both generations, so rows
+    // beyond the old generation's id range silently vanish from every indexed
+    // query. `RowIdIndexKey` guards the row-id index against exactly this with
+    // the manifest e-tag; the mask must not share entries across generations
+    // either.
+    #[tokio::test]
+    async fn test_deletion_mask_stale_after_dataset_recreated_at_same_uri() {
+        use lance_core::utils::tempfile::TempStrDir;
+
+        let tmp = TempStrDir::default();
+        let tmp_str = tmp.as_str();
+        // Shared so the cache stays warm across the drop, as it would for a
+        // host that keeps one session open for the lifetime of the process.
+        let session = Arc::new(crate::session::Session::default());
+
+        let write = |rows: i32| {
+            let test_data = BatchGenerator::new()
+                .col(Box::new(IncrementingInt32::new().named("x")))
+                .batch(rows);
+            let params = WriteParams {
+                enable_stable_row_ids: true,
+                session: Some(session.clone()),
+                ..Default::default()
+            };
+            async move {
+                Dataset::write(test_data, tmp_str, Some(params))
+                    .await
+                    .unwrap()
+            }
+        };
+
+        // Incarnation A: 10 rows, stable ids 0..=9. Deleting x = 9 lands at
+        // version 2 with a cached allow-list of ids 0..=8.
+        let mut ds = write(10).await;
+        let ds = (*ds.delete("x = 9").await.unwrap().new_dataset).clone();
+        assert_eq!(ds.manifest.version, 2);
+        // On unix the commit result carries the object store's e-tag for the
+        // manifest, so this exercises the e-tag-keyed cache branch; pin that
+        // so the test cannot silently degrade to the no-e-tag bypass. On
+        // Windows the rename-based commit handler discards e-tags by design
+        // ("re-name can change e-tag"), and this test then covers the bypass
+        // branch instead.
+        if cfg!(unix) {
+            assert!(
+                ds.manifest_location.e_tag.is_some(),
+                "unix local commits carry an e-tag; without one this test would \
+                 exercise the cache bypass instead of the e-tag-keyed path"
+            );
+        }
+        let fragments = RoaringBitmap::from_iter(0..1);
+        let mask = DatasetPreFilter::create_deletion_mask(Arc::new(ds.clone()), fragments.clone())
+            .expect("mask present: dataset has a deletion file")
+            .await
+            .unwrap();
+        let expected_a = RowAddrTreeMap::from_iter(0..9);
+        assert_eq!(mask.allow_list(), Some(&expected_a));
+
+        drop(ds);
+        std::fs::remove_dir_all(tmp_str).unwrap();
+
+        // Incarnation B: 20 rows, stable ids 0..=19, also reaching version 2.
+        // Longer than A so a stale hit is observable: the reincarnation's own
+        // allow-list must cover ids 9..=18, which never existed in A.
+        let mut ds = write(20).await;
+        let ds = (*ds.delete("x = 19").await.unwrap().new_dataset).clone();
+        assert_eq!(ds.manifest.version, 2);
+        let mask = DatasetPreFilter::create_deletion_mask(Arc::new(ds), fragments)
+            .expect("mask present: dataset has a deletion file")
+            .await
+            .unwrap();
+        let expected_b = RowAddrTreeMap::from_iter(0..19);
+        assert_eq!(
+            mask.allow_list(),
+            Some(&expected_b),
+            "deletion mask must reflect the recreated dataset, not the previous \
+             incarnation cached at the same URI and version"
+        );
     }
 }

--- a/rust/lance/src/session/caches.rs
+++ b/rust/lance/src/session/caches.rs
@@ -162,20 +162,32 @@ impl CacheKey for DeletionFileKey<'_> {
 }
 
 #[derive(Debug)]
-pub struct RowAddrMaskKey {
+pub struct RowAddrMaskKey<'a> {
     pub version: u64,
     /// `Some(hash)` when the mask is restricted to a fragment subset; `None`
     /// when it covers all fragments in the dataset. Two consumers that ask
     /// for different subsets must not poison each other's cache entry.
     pub restrict_hash: Option<u64>,
+    /// A dataset dropped and recreated at the same URI restarts its version
+    /// history at 1, so a long-lived session's cache can otherwise serve the
+    /// previous incarnation's mask for a version the new incarnation also
+    /// holds. The e-tag disambiguates generations the same way
+    /// [`ManifestKey::e_tag`] does. Callers without one must not share the
+    /// cached mask at all (see `do_create_deletion_mask_row_id`).
+    pub e_tag: Option<&'a str>,
 }
 
-impl CacheKey for RowAddrMaskKey {
+impl CacheKey for RowAddrMaskKey<'_> {
     type ValueType = RowAddrMask;
+    // Only the legacy display form. Identity comes from `write_key` below.
     fn key(&self) -> Cow<'_, str> {
-        match self.restrict_hash {
-            None => Cow::Owned(format!("row_addr_mask/{}", self.version)),
-            Some(h) => Cow::Owned(format!("row_addr_mask/{}/{:x}", self.version, h)),
+        match (self.restrict_hash, self.e_tag) {
+            (None, None) => Cow::Owned(format!("row_addr_mask/{}/", self.version)),
+            (Some(h), None) => Cow::Owned(format!("row_addr_mask/{}/{:x}", self.version, h)),
+            (None, Some(e)) => Cow::Owned(format!("row_addr_mask/{}/{}", self.version, e)),
+            (Some(h), Some(e)) => {
+                Cow::Owned(format!("row_addr_mask/{}/{:x}/{}", self.version, h, e))
+            }
         }
     }
     fn type_name() -> &'static str {
@@ -183,7 +195,7 @@ impl CacheKey for RowAddrMaskKey {
     }
 
     fn schema() -> CacheKeySchema {
-        CacheKeySchema::new("lance.dataset.row-address-mask-key", 1)
+        CacheKeySchema::new("lance.dataset.row-address-mask-key", 2)
     }
 
     fn write_key(&self, builder: &mut KeyBuilder) {
@@ -191,6 +203,12 @@ impl CacheKey for RowAddrMaskKey {
         if let Some(restrict_hash) = self.restrict_hash {
             builder.write_some();
             builder.write_u64(restrict_hash);
+        } else {
+            builder.write_none();
+        }
+        if let Some(e_tag) = self.e_tag {
+            builder.write_some();
+            builder.write_str(e_tag);
         } else {
             builder.write_none();
         }
@@ -434,6 +452,47 @@ mod tests {
                 .get_with_key(&RowIdIndexKey {
                     version: 5,
                     e_tag: Some("second-etag"),
+                })
+                .await
+                .is_none()
+        );
+    }
+
+    #[tokio::test]
+    async fn row_addr_mask_key_separates_manifest_generations() {
+        let cache = LanceCache::with_capacity(4096);
+        let mask = || {
+            Arc::new(RowAddrMask::from_allowed(
+                lance_select::RowAddrTreeMap::new(),
+            ))
+        };
+        let key = RowAddrMaskKey {
+            version: 5,
+            restrict_hash: None,
+            e_tag: Some("first-etag"),
+        };
+        cache.insert_with_key(&key, mask()).await;
+        assert!(cache.get_with_key(&key).await.is_some());
+
+        // Same version and restriction, different dataset generation.
+        assert!(
+            cache
+                .get_with_key(&RowAddrMaskKey {
+                    version: 5,
+                    restrict_hash: None,
+                    e_tag: Some("second-etag"),
+                })
+                .await
+                .is_none()
+        );
+        // A different fragment restriction must not alias the unrestricted
+        // entry either, even within one generation.
+        assert!(
+            cache
+                .get_with_key(&RowAddrMaskKey {
+                    version: 5,
+                    restrict_hash: Some(0xa),
+                    e_tag: Some("first-etag"),
                 })
                 .await
                 .is_none()


### PR DESCRIPTION
Closes #9079.

`RowAddrMaskKey` was scoped by `{version, restrict_hash}`, but the metadata cache it lives in is namespaced by dataset URI alone. A dataset dropped and recreated at the same URI restarts its version history at 1, so a long-lived session could serve the new incarnation the previous incarnation's cached stable-row-id allow-list. Stable row ids restart near 0 in both generations, so every row beyond the old generation's id range silently vanished from every indexed query.

The fix carries the manifest e-tag in the key, and skips the shared cache entirely when there is no e-tag. That second half is the same policy `get_row_id_index` already applies to `RowIdIndexKey` (`rust/lance/src/dataset/rowids.rs:82`), whose comment describes this exact hazard.

## Changes

- `rust/lance/src/session/caches.rs`: `RowAddrMaskKey` gains an `e_tag` field, written into the key identity, with the schema version bumped from 1 to 2.
- `rust/lance/src/index/prefilter.rs`: the mask loader is hoisted into a closure so the e-tag-keyed path and the no-e-tag bypass can share it.

## The cost of the bypass, and why it is still the right shape here

Where the manifest has no e-tag, the allow-list is now rebuilt per call instead of once per `{version, restrict_hash}`. That is a real cost, and it is worth naming the configurations it lands on: `s3+ddb://` never carries one, because the DynamoDB commit handler sets `e_tag: None` deliberately in both location paths (`rust/lance-table/src/io/commit/dynamodb.rs:319` and `:391`); on Windows the rename-based commit handler discards it too; detached versions have none. The recompute walks the restricted fragment set and folds a treemap, so it scales with live rows in that set. The underlying sequence and deletion-vector loads stay cached.

I went with matching the sibling policy rather than inventing a narrower rule, for two reasons. It is the behavior those same datasets already get for the row-id index, so this does not introduce a new class of cost, and a wrong allow-list is silent missing rows while a missed cache hit is only slow. The real fix is to give those handlers a generation token: `ManifestLocation::identity` is documented as exactly that, but the DynamoDB paths leave it `None` too and `ExternalManifestStore::get_identity` defaults to `Ok(None)`. Populating it would let both keys stay cached, and I am happy to follow up there if you would rather have that first.

## Testing

- `test_deletion_mask_stale_after_dataset_recreated_at_same_uri` builds two incarnations at one URI, both reaching version 2, the second longer so a stale hit is observable. With the e-tag dropped from the key it fails with the first incarnation's `{0..8}` where `{0..18}` is correct.
- `row_addr_mask_key_separates_manifest_generations` pins the key identity: same version and restriction with a different e-tag must miss, and a different fragment restriction must not alias the unrestricted entry.
- The test asserts `e_tag.is_some()` under `cfg!(unix)` so it cannot silently degrade into only covering the bypass. On Windows the rename-based commit handler discards e-tags by design, and the test covers the bypass there instead.
