### PR TITLE
feat: add cell-unchanged preconditions to commit transactions

### DIFF
--- a/protos/transaction.proto
+++ b/protos/transaction.proto
@@ -407,6 +407,24 @@ message Transaction {
     repeated BasePath new_bases = 1;
   }
 
+  // A condition that must hold for the commit to proceed.
+  message Precondition {
+    // The columns that must be unchanged.
+    repeated int32 field_ids = 1;
+
+    /* The rows that must be unchanged, in `RowAddrTreeMap` serialization:
+     * a u32 entry count followed by, per fragment, a u32 fragment id, a u32
+     * bitmap byte length, and a roaring bitmap of row offsets within that
+     * fragment. A zero bitmap length marks the entire fragment as selected.
+     */
+    bytes rows = 2;
+  }
+
+  // Conditions that must hold on the manifest a transaction lands on.
+  // If any precondition is violated by a concurrent transaction, the commit
+  // fails instead of rebasing the transaction over the changed data.
+  repeated Precondition preconditions = 5;
+
   // The operation of this transaction.
   oneof operation {
     Append append = 100;

--- a/rust/lance-table/src/transaction.rs
+++ b/rust/lance-table/src/transaction.rs
@@ -39,7 +39,7 @@ mod validate;
 #[cfg(test)]
 pub(crate) mod test_support;
 
-pub use builder::{Transaction, TransactionBuilder};
+pub use builder::{Precondition, Transaction, TransactionBuilder};
 pub use operation::{
     DataOverlayGroup, DataReplacementGroup, Operation, RewriteGroup, RewrittenIndex, UpdateMode,
     UpdatedFragmentOffsets,

--- a/rust/lance-table/src/transaction/builder.rs
+++ b/rust/lance-table/src/transaction/builder.rs
@@ -5,6 +5,7 @@
 
 use crate::transaction::Operation;
 use lance_core::deepsize::DeepSizeOf;
+use lance_select::RowAddrTreeMap;
 use std::collections::HashMap;
 use std::sync::Arc;
 use uuid::Uuid;
@@ -22,6 +23,22 @@ pub struct Transaction {
     pub operation: Operation,
     pub tag: Option<String>,
     pub transaction_properties: Option<Arc<HashMap<String, String>>>,
+    /// Conditions that must hold for this transaction to commit. A commit is
+    /// rejected instead of rebased when a concurrent transaction violates one.
+    pub preconditions: Vec<Precondition>,
+}
+
+/// A declaration that specific cells of the dataset must be unchanged when
+/// this transaction commits.
+///
+/// `rows` holds the protected row addresses; `field_ids` the protected
+/// columns. If a concurrent transaction modified any protected cell, this
+/// transaction's commit is rejected rather than rebased, since a staged value
+/// computed from the old state would be stale.
+#[derive(Debug, Clone, DeepSizeOf, PartialEq)]
+pub struct Precondition {
+    pub field_ids: Vec<i32>,
+    pub rows: RowAddrTreeMap,
 }
 
 /// Add TransactionBuilder for flexibly setting option without using `mut`
@@ -32,6 +49,7 @@ pub struct TransactionBuilder {
     operation: Operation,
     tag: Option<String>,
     transaction_properties: Option<Arc<HashMap<String, String>>>,
+    preconditions: Vec<Precondition>,
 }
 
 impl TransactionBuilder {
@@ -42,7 +60,13 @@ impl TransactionBuilder {
             operation,
             tag: None,
             transaction_properties: None,
+            preconditions: Vec::new(),
         }
+    }
+
+    pub fn precondition(mut self, precondition: Precondition) -> Self {
+        self.preconditions.push(precondition);
+        self
     }
 
     pub fn uuid(mut self, uuid: String) -> Self {
@@ -73,6 +97,7 @@ impl TransactionBuilder {
             operation: self.operation,
             tag: self.tag,
             transaction_properties: self.transaction_properties,
+            preconditions: self.preconditions,
         }
     }
 }

--- a/rust/lance-table/src/transaction/manifest_build.rs
+++ b/rust/lance-table/src/transaction/manifest_build.rs
@@ -2110,6 +2110,7 @@ mod tests {
     fn test_proto_legacy_field_9_read() {
         // Simulate a manifest written by old Lance: only field 9, no field 10.
         let pb_tx = pb::Transaction {
+            preconditions: Vec::new(),
             read_version: 1,
             uuid: "test".to_string(),
             tag: String::new(),
@@ -2159,6 +2160,7 @@ mod tests {
             .unwrap();
 
         let pb_tx = pb::Transaction {
+            preconditions: Vec::new(),
             read_version: 1,
             uuid: "test".to_string(),
             tag: String::new(),

--- a/rust/lance-table/src/transaction/proto.rs
+++ b/rust/lance-table/src/transaction/proto.rs
@@ -13,13 +13,14 @@ use crate::format::pb;
 use crate::format::{BasePath, Fragment, IndexFile, IndexMetadata, overlay::DataOverlayFile};
 use crate::system_index::mem_wal::CompactedSsTable;
 use crate::transaction::{
-    DataOverlayGroup, DataReplacementGroup, Operation, RewriteGroup, RewrittenIndex, Transaction,
-    UpdateMap, UpdateMapEntry, UpdateMode, UpdatedFragmentOffsets, translate_config_updates,
-    translate_schema_metadata_updates,
+    DataOverlayGroup, DataReplacementGroup, Operation, Precondition, RewriteGroup, RewrittenIndex,
+    Transaction, UpdateMap, UpdateMapEntry, UpdateMode, UpdatedFragmentOffsets,
+    translate_config_updates, translate_schema_metadata_updates,
 };
 use lance_core::datatypes::Schema;
 use lance_core::{Error, Result};
 use lance_file::datatypes::Fields;
+use lance_select::RowAddrTreeMap;
 use roaring::RoaringBitmap;
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -421,6 +422,16 @@ impl TryFrom<pb::Transaction> for Transaction {
             } else {
                 Some(Arc::new(message.transaction_properties))
             },
+            preconditions: message
+                .preconditions
+                .into_iter()
+                .map(|p| {
+                    Ok(Precondition {
+                        field_ids: p.field_ids,
+                        rows: RowAddrTreeMap::deserialize_from(p.rows.as_slice())?,
+                    })
+                })
+                .collect::<Result<Vec<_>>>()?,
         })
     }
 }
@@ -713,12 +724,25 @@ impl From<&Transaction> for pb::Transaction {
             .as_ref()
             .map(|arc| arc.as_ref().clone())
             .unwrap_or_default();
+        let mut preconditions = Vec::with_capacity(value.preconditions.len());
+        for precondition in &value.preconditions {
+            let mut rows = Vec::with_capacity(precondition.rows.serialized_size());
+            precondition
+                .rows
+                .serialize_into(&mut rows)
+                .expect("serialization into an in-memory buffer cannot fail");
+            preconditions.push(pb::transaction::Precondition {
+                field_ids: precondition.field_ids.clone(),
+                rows,
+            });
+        }
         Self {
             read_version: value.read_version,
             uuid: value.uuid.clone(),
             operation: Some(operation),
             tag: value.tag.clone().unwrap_or("".to_string()),
             transaction_properties,
+            preconditions,
         }
     }
 }

--- a/rust/lance/src/dataset/blob.rs
+++ b/rust/lance/src/dataset/blob.rs
@@ -5988,6 +5988,7 @@ mod tests {
             },
             tag: None,
             transaction_properties: None,
+            preconditions: Vec::new(),
         };
         let dataset = Arc::new(
             CommitBuilder::new(dataset)
@@ -6171,6 +6172,7 @@ mod tests {
             },
             tag: None,
             transaction_properties: None,
+            preconditions: Vec::new(),
         };
         let dataset = Arc::new(
             CommitBuilder::new(dataset)

--- a/rust/lance/src/dataset/write/commit.rs
+++ b/rust/lance/src/dataset/write/commit.rs
@@ -11,6 +11,7 @@ use lance_select::RowAddrTreeMap;
 use lance_table::{
     format::{DataStorageFormat, is_detached_version},
     io::commit::{CommitConfig, CommitHandler, ManifestNamingScheme},
+    transaction::Precondition,
 };
 
 use crate::io::commit::DEFAULT_COMMIT_RETRY_TIMEOUT;
@@ -54,6 +55,8 @@ pub struct CommitBuilder<'a> {
     timeout: Option<Duration>,
     /// When `Some`, this commit is the second step of `migrate_to_stable_row_ids`.
     migration_next_row_id: Option<u64>,
+    /// Cells (fields × rows) that must be unchanged for this commit to land.
+    preconditions: Vec<Precondition>,
 }
 
 /// Default timeout applied to [`CommitBuilder::execute`] when none is set.
