### PR TITLE
feat(format): add cell preconditions to the transaction format

### DIFF
--- a/docs/src/format/table/transaction.md
+++ b/docs/src/format/table/transaction.md
@@ -50,7 +50,8 @@ For detailed conflict detection and resolution mechanisms, see the [Conflict Res
 The authoritative specification for transaction types is defined in [`protos/transaction.proto`](https://github.com/lancedb/lance/blob/main/protos/transaction.proto).
 
 Each transaction contains a `read_version` field indicating the table version from which the transaction was built,
-a `uuid` field uniquely identifying the transaction, and an `operation` field specifying one of the following transaction types:
+a `uuid` field uniquely identifying the transaction, and an `operation` field specifying one of the following transaction types.
+It may also carry `preconditions` declaring cells that must be unchanged relative to the read version (see [Preconditions](#preconditions)):
 
 In the following section, we will describe each transaction type and its compatibility with other transaction types. This
 compatibility is not always bi-directional. We are describing it from the perspective of the operation being committed. For example, we say that an Append is not compatible with an Overwrite which means that if we are trying to commit an Append, and an
@@ -555,6 +556,76 @@ Adds new base paths to the table, enabling reference to data files in additional
 An UpdateBases operation only modifies the base paths. As a result, it only conflicts with other
 UpdateBases operations and even then only conflicts if the two operations have base paths with the
 same id, name, or path.
+
+## Preconditions
+
+A transaction may declare that specific cells must be unchanged relative to its `read_version`
+when it commits. A cell is a `(field, row address)` pair; a precondition declares a set of cells as
+the cartesian product of a list of field ids and a set of physical row addresses.
+
+This supports read-compute-write workflows such as publishing a derived column `y = f(x)`: the
+staged values are only correct if the cells of `x` they were computed from still hold the same
+contents at commit time. Conflict detection alone cannot guard this: a transaction that reads `x`
+and writes `y` is compatible with a concurrent update of `x`, and rebasing over it would silently
+publish stale values.
+
+### Semantics
+
+- **Conjunctive composition.** `preconditions` is a repeated field; every entry must hold. If any
+  entry is violated, the commit fails; it is never rebased over the changed cells. The caller may
+  recompute against a newer version and retry.
+- **Absent or empty means no conditions.** A transaction without preconditions commits normally.
+- **Degenerate entries.** An entry with an empty `field_ids` or an empty `rows` list declares no
+  cells; producers must not emit them.
+- **Invalid encodings.** Consumers must reject transactions whose preconditions are malformed
+  (negative field ids, duplicate fragment entries, `bitmap` values that are not valid portable
+  Roaring bitmaps, `full` set to false) as corrupt.
+
+### What "unchanged" means
+
+"Unchanged" is defined conservatively and evaluated against the state at the transaction's
+`read_version` — not the latest version. Two checks must both pass.
+
+Field validity (schema): every field id declared in a precondition must still exist in the schema,
+with the same data type and nullability it had at the read version. A concurrent operation that
+removes a declared field — for example, `Project` can drop a field while retaining a data file that
+is shared with other live fields, leaving `files` untouched — changes the declared cells even when
+no manifest structure changed. A field name change does not affect cell contents and does not
+violate the precondition.
+
+Manifest structure (fragments and overlays): for each fragment appearing in a precondition's rows:
+
+- If the fragment no longer exists, the declared cells are changed. A concurrent rewrite that
+  relocates the declared rows counts as a change; transparent remapping through compaction is not
+  required.
+- If the fragment's data files differ from the read version, the declared cells are changed.
+- A change to the deletion vector does not count as a change: a deleted row is masked, so any staged
+  value on it is invisible to readers and does not need to be recomputed.
+- If any overlay affecting declared cells was added, modified, removed, or narrowed since the read
+  version, the declared cells are changed. An overlay that already existed at the read version and
+  is unchanged does not count as a change.
+
+Implementations may over-reject — declaring a cell changed when its contents were in fact
+preserved, for example at whole-fragment granularity for base data — but must never under-reject:
+a commit must not land when a declared cell actually changed or its field no longer exists.
+
+Row addresses are physical addresses valid at the `read_version`. Preconditions based on stable
+row ids are reserved for a future revision.
+
+### Encoding
+
+The authoritative schema is the `Transaction.Precondition` message in
+[`protos/transaction.proto`](https://github.com/lancedb/lance/blob/main/protos/transaction.proto):
+
+- `field_ids`: repeated int32 schema field ids.
+- `rows`: repeated per-fragment `RowSelection` entries:
+    - `fragment_id` (uint32): the fragment the selection applies to. Entries must not repeat the
+      same fragment within one precondition.
+    - `coverage` (exactly one of):
+        - `full` (bool): the entire fragment is selected.
+        - `bitmap` (bytes): the selected row offsets within the fragment, in the Roaring Bitmap
+          *portable* serialization. Consumers must reject bitmaps that are not valid
+          portable-serialized Roaring bitmaps.
 
 ## Conflict Resolution
 

--- a/protos/transaction.proto
+++ b/protos/transaction.proto
@@ -407,6 +407,89 @@ message Transaction {
     repeated BasePath new_bases = 1;
   }
 
+  /* A condition that must hold for the commit to proceed.
+   *
+   * A precondition declares a set of cells — the cartesian product of the
+   * declared fields and row addresses — whose contents must be identical
+   * to what they held at the transaction's read_version when the
+   * transaction commits. If a concurrent transaction changed any declared
+   * cell, the commit is rejected instead of rebased over the change,
+   * because values computed from the old cell contents would be stale.
+   *
+   * "Unchanged" is defined conservatively and evaluated against the state
+   * at the read_version, not the latest version:
+   *
+   * - Field validity: every declared field must still exist in the schema
+   *   with the same data type and nullability it had at the read_version.
+   *   A concurrent operation that removes the field (e.g. Project) or
+   *   alters its type violates the precondition, even if the fragment
+   *   data files carrying it are unchanged.
+   * - Manifest structure: a declared cell counts as changed if its
+   *   fragment was removed, if the fragment's data files were replaced, or
+   *   if an overlay affecting the cell was added, modified, removed, or
+   *   narrowed. A change to the deletion vector does not count as a change:
+   *   a deleted row is masked, so any staged value on it is invisible to
+   *   readers and does not need to be recomputed.
+   *
+   * Implementations may over-reject (declare a cell changed when its
+   * contents were in fact preserved, e.g. at fragment granularity), but
+   * must never under-reject (declare a cell unchanged when its contents
+   * changed or its field no longer exists).
+   */
+  message Precondition {
+    /* The ids of the fields (columns) whose cells must be unchanged.
+     * Entries must be valid, non-negative schema field ids that exist in
+     * the schema at the read_version. An empty list declares no cells; it
+     * is degenerate and producers should not emit it.
+     */
+    repeated int32 field_ids = 1;
+
+    /* The rows that must be unchanged: one entry per fragment. An empty
+     * list declares no cells; it is degenerate and producers should not
+     * emit it.
+     *
+     * Entries are physical row addresses valid at the read_version: a
+     * concurrent rewrite (compaction) that relocates the declared rows
+     * counts as a change. Stable row id based preconditions are reserved
+     * for a future revision.
+     */
+    repeated RowSelection rows = 2;
+
+    /* A per-fragment selection of row addresses. */
+    message RowSelection {
+      /* The fragment the selection applies to. Entries must not repeat
+       * the same fragment within one precondition.
+       */
+      uint32 fragment_id = 1;
+
+      /* Which rows of the fragment are selected. */
+      oneof coverage {
+        /* The entire fragment is selected. Must be true when set. */
+        bool full = 2;
+
+        /* The selected row offsets within the fragment, in the Roaring
+         * Bitmap portable serialization. Consumers must reject bitmaps
+         * that are not valid portable-serialized Roaring bitmaps.
+         */
+        bytes bitmap = 3;
+      }
+    }
+  }
+
+  /* Conditions that must hold on the manifest a transaction lands on.
+   *
+   * The entries are conjunctive: every precondition must hold. If any
+   * precondition is violated, the commit fails and may be retried by the
+   * caller after recomputing against a newer read_version; it is never
+   * silently rebased over the changed cells.
+   *
+   * Absent or empty means no conditions: the transaction commits normally.
+   * Producers must write valid encodings; consumers must reject invalid
+   * encodings (undecodable rows, negative field ids) as corrupt
+   * transactions.
+   */
+  repeated Precondition preconditions = 5;
+
   // The operation of this transaction.
   oneof operation {
     Append append = 100;

--- a/rust/lance-table/src/transaction/manifest_build.rs
+++ b/rust/lance-table/src/transaction/manifest_build.rs
@@ -2140,6 +2140,7 @@ mod tests {
     fn test_proto_legacy_field_9_read() {
         // Simulate a manifest written by old Lance: only field 9, no field 10.
         let pb_tx = pb::Transaction {
+            preconditions: Vec::new(),
             read_version: 1,
             uuid: "test".to_string(),
             tag: String::new(),
@@ -2189,6 +2190,7 @@ mod tests {
             .unwrap();
 
         let pb_tx = pb::Transaction {
+            preconditions: Vec::new(),
             read_version: 1,
             uuid: "test".to_string(),
             tag: String::new(),

--- a/rust/lance-table/src/transaction/proto.rs
+++ b/rust/lance-table/src/transaction/proto.rs
@@ -719,6 +719,9 @@ impl From<&Transaction> for pb::Transaction {
             operation: Some(operation),
             tag: value.tag.clone().unwrap_or("".to_string()),
             transaction_properties,
+            // Populated by the commit-precondition implementation; nothing
+            // produces preconditions yet.
+            preconditions: Vec::new(),
         }
     }
 }


### PR DESCRIPTION
feat(format): add cell preconditions to the transaction format

Part of #8976. Vote-only PR: proto change, format specification, and compile-required edits. The builder and commit-loop implementation is intentionally excluded and lands in the follow-up #9118, per the persisted-format change process.

## Contract being accepted

A transaction may carry `preconditions`: declarations that specific cells must be **unchanged relative to the transaction's `read_version`** when the commit lands. A cell is a `(field, physical row address)` pair; each precondition declares a set of cells as the cartesian product of field ids and a per-fragment row selection.

Motivating case: read-compute-write workloads such as publishing a derived column `y = f(x)`. The staged values are only valid if the cells of `x` they were computed from still hold the same contents. Conflict compatibility cannot guard this — a read-`x`-write-`y` transaction is compatible with a concurrent update of `x`, and rebasing over it silently publishes stale values.

## Semantics fixed by this spec

The specification (`docs/src/format/table/transaction.md`, new "Preconditions" section) pins the points that must be decided language-agnostically, before any implementation fixes them by accident:

1. **Composition** — `preconditions` is repeated and conjunctive: every entry must hold. A violation rejects the commit; it is never rebased over the changed cells.
2. **Absent / empty / invalid** — absent or empty means no conditions. Entries with empty `field_ids` or empty `rows` are degenerate (declare no cells); producers must not emit them. Consumers must reject negative field ids, duplicate fragment entries, invalid Roaring bitmaps, or `full = false` as corrupt transactions.
3. **"Unchanged"** — defined conservatively, evaluated against the pinned `read_version` state, and checked at two levels. Field validity: every declared field must still exist with the same data type and nullability it had at the read version — a concurrent `Project` that drops the field while retaining its shared data file violates the precondition even when no manifest structure changed. Manifest structure: fragment removal, or any data file **carrying a declared field** being replaced / removed / with the declared field added or dropped from it, or any overlay affecting declared cells added / modified / removed / narrowed counts as a change. An overlay already present at the read version and unchanged does not. **Files carrying no declared field may be added or removed** (for example by a concurrent column addition) without violating the precondition. **Masking exception**: deletion-vector changes do not count as a change — a deleted row is masked, so any staged value on it is invisible to readers and does not need recomputation. Implementations may over-reject but must never under-reject.

The `rows` encoding is fully specified in the proto: one `RowSelection` per fragment (`fragment_id` + a `coverage` oneof of `full` or a Roaring Bitmap *portable-serialized* bitmap of row offsets). Stable-row-id preconditions are explicitly reserved for a future revision.

## Compatibility

- Proto: additive field (`repeated Precondition preconditions = 5` on `Transaction`; field 5 previously unused). Old readers ignore it; new readers see it absent for old writers. No field numbers reused or retyped.
- The feature is inert until a producer emits it: no behavior change for any existing transaction.
- `transaction.proto` is a stable persisted contract (transaction logs and inline manifest transactions), so this change requires the format-spec vote.