### PR TITLE
fix(index)!: do not route json_extract predicates to JSON indices

### DIFF
--- a/rust/lance-index/src/scalar/expression.rs
+++ b/rust/lance-index/src/scalar/expression.rs
@@ -142,7 +142,7 @@ pub trait ScalarQueryParser: std::fmt::Debug + Send + Sync {
     /// is "x = 7" and we have a scalar index on "x" then we apply the index to the "x" column reference.
     ///
     /// However, some indexes are designed to run on projections of the indexed column.  For example,
-    /// if a query is "json_extract(json, '$.name') = 'books'" and we have a JSON index on the "json" column
+    /// if a query is "json_get_string(json, '$.name') = 'books'" and we have a JSON index on the "json" column
     /// then we apply the index to the projection of the "json" column.
     ///
     /// This function is used to test if a potential column reference is a reference the index handles.
@@ -2090,7 +2090,7 @@ fn extract_nested_column_path(expr: &Expr) -> Option<String> {
 //
 // There's two ways to get a column.  First, the obvious way, is a
 // simple column reference (e.g. x = 7).  Second, a more complex way,
-// is some kind of projection into a column (e.g. json_extract(json, '$.name')).
+// is some kind of projection into a column (e.g. json_get_string(json, '$.name')).
 // Third way is nested field access (e.g. get_field(metadata, "status.code"))
 fn maybe_indexed_column<'b>(
     expr: &Expr,
@@ -2994,9 +2994,11 @@ mod tests {
             ),
         ]);
 