@@ -78,6 +81,7 @@ impl<'a> CommitBuilder<'a> {
             transaction_properties: None,
             timeout: Some(DEFAULT_COMMIT_TIMEOUT),
             migration_next_row_id: None,
+            preconditions: Vec::new(),
         }
     }
 
@@ -274,6 +278,31 @@ impl<'a> CommitBuilder<'a> {
         self
     }
 
+    /// Require the given cells (fields × rows) to be unchanged when this
+    /// transaction commits.
+    ///
+    /// A staged value computed from other columns is only correct if those
+    /// columns did not change between the read version and publication. When a
+    /// concurrent transaction modified any protected cell, this commit is
+    /// rejected with [`Error::PrerequisiteFailed`] instead of rebased, so the
+    /// caller can recompute and retry. Physical row addresses: if a concurrent
+    /// rewrite relocates the rows, the precondition is reported as violated.
+    ///
+    /// The precondition is carried on the transaction itself, so a lost
+    /// successful response is still recovered correctly: the retried commit
+    /// re-checks the same declared dependencies rather than publishing twice.
+    pub fn with_cells_unchanged(
+        mut self,
+        field_ids: impl IntoIterator<Item = i32>,
+        rows: RowAddrTreeMap,
+    ) -> Self {
+        self.preconditions.push(Precondition {
+            field_ids: field_ids.into_iter().collect(),
+            rows,
+        });
+        self
+    }
+
     pub async fn execute(self, transaction: Transaction) -> Result<Dataset> {
         let timeout = self.timeout;
         if let Some(t) = timeout
@@ -300,7 +329,24 @@ impl<'a> CommitBuilder<'a> {
         }
     }
 
