### PR TITLE
feat: support cross-column vector refinement

### DIFF
--- a/docs/src/quickstart/vector-search.md
+++ b/docs/src/quickstart/vector-search.md
@@ -311,9 +311,11 @@ The refinement column does not need an index. The final `_distance` and
 together and set a positive `refine_factor`; omitting them preserves ordinary
 same-column refinement. Batched queries must have matching query counts.
 
-For a quantized coarse index, candidates are selected using its approximate
-distances. Cross-column refinement replaces the ordinary exact refinement step;
-it does not first rerank candidates using the coarse column's original values.
+For a fully indexed coarse search, quantized candidates are selected using the
+index's approximate distances. Cross-column refinement replaces the ordinary
+same-column exact refinement step. If appended or updated coarse vectors must be
+merged with index results, Lance's existing merge path may read and rescore coarse
+vectors before selecting the final coarse TopM.
 With `use_index=False`, Lance selects exact coarse TopM before refinement, which
 is still different from a full scan in the final vector space.
 

--- a/docs/src/quickstart/vector-search.md
+++ b/docs/src/quickstart/vector-search.md
@@ -276,6 +276,57 @@ result = sift1m.to_table(
 print(result.to_pandas())
 ```
 
+## Refine Using Another Vector Column
+
+If a dataset stores two vector representations of each row, you can generate
+candidates with one column and rerank them with the other. For example, index a
+128-dimensional projection and compute final distances with the original
+1024-dimensional vectors. Both columns must be `FixedSizeList<Float32>`.
+
+Given a dataset `ds` with `short_vector` and `full_vector` columns, and a query
+represented in both spaces:
+
+```python
+results = ds.to_table(
+    columns=["_distance"],
+    with_row_id=True,
+    nearest={
+        "column": "short_vector",
+        "q": short_query,
+        "metric": "l2",
+        "k": 10,
+        "nprobes": 4,
+        "refine_factor": 2,
+        "refine_column": "full_vector",
+        "refine_q": full_query,
+        "refine_metric": "cosine",
+    },
+)
+```
+
+Lance selects up to 20 coarse candidates, reads their `full_vector` values from
+the same dataset snapshot, computes cosine distances, and returns the best 10.
+The refinement column does not need an index. The final `_distance` and
+`distance_range` refer to the refinement metric. Supply all three new parameters
+together and set a positive `refine_factor`; omitting them preserves ordinary
+same-column refinement. Batched queries must have matching query counts.
+
+For a quantized coarse index, candidates are selected using its approximate
+distances. Cross-column refinement replaces the ordinary exact refinement step;
+it does not first rerank candidates using the coarse column's original values.
+With `use_index=False`, Lance selects exact coarse TopM before refinement, which
+is still different from a full scan in the final vector space.
+
+Scalar prefilters restrict candidates before selection. Postfilters run after
+the final TopK and may return fewer than `k` rows. Vector and full-text query
+filters cannot be combined with cross-column refinement. Null or invalid
+refinement vectors can also reduce the result count.
+
+Produce both query representations before calling Lance. For a PCA projection,
+apply the same fitted transform and preprocessing used for the stored short
+vectors. Increasing the candidate budget can improve recall, but increases
+random reads of the refinement column, especially on remote storage.
+
 ## Next Steps
 
 Check out **[Full-text Search](../quickstart/full-text-search.md)**, where we show how to create and query a BM25 index for keyword-based search in Lance.

--- a/python/python/benchmarks/cross_column_refinement.py
+++ b/python/python/benchmarks/cross_column_refinement.py
@@ -1,0 +1,253 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright The Lance Authors
+"""Compare cross-column refinement with Python reranking and full-vector indices.
+
+Run from python/ after the initial make install:
+    uv run maturin develop --uv --profile release-with-debug
+    uv run python python/benchmarks/cross_column_refinement.py \
+        --build-label release-with-debug --output results.json
+
+The synthetic vectors have decreasing coordinate variance. The coarse column
+contains their first coordinates; no embedding model, PCA fit, or private data is
+required. Queries are held out of the dataset. Results describe this synthetic
+workload, not semantic relevance or production recall.
+"""
+
+import argparse
+import json
+import platform
+import tempfile
+import time
+from pathlib import Path
+
+import lance
+import numpy as np
+import pyarrow as pa
+
+
+def run(args, path):
+    rng = np.random.default_rng(args.seed)
+    full = rng.standard_normal(
+        (args.rows + args.queries, args.dimensions), dtype=np.float32
+    )
+    full *= np.exp(-np.arange(args.dimensions) / (args.dimensions / 4))
+    full /= np.linalg.norm(full, axis=1, keepdims=True)
+    queries = full[args.rows :].copy()
+    full = full[: args.rows]
+    short = np.ascontiguousarray(full[:, : args.coarse_dimensions])
+    table = pa.table(
+        {
+            "full_vector": pa.FixedSizeListArray.from_arrays(
+                pa.array(full.reshape(-1)), args.dimensions
+            ),
+            "short_vector": pa.FixedSizeListArray.from_arrays(
+                pa.array(short.reshape(-1)), args.coarse_dimensions
+            ),
+        }
+    )
+    ds = lance.write_dataset(table, path, max_rows_per_file=2048)
+    specs = {
+        "full_flat": ("full_vector", "IVF_FLAT", "cosine", {}),
+        "short_flat": ("short_vector", "IVF_FLAT", "l2", {}),
+        "full_pq": (
+            "full_vector",
+            "IVF_PQ",
+            "cosine",
+            {
+                "num_sub_vectors": args.dimensions // 16,
+                "num_bits": 4,
+            },
+        ),
+    }
+    build_seconds = {}
+    for name, (column, kind, metric, options) in specs.items():
+        started = time.perf_counter()
+        ds.create_index(
+            column,
+            kind,
+            name=name,
+            metric=metric,
+            num_partitions=args.partitions,
+            **options,
+        )
+        build_seconds[name] = time.perf_counter() - started
+    ds = lance.dataset(path, index_cache_size_bytes=1024**3)
+    segments = {
+        index.name: [segment.uuid for segment in index.segments]
+        for index in ds.describe_indices()
+    }
+    index_bytes = {
+        name: sum(
+            f.stat().st_size
+            for segment in ids
+            for f in (path / "_indices" / segment).rglob("*")
+            if f.is_file()
+        )
+        for name, ids in segments.items()
+    }
+
+    def search(query, *, short_space=False, index=None, factor=None, cross=False):
+        nearest = {
+            "column": "short_vector" if short_space else "full_vector",
+            "q": query[: args.coarse_dimensions] if short_space else query,
+            "metric": "l2" if short_space else "cosine",
+            "k": args.k,
+            "nprobes": args.nprobes,
+            "use_index": index is not None,
+            "query_parallelism": 1,
+        }
+        if factor is not None:
+            nearest["refine_factor"] = factor
+        if cross:
+            nearest.update(
+                refine_column="full_vector", refine_q=query, refine_metric="cosine"
+            )
+        return ds.scanner(
+            columns=["_distance"],
+            with_row_id=True,
+            nearest=nearest,
+            index_segments=segments[index] if index else None,
+        ).to_table()
+
+    def python_refine(query):
+        # Projection asks Lance to fetch final vectors only for coarse TopM.
+        # This avoids an unnecessary second Python-to-Lance query round trip.
+        candidates = ds.scanner(
+            columns=["full_vector", "_distance"],
+            with_row_id=True,
+            index_segments=segments["short_flat"],
+            nearest={
+                "column": "short_vector",
+                "q": query[: args.coarse_dimensions],
+                "metric": "l2",
+                "k": args.k * args.factor,
+                "nprobes": args.nprobes,
+                "query_parallelism": 1,
+            },
+        ).to_table()
+        vectors = candidates["full_vector"].combine_chunks().values.to_numpy()
+        vectors = vectors.reshape(-1, args.dimensions)
+        distances = 1 - (vectors * query).sum(axis=1) / (
+            np.linalg.norm(vectors, axis=1) * np.linalg.norm(query)
+        )
+        row_ids = candidates["_rowid"].to_numpy()
+        order = np.lexsort((row_ids, distances))[: args.k]
+        return pa.table({"_rowid": row_ids[order], "_distance": distances[order]})
+
+    paths = {
+        "full_exact": lambda q: search(q),
+        "short_exact": lambda q: search(q, short_space=True),
+        "full_ivf_flat": lambda q: search(q, index="full_flat"),
+        "short_ivf_flat": lambda q: search(q, short_space=True, index="short_flat"),
+        "native_refine": lambda q: search(
+            q, short_space=True, index="short_flat", factor=args.factor, cross=True
+        ),
+        "python_refine": python_refine,
+        "full_ivf_pq": lambda q: search(q, index="full_pq"),
+        "full_ivf_pq_refine": lambda q: search(q, index="full_pq", factor=args.factor),
+    }
+    ground_truth = [set(search(q)["_rowid"].to_pylist()) for q in queries]
+    # Warm each path on the query set, then interleave timed paths in random order.
+    for query in queries:
+        native = paths["native_refine"](query)
+        python = python_refine(query)
+        assert native["_rowid"].to_pylist() == python["_rowid"].to_pylist()
+        np.testing.assert_allclose(native["_distance"], python["_distance"], atol=2e-6)
+        for name, execute in paths.items():
+            if name not in {"native_refine", "python_refine"}:
+                execute(query)
+    observations = {name: [] for name in paths}
+    for qi in rng.permutation(len(queries)):
+        for name in rng.permutation(list(paths)):
+            started = time.perf_counter()
+            result = paths[name](queries[qi])
+            elapsed_ms = (time.perf_counter() - started) * 1000
+            ids = result["_rowid"].to_pylist()
+            observations[name].append(
+                {
+                    "query": int(qi),
+                    "elapsed_ms": elapsed_ms,
+                    "recall": len(set(ids) & ground_truth[qi]) / args.k,
+                }
+            )
+    summary = {}
+    for name, samples in observations.items():
+        latency = [sample["elapsed_ms"] for sample in samples]
+        summary[name] = {
+            "recall_at_k": float(np.mean([sample["recall"] for sample in samples])),
+            "p50_ms": float(np.median(latency)),
+            "p95_ms": float(np.percentile(latency, 95)),
+            "sequential_qps": 1000 / float(np.mean(latency)),
+        }
+    return {
+        "parameters": {
+            k: str(v) if isinstance(v, Path) else v for k, v in vars(args).items()
+        },
+        "environment": {
+            "platform": platform.platform(),
+            "python": platform.python_version(),
+            "lance": lance.__version__,
+        },
+        "workload": "local, held-out synthetic queries, warmed paths, no scalar filter",
+        "timing": (
+            "query planning through Arrow results; "
+            "excludes input generation and index construction"
+        ),
+        "native_matches_python": True,
+        "index_configuration": specs,
+        "index_bytes": index_bytes,
+        "index_build_seconds": build_seconds,
+        "summary": summary,
+        "observations": observations,
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--rows", type=int, default=20_000)
+    parser.add_argument("--queries", type=int, default=100)
+    parser.add_argument("--dimensions", type=int, default=1024)
+    parser.add_argument("--coarse-dimensions", type=int, default=128)
+    parser.add_argument("--partitions", type=int, default=32)
+    parser.add_argument("--nprobes", type=int, default=4)
+    parser.add_argument("--k", type=int, default=10)
+    parser.add_argument("--factor", type=int, default=10)
+    parser.add_argument("--seed", type=int, default=734)
+    parser.add_argument("--output", type=Path)
+    parser.add_argument("--tmpdir", type=Path)
+    parser.add_argument("--build-label", default="unspecified")
+    args = parser.parse_args()
+    if (
+        min(
+            args.rows,
+            args.queries,
+            args.dimensions,
+            args.coarse_dimensions,
+            args.partitions,
+            args.nprobes,
+            args.k,
+            args.factor,
+        )
+        < 1
+        or args.dimensions % 16
+        or args.coarse_dimensions >= args.dimensions
+        or args.nprobes > args.partitions
+        or args.rows < max(256, args.k)
+    ):
+        parser.error(
+            "Require positive counts, full dimensions divisible by 16, "
+            "coarse dimensions < full dimensions, nprobes <= partitions, "
+            "and rows >= max(256, k)"
+        )
+    with tempfile.TemporaryDirectory(
+        prefix="lance-refinement-", dir=args.tmpdir
+    ) as tmp:
+        result = run(args, Path(tmp) / "vectors.lance")
+    rendered = json.dumps(result, indent=2)
+    if args.output:
+        args.output.write_text(rendered + "\n")
+    print(json.dumps(result["summary"], indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/python/python/benchmarks/cross_column_refinement_dataset.py
+++ b/python/python/benchmarks/cross_column_refinement_dataset.py
@@ -6,6 +6,8 @@ The NPZ query file contains Float32 arrays ``full`` and ``coarse`` and UInt64
 ``rowids`` identifying the in-corpus query rows. Recall excludes each query row
 before candidate selection. A separate unfiltered workload measures latency only.
 No dataset or index is created or changed. All indices must cover the snapshot.
+Both indexed columns also run same-column refinement with the same nprobes and
+factor as cross-column refinement; unrefined paths remain as separate baselines.
 
 Run from python/ with an optimized extension already installed:
     uv run --no-sync python python/benchmarks/cross_column_refinement_dataset.py \
@@ -47,6 +49,16 @@ def configurations(pairs):
     for probes, factor in pairs:
         paths.extend(
             {
+                "name": f"{space}_refine_p{probes}_f{factor}",
+                "kind": "same",
+                "space": space,
+                "nprobes": probes,
+                "factor": factor,
+            }
+            for space in ("full", "coarse")
+        )
+        paths.extend(
+            {
                 "name": f"{kind}_p{probes}_f{factor}",
                 "kind": kind,
                 "space": "coarse",
@@ -58,7 +70,7 @@ def configurations(pairs):
     return paths
 
 
-def execute(ds, queries, segments, args, config, qi, exclude_self):
+def make_scanner(ds, queries, segments, args, config, qi, exclude_self):
     space = config["space"]
     kind = config["kind"]
     nearest = {
@@ -80,15 +92,23 @@ def execute(ds, queries, segments, args, config, qi, exclude_self):
         )
     elif kind == "numpy":
         nearest["k"] *= config["factor"]
-    table = ds.scanner(
+    elif kind == "same":
+        nearest["refine_factor"] = config["factor"]
+    return ds.scanner(
         columns=[args.full_column, "_distance"] if kind == "numpy" else ["_distance"],
         with_row_id=True,
         nearest=nearest,
         index_segments=segments[space] if kind != "exact" else None,
         filter=f"_rowid != {int(queries['rowids'][qi])}" if exclude_self else None,
         prefilter=True,
+    )
+
+
+def execute(ds, queries, segments, args, config, qi, exclude_self):
+    table = make_scanner(
+        ds, queries, segments, args, config, qi, exclude_self
     ).to_table()
-    if kind != "numpy":
+    if config["kind"] != "numpy":
         return table
     array = table[args.full_column].combine_chunks()
     vectors = array.values.to_numpy().reshape(len(array), array.type.list_size)
@@ -187,6 +207,12 @@ def run(args):
         "configurations": configs,
         "index_segments": segments,
         "index_bytes": index_bytes,
+        "plans": {
+            config["name"]: make_scanner(
+                ds, queries, segments, args, config, 0, True
+            ).explain_plan()
+            for config in configs
+        },
         "workloads": {},
     }
     for exclude_self in (True, False):

--- a/python/python/benchmarks/cross_column_refinement_dataset.py
+++ b/python/python/benchmarks/cross_column_refinement_dataset.py
@@ -1,0 +1,266 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright The Lance Authors
+"""Read-only refinement comparison on an existing dataset and fixed queries.
+
+The NPZ query file contains Float32 arrays ``full`` and ``coarse`` and UInt64
+``rowids`` identifying the in-corpus query rows. Recall excludes each query row
+before candidate selection. A separate unfiltered workload measures latency only.
+No dataset or index is created or changed. All indices must cover the snapshot.
+
+Run from python/ with an optimized extension already installed:
+    uv run --no-sync python python/benchmarks/cross_column_refinement_dataset.py \
+        --uri /path/to/data.lance --version 4 --queries queries.npz \
+        --full-column full_vector --coarse-column short_vector \
+        --full-index full_flat --coarse-index short_flat --output results.json
+
+Results are relative to full-column exact cosine search, not relevance labels.
+The JSON output includes row IDs and should be treated as dataset-derived data.
+"""
+
+import argparse
+import hashlib
+import json
+import platform
+import time
+from pathlib import Path
+
+import lance
+import numpy as np
+import pyarrow as pa
+
+
+def configurations(pairs):
+    paths = [
+        {"name": "full_exact", "kind": "exact", "space": "full"},
+        {"name": "coarse_exact", "kind": "exact", "space": "coarse"},
+    ]
+    for space in ("full", "coarse"):
+        paths.extend(
+            {
+                "name": f"{space}_ann_p{probes}",
+                "kind": "ann",
+                "space": space,
+                "nprobes": probes,
+            }
+            for probes in sorted({probes for probes, _ in pairs})
+        )
+    for probes, factor in pairs:
+        paths.extend(
+            {
+                "name": f"{kind}_p{probes}_f{factor}",
+                "kind": kind,
+                "space": "coarse",
+                "nprobes": probes,
+                "factor": factor,
+            }
+            for kind in ("native", "numpy")
+        )
+    return paths
+
+
+def execute(ds, queries, segments, args, config, qi, exclude_self):
+    space = config["space"]
+    kind = config["kind"]
+    nearest = {
+        "column": args.full_column if space == "full" else args.coarse_column,
+        "q": queries[space][qi],
+        "k": args.k,
+        "metric": "cosine" if space == "full" else "l2",
+        "use_index": kind != "exact",
+        "query_parallelism": 1,
+    }
+    if "nprobes" in config:
+        nearest["nprobes"] = config["nprobes"]
+    if kind == "native":
+        nearest.update(
+            refine_factor=config["factor"],
+            refine_column=args.full_column,
+            refine_q=queries["full"][qi],
+            refine_metric="cosine",
+        )
+    elif kind == "numpy":
+        nearest["k"] *= config["factor"]
+    table = ds.scanner(
+        columns=[args.full_column, "_distance"] if kind == "numpy" else ["_distance"],
+        with_row_id=True,
+        nearest=nearest,
+        index_segments=segments[space] if kind != "exact" else None,
+        filter=f"_rowid != {int(queries['rowids'][qi])}" if exclude_self else None,
+        prefilter=True,
+    ).to_table()
+    if kind != "numpy":
+        return table
+    array = table[args.full_column].combine_chunks()
+    vectors = array.values.to_numpy().reshape(len(array), array.type.list_size)
+    query = queries["full"][qi]
+    distances = 1 - (vectors * query).sum(axis=1) / (
+        np.linalg.norm(vectors, axis=1) * np.linalg.norm(query)
+    )
+    rowids = table["_rowid"].to_numpy()
+    order = np.lexsort((rowids, distances))[: args.k]
+    return pa.table({"_rowid": rowids[order], "_distance": distances[order]})
+
+
+def summarize(records, truth, k):
+    summary = {}
+    for name, samples in records.items():
+        elapsed = [s["elapsed_ms"] for s in samples]
+        row = {
+            "n": len(samples),
+            "p50_ms": float(np.median(elapsed)),
+            "p95_ms": float(np.percentile(elapsed, 95)),
+            "mean_ms": float(np.mean(elapsed)),
+            "sequential_qps": 1000 / float(np.mean(elapsed)),
+        }
+        if truth is not None:
+            recalls = np.array(
+                [len(set(s["rowids"]) & set(truth[s["query"]])) / k for s in samples]
+            )
+            rng = np.random.default_rng(91)
+            boot = recalls[rng.integers(0, len(recalls), (2000, len(recalls)))].mean(
+                axis=1
+            )
+            row.update(
+                recall_at_k=float(recalls.mean()),
+                recall_95ci=np.quantile(boot, [0.025, 0.975]).tolist(),
+                top1_agreement=float(
+                    np.mean([s["rowids"][0] == truth[s["query"]][0] for s in samples])
+                ),
+            )
+        summary[name] = row
+    return summary
+
+
+def run(args):
+    pairs = [tuple(map(int, pair.split(":"))) for pair in args.pairs.split(",")]
+    if any(len(pair) != 2 or min(pair) < 1 for pair in pairs):
+        raise ValueError("pairs must be positive nprobes:factor pairs")
+    configs = configurations(pairs)
+    with np.load(args.queries, allow_pickle=False) as archive:
+        queries = {key: archive[key] for key in ("full", "coarse", "rowids")}
+    count = len(queries["rowids"])
+    if not count or any(len(queries[key]) != count for key in ("full", "coarse")):
+        raise ValueError("Query arrays must have matching, nonzero lengths")
+    for space in ("full", "coarse"):
+        if queries[space].ndim != 2 or queries[space].dtype != np.float32:
+            raise ValueError("Vector queries must be 2D Float32 arrays")
+    ds = lance.dataset(
+        args.uri,
+        version=args.version,
+        index_cache_size_bytes=args.cache_gib * 1024**3,
+        metadata_cache_size_bytes=128 * 1024**2,
+    )
+    index_names = {"full": args.full_index, "coarse": args.coarse_index}
+    described = {index.name: index for index in ds.describe_indices()}
+    segments = {
+        space: [segment.uuid for segment in described[name].segments]
+        for space, name in index_names.items()
+    }
+    index_bytes = {}
+    for space, name in index_names.items():
+        statistics = ds.index_statistics(name)
+        if statistics["num_unindexed_rows"] != 0:
+            raise ValueError(f"Index {name} does not cover the complete snapshot")
+        local_files = Path(args.uri) / "_indices"
+        if local_files.is_dir():
+            index_bytes[space] = sum(
+                file.stat().st_size
+                for segment in segments[space]
+                for file in (local_files / segment).rglob("*")
+                if file.is_file()
+            )
+        ds.prewarm_index(name)
+    extension = Path(lance.__file__).parent / "lance.abi3.so"
+    output = {
+        "parameters": {
+            k: str(v) if isinstance(v, Path) else v for k, v in vars(args).items()
+        },
+        "snapshot": {"version": ds.version, "rows": ds.count_rows()},
+        "environment": {
+            "platform": platform.platform(),
+            "python": platform.python_version(),
+            "lance": lance.__version__,
+            "extension_sha256": hashlib.sha256(extension.read_bytes()).hexdigest()
+            if extension.exists()
+            else None,
+        },
+        "configurations": configs,
+        "index_segments": segments,
+        "index_bytes": index_bytes,
+        "workloads": {},
+    }
+    for exclude_self in (True, False):
+        mode = "self_excluded" if exclude_self else "unfiltered_latency_only"
+        # Warm all indexed paths on the same fixed queries. Exact scans warm once.
+        for config in configs:
+            warm_count = min(count, 20) if config["kind"] != "exact" else 1
+            for qi in range(warm_count):
+                execute(ds, queries, segments, args, config, qi, exclude_self)
+        records = {config["name"]: [] for config in configs}
+        rng = np.random.default_rng(args.seed)
+        for position, qi in enumerate(rng.permutation(count)):
+            current = {}
+            for ci in rng.permutation(len(configs)):
+                config = configs[ci]
+                started = time.perf_counter()
+                result = execute(ds, queries, segments, args, config, qi, exclude_self)
+                elapsed = (time.perf_counter() - started) * 1000
+                ids = result["_rowid"].to_pylist()
+                distances = result["_distance"].to_pylist()
+                assert len(ids) == args.k
+                if exclude_self:
+                    assert int(queries["rowids"][qi]) not in ids
+                sample = {
+                    "query": int(qi),
+                    "elapsed_ms": elapsed,
+                    "rowids": ids,
+                    "distances": distances,
+                }
+                records[config["name"]].append(sample)
+                current[config["name"]] = sample
+            for probes, factor in pairs:
+                native = current[f"native_p{probes}_f{factor}"]
+                numpy = current[f"numpy_p{probes}_f{factor}"]
+                np.testing.assert_array_equal(native["rowids"], numpy["rowids"])
+                np.testing.assert_allclose(
+                    native["distances"], numpy["distances"], atol=2e-6
+                )
+            if position % 10 == 0:
+                print(f"{mode}: {position + 1}/{count} queries", flush=True)
+        truth = (
+            {s["query"]: s["rowids"] for s in records["full_exact"]}
+            if exclude_self
+            else None
+        )
+        output["workloads"][mode] = {
+            "summary": summarize(records, truth, args.k),
+            "observations": records,
+            "native_matches_numpy": True,
+        }
+        args.output.write_text(json.dumps(output, indent=2) + "\n")
+        print(json.dumps(output["workloads"][mode]["summary"], indent=2), flush=True)
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--uri", required=True)
+    parser.add_argument("--version", type=int, required=True)
+    parser.add_argument("--queries", type=Path, required=True)
+    parser.add_argument("--full-column", required=True)
+    parser.add_argument("--coarse-column", required=True)
+    parser.add_argument("--full-index", required=True)
+    parser.add_argument("--coarse-index", required=True)
+    parser.add_argument("--pairs", default="4:2,16:2,16:10,64:50")
+    parser.add_argument("--k", type=int, default=10)
+    parser.add_argument("--cache-gib", type=int, default=8)
+    parser.add_argument("--seed", type=int, default=734)
+    parser.add_argument("--build-label", default="unspecified")
+    parser.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args()
+    if min(args.k, args.cache_gib) < 1:
+        parser.error("k and cache-gib must be positive")
+    run(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/python/python/lance/dataset.py
+++ b/python/python/lance/dataset.py
@@ -6961,6 +6961,9 @@ class ScannerBuilder:
         query_parallelism: Optional[int] = None,
         approx_mode: Literal["fast", "normal", "accurate"] = "normal",
         distance_range: Optional[tuple[Optional[float], Optional[float]]] = None,
+        refine_column: Optional[str] = None,
+        refine_q: Optional[QueryVectorLike] = None,
+        refine_metric: Optional[str] = None,
     ) -> ScannerBuilder:
         """Configure nearest neighbor search.
 
@@ -6990,6 +6993,22 @@ class ScannerBuilder:
             setting. ``fast`` favors lower latency and may reduce recall,
             ``normal`` uses the default balance, and ``accurate`` favors higher
             recall and may increase latency.
+        refine_column, refine_q, refine_metric: optional
+            Supply all three to rerank ``k * refine_factor`` coarse candidates
+            using another Float32 fixed-size vector column. ``refine_q`` must
+            match that column's dimension and the number of coarse queries.
+            Requires an explicit positive ``refine_factor``. Final ``_distance``
+            and ``distance_range`` use ``refine_metric``. With ``use_index=False``,
+            coarse TopM still precedes refinement. Query filters are unsupported;
+            scalar filters retain their usual prefilter/postfilter behavior.
+
+        Examples
+        --------
+        .. code-block:: python
+
+            builder.nearest("pca128", q128, k=10, refine_factor=2,
+                            refine_column="embedding", refine_q=q1024,
+                            refine_metric="cosine")
         """
         self._nearest = _build_vector_search_query(
             column,
@@ -7006,6 +7025,9 @@ class ScannerBuilder:
             query_parallelism=query_parallelism,
             approx_mode=approx_mode,
             distance_range=distance_range,
+            refine_column=refine_column,
+            refine_q=refine_q,
+            refine_metric=refine_metric,
         )
         return self
 
@@ -8193,6 +8215,9 @@ def _build_vector_search_query(
     query_parallelism: Optional[int] = None,
     approx_mode: Literal["fast", "normal", "accurate"] = "normal",
     distance_range: Optional[tuple[Optional[float], Optional[float]]] = None,
+    refine_column: Optional[str] = None,
+    refine_q: Optional[QueryVectorLike] = None,
+    refine_metric: Optional[str] = None,
 ) -> dict:
     """Configure nearest neighbor search.
 
@@ -8245,6 +8270,8 @@ def _build_vector_search_query(
         Both bounds are optional. The lower bound is inclusive and the upper
         bound is exclusive, so (0.0, 1.0) keeps distances d where
         0.0 <= d < 1.0, (None, 0.5) keeps d < 0.5, and (0.5, None) keeps d >= 0.5.
+    refine_column, refine_q, refine_metric: optional
+        Cross-column refinement parameters; see ``ScannerBuilder.nearest``.
 
     Returns
     -------
@@ -8252,6 +8279,13 @@ def _build_vector_search_query(
         The scanner builder for method chaining.
     """
     q, q_dim = _coerce_query_vector(q)
+    refine_args = (refine_column, refine_q, refine_metric)
+    if any(value is not None for value in refine_args):
+        if not all(value is not None for value in refine_args):
+            raise ValueError(
+                "refine_column, refine_q, and refine_metric must be provided together"
+            )
+        refine_q, _ = _coerce_query_vector(refine_q)
 
     lance_field = dataset._ds.lance_schema.field_case_insensitive(column)
     if lance_field is None:
@@ -8338,6 +8372,9 @@ def _build_vector_search_query(
         "query_parallelism": query_parallelism,
         "approx_mode": approx_mode,
         "distance_range": distance_range,
+        "refine_column": refine_column,
+        "refine_q": refine_q,
+        "refine_metric": refine_metric,
     }
 
 

--- a/python/python/tests/test_vector_index.py
+++ b/python/python/tests/test_vector_index.py
@@ -307,15 +307,25 @@ def test_cross_column_refinement(
         ("IVF_HNSW_SQ", {"max_level": 2, "m": 4, "ef_construction": 16}),
     ],
 )
+@pytest.mark.parametrize("index_mode", ["complete", "appended", "updated"])
 def test_cross_column_candidate_budget_and_range(
-    cross_column_dataset, index_type, kwargs
+    cross_column_dataset, index_type, kwargs, index_mode
 ):
     path, table, coarse, original = cross_column_dataset
-    ds = lance.write_dataset(table, path, max_rows_per_file=128)
+    initial = 256 if index_mode == "appended" else len(table)
+    ds = lance.write_dataset(table.slice(0, initial), path, max_rows_per_file=128)
     ds.create_index("coarse", index_type, metric="l2", num_partitions=4, **kwargs)
-    query_id = 33
+    query_id = 260 if index_mode == "appended" else 33
+    if index_mode == "appended":
+        ds = lance.write_dataset(table.slice(initial), path, mode="append")
+    elif index_mode == "updated":
+        ds.update({"coarse": str(coarse[query_id].tolist())}, where="id = 319")
     common = dict(column="coarse", q=coarse[query_id], metric="l2", nprobes=4)
     candidates = ds.to_table(columns=["id"], nearest={**common, "k": 20})
+    if index_mode == "appended":
+        assert query_id in candidates["id"].to_pylist()
+    elif index_mode == "updated":
+        assert 319 in candidates["id"].to_pylist()
     if index_type == "IVF_FLAT":
         legacy = ds.to_table(
             columns=["id"], nearest={**common, "k": 10, "refine_factor": 2}

--- a/python/python/tests/test_vector_index.py
+++ b/python/python/tests/test_vector_index.py
@@ -203,6 +203,269 @@ def test_flat(dataset):
     run(dataset)
 
 
+@pytest.fixture
+def cross_column_dataset(tmp_path):
+    rng = np.random.default_rng(734)
+    coarse = rng.normal(size=(320, 4)).astype(np.float32)
+    original = rng.normal(size=(320, 16)).astype(np.float32)
+    original[1] = 0
+    original[2] = np.nan
+    values = original.tolist()
+    values[3] = None
+    table = pa.table(
+        {
+            "id": np.arange(320),
+            "coarse": pa.array(coarse.tolist(), type=pa.list_(pa.float32(), 4)),
+            "original": pa.array(values, type=pa.list_(pa.float32(), 16)),
+        }
+    )
+    return tmp_path, table, coarse, original
+
+
+@pytest.mark.parametrize("index_mode", ["none", "complete", "appended"])
+@pytest.mark.parametrize("stable_ids", [False, True])
+@pytest.mark.parametrize("prefilter", [False, True])
+def test_cross_column_refinement(
+    cross_column_dataset, index_mode, stable_ids, prefilter
+):
+    path, table, coarse, original = cross_column_dataset
+    initial = 256 if index_mode == "appended" else len(table)
+    ds = lance.write_dataset(
+        table.slice(0, initial),
+        path,
+        max_rows_per_file=128,
+        enable_stable_row_ids=stable_ids,
+    )
+    if index_mode != "none":
+        ds.create_index("coarse", "IVF_FLAT", metric="l2", num_partitions=4)
+    if initial < len(table):
+        ds = lance.write_dataset(table.slice(initial), path, mode="append")
+    ds.delete("id = 9")
+    queries = [260, 33]
+    # M covers all rows so independent full-space exact results are the reference.
+    nearest = dict(
+        column="coarse",
+        q=coarse[queries],
+        metric="l2",
+        k=10,
+        nprobes=4,
+        refine_factor=40,
+        refine_column="original",
+        refine_q=original[queries],
+        refine_metric="cosine",
+    )
+    scanner = ds.scanner(
+        columns=["id"],
+        nearest=nearest,
+        with_row_id=True,
+        filter="id >= 20",
+        prefilter=prefilter,
+    )
+    plan = scanner.explain_plan()
+    assert "metric=cosine" in plan
+    if index_mode != "none":
+        assert "ANNSubIndex" in plan
+    actual = scanner.to_table()
+    for qi, query_id in enumerate(queries):
+        part = actual.filter(pc.equal(actual["query_index"], qi))
+        single = ds.to_table(
+            columns=["id"],
+            filter="id >= 20",
+            prefilter=prefilter,
+            nearest={**nearest, "q": coarse[query_id], "refine_q": original[query_id]},
+        )
+        assert part["id"].to_pylist() == single["id"].to_pylist()
+        candidate_ids = np.arange(len(table))
+        valid = ~np.isin(candidate_ids, [1, 2, 3, 9])
+        if prefilter:
+            valid &= candidate_ids >= 20
+        candidate_ids = candidate_ids[valid]
+        vectors = original[candidate_ids].astype(np.float64)
+        query = original[query_id].astype(np.float64)
+        distances = 1 - vectors @ query / np.linalg.norm(
+            vectors, axis=1
+        ) / np.linalg.norm(query)
+        order = np.argsort(distances)[:10]
+        expected = candidate_ids[order]
+        expected_distances = distances[order]
+        if not prefilter:
+            keep = expected >= 20
+            expected, expected_distances = expected[keep], expected_distances[keep]
+        assert part["id"].to_pylist() == expected.tolist()
+        np.testing.assert_allclose(
+            part["_distance"].to_numpy(), expected_distances, atol=2e-6
+        )
+    assert "coarse" not in actual.column_names and "original" not in actual.column_names
+
+
+@pytest.mark.parametrize(
+    "index_type, kwargs",
+    [
+        ("IVF_FLAT", {}),
+        ("IVF_PQ", {"num_sub_vectors": 2, "num_bits": 4}),
+        ("IVF_SQ", {}),
+        ("IVF_HNSW_SQ", {"max_level": 2, "m": 4, "ef_construction": 16}),
+    ],
+)
+def test_cross_column_candidate_budget_and_range(
+    cross_column_dataset, index_type, kwargs
+):
+    path, table, coarse, original = cross_column_dataset
+    ds = lance.write_dataset(table, path, max_rows_per_file=128)
+    ds.create_index("coarse", index_type, metric="l2", num_partitions=4, **kwargs)
+    query_id = 33
+    common = dict(column="coarse", q=coarse[query_id], metric="l2", nprobes=4)
+    candidates = ds.to_table(columns=["id"], nearest={**common, "k": 20})
+    if index_type == "IVF_FLAT":
+        legacy = ds.to_table(
+            columns=["id"], nearest={**common, "k": 10, "refine_factor": 2}
+        )
+        assert legacy["id"].to_pylist() == candidates["id"].to_pylist()[:10]
+    ids = np.asarray(candidates["id"])
+    ids = ids[~np.isin(ids, [1, 2, 3])]
+    vectors = original[ids].astype(np.float64)
+    query = original[query_id].astype(np.float64)
+    distances = 1 - vectors @ query / np.linalg.norm(vectors, axis=1) / np.linalg.norm(
+        query
+    )
+    order = np.argsort(distances)
+    # A final-space bound must not eliminate candidates in the coarse L2 space.
+    for bounds in [None, (None, 0.9)]:
+        options = {
+            **common,
+            "k": 10,
+            "refine_factor": 2,
+            "refine_column": "original",
+            "refine_q": query,
+            "refine_metric": "cosine",
+            "distance_range": bounds,
+        }
+        actual = ds.to_table(columns=["id"], nearest=options)
+        keep = order if bounds is None else order[distances[order] < bounds[1]]
+        assert actual["id"].to_pylist() == ids[keep[:10]].tolist()
+    empty = ds.to_table(
+        columns=["id"],
+        filter="id < 0",
+        prefilter=True,
+        nearest=options,
+    )
+    assert len(empty) == 0
+
+
+@pytest.mark.parametrize(
+    "override, message",
+    [
+        ({"refine_q": None}, "provided together"),
+        ({"refine_factor": None}, "positive refine_factor"),
+        ({"refine_q": np.ones(15)}, "dim"),
+        ({"refine_q": np.ones((2, 16))}, "batch shape"),
+        ({"refine_q": np.full(16, np.nan)}, "finite"),
+        ({"refine_q": np.zeros(16)}, "nonzero norm"),
+        ({"refine_column": "id"}, "vector"),
+    ],
+)
+def test_cross_column_validation(cross_column_dataset, override, message):
+    path, table, coarse, original = cross_column_dataset
+    ds = lance.write_dataset(table, path)
+    nearest = dict(
+        column="coarse",
+        q=coarse[10],
+        metric="l2",
+        k=10,
+        refine_factor=2,
+        refine_column="original",
+        refine_q=original[10],
+        refine_metric="cosine",
+    )
+    with pytest.raises((ValueError, OSError), match=message):
+        ds.to_table(nearest={**nearest, **override})
+
+
+def test_cross_column_refinement_rejects_query_filter(cross_column_dataset):
+    path, table, coarse, original = cross_column_dataset
+    table = table.append_column("text", pa.array(["document"] * len(table)))
+    ds = lance.write_dataset(table, path)
+    with pytest.raises((ValueError, OSError), match="does not support.*query filter"):
+        ds.to_table(
+            filter=MatchQuery("document", "text"),
+            prefilter=True,
+            nearest=dict(
+                column="coarse",
+                q=coarse[33],
+                k=10,
+                refine_factor=2,
+                refine_column="original",
+                refine_q=original[33],
+                refine_metric="cosine",
+            ),
+        )
+
+
+@pytest.mark.parametrize("stable_ids", [False, True])
+def test_cross_column_refinement_updated_column(cross_column_dataset, stable_ids):
+    path, table, coarse, original = cross_column_dataset
+    ds = lance.write_dataset(
+        table, path, max_rows_per_file=128, enable_stable_row_ids=stable_ids
+    )
+    ds.create_index("coarse", "IVF_FLAT", metric="l2", num_partitions=4)
+    pinned = lance.dataset(path, version=ds.version)
+    query_id = 33
+    nearest = dict(
+        column="coarse",
+        q=coarse[query_id],
+        metric="l2",
+        k=10,
+        nprobes=4,
+        refine_factor=2,
+        refine_column="original",
+        refine_q=original[query_id],
+        refine_metric="cosine",
+    )
+    before = pinned.to_table(columns=["id", "_distance"], nearest=nearest)
+    assert before["id"][0].as_py() == query_id
+    updated_vector = (-original[query_id]).tolist()
+    ds.update({"original": str(updated_vector)}, where=f"id = {query_id}")
+    after = ds.to_table(columns=["id", "_distance"], nearest=nearest)
+    assert query_id not in after["id"].to_pylist()
+    assert pinned.to_table(columns=["id", "_distance"], nearest=nearest).equals(before)
+
+
+def test_cross_column_refinement_nested_column(cross_column_dataset):
+    path, table, coarse, original = cross_column_dataset
+    nested = pa.table(
+        {
+            "id": table["id"],
+            "coarse": table["coarse"],
+            "payload": pa.StructArray.from_arrays(
+                [table["original"].combine_chunks()], names=["original"]
+            ),
+        }
+    )
+    ds = lance.write_dataset(nested, path)
+    nearest = dict(
+        column="coarse",
+        q=coarse[33],
+        k=10,
+        metric="l2",
+        refine_factor=40,
+        refine_column="payload.original",
+        refine_q=original[33],
+        refine_metric="cosine",
+    )
+    actual = ds.to_table(columns=["id", "_distance"], nearest=nearest)
+    expected = ds.to_table(
+        columns=["id", "_distance"],
+        nearest={
+            "column": "payload.original",
+            "q": original[33],
+            "k": 10,
+            "metric": "cosine",
+            "use_index": False,
+        },
+    )
+    assert actual.equals(expected)
+
+
 @pytest.mark.parametrize(
     "queries",
     [

--- a/python/src/dataset.rs
+++ b/python/src/dataset.rs
@@ -1578,7 +1578,7 @@ impl Dataset {
                     None
                 };
 
-            scanner
+            let scanner = scanner
                 .map(|s| {
                     let mut s = s.minimum_nprobes(minimum_nprobes);
                     if let Some(maximum_nprobes) = maximum_nprobes {
@@ -1602,6 +1602,27 @@ impl Dataset {
                     s
                 })
                 .map_err(|err| PyValueError::new_err(err.to_string()))?;
+            let refine_column = nearest.get_item("refine_column")?.filter(|v| !v.is_none());
+            let refine_q = nearest.get_item("refine_q")?.filter(|v| !v.is_none());
+            let refine_metric = nearest.get_item("refine_metric")?.filter(|v| !v.is_none());
+            match (refine_column, refine_q, refine_metric) {
+                (None, None, None) => {}
+                (Some(column), Some(query), Some(metric)) => {
+                    let column: String = column.extract()?;
+                    let key = make_array(ArrayData::from_pyarrow_bound(&query)?);
+                    let metric: String = metric.extract()?;
+                    let metric = MetricType::try_from(metric.to_lowercase().as_str())
+                        .map_err(|e| PyValueError::new_err(e.to_string()))?;
+                    scanner
+                        .with_refine_column(&column, key.as_ref(), metric)
+                        .map_err(|e| PyValueError::new_err(e.to_string()))?;
+                }
+                _ => {
+                    return Err(PyValueError::new_err(
+                        "refine_column, refine_q, and refine_metric must be provided together",
+                    ));
+                }
+            }
         }
         if let Some(orderings) = order_by {
             scanner

--- a/rust/lance/src/dataset/scanner.rs
+++ b/rust/lance/src/dataset/scanner.rs
@@ -12,9 +12,9 @@ use std::task::{Context, Poll};
 
 use crate::index::DatasetIndexExt;
 use arrow::array::AsArray;
-use arrow_array::{Array, Float32Array, Int64Array, RecordBatch};
+use arrow_array::{Array, ArrayRef, Float32Array, Int64Array, RecordBatch, types::Float32Type};
 use arrow_schema::{DataType, Field as ArrowField, Schema as ArrowSchema, SchemaRef, SortOptions};
-use arrow_select::concat::concat_batches;
+use arrow_select::concat::{concat, concat_batches};
 use async_recursion::async_recursion;
 use chrono::Utc;
 use datafusion::catalog::Session;
@@ -1134,6 +1134,8 @@ pub struct Scanner {
     ordering: Option<Vec<ColumnOrdering>>,
 
     nearest: Option<Query>,
+    /// When set, score coarse candidates in this separate vector space.
+    nearest_refine: Option<VectorRefinement>,
     nearest_query_count: usize,
     /// True when the query shape represents a batch of single-vector queries
     /// (list-like query on a fixed-size vector column, or multiple concatenated vectors).
@@ -1384,6 +1386,13 @@ impl TakeOperation {
     }
 }
 
+#[derive(Clone)]
+struct VectorRefinement {
+    column: String,
+    key: ArrayRef,
+    metric: MetricType,
+}
+
 impl Scanner {
     pub fn new(dataset: Arc<Dataset>) -> Self {
         let projection_plan = ProjectionPlan::full(dataset.clone()).unwrap();
@@ -1407,6 +1416,7 @@ impl Scanner {
             offset: None,
             ordering: None,
             nearest: None,
+            nearest_refine: None,
             nearest_query_count: 1,
             is_batch_nearest: false,
             use_stats: true,
@@ -2024,6 +2034,7 @@ impl Scanner {
         });
         self.nearest_query_count = query_count;
         self.is_batch_nearest = is_batch_nearest;
+        self.nearest_refine = None;
         Ok(self)
     }
 
@@ -2145,6 +2156,116 @@ impl Scanner {
             q.refine_factor = Some(factor)
         };
         self
+    }
+
+    /// Refine candidates using a separate Float32 fixed-size vector column.
+    ///
+    /// Call after [`Self::nearest`] and set a positive [`Self::refine`] factor
+    /// before execution. The coarse search returns at most `k * factor` candidates;
+    /// their final `_distance` and [`Self::distance_range`] use `metric` and `query`.
+    /// This replaces same-column exact refinement, including for quantized indices.
+    /// Without an index, coarse exact TopM still precedes cross-column refinement.
+    ///
+    /// Both columns must contain single Float32 vectors. Query dimensions may differ,
+    /// but batch queries must have matching counts and both queries must be batches.
+    /// Scalar prefilters apply before candidate selection; postfilters apply after
+    /// the final TopK. Vector and full-text query filters are not supported.
+    /// Null or invalid refinement vectors can result in fewer than `k` rows.
+    /// Calling [`Self::nearest`] again clears this setting.
+    ///
+    /// ```
+    /// # use lance::{Dataset, Result};
+    /// # use arrow_array::Float32Array;
+    /// # use lance_linalg::distance::MetricType;
+    /// # async fn example(dataset: &Dataset, coarse: &Float32Array, full: &Float32Array) -> Result<()> {
+    /// let mut scan = dataset.scan();
+    /// scan.nearest("short_vector", coarse, 10)?.refine(2);
+    /// scan.with_refine_column("full_vector", full, MetricType::Cosine)?;
+    /// let results = scan.try_into_batch().await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn with_refine_column(
+        &mut self,
+        column: impl AsRef<str>,
+        query: &dyn Array,
+        metric: MetricType,
+    ) -> Result<&mut Self> {
+        let column = column.as_ref();
+        let nearest = self.nearest.as_ref().ok_or_else(|| {
+            Error::invalid_input("nearest must be set before refine_column".to_string())
+        })?;
+        for name in [nearest.column.as_str(), column] {
+            let (vector_type, element_type) = get_vector_type(self.dataset.schema(), name)?;
+            if !matches!(vector_type, DataType::FixedSizeList(_, _))
+                || element_type != DataType::Float32
+            {
+                return Err(Error::not_supported(format!(
+                    "cross-column refinement requires Float32 fixed-size vectors; column {name} has type {vector_type}"
+                )));
+            }
+        }
+        validate_distance_type_for(metric, &DataType::Float32)?;
+        let query_element_type = match query.data_type() {
+            DataType::List(field) | DataType::FixedSizeList(field, _) => field.data_type(),
+            data_type => data_type,
+        };
+        if query_element_type != &DataType::Float32 {
+            return Err(Error::invalid_input(format!(
+                "refine_q must contain Float32 values, got {}",
+                query.data_type()
+            )));
+        }
+        if query.null_count() > 0 {
+            return Err(Error::invalid_input(
+                "refine_q must contain only finite, non-null values".to_string(),
+            ));
+        }
+        let mut validation = Self::new(self.dataset.clone());
+        validation.nearest(column, query, nearest.k)?;
+        if validation.nearest_query_count != self.nearest_query_count
+            || validation.is_batch_nearest != self.is_batch_nearest
+        {
+            return Err(Error::invalid_input(format!(
+                "refine_q batch shape must match q: expected {} queries (batch={}), got {} (batch={})",
+                self.nearest_query_count,
+                self.is_batch_nearest,
+                validation.nearest_query_count,
+                validation.is_batch_nearest
+            )));
+        }
+        // Respect offsets when a caller passes a slice of a batch query array.
+        let vectors = if let Some(list) = query.as_list_opt::<i32>() {
+            (0..list.len()).map(|i| list.value(i)).collect::<Vec<_>>()
+        } else if let Some(list) = query.as_fixed_size_list_opt() {
+            (0..list.len()).map(|i| list.value(i)).collect::<Vec<_>>()
+        } else {
+            vec![query.slice(0, query.len())]
+        };
+        let key = concat(&vectors.iter().map(|v| v.as_ref()).collect::<Vec<_>>())?;
+        let values = key.as_primitive::<Float32Type>();
+        if values.null_count() > 0 || values.values().iter().any(|v| !v.is_finite()) {
+            return Err(Error::invalid_input(
+                "refine_q must contain only finite, non-null values".to_string(),
+            ));
+        }
+        let dim = get_vector_dim(self.dataset.schema(), column)?;
+        if metric == MetricType::Cosine
+            && values
+                .values()
+                .chunks_exact(dim)
+                .any(|v| v.iter().all(|x| *x == 0.0))
+        {
+            return Err(Error::invalid_input(
+                "refine_q must have nonzero norm for cosine distance".to_string(),
+            ));
+        }
+        self.nearest_refine = Some(VectorRefinement {
+            column: column.to_string(),
+            key,
+            metric,
+        });
+        Ok(self)
     }
 
     /// Change the distance [MetricType], i.e, L2 or Cosine distance.