+        // The typed accessors decode the path value, matching the representation
+        // the index was trained on, so they route.
         check_simple(
             &index_info,
-            "json_extract(json, '$.name') = 'foo'",
+            "json_get_string(json, '$.name') = 'foo'",
             "json",
             JsonQuery::new(
                 Arc::new(SargableQuery::Equals(ScalarValue::Utf8(Some(
@@ -3005,6 +3007,14 @@ mod tests {
                 "$.name".to_string(),
             ),
         );
+        // `json_extract` evaluates to serialized JSON text, which does not match the
+        // decoded keys in the index, so it must not route.
+        // https://github.com/lance-format/lance/issues/8806
+        check_no_index(&index_info, "json_extract(json, '$.name') = 'foo'");
+        check_no_index(&index_info, "json_extract(json, '$.name') = '\"foo\"'");
+        check_no_index(&index_info, "json_extract(json, '$.name') < 'foo'");
+        // A typed accessor on a path the index was not built for still declines.
+        check_no_index(&index_info, "json_get_string(json, '$.other') = 'foo'");
 
         check_no_index(&index_info, "size BETWEEN 5 AND 10");
         // Cast case.  We will cast 5 (an int64) to Int16 and then coerce to UInt32
@@ -4196,7 +4206,7 @@ mod tests {
         );
         check(
             &index_info,
-            "json_extract(json, '$.b') = 'foo'",
+            "json_get_string(json, '$.b') = 'foo'",
             Some(expected_b),
             false,
         );
@@ -4215,13 +4225,13 @@ mod tests {
         );
         check(
             &index_info,
-            "json_extract(json, '$.a') = 'foo'",
+            "json_get_string(json, '$.a') = 'foo'",
             Some(expected_a),
             false,
         );
 
         // Query against an unindexed path must not bind to either index.
-        check_no_index(&index_info, "json_extract(json, '$.c') = 'foo'");
+        check_no_index(&index_info, "json_get_string(json, '$.c') = 'foo'");
     }
 
     #[test]

--- a/rust/lance-index/src/scalar/json.rs
+++ b/rust/lance-index/src/scalar/json.rs
@@ -401,37 +401,29 @@ impl ScalarQueryParser for JsonQueryParser {
     fn is_valid_reference(&self, func: &Expr, _data_type: &DataType) -> Option<DataType> {
         match func {
             Expr::ScalarFunction(udf) => {
-                // Support multiple JSON extraction functions
-                let json_functions = [
-                    "json_extract",
-                    "json_get",
-                    "json_get_int",
-                    "json_get_float",
-                    "json_get_bool",
-                    "json_get_string",
-                ];
-                if !json_functions.contains(&udf.name()) {
-                    return None;
-                }
+                // Only the typed accessors are routable. `json_extract` evaluates to
+                // serialized JSON text (`"click"`, `2`) while index keys hold decoded
+                // native values (`click`, `2`), so an indexed `json_extract` predicate
+                // would answer a different question than the unindexed one. Quoting is
+                // also not order-preserving (`ab` < `ab!` but `"ab"` > `"ab!"`), so even
+                // a Utf8 index cannot serve `json_extract` ranges. Let these fall back
+                // to a full scan until literals are transcoded into the index's
+                // representation. See https://github.com/lance-format/lance/issues/8806.
+                let value_type = match udf.name() {
+                    "json_get_int" => DataType::Int64,
+                    "json_get_float" => DataType::Float64,
+                    "json_get_bool" => DataType::Boolean,
+                    "json_get_string" => DataType::Utf8,
+                    _ => return None,
+                };
                 if udf.args.len() != 2 {
                     return None;
                 }
                 // We already know index 0 is a column reference to the column so we just need to
                 // ensure that index 1 matches our path
                 match &udf.args[1] {
-                    Expr::Literal(ScalarValue::Utf8(Some(path)), _) => {
-                        if path == &self.path {
-                            // Return the appropriate type based on the function
-                            match udf.name() {
-                                "json_get_int" => Some(DataType::Int64),
-                                "json_get_float" => Some(DataType::Float64),
-                                "json_get_bool" => Some(DataType::Boolean),
-                                "json_get_string" | "json_extract" => Some(DataType::Utf8),
-                                _ => None,
-                            }
-                        } else {
-                            None
-                        }
+                    Expr::Literal(ScalarValue::Utf8(Some(path)), _) if path == &self.path => {
+                        Some(value_type)
                     }
                     _ => None,
                 }

--- a/rust/lance/src/dataset/tests/dataset_index.rs
+++ b/rust/lance/src/dataset/tests/dataset_index.rs
@@ -6415,6 +6415,81 @@ async fn test_optimize_append_json_btree_preserves_float_type() {
     assert_eq!(indexed.num_rows(), baseline.num_rows());
 }
 
+/// `json_extract` evaluates to serialized JSON text (`"click"`, `9`) while a JSON-path
+/// index stores decoded native values (`click`, `9`). The index must decline these
+/// predicates instead of answering them against a different representation.
+///
+/// The cases run sequentially rather than as separate `rstest` cases because each
+/// index build reserves a fixed slice of the shared DataFusion memory pool, and
+/// several concurrent builds exhaust it.
+///
+/// Regression test for https://github.com/lance-format/lance/issues/8806.
+#[tokio::test]
+async fn test_json_extract_matches_unindexed_results() {
+    let cases = [
+        (
+            vec![
+                r#"{"val": "click"}"#,
+                r#"{"val": "view"}"#,
+                r#"{"val": "click"}"#,
+            ],
+            r#"json_extract(json, 'val') = '"click"'"#,
+        ),
+        (
+            vec![r#"{"val": "a"}"#, r#"{"val": "m"}"#, r#"{"val": "z"}"#],
+            r#"json_extract(json, 'val') > '"m"'"#,
+        ),
+        (
+            vec![r#"{"val": 9}"#, r#"{"val": 10}"#, r#"{"val": 9}"#],
+            "json_extract(json, 'val') = '9'",
+        ),
+        (
+            vec![r#"{"val": 9}"#, r#"{"val": 10}"#, r#"{"val": 100}"#],
+            "json_extract(json, 'val') < '100'",
+        ),
+    ];
+
+    fn sorted_matches(batch: &RecordBatch) -> Vec<String> {
+        let mut rows = batch
+            .column_by_name("json")
+            .unwrap()
+            .as_string::<i32>()
+            .iter()
+            .map(|value| value.unwrap().to_string())
+            .collect::<Vec<_>>();
+        rows.sort();
+        rows
+    }
+
+    for (values, predicate) in cases {
+        let dataset = json_btree_dataset(values).await;
+
+        let indexed = dataset
+            .scan()
+            .filter(predicate)
+            .unwrap()
+            .try_into_batch()
+            .await
+            .unwrap();
+        let mut baseline_scan = dataset.scan();
+        baseline_scan.use_scalar_index(false);
+        let baseline = baseline_scan
+            .filter(predicate)
+            .unwrap()
+            .try_into_batch()
+            .await
+            .unwrap();
+
+        // Guard against both scans matching nothing, which would pass vacuously.
+        assert!(baseline.num_rows() > 0, "no rows matched {predicate}");
+        assert_eq!(
+            sorted_matches(&indexed),
+            sorted_matches(&baseline),
+            "index changed results for {predicate}"
+        );
+    }
+}
+
 async fn prepare_json_dataset() -> (Dataset, String) {
     let text_col = Arc::new(StringArray::from(vec![
         r#"{


### PR DESCRIPTION
A JSON-path index stores the value at `path` decoded into a native Arrow type: `{"val": "click"}` trains a Utf8 btree whose key is `click`, and `{"val": 9}` trains an Int64 btree whose key is `9`. But `json_extract` evaluates to *serialized* JSON text — `"click"` with quotes, `9` as text.

This caused some problems we could potentially fix:

  * `json_extract(v, 'val') = '"click"'` searched for a quoted key and matched nothing, where the unindexed scan matched.
  * A numeric path took a `Utf8` literal into an `Int64` btree, whose page scan selects its comparator from the query's type on the stated invariant that the two always agree, and panicked.

But it also meant some subtle issues we could not fix:

  * `json_extract(v, 'val') > '"m"'` returned every row: quoting is not order-preserving (`ab` < `ab!` but `"ab"` > `"ab!"`), so a decoded-key btree cannot answer a text-ordered range, and its page min/max pruning is unsound for one.

This PR changes the index to decline these predicates so they fall back to a full scan.  It's unfortunate, but I think we'd need a specialized string-based index if we wanted to fully support `json_extract`.  If there is sufficient demand then we can investigate this approach.

Fixes #8806