-    async fn execute_inner(self, transaction: Transaction) -> Result<Dataset> {
+    async fn execute_inner(self, mut transaction: Transaction) -> Result<Dataset> {
+        if !self.preconditions.is_empty() {
+            if self.detached {
+                return Err(Error::invalid_input_source(
+                    "commit preconditions cannot be enforced on a detached commit".into(),
+                ));
+            }
+            if matches!(transaction.operation, Operation::Overwrite { .. }) {
+                // Overwrite replaces the entire dataset, so cell-level protection
+                // is meaningless. Its read_version is 0, so the pinned baseline
+                // the preconditions are evaluated against would not even be the
+                // state the values were computed from.
+                return Err(Error::invalid_input_source(
+                    "commit preconditions are incompatible with Overwrite".into(),
+                ));
+            }
+            transaction.preconditions = self.preconditions.clone();
+        }
         let session = self
             .session
             .or_else(|| self.dest.dataset().map(|ds| ds.session.clone()))
@@ -587,6 +633,7 @@ impl<'a> CommitBuilder<'a> {
             },
             read_version,
             tag: None,
+            preconditions: Vec::new(),
             transaction_properties: None,
         };
         let dataset = self.execute(merged.clone()).await?;
@@ -657,6 +704,7 @@ mod tests {
             read_version,
             tag: None,
             transaction_properties: None,
+            preconditions: Vec::new(),
         }
     }
 
@@ -1129,6 +1177,7 @@ mod tests {
             read_version: 1,
             tag: None,
             transaction_properties: None,
+            preconditions: Vec::new(),
         };
         let res = CommitBuilder::new(dataset.clone())
             .execute_batch(vec![update_transaction])