@@ -2865,6 +2986,25 @@ impl Scanner {
     }
 
     fn validate_options(&self) -> Result<()> {
+        if self.nearest_refine.is_some() {
+            let query = self.nearest.as_ref().ok_or_else(|| {
+                Error::invalid_input("refine_column requires nearest".to_string())
+            })?;
+            let factor = query.refine_factor.filter(|f| *f > 0).ok_or_else(|| {
+                Error::invalid_input(
+                    "refine_column requires an explicit positive refine_factor".to_string(),
+                )
+            })?;
+            query.k.checked_mul(factor as usize).ok_or_else(|| {
+                Error::invalid_input("k * refine_factor overflows the candidate budget".to_string())
+            })?;
+            if self.filter.query_filter.is_some() {
+                return Err(Error::not_supported(
+                    "cross-column refinement does not support a vector or full-text query filter"
+                        .to_string(),
+                ));
+            }
+        }
         if self.batch_readahead == 0 {
             return Err(Error::invalid_input_source(
                 "batch_readahead must be greater than 0, got 0".into(),
@@ -5265,6 +5405,41 @@ impl Scanner {
         filter_plan: &ExprFilterPlan,
         q: &Query,
     ) -> Result<Arc<dyn ExecutionPlan>> {
+        if let Some(refine) = &self.nearest_refine {
+            if self.is_batch_nearest {
+                return self.batch_indexed_vector_search(filter_plan, q).await;
+            }
+            let factor = q.refine_factor.filter(|f| *f > 0).ok_or_else(|| {
+                Error::invalid_input(
+                    "refine_column requires an explicit positive refine_factor".to_string(),
+                )
+            })?;
+            let mut coarse = q.clone();
+            coarse.k = q.k.checked_mul(factor as usize).ok_or_else(|| {
+                Error::invalid_input("k * refine_factor overflows the candidate budget".to_string())
+            })?;
+            coarse.refine_factor = None;
+            // Bounds apply to the final distance space, not the coarse index.
+            coarse.lower_bound = None;
+            coarse.upper_bound = None;
+            let mut coarse_scanner = self.clone();
+            coarse_scanner.nearest_refine = None;
+            coarse_scanner.nearest = Some(coarse.clone());
+            // Merge indexed, appended, and updated rows before cross-column scoring.
+            let candidates = coarse_scanner.vector_search(filter_plan, &coarse).await?;
+            let projection = self
+                .dataset
+                .empty_projection()
+                .union_column(&refine.column, OnMissing::Error)?;
+            let candidates = self.take(candidates, projection)?;
+            let mut final_query = q.clone();
+            final_query.column = refine.column.clone();
+            final_query.key = refine.key.clone();
+            final_query.metric_type = Some(refine.metric);
+            final_query.refine_factor = None;
+            final_query.use_index = false;
+            return self.flat_knn(candidates, &final_query);
+        }
         let mut q = q.clone();
 
         // Sanity check
@@ -5543,6 +5718,12 @@ impl Scanner {
             single_scanner.nearest_query_count = 1;
             single_scanner.is_batch_nearest = false;
             single_scanner.nearest = Some(single_query.clone());
+            if let Some(refine) = &self.nearest_refine {
+                let mut single_refine = refine.clone();
+                let refine_dim = refine.key.len() / self.nearest_query_count;
+                single_refine.key = refine.key.slice(query_index * refine_dim, refine_dim);
+                single_scanner.nearest_refine = Some(single_refine);
+            }
 
             let single_plan = single_scanner
                 .vector_search(filter_plan, &single_query)
@@ -8991,6 +9172,207 @@ mod test {
             .copied()
             .collect();
         assert_eq!(expected_i, actual_i);
+    }
+
+    #[rstest]
+    #[case::flat(None)]
+    #[case::ivf_flat(Some(VectorIndexParams::with_ivf_flat_params(
+        MetricType::L2,
+        IvfBuildParams::new(2)
+    )))]
+    #[case::ivf_pq(Some(VectorIndexParams::ivf_pq(2, 4, 2, MetricType::L2, 2)))]
+    #[tokio::test]
+    async fn test_cross_column_refinement_candidates(
+        #[case] index_params: Option<VectorIndexParams>,
+        #[values(MetricType::L2, MetricType::Cosine, MetricType::Dot)] metric: MetricType,
+    ) {
+        let mut dataset = gen_batch()
+            .col("id", array::step::<Int32Type>())
+            .col("coarse", array::rand_vec::<Float32Type>(Dimension::from(4)))
+            .col("full", array::rand_vec::<Float32Type>(Dimension::from(8)))
+            .into_ram_dataset(FragmentCount::from(2), FragmentRowCount::from(32))
+            .await
+            .unwrap();
+        if let Some(params) = &index_params {
+            dataset
+                .create_index(&["coarse"], IndexType::Vector, None, params, false)
+                .await
+                .unwrap();
+        }
+        let coarse_query = Float32Array::from(vec![0.1, 0.2, 0.3, 0.4]);
+        let full_query = Float32Array::from(vec![0.4, 0.3, 0.2, 0.1, 0.5, 0.6, 0.7, 0.8]);
+        let candidates = dataset
+            .scan()
+            .nearest("coarse", &coarse_query, 12)
+            .unwrap()
+            .distance_metric(MetricType::L2)
+            .nprobes(2)
+            .project(&["id", "full"])
+            .unwrap()
+            .try_into_batch()
+            .await
+            .unwrap();
+        assert_eq!(candidates.num_rows(), 12);
+        let vectors = candidates["full"].as_fixed_size_list();
+        let ids = candidates["id"].as_primitive::<Int32Type>();
+        let mut expected = (0..candidates.num_rows())
+            .map(|i| {
+                let vector = vectors.value(i);
+                let vector = vector.as_primitive::<Float32Type>();
+                let pairs = vector.values().iter().zip(full_query.values().iter());
+                let dot = pairs
+                    .clone()
+                    .map(|(&a, &b)| f64::from(a) * f64::from(b))
+                    .sum::<f64>();
+                let distance = match metric {
+                    MetricType::L2 => pairs
+                        .map(|(&a, &b)| (f64::from(a) - f64::from(b)).powi(2))
+                        .sum(),
+                    MetricType::Cosine => {
+                        let norm = vector
+                            .values()
+                            .iter()
+                            .map(|&v| f64::from(v).powi(2))
+                            .sum::<f64>()
+                            .sqrt();
+                        let query_norm = full_query
+                            .values()
+                            .iter()
+                            .map(|&v| f64::from(v).powi(2))
+                            .sum::<f64>()
+                            .sqrt();
+                        1.0 - dot / (norm * query_norm)
+                    }
+                    MetricType::Dot => 1.0 - dot,
+                    _ => unreachable!(),
+                };
+                (ids.value(i), distance as f32)
+            })
+            .collect::<Vec<_>>();
+        expected.sort_by(|a, b| a.1.total_cmp(&b.1).then(a.0.cmp(&b.0)));
+        expected.truncate(6);
+
+        let mut scan = dataset.scan();
+        scan.nearest("coarse", &coarse_query, 6)
+            .unwrap()
+            .distance_metric(MetricType::L2)
+            .nprobes(2)
+            .refine(2)
+            .with_refine_column("full", &full_query, metric)
+            .unwrap()
+            .project(&["id", DIST_COL])
+            .unwrap();
+        let plan = scan.explain_plan(false).await.unwrap();
+        if index_params.is_some() {
+            assert!(plan.contains("ANNSubIndex"), "{plan}");
+            // Quantized candidates go directly to final-space scoring.
+            assert_eq!(plan.matches("KNNVectorDistance").count(), 1, "{plan}");
+        }
+        let result = scan.try_into_batch().await.unwrap();
+        let actual_ids = result["id"].as_primitive::<Int32Type>();
+        let actual_distances = result[DIST_COL].as_primitive::<Float32Type>();
+        assert_eq!(result.num_rows(), expected.len());
+        for (i, (id, distance)) in expected.iter().enumerate() {
+            assert_eq!(actual_ids.value(i), *id);
+            assert!((actual_distances.value(i) - distance).abs() < 1e-5);
+        }
+        assert!(result.schema().column_with_name("full").is_none());
+        assert!(result.schema().column_with_name("coarse").is_none());
+    }
+
+    #[tokio::test]
+    async fn test_cross_column_refinement_validation_and_reset() {
+        let dataset = gen_batch()
+            .col("id", array::step::<Int32Type>())
+            .col("coarse", array::rand_vec::<Float32Type>(Dimension::from(4)))
+            .col("full", array::rand_vec::<Float32Type>(Dimension::from(8)))
+            .into_ram_dataset(FragmentCount::from(1), FragmentRowCount::from(8))
+            .await
+            .unwrap();
+        let coarse = Float32Array::from(vec![0.1; 4]);
+        let full = Float32Array::from(vec![0.1; 8]);
+        let mut scan = dataset.scan();
+        let error = scan
+            .with_refine_column("full", &full, MetricType::Cosine)
+            .err()
+            .unwrap();
+        assert!(matches!(error, Error::InvalidInput { .. }));
+        assert!(error.to_string().contains("nearest must be set"));
+        scan.nearest("coarse", &coarse, 2).unwrap();
+        let error = scan
+            .with_refine_column("id", &full, MetricType::Cosine)
+            .err()
+            .unwrap();
+        assert!(matches!(error, Error::InvalidInput { .. }));
+        assert!(error.to_string().contains("vector"));
+        let wrong_type = arrow_array::Float64Array::from(vec![0.1; 8]);
+        let error = scan
+            .with_refine_column("full", &wrong_type, MetricType::Cosine)
+            .err()
+            .unwrap();
+        assert!(matches!(error, Error::InvalidInput { .. }));
+        assert!(error.to_string().contains("Float32"));
+        scan.with_refine_column("full", &full, MetricType::Cosine)
+            .unwrap();
+        for factor in [None, Some(0)] {
+            scan.nearest_mut().unwrap().refine_factor = factor;
+            let error = scan.validate_options().unwrap_err();
+            assert!(matches!(error, Error::InvalidInput { .. }));
+            assert!(error.to_string().contains("positive refine_factor"));
+        }
+        scan.refine(2);
+        scan.nearest_mut().unwrap().k = usize::MAX;
+        let error = scan.validate_options().unwrap_err();
+        assert!(matches!(error, Error::InvalidInput { .. }));
+        assert!(error.to_string().contains("overflows"));
+        scan.nearest("coarse", &coarse, 2).unwrap();
+        assert!(scan.nearest_refine.is_none());
+        scan.validate_options().unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_cross_column_refinement_sliced_batch_query() {
+        let dataset = gen_batch()
+            .col("coarse", array::rand_vec::<Float32Type>(Dimension::from(4)))
+            .col("full", array::rand_vec::<Float32Type>(Dimension::from(8)))
+            .into_ram_dataset(FragmentCount::from(1), FragmentRowCount::from(8))
+            .await
+            .unwrap();
+        let coarse =
+            FixedSizeListArray::try_new_from_values(Float32Array::from(vec![0.1; 4]), 4).unwrap();
+        let full_values = Float32Array::from((0..24).map(|v| v as f32).collect::<Vec<_>>());
+        let full = FixedSizeListArray::try_new_from_values(full_values, 8)
+            .unwrap()
+            .slice(1, 1);
+        let mut scan = dataset.scan();
+        scan.nearest("coarse", &coarse, 2)
+            .unwrap()
+            .refine(2)
+            .with_refine_column("full", &full, MetricType::L2)
+            .unwrap()
+            .project(&[DIST_COL])
+            .unwrap()
+            .with_row_id();
+        let batch = scan.try_into_batch().await.unwrap();
+        let mut single = dataset.scan();
+        single
+            .nearest("coarse", coarse.value(0).as_ref(), 2)
+            .unwrap()
+            .refine(2)
+            .with_refine_column("full", full.value(0).as_ref(), MetricType::L2)
+            .unwrap()
+            .project(&[DIST_COL])
+            .unwrap()
+            .with_row_id();
+        let single = single.try_into_batch().await.unwrap();
+        assert_eq!(
+            batch[ROW_ID].as_primitive::<UInt64Type>().values(),
+            single[ROW_ID].as_primitive::<UInt64Type>().values()
+        );
+        assert_eq!(
+            batch[DIST_COL].as_primitive::<Float32Type>().values(),
+            single[DIST_COL].as_primitive::<Float32Type>().values()
+        );
     }
 
     fn batch_knn_two_queries() -> (FixedSizeListArray, Vec<f32>) {

--- a/rust/lance/src/index/vector/ivf/v2.rs
+++ b/rust/lance/src/index/vector/ivf/v2.rs
@@ -5926,11 +5926,13 @@ mod tests {
         let mut ivf_params = IvfBuildParams::new(1);
         ivf_params.max_iters = 2;
         ivf_params.sample_rate = 16;
+        // Use the same 4-bit capacity as the single-vector tests to avoid
+        // random PQ training pushing recall below the threshold (#8764).
         let params = VectorIndexParams::with_ivf_hnsw_pq_params(
             DistanceType::Cosine,
             ivf_params,
             lightweight_hnsw_params(),
-            lightweight_pq_params(),
+            lightweight_pq_params_with_bits(4),
         );
         dataset
             .create_index(&["vector"], IndexType::Vector, None, &params, true)


### PR DESCRIPTION
Closes #9126.

Applications can store a compact vector column for candidate generation and a different vector column for final scoring. This adds native cross-column refinement to the Rust scanner and Python bindings, keeping candidate selection, row lookup, and final TopK in one query plan and dataset snapshot.

For example, `k=10, refine_factor=2` selects up to 20 coarse candidates and scores their full vectors:

```python
ds.to_table(
    columns=["_distance"],
    with_row_id=True,
    nearest={
        "column": "short_vector", "q": short_query, "metric": "l2",
        "k": 10, "nprobes": 4, "refine_factor": 2,
        "refine_column": "full_vector",
        "refine_q": full_query,
        "refine_metric": "cosine",
    },
)
```

Indexed and unindexed candidates are merged in the coarse space before reading the refinement column. Final `_distance` and `distance_range` use the refinement metric. For fully indexed searches, quantized candidates use approximate index distances and cross-column scoring replaces same-column exact refinement. Merging appended or updated coarse vectors with index results may still read and rescore coarse vectors before selecting the final coarse candidates.

The initial scope is single Float32 fixed-size vector columns, including paired batch queries and nested refinement columns. Scalar prefilter/postfilter semantics are preserved; vector/full-text query filters are explicitly rejected. Omitting the options preserves existing refinement. No storage format changes or embedding/PCA dependencies.

### Validation

- 34 Rust regression tests covering cross-column refinement, batch KNN, and multivector indexing passed, along with the `with_refine_column` doctest.
- 43 Python cross-column refinement and batch-search tests passed. Python environment setup and the required development build completed successfully.
- Workspace Clippy, Rust formatting, Python `make lint`, and commit hooks passed. Pyright reports 0 errors with existing stub/source warnings.

API discussion: #9126. Related #8741 performs refinement within the stored quantized index representation; this PR scores another dataset column.
