### PR TITLE
feat: add recoverable data file part targets

### DIFF
--- a/rust/lance/src/dataset.rs
+++ b/rust/lance/src/dataset.rs
@@ -117,7 +117,7 @@ pub(crate) mod versions;
 pub mod write;
 
 pub use data_file::DataFileTarget;
-pub use data_file_part::DataFilePart;
+pub use data_file_part::{DataFilePart, DataFilePartTarget};
 
 pub(crate) use take::row_offsets_to_row_addresses;
 

--- a/rust/lance/src/dataset/data_file.rs
+++ b/rust/lance/src/dataset/data_file.rs
@@ -4,6 +4,7 @@
 use std::{
     collections::{HashMap, HashSet},
     io::Cursor,
+    ops::Range,
     sync::Arc,
 };
 
@@ -19,7 +20,7 @@ use object_store::path::{Path, PathPart};
 use prost::Message;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
-use super::{Dataset, fragment::write::generate_random_filename};
+use super::{DataFilePartTarget, Dataset, fragment::write::generate_random_filename};
 use crate::blob::prepared_to_logical_blob_schema;
 
 /// Serializable identity and logical schema of a final concatenated data file.
@@ -120,6 +121,17 @@ impl DataFileTarget {
             schema,
             version,
         })
+    }
+
+    /// Allocate a serializable identity for one staging part before writing it.
+    ///
+    /// Persist the returned target before calling
+    /// [`Dataset::write_data_file_part_to`](Dataset::write_data_file_part_to). If
+    /// completion is not checkpointed, the same identity can be passed to
+    /// [`Dataset::recover_data_file_part`](Dataset::recover_data_file_part) to
+    /// validate and recover the completed file.
+    pub fn new_part(&self, blob_ids: Option<Range<u32>>) -> Result<DataFilePartTarget> {
+        DataFilePartTarget::new(self, blob_ids)
     }
 
     pub(super) fn blob_target_id(&self) -> Option<BlobTargetId> {

--- a/rust/lance/src/dataset/data_file_part.rs
+++ b/rust/lance/src/dataset/data_file_part.rs
@@ -12,7 +12,121 @@ use lance_io::{
 use object_store::path::PathPart;
 use serde::{Deserialize, Serialize};
 
+use super::fragment::write::generate_random_filename;
 use super::{DataFileTarget, Dataset};
+
+/// Serializable identity of a data-file part allocated before the write starts.
+///
+/// Checkpoint this value before writing so a caller can distinguish an absent
+/// part from a complete part whose completion response was lost. A part target
+/// belongs to exactly one [`DataFileTarget`] and carries the Blob v2 ID lease
+/// used by that write.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct DataFilePartTarget {
+    target_file_name: String,
+    base_id: Option<u32>,
+    file_name: String,
+    blob_ids: Option<Range<u32>>,
+}
+
+impl DataFilePartTarget {
+    pub(super) fn new(target: &DataFileTarget, blob_ids: Option<Range<u32>>) -> Result<Self> {
+        let part = Self {
+            target_file_name: target.file_name.clone(),
+            base_id: target.base_id,
+            file_name: format!("{}.part", generate_random_filename()),
+            blob_ids,
+        };
+        part.validate_for(target)?;
+        Ok(part)
+    }
+
+    /// Object name within the target's staging-parts directory.
+    pub fn file_name(&self) -> &str {
+        &self.file_name
+    }
+
+    /// Blob v2 ID lease reserved for this part.
+    pub fn blob_ids(&self) -> Option<&Range<u32>> {
+        self.blob_ids.as_ref()
+    }
+
+    pub(super) fn validate_for(&self, target: &DataFileTarget) -> Result<()> {
+        PathPart::parse(&self.file_name)
+            .map_err(|error| Error::invalid_input(format!("invalid part identity: {error}")))?;
+        if self.file_name.is_empty() {
+            return Err(Error::invalid_input(
+                "DataFilePartTarget.file_name must select a child object",
+            ));
+        }
+        if self.target_file_name != target.file_name || self.base_id != target.base_id {
+            return Err(Error::invalid_input(format!(
+                "part target '{}' belongs to target {:?} in base {:?}, not {:?} in base {:?}",
+                self.file_name,
+                self.target_file_name,
+                self.base_id,
+                target.file_name,
+                target.base_id
+            )));
+        }
+        if let Some(blob_ids) = &self.blob_ids
+            && (blob_ids.start == 0 || blob_ids.start >= blob_ids.end)
+        {
+            return Err(Error::invalid_input(format!(
+                "part Blob ID range must be non-empty and start at 1 or greater, got {}..{}",
+                blob_ids.start, blob_ids.end
+            )));
+        }
+        let has_blob = target
+            .schema
+            .fields_pre_order()
+            .any(|field| field.is_blob_v2());
+        if has_blob && self.blob_ids.is_none() {
+            return Err(Error::invalid_input(
+                "write_data_file_part requires a non-empty Blob ID range for a schema containing Blob v2 fields",
+            ));
+        }
+        Ok(())
+    }
+
+    pub(super) fn completed(&self, num_rows: u64, size_bytes: u64) -> Result<DataFilePart> {
+        Ok(DataFilePart {
+            target_file_name: self.target_file_name.clone(),
+            base_id: self.base_id,
+            file_name: self.file_name.clone(),
+            blob_ids: self.blob_ids.clone(),
+            num_rows,
+            size_bytes: NonZeroU64::new(size_bytes)
+                .ok_or_else(|| Error::internal("completed part has zero file size"))?,
+        })
+    }
+
+    pub(super) async fn recover(
+        &self,
+        dataset: &Dataset,
+        target: &DataFileTarget,
+        expected_num_rows: u64,
+    ) -> Result<DataFilePart> {
+        dataset.validate_data_file_target(target)?;
+        self.validate_for(target)?;
+        let store = dataset.object_store(target.base_id).await?;
+        let dir = target.parts_dir(&dataset.data_file_dir_for_base(target.base_id)?);
+        let path = dir.join(self.file_name.as_str());
+        let size = store.size(&path).await?;
+        let scheduler = ScanScheduler::new(store.clone(), SchedulerConfig::max_bandwidth(&store));
+        let file = scheduler
+            .open_file(&path, &CachedFileSize::new(size))
+            .await?;
+        let opened = OpenedDataFilePart::open(
+            EncodedFileInput::new(file).with_expected_num_rows(expected_num_rows),
+            self.blob_ids.clone(),
+            target.blob_target_id(),
+        )
+        .await?;
+        self.completed(opened.num_rows(), size)
+    }
+}
 
 /// Serializable description of a completed staging part, containing its identity
 /// and expected metadata rather than file contents or open readers.

--- a/rust/lance/src/dataset/tests/data_file_part.rs
+++ b/rust/lance/src/dataset/tests/data_file_part.rs
@@ -183,7 +183,7 @@ async fn target_uses_an_ordinary_generated_data_file_name() {
 
 #[tokio::test]
 async fn checkpointed_part_target_recovers_a_lost_completion() {
-    let batch = arrow_array::record_batch!(("id", Int32, [1, 2]),).unwrap();
+    let batch = arrow_array::record_batch!(("id", Int32, [1, 2])).unwrap();
     let dataset = dataset_of(batch.clone(), LanceFileVersion::V2_2).await;
     let target = DataFileTarget::new(
         None,
@@ -221,7 +221,7 @@ async fn checkpointed_part_target_recovers_a_lost_completion() {
 
 #[tokio::test]
 async fn caller_directed_part_rejects_a_foreign_or_invalid_target() {
-    let batch = arrow_array::record_batch!(("id", Int32, [1]),).unwrap();
+    let batch = arrow_array::record_batch!(("id", Int32, [1])).unwrap();
     let dataset = dataset_of(batch.clone(), LanceFileVersion::V2_2).await;
     let target = DataFileTarget::new(
         None,

--- a/rust/lance/src/dataset/tests/data_file_part.rs
+++ b/rust/lance/src/dataset/tests/data_file_part.rs
@@ -27,7 +27,7 @@ use crate::blob::{BlobArrayBuilder, BlobDescriptorArrayBuilder, blob_field};
 use crate::dataset::fragment::FileFragment;
 use crate::dataset::transaction::{DataReplacementGroup, Operation};
 use crate::dataset::write::WriteParams;
-use crate::dataset::{DataFilePart, DataFileTarget, WriteDestination};
+use crate::dataset::{DataFilePart, DataFilePartTarget, DataFileTarget, WriteDestination};
 use crate::{Dataset, Result};
 
 async fn dataset_of(batch: RecordBatch, version: LanceFileVersion) -> Dataset {
@@ -179,6 +179,93 @@ async fn target_uses_an_ordinary_generated_data_file_name() {
     assert_eq!(restored.base_id, first.base_id);
     assert_eq!(restored.schema, first.schema);
     assert_eq!(restored.version, first.version);
+}
+
+#[tokio::test]
+async fn checkpointed_part_target_recovers_a_lost_completion() {
+    let batch = arrow_array::record_batch!(("id", Int32, [1, 2]),).unwrap();
+    let dataset = dataset_of(batch.clone(), LanceFileVersion::V2_2).await;
+    let target = DataFileTarget::new(
+        None,
+        Arc::new(dataset.schema().clone()),
+        ConcreteFileVersion::V2_2,
+    )
+    .unwrap();
+    let part_target = target.new_part(None).unwrap();
+    let checkpoint = serde_json::to_vec(&part_target).unwrap();
+    let restored: DataFilePartTarget = serde_json::from_slice(&checkpoint).unwrap();
+    assert_eq!(restored, part_target);
+    assert!(restored.file_name().ends_with(".part"));
+    assert_eq!(restored.blob_ids(), None);
+
+    let written = dataset
+        .write_data_file_part_to(&target, &restored, stream::iter([Ok(batch)]))
+        .await
+        .unwrap();
+    let recovered = dataset
+        .recover_data_file_part(&target, &restored, 2)
+        .await
+        .unwrap();
+    assert_eq!(
+        serde_json::to_value(&recovered).unwrap(),
+        serde_json::to_value(&written).unwrap()
+    );
+
+    let error = dataset
+        .recover_data_file_part(&target, &restored, 3)
+        .await
+        .unwrap_err();
+    assert!(matches!(error, Error::InvalidInput { .. }), "{error}");
+    assert!(error.to_string().contains("3 were expected"), "{error}");
+}
+
+#[tokio::test]
+async fn caller_directed_part_rejects_a_foreign_or_invalid_target() {
+    let batch = arrow_array::record_batch!(("id", Int32, [1]),).unwrap();
+    let dataset = dataset_of(batch.clone(), LanceFileVersion::V2_2).await;
+    let target = DataFileTarget::new(
+        None,
+        Arc::new(dataset.schema().clone()),
+        ConcreteFileVersion::V2_2,
+    )
+    .unwrap();
+    let neighbor = DataFileTarget::new(
+        None,
+        Arc::new(dataset.schema().clone()),
+        ConcreteFileVersion::V2_2,
+    )
+    .unwrap();
+    let part_target = target.new_part(None).unwrap();
+
+    let error = dataset
+        .write_data_file_part_to(&neighbor, &part_target, stream::iter([Ok(batch.clone())]))
+        .await
+        .unwrap_err();
+    assert!(matches!(error, Error::InvalidInput { .. }), "{error}");
+    assert!(error.to_string().contains("belongs to target"), "{error}");
+
+    for (field, replacement, message) in [
+        (
+            "file_name",
+            serde_json::json!("../outside.part"),
+            "part identity",
+        ),
+        (
+            "blob_ids",
+            serde_json::json!({"start": 0, "end": 1}),
+            "Blob ID range",
+        ),
+    ] {
+        let mut description = serde_json::to_value(&part_target).unwrap();
+        description[field] = replacement;
+        let invalid: DataFilePartTarget = serde_json::from_value(description).unwrap();
+        let error = dataset
+            .write_data_file_part_to(&target, &invalid, stream::iter([Ok(batch.clone())]))
+            .await
+            .unwrap_err();
+        assert!(matches!(error, Error::InvalidInput { .. }), "{error}");
+        assert!(error.to_string().contains(message), "{error}");
+    }
 }
 
 #[test]

--- a/rust/lance/src/dataset/write.rs
+++ b/rust/lance/src/dataset/write.rs
@@ -55,6 +55,7 @@ use crate::index::DatasetIndexExt;
 use crate::index::scalar::{IndexDetails, fetch_index_details};
 use crate::session::Session;
 
+use super::fragment::write::generate_random_filename;
 use super::progress::{NoopFragmentWriteProgress, WriteFragmentProgress};
 use super::transaction::Transaction;
 use super::utils::SchemaAdapter;

--- a/rust/lance/src/dataset/write.rs
+++ b/rust/lance/src/dataset/write.rs
@@ -55,12 +55,11 @@ use crate::index::DatasetIndexExt;
 use crate::index::scalar::{IndexDetails, fetch_index_details};
 use crate::session::Session;
 
-use super::fragment::write::generate_random_filename;
 use super::progress::{NoopFragmentWriteProgress, WriteFragmentProgress};
 use super::transaction::Transaction;
 use super::utils::SchemaAdapter;
 use super::versions;
-use super::{DATA_DIR, DataFilePart, DataFileTarget};
+use super::{DATA_DIR, DataFilePart, DataFilePartTarget, DataFileTarget};
 
 mod commit;
 pub mod delete;
@@ -158,20 +157,29 @@ impl Dataset {
         blob_ids: Option<Range<u32>>,
         data: impl Stream<Item = Result<RecordBatch>> + Send,
     ) -> Result<DataFilePart> {
-        self.validate_data_file_target(target)?;
-        validate_blob_v2_write_schema(target.schema.as_ref())?;
-        let part_blob_ids = blob_ids.clone();
-        let has_blob = target
-            .schema
-            .fields_pre_order()
-            .any(|field| field.is_blob_v2());
-        if has_blob && blob_ids.is_none() {
-            return Err(Error::invalid_input(
-                "write_data_file_part requires a non-empty Blob ID range for a schema containing Blob v2 fields",
-            ));
-        }
+        let part_target = target.new_part(blob_ids)?;
+        self.write_data_file_part_to(target, &part_target, data)
+            .await
+    }
 
-        let mut preprocessor = if let Some(blob_ids) = blob_ids {
+    /// Write one independently complete Lance file to a caller-checkpointed part target.
+    ///
+    /// Allocate and persist `part_target` before calling this method. If the
+    /// completion response is lost, use [`Self::recover_data_file_part`] with
+    /// the same target and expected physical row count. The caller must fence
+    /// stale writers and must not write the same part target concurrently.
+    pub async fn write_data_file_part_to(
+        &self,
+        target: &DataFileTarget,
+        part_target: &DataFilePartTarget,
+        data: impl Stream<Item = Result<RecordBatch>> + Send,
+    ) -> Result<DataFilePart> {
+        self.validate_data_file_target(target)?;
+        part_target.validate_for(target)?;
+        validate_blob_v2_write_schema(target.schema.as_ref())?;
+        let part_blob_ids = part_target.blob_ids().cloned();
+
+        let mut preprocessor = if let Some(blob_ids) = part_blob_ids.clone() {
             let data_dir = self.data_file_dir_for_base(target.base_id)?;
             let object_store = self.object_store(target.base_id).await?;
             let external_base_resolver = blob_v2_external_base_resolver(
@@ -199,10 +207,9 @@ impl Dataset {
             None
         };
 
-        let file_name = format!("{}.part", generate_random_filename());
         let path = target
             .parts_dir(&self.data_file_dir_for_base(target.base_id)?)
-            .join(file_name.as_str());
+            .join(part_target.file_name());
         let store = self.object_store(target.base_id).await?;
         let mut writer = file_versions::create_writer(
             target.version,
@@ -229,15 +236,7 @@ impl Dataset {
         .await;
 
         match write_result {
-            Ok(summary) => Ok(DataFilePart {
-                target_file_name: target.file_name.clone(),
-                base_id: target.base_id,
-                file_name,
-                blob_ids: part_blob_ids,
-                num_rows: summary.num_rows,
-                size_bytes: NonZeroU64::new(summary.size_bytes)
-                    .ok_or_else(|| Error::internal("completed part has zero file size"))?,
-            }),
+            Ok(summary) => part_target.completed(summary.num_rows, summary.size_bytes),
             Err(error) => {
                 writer.abort().await;
                 if let Some(preprocessor) = preprocessor.as_mut() {
@@ -246,6 +245,21 @@ impl Dataset {
                 Err(error)
             }
         }
+    }
+
+    /// Recover a complete data-file part whose target was checkpointed before writing.
+    ///
+    /// The file is reopened and its footer, physical row count, Blob v2
+    /// descriptors, checkpointed target association, and Blob ID lease are
+    /// validated. Missing, incomplete, or mismatched objects return an error
+    /// and are never treated as completed parts.
+    pub async fn recover_data_file_part(
+        &self,
+        target: &DataFileTarget,
+        part_target: &DataFilePartTarget,
+        expected_num_rows: u64,
+    ) -> Result<DataFilePart> {
+        part_target.recover(self, target, expected_num_rows).await
     }
 
     /// Reopen, validate, and concatenate parts into the final data file.


### PR DESCRIPTION
## Summary

Add a caller-allocated, serializable `DataFilePartTarget` so distributed writers can checkpoint the exact staging identity before a write starts. A caller can later recover a completed part when the write succeeded but its completion response or checkpoint update was lost.

The existing `write_data_file_part` API remains unchanged and delegates through the new target-aware path.

## Recovery structure

```mermaid
sequenceDiagram
    participant C as Coordinator
    participant W as Part writer
    participant S as Object store
    C->>C: Allocate DataFilePartTarget
    C->>C: Persist target and Blob ID lease
    C->>W: Write exact part target
    W->>S: Write complete Lance part
    alt completion is recorded
        W-->>C: DataFilePart
    else completion response is lost
        C->>S: Reopen expected object
        S-->>C: Validate footer, rows, and Blob descriptors
        C->>C: Reconstruct DataFilePart
    end
```

## API

- `DataFileTarget::new_part` allocates the part identity and Blob v2 lease association before I/O.
- `Dataset::write_data_file_part_to` writes to that exact checkpointed identity.
- `Dataset::recover_data_file_part` reopens the object and reconstructs `DataFilePart` only after validating a complete footer, the expected physical row count, Blob descriptors, and the checkpointed target association.

Callers remain responsible for checkpoint durability, stale-writer fencing, logical row coverage, commit state, and cleanup. The change does not introduce a new Lance file or manifest format.