@@ -1231,6 +1280,201 @@ mod tests {
             io_stats.read_iops < 10,
             "read_iops = {}; a full listing was likely used",
             io_stats.read_iops
+        );
+    }
+    #[test]
+    fn test_cells_unchanged_precondition_round_trips_through_proto() {
+        use lance_table::transaction::Precondition as TablePrecondition;
+
+        // The precondition must survive the transaction's proto round trip: the
+        // lost-response recovery in verify_commit_outcome compares
+        // committed_transaction == transaction byte-wise, and the read-back copy
+        // is deserialized from disk.
+        let mut rows = roaring::RoaringTreemap::new();
+        rows.insert(1_u64);
+        rows.insert(3_u64);
+        let protected = lance_select::RowAddrTreeMap::from(rows); // all in fragment 0
+
+        let mut transaction = sample_transaction(1);
+        transaction.preconditions = vec![TablePrecondition {
+            field_ids: vec![3, 4],
+            rows: protected,
+        }];
+
+        let pb: lance_table::format::pb::Transaction =
+            lance_table::format::pb::Transaction::from(&transaction);
+        let round_tripped = lance_table::transaction::Transaction::try_from(pb.clone()).unwrap();
+
+        assert_eq!(round_tripped, transaction);
+        assert_eq!(round_tripped.preconditions.len(), 1);
+        assert_eq!(round_tripped.preconditions[0].field_ids, vec![3, 4]);
+        let rows_back = round_tripped.preconditions[0]
+            .rows
+            .get_fragment_bitmap(0)
+            .unwrap();
+        assert_eq!(rows_back.len(), 2);
+        assert_eq!(pb.preconditions[0].field_ids, vec![3, 4]);
+    }
+
+    #[test]
+    fn test_is_precondition_violated_detects_data_file_rewrite() {
+        use lance_select::RowAddrTreeMap;
+        use roaring::RoaringTreemap;
+
+        let mut rows = RoaringTreemap::new();
+        rows.insert(1_u64);
+        rows.insert(2_u64);
+        let protected = RowAddrTreeMap::from(rows);
+
+        let precondition = lance_table::transaction::Precondition {
+            field_ids: vec![0],
+            rows: protected,
+        };
+
+        let before_frag = sample_fragment();
+        let mut after_frag = sample_fragment();
+        after_frag.files[0].path = "rewritten.lance".to_string();
+
+        let mut before = HashMap::new();
+        before.insert(0_u64, &before_frag);
+        let mut after = HashMap::new();
+        after.insert(0_u64, &after_frag);
+
+        // A rewrite replaced the data files: protected cells are gone.
+        assert!(
+            crate::io::commit::is_precondition_violated(&precondition, &before, &after).unwrap()
+        );
+
+        // Same files: no violation.
+        let mut same_after = HashMap::new();
+        same_after.insert(0_u64, &before_frag);
+        assert!(
+            !crate::io::commit::is_precondition_violated(&precondition, &before, &same_after)
+                .unwrap()
+        );
+
+        // Fragment removed: the protected rows no longer exist.
+        let removed = HashMap::new();
+        assert!(
+            crate::io::commit::is_precondition_violated(&precondition, &before, &removed).unwrap()
+        );
+    }
+
+    use lance_table::format::overlay::{DataOverlayFile, OverlayCoverage};
+    use roaring::{RoaringBitmap, RoaringTreemap};
+
+    fn sample_overlay(
+        field_ids: &[i32],
+        covered: &[u32],
+        committed_version: u64,
+    ) -> DataOverlayFile {
+        let (major_version, minor_version) =
+            LanceFileVersion::Stable.resolve().to_data_file_numbers();
+        DataOverlayFile {
+            data_file: DataFile {
+                path: "overlay.lance".to_string(),
+                fields: Arc::from(field_ids),
+                column_indices: Arc::from(vec![0; field_ids.len()]),
+                file_major_version: major_version,
+                file_minor_version: minor_version,
+                file_size_bytes: CachedFileSize::new(100),
+                base_id: None,
+            },
+            coverage: OverlayCoverage::Shared(Arc::new(RoaringBitmap::from_iter(
+                covered.iter().copied(),
+            ))),
+            committed_version,
+        }
+    }
+
+    fn fragment_map(frag: &Fragment) -> HashMap<u64, &Fragment> {
+        HashMap::from([(0, frag)])
+    }
+
+    #[test]
+    fn test_is_precondition_violated_overlays() {
+        let mut rows = RoaringTreemap::new();
+        rows.insert(1_u64);
+        rows.insert(2);
+        let protected_rows = RowAddrTreeMap::from(rows);
+        let precondition = lance_table::transaction::Precondition {
+            field_ids: vec![0],
+            rows: protected_rows,
+        };
+
+        // An overlay that already existed at the read version and is unchanged
+        // does not violate: the values read then were the overlay's values, and
+        // they are still there.
+        let mut before_frag = sample_fragment();
+        before_frag.overlays = vec![sample_overlay(&[0], &[1, 2], 1)];
+        let unchanged_after = before_frag.clone();
+        assert!(
+            !crate::io::commit::is_precondition_violated(
+                &precondition,
+                &fragment_map(&before_frag),
+                &fragment_map(&unchanged_after),
+            )
+            .unwrap()
+        );
+
+        // A new overlay supplying a value for a protected cell violates.
+        let mut with_new_overlay = before_frag.clone();
+        with_new_overlay.overlays = vec![
+            sample_overlay(&[0], &[1, 2], 1),
+            sample_overlay(&[0], &[2], 3),
+        ];
+        assert!(
+            crate::io::commit::is_precondition_violated(
+                &precondition,
+                &fragment_map(&before_frag),
+                &fragment_map(&with_new_overlay),
+            )
+            .unwrap()
+        );
+
+        // A new overlay on a different field does not violate.
+        let mut other_field_overlay = before_frag.clone();
+        other_field_overlay.overlays = vec![
+            sample_overlay(&[0], &[1, 2], 1),
+            sample_overlay(&[7], &[2], 3),
+        ];
+        assert!(
+            !crate::io::commit::is_precondition_violated(
+                &precondition,
+                &fragment_map(&before_frag),
+                &fragment_map(&other_field_overlay),
+            )
+            .unwrap()
+        );
+
+        // A new overlay on the protected field but disjoint rows does not
+        // violate.
+        let mut disjoint_rows_overlay = before_frag.clone();
+        disjoint_rows_overlay.overlays = vec![
+            sample_overlay(&[0], &[1, 2], 1),
+            sample_overlay(&[0], &[5, 6], 3),
+        ];
+        assert!(
+            !crate::io::commit::is_precondition_violated(
+                &precondition,
+                &fragment_map(&before_frag),
+                &fragment_map(&disjoint_rows_overlay),
+            )
+            .unwrap()
+        );
+
+        // An overlay removed since the read version lets the base values it
+        // shadowed resurface: a change to those cells, checked against the
+        // pre-removal coverage.
+        let mut overlay_removed = before_frag.clone();
+        overlay_removed.overlays = vec![];
+        assert!(
+            crate::io::commit::is_precondition_violated(
+                &precondition,
+                &fragment_map(&before_frag),
+                &fragment_map(&overlay_removed),
+            )
+            .unwrap()
         );
     }
 }

