### PR TITLE
feat(transaction): declare source fields and replaced offsets on DataReplacement

### DIFF
--- a/java/lance-jni/src/transaction.rs
+++ b/java/lance-jni/src/transaction.rs
@@ -1125,7 +1125,7 @@ fn convert_to_java_operation_inner<'local>(
             )?;
             Ok(java_operation)
         }
-        Operation::DataReplacement { replacements } => {
+        Operation::DataReplacement { replacements, .. } => {
             let java_replacements = export_vec(env, &replacements)?;
 
             Ok(env.new_object(
@@ -1998,7 +1998,11 @@ fn convert_to_rust_operation(
                 import_vec_from_method(env, java_operation, "replacements", |env, replacement| {
                     replacement.extract_object(env)
                 })?;
-            Operation::DataReplacement { replacements }
+            Operation::DataReplacement {
+                replacements,
+                source_fields: Vec::new(),
+                replaced_offsets: None,
+            }
         }
         "DataOverlay" => {
             let groups = import_vec_from_method(env, java_operation, "getGroups", |env, group| {

--- a/protos/transaction.proto
+++ b/protos/transaction.proto
@@ -365,6 +365,12 @@ message Transaction {
   // An operation that replaces the data in a region of the table with new data.
   message DataReplacement {
     repeated DataReplacementGroup replacements = 1;
+    /* Field ids the values were computed from; a concurrent change to one on a
+     * replaced fragment conflicts. Empty declares no dependencies. */
+    repeated int32 source_fields = 2;
+    /* Rows whose values changed, as RoaringBitmap bytes, for last_updated
+     * stamping. Absent stamps every row. */
+    map<uint64, bytes> replaced_offset_bitmaps = 3;
   }
 
   /* Overlay files to append to a single fragment, in order (the last entry is

--- a/python/src/transaction.rs
+++ b/python/src/transaction.rs
@@ -514,7 +514,11 @@ impl FromPyObject<'_, '_> for PyLance<Operation> {
             "DataReplacement" => {
                 let replacements = extract_vec(&ob.getattr("replacements")?)?;
 
-                let op = Operation::DataReplacement { replacements };
+                let op = Operation::DataReplacement {
+                    replacements,
+                    source_fields: Vec::new(),
+                    replaced_offsets: None,
+                };
 
                 Ok(Self(op))
             }
@@ -681,7 +685,7 @@ impl<'py> IntoPyObject<'py> for PyLance<&Operation> {
                     updated_fragment_offsets,
                 ))
             }
-            Operation::DataReplacement { replacements } => {
+            Operation::DataReplacement { replacements, .. } => {
                 let replacements = export_vec(py, replacements.as_slice())?;
                 let cls = namespace
                     .getattr("DataReplacement")

--- a/rust/lance-table/src/transaction/conflicts.rs
+++ b/rust/lance-table/src/transaction/conflicts.rs
@@ -198,9 +198,21 @@ impl PartialEq for Operation {
                     && a_field == b_field
             }
             (
-                Self::DataReplacement { replacements: a },
-                Self::DataReplacement { replacements: b },
-            ) => a.len() == b.len() && a.iter().all(|r| b.contains(r)),
+                Self::DataReplacement {
+                    replacements: a,
+                    source_fields: a_sources,
+                    replaced_offsets: a_offsets,
+                },
+                Self::DataReplacement {
+                    replacements: b,
+                    source_fields: b_sources,
+                    replaced_offsets: b_offsets,
+                },
+            ) => {
+                compare_vec(a, b)
+                    && compare_vec(a_sources, b_sources)
+                    && a_offsets.as_ref().map(|o| &o.0) == b_offsets.as_ref().map(|o| &o.0)
+            }
             // Handle all remaining combinations.
             // We spell out all combinations explicitly to prevent
             // us accidentally handling a new case in the wrong way.

--- a/rust/lance-table/src/transaction/manifest_build.rs
+++ b/rust/lance-table/src/transaction/manifest_build.rs
@@ -943,7 +943,11 @@ impl Transaction {
             Operation::Restore { .. } => {
                 unreachable!()
             }
-            Operation::DataReplacement { replacements } => {
+            Operation::DataReplacement {
+                replacements,
+                replaced_offsets,
+                ..
+            } => {
                 log::warn!(
                     "Building manifest with DataReplacement operation. This operation is not stable yet, please use with caution."
                 );
@@ -1144,16 +1148,45 @@ impl Transaction {
 
                 // A replacement changes what its rows read as, so stamp them
                 // updated. Without this, get_updated_rows never reports them and
-                // an incremental consumer skips them for good.
+                // an incremental consumer skips them for good. A caller that
+                // changed only some rows says which; a fragment with no stamps
+                // to keep takes a full one.
                 if next_row_id.is_some() {
                     let new_version = current_manifest.map_or(1, |m| m.version + 1);
+                    let prev_version = current_manifest.map_or(0, |m| m.version);
                     for fragment in final_fragments
                         .iter_mut()
                         .filter(|f| fragments_changed.contains(&f.id))
                     {
-                        crate::rowids::version::refresh_row_latest_update_meta_for_full_frag_rewrite_cols(
+                        let partial = replaced_offsets
+                            .as_ref()
+                            .and_then(|UpdatedFragmentOffsets(m)| m.get(&fragment.id))
+                            .filter(|bitmap| !bitmap.is_empty())
+                            .filter(|_| fragment.last_updated_at_version_meta.is_some());
+                        let Some(bitmap) = partial else {
+                            crate::rowids::version::refresh_row_latest_update_meta_for_full_frag_rewrite_cols(
+                                fragment,
+                                new_version,
+                            )?;
+                            continue;
+                        };
+                        let physical_rows = fragment.physical_rows.unwrap_or(1 << 24);
+                        if bitmap.len() as usize > physical_rows
+                            || bitmap
+                                .max()
+                                .is_some_and(|max| max as usize >= physical_rows)
+                        {
+                            return Err(Error::invalid_input(format!(
+                                "replacedOffsets for fragment {} exceed its {} physical rows",
+                                fragment.id, physical_rows
+                            )));
+                        }
+                        let offsets: Vec<usize> = bitmap.iter().map(|o| o as usize).collect();
+                        crate::rowids::version::refresh_row_latest_update_meta_for_partial_frag_rewrite_cols(
                             fragment,
+                            &offsets,
                             new_version,
+                            prev_version,
                         )?;
                     }
                 }
@@ -1866,6 +1899,159 @@ mod tests {
         assert!(
             out.fragments[0].last_updated_at_version_meta.is_none(),
             "fragment with no prior version metadata must not have fabricated prev_version stamped on unmatched rows"
+        );
+    }
+
+    /// A replacement that says which rows it changed stamps only those; the
+    /// rest keep the version that last touched them. Without offsets, or on a
+    /// fragment with no stamps to keep, every row takes the new version.
+    #[test]
+    fn test_data_replacement_stamps_only_replaced_offsets() {
+        let stamped_at = |meta: &Option<RowDatasetVersionMeta>| -> Vec<u64> {
+            meta.as_ref()
+                .expect("stamped")
+                .load_sequence()
+                .unwrap()
+                .versions()
+                .collect()
+        };
+        let fragment_with = |version_meta: Option<RowDatasetVersionMeta>| {
+            let row_ids = RowIdSequence::from([10u64, 11, 12, 13, 14].as_slice());
+            Fragment {
+                id: 1,
+                files: vec![DataFile::new(
+                    "data.lance",
+                    vec![0],
+                    vec![0],
+                    LanceFileVersion::Stable.resolve(),
+                    None,
+                    None,
+                )],
+                overlays: vec![],
+                deletion_file: None,
+                row_id_meta: Some(RowIdMeta::Inline(write_row_ids(&row_ids).into())),
+                physical_rows: Some(5),
+                last_updated_at_version_meta: version_meta.clone(),
+                created_at_version_meta: version_meta,
+            }
+        };
+        let replacement = || {
+            DataReplacementGroup(
+                1,
+                DataFile::new(
+                    "replaced.lance",
+                    vec![0],
+                    vec![0],
+                    LanceFileVersion::Stable.resolve(),
+                    None,
+                    None,
+                ),
+            )
+        };
+        let build = |fragment: Fragment, replaced_offsets: Option<UpdatedFragmentOffsets>| {
+            let manifest = make_stable_row_id_manifest(vec![fragment]);
+            let tx = Transaction::new(
+                manifest.version,
+                Operation::DataReplacement {
+                    replacements: vec![replacement()],
+                    source_fields: Vec::new(),
+                    replaced_offsets,
+                },
+                None,
+            );
+            let (out, _) = tx
+                .build_manifest(Some(&manifest), vec![], "txn", &default_build_config())
+                .unwrap();
+            (out, manifest.version + 1)
+        };
+        let stamped_v1 = Some(
+            RowDatasetVersionMeta::from_sequence(
+                &RowDatasetVersionSequence::from_uniform_row_count(5, 1),
+            )
+            .unwrap(),
+        );
+        let partial = || {
+            Some(UpdatedFragmentOffsets(HashMap::from([(
+                1u64,
+                RoaringBitmap::from_iter([1u32, 3]),
+            )])))
+        };
+
+        let (out, new_version) = build(fragment_with(stamped_v1.clone()), partial());
+        assert_eq!(
+            stamped_at(&out.fragments[0].last_updated_at_version_meta),
+            vec![1, new_version, 1, new_version, 1],
+            "only the replaced offsets take the new version"
+        );
+
+        let (out, new_version) = build(fragment_with(stamped_v1), None);
+        assert_eq!(
+            stamped_at(&out.fragments[0].last_updated_at_version_meta),
+            vec![new_version; 5],
+            "no offsets means the whole fragment was replaced"
+        );
+
+        let (out, new_version) = build(fragment_with(None), partial());
+        assert_eq!(
+            stamped_at(&out.fragments[0].last_updated_at_version_meta),
+            vec![new_version; 5],
+            "a fragment with no stamps cannot keep any, so it takes a full one"
+        );
+    }
+
+    #[test]
+    fn test_data_replacement_offsets_past_the_fragment_are_rejected() {
+        let row_ids = RowIdSequence::from([10u64, 11, 12, 13, 14].as_slice());
+        let version_meta = RowDatasetVersionMeta::from_sequence(
+            &RowDatasetVersionSequence::from_uniform_row_count(5, 1),
+        )
+        .unwrap();
+        let fragment = Fragment {
+            id: 1,
+            files: vec![DataFile::new(
+                "data.lance",
+                vec![0],
+                vec![0],
+                LanceFileVersion::Stable.resolve(),
+                None,
+                None,
+            )],
+            overlays: vec![],
+            deletion_file: None,
+            row_id_meta: Some(RowIdMeta::Inline(write_row_ids(&row_ids).into())),
+            physical_rows: Some(5),
+            last_updated_at_version_meta: Some(version_meta.clone()),
+            created_at_version_meta: Some(version_meta),
+        };
+        let manifest = make_stable_row_id_manifest(vec![fragment]);
+        let tx = Transaction::new(
+            manifest.version,
+            Operation::DataReplacement {
+                replacements: vec![DataReplacementGroup(
+                    1,
+                    DataFile::new(
+                        "replaced.lance",
+                        vec![0],
+                        vec![0],
+                        LanceFileVersion::Stable.resolve(),
+                        None,
+                        None,
+                    ),
+                )],
+                source_fields: Vec::new(),
+                replaced_offsets: Some(UpdatedFragmentOffsets(HashMap::from([(
+                    1u64,
+                    RoaringBitmap::from_iter([7u32]),
+                )]))),
+            },
+            None,
+        );
+        let error = tx
+            .build_manifest(Some(&manifest), vec![], "txn", &default_build_config())
+            .unwrap_err();
+        assert!(
+            error.to_string().contains("exceed its 5 physical rows"),
+            "{error}"
         );
     }
 
@@ -2742,6 +2928,8 @@ mod tests {
                     0,
                     DataFile::new_legacy_from_fields("f5-new.lance", vec![5], None),
                 )],
+                source_fields: Vec::new(),
+                replaced_offsets: None,
             },
             None,
         );
@@ -2802,6 +2990,8 @@ mod tests {
                         None,
                     ),
                 )],
+                source_fields: Vec::new(),
+                replaced_offsets: None,
             },
             None,
         );

--- a/rust/lance-table/src/transaction/operation.rs
+++ b/rust/lance-table/src/transaction/operation.rs
@@ -107,6 +107,12 @@ pub enum Operation {
     /// with a new column A, the operation is not allowed.
     DataReplacement {
         replacements: Vec<DataReplacementGroup>,
+        /// Field ids the values were computed from, distinct from the fields
+        /// written. A concurrent change to one on a replaced fragment conflicts.
+        source_fields: Vec<i32>,
+        /// Rows whose values changed, for row-level `last_updated` stamping.
+        /// `None` stamps every row.
+        replaced_offsets: Option<UpdatedFragmentOffsets>,
     },
     /// Attach overlay files to fragments, supplying new values for a subset of
     /// `(physical offset, field)` cells without rewriting the fragments' base

--- a/rust/lance-table/src/transaction/proto.rs
+++ b/rust/lance-table/src/transaction/proto.rs
@@ -25,6 +25,40 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use uuid::Uuid;
 
+/// Per-fragment offsets as RoaringBitmap bytes, the `Update` encoding.
+fn offset_bitmaps_to_proto(offsets: Option<&UpdatedFragmentOffsets>) -> HashMap<u64, Vec<u8>> {
+    offsets
+        .map(|UpdatedFragmentOffsets(m)| {
+            m.iter()
+                .filter(|(_, b)| !b.is_empty())
+                .map(|(frag_id, b)| {
+                    let mut buf = Vec::new();
+                    b.serialize_into(&mut buf)
+                        .expect("RoaringBitmap serialization cannot fail");
+                    (*frag_id, buf)
+                })
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+fn offset_bitmaps_from_proto(
+    bitmaps: HashMap<u64, Vec<u8>>,
+    what: &str,
+) -> Result<Option<UpdatedFragmentOffsets>> {
+    let m = bitmaps
+        .into_iter()
+        .filter(|(_, bytes)| !bytes.is_empty())
+        .map(|(id, bytes)| {
+            let bitmap = RoaringBitmap::deserialize_from(bytes.as_slice()).map_err(|e| {
+                Error::invalid_input(format!("invalid {what} for fragment {id}: {e}"))
+            })?;
+            Ok((id, bitmap))
+        })
+        .collect::<Result<HashMap<_, _>>>()?;
+    Ok((!m.is_empty()).then_some(UpdatedFragmentOffsets(m)))
+}
+
 impl From<&DataReplacementGroup> for pb::transaction::DataReplacementGroup {
     fn from(DataReplacementGroup(fragment_id, new_file): &DataReplacementGroup) -> Self {
         Self {
@@ -373,12 +407,21 @@ impl TryFrom<pb::Transaction> for Transaction {
                 }
             }
             Some(pb::transaction::Operation::DataReplacement(
-                pb::transaction::DataReplacement { replacements },
+                pb::transaction::DataReplacement {
+                    replacements,
+                    source_fields,
+                    replaced_offset_bitmaps,
+                },
             )) => Operation::DataReplacement {
                 replacements: replacements
                     .into_iter()
                     .map(DataReplacementGroup::try_from)
                     .collect::<Result<Vec<_>>>()?,
+                source_fields,
+                replaced_offsets: offset_bitmaps_from_proto(
+                    replaced_offset_bitmaps,
+                    "replaced_offset_bitmaps",
+                )?,
             },
             Some(pb::transaction::Operation::UpdateMemWalState(
                 pb::transaction::UpdateMemWalState { compacted_sstables },
@@ -673,14 +716,18 @@ impl From<&Transaction> for pb::Transaction {
                 schema_metadata: Default::default(),
                 field_metadata: Default::default(),
             }),
-            Operation::DataReplacement { replacements } => {
-                pb::transaction::Operation::DataReplacement(pb::transaction::DataReplacement {
-                    replacements: replacements
-                        .iter()
-                        .map(pb::transaction::DataReplacementGroup::from)
-                        .collect(),
-                })
-            }
+            Operation::DataReplacement {
+                replacements,
+                source_fields,
+                replaced_offsets,
+            } => pb::transaction::Operation::DataReplacement(pb::transaction::DataReplacement {
+                replacements: replacements
+                    .iter()
+                    .map(pb::transaction::DataReplacementGroup::from)
+                    .collect(),
+                source_fields: source_fields.clone(),
+                replaced_offset_bitmaps: offset_bitmaps_to_proto(replaced_offsets.as_ref()),
+            }),
             Operation::DataOverlay { groups } => {
                 pb::transaction::Operation::DataOverlay(pb::transaction::DataOverlay {
                     groups: groups
@@ -810,6 +857,56 @@ mod tests {
     use super::*;
     use crate::format::DataFile;
     use crate::format::overlay::OverlayCoverage;
+
+    /// A DataReplacement's source fields and replaced offsets survive the
+    /// protobuf round-trip; absent on the wire, they read back as no
+    /// dependencies and no offsets, which is what every older writer produced.
+    #[test]
+    fn test_data_replacement_dependencies_roundtrip() {
+        let operation = Operation::DataReplacement {
+            replacements: vec![DataReplacementGroup(
+                4,
+                DataFile::new_legacy_from_fields("replacement.lance", vec![7], None),
+            )],
+            source_fields: vec![1, 3],
+            replaced_offsets: Some(UpdatedFragmentOffsets(HashMap::from([(
+                4,
+                roaring::RoaringBitmap::from_iter([2u32, 5, 9]),
+            )]))),
+        };
+        let transaction = Transaction::new(1, operation.clone(), None);
+        let message = pb::Transaction::from(&transaction);
+        let read_back = Transaction::try_from(message).unwrap();
+        assert_eq!(read_back.operation, operation);
+
+        let legacy = pb::Transaction {
+            read_version: 1,
+            uuid: Uuid::new_v4().to_string(),
+            operation: Some(pb::transaction::Operation::DataReplacement(
+                pb::transaction::DataReplacement {
+                    replacements: vec![pb::transaction::DataReplacementGroup::from(
+                        &DataReplacementGroup(
+                            4,
+                            DataFile::new_legacy_from_fields("replacement.lance", vec![7], None),
+                        ),
+                    )],
+                    ..Default::default()
+                },
+            )),
+            ..Default::default()
+        };
+        match Transaction::try_from(legacy).unwrap().operation {
+            Operation::DataReplacement {
+                source_fields,
+                replaced_offsets,
+                ..
+            } => {
+                assert!(source_fields.is_empty());
+                assert!(replaced_offsets.is_none());
+            }
+            other => panic!("expected DataReplacement, got {other:?}"),
+        }
+    }
 
     #[test]
     fn test_data_overlay_operation_roundtrips() {

--- a/rust/lance-table/src/transaction/validate.rs
+++ b/rust/lance-table/src/transaction/validate.rs
@@ -94,6 +94,24 @@ pub fn validate_operation(manifest: Option<&Manifest>, operation: &Operation) ->
             }
             Ok(())
         }
+        // The offsets stamp version metadata by fragment id, so a key outside
+        // the replacements would corrupt an unrelated fragment's metadata.
+        Operation::DataReplacement {
+            replacements,
+            replaced_offsets: Some(UpdatedFragmentOffsets(off_map)),
+            ..
+        } => {
+            let replaced_ids: HashSet<u64> = replacements.iter().map(|r| r.0).collect();
+            for &frag_id in off_map.keys() {
+                if !replaced_ids.contains(&frag_id) {
+                    return Err(Error::invalid_input(format!(
+                        "replacedOffsets key {frag_id} is not in replacements; \
+                         offsets must reference only fragments being replaced"
+                    )));
+                }
+            }
+            Ok(())
+        }
         _ => Ok(()),
     }
 }
@@ -425,6 +443,36 @@ mod tests {
     use roaring::RoaringBitmap;
     use std::collections::HashMap;
     use std::sync::Arc;
+
+    /// An offsets key outside the replacements would stamp an unrelated
+    /// fragment's version metadata.
+    #[test]
+    fn test_data_replacement_offsets_must_name_a_replaced_fragment() {
+        use crate::format::DataFile;
+        use crate::transaction::DataReplacementGroup;
+        use roaring::RoaringBitmap;
+        use std::collections::HashMap;
+        let replacement = DataReplacementGroup(
+            3,
+            DataFile::new_legacy_from_fields("replacement.lance", vec![0], None),
+        );
+        let manifest =
+            crate::transaction::test_support::make_stable_row_id_manifest(vec![Fragment::new(3)]);
+        let with_offsets = |fragment_id: u64| Operation::DataReplacement {
+            replacements: vec![replacement.clone()],
+            source_fields: Vec::new(),
+            replaced_offsets: Some(UpdatedFragmentOffsets(HashMap::from([(
+                fragment_id,
+                RoaringBitmap::from_iter([0u32]),
+            )]))),
+        };
+        assert!(validate_operation(Some(&manifest), &with_offsets(3)).is_ok());
+        let error = validate_operation(Some(&manifest), &with_offsets(4)).unwrap_err();
+        assert!(
+            error.to_string().contains("is not in replacements"),
+            "{error}"
+        );
+    }
 
     #[test]
     fn test_merge_fragments_valid() {

--- a/rust/lance/src/dataset/blob.rs
+++ b/rust/lance/src/dataset/blob.rs
@@ -5986,6 +5986,8 @@ mod tests {
             uuid: Uuid::new_v4().hyphenated().to_string(),
             operation: Operation::DataReplacement {
                 replacements: vec![DataReplacementGroup(0, data_file)],
+                source_fields: Vec::new(),
+                replaced_offsets: None,
             },
             tag: None,
             transaction_properties: None,
@@ -6169,6 +6171,8 @@ mod tests {
             uuid: Uuid::new_v4().hyphenated().to_string(),
             operation: Operation::DataReplacement {
                 replacements: vec![DataReplacementGroup(0, data_file)],
+                source_fields: Vec::new(),
+                replaced_offsets: None,
             },
             tag: None,
             transaction_properties: None,

--- a/rust/lance/src/dataset/tests/data_file_part.rs
+++ b/rust/lance/src/dataset/tests/data_file_part.rs
@@ -93,6 +93,8 @@ async fn commit(dataset: &Dataset, replacement: DataReplacementGroup) -> Result<
         WriteDestination::Dataset(Arc::new(dataset.clone())),
         Operation::DataReplacement {
             replacements: vec![replacement],
+            source_fields: Vec::new(),
+            replaced_offsets: None,
         },
         Some(dataset.version_id()),
         None,

--- a/rust/lance/src/dataset/tests/dataset_index.rs
+++ b/rust/lance/src/dataset/tests/dataset_index.rs
@@ -2976,6 +2976,8 @@ async fn test_partial_compound_hybrid_prunes_same_path_different_base_rewrite() 
         WriteDestination::Dataset(Arc::new(dataset)),
         Operation::DataReplacement {
             replacements: vec![DataReplacementGroup(1, replacement_file)],
+            source_fields: Vec::new(),
+            replaced_offsets: None,
         },
         Some(read_version),
         None,

--- a/rust/lance/src/dataset/tests/dataset_merge_update.rs
+++ b/rust/lance/src/dataset/tests/dataset_merge_update.rs
@@ -690,6 +690,8 @@ async fn test_datafile_replacement() {
         WriteDestination::Dataset(dataset.clone()),
         Operation::DataReplacement {
             replacements: vec![],
+            source_fields: Vec::new(),
+            replaced_offsets: None,
         },
         Some(1),
         None,
@@ -719,6 +721,8 @@ async fn test_datafile_replacement() {
         WriteDestination::Dataset(Arc::new(dataset)),
         Operation::DataReplacement {
             replacements: vec![],
+            source_fields: Vec::new(),
+            replaced_offsets: None,
         },
         Some(3),
         None,
@@ -773,6 +777,8 @@ async fn test_datafile_replacement() {
         WriteDestination::Dataset(Arc::new(dataset)),
         Operation::DataReplacement {
             replacements: vec![DataReplacementGroup(0, new_data_file)],
+            source_fields: Vec::new(),
+            replaced_offsets: None,
         },
         Some(4),
         None,
@@ -890,6 +896,8 @@ async fn test_datafile_partial_replacement() {
         WriteDestination::Dataset(Arc::new(dataset)),
         Operation::DataReplacement {
             replacements: vec![DataReplacementGroup(0, new_data_file)],
+            source_fields: Vec::new(),
+            replaced_offsets: None,
         },
         Some(3),
         None,
@@ -951,6 +959,8 @@ async fn test_datafile_partial_replacement() {
         WriteDestination::Dataset(Arc::new(dataset)),
         Operation::DataReplacement {
             replacements: vec![DataReplacementGroup(0, new_data_file)],
+            source_fields: Vec::new(),
+            replaced_offsets: None,
         },
         Some(4),
         None,
@@ -1056,6 +1066,8 @@ async fn test_datafile_replacement_error() {
         WriteDestination::Dataset(Arc::new(dataset.clone())),
         Operation::DataReplacement {
             replacements: vec![DataReplacementGroup(0, new_data_file)],
+            source_fields: Vec::new(),
+            replaced_offsets: None,
         },
         // read at the current version (after the Merge above)
         Some(dataset.manifest.version),
@@ -2621,6 +2633,8 @@ async fn test_data_replacement_advances_row_lineage() {
         WriteDestination::Dataset(Arc::new(dataset)),
         Operation::DataReplacement {
             replacements: vec![DataReplacementGroup(0, new_data_file)],
+            source_fields: Vec::new(),
+            replaced_offsets: None,
         },
         Some(read_version),
         None,
@@ -2730,6 +2744,8 @@ async fn test_data_replacement_invalidates_index_bitmap() {
         WriteDestination::Dataset(Arc::new(dataset)),
         Operation::DataReplacement {
             replacements: vec![DataReplacementGroup(0, new_data_file)],
+            source_fields: Vec::new(),
+            replaced_offsets: None,
         },
         Some(read_version),
         None,
@@ -3014,6 +3030,8 @@ async fn test_data_replacement_populates_invalidated_bitmap() {
         WriteDestination::Dataset(Arc::new(dataset)),
         Operation::DataReplacement {
             replacements: vec![DataReplacementGroup(0, new_data_file)],
+            source_fields: Vec::new(),
+            replaced_offsets: None,
         },
         Some(read_version),
         None,
@@ -3133,6 +3151,8 @@ async fn test_fts_stale_entries_after_data_replacement() {
         WriteDestination::Dataset(Arc::new(dataset)),
         Operation::DataReplacement {
             replacements: vec![DataReplacementGroup(1, new_data_file)],
+            source_fields: Vec::new(),
+            replaced_offsets: None,
         },
         Some(read_version),
         None,
@@ -3273,6 +3293,8 @@ async fn test_cross_column_fast_search_blocks_column_local_stale_postings() {
         WriteDestination::Dataset(Arc::new(dataset)),
         Operation::DataReplacement {
             replacements: vec![DataReplacementGroup(1, replacement_file)],
+            source_fields: Vec::new(),
+            replaced_offsets: None,
         },
         Some(read_version),
         None,
@@ -3444,6 +3466,8 @@ async fn test_vector_index_after_data_replacement() {
         WriteDestination::Dataset(Arc::new(dataset)),
         Operation::DataReplacement {
             replacements: vec![DataReplacementGroup(frag1_id, new_data_file)],
+            source_fields: Vec::new(),
+            replaced_offsets: None,
         },
         Some(read_version),
         None,

--- a/rust/lance/src/dataset/tests/fragment_write_columns.rs
+++ b/rust/lance/src/dataset/tests/fragment_write_columns.rs
@@ -97,7 +97,11 @@ async fn commit(dataset: &Dataset, replacements: Vec<DataReplacementGroup>) -> R
     let read_version = dataset.manifest.version;
     Dataset::commit(
         WriteDestination::Dataset(Arc::new(dataset.clone())),
-        Operation::DataReplacement { replacements },
+        Operation::DataReplacement {
+            replacements,
+            source_fields: Vec::new(),
+            replaced_offsets: None,
+        },
         Some(read_version),
         None,
         None,

--- a/rust/lance/src/io/commit/conflict_resolver.rs
+++ b/rust/lance/src/io/commit/conflict_resolver.rs
@@ -178,7 +178,7 @@ impl<'a> TransactionRebase<'a> {
                     conflicting_mem_wal_compacted_sstables: Vec::new(),
                 })
             }
-            Operation::DataReplacement { replacements } => {
+            Operation::DataReplacement { replacements, .. } => {
                 let modified_fragment_ids =
                     replacements.iter().map(|r| r.0).collect::<HashSet<_>>();
                 let initial_fragments =
@@ -886,7 +886,7 @@ impl<'a> TransactionRebase<'a> {
                     }
                 }
                 Operation::UpdateConfig { .. } => Ok(()),
-                Operation::DataReplacement { replacements } => {
+                Operation::DataReplacement { replacements, .. } => {
                     // A data replacement only conflicts if it is updating a field the
                     // index depends on -- whether keyed on or merely carried, since
                     // `fields` lists both (see `IndexMetadata::covering_fields`).
@@ -1006,7 +1006,7 @@ impl<'a> TransactionRebase<'a> {
                         Ok(())
                     }
                 }
-                Operation::DataReplacement { replacements } => {
+                Operation::DataReplacement { replacements, .. } => {
                     // These conflict if the rewrite touches any of the fragments being replaced.
                     for replacement in replacements {
                         for group in groups {
@@ -1208,16 +1208,38 @@ impl<'a> TransactionRebase<'a> {
         other_transaction: &Transaction,
         other_version: u64,
     ) -> Result<()> {
-        if let Operation::DataReplacement { replacements } = &self.transaction.operation {
+        if let Operation::DataReplacement {
+            replacements,
+            source_fields,
+            ..
+        } = &self.transaction.operation
+        {
+            let changes_a_source =
+                |fields: &[i32]| fields.iter().any(|f| *f >= 0 && source_fields.contains(f));
             match &other_transaction.operation {
                 Operation::Append { .. }
                 | Operation::Clone { .. }
                 | Operation::UpdateConfig { .. }
                 | Operation::ReserveFragments { .. }
+                | Operation::UpdateBases { .. } => Ok(()),
                 // Both a column replacement and an overlay preserve physical row
                 // addresses; the overlay is newer and wins its covered cells.
-                | Operation::DataOverlay { .. }
-                | Operation::UpdateBases { .. } => Ok(()),
+                Operation::DataOverlay { groups } => {
+                    for replacement in replacements {
+                        for group in groups.iter().filter(|g| g.fragment_id == replacement.0) {
+                            if group
+                                .overlays
+                                .iter()
+                                .any(|overlay| changes_a_source(&overlay.data_file.fields))
+                            {
+                                return Err(
+                                    self.retryable_conflict_err(other_transaction, other_version)
+                                );
+                            }
+                        }
+                    }
+                    Ok(())
+                }
                 Operation::Project { schema, .. } => {
                     // A project operation can drop fields.  If the project
                     // dropped a field this operation was replacing then
@@ -1233,6 +1255,15 @@ impl<'a> TransactionRebase<'a> {
                                 ));
                             }
                         }
+                    }
+                    // A dropped source field is unrecoverable, like a dropped one.
+                    if source_fields
+                        .iter()
+                        .any(|f| *f >= 0 && schema.field_by_id(*f).is_none())
+                    {
+                        return Err(
+                            self.incompatible_conflict_err(other_transaction, other_version)
+                        );
                     }
                     Ok(())
                 }
@@ -1290,7 +1321,10 @@ impl<'a> TransactionRebase<'a> {
                             .fields
                             .iter()
                             .any(|f| *f >= 0 && fields_modified.contains(&(*f as u32)));
-                        if moved_rows || field_rewritten {
+                        let source_rewritten = source_fields
+                            .iter()
+                            .any(|f| *f >= 0 && fields_modified.contains(&(*f as u32)));
+                        if moved_rows || field_rewritten || source_rewritten {
                             return Err(
                                 self.retryable_conflict_err(other_transaction, other_version)
                             );
@@ -1339,8 +1373,11 @@ impl<'a> TransactionRebase<'a> {
                 }
                 Operation::DataReplacement {
                     replacements: other_replacements,
+                    source_fields: other_source_fields,
+                    ..
                 } => {
-                    // These conflict if there is overlap in fragment id && fields.
+                    // Conflict on a shared fragment when the written fields overlap,
+                    // or either side wrote a field the other computed from.
                     for replacement in replacements {
                         for other_replacement in other_replacements {
                             if replacement.0 != other_replacement.0 {
@@ -1352,6 +1389,17 @@ impl<'a> TransactionRebase<'a> {
                                     return Err(self
                                         .retryable_conflict_err(other_transaction, other_version));
                                 }
+                            }
+                            if changes_a_source(&other_replacement.1.fields)
+                                || replacement
+                                    .1
+                                    .fields
+                                    .iter()
+                                    .any(|f| *f >= 0 && other_source_fields.contains(f))
+                            {
+                                return Err(
+                                    self.retryable_conflict_err(other_transaction, other_version)
+                                );
                             }
                         }
                     }
@@ -1396,8 +1444,33 @@ impl<'a> TransactionRebase<'a> {
             | Operation::UpdateConfig { .. }
             | Operation::UpdateBases { .. }
             | Operation::Clone { .. }
-            | Operation::DataReplacement { .. }
             | Operation::DataOverlay { .. } => Ok(()),
+            // Overlaying a field the earlier replacement computed from stales it.
+            Operation::DataReplacement {
+                replacements,
+                source_fields,
+                ..
+            } => {
+                let Operation::DataOverlay { groups } = &self.transaction.operation else {
+                    return Err(wrong_operation_err(&self.transaction.operation));
+                };
+                for replacement in replacements {
+                    for group in groups.iter().filter(|g| g.fragment_id == replacement.0) {
+                        if group.overlays.iter().any(|overlay| {
+                            overlay
+                                .data_file
+                                .fields
+                                .iter()
+                                .any(|f| *f >= 0 && source_fields.contains(f))
+                        }) {
+                            return Err(
+                                self.retryable_conflict_err(other_transaction, other_version)
+                            );
+                        }
+                    }
+                }
+                Ok(())
+            }
             // A concurrent Delete only tombstones rows via a deletion vector,
             // which preserves physical offsets; the overlay value for a deleted
             // offset is simply inert. Conflict only if the whole overlaid
@@ -3657,6 +3730,8 @@ mod tests {
                         1,
                         DataFile::new_legacy_from_fields("r.lance", vec![0], None),
                     )],
+                    source_fields: Vec::new(),
+                    replaced_offsets: None,
                 },
                 Compatible,
             ),
@@ -4025,6 +4100,8 @@ mod tests {
                 "replacement",
                 Operation::DataReplacement {
                     replacements: vec![DataReplacementGroup(0, file())],
+                    source_fields: Vec::new(),
+                    replaced_offsets: None,
                 },
             ),
             (
@@ -4988,7 +5065,7 @@ mod tests {
                     .map(|f| f.id)
                     .chain(removed_fragment_ids.iter().copied()),
             ),
-            Operation::DataReplacement { replacements } => {
+            Operation::DataReplacement { replacements, .. } => {
                 Box::new(replacements.iter().map(|r| r.0))
             }
             Operation::DataOverlay { groups } => Box::new(groups.iter().map(|g| g.fragment_id)),
@@ -4998,6 +5075,7 @@ mod tests {
     #[tokio::test]
     async fn test_conflicts_data_replacement() {
         use io::commit::conflict_resolver::tests::{ConflictResult::*, modified_fragment_ids};
+        use lance_table::format::overlay::DataOverlayFile;
 
         let fragment0 = Fragment::new(0);
         let fragment1 = Fragment::new(1);
@@ -5009,14 +5087,54 @@ mod tests {
         let data_file_frag1_fields01 =
             DataFile::new_legacy_from_fields("path1_01", vec![0, 1], None);
 
+        // Our replacement of fragment 0, computed from field 2.
+        let computed_from_2 = || Operation::DataReplacement {
+            replacements: vec![DataReplacementGroup(0, data_file_frag0_fields01.clone())],
+            source_fields: vec![2],
+            replaced_offsets: None,
+        };
+        let rewrite_of = |fragment: u64, field: u32| Operation::Update {
+            updated_fragments: vec![Fragment::new(fragment)],
+            removed_fragment_ids: vec![],
+            new_fragments: vec![],
+            fields_modified: vec![field],
+            compacted_sstables: Vec::new(),
+            fields_for_preserving_frag_bitmap: vec![],
+            update_mode: Some(RewriteColumns),
+            inserted_rows_filter: None,
+            updated_fragment_offsets: None,
+        };
+        let replacement_of = |fragment: u64, field: i32| Operation::DataReplacement {
+            replacements: vec![DataReplacementGroup(
+                fragment,
+                DataFile::new_legacy_from_fields("other.lance", vec![field], None),
+            )],
+            source_fields: Vec::new(),
+            replaced_offsets: None,
+        };
+        let overlay_of = |fragment: u64, field: i32| Operation::DataOverlay {
+            groups: vec![DataOverlayGroup {
+                fragment_id: fragment,
+                overlays: vec![DataOverlayFile {
+                    data_file: DataFile::new_legacy_from_fields("overlay.lance", vec![field], None),
+                    coverage: OverlayCoverage::dense(RoaringBitmap::from_iter([0u32])),
+                    committed_version: 0,
+                }],
+            }],
+        };
+
         let cases = vec![
             (
                 "Different fragments",
                 Operation::DataReplacement {
                     replacements: vec![DataReplacementGroup(0, data_file_frag0_fields01.clone())],
+                    source_fields: Vec::new(),
+                    replaced_offsets: None,
                 },
                 Operation::DataReplacement {
                     replacements: vec![DataReplacementGroup(1, data_file_frag1_fields01)],
+                    source_fields: Vec::new(),
+                    replaced_offsets: None,
                 },
                 Compatible,
             ),
@@ -5024,9 +5142,13 @@ mod tests {
                 "Same fragment, different fields",
                 Operation::DataReplacement {
                     replacements: vec![DataReplacementGroup(0, data_file_frag0_fields01.clone())],
+                    source_fields: Vec::new(),
+                    replaced_offsets: None,
                 },
                 Operation::DataReplacement {
                     replacements: vec![DataReplacementGroup(0, data_file_frag0_fields23)],
+                    source_fields: Vec::new(),
+                    replaced_offsets: None,
                 },
                 Compatible,
             ),
@@ -5034,9 +5156,13 @@ mod tests {
                 "Same fragment, same fields",
                 Operation::DataReplacement {
                     replacements: vec![DataReplacementGroup(0, data_file_frag0_fields01.clone())],
+                    source_fields: Vec::new(),
+                    replaced_offsets: None,
                 },
                 Operation::DataReplacement {
                     replacements: vec![DataReplacementGroup(0, data_file_frag0_fields01.clone())],
+                    source_fields: Vec::new(),
+                    replaced_offsets: None,
                 },
                 Retryable,
             ),
@@ -5044,12 +5170,16 @@ mod tests {
                 "Same fragment, overlapping fields",
                 Operation::DataReplacement {
                     replacements: vec![DataReplacementGroup(0, data_file_frag0_fields01.clone())],
+                    source_fields: Vec::new(),
+                    replaced_offsets: None,
                 },
                 Operation::DataReplacement {
                     replacements: vec![DataReplacementGroup(
                         0,
                         DataFile::new_legacy_from_fields("path0_12", vec![1, 2], None),
                     )],
+                    source_fields: Vec::new(),
+                    replaced_offsets: None,
                 },
                 Retryable,
             ),
@@ -5057,6 +5187,8 @@ mod tests {
                 "DataReplacement vs Rewrite on same fragment",
                 Operation::DataReplacement {
                     replacements: vec![DataReplacementGroup(0, data_file_frag0_fields01.clone())],
+                    source_fields: Vec::new(),
+                    replaced_offsets: None,
                 },
                 Operation::Rewrite {
                     groups: vec![RewriteGroup {
@@ -5072,6 +5204,8 @@ mod tests {
                 "DataReplacement vs Rewrite on different fragment",
                 Operation::DataReplacement {
                     replacements: vec![DataReplacementGroup(0, data_file_frag0_fields01.clone())],
+                    source_fields: Vec::new(),
+                    replaced_offsets: None,
                 },
                 Operation::Rewrite {
                     groups: vec![RewriteGroup {
@@ -5083,6 +5217,84 @@ mod tests {
                 },
                 Compatible,
             ),
+            // A replacement declares the fields its values were computed from.
+            // Changing one on a replaced fragment conflicts; elsewhere it does not.
+            (
+                "source field rewritten, same fragment",
+                computed_from_2(),
+                rewrite_of(0, 2),
+                Retryable,
+            ),
+            (
+                "source field rewritten, other fragment",
+                computed_from_2(),
+                rewrite_of(1, 2),
+                Compatible,
+            ),
+            (
+                "source field replaced, same fragment",
+                computed_from_2(),
+                replacement_of(0, 2),
+                Retryable,
+            ),
+            (
+                "source field replaced, other fragment",
+                computed_from_2(),
+                replacement_of(1, 2),
+                Compatible,
+            ),
+            (
+                "source field overlaid, same fragment",
+                computed_from_2(),
+                overlay_of(0, 2),
+                Retryable,
+            ),
+            (
+                "unrelated field overlaid, same fragment",
+                computed_from_2(),
+                overlay_of(0, 3),
+                Compatible,
+            ),
+            // The same dependency in the other commit order.
+            (
+                "source field replaced after computed, same fragment",
+                replacement_of(0, 2),
+                computed_from_2(),
+                Retryable,
+            ),
+            (
+                "unrelated field replaced after computed, same fragment",
+                replacement_of(0, 3),
+                computed_from_2(),
+                Compatible,
+            ),
+            (
+                "source field replaced after computed, other fragment",
+                replacement_of(1, 2),
+                computed_from_2(),
+                Compatible,
+            ),
+            (
+                "source field overlaid after computed, same fragment",
+                overlay_of(0, 2),
+                computed_from_2(),
+                Retryable,
+            ),
+            (
+                "unrelated field overlaid after computed, same fragment",
+                overlay_of(0, 3),
+                computed_from_2(),
+                Compatible,
+            ),
+            (
+                "source field dropped",
+                computed_from_2(),
+                Operation::Project {
+                    schema: lance_core::datatypes::Schema::default(),
+                    preserves_nullability: true,
+                },
+                NotCompatible,
+            ),
             // A concurrent Update/Delete only invalidates our positional file when it
             // removes our target fragment outright, or (a horizontal update) rewrites
             // one of our fields. A deletion-vector-only change stays aligned.
@@ -5090,6 +5302,8 @@ mod tests {
                 "DataReplacement vs Update (RewriteColumns) on a different field",
                 Operation::DataReplacement {
                     replacements: vec![DataReplacementGroup(0, data_file_frag0_fields01.clone())],
+                    source_fields: Vec::new(),
+                    replaced_offsets: None,
                 },
                 Operation::Update {
                     updated_fragments: vec![Fragment::new(0)],
@@ -5109,6 +5323,8 @@ mod tests {
                 "DataReplacement vs Update (RewriteColumns) with inserts on a different field",
                 Operation::DataReplacement {
                     replacements: vec![DataReplacementGroup(0, data_file_frag0_fields01.clone())],
+                    source_fields: Vec::new(),
+                    replaced_offsets: None,
                 },
                 Operation::Update {
                     updated_fragments: vec![Fragment::new(0)],
@@ -5127,6 +5343,8 @@ mod tests {
                 "DataReplacement vs Update (RewriteColumns) that rewrote one of our fields",
                 Operation::DataReplacement {
                     replacements: vec![DataReplacementGroup(0, data_file_frag0_fields01.clone())],
+                    source_fields: Vec::new(),
+                    replaced_offsets: None,
                 },
                 Operation::Update {
                     updated_fragments: vec![Fragment::new(0)],
@@ -5145,6 +5363,8 @@ mod tests {
                 "DataReplacement vs Update (RewriteRows) that moved our rows",
                 Operation::DataReplacement {
                     replacements: vec![DataReplacementGroup(0, data_file_frag0_fields01.clone())],
+                    source_fields: Vec::new(),
+                    replaced_offsets: None,
                 },
                 Operation::Update {
                     updated_fragments: vec![Fragment::new(0)],
@@ -5163,6 +5383,8 @@ mod tests {
                 "DataReplacement vs Update that removed our fragment",
                 Operation::DataReplacement {
                     replacements: vec![DataReplacementGroup(0, data_file_frag0_fields01.clone())],
+                    source_fields: Vec::new(),
+                    replaced_offsets: None,
                 },
                 Operation::Update {
                     updated_fragments: vec![],
@@ -5181,6 +5403,8 @@ mod tests {
                 "DataReplacement vs Update (RewriteRows) that moved a different fragment's rows",
                 Operation::DataReplacement {
                     replacements: vec![DataReplacementGroup(0, data_file_frag0_fields01.clone())],
+                    source_fields: Vec::new(),
+                    replaced_offsets: None,
                 },
                 Operation::Update {
                     updated_fragments: vec![Fragment::new(1)],
@@ -5199,6 +5423,8 @@ mod tests {
                 "DataReplacement vs Delete (deletion-vector only) on same fragment",
                 Operation::DataReplacement {
                     replacements: vec![DataReplacementGroup(0, data_file_frag0_fields01.clone())],
+                    source_fields: Vec::new(),
+                    replaced_offsets: None,
                 },
                 Operation::Delete {
                     deleted_fragment_ids: vec![],
@@ -5211,6 +5437,8 @@ mod tests {
                 "DataReplacement vs Delete that removes the fragment",
                 Operation::DataReplacement {
                     replacements: vec![DataReplacementGroup(0, data_file_frag0_fields01.clone())],
+                    source_fields: Vec::new(),
+                    replaced_offsets: None,
                 },
                 Operation::Delete {
                     deleted_fragment_ids: vec![0],
@@ -5224,6 +5452,8 @@ mod tests {
                 "DataReplacement vs Merge",
                 Operation::DataReplacement {
                     replacements: vec![DataReplacementGroup(0, data_file_frag0_fields01)],
+                    source_fields: Vec::new(),
+                    replaced_offsets: None,
                 },
                 Operation::Merge {
                     fragments: vec![Fragment::new(0)],
@@ -5264,6 +5494,8 @@ mod tests {
                         0,
                         DataFile::new_legacy_from_fields("path0_3", vec![3], None),
                     )],
+                    source_fields: Vec::new(),
+                    replaced_offsets: None,
                 },
                 Retryable,
             ),


### PR DESCRIPTION
A column replacement computed from other columns has no way to say so. It declares only the fields it writes, so a concurrent commit that rewrites one of its inputs on the same fragment does not conflict and stale values land. Callers have worked around that by publishing through Update/RewriteColumns, which conflicts on the whole fragment and so also blocks a sibling replacement of an unrelated column.

DataReplacement gains `source_fields`, the field ids the values were computed from, and `replaced_offsets`, the rows whose values changed. A concurrent Update, DataReplacement or DataOverlay that changed a source field on a replaced fragment conflicts, whichever commits first; a Project that dropped one is incompatible, as a dropped written field already is. The manifest stamps last_updated only on the replaced offsets, falling back to a full stamp for a fragment with no stamps to keep. Both fields are additive on the wire: absent, they read as no dependencies and a full stamp, which is what every existing writer produced.

The Python and Java bindings construct the operation with no dependencies and a full stamp, as before; exposing the two fields there is a follow-up.
