### PR TITLE
feat(python): add scan_stats_callback to LanceFragment.scanner

### DIFF
--- a/python/python/lance/fragment.py
+++ b/python/python/lance/fragment.py
@@ -54,7 +54,7 @@ if TYPE_CHECKING:
         ReaderLike,
         Transaction,
     )
-    from .lance import LanceSchema
+    from .lance import LanceSchema, ScanStatistics
     from .namespace import LanceNamespace
 
 
@@ -576,8 +576,17 @@ class LanceFragment(pa.dataset.Fragment):
         include_deleted_rows: Optional[bool] = None,
         batch_size_bytes: Optional[int] = None,
         strict_batch_size: Optional[bool] = None,
+        scan_stats_callback: Optional[Callable[[ScanStatistics], None]] = None,
     ) -> "LanceScanner":
-        """See Dataset::scanner for details"""
+        """See Dataset::scanner for details
+
+        Parameters
+        ----------
+        scan_stats_callback: Callable[[ScanStatistics], None], default None
+            A callback function that will be called with the scan statistics after the
+            scan is complete.  Errors raised by the callback will be logged but not
+            re-raised.
+        """
         filter_str = str(filter) if filter is not None else None
 
         columns_arg = {}
@@ -603,6 +612,7 @@ class LanceFragment(pa.dataset.Fragment):
             include_deleted_rows=include_deleted_rows,
             batch_size_bytes=batch_size_bytes,
             strict_batch_size=strict_batch_size,
+            scan_stats_callback=scan_stats_callback,
             **columns_arg,
         )
         from .dataset import LanceScanner
@@ -635,7 +645,7 @@ class LanceFragment(pa.dataset.Fragment):
             "_full_text_query": None,
             "_use_scalar_index": use_scalar_index,
             "_include_deleted_rows": include_deleted_rows,
-            "_scan_stats_callback": None,
+            "_scan_stats_callback": scan_stats_callback,
             "_strict_batch_size": (
                 strict_batch_size if strict_batch_size is not None else False
             ),

--- a/python/python/lance/lance/__init__.pyi
+++ b/python/python/lance/lance/__init__.pyi
@@ -741,6 +741,7 @@ class _Fragment:
         include_deleted_rows: Optional[bool] = None,
         batch_size_bytes: Optional[int] = None,
         strict_batch_size: Optional[bool] = None,
+        scan_stats_callback: Optional[Callable[[Any], None]] = None,
     ) -> _Scanner: ...
     def add_columns_from_reader(
         self,

--- a/python/python/tests/test_fragment.py
+++ b/python/python/tests/test_fragment.py
@@ -1547,3 +1547,22 @@ def test_fragment_scanner_batch_size_bytes(tmp_path: Path):
     small_budget = list(fragment.to_batches(batch_size_bytes=64 * 1024))
     assert len(small_budget) > len(default_batches)
     assert pa.Table.from_batches(small_budget) == fragment.to_table()
+
+
+def test_fragment_scanner_scan_stats_callback(tmp_path: Path):
+    dataset = write_dataset(
+        pa.table({"a": range(200)}), tmp_path, max_rows_per_file=100
+    )
+    fragments = dataset.get_fragments()
+    assert len(fragments) == 2
+
+    calls = []
+
+    def scan_stats_callback(stats: lance.ScanStatistics):
+        calls.append(stats)
+
+    result = fragments[0].scanner(scan_stats_callback=scan_stats_callback).to_table()
+    assert result.num_rows == 100
+    assert len(calls) == 1, "Callback should have been called exactly once"
+    assert calls[0].bytes_read > 0, "Expected some bytes read"
+    assert calls[0].iops > 0, "Expected some I/O operations"

--- a/python/src/dataset.rs
+++ b/python/src/dataset.rs
@@ -4582,7 +4582,9 @@ impl Dataset {
         .infer_error()
     }
 
-    fn make_scan_stats_callback(callback: Bound<'_, PyAny>) -> PyResult<ExecutionStatsCallback> {
+    pub(crate) fn make_scan_stats_callback(
+        callback: Bound<'_, PyAny>,
+    ) -> PyResult<ExecutionStatsCallback> {
         if !callback.is_callable() {
             return Err(PyValueError::new_err("Callback must be callable"));
         }

--- a/python/src/fragment.rs
+++ b/python/src/fragment.rs
@@ -213,7 +213,7 @@ impl FileFragment {
     }
 
     #[allow(clippy::too_many_arguments)]
-    #[pyo3(signature=(columns=None, columns_with_transform=None, batch_size=None, filter=None, limit=None, offset=None, with_row_id=None, with_row_address=None, batch_readahead=None, blob_handling=None, order_by=None, use_scalar_index=None, io_buffer_size=None, late_materialization=None, include_deleted_rows=None, batch_size_bytes=None, strict_batch_size=None))]
+    #[pyo3(signature=(columns=None, columns_with_transform=None, batch_size=None, filter=None, limit=None, offset=None, with_row_id=None, with_row_address=None, batch_readahead=None, blob_handling=None, order_by=None, use_scalar_index=None, io_buffer_size=None, late_materialization=None, include_deleted_rows=None, batch_size_bytes=None, strict_batch_size=None, scan_stats_callback=None))]
     fn scanner(
         self_: PyRef<'_, Self>,
         columns: Option<Vec<String>>,
@@ -233,6 +233,7 @@ impl FileFragment {
         include_deleted_rows: Option<bool>,
         batch_size_bytes: Option<u64>,
         strict_batch_size: Option<bool>,
+        scan_stats_callback: Option<&Bound<'_, PyAny>>,
     ) -> PyResult<Scanner> {
         let mut scanner = self_.fragment.scan();
 
@@ -333,6 +334,10 @@ impl FileFragment {
         }
         if let Some(strict_batch_size) = strict_batch_size {
             scanner.strict_batch_size(strict_batch_size);
+        }
+        if let Some(scan_stats_callback) = scan_stats_callback {
+            let callback = Dataset::make_scan_stats_callback(scan_stats_callback.clone())?;
+            scanner.scan_stats_callback(callback);
         }
         let scn = Arc::new(scanner);
         Ok(Scanner::new(scn))


### PR DESCRIPTION
## Summary

`LanceDataset.scanner` already accepts `scan_stats_callback`, but per-fragment scans through `LanceFragment.scanner` had no way to observe `ScanStatistics`. This PR adds the same parameter to the fragment scanner.

- Add `scan_stats_callback` (default `None`) to `LanceFragment.scanner` in `python/python/lance/fragment.py`, forward it to the binding, record it in the scanner snapshot, and document it in the docstring.
- Thread the callback through `_Fragment.scanner` in `python/src/fragment.rs` to `ScannerBuilder::scan_stats_callback`, reusing the same `make_scan_stats_callback` helper the dataset path uses (now `pub(crate)`).
- Update the `_Fragment.scanner` type stub.

## Test plan

- [x] New `test_fragment_scanner_scan_stats_callback` in `python/python/tests/test_fragment.py` scans one fragment of a two-fragment dataset and asserts the callback fires exactly once with `bytes_read > 0` and `iops > 0`, mirroring `test_scan_statistics_callback` at the dataset level.
- [x] `uv run pytest python/tests/test_fragment.py` (86 passed)
- [x] `uv run pytest python/tests/test_scalar_index.py::test_scan_statistics_callback`
- [x] `uv run make lint` (ruff, pyright, `cargo fmt --check`, `cargo clippy -- -D warnings`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UVZyfhAVqHyom52mZ6398t