--- a/rust/lance/src/io/commit.rs
+++ b/rust/lance/src/io/commit.rs
@@ -33,16 +33,19 @@ use lance_file::version::LanceFileVersion;
 
 use lance_index::metrics::NoOpMetricsCollector;
 use lance_io::utils::CachedFileSize;
+use lance_select::RowAddrSelection;
 use lance_select::RowAddrTreeMap;
 use lance_table::feature_flags::ensure_can_write_manifest;
 use lance_table::format::{
     DETACHED_VERSION_MASK, DeletionFile, Fragment, IndexMetadata, Manifest, WriterVersion,
-    is_detached_version, list_index_files_with_sizes, operation_may_change_schema, pb,
+    is_detached_version, list_index_files_with_sizes, operation_may_change_schema,
+    overlay::DataOverlayFile, pb,
 };
 use lance_table::io::commit::{
     CommitConfig, CommitError, CommitHandler, ManifestLocation, ManifestNamingScheme,
 };
 use lance_table::io::manifest::read_manifest;
+use lance_table::transaction::Precondition;
 use rand::{Rng, rng};
 use roaring::RoaringBitmap;
 
@@ -1384,6 +1387,152 @@ async fn record_successful_commit(
     }
 }
 
+/// Whether a protected cell was touched by any fragment-level change between
+/// the read version and the current manifest.
+///
+/// Compares the structural pointers of the fragments the preconditions cover:
+/// data-file identity (a rewrite replaces files), deletion-file identity (a
+/// concurrent delete), and overlay changes (an overlay added, changed, or
+/// removed since the read version). Overlays that already existed at the read
+/// version and are unchanged do not violate: the values read then are the
+/// overlay's values, and they are still there. Fragment removal also
+/// violates — the removed row addresses no longer exist. Row relocation via
+/// compaction is rejected rather than remapped, matching the initial scope in
+/// #8976/#9043.
+pub(crate) fn is_precondition_violated(
+    precondition: &Precondition,
+    read_version_fragments: &HashMap<u64, &Fragment>,
+    current_fragments: &HashMap<u64, &Fragment>,
+) -> Result<bool> {
+    let protected_by_fragment = precondition.rows.iter().fold(
+        HashMap::<u32, RoaringBitmap>::new(),
+        |mut acc, (fragment_id, selection)| {
+            match selection {
+                // Full fragment: every offset is protected.
+                RowAddrSelection::Full => {
+                    acc.insert(*fragment_id, RoaringBitmap::full());
+                }
+                RowAddrSelection::Partial(offsets) => {
+                    let protected = acc.entry(*fragment_id).or_insert_with(RoaringBitmap::new);
+                    *protected |= offsets;
+                }
+            }
+            acc
+        },
+    );
+
+    for (fragment_id, protected_offsets) in &protected_by_fragment {
+        let fragment_id_u64 = u64::from(*fragment_id);
+        let before = read_version_fragments.get(&fragment_id_u64);
+        let after = current_fragments.get(&fragment_id_u64);
+        match (before, after) {
+            // Fragment removed entirely: the protected rows no longer exist.
+            (Some(_), None) => return Ok(true),
+            // Fragment created after the read version cannot contain rows the
+            // preconditions declared, which pointed at the read version.
+            (None, Some(_)) => continue,
+            // Neither manifest has the fragment: the protected rows never
+            // existed in this coordinate space, nothing to protect.
+            (None, None) => {}
+            (Some(before), Some(after)) => {
+                // A rewrite replaces the data files; every cell in the fragment
+                // is re-derived from a new snapshot, so protected or not it is
+                // no longer the cell that was read.
+                if before.files != after.files {
+                    return Ok(true);
+                }
+                if before.deletion_file != after.deletion_file {
+                    return Ok(true);
+                }
+                if before.overlays != after.overlays {
+                    // Overlays added or changed since the read version supply
+                    // new values for their covered cells.
+                    for overlay in &after.overlays {
+                        if before.overlays.iter().any(|b| b == overlay) {
+                            // Unchanged since the read version: the values read
+                            // then are still there.
+                            continue;
+                        }
+                        if overlay_covers_protected(overlay, precondition, protected_offsets)? {
+                            return Ok(true);
+                        }
+                    }
+                    // Overlays removed or narrowed since the read version let
+                    // the base values they shadowed resurface — also a change
+                    // to those cells. Check the pre-change coverage: a narrowed
+                    // overlay no longer reports the rows it used to cover.
+                    for overlay in &before.overlays {
+                        if after.overlays.iter().any(|a| a == overlay) {
+                            continue;
+                        }
+                        if overlay_covers_protected(overlay, precondition, protected_offsets)? {
+                            return Ok(true);
+                        }
+                    }
+                }
+            }
+        }
+    }
+    Ok(false)
+}
+
+/// Whether an overlay supplies a value for any protected (field, row) cell.
+fn overlay_covers_protected(
+    overlay: &DataOverlayFile,
+    precondition: &Precondition,
+    protected_offsets: &RoaringBitmap,
+) -> Result<bool> {
+    for (field_pos, field_id) in overlay.data_file.fields.iter().enumerate() {
+        if !precondition.field_ids.contains(field_id) {
+            continue;
+        }
+        let covered = overlay.coverage_for_field(field_pos)?;
+        if !(protected_offsets & covered.as_ref()).is_empty() {
+            return Ok(true);
+        }
+    }
+    Ok(false)
+}
+
+/// Evaluate the transaction's preconditions against the current manifest.
+///
+/// Runs on every attempt, before rebase: a precondition answers "is the world I
+/// read still the world I'm publishing into?", which rebase's compatibility
+/// question ("can these two transactions be linearized?") does not cover — a
+/// concurrent delete can be absorbed by rebase while still changing the cells
+/// a derived column was computed from.
+pub(crate) fn evaluate_preconditions(
+    transaction: &Transaction,
+    read_version_manifest: &Manifest,
+    current_manifest: &Manifest,
+) -> Result<()> {
+    if transaction.preconditions.is_empty() {
+        return Ok(());
+    }
+    let read_fragments: HashMap<u64, &Fragment> = read_version_manifest
+        .fragments
+        .iter()
+        .map(|f| (f.id, f))
+        .collect();
+    let current_fragments: HashMap<u64, &Fragment> = current_manifest
+        .fragments
+        .iter()
+        .map(|f| (f.id, f))
+        .collect();
+    for precondition in &transaction.preconditions {
+        if is_precondition_violated(precondition, &read_fragments, &current_fragments)? {
+            return Err(Error::retryable_commit_conflict_source(
+                current_manifest.version,
+                lance_core::box_error(lance_core::Error::prerequisite_failed(format!(
+                    "cells covered by preconditions (fields {:?}) changed",
+                    precondition.field_ids
+                ))),
+            ));
+        }
+    }
+    Ok(())
+}
+
 /// Attempt to commit a transaction, with retries and conflict resolution.
 #[allow(clippy::too_many_arguments)]
 pub(crate) async fn commit_transaction(
@@ -1458,6 +1607,18 @@ pub(crate) async fn commit_transaction(
 
             ensure_can_write_manifest(&dataset.manifest)?;
 
+            // Precondition evaluation is orthogonal to rebase: a concurrent
+            // transaction can be absorbable (so rebase passes) while still
+            // invalidating the cells the transaction's values were computed
+            // from. Runs before rebase so a violating attempt is rejected
+            // before finish() spends IO on replay (finish_delete_update can
+            // write merged deletion files).
+            evaluate_preconditions(
+                &transaction,
+                read_version_dataset.manifest.as_ref(),
+                &dataset.manifest,
+            )?;
+
             // See if we can retry the commit. Try to account for all
             // transactions that have been committed since the read_version.
             // Use small amount of backoff to handle transactions that all
@@ -1473,6 +1634,15 @@ pub(crate) async fn commit_transaction(
             transaction = rebase.finish(&dataset).await?;
         } else {
             ensure_can_write_manifest(&dataset.manifest)?;
+            if !transaction.preconditions.is_empty() {
+                // Defense in depth: CommitBuilder rejects this combination,
+                // but commit_transaction has non-builder callers.
+                return Err(Error::invalid_input_source(
+                    "commit preconditions are incompatible with strict overwrite \
+                     (Overwrite with num_retries = 0)"
+                        .into(),
+                ));
+            }
         }
 
         // Recomputed every attempt: the rebase above may have rewritten the
@@ -1739,6 +1909,7 @@ mod tests {
     use super::*;
 
     use crate::Dataset;
+    use crate::dataset::write::CommitBuilder;
     use crate::dataset::{WriteMode, WriteParams};
     use crate::index::DatasetIndexExt;
     use crate::index::vector::VectorIndexParams;
@@ -3320,5 +3491,89 @@ mod tests {
             index_segment("idx_a", Some(RoaringBitmap::from_iter(5..10))),
         ];
         assert!(detect_overlapping_fragments(&disjoint).is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_precondition_violated_by_concurrent_delete() {
+        use roaring::RoaringTreemap;
+
+        // Version 1: one fragment with rows id = 0..10.
+        let schema = Arc::new(ArrowSchema::new(vec![ArrowField::new(
+            "id",
+            DataType::Int64,
+            false,
+        )]));
+        let data = RecordBatch::try_new(
+            schema.clone(),
+            vec![Arc::new(Int64Array::from_iter_values(0..10))],
+        )
+        .unwrap();
+        let reader = RecordBatchIterator::new(vec![Ok(data)], schema);
+        let dataset = Dataset::write(
+            reader,
+            "memory://test_precondition_violated_by_concurrent_delete",
+            None,
+        )
+        .await
+        .unwrap();
+        assert_eq!(dataset.manifest.version, 1);
+        let fragment_id = dataset.manifest.fragments[0].id;
+
+        // A concurrent delete of rows 1 and 2 lands at version 2 before our
+        // commit runs. Deleting rows is compatible with an append, so without
+        // the precondition the commit would simply rebase over it.
+        let mut other = dataset.clone();
+        other.delete("id >= 1 AND id <= 2").await.unwrap();
+        assert_eq!(other.manifest.version, 2);
+
+        // Our append is based on version 1 and declares the deleted rows as a
+        // read dependency: the staged values were computed from those cells,
+        // which no longer hold the values we read.
+        let mut protected = RoaringTreemap::new();
+        for offset in [1_u64, 2] {
+            protected.insert((fragment_id << 32) | offset);
+        }
+        let mut appended_fragment = Fragment::new(100_000);
+        appended_fragment.physical_rows = Some(1);
+        let transaction = Transaction {
+            read_version: 1,
+            uuid: uuid::Uuid::new_v4().hyphenated().to_string(),
+            operation: Operation::Append {
+                fragments: vec![appended_fragment],
+            },
+            tag: None,
+            transaction_properties: None,
+            preconditions: vec![Precondition {
+                field_ids: vec![0],
+                rows: RowAddrTreeMap::from(protected),
+            }],
+        };
+        let control = Transaction {
+            preconditions: Vec::new(),
+            ..transaction.clone()
+        };
+
+        let err = CommitBuilder::new(Arc::new(dataset.clone()))
+            .execute(transaction)
+            .await
+            .unwrap_err();
+        let Error::RetryableCommitConflict { source, .. } = err else {
+            panic!("expected RetryableCommitConflict, got: {err:?}");
+        };
+        let cause = source
+            .downcast_ref::<Error>()
+            .expect("expected PrerequisiteFailed cause");
+        assert!(
+            matches!(cause, Error::PrerequisiteFailed { .. }),
+            "expected PrerequisiteFailed, got: {cause:?}"
+        );
+
+        // Control: the same append without preconditions rebases over the
+        // delete and lands at version 3.
+        let committed = CommitBuilder::new(Arc::new(dataset))
+            .execute(control)
+            .await
+            .unwrap();
+        assert_eq!(committed.manifest.version, 3);
     }
 }


### PR DESCRIPTION
Closes #8976.

## Summary

A read-compute-write task (e.g. publishing derived column `y = f(x)`) can now declare that the cells it read must be unchanged at commit time. The commit loop evaluates the declarations against the pinned read-version state on every attempt and rejects the commit — instead of rebasing over the changed data — when a concurrent transaction modified any protected cell.

```rust
CommitBuilder::new(dataset)
    .with_cells_unchanged([x_field_id], rows_read)
    .execute(transaction)
    .await?
```

## Design

- **The precondition travels on `Transaction` and in `transaction.proto`.** `verify_commit_outcome` detects a lost-response landing by comparing the committed transaction read back from the manifest against the in-memory one; anything not in the proto breaks that equality and a landed commit would be misclassified, recomputed, and republished (the double-publish #9043 forbids). This is also what distinguishes this from #8801's `CommitPrecondition`, which covers state re-derivable from the latest manifest — a declared read set only exists at staging time.
- **Evaluation runs in the commit loop against the pinned read-version state, before rebase, and is not gated on `check_txn`.** Conflict compatibility and precondition validity are orthogonal: a concurrent `Delete` can be absorbable by rebase while still invalidating the cells a staged value was computed from. Re-checking against the same original dependencies on every attempt gives #9043's "concurrent winner re-checks against the original dependencies" for free. `conflict_resolver.rs` is untouched, keeping the #6898 differential-oracle constraint.
- **Violation reports `PrerequisiteFailed` nested inside `RetryableCommitConflict`**, so `execute_with_retry` (delete/update/merge_insert) recomputes and retries against the latest version automatically.
- **Guards**: preconditions are rejected at build time for detached commits and for `Overwrite` (cell-level protection is meaningless when the dataset is replaced, and overwrite's `read_version = 0` leaves no aligned baseline); the strict-overwrite path in `commit_transaction` defends in depth for non-builder callers.

## Known limitations (for reviewers)

- **Fragment-granular detection for base data**: any data-file change on a protected fragment violates, including field-disjoint column updates (`Operation::Update` could enable field-level precision via `fields_modified`). Safe direction; required for #9043's field-disjoint composition to stop rejecting each other.
- **Deletion-file identity is fragment-granular**: a concurrent delete of non-protected rows in the same fragment also violates.
- **Overlay narrowing outside the protected region over-rejects**: matching is by full content equality, so an overlay narrowed only in unrelated rows is treated as changed.
- Stable row-id preconditions are left for a future change, per the issue.
- `execute_batch` (append-only today) does not carry preconditions.

Phase 2 (#9043, field-disjoint `Update × Update` composition) lands in v1 per the maintainer's confirmation below, and ports to the V2 actions from #6898 after cutover.