### PR TITLE
feat(mem_wal): stable row ids for WAL-backed tables

### DIFF
--- a/docs/src/format/table/mem_wal.md
+++ b/docs/src/format/table/mem_wal.md
@@ -317,7 +317,7 @@ The manifest contains:
 - **WAL pointers**: `replay_after_wal_entry_position` and `wal_entry_position_last_seen`.
 - **SSTable generation state**: `current_generation` and `sstables`.
 - **Lifecycle state**: `status`, either `ACTIVE` or `SEALED`.
-- **Row id reservation**: `row_id_reservation`, present only on a shard that
+- **Row id reservations**: `row_id_reservations`, non-empty only on a shard that
   assigns stable row ids.
 
 `shard_field_entries` stores computed shard field values as raw Arrow scalar bytes keyed by `ShardingField.field_id`.
@@ -333,19 +333,25 @@ Recovery must still probe or list WAL files to find the actual tail.
 
 `current_generation` is the generation number to assign to the next SSTable created by flushing the MemTable.
 Each entry in `sstables` records a published SSTable's `generation` and `path`.
+On a shard that assigns stable row ids each entry also records `max_row_id`, the highest id held by any row of that generation, which is what lets a successor place a reserved range without reading the generation back.
+It is absent on a generation flushed before the field existed and on one holding nothing but tombstones, which carry no id.
 
 `status = SEALED` marks a reversible in-flight drop-table operation.
 Sealed shards refuse new writer claims.
 
-`row_id_reservation` records the half-open range of stable row ids the shard
-holds exclusively, taken with an `Operation::ReserveRowIds` commit against the
-base table and written here before any id is issued from it.
-A crash between the two leaks the chunk, which is harmless: ids need not be
-contiguous, and the base table's `next_row_id` has already moved past them.
+`row_id_reservations` records the half-open ranges of stable row ids the shard holds exclusively, each taken with an `Operation::ReserveRowIds` commit against the base table and written here before any id is issued from it.
+There is more than one because a shard reserves its next range in the background while still drawing from the current one.
+A crash between the two commits leaks that chunk, which is harmless: ids need not be contiguous, and the base table's `next_row_id` has already moved past them.
 
-The range is bound to the `writer_epoch` that took it.
-A successor must reserve a fresh range rather than resume one it finds on disk:
-two writers drawing from one range would assign duplicate ids.
+How far into a range the shard got is deliberately not recorded, because writing it would mean a manifest commit on every write.
+A successor derives the position instead, as the highest id inside any recorded range it can find across three places: the memtables its WAL replay rebuilt, the `max_row_id` of every generation in `sstables`, and the base fragments whose row ids overlap a range.
+The third is not redundant. A generation that compacted and then aged out of the retention window is in neither of the first two, and its ids are live in the base table.
+
+A shard draws from its oldest range and gives up that range's remainder as soon as a request outgrows it, so at most one range is ever partly consumed.
+That is what makes a single derived id sufficient: the range holding it resumes one past it, ranges below it are spent, and ranges above it were never drawn from.
+
+A successor that cannot read one of the three sources must abandon every range and reserve fresh, rather than resume a range whose position is uncertain.
+Abandoning costs ids, which are plentiful; two writers drawing from one range assign duplicate ids, which no later operation detects.
 
 The manifest is serialized as the `ShardManifest` protobuf message.
 

--- a/docs/src/format/table/mem_wal.md
+++ b/docs/src/format/table/mem_wal.md
@@ -204,6 +204,30 @@ Tombstone rows follow the same forward row ordering and deletion-vector rules as
 If the newest row for a primary key is a tombstone, the deletion vector keeps that tombstone row and hides older rows for the key.
 Read planning then filters `_tombstone = false`, so the key is absent from query results.
 
+### Stable Row Id Rows
+
+A shard opened with `enable_row_ids` carries an internal `__wal_row_id` column
+alongside `_tombstone`, holding the stable row id of the row.
+
+The id is resolved on the write path and injected before the WAL append, so the
+log entry carries it and a replay reproduces it unchanged.
+Nothing downstream assigns one: the MemTable, the flush, the SSTable and
+compaction all carry it through.
+Compaction writes the surviving rows as a fragment whose `row_id_meta` already
+holds these ids, so the table's own row-id assignment skips them.
+
+The column is nullable because a tombstone carries no id.
+A delete marker exists only to shadow a primary key, and compaction resolves the
+base row it supersedes by key rather than by id.
+Read planning surfaces the column as `_rowid` when a query projects it, and
+strips it otherwise; the `_tombstone = false` filter has already removed every
+row that can hold a null there.
+
+A shard must be drained of SSTables before the feature is enabled on it.
+SSTables written before the column existed are not supported: a query projecting
+`_rowid` over one is refused rather than answered with nulls, because a null
+there is indistinguishable from a row that legitimately has no id.
+
 ### SSTable Primary-Key Sidecars
 
 Primary-key MemTables maintain an implicit BTree for primary-key deduplication, independent of `maintained_indexes`.
@@ -293,6 +317,8 @@ The manifest contains:
 - **WAL pointers**: `replay_after_wal_entry_position` and `wal_entry_position_last_seen`.
 - **SSTable generation state**: `current_generation` and `sstables`.
 - **Lifecycle state**: `status`, either `ACTIVE` or `SEALED`.
+- **Row id reservation**: `row_id_reservation`, present only on a shard that
+  assigns stable row ids.
 
 `shard_field_entries` stores computed shard field values as raw Arrow scalar bytes keyed by `ShardingField.field_id`.
 The matching `ShardingField.result_type` determines how to decode each value.
@@ -310,6 +336,16 @@ Each entry in `sstables` records a published SSTable's `generation` and `path`.
 
 `status = SEALED` marks a reversible in-flight drop-table operation.
 Sealed shards refuse new writer claims.
+
+`row_id_reservation` records the half-open range of stable row ids the shard
+holds exclusively, taken with an `Operation::ReserveRowIds` commit against the
+base table and written here before any id is issued from it.
+A crash between the two leaks the chunk, which is harmless: ids need not be
+contiguous, and the base table's `next_row_id` has already moved past them.
+
+The range is bound to the `writer_epoch` that took it.
+A successor must reserve a fresh range rather than resume one it finds on disk:
+two writers drawing from one range would assign duplicate ids.
 
 The manifest is serialized as the `ShardManifest` protobuf message.
 

--- a/docs/src/format/table/transaction.md
+++ b/docs/src/format/table/transaction.md
@@ -353,6 +353,36 @@ only conflicts with operations that modify the max fragment id. Here are the ope
 - Overwrite
 - Restore
 
+### ReserveRowIds
+
+Pre-allocates stable row IDs, advancing `next_row_id` past them without adding
+any fragments.
+This lets a writer stamp a row's ID into data it has not committed yet -- the
+MemWAL assigns a row its ID on the write path, long before the row reaches a
+base fragment.
+
+The reserved IDs are never handed back: a writer that crashes before using them
+leaks the chunk, which is harmless because row IDs need not be contiguous.
+Only valid on a table that already uses stable row IDs.
+
+<details>
+<summary>ReserveRowIds protobuf message</summary>
+
+```protobuf
+%%% proto.message.ReserveRowIds %%%
+```
+
+</details>
+
+#### ReserveRowIds Compatibility
+
+Like ReserveFragments, this only advances a counter in the manifest, so it
+conflicts only with operations that replace the manifest wholesale. Here are the
+operations that conflict with ReserveRowIds:
+
+- Overwrite
+- Restore
+
 ### Clone
 
 Creates a shallow or deep copy of the table.

--- a/protos/table.proto
+++ b/protos/table.proto
@@ -749,30 +749,34 @@ message ShardManifest {
    */
   ShardStatus status = 15;
 
-  /* Stable row ids this shard has reserved from the base dataset and may
-   * still hand out. Absent when the shard has never reserved, or when the
-   * feature is off.
+  /* Stable row id ranges this shard has reserved from the base dataset and
+   * may still hand out, in the order they were taken. Empty when the shard has
+   * never reserved, or when the feature is off.
+   *
+   * More than one because a shard reserves its next range in the background
+   * while it is still drawing from the current one. A range drops out once it
+   * is exhausted.
    */
-  optional RowIdReservation row_id_reservation = 16;
+  repeated RowIdReservation row_id_reservations = 16;
 }
 
 /* A half-open range of stable row ids a shard holds exclusively, taken with an
  * Operation::ReserveRowIds commit against the base dataset and persisted here
  * before any id is issued from it.
  *
- * Bound to the writer epoch that took it: a new epoch must re-reserve rather
- * than resume a range it finds on disk, because two writers drawing from one
- * range would mint duplicate ids.
+ * How far into the range a shard got is deliberately *not* recorded: writing it
+ * would mean a manifest commit per write. A successor derives it instead, from
+ * the highest id in the range it can find across its memtables, its SSTables
+ * (SsTable.max_row_id) and the overlapping base fragments. A range it cannot
+ * derive a position for is dropped rather than guessed at, which abandons ids
+ * but can never issue one twice.
  */
 message RowIdReservation {
-  // First id in the range that has not been issued yet.
-  uint64 next = 1;
+  // First id in the range.
+  uint64 start = 1;
 
-  // One past the last id in the range. `next == end` means exhausted.
+  // One past the last id in the range.
   uint64 end = 2;
-
-  // The writer epoch that committed the reservation.
-  uint64 writer_epoch = 3;
 }
 
 // A shard field value stored as raw Arrow scalar bytes.
@@ -820,6 +824,15 @@ message SsTable {
 
      Absent also on a table with no primary key. */
   optional uint64 primary_key_bytes = 5;
+
+  /* Highest stable row id held by any row in this SSTable.
+
+     Recorded at flush so a successor can tell how far into a reserved range its
+     predecessor got without reading the SSTable back. Absent on an SSTable
+     written before this field existed and on a shard that does not assign
+     stable row ids -- in the first case a reader must treat the range as
+     underivable and abandon it, not read the missing value as zero. */
+  optional uint64 max_row_id = 6;
 }
 
 // A pointer to the latest SSTable compacted for a shard.

--- a/protos/table.proto
+++ b/protos/table.proto
@@ -748,6 +748,31 @@ message ShardManifest {
    * (drop-table 2PC). A SEALED manifest refuses claims at claim_epoch.
    */
   ShardStatus status = 15;
+
+  /* Stable row ids this shard has reserved from the base dataset and may
+   * still hand out. Absent when the shard has never reserved, or when the
+   * feature is off.
+   */
+  optional RowIdReservation row_id_reservation = 16;
+}
+
+/* A half-open range of stable row ids a shard holds exclusively, taken with an
+ * Operation::ReserveRowIds commit against the base dataset and persisted here
+ * before any id is issued from it.
+ *
+ * Bound to the writer epoch that took it: a new epoch must re-reserve rather
+ * than resume a range it finds on disk, because two writers drawing from one
+ * range would mint duplicate ids.
+ */
+message RowIdReservation {
+  // First id in the range that has not been issued yet.
+  uint64 next = 1;
+
+  // One past the last id in the range. `next == end` means exhausted.
+  uint64 end = 2;
+
+  // The writer epoch that committed the reservation.
+  uint64 writer_epoch = 3;
 }
 
 // A shard field value stored as raw Arrow scalar bytes.

--- a/protos/transaction.proto
+++ b/protos/transaction.proto
@@ -195,6 +195,13 @@ message Transaction {
     uint32 num_fragments = 1;
   }
 
+  /* An operation that reserves stable row ids for future use, advancing
+   * `next_row_id` without adding any fragments.
+   */
+  message ReserveRowIds {
+    uint64 num_row_ids = 1;
+  }
+
   // An operation that clones a dataset.
   message Clone {
     /* - true:  Performs a metadata-only clone (copies manifest without data files).
@@ -425,6 +432,7 @@ message Transaction {
     Clone clone = 113;
     UpdateBases update_bases = 114;
     DataOverlay data_overlay = 115;
+    ReserveRowIds reserve_row_ids = 116;
   }
 
   // Fields 200/202 (`blob_append` / `blob_overwrite`) previously represented blob dataset ops.

--- a/rust/lance-table/src/format/transaction.rs
+++ b/rust/lance-table/src/format/transaction.rs
@@ -57,6 +57,7 @@ pub fn operation_may_change_schema(transaction: &pb::Transaction) -> bool {
                 | Operation::Rewrite(_)
                 | Operation::DataReplacement(_)
                 | Operation::ReserveFragments(_)
+                | Operation::ReserveRowIds(_)
                 | Operation::Update(_)
                 | Operation::UpdateConfig(_)
                 | Operation::UpdateMemWalState(_)

--- a/rust/lance-table/src/system_index/mem_wal.rs
+++ b/rust/lance-table/src/system_index/mem_wal.rs
@@ -52,6 +52,14 @@ pub struct SsTable {
     /// [`Self::in_memory_bytes`], and is also `None` on a table with no primary
     /// key.
     pub primary_key_bytes: Option<u64>,
+    /// Highest stable row id held by any row in this SSTable.
+    ///
+    /// Recorded at flush so a successor can tell how far into a reserved range
+    /// its predecessor got without reading the SSTable back -- see
+    /// [`RowIdReservation`]. `None` on an SSTable written before this field
+    /// existed and on a shard that does not assign stable row ids; a reader must
+    /// carry the first case as *underivable* rather than as zero.
+    pub max_row_id: Option<u64>,
 }
 
 impl SsTable {
@@ -63,6 +71,7 @@ impl SsTable {
             in_memory_bytes: None,
             physical_rows: None,
             primary_key_bytes: None,
+            max_row_id: None,
         }
     }
 }
@@ -75,6 +84,7 @@ impl From<&SsTable> for pb::SsTable {
             in_memory_bytes: sstable.in_memory_bytes,
             physical_rows: sstable.physical_rows,
             primary_key_bytes: sstable.primary_key_bytes,
+            max_row_id: sstable.max_row_id,
         }
     }
 }
@@ -87,6 +97,7 @@ impl From<pb::SsTable> for SsTable {
             in_memory_bytes: sstable.in_memory_bytes,
             physical_rows: sstable.physical_rows,
             primary_key_bytes: sstable.primary_key_bytes,
+            max_row_id: sstable.max_row_id,
         }
     }
 }
@@ -228,47 +239,36 @@ impl ShardStatus {
 /// A half-open range of stable row ids a shard holds exclusively.
 ///
 /// Taken with an [`crate::transaction::Operation::ReserveRowIds`] commit
-/// against the base dataset and persisted in the shard manifest *before* any id
-/// is issued from it, so a crash leaks the chunk rather than reissuing it.
+/// against the base dataset and recorded in the shard manifest *before* any id
+/// is issued from it, so a successor finds every range its predecessor held.
 ///
-/// `writer_epoch` binds the range to the writer that took it. A successor must
-/// re-reserve rather than resume a range it finds on disk: two writers drawing
-/// from one range mint duplicate ids, which is silent corruption.
+/// How far into the range the predecessor got is deliberately not recorded:
+/// writing it would put a manifest commit on every write. A successor derives
+/// it instead, as the highest id in the range across its memtables, its
+/// SSTables ([`SsTable::max_row_id`]) and the base fragments overlapping it --
+/// the three places an issued id can be. A range it cannot derive a position
+/// for is dropped rather than guessed at, which abandons ids but can never
+/// issue one twice.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, DeepSizeOf)]
 pub struct RowIdReservation {
-    /// First id in the range that has not been issued yet.
-    pub next: u64,
-    /// One past the last id in the range; `next == end` means exhausted.
+    /// First id in the range.
+    pub start: u64,
+    /// One past the last id in the range.
     pub end: u64,
-    /// The writer epoch that committed the reservation.
-    pub writer_epoch: u64,
 }
 
 impl RowIdReservation {
-    /// Ids still available in this range.
-    pub fn remaining(&self) -> u64 {
-        self.end.saturating_sub(self.next)
-    }
-
-    /// Take `count` ids, returning the half-open range and advancing `next`.
-    /// `None` when the range cannot cover the request -- the caller reserves a
-    /// fresh chunk instead of splitting across two.
-    pub fn take(&mut self, count: u64) -> Option<std::ops::Range<u64>> {
-        if self.remaining() < count {
-            return None;
-        }
-        let start = self.next;
-        self.next += count;
-        Some(start..self.next)
+    /// Whether `id` falls in this range.
+    pub fn contains(&self, id: u64) -> bool {
+        self.start <= id && id < self.end
     }
 }
 
 impl From<&RowIdReservation> for pb::RowIdReservation {
     fn from(r: &RowIdReservation) -> Self {
         Self {
-            next: r.next,
+            start: r.start,
             end: r.end,
-            writer_epoch: r.writer_epoch,
         }
     }
 }
@@ -276,9 +276,8 @@ impl From<&RowIdReservation> for pb::RowIdReservation {
 impl From<pb::RowIdReservation> for RowIdReservation {
     fn from(r: pb::RowIdReservation) -> Self {
         Self {
-            next: r.next,
+            start: r.start,
             end: r.end,
-            writer_epoch: r.writer_epoch,
         }
     }
 }
@@ -311,9 +310,14 @@ pub struct ShardManifest {
     /// Lifecycle status (drop-table 2PC). Defaults to `Active`; preserved
     /// across claims via `..base` so only fresh constructions set it.
     pub status: ShardStatus,
-    /// Stable row ids this shard reserved and may still issue. `None` when the
-    /// shard has never reserved, or when stable row ids are off.
-    pub row_id_reservation: Option<RowIdReservation>,
+    /// Stable row id ranges this shard reserved and may still issue, in the
+    /// order they were taken. Empty when the shard has never reserved, or when
+    /// stable row ids are off.
+    ///
+    /// More than one because a shard reserves its next range in the background
+    /// while still drawing from the current one. A range drops out once it is
+    /// exhausted.
+    pub row_id_reservations: Vec<RowIdReservation>,
 }
 
 impl ShardManifest {
@@ -331,7 +335,7 @@ impl DeepSizeOf for ShardManifest {
     fn deep_size_of_children(&self, context: &mut lance_core::deepsize::Context) -> usize {
         self.shard_field_values.deep_size_of_children(context)
             + self.sstables.deep_size_of_children(context)
-            + self.row_id_reservation.deep_size_of_children(context)
+            + self.row_id_reservations.deep_size_of_children(context)
     }
 }
 
@@ -355,7 +359,7 @@ impl From<&ShardManifest> for pb::ShardManifest {
             current_generation: rm.current_generation,
             sstables: rm.sstables.iter().map(|sstable| sstable.into()).collect(),
             status: rm.status.to_i32(),
-            row_id_reservation: rm.row_id_reservation.as_ref().map(Into::into),
+            row_id_reservations: rm.row_id_reservations.iter().map(Into::into).collect(),
         }
     }
 }
@@ -385,7 +389,11 @@ impl TryFrom<pb::ShardManifest> for ShardManifest {
             current_generation: rm.current_generation,
             sstables: rm.sstables.into_iter().map(SsTable::from).collect(),
             status: ShardStatus::from_i32(rm.status),
-            row_id_reservation: rm.row_id_reservation.map(RowIdReservation::from),
+            row_id_reservations: rm
+                .row_id_reservations
+                .into_iter()
+                .map(RowIdReservation::from)
+                .collect(),
         })
     }
 }
@@ -693,12 +701,17 @@ mod tests {
             in_memory_bytes: None,
             physical_rows: None,
             primary_key_bytes: None,
+            max_row_id: None,
         };
         let decoded = SsTable::from(legacy);
         assert_eq!(decoded.generation, 7);
         assert_eq!(decoded.in_memory_bytes, None);
         assert_eq!(decoded.physical_rows, None);
         assert_eq!(decoded.primary_key_bytes, None);
+        // Not zero: zero is a valid row id, and a reader that took it for one
+        // would place a reserved range as barely touched when the generation
+        // may hold its whole contents.
+        assert_eq!(decoded.max_row_id, None);
     }
 
     /// All three survive the round trip, so a reader sees what the flush
@@ -711,11 +724,80 @@ mod tests {
             in_memory_bytes: Some(4_096),
             physical_rows: Some(10),
             primary_key_bytes: Some(80),
+            max_row_id: Some(1_000_042),
         };
         let encoded = pb::SsTable::from(&recorded);
         assert_eq!(encoded.in_memory_bytes, Some(4_096));
         assert_eq!(encoded.physical_rows, Some(10));
         assert_eq!(encoded.primary_key_bytes, Some(80));
+        assert_eq!(encoded.max_row_id, Some(1_000_042));
         assert_eq!(SsTable::from(encoded), recorded);
+    }
+
+    /// A shard holds more than one range while a background reservation is in
+    /// flight, and their order is what a successor places them by -- so the
+    /// round trip has to preserve the sequence, not just the set.
+    #[test]
+    fn every_reserved_range_survives_the_round_trip_in_order() {
+        let manifest = ShardManifest {
+            shard_id: Uuid::nil(),
+            version: 3,
+            shard_spec_id: 0,
+            shard_field_values: HashMap::new(),
+            writer_epoch: 5,
+            replay_after_wal_entry_position: 0,
+            wal_entry_position_last_seen: 0,
+            current_generation: 1,
+            sstables: Vec::new(),
+            status: ShardStatus::Active,
+            row_id_reservations: vec![
+                RowIdReservation {
+                    start: 100,
+                    end: 200,
+                },
+                RowIdReservation {
+                    start: 900,
+                    end: 1_000,
+                },
+            ],
+        };
+
+        let encoded = pb::ShardManifest::from(&manifest);
+        assert_eq!(encoded.row_id_reservations.len(), 2);
+        assert_eq!(
+            ShardManifest::try_from(encoded)
+                .unwrap()
+                .row_id_reservations,
+            manifest.row_id_reservations
+        );
+    }
+
+    /// A shard that has never reserved decodes as holding nothing, which is what
+    /// sends it to reserve rather than to resume.
+    #[test]
+    fn a_manifest_with_no_reserved_ranges_decodes_as_empty() {
+        let legacy = pb::ShardManifest {
+            shard_id: Some((&Uuid::nil()).into()),
+            row_id_reservations: Vec::new(),
+            ..Default::default()
+        };
+        assert!(
+            ShardManifest::try_from(legacy)
+                .unwrap()
+                .row_id_reservations
+                .is_empty()
+        );
+    }
+
+    #[test]
+    fn a_range_contains_its_start_but_not_its_end() {
+        let range = RowIdReservation {
+            start: 100,
+            end: 200,
+        };
+        assert!(range.contains(100));
+        assert!(range.contains(199));
+        assert!(!range.contains(200));
+        assert!(!range.contains(99));
     }
 }

--- a/rust/lance-table/src/system_index/mem_wal.rs
+++ b/rust/lance-table/src/system_index/mem_wal.rs
@@ -225,6 +225,64 @@ impl ShardStatus {
     }
 }
 
+/// A half-open range of stable row ids a shard holds exclusively.
+///
+/// Taken with an [`crate::transaction::Operation::ReserveRowIds`] commit
+/// against the base dataset and persisted in the shard manifest *before* any id
+/// is issued from it, so a crash leaks the chunk rather than reissuing it.
+///
+/// `writer_epoch` binds the range to the writer that took it. A successor must
+/// re-reserve rather than resume a range it finds on disk: two writers drawing
+/// from one range mint duplicate ids, which is silent corruption.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, DeepSizeOf)]
+pub struct RowIdReservation {
+    /// First id in the range that has not been issued yet.
+    pub next: u64,
+    /// One past the last id in the range; `next == end` means exhausted.
+    pub end: u64,
+    /// The writer epoch that committed the reservation.
+    pub writer_epoch: u64,
+}
+
+impl RowIdReservation {
+    /// Ids still available in this range.
+    pub fn remaining(&self) -> u64 {
+        self.end.saturating_sub(self.next)
+    }
+
+    /// Take `count` ids, returning the half-open range and advancing `next`.
+    /// `None` when the range cannot cover the request -- the caller reserves a
+    /// fresh chunk instead of splitting across two.
+    pub fn take(&mut self, count: u64) -> Option<std::ops::Range<u64>> {
+        if self.remaining() < count {
+            return None;
+        }
+        let start = self.next;
+        self.next += count;
+        Some(start..self.next)
+    }
+}
+
+impl From<&RowIdReservation> for pb::RowIdReservation {
+    fn from(r: &RowIdReservation) -> Self {
+        Self {
+            next: r.next,
+            end: r.end,
+            writer_epoch: r.writer_epoch,
+        }
+    }
+}
+
+impl From<pb::RowIdReservation> for RowIdReservation {
+    fn from(r: pb::RowIdReservation) -> Self {
+        Self {
+            next: r.next,
+            end: r.end,
+            writer_epoch: r.writer_epoch,
+        }
+    }
+}
+
 /// Shard manifest containing epoch-based fencing and WAL state.
 /// Each shard has exactly one active writer at any time.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -253,6 +311,9 @@ pub struct ShardManifest {
     /// Lifecycle status (drop-table 2PC). Defaults to `Active`; preserved
     /// across claims via `..base` so only fresh constructions set it.
     pub status: ShardStatus,
+    /// Stable row ids this shard reserved and may still issue. `None` when the
+    /// shard has never reserved, or when stable row ids are off.
+    pub row_id_reservation: Option<RowIdReservation>,
 }
 
 impl ShardManifest {
@@ -270,6 +331,7 @@ impl DeepSizeOf for ShardManifest {
     fn deep_size_of_children(&self, context: &mut lance_core::deepsize::Context) -> usize {
         self.shard_field_values.deep_size_of_children(context)
             + self.sstables.deep_size_of_children(context)
+            + self.row_id_reservation.deep_size_of_children(context)
     }
 }
 
@@ -293,6 +355,7 @@ impl From<&ShardManifest> for pb::ShardManifest {
             current_generation: rm.current_generation,
             sstables: rm.sstables.iter().map(|sstable| sstable.into()).collect(),
             status: rm.status.to_i32(),
+            row_id_reservation: rm.row_id_reservation.as_ref().map(Into::into),
         }
     }
 }
@@ -322,6 +385,7 @@ impl TryFrom<pb::ShardManifest> for ShardManifest {
             current_generation: rm.current_generation,
             sstables: rm.sstables.into_iter().map(SsTable::from).collect(),
             status: ShardStatus::from_i32(rm.status),
+            row_id_reservation: rm.row_id_reservation.map(RowIdReservation::from),
         })
     }
 }

--- a/rust/lance-table/src/transaction/conflicts.rs
+++ b/rust/lance-table/src/transaction/conflicts.rs
@@ -862,6 +862,10 @@ impl PartialEq for Operation {
             }
             (Self::DataOverlay { groups: a }, Self::DataOverlay { groups: b }) => compare_vec(a, b),
             (Self::DataOverlay { .. }, _) | (_, Self::DataOverlay { .. }) => false,
+            (Self::ReserveRowIds { num_row_ids: a }, Self::ReserveRowIds { num_row_ids: b }) => {
+                a == b
+            }
+            (Self::ReserveRowIds { .. }, _) | (_, Self::ReserveRowIds { .. }) => false,
         }
     }
 }

--- a/rust/lance-table/src/transaction/manifest_build.rs
+++ b/rust/lance-table/src/transaction/manifest_build.rs
@@ -874,6 +874,24 @@ impl Transaction {
             Operation::ReserveFragments { .. } | Operation::UpdateConfig { .. } => {
                 final_fragments.extend(maybe_existing_fragments?.clone());
             }
+            Operation::ReserveRowIds { num_row_ids } => {
+                final_fragments.extend(maybe_existing_fragments?.clone());
+                // Advance the *local* cursor, not `manifest.next_row_id`: the
+                // manifest field is overwritten from this local unconditionally
+                // at the end of `build_manifest`, so a bump written there would
+                // be clobbered.
+                let Some(next_row_id) = &mut next_row_id else {
+                    return Err(Error::not_supported_source(
+                        "ReserveRowIds requires a dataset that uses stable row ids".into(),
+                    ));
+                };
+                *next_row_id = next_row_id.checked_add(*num_row_ids).ok_or_else(|| {
+                    Error::invalid_input(format!(
+                        "reserving {} row ids would overflow next_row_id ({})",
+                        num_row_ids, next_row_id
+                    ))
+                })?;
+            }
             Operation::Merge { fragments, .. } => {
                 let existing_fragments = maybe_existing_fragments?;
                 let mut merged_fragments = fragments.clone();

--- a/rust/lance-table/src/transaction/operation.rs
+++ b/rust/lance-table/src/transaction/operation.rs
@@ -134,6 +134,18 @@ pub enum Operation {
     /// indices to be remapped to the new row ids as part of the operation.
     ReserveFragments { num_fragments: u32 },
 
+    /// Reserves stable row ids for future use.
+    ///
+    /// Advances the manifest's `next_row_id` by `num_row_ids` without adding
+    /// any fragments, so a writer can hold a range of ids and stamp them into
+    /// rows it has not committed yet. The WAL uses this to assign a row's id at
+    /// insert time, long before the row reaches a base fragment.
+    ///
+    /// The reserved ids are never handed back: a writer that crashes before
+    /// using them leaks the chunk, which is harmless because ids need not be
+    /// contiguous. Only valid on a dataset that already uses stable row ids.
+    ReserveRowIds { num_row_ids: u64 },
+
     /// Update values in the dataset.
     ///
     /// Updates are generally vertical or horizontal.
@@ -261,6 +273,7 @@ impl std::fmt::Display for Operation {
             Self::Merge { .. } => write!(f, "Merge"),
             Self::Restore { .. } => write!(f, "Restore"),
             Self::ReserveFragments { .. } => write!(f, "ReserveFragments"),
+            Self::ReserveRowIds { .. } => write!(f, "ReserveRowIds"),
             Self::Update { .. } => write!(f, "Update"),
             Self::Project { .. } => write!(f, "Project"),
             Self::UpdateConfig { .. } => write!(f, "UpdateConfig"),
@@ -319,6 +332,7 @@ impl Operation {
             Self::Rewrite { .. } => "Rewrite",
             Self::Merge { .. } => "Merge",
             Self::ReserveFragments { .. } => "ReserveFragments",
+            Self::ReserveRowIds { .. } => "ReserveRowIds",
             Self::Restore { .. } => "Restore",
             Self::Update { .. } => "Update",
             Self::Project { .. } => "Project",

--- a/rust/lance-table/src/transaction/proto.rs
+++ b/rust/lance-table/src/transaction/proto.rs
@@ -148,6 +148,9 @@ impl TryFrom<pb::Transaction> for Transaction {
             Some(pb::transaction::Operation::ReserveFragments(
                 pb::transaction::ReserveFragments { num_fragments },
             )) => Operation::ReserveFragments { num_fragments },
+            Some(pb::transaction::Operation::ReserveRowIds(pb::transaction::ReserveRowIds {
+                num_row_ids,
+            })) => Operation::ReserveRowIds { num_row_ids },
             Some(pb::transaction::Operation::Rewrite(pb::transaction::Rewrite {
                 old_fragments,
                 new_fragments,
@@ -550,6 +553,11 @@ impl From<&Transaction> for pb::Transaction {
             Operation::ReserveFragments { num_fragments } => {
                 pb::transaction::Operation::ReserveFragments(pb::transaction::ReserveFragments {
                     num_fragments: *num_fragments,
+                })
+            }
+            Operation::ReserveRowIds { num_row_ids } => {
+                pb::transaction::Operation::ReserveRowIds(pb::transaction::ReserveRowIds {
+                    num_row_ids: *num_row_ids,
                 })
             }
             Operation::Rewrite {

--- a/rust/lance/benches/mem_wal/write/mem_wal_write.rs
+++ b/rust/lance/benches/mem_wal/write/mem_wal_write.rs
@@ -615,6 +615,7 @@ fn bench_lance_memwal_write(c: &mut Criterion) {
                                     max_memtable_size: max_memtable_size
                                         .unwrap_or(default_config.max_memtable_size),
                                     max_memtable_rows: default_config.max_memtable_rows,
+                                    enable_row_ids: false,
                                     max_memtable_batches: default_config.max_memtable_batches,
                                     manifest_scan_batch_size: default_config
                                         .manifest_scan_batch_size,

--- a/rust/lance/src/dataset.rs
+++ b/rust/lance/src/dataset.rs
@@ -157,7 +157,7 @@ use lance_table::rowids::{RowIdSequence, write_row_ids};
 pub use schema_evolution::{
     BatchInfo, BatchUDF, ColumnAlteration, NewColumnTransform, UDFCheckpointStore,
 };
-pub use take::TakeBuilder;
+pub use take::{MissingRowPolicy, TakeBuilder};
 use uuid::Uuid;
 pub use write::merge_insert::{
     MergeInsertBuilder, MergeInsertJob, MergeInsertWriteMode, MergeStats, UncommittedMergeInsert,

--- a/rust/lance/src/dataset/mem_wal.rs
+++ b/rust/lance/src/dataset/mem_wal.rs
@@ -33,6 +33,7 @@
 //! monotonically increasing writer epochs in the shard manifest.
 
 mod api;
+pub mod compaction;
 mod hnsw;
 pub mod index;
 mod manifest;
@@ -179,6 +180,7 @@ fn append_field_if_absent(
 }
 
 pub use api::{DatasetMemWalExt, InitializeMemWalBuilder, validate_maintained_indexes};
+pub use compaction::{PreAssignedRows, commit_preassigned_rows};
 pub use index::{MemIndexKind, MemTableVisibility};
 pub use manifest::ShardManifestStore;
 pub use memtable::scanner::MemTableScanner;

--- a/rust/lance/src/dataset/mem_wal.rs
+++ b/rust/lance/src/dataset/mem_wal.rs
@@ -75,6 +75,36 @@ pub fn tombstone_field() -> ArrowField {
     ArrowField::new(TOMBSTONE, DataType::Boolean, false)
 }
 
+/// Column name for the mem_wal stable row id.
+///
+/// `__wal_row_id` is a *physical* column present in mem_wal memtables and
+/// SSTables, holding the stable row id the write path assigned to the row. Like
+/// [`TOMBSTONE`] it is owned end to end by lance and never named by a caller;
+/// unlike it, the column is surfaced at scan egress -- renamed to
+/// [`lance_core::ROW_ID`] when the projection asks for it, stripped otherwise.
+///
+/// The id is resolved on the write path and injected before the WAL append, so
+/// the log entry carries it and a replay restores it byte for byte. Nothing
+/// downstream of [`write::ShardWriter::put_with_row_ids`] ever mints one --
+/// not the flush, not compaction.
+pub const WAL_ROW_ID: &str = "__wal_row_id";
+
+/// The mem_wal row id field appended to the storage schema, after
+/// [`tombstone_field`].
+///
+/// Nullable, because a tombstone carries no id: a delete sentinel exists only
+/// to shadow a primary key, and compaction resolves the base row it supersedes
+/// by key rather than by id. Nullability also keeps
+/// [`write::build_tombstone_batch`](write) null-filling as it already does and
+/// keeps [`relax_non_pk_nullability`] a no-op over the column.
+///
+/// The nullability stops at storage: at scan egress the column is renamed to
+/// `_rowid` and rebound non-nullable, which is sound because the `NOT
+/// _tombstone` fold has already removed every tombstone by that point.
+pub fn wal_row_id_field() -> ArrowField {
+    ArrowField::new(WAL_ROW_ID, DataType::UInt64, true)
+}
+
 /// Derive a shard's *storage* schema from its *logical* (base table) schema by
 /// widening every top-level field to nullable except the primary key and
 /// `_tombstone`.
@@ -120,11 +150,28 @@ pub fn relax_non_pk_nullability(
 /// path) is returned unchanged. Schema-level metadata and per-field metadata
 /// (e.g. the `lance-schema:unenforced-primary-key` marker) are preserved.
 pub fn schema_with_tombstone(base: &ArrowSchema) -> Arc<ArrowSchema> {
-    if base.column_with_name(TOMBSTONE).is_some() {
+    append_field_if_absent(base, TOMBSTONE, tombstone_field)
+}
+
+/// Extend a schema with the trailing `__wal_row_id` column, for a shard that
+/// assigns stable row ids. Applied after [`schema_with_tombstone`], so the two
+/// physical columns always appear in that order.
+///
+/// Idempotent, and metadata-preserving, for the same reasons.
+pub fn schema_with_wal_row_id(base: &ArrowSchema) -> Arc<ArrowSchema> {
+    append_field_if_absent(base, WAL_ROW_ID, wal_row_id_field)
+}
+
+fn append_field_if_absent(
+    base: &ArrowSchema,
+    name: &str,
+    field: impl FnOnce() -> ArrowField,
+) -> Arc<ArrowSchema> {
+    if base.column_with_name(name).is_some() {
         return Arc::new(base.clone());
     }
     let mut fields: Vec<ArrowField> = base.fields().iter().map(|f| f.as_ref().clone()).collect();
-    fields.push(tombstone_field());
+    fields.push(field());
     Arc::new(ArrowSchema::new_with_metadata(
         fields,
         base.metadata().clone(),

--- a/rust/lance/src/dataset/mem_wal/compaction.rs
+++ b/rust/lance/src/dataset/mem_wal/compaction.rs
@@ -1,0 +1,502 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+//! Committing an SSTable prefix into the base table with the row ids it
+//! already carries.
+//!
+//! On a shard that assigns stable row ids ([`super::WAL_ROW_ID`]), every
+//! SSTable row was stamped with its id at insert. Compaction therefore has
+//! nothing to resolve and nothing to mint, which is what lets it run in a
+//! process with no shard claim, no shard manifest and no reservation.
+//!
+//! `merge_insert` cannot serve this. It preserves the id of a key that already
+//! exists in the base table, but *mints* one for a key that does not -- and a
+//! key arriving from the WAL is exactly that case. Its id would change the
+//! moment it compacted, and a take by the WAL-era id would silently miss. So
+//! the merge is replaced by one explicit [`Operation::Update`] carrying:
+//!
+//! * **new fragments** whose `row_id_meta` already holds their ids, which
+//!   `assign_row_ids` then skips rather than re-assigns;
+//! * **updated fragments** whose deletion vectors mask every base row the
+//!   commit supersedes -- which is also why a tombstone never needs an id of
+//!   its own, and why there is no separate delete pass;
+//! * the **compacted-SSTable watermark**, on the same commit as the data.
+//!
+//! The caller owns the address resolution and the retry. An address is
+//! version-scoped and a concurrent base commit invalidates it; an id is stable
+//! and survives any rewrite by construction. So a conflict means "re-resolve the
+//! addresses and rebuild the masks", never "re-assign the ids".
+
+use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
+
+use arrow_array::RecordBatch;
+use lance_core::utils::address::RowAddress;
+use lance_core::utils::deletion::DeletionVector;
+use lance_core::{Error, Result};
+use lance_index::mem_wal::CompactedSsTable;
+use lance_select::{RowAddrTreeMap, RowSetOps};
+use lance_table::format::{Fragment, RowIdMeta};
+use lance_table::io::deletion::write_deletion_file;
+use lance_table::rowids::{RowIdSequence, write_row_ids};
+use roaring::RoaringBitmap;
+
+use crate::dataset::rowids::get_row_id_index;
+use crate::dataset::transaction::{Operation, Transaction};
+use crate::dataset::write::CommitBuilder;
+use crate::dataset::{Dataset, InsertBuilder, WriteMode, WriteParams};
+use crate::io::deletion::read_dataset_deletion_file;
+
+/// A compacted SSTable prefix, already deduped newest-per-key by its caller.
+pub struct PreAssignedRows {
+    /// The surviving rows, projected to the base table's schema.
+    pub rows: RecordBatch,
+    /// One stable row id per surviving row, in the same order.
+    pub row_ids: Vec<u64>,
+    /// Addresses of the base rows this commit supersedes: the older copies of
+    /// the surviving keys, plus every row a tombstone in the prefix deletes.
+    ///
+    /// Must be **exact**. Lance intersects it against existing deletions and
+    /// unions it into the rebased deletion vectors, so a superset produces
+    /// spurious conflicts and a subset lets a concurrent delete remove the
+    /// wrong rows.
+    pub superseded: RowAddrTreeMap,
+    /// The SSTables this commit marks compacted.
+    pub compacted_sstables: Vec<CompactedSsTable>,
+}
+
+/// Commit `input` against `dataset`, keeping every row's id exactly as given.
+///
+/// Fails rather than repairs when the ids are not committable: an id repeated
+/// within the commit, or one already live in the base table at an address this
+/// commit does not supersede, would give one logical row two live copies, and
+/// nothing downstream catches that -- `assign_row_ids` skips a fragment whose
+/// sequence is already complete.
+///
+/// Returns a [`CommitConflict`](Error::RetryableCommitConflict) when a
+/// concurrent commit moved the base rows out from under `superseded`; the
+/// caller re-resolves the addresses and calls again.
+pub async fn commit_preassigned_rows(
+    dataset: Arc<Dataset>,
+    input: PreAssignedRows,
+) -> Result<Dataset> {
+    let PreAssignedRows {
+        rows,
+        row_ids,
+        superseded,
+        compacted_sstables,
+    } = input;
+
+    if rows.num_rows() != row_ids.len() {
+        return Err(Error::invalid_input(format!(
+            "{} rows but {} row ids",
+            rows.num_rows(),
+            row_ids.len()
+        )));
+    }
+    validate_ids(&dataset, &row_ids, &superseded).await?;
+
+    let new_fragments = write_id_bearing_fragments(&dataset, &rows, &row_ids).await?;
+    let updated_fragments = mask_superseded_rows(&dataset, &superseded).await?;
+
+    let operation = Operation::Update {
+        removed_fragment_ids: Vec::new(),
+        updated_fragments,
+        new_fragments,
+        fields_modified: Vec::new(),
+        compacted_sstables,
+        fields_for_preserving_frag_bitmap: Vec::new(),
+        update_mode: None,
+        inserted_rows_filter: None,
+        updated_fragment_offsets: None,
+    };
+    let transaction = Transaction::new(dataset.manifest.version, operation, None);
+
+    CommitBuilder::new(dataset)
+        .with_affected_rows(superseded)
+        .execute(transaction)
+        .await
+}
+
+/// Write the rows as data files and stamp each resulting fragment with the ids
+/// its rows already carry.
+///
+/// [`RowIdMeta::Inline`] rather than `External`: `assign_row_ids` computes an
+/// `External` fragment's existing row count as zero and would append a *second*
+/// set of ids on top. Nothing writes `External` today, but the skip property
+/// this design rests on is specific to `Inline`.
+///
+/// The ids come out of a hash-ordered dedup, which is the worst case for the
+/// sequence's run encoding -- roughly 8 bytes per row, held inline in the
+/// manifest. Sorting the rows by id first would recover most of that; it is
+/// left undone deliberately, because the sort has to carry every column of a
+/// batch that is already materialized, and the manifest growth is linear in
+/// compaction size rather than unbounded.
+async fn write_id_bearing_fragments(
+    dataset: &Arc<Dataset>,
+    rows: &RecordBatch,
+    row_ids: &[u64],
+) -> Result<Vec<Fragment>> {
+    if rows.num_rows() == 0 {
+        return Ok(Vec::new());
+    }
+
+    let schema = rows.schema();
+    let reader = arrow_array::RecordBatchIterator::new(vec![Ok(rows.clone())], schema);
+    let staged = InsertBuilder::new(dataset.clone())
+        .with_params(&WriteParams {
+            mode: WriteMode::Append,
+            ..Default::default()
+        })
+        .execute_uncommitted_stream(reader)
+        .await?;
+
+    let Operation::Append { mut fragments } = staged.operation else {
+        return Err(Error::internal(format!(
+            "staging pre-assigned rows produced {} rather than an Append",
+            staged.operation.name()
+        )));
+    };
+
+    // The writer preserves input order across the fragments it produces, so the
+    // ids slice in the same order.
+    let mut offset = 0usize;
+    for fragment in fragments.iter_mut() {
+        let count = fragment.physical_rows.ok_or_else(|| {
+            Error::internal(format!(
+                "fragment {} was written without a physical row count, so its ids \
+                 cannot be aligned",
+                fragment.id
+            ))
+        })?;
+        let end = offset.checked_add(count).ok_or_else(|| {
+            Error::internal("physical row counts overflowed while aligning row ids".to_string())
+        })?;
+        if end > row_ids.len() {
+            return Err(Error::internal(format!(
+                "staged fragments hold more rows than the {} ids given for them",
+                row_ids.len()
+            )));
+        }
+        let sequence = RowIdSequence::from(&row_ids[offset..end]);
+        fragment.row_id_meta = Some(RowIdMeta::Inline(write_row_ids(&sequence).into()));
+        offset = end;
+    }
+    if offset != row_ids.len() {
+        return Err(Error::internal(format!(
+            "staged fragments hold {offset} rows but {} ids were given",
+            row_ids.len()
+        )));
+    }
+    Ok(fragments)
+}
+
+/// Write a deletion file per affected base fragment, unioning the superseded
+/// offsets into whatever that fragment already masks.
+async fn mask_superseded_rows(
+    dataset: &Arc<Dataset>,
+    superseded: &RowAddrTreeMap,
+) -> Result<Vec<Fragment>> {
+    let by_id: HashMap<u64, &Fragment> = dataset
+        .manifest
+        .fragments
+        .iter()
+        .map(|fragment| (fragment.id, fragment))
+        .collect();
+
+    let mut updated = Vec::new();
+    for (fragment_id, _) in superseded.iter() {
+        let fragment_id = *fragment_id as u64;
+        let Some(fragment) = by_id.get(&fragment_id) else {
+            // The fragment was rewritten out from under us; the commit below
+            // detects it as a conflict and the caller re-resolves.
+            continue;
+        };
+        let Some(offsets) = superseded.get_fragment_bitmap(fragment_id as u32) else {
+            continue;
+        };
+
+        let mut merged: RoaringBitmap = offsets.clone();
+        if let Some(existing) = &fragment.deletion_file {
+            let existing = read_dataset_deletion_file(dataset, fragment_id, existing).await?;
+            merged |= RoaringBitmap::from(existing.as_ref());
+        }
+
+        let mut next = (*fragment).clone();
+        next.deletion_file = write_deletion_file(
+            &dataset.base,
+            fragment_id,
+            dataset.manifest.version,
+            &DeletionVector::from(merged),
+            dataset.object_store.as_ref(),
+        )
+        .await?;
+        updated.push(next);
+    }
+    Ok(updated)
+}
+
+/// The whole invariant: every id is unique within the commit, and is either
+/// superseded by it or absent from the base table.
+///
+/// Deliberately says nothing about any reservation. The reservation is a
+/// property of the writing pod and this check has to hold in the job path,
+/// where there is none -- and a reservation-relative form would also be
+/// *wrong*: a prefix compaction can carry a row whose id was assigned into a
+/// generation being compacted in this same pass, so it is neither live in base
+/// nor drawn from the current chunk.
+async fn validate_ids(
+    dataset: &Arc<Dataset>,
+    row_ids: &[u64],
+    superseded: &RowAddrTreeMap,
+) -> Result<()> {
+    let mut seen: HashSet<u64> = HashSet::with_capacity(row_ids.len());
+    for id in row_ids {
+        if !seen.insert(*id) {
+            return Err(Error::invalid_input(format!(
+                "row id {id} appears twice in one commit"
+            )));
+        }
+    }
+
+    let Some(index) = get_row_id_index(dataset).await? else {
+        return Err(Error::invalid_input(
+            "committing pre-assigned row ids requires a dataset that uses stable row ids"
+                .to_string(),
+        ));
+    };
+    for id in row_ids {
+        let Some(address) = index.get(*id)? else {
+            continue;
+        };
+        let address = RowAddress::from(address);
+        if !superseded.contains(u64::from(address)) {
+            return Err(Error::invalid_input(format!(
+                "row id {id} is live in the base table at {address} and this commit does \
+                 not supersede it; committing would give one id two live rows"
+            )));
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arrow_array::{Int32Array, RecordBatchIterator};
+    use arrow_schema::{DataType, Field, Schema as ArrowSchema};
+
+    fn schema() -> Arc<ArrowSchema> {
+        Arc::new(ArrowSchema::new(vec![
+            Field::new("id", DataType::Int32, false),
+            Field::new("value", DataType::Int32, true),
+        ]))
+    }
+
+    fn batch(rows: &[(i32, i32)]) -> RecordBatch {
+        RecordBatch::try_new(
+            schema(),
+            vec![
+                Arc::new(Int32Array::from_iter_values(rows.iter().map(|(id, _)| *id))),
+                Arc::new(Int32Array::from_iter_values(rows.iter().map(|(_, v)| *v))),
+            ],
+        )
+        .unwrap()
+    }
+
+    async fn base(rows: &[(i32, i32)]) -> Arc<Dataset> {
+        let initial = batch(rows);
+        let reader = RecordBatchIterator::new(vec![Ok(initial)], schema());
+        Arc::new(
+            Dataset::write(
+                reader,
+                "memory://",
+                Some(WriteParams {
+                    enable_stable_row_ids: true,
+                    ..Default::default()
+                }),
+            )
+            .await
+            .unwrap(),
+        )
+    }
+
+    /// Read back every live `(id, value, _rowid)`, sorted by id.
+    async fn live_rows(dataset: &Dataset) -> Vec<(i32, i32, u64)> {
+        use arrow_array::cast::AsArray;
+        use arrow_array::types::{Int32Type, UInt64Type};
+
+        let mut scan = dataset.scan();
+        scan.with_row_id();
+        let batch = scan.try_into_batch().await.unwrap();
+        let ids = batch["id"].as_primitive::<Int32Type>();
+        let values = batch["value"].as_primitive::<Int32Type>();
+        let row_ids = batch[lance_core::ROW_ID].as_primitive::<UInt64Type>();
+        let mut out: Vec<(i32, i32, u64)> = (0..batch.num_rows())
+            .map(|i| (ids.value(i), values.value(i), row_ids.value(i)))
+            .collect();
+        out.sort();
+        out
+    }
+
+    /// Addresses of the base rows holding the given primary keys.
+    async fn addresses_of(dataset: &Dataset, keys: &[i32]) -> RowAddrTreeMap {
+        use arrow_array::cast::AsArray;
+        use arrow_array::types::{Int32Type, UInt64Type};
+
+        let mut scan = dataset.scan();
+        scan.with_row_address();
+        let batch = scan.try_into_batch().await.unwrap();
+        let ids = batch["id"].as_primitive::<Int32Type>();
+        let addrs = batch[lance_core::ROW_ADDR].as_primitive::<UInt64Type>();
+        let mut selected = RowAddrTreeMap::new();
+        for i in 0..batch.num_rows() {
+            if keys.contains(&ids.value(i)) {
+                selected.insert(addrs.value(i));
+            }
+        }
+        selected
+    }
+
+    /// A key that is new to base keeps the id the WAL assigned it, rather than
+    /// being minted a fresh one the way `merge_insert` would.
+    #[tokio::test]
+    async fn a_new_key_keeps_the_id_it_arrived_with() {
+        let dataset = base(&[(1, 10), (2, 20)]).await;
+        assert_eq!(dataset.manifest.next_row_id, 2);
+
+        let committed = commit_preassigned_rows(
+            dataset,
+            PreAssignedRows {
+                rows: batch(&[(3, 30), (4, 40)]),
+                // Deliberately far above `next_row_id`: a reservation leaves
+                // gaps, and the commit must honour the ids rather than
+                // re-sequence them.
+                row_ids: vec![500, 501],
+                superseded: RowAddrTreeMap::new(),
+                compacted_sstables: Vec::new(),
+            },
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            live_rows(&committed).await,
+            vec![(1, 10, 0), (2, 20, 1), (3, 30, 500), (4, 40, 501)]
+        );
+    }
+
+    /// An updated key keeps its id and loses its old copy, in one commit.
+    #[tokio::test]
+    async fn an_updated_key_keeps_its_id_and_its_old_copy_is_masked() {
+        let dataset = base(&[(1, 10), (2, 20)]).await;
+        let superseded = addresses_of(&dataset, &[2]).await;
+
+        let committed = commit_preassigned_rows(
+            dataset,
+            PreAssignedRows {
+                rows: batch(&[(2, 99)]),
+                row_ids: vec![1],
+                superseded,
+                compacted_sstables: Vec::new(),
+            },
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            live_rows(&committed).await,
+            vec![(1, 10, 0), (2, 99, 1)],
+            "the updated row keeps id 1 and appears exactly once"
+        );
+    }
+
+    /// A tombstone-winning key is masked with no replacement row, which is why
+    /// a tombstone never needs an id and there is no separate delete pass.
+    #[tokio::test]
+    async fn a_superseded_key_with_no_replacement_row_is_deleted() {
+        let dataset = base(&[(1, 10), (2, 20)]).await;
+        let superseded = addresses_of(&dataset, &[1]).await;
+
+        let committed = commit_preassigned_rows(
+            dataset,
+            PreAssignedRows {
+                rows: RecordBatch::new_empty(schema()),
+                row_ids: Vec::new(),
+                superseded,
+                compacted_sstables: Vec::new(),
+            },
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(live_rows(&committed).await, vec![(2, 20, 1)]);
+    }
+
+    /// Two rows sharing an id would give one logical row two live copies, and
+    /// nothing downstream catches it -- `assign_row_ids` skips a fragment whose
+    /// sequence is already complete.
+    #[tokio::test]
+    async fn a_repeated_id_within_one_commit_is_rejected() {
+        let dataset = base(&[(1, 10)]).await;
+
+        let err = commit_preassigned_rows(
+            dataset,
+            PreAssignedRows {
+                rows: batch(&[(3, 30), (4, 40)]),
+                row_ids: vec![500, 500],
+                superseded: RowAddrTreeMap::new(),
+                compacted_sstables: Vec::new(),
+            },
+        )
+        .await
+        .unwrap_err();
+
+        assert!(matches!(err, Error::InvalidInput { .. }), "got {err:?}");
+        assert!(err.to_string().contains("appears twice"), "{err}");
+    }
+
+    /// Reusing an id that is still live in base without superseding it is the
+    /// same corruption from the other direction.
+    #[tokio::test]
+    async fn an_id_live_in_base_that_is_not_superseded_is_rejected() {
+        let dataset = base(&[(1, 10), (2, 20)]).await;
+
+        let err = commit_preassigned_rows(
+            dataset,
+            PreAssignedRows {
+                rows: batch(&[(3, 30)]),
+                row_ids: vec![1],
+                superseded: RowAddrTreeMap::new(),
+                compacted_sstables: Vec::new(),
+            },
+        )
+        .await
+        .unwrap_err();
+
+        assert!(matches!(err, Error::InvalidInput { .. }), "got {err:?}");
+        assert!(err.to_string().contains("live in the base table"), "{err}");
+    }
+
+    /// A dataset without stable row ids has nowhere to put them.
+    #[tokio::test]
+    async fn a_dataset_without_stable_row_ids_is_rejected() {
+        let reader = RecordBatchIterator::new(vec![Ok(batch(&[(1, 10)]))], schema());
+        let dataset = Arc::new(Dataset::write(reader, "memory://", None).await.unwrap());
+
+        let err = commit_preassigned_rows(
+            dataset,
+            PreAssignedRows {
+                rows: batch(&[(2, 20)]),
+                row_ids: vec![7],
+                superseded: RowAddrTreeMap::new(),
+                compacted_sstables: Vec::new(),
+            },
+        )
+        .await
+        .unwrap_err();
+
+        assert!(matches!(err, Error::InvalidInput { .. }), "got {err:?}");
+        assert!(err.to_string().contains("stable row ids"), "{err}");
+    }
+}

--- a/rust/lance/src/dataset/mem_wal/compaction.rs
+++ b/rust/lance/src/dataset/mem_wal/compaction.rs
@@ -31,7 +31,6 @@ use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
 use arrow_array::RecordBatch;
-use lance_core::utils::address::RowAddress;
 use lance_core::utils::deletion::DeletionVector;
 use lance_core::{Error, Result};
 use lance_index::mem_wal::CompactedSsTable;
@@ -269,7 +268,6 @@ async fn validate_ids(
         let Some(address) = index.get(*id)? else {
             continue;
         };
-        let address = RowAddress::from(address);
         if !superseded.contains(u64::from(address)) {
             return Err(Error::invalid_input(format!(
                 "row id {id} is live in the base table at {address} and this commit does \

--- a/rust/lance/src/dataset/mem_wal/manifest.rs
+++ b/rust/lance/src/dataset/mem_wal/manifest.rs
@@ -210,6 +210,7 @@ impl ShardManifestStore {
             current_generation: 1,
             sstables: vec![],
             status: ShardStatus::Active,
+            row_id_reservation: None,
         };
 
         match self.write(&manifest).await {
@@ -513,6 +514,7 @@ impl ShardManifestStore {
                     wal_entry_position_last_seen: 0,
                     current_generation: 1,
                     sstables: vec![],
+                    row_id_reservation: None,
                     status: ShardStatus::Active,
                 }
             };
@@ -708,6 +710,7 @@ mod tests {
             current_generation: 1,
             sstables: vec![],
             status: ShardStatus::Active,
+            row_id_reservation: None,
         }
     }
 

--- a/rust/lance/src/dataset/mem_wal/manifest.rs
+++ b/rust/lance/src/dataset/mem_wal/manifest.rs
@@ -210,7 +210,7 @@ impl ShardManifestStore {
             current_generation: 1,
             sstables: vec![],
             status: ShardStatus::Active,
-            row_id_reservation: None,
+            row_id_reservations: Vec::new(),
         };
 
         match self.write(&manifest).await {
@@ -514,7 +514,7 @@ impl ShardManifestStore {
                     wal_entry_position_last_seen: 0,
                     current_generation: 1,
                     sstables: vec![],
-                    row_id_reservation: None,
+                    row_id_reservations: Vec::new(),
                     status: ShardStatus::Active,
                 }
             };
@@ -710,7 +710,7 @@ mod tests {
             current_generation: 1,
             sstables: vec![],
             status: ShardStatus::Active,
-            row_id_reservation: None,
+            row_id_reservations: Vec::new(),
         }
     }
 

--- a/rust/lance/src/dataset/mem_wal/memtable/flush.rs
+++ b/rust/lance/src/dataset/mem_wal/memtable/flush.rs
@@ -7,6 +7,8 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use arrow_array::RecordBatch;
+use arrow_array::cast::AsArray;
+use arrow_array::types::UInt64Type;
 use bytes::Bytes;
 use lance_core::cache::LanceCache;
 use lance_core::utils::deletion::DeletionVector;
@@ -29,6 +31,7 @@ use super::super::index::MemIndexConfig;
 use super::super::memtable::MemTable;
 use crate::Dataset;
 use crate::dataset::builder::DatasetBuilder;
+use crate::dataset::mem_wal::WAL_ROW_ID;
 use crate::dataset::mem_wal::manifest::ShardManifestStore;
 use crate::dataset::mem_wal::scanner::SsTableWarmer;
 use crate::dataset::mem_wal::scanner::exec::{compute_pk_hash, validate_pk_types};
@@ -90,13 +93,14 @@ pub struct MemTableFlusher {
 /// appending store bumps these counters before it publishes the batch, so only
 /// a sealed one agrees with what a scan of it will see.
 #[derive(Clone, Copy)]
-struct FlushedSize {
+struct FlushedStats {
     in_memory_bytes: Option<u64>,
     physical_rows: Option<u64>,
     primary_key_bytes: Option<u64>,
+    max_row_id: Option<u64>,
 }
 
-impl FlushedSize {
+impl FlushedStats {
     /// Zero reads as unmeasured. An empty memtable is refused before a flush
     /// gets here, so a flushed generation always holds rows and a zero can only
     /// mean the accounting failed.
@@ -109,6 +113,7 @@ impl FlushedSize {
             // Zero means the table has no primary key, which is not a
             // measurement of one.
             primary_key_bytes: Some(memtable.pk_bytes() as u64).filter(|b| *b > 0),
+            max_row_id: max_row_id(memtable),
         }
     }
 
@@ -119,8 +124,31 @@ impl FlushedSize {
             in_memory_bytes: self.in_memory_bytes,
             physical_rows: self.physical_rows,
             primary_key_bytes: self.primary_key_bytes,
+            max_row_id: self.max_row_id,
         }
     }
+}
+
+/// Highest stable row id in `memtable`, or `None` on a shard that assigns none.
+///
+/// Recorded on the SSTable so a successor can derive how far into a reserved
+/// range its predecessor got without reading the generation back --
+/// `RowIdReservation` carries the range but not the position within it.
+///
+/// Nulls are skipped: a tombstone shadows a primary key and needs no id of its
+/// own. A generation of nothing but tombstones therefore reports `None`, the
+/// same as a shard with no ids at all, and means the same thing to a reader --
+/// this generation constrains no range.
+fn max_row_id(memtable: &MemTable) -> Option<u64> {
+    memtable
+        .batch_store()
+        .to_vec()
+        .iter()
+        .filter_map(|batch| {
+            let ids = batch.column_by_name(WAL_ROW_ID)?;
+            ids.as_primitive_opt::<UInt64Type>()?.iter().flatten().max()
+        })
+        .max()
 }
 
 impl MemTableFlusher {
@@ -271,7 +299,7 @@ impl MemTableFlusher {
 
         let random_hash = generate_random_hash();
         let generation = memtable.generation();
-        let size = FlushedSize::of(memtable);
+        let stats = FlushedStats::of(memtable);
         let gen_folder_name = format!("{}_gen_{}", random_hash, generation);
         let gen_path = sstable_path(&self.base_path, &self.shard_id, &random_hash, generation);
 
@@ -313,7 +341,7 @@ impl MemTableFlusher {
                 generation,
                 &gen_folder_name,
                 covered_wal_entry_position,
-                size,
+                stats,
             )
             .await?;
 
@@ -323,7 +351,7 @@ impl MemTableFlusher {
         );
 
         Ok(FlushResult {
-            sstable: size.sstable(generation, gen_folder_name),
+            sstable: stats.sstable(generation, gen_folder_name),
             rows_flushed,
             covered_wal_entry_position,
         })
@@ -503,7 +531,7 @@ impl MemTableFlusher {
 
         let random_hash = generate_random_hash();
         let generation = memtable.generation();
-        let size = FlushedSize::of(memtable);
+        let stats = FlushedStats::of(memtable);
         let gen_folder_name = format!("{}_gen_{}", random_hash, generation);
         let gen_path = sstable_path(&self.base_path, &self.shard_id, &random_hash, generation);
 
@@ -616,7 +644,7 @@ impl MemTableFlusher {
                 generation,
                 &gen_folder_name,
                 covered_wal_entry_position,
-                size,
+                stats,
             )
             .await?;
 
@@ -626,7 +654,7 @@ impl MemTableFlusher {
         );
 
         Ok(FlushResult {
-            sstable: size.sstable(generation, gen_folder_name),
+            sstable: stats.sstable(generation, gen_folder_name),
             rows_flushed: memtable.row_count(),
             covered_wal_entry_position,
         })
@@ -1166,14 +1194,14 @@ impl MemTableFlusher {
         generation: u64,
         gen_path: &str,
         covered_wal_entry_position: u64,
-        size: FlushedSize,
+        stats: FlushedStats,
     ) -> Result<ShardManifest> {
         let gen_path = gen_path.to_string();
 
         self.manifest_store
             .commit_update(epoch, |current| {
                 let mut sstables = current.sstables.clone();
-                sstables.push(size.sstable(generation, gen_path.clone()));
+                sstables.push(stats.sstable(generation, gen_path.clone()));
 
                 ShardManifest {
                     version: current.next_version(),

--- a/rust/lance/src/dataset/mem_wal/scanner/fts_search.rs
+++ b/rust/lance/src/dataset/mem_wal/scanner/fts_search.rs
@@ -55,8 +55,12 @@ use super::block_list::compute_source_block_lists;
 use super::collector::LsmDataSourceCollector;
 use super::data_source::LsmDataSource;
 use super::exec::PkBlockFilterExec;
-use super::projection::{project_to_canonical, validate_projection_names};
+use super::projection::{
+    cols_with_wal_row_id, project_to_canonical, surface_wal_row_id, validate_projection_names,
+    wants_row_id,
+};
 use super::sstable_cache::{DatasetCache, SsTableWarmer, open_sstable};
+use crate::dataset::mem_wal::WAL_ROW_ID;
 use crate::dataset::mem_wal::memtable::scanner::MemTableScanner;
 use crate::index::scalar::inverted::{indexed_fts_document_granularities, resolve_fts_field};
 use crate::session::Session;
@@ -553,6 +557,11 @@ impl LsmFtsSearchPlanner {
                 let mut scanner = dataset.scan();
                 let cols = self.fts_scanner_projection(projection);
                 scanner.project(&cols.iter().map(|s| s.as_str()).collect::<Vec<_>>())?;
+                // The WAL arms answer `_rowid` from `__wal_row_id`, so base
+                // opting in lines the union up rather than breaking it.
+                if wants_row_id(projection) {
+                    scanner.with_row_id();
+                }
                 if let Some(ref filter) = self.filter {
                     // `prefilter(true)` is required: without it the scanner
                     // post-filters the unfiltered BM25 top-k, dropping matching
@@ -580,6 +589,10 @@ impl LsmFtsSearchPlanner {
                 .await?;
                 let mut scanner = dataset.scan();
                 let cols = self.fts_scanner_projection(projection);
+                let cols = cols_with_wal_row_id(
+                    &cols,
+                    wants_row_id(projection) && dataset.schema().field(WAL_ROW_ID).is_some(),
+                );
                 scanner.project(&cols.iter().map(|s| s.as_str()).collect::<Vec<_>>())?;
                 if let Some(ref filter) = self.filter {
                     // See the base arm: `prefilter(true)` makes this a true
@@ -594,7 +607,7 @@ impl LsmFtsSearchPlanner {
                     bound_query = bound_query.limit(None);
                 }
                 scanner.full_text_search(bound_query)?;
-                scanner.create_plan().await
+                surface_wal_row_id(scanner.create_plan().await?)
             }
             LsmDataSource::ActiveMemTable {
                 batch_store,
@@ -611,6 +624,10 @@ impl LsmFtsSearchPlanner {
                 let mut scanner =
                     MemTableScanner::new(batch_store.clone(), index_store.clone(), schema.clone());
                 let cols = self.fts_scanner_projection(projection);
+                let cols = cols_with_wal_row_id(
+                    &cols,
+                    wants_row_id(projection) && schema.column_with_name(WAL_ROW_ID).is_some(),
+                );
                 scanner.project(&cols.iter().map(|s| s.as_str()).collect::<Vec<_>>())?;
                 if let Some(ref filter) = self.filter {
                     // Honored inside `plan_fts_search`: the materialized hits are
@@ -633,7 +650,7 @@ impl LsmFtsSearchPlanner {
                     bound_query = bound_query.limit(None);
                 }
                 scanner.full_text_search(bound_query)?;
-                scanner.create_plan().await
+                surface_wal_row_id(scanner.create_plan().await?)
             }
         }
     }

--- a/rust/lance/src/dataset/mem_wal/scanner/planner.rs
+++ b/rust/lance/src/dataset/mem_wal/scanner/planner.rs
@@ -13,18 +13,40 @@ use datafusion::prelude::{Expr, col};
 use lance_core::Result;
 use tracing::instrument;
 
-use crate::dataset::mem_wal::TOMBSTONE;
+use crate::dataset::mem_wal::{TOMBSTONE, WAL_ROW_ID};
 
 use super::collector::LsmDataSourceCollector;
 use super::data_source::LsmDataSource;
 use super::exec::{MEMTABLE_GEN_COLUMN, MemtableGenTagExec, PkBlockFilterExec, ROW_ADDRESS_COLUMN};
 use super::projection::{
-    build_scanner_projection, canonical_output_schema, null_columns, project_to_canonical,
-    validate_projection_names,
+    build_scanner_projection, canonical_output_schema, cols_with_wal_row_id, null_columns,
+    project_to_canonical, surface_wal_row_id, validate_projection_names, wants_row_id,
 };
 use super::sstable_cache::{DatasetCache, SsTableWarmer, open_sstable};
 use crate::session::Session;
 use lance_io::object_store::ObjectStoreParams;
+
+/// Reject a `_rowid` projection over a mem_wal source that predates
+/// `__wal_row_id`.
+///
+/// The alternative is a silent NULL for every row the WAL holds, which reads
+/// exactly like a row that legitimately has no id — so a stale base row would
+/// answer a take that should have hit the WAL. Fail loud instead: the feature
+/// has no backward compatibility, and a shard is drained before it is enabled.
+fn require_wal_row_id(present: bool, source: &LsmDataSource) -> Result<()> {
+    if present {
+        return Ok(());
+    }
+    Err(lance_core::Error::not_supported_source(
+        format!(
+            "_rowid was requested but {} predates the {} column; \
+         drain the shard's SSTables before enabling stable row ids",
+            source.display_name(),
+            WAL_ROW_ID
+        )
+        .into(),
+    ))
+}
 
 /// Combine the user filter (if any) with `NOT _tombstone` so tombstone rows are
 /// dropped from a WAL-arm scan. Used only for sources whose schema carries the
@@ -138,7 +160,6 @@ impl LsmScanPlanner {
             .unwrap_or(false);
         let keep_row_address = keep_row_address || user_wants_rowaddr;
         validate_projection_names(projection, &self.base_schema, &[])?;
-
         // 1. Collect all data sources
         let sources = self.collector.collect()?;
 
@@ -221,6 +242,16 @@ impl LsmScanPlanner {
                 scan
             };
 
+            // Rename `__wal_row_id` into `_rowid` last, so a per-arm `_rowid`
+            // used as a recency key upstream is overwritten rather than
+            // surfaced. The base arm already produced real ids via
+            // `with_row_id()`.
+            let scan = if is_base {
+                scan
+            } else {
+                surface_wal_row_id(scan)?
+            };
+
             // Tag with generation only if the caller wants `_memtable_gen`.
             let plan: Arc<dyn ExecutionPlan> = if with_memtable_gen {
                 Arc::new(MemtableGenTagExec::new(scan, source.generation()))
@@ -296,6 +327,7 @@ impl LsmScanPlanner {
         filter: Option<&Expr>,
         fetch: Option<usize>,
     ) -> Result<Arc<dyn ExecutionPlan>> {
+        let keep_row_id = wants_row_id(projection);
         match source {
             LsmDataSource::BaseTable { dataset } => {
                 // Use Lance Scanner
@@ -306,9 +338,12 @@ impl LsmScanPlanner {
                     build_scanner_projection(projection, &self.base_schema, &self.pk_columns);
                 scanner.project(&cols.iter().map(|s| s.as_str()).collect::<Vec<_>>())?;
                 scanner.with_row_address();
-                // No `with_row_id()`: opting in only for base would mismatch
-                // the union schema against flushed/active. `_rowid` stays NULL
-                // for every row via `project_to_canonical`.
+                // The WAL arms answer `_rowid` from their own `__wal_row_id`
+                // column, so base opting in here lines the union up rather than
+                // breaking it.
+                if keep_row_id {
+                    scanner.with_row_id();
+                }
 
                 if let Some(expr) = filter {
                     scanner.filter_expr(expr.clone());
@@ -334,6 +369,10 @@ impl LsmScanPlanner {
 
                 let cols =
                     build_scanner_projection(projection, &self.base_schema, &self.pk_columns);
+                if keep_row_id {
+                    require_wal_row_id(dataset.schema().field(WAL_ROW_ID).is_some(), source)?;
+                }
+                let cols = cols_with_wal_row_id(&cols, keep_row_id);
                 scanner.project(&cols.iter().map(|s| s.as_str()).collect::<Vec<_>>())?;
                 scanner.with_row_address();
 
@@ -374,6 +413,10 @@ impl LsmScanPlanner {
 
                 let cols =
                     build_scanner_projection(projection, &self.base_schema, &self.pk_columns);
+                if keep_row_id {
+                    require_wal_row_id(schema.column_with_name(WAL_ROW_ID).is_some(), source)?;
+                }
+                let cols = cols_with_wal_row_id(&cols, keep_row_id);
                 scanner.project(&cols.iter().map(|s| s.as_str()).collect::<Vec<_>>())?;
                 scanner.with_row_address();
 
@@ -1841,7 +1884,7 @@ mod integration_tests {
             setup_multi_level_lsm().await;
 
         let mut scanner = LsmScanner::new(base_dataset, shard_snapshots, pk_columns)
-            .project(&["id", "_rowoffset", "name", "_rowaddr", "_rowid"])
+            .project(&["id", "_rowoffset", "name", "_rowaddr"])
             .unwrap();
         if let Some((shard_id, memtable)) = active_memtable {
             scanner = scanner.with_in_memory_memtables(shard_id, memtable);
@@ -1864,10 +1907,10 @@ mod integration_tests {
             .collect();
         assert_eq!(
             names,
-            vec!["id", "_rowoffset", "name", "_rowaddr", "_rowid"],
+            vec!["id", "_rowoffset", "name", "_rowaddr"],
             "system columns must appear at the user's requested position"
         );
-        for sys in ["_rowoffset", "_rowaddr", "_rowid"] {
+        for sys in ["_rowoffset", "_rowaddr"] {
             assert!(is_system_column(sys));
         }
 
@@ -1878,16 +1921,16 @@ mod integration_tests {
         //   id=4   → gen2   (1 row,  NULL  `_rowaddr`)
         //   id=5,6 → active (2 rows, NULL  `_rowaddr`)
         //   id=7   → active (1 row,  NULL  `_rowaddr`)
-        // Total 7 rows, 2 real / 5 NULL `_rowaddr`. `_rowid` and
-        // `_rowoffset` are NULL everywhere (no opt-in / no scanner support).
+        // Total 7 rows, 2 real / 5 NULL `_rowaddr`. `_rowoffset` is NULL
+        // everywhere (no scanner support). `_rowid` is covered separately:
+        // this shard predates `__wal_row_id`, so it is rejected rather than
+        // NULL-filled.
         let mut rowaddr_real = 0usize;
         let mut rowaddr_null = 0usize;
-        let mut rowid_null = 0usize;
         let mut rowoffset_null = 0usize;
         let mut total = 0usize;
         for batch in &batches {
             let rowaddr = batch.column_by_name("_rowaddr").unwrap();
-            let rowid = batch.column_by_name("_rowid").unwrap();
             let rowoffset = batch.column_by_name("_rowoffset").unwrap();
             for i in 0..batch.num_rows() {
                 total += 1;
@@ -1895,9 +1938,6 @@ mod integration_tests {
                     rowaddr_null += 1;
                 } else {
                     rowaddr_real += 1;
-                }
-                if rowid.is_null(i) {
-                    rowid_null += 1;
                 }
                 if rowoffset.is_null(i) {
                     rowoffset_null += 1;
@@ -1913,7 +1953,6 @@ mod integration_tests {
             rowaddr_null, 5,
             "expected 5 rows (id=3-7) with NULL `_rowaddr` from non-base sources"
         );
-        assert_eq!(rowid_null, total, "_rowid must be NULL for every row");
         assert_eq!(
             rowoffset_null, total,
             "_rowoffset must be NULL for every row"
@@ -1921,13 +1960,11 @@ mod integration_tests {
     }
 
     #[tokio::test]
-    async fn test_lsm_scan_projection_with_rowid_only_no_rowaddr() {
-        // Test 4: when only `_rowid` (not `_rowaddr`) is requested, the
-        // canonical-projection wrap activates (system column triggers it),
-        // but the per-arm `null_columns(_rowaddr)` wrap stays off
-        // (`keep_row_address` remains false). `_rowid` ends up NULL for
-        // every row because no arm opts into `with_row_id()` in this
-        // planner (a base-only opt-in would mismatch the union schema).
+    async fn a_rowid_projection_is_rejected_on_a_shard_without_wal_row_ids() {
+        // `_rowid` is answered from the shard's own `__wal_row_id` column. A
+        // shard that predates it has no answer, and NULL-filling would read
+        // exactly like a row that legitimately has no id -- so a take routed
+        // by that NULL would silently return base's stale copy. Reject.
         let (base_dataset, shard_snapshots, active_memtable, pk_columns, _temp_path) =
             setup_multi_level_lsm().await;
 
@@ -1938,47 +1975,14 @@ mod integration_tests {
             scanner = scanner.with_in_memory_memtables(shard_id, memtable);
         }
 
-        let plan = scanner.create_plan().await.unwrap();
-        let plan_str = format!(
-            "{}",
-            datafusion::physical_plan::displayable(plan.as_ref()).indent(true)
-        );
-        // Canonical wrap activates for the user-requested `_rowid`.
+        let err = scanner.create_plan().await.unwrap_err();
         assert!(
-            plan_str.contains("ProjectionExec"),
-            "expected canonical projection wrap, got:\n{plan_str}",
+            matches!(err, lance_core::Error::NotSupported { .. }),
+            "expected NotSupported, got {err:?}"
         );
-        // The per-arm `null_columns(_rowaddr)` wrap is gated on
-        // `keep_row_address`, which stays false here. So no
-        // `NULL as _rowaddr` projection should appear.
         assert!(
-            !plan_str.contains("NULL as _rowaddr"),
-            "no per-arm `_rowaddr` NULL'ing expected when caller didn't ask for `_rowaddr`, got:\n{plan_str}",
-        );
-
-        let batches: Vec<RecordBatch> = scanner
-            .try_into_stream()
-            .await
-            .unwrap()
-            .try_collect()
-            .await
-            .unwrap();
-
-        let mut total = 0usize;
-        let mut rowid_null = 0usize;
-        for batch in &batches {
-            let rowid = batch.column_by_name("_rowid").unwrap();
-            for i in 0..batch.num_rows() {
-                total += 1;
-                if rowid.is_null(i) {
-                    rowid_null += 1;
-                }
-            }
-        }
-        assert_eq!(total, 7, "expected 7 unique pks after dedup");
-        assert_eq!(
-            rowid_null, total,
-            "_rowid must be NULL for every row (no opt-in)"
+            err.to_string().contains("__wal_row_id"),
+            "the message must name the missing column: {err}"
         );
     }
 

--- a/rust/lance/src/dataset/mem_wal/scanner/point_lookup.rs
+++ b/rust/lance/src/dataset/mem_wal/scanner/point_lookup.rs
@@ -29,14 +29,15 @@ use tracing::instrument;
 
 use crate::dataset::mem_wal::index::{IndexStore, MemTableVisibility};
 use crate::dataset::mem_wal::memtable::batch_store::BatchStore;
-use crate::dataset::mem_wal::{TOMBSTONE, relax_non_pk_nullability};
+use crate::dataset::mem_wal::{TOMBSTONE, WAL_ROW_ID, relax_non_pk_nullability};
 
 use super::collector::LsmDataSourceCollector;
 use super::data_source::LsmDataSource;
 use super::exec::{BloomFilterGuardExec, CoalesceFirstExec, compute_pk_hash_from_scalars};
 use super::projection::{
-    DISTANCE_COLUMN, build_scanner_projection, canonical_output_schema, force_schema, null_columns,
-    project_to_canonical, validate_projection_names, wants_row_address, wants_row_id,
+    DISTANCE_COLUMN, build_scanner_projection, canonical_output_schema, cols_with_wal_row_id,
+    force_schema, null_columns, project_to_canonical, surface_wal_row_id,
+    validate_projection_names, wants_row_address, wants_row_id,
 };
 use super::sstable_cache::{DatasetCache, SsTableWarmer, open_sstable};
 use crate::session::Session;
@@ -687,9 +688,14 @@ impl LsmPointLookupPlanner {
                 // a deleted key (gen written before deletes existed lack it →
                 // `project_to_carry` synthesizes `false`).
                 let cols = cols_with_tombstone(&cols, dataset.schema().field(TOMBSTONE).is_some());
+                let cols = cols_with_wal_row_id(
+                    &cols,
+                    want_row_id && dataset.schema().field(WAL_ROW_ID).is_some(),
+                );
                 scanner.project(&cols.iter().map(|s| s.as_str()).collect::<Vec<_>>())?;
                 scanner.filter_expr(filter.clone());
-                Box::pin(scanner.create_plan()).await?
+                let plan = Box::pin(scanner.create_plan()).await?;
+                surface_wal_row_id(plan)?
             }
             LsmDataSource::ActiveMemTable {
                 batch_store,
@@ -708,6 +714,10 @@ impl LsmPointLookupPlanner {
                 // Carry `_tombstone` through so the post-coalesce filter can drop
                 // a deleted key; it survives the sort below.
                 let cols = cols_with_tombstone(&cols, schema.column_with_name(TOMBSTONE).is_some());
+                let cols = cols_with_wal_row_id(
+                    &cols,
+                    want_row_id && schema.column_with_name(WAL_ROW_ID).is_some(),
+                );
                 scanner.project(&cols.iter().map(|s| s.as_str()).collect::<Vec<_>>())?;
                 scanner.filter_expr(filter.clone());
                 // Expose `_rowid` (the BatchStore row offset, monotonic with
@@ -735,11 +745,12 @@ impl LsmPointLookupPlanner {
                 })?;
                 let newest: Arc<dyn ExecutionPlan> =
                     Arc::new(SortExec::new(ordering, raw).with_fetch(Some(1)));
-                // Per-source `_rowid` would collide with the base table's;
-                // NULL it before canonicalization (the value is internal to
-                // this arm). project_to_canonical drops it entirely when
-                // the user didn't request `_rowid` in the projection.
-                null_columns(newest, &[lance_core::ROW_ID])?
+                // Per-source `_rowid` is the batch-store row offset, not an
+                // identity: NULL it before canonicalization. Only then may
+                // `__wal_row_id` -- the stable id -- take the name; ordering
+                // matters, since the sort above still needs the offset.
+                let cleared = null_columns(newest, &[lance_core::ROW_ID])?;
+                surface_wal_row_id(cleared)?
             }
         };
         // Output carries `_tombstone` (canonical + the marker) so it survives

--- a/rust/lance/src/dataset/mem_wal/scanner/projection.rs
+++ b/rust/lance/src/dataset/mem_wal/scanner/projection.rs
@@ -25,6 +25,8 @@ use datafusion::physical_plan::projection::ProjectionExec;
 use datafusion::scalar::ScalarValue;
 use lance_core::{ROW_ADDR, ROW_ID, Result, is_system_column};
 
+use crate::dataset::mem_wal::WAL_ROW_ID;
+
 use super::exec::SchemaRelabelExec;
 
 /// Column name for distance in vector search results.
@@ -47,6 +49,73 @@ pub fn wants_row_address(projection: Option<&[String]>) -> bool {
 /// Auto-managed by the planner; must never reach `scanner.project()`.
 fn is_auto_managed(col: &str) -> bool {
     col == DISTANCE_COLUMN || is_system_column(col)
+}
+
+/// Append the physical `__wal_row_id` column to a scanner projection when the
+/// source carries it and the caller asked for `_rowid`.
+///
+/// The mem_wal arms answer `_rowid` from this column, not from the scanner's
+/// own `_rowid` — which, on the active memtable, is the batch-store row offset
+/// used as a recency sort key. [`surface_wal_row_id`] renames it at the end of
+/// the arm, after that internal value has been cleared.
+pub fn cols_with_wal_row_id(cols: &[String], present: bool) -> Vec<String> {
+    if !present {
+        return cols.to_vec();
+    }
+    let mut out = cols.to_vec();
+    if !out.iter().any(|c| c == WAL_ROW_ID) {
+        out.push(WAL_ROW_ID.to_string());
+    }
+    out
+}
+
+/// Rename `__wal_row_id` to `_rowid`, replacing any `_rowid` the arm carried
+/// for its own purposes.
+///
+/// Runs last in an arm, after [`null_columns`] has cleared the internal
+/// `_rowid`: the two are different values (a stable identity versus a memtable
+/// row position) and only one of them may leave the arm. A no-op when the
+/// source has no `__wal_row_id`.
+///
+/// Stays nullable, matching both [`canonical_output_schema`] and the base arm's
+/// `ROW_ID_FIELD`; the tombstone fold has already removed the only rows that
+/// can hold a null there.
+pub fn surface_wal_row_id(plan: Arc<dyn ExecutionPlan>) -> Result<Arc<dyn ExecutionPlan>> {
+    let input_schema = plan.schema();
+    let Some((wal_idx, _)) = input_schema.column_with_name(WAL_ROW_ID) else {
+        return Ok(plan);
+    };
+    let mut project_exprs: Vec<(Arc<dyn PhysicalExpr>, String)> =
+        Vec::with_capacity(input_schema.fields().len());
+    let mut renamed = false;
+    for (idx, field) in input_schema.fields().iter().enumerate() {
+        let name = field.name();
+        if name == WAL_ROW_ID {
+            continue;
+        }
+        if name == ROW_ID {
+            project_exprs.push((
+                Arc::new(Column::new(WAL_ROW_ID, wal_idx)),
+                ROW_ID.to_string(),
+            ));
+            renamed = true;
+        } else {
+            project_exprs.push((Arc::new(Column::new(name, idx)), name.clone()));
+        }
+    }
+    if !renamed {
+        project_exprs.push((
+            Arc::new(Column::new(WAL_ROW_ID, wal_idx)),
+            ROW_ID.to_string(),
+        ));
+    }
+    let projected = ProjectionExec::try_new(project_exprs, plan).map_err(|e| {
+        lance_core::Error::internal(format!(
+            "Failed to build {} rename ProjectionExec: {}",
+            WAL_ROW_ID, e
+        ))
+    })?;
+    Ok(Arc::new(projected))
 }
 
 /// Projection to pass to underlying scanners: user cols minus

--- a/rust/lance/src/dataset/mem_wal/scanner/vector_search.rs
+++ b/rust/lance/src/dataset/mem_wal/scanner/vector_search.rs
@@ -28,9 +28,12 @@ use crate::io::exec::TakeExec;
 
 use super::collector::LsmDataSourceCollector;
 use super::data_source::LsmDataSource;
+use crate::dataset::mem_wal::WAL_ROW_ID;
+
 use super::projection::{
-    DISTANCE_COLUMN, build_scanner_projection, canonical_output_schema, null_columns,
-    project_to_canonical, validate_projection_names, wants_row_id,
+    DISTANCE_COLUMN, build_scanner_projection, canonical_output_schema, cols_with_wal_row_id,
+    null_columns, project_to_canonical, surface_wal_row_id, validate_projection_names,
+    wants_row_id,
 };
 use super::sstable_cache::{DatasetCache, SsTableWarmer, open_sstable};
 use crate::session::Session;
@@ -332,13 +335,14 @@ impl LsmVectorSearchPlanner {
                 None => knn,
             };
             // Lance's `fast_search()` and the active scan both produce a
-            // per-source `_rowid` that would collide with base row ids in the
-            // canonical output, so NULL it on non-base arms. The base arm keeps
-            // its real `_rowid` to drive the post-rerank take.
+            // per-source `_rowid` that is a physical position, not an identity,
+            // so NULL it on non-base arms and only then let `__wal_row_id` take
+            // the name. The base arm keeps its real `_rowid` to drive the
+            // post-rerank take.
             let after_null = if is_base {
                 knn
             } else {
-                null_columns(knn, &[lance_core::ROW_ID])?
+                surface_wal_row_id(null_columns(knn, &[lance_core::ROW_ID])?)?
             };
             // Normalize each source to the canonical output schema.
             let normalized = project_to_canonical(after_null, &canonical_schema)?;
@@ -478,6 +482,10 @@ impl LsmVectorSearchPlanner {
                 let mut scanner = dataset.scan();
                 let cols =
                     build_scanner_projection(projection, &self.base_schema, &self.pk_columns);
+                let cols = cols_with_wal_row_id(
+                    &cols,
+                    wants_row_id(projection) && dataset.schema().field(WAL_ROW_ID).is_some(),
+                );
                 scanner.project(&cols.iter().map(|s| s.as_str()).collect::<Vec<_>>())?;
                 if let Some(ref filter) = self.filter {
                     // See the base arm: `prefilter(true)` makes this a true
@@ -485,7 +493,9 @@ impl LsmVectorSearchPlanner {
                     scanner.filter_expr(filter.clone());
                     scanner.prefilter(true);
                 }
-                // No `with_row_id/address`: per-source IDs would collide with base.
+                // No `with_row_id/address`: the scanner's own `_rowid` is a
+                // physical position here. The stable id rides `__wal_row_id`
+                // above and is renamed at the end of the arm.
                 let query_arr = single_query_array(query_vector);
                 scanner.nearest(&self.vector_column, query_arr.as_ref(), k)?;
                 scanner.distance_range(self.distance_range.0, self.distance_range.1);
@@ -511,6 +521,10 @@ impl LsmVectorSearchPlanner {
                 // PK auto-included so the staleness filter retains its bloom hash key.
                 let cols =
                     build_scanner_projection(projection, &self.base_schema, &self.pk_columns);
+                let cols = cols_with_wal_row_id(
+                    &cols,
+                    wants_row_id(projection) && schema.column_with_name(WAL_ROW_ID).is_some(),
+                );
                 scanner.project(&cols.iter().map(|s| s.as_str()).collect::<Vec<_>>())?;
                 if let Some(ref filter) = self.filter {
                     // Routed to filtered brute-force (see `plan_vector_search`):

--- a/rust/lance/src/dataset/mem_wal/write.rs
+++ b/rust/lance/src/dataset/mem_wal/write.rs
@@ -19,8 +19,8 @@ use std::sync::{Arc, RwLock as StdRwLock};
 use std::time::{Duration, Instant};
 
 use arc_swap::ArcSwap;
-use arrow_array::{ArrayRef, BooleanArray, RecordBatch, new_null_array};
-use arrow_schema::Schema as ArrowSchema;
+use arrow_array::{Array, ArrayRef, BooleanArray, RecordBatch, UInt64Array, new_null_array};
+use arrow_schema::{FieldRef as ArrowFieldRef, Schema as ArrowSchema};
 use async_trait::async_trait;
 use lance_core::datatypes::Schema;
 use lance_core::{Error, Result};
@@ -56,7 +56,9 @@ use super::wal::{
     BatchDurableWatcher, TriggerIndexApply, TriggerWalFlush, WalAppender, WalFlushSource,
     WalOnlyState, WalRetryConfig, WalTailer, WriterCursors, apply_index_range, empty_flush_result,
 };
-use super::{TOMBSTONE, relax_non_pk_nullability, schema_with_tombstone};
+use super::{
+    TOMBSTONE, WAL_ROW_ID, relax_non_pk_nullability, schema_with_tombstone, schema_with_wal_row_id,
+};
 use crate::session::Session;
 
 use super::manifest::ShardManifestStore;
@@ -244,6 +246,19 @@ pub struct ShardWriterConfig {
     /// Default: `None`.
     pub session: Option<Arc<Session>>,
 
+    /// Whether this shard carries a stable row id per row.
+    ///
+    /// When `true`, the storage schema gains the physical
+    /// [`WAL_ROW_ID`](super::WAL_ROW_ID) column and every write must supply the
+    /// ids: [`ShardWriter::put`] is rejected in favour of
+    /// [`ShardWriter::put_with_row_ids`]. A delete still goes through
+    /// [`ShardWriter::delete`] and null-fills the column, because a tombstone
+    /// carries no identity of its own.
+    ///
+    /// Only valid on a base dataset created with stable row ids, and only in
+    /// memtable mode. Default: `false`.
+    pub enable_row_ids: bool,
+
     /// Admission control for every `put`, **replacing** lance's built-in
     /// per-shard valve ([`LocalBackpressureController`]).
     ///
@@ -276,6 +291,7 @@ impl Default for ShardWriterConfig {
             stats_log_interval: Some(Duration::from_secs(60)), // 1 minute
             frozen_memtable_grace: Duration::ZERO,
             enable_memtable: true,
+            enable_row_ids: false,
             hnsw_params: HashMap::new(),
             warmer: None,
             observer: None,
@@ -393,6 +409,12 @@ impl ShardWriterConfig {
     /// full WAL-only-mode contract. Defaults to `true`.
     pub fn with_enable_memtable(mut self, enable: bool) -> Self {
         self.enable_memtable = enable;
+        self
+    }
+
+    /// Carry a stable row id per row. See [`ShardWriterConfig::enable_row_ids`].
+    pub fn with_enable_row_ids(mut self, enable: bool) -> Self {
+        self.enable_row_ids = enable;
         self
     }
 
@@ -1583,6 +1605,56 @@ fn ensure_tombstone_column(
     })
 }
 
+/// Re-label `batch` to the storage schema, injecting `_tombstone = false` and
+/// `__wal_row_id = row_ids` when absent.
+///
+/// The row-id sibling of [`ensure_tombstone_column`], for a shard that assigns
+/// stable ids. `row_ids` is one id per row of `batch`, resolved by the caller
+/// before the WAL append so the log entry carries them and a replay restores
+/// them unchanged.
+///
+/// A batch that already carries the column keeps its ids: that is the replay
+/// path, where the entry was written with them.
+fn ensure_row_id_column(
+    batch: RecordBatch,
+    storage_schema: &Arc<ArrowSchema>,
+    row_ids: &UInt64Array,
+) -> Result<RecordBatch> {
+    if batch.num_rows() != row_ids.len() {
+        return Err(Error::invalid_input(format!(
+            "row id count {} does not match the batch's {} rows",
+            row_ids.len(),
+            batch.num_rows()
+        )));
+    }
+    if row_ids.null_count() > 0 {
+        return Err(Error::invalid_input(
+            "row ids must not be null: a null id belongs only to a tombstone, \
+             which the delete path builds instead",
+        ));
+    }
+    let batch = ensure_tombstone_column(batch, &strip_row_id_field(storage_schema))?;
+    let mut columns: Vec<ArrayRef> = batch.columns().to_vec();
+    columns.push(Arc::new(row_ids.clone()));
+    RecordBatch::try_new(storage_schema.clone(), columns)
+        .map_err(|e| Error::invalid_input(format!("failed to inject {} column: {}", WAL_ROW_ID, e)))
+}
+
+/// `storage_schema` without its trailing `__wal_row_id` field, so
+/// [`ensure_tombstone_column`] can re-label against the schema it expects.
+fn strip_row_id_field(storage_schema: &Arc<ArrowSchema>) -> Arc<ArrowSchema> {
+    let fields: Vec<ArrowFieldRef> = storage_schema
+        .fields()
+        .iter()
+        .filter(|f| f.name() != WAL_ROW_ID)
+        .cloned()
+        .collect();
+    Arc::new(ArrowSchema::new_with_metadata(
+        fields,
+        storage_schema.metadata().clone(),
+    ))
+}
+
 /// Build a tombstone batch from a key-only `keys` batch: primary keys carried
 /// through, `_tombstone` true, every other column null.
 ///
@@ -2033,6 +2105,15 @@ impl ShardWriter {
             ));
         }
 
+        // WAL-only mode has no memtable to carry the ids and rejects `delete`
+        // and `put_no_wait` outright; the row-id write path is built on the
+        // memtable ones.
+        if !config.enable_memtable && config.enable_row_ids {
+            return Err(Error::invalid_input(
+                "enable_row_ids requires enable_memtable = true",
+            ));
+        }
+
         // A durable writer needs a flush ticker to make progress, in either
         // mode. With `durable_write` on, a put becomes durable only once its WAL
         // append lands, and neither mode self-triggers that append per put — the
@@ -2053,6 +2134,15 @@ impl ShardWriter {
         // `_tombstone` and appends it here — idempotent across reopens.
         let logical_schema = schema;
         let tombstoned = schema_with_tombstone(&logical_schema);
+        // `__wal_row_id` follows `_tombstone`, and only on a shard that assigns
+        // ids. It is nullable, so `relax_non_pk_nullability` below leaves it
+        // alone and `build_tombstone_batch` null-fills it like any other
+        // non-PK column.
+        let tombstoned = if config.enable_row_ids {
+            schema_with_wal_row_id(&tombstoned)
+        } else {
+            tombstoned
+        };
 
         let base_uri = base_uri.into();
         let shard_id = config.shard_id;
@@ -2577,6 +2667,7 @@ impl ShardWriter {
                 writer_state,
                 backpressure,
             } => {
+                self.reject_missing_row_ids()?;
                 // Callers pass logical-shaped batches and never name
                 // `_tombstone`.
                 let batches = batches
@@ -2703,6 +2794,7 @@ impl ShardWriter {
                 writer_state,
                 backpressure,
             } => {
+                self.reject_missing_row_ids()?;
                 // Mirrors `put`.
                 let batches = batches
                     .into_iter()
@@ -2715,6 +2807,85 @@ impl ShardWriter {
                 "put_no_wait is only supported in MemTable mode",
             )),
         }
+    }
+
+    /// Like [`Self::put`], but stamping each row with the stable row id the
+    /// caller resolved for it.
+    ///
+    /// `row_ids[i]` holds one id per row of `batches[i]`. The ids are injected
+    /// as the physical [`WAL_ROW_ID`](super::WAL_ROW_ID) column *before* the WAL
+    /// append, so the log entry carries them and a replay reproduces them
+    /// exactly. Nothing downstream mints: the memtable, the SSTable and
+    /// compaction all carry these ids through unchanged.
+    ///
+    /// Only valid on a shard opened with
+    /// [`ShardWriterConfig::enable_row_ids`]; [`Self::put`] is rejected there in
+    /// turn, so a row can never reach storage without an id.
+    #[instrument(name = "sw_put_with_row_ids", level = "info", skip_all, fields(batch_count = batches.len(), shard_id = %self.config.shard_id))]
+    pub async fn put_with_row_ids(
+        &self,
+        batches: Vec<RecordBatch>,
+        row_ids: Vec<UInt64Array>,
+    ) -> Result<WriteResult> {
+        let (result, watcher) = self.put_no_wait_with_row_ids(batches, row_ids).await?;
+        if let Some(mut watcher) = watcher {
+            watcher.wait().await?;
+        }
+        Ok(result)
+    }
+
+    /// Like [`Self::put_with_row_ids`], but returns the durability watcher
+    /// *without* awaiting it. The row-id analog of [`Self::put_no_wait`].
+    #[instrument(name = "sw_put_no_wait_with_row_ids", level = "info", skip_all, fields(batch_count = batches.len(), shard_id = %self.config.shard_id))]
+    pub async fn put_no_wait_with_row_ids(
+        &self,
+        batches: Vec<RecordBatch>,
+        row_ids: Vec<UInt64Array>,
+    ) -> Result<(WriteResult, Option<BatchDurableWatcher>)> {
+        Self::validate_non_empty(&batches)?;
+        self.validate_against_logical_schema(&batches)?;
+        if !self.config.enable_row_ids {
+            return Err(Error::invalid_input(
+                "put_with_row_ids requires a shard opened with enable_row_ids",
+            ));
+        }
+        if batches.len() != row_ids.len() {
+            return Err(Error::invalid_input(format!(
+                "got {} row id arrays for {} batches",
+                row_ids.len(),
+                batches.len()
+            )));
+        }
+
+        match &self.mode {
+            WriterMode::MemTable {
+                state,
+                writer_state,
+                backpressure,
+            } => {
+                let batches = batches
+                    .into_iter()
+                    .zip(row_ids.iter())
+                    .map(|(b, ids)| ensure_row_id_column(b, &writer_state.schema, ids))
+                    .collect::<Result<Vec<_>>>()?;
+                self.put_memtable_no_wait(batches, state, writer_state, backpressure)
+                    .await
+            }
+            WriterMode::WalOnly { .. } => Err(Error::invalid_input(
+                "put_with_row_ids is only supported in MemTable mode",
+            )),
+        }
+    }
+
+    /// Reject an id-less put on a shard that assigns ids: the row would reach
+    /// storage with a null `__wal_row_id`, which only a tombstone may carry.
+    fn reject_missing_row_ids(&self) -> Result<()> {
+        if self.config.enable_row_ids {
+            return Err(Error::invalid_input(
+                "this shard assigns stable row ids; use put_with_row_ids",
+            ));
+        }
+        Ok(())
     }
 
     /// Reject caller input that violates the logical schema: wrong column names,
@@ -11141,5 +11312,268 @@ mod shard_writer_tests {
             err.to_string().contains("must not be nullable"),
             "unexpected error: {err}"
         );
+    }
+
+    /// A shard opened with `enable_row_ids` carries the caller's ids through
+    /// the memtable, the flush and the SSTable, and surfaces them as `_rowid`
+    /// on every arm of the LSM read.
+    #[tokio::test]
+    async fn wal_row_ids_survive_the_flush_and_surface_as_rowid() {
+        use crate::dataset::mem_wal::scanner::{LsmScanner, ShardSnapshot};
+        use arrow_array::UInt64Array;
+        use arrow_array::cast::AsArray;
+        use arrow_array::types::UInt64Type;
+        use tempfile::TempDir;
+
+        let vector_dim = 8;
+        let schema = create_test_schema(vector_dim);
+        let temp_dir = TempDir::new().unwrap();
+        let uri = format!("file://{}", temp_dir.path().display());
+
+        let initial = create_test_batch(&schema, 0, 4, vector_dim);
+        let mut dataset = Dataset::write(
+            RecordBatchIterator::new([Ok(initial)], schema.clone()),
+            &uri,
+            Some(WriteParams {
+                enable_stable_row_ids: true,
+                ..Default::default()
+            }),
+        )
+        .await
+        .unwrap();
+        dataset.initialize_mem_wal().execute().await.unwrap();
+
+        let shard_id = Uuid::new_v4();
+        let writer = dataset
+            .mem_wal_writer(
+                shard_id,
+                ShardWriterConfig::new(shard_id).with_enable_row_ids(true),
+            )
+            .await
+            .unwrap();
+
+        // Two generations: one flushed, one still in the active memtable.
+        writer
+            .put_with_row_ids(
+                vec![create_test_batch(&schema, 100, 3, vector_dim)],
+                vec![UInt64Array::from(vec![1_000, 1_001, 1_002])],
+            )
+            .await
+            .unwrap();
+        writer.force_seal_active().await.unwrap();
+        writer.wait_for_flush_drain().await.unwrap();
+        writer
+            .put_with_row_ids(
+                vec![create_test_batch(&schema, 200, 2, vector_dim)],
+                vec![UInt64Array::from(vec![2_000, 2_001])],
+            )
+            .await
+            .unwrap();
+
+        let manifest = writer.manifest().await.unwrap().unwrap();
+        let mut snapshot =
+            ShardSnapshot::new(shard_id).with_current_generation(manifest.current_generation);
+        for sstable in &manifest.sstables {
+            snapshot = snapshot.with_sstable(sstable.generation, sstable.path.clone());
+        }
+
+        let batch = LsmScanner::new(
+            Arc::new(dataset.clone()),
+            vec![snapshot],
+            vec!["id".to_string()],
+        )
+        .with_in_memory_memtables(shard_id, writer.in_memory_memtable_refs().await.unwrap())
+        .project(&["id", "_rowid"])
+        .unwrap()
+        .try_into_batch()
+        .await
+        .unwrap();
+
+        let ids = batch
+            .column_by_name("id")
+            .unwrap()
+            .as_primitive::<arrow_array::types::Int64Type>();
+        let row_ids = batch
+            .column_by_name("_rowid")
+            .unwrap()
+            .as_primitive::<UInt64Type>();
+        let mut seen: Vec<(i64, u64)> = (0..batch.num_rows())
+            .map(|i| (ids.value(i), row_ids.value(i)))
+            .collect();
+        seen.sort();
+
+        // Base rows keep the ids the initial write assigned (0..4); the WAL
+        // rows keep the ids the caller resolved, through the flush and the
+        // SSTable.
+        assert_eq!(
+            seen,
+            vec![
+                (0, 0),
+                (1, 1),
+                (2, 2),
+                (3, 3),
+                (100, 1_000),
+                (101, 1_001),
+                (102, 1_002),
+                (200, 2_000),
+                (201, 2_001),
+            ]
+        );
+
+        writer.close().await.unwrap();
+    }
+
+    /// A delete carries no id, and its tombstone never reaches the output.
+    #[tokio::test]
+    async fn a_tombstone_carries_no_row_id_and_is_dropped_at_egress() {
+        use crate::dataset::mem_wal::scanner::{LsmScanner, ShardSnapshot};
+        use arrow_array::UInt64Array;
+        use arrow_array::cast::AsArray;
+        use arrow_array::types::UInt64Type;
+        use tempfile::TempDir;
+
+        let vector_dim = 8;
+        let schema = create_test_schema(vector_dim);
+        let temp_dir = TempDir::new().unwrap();
+        let uri = format!("file://{}", temp_dir.path().display());
+
+        let mut dataset = Dataset::write(
+            RecordBatchIterator::new(
+                [Ok(create_test_batch(&schema, 0, 2, vector_dim))],
+                schema.clone(),
+            ),
+            &uri,
+            Some(WriteParams {
+                enable_stable_row_ids: true,
+                ..Default::default()
+            }),
+        )
+        .await
+        .unwrap();
+        dataset.initialize_mem_wal().execute().await.unwrap();
+
+        let shard_id = Uuid::new_v4();
+        let writer = dataset
+            .mem_wal_writer(
+                shard_id,
+                ShardWriterConfig::new(shard_id).with_enable_row_ids(true),
+            )
+            .await
+            .unwrap();
+
+        writer
+            .put_with_row_ids(
+                vec![create_test_batch(&schema, 100, 2, vector_dim)],
+                vec![UInt64Array::from(vec![5_000, 5_001])],
+            )
+            .await
+            .unwrap();
+
+        let keys = RecordBatch::try_new(
+            Arc::new(ArrowSchema::new(vec![Field::new(
+                "id",
+                DataType::Int64,
+                false,
+            )])),
+            vec![Arc::new(Int64Array::from(vec![100i64]))],
+        )
+        .unwrap();
+        writer.delete(vec![keys]).await.unwrap();
+
+        let manifest = writer.manifest().await.unwrap().unwrap();
+        let snapshot =
+            ShardSnapshot::new(shard_id).with_current_generation(manifest.current_generation);
+        let batch = LsmScanner::new(
+            Arc::new(dataset.clone()),
+            vec![snapshot],
+            vec!["id".to_string()],
+        )
+        .with_in_memory_memtables(shard_id, writer.in_memory_memtable_refs().await.unwrap())
+        .project(&["id", "_rowid"])
+        .unwrap()
+        .try_into_batch()
+        .await
+        .unwrap();
+
+        let ids = batch
+            .column_by_name("id")
+            .unwrap()
+            .as_primitive::<arrow_array::types::Int64Type>();
+        let row_ids = batch
+            .column_by_name("_rowid")
+            .unwrap()
+            .as_primitive::<UInt64Type>();
+        let mut seen: Vec<(i64, u64)> = (0..batch.num_rows())
+            .map(|i| (ids.value(i), row_ids.value(i)))
+            .collect();
+        seen.sort();
+        assert_eq!(seen, vec![(0, 0), (1, 1), (101, 5_001)]);
+
+        writer.close().await.unwrap();
+    }
+
+    /// `put` and `put_with_row_ids` are mutually exclusive per shard, so a row
+    /// can never reach storage without an id (and an id can never be handed to
+    /// a shard that has nowhere to put it).
+    #[tokio::test]
+    async fn put_and_put_with_row_ids_are_mutually_exclusive() {
+        use arrow_array::UInt64Array;
+        use tempfile::TempDir;
+
+        let vector_dim = 8;
+        let schema = create_test_schema(vector_dim);
+        let temp_dir = TempDir::new().unwrap();
+        let uri = format!("file://{}", temp_dir.path().display());
+
+        let mut dataset = Dataset::write(
+            RecordBatchIterator::new(
+                [Ok(create_test_batch(&schema, 0, 2, vector_dim))],
+                schema.clone(),
+            ),
+            &uri,
+            Some(WriteParams {
+                enable_stable_row_ids: true,
+                ..Default::default()
+            }),
+        )
+        .await
+        .unwrap();
+        dataset.initialize_mem_wal().execute().await.unwrap();
+
+        let shard_id = Uuid::new_v4();
+        let with_ids = dataset
+            .mem_wal_writer(
+                shard_id,
+                ShardWriterConfig::new(shard_id).with_enable_row_ids(true),
+            )
+            .await
+            .unwrap();
+        let err = with_ids
+            .put(vec![create_test_batch(&schema, 10, 1, vector_dim)])
+            .await
+            .unwrap_err();
+        assert!(
+            err.to_string().contains("put_with_row_ids"),
+            "unexpected error: {err}"
+        );
+        with_ids.close().await.unwrap();
+
+        let plain_shard = Uuid::new_v4();
+        let plain = dataset
+            .mem_wal_writer(plain_shard, ShardWriterConfig::new(plain_shard))
+            .await
+            .unwrap();
+        let err = plain
+            .put_with_row_ids(
+                vec![create_test_batch(&schema, 10, 1, vector_dim)],
+                vec![UInt64Array::from(vec![7u64])],
+            )
+            .await
+            .unwrap_err();
+        assert!(
+            err.to_string().contains("enable_row_ids"),
+            "unexpected error: {err}"
+        );
+        plain.close().await.unwrap();
     }
 }

--- a/rust/lance/src/dataset/rowids.rs
+++ b/rust/lance/src/dataset/rowids.rs
@@ -13,7 +13,11 @@ use lance_select::{RowAddrSelection, RowAddrTreeMap};
 use lance_table::{
     format::{Fragment, RowIdMeta},
     rowids::{FragmentRowIdIndex, RowIdIndex, RowIdSequence, read_row_ids},
+    transaction::{Operation, Transaction},
 };
+
+use crate::dataset::write::CommitBuilder;
+use std::ops::Range;
 use std::sync::Arc;
 
 pub(super) use validate::validate_stable_row_ids;
@@ -69,6 +73,49 @@ pub fn load_row_id_sequences<'a>(
             load_row_id_sequence(dataset, fragment).map_ok(move |seq| (fragment.id as u32, seq))
         })
         .buffer_unordered(dataset.object_store.io_parallelism())
+}
+
+/// Reserve `count` stable row ids, advancing the dataset's `next_row_id` past
+/// them so no future append can hand them out.
+///
+/// Returns the reserved half-open range and the dataset at the commit that took
+/// it. The caller owns the range outright: a writer can stamp these ids into
+/// rows long before they reach a fragment, which is what lets the WAL assign a
+/// row's id at insert time. Ids need not be contiguous, so a range that is
+/// never fully used is simply lost.
+///
+/// The commit is conflict-free against every concurrent operation except an
+/// overwrite or a restore.
+pub async fn reserve_row_ids(dataset: &Dataset, count: u64) -> Result<(Dataset, Range<u64>)> {
+    if count == 0 {
+        return Err(Error::invalid_input("cannot reserve 0 row ids".to_string()));
+    }
+    if !dataset.manifest.uses_stable_row_ids() {
+        return Err(Error::invalid_input(
+            "cannot reserve row ids on a dataset that does not use stable row ids".to_string(),
+        ));
+    }
+
+    let transaction = Transaction::new(
+        dataset.manifest.version,
+        Operation::ReserveRowIds { num_row_ids: count },
+        None,
+    );
+    let committed = CommitBuilder::new(Arc::new(dataset.clone()))
+        .execute(transaction)
+        .await?;
+
+    // `next_row_id` after the commit is the exclusive end of the range this
+    // commit reserved; nothing else could have moved it, because the commit
+    // rebases onto whatever landed first and re-applies the bump.
+    let end = committed.manifest.next_row_id;
+    let start = end.checked_sub(count).ok_or_else(|| {
+        Error::internal(format!(
+            "reserving {} row ids left next_row_id at {}, which is below the reservation",
+            count, end
+        ))
+    })?;
+    Ok((committed, start..end))
 }
 
 pub async fn get_row_id_index(dataset: &Dataset) -> Result<Option<Arc<RowIdIndex>>> {
@@ -326,6 +373,162 @@ mod test {
         assert!(index.get(0).unwrap().is_none());
 
         assert_eq!(dataset.manifest().next_row_id, 0);
+    }
+
+    #[tokio::test]
+    async fn reserve_row_ids_advances_the_counter_and_pushes_appends_above_it() {
+        let batch = sequence_batch(0..10);
+        let reader = RecordBatchIterator::new(vec![Ok(batch.clone())], batch.schema());
+        let temp_dir = lance_core::utils::tempfile::TempStrDir::default();
+        let tmp_path = &temp_dir;
+        let dataset = Dataset::write(
+            reader,
+            tmp_path,
+            Some(WriteParams {
+                enable_stable_row_ids: true,
+                ..Default::default()
+            }),
+        )
+        .await
+        .unwrap();
+        assert_eq!(dataset.manifest().next_row_id, 10);
+
+        let (dataset, reserved) = reserve_row_ids(&dataset, 1000).await.unwrap();
+        assert_eq!(reserved, 10..1010);
+        assert_eq!(dataset.manifest().next_row_id, 1010);
+
+        // A subsequent append starts above the reserved range rather than
+        // colliding with it.
+        let reader = RecordBatchIterator::new(vec![Ok(batch.clone())], batch.schema());
+        let dataset = Dataset::write(
+            reader,
+            tmp_path,
+            Some(WriteParams {
+                mode: WriteMode::Append,
+                ..Default::default()
+            }),
+        )
+        .await
+        .unwrap();
+        assert_eq!(dataset.manifest().next_row_id, 1020);
+
+        let index = get_row_id_index(&dataset).await.unwrap().unwrap();
+        for id in reserved.clone() {
+            assert!(
+                index.get(id).unwrap().is_none(),
+                "reserved id {id} must not be handed to a row"
+            );
+        }
+        assert!(index.get(1010).unwrap().is_some());
+    }
+
+    #[tokio::test]
+    async fn reserve_row_ids_rejects_a_dataset_without_stable_row_ids() {
+        let batch = sequence_batch(0..10);
+        let reader = RecordBatchIterator::new(vec![Ok(batch.clone())], batch.schema());
+        let dataset = Dataset::write(reader, "memory://", None).await.unwrap();
+
+        let err = reserve_row_ids(&dataset, 10).await.unwrap_err();
+        assert!(matches!(err, Error::InvalidInput { .. }), "got {err:?}");
+        assert!(
+            err.to_string().contains("stable row ids"),
+            "unhelpful message: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn reserve_row_ids_does_not_conflict_with_a_concurrent_append() {
+        let batch = sequence_batch(0..10);
+        let reader = RecordBatchIterator::new(vec![Ok(batch.clone())], batch.schema());
+        let temp_dir = lance_core::utils::tempfile::TempStrDir::default();
+        let tmp_path = &temp_dir;
+        let dataset = Dataset::write(
+            reader,
+            tmp_path,
+            Some(WriteParams {
+                enable_stable_row_ids: true,
+                ..Default::default()
+            }),
+        )
+        .await
+        .unwrap();
+
+        // Both transactions read version 2; the append lands first and the
+        // reserve rebases onto it.
+        let append = Transaction::new(
+            dataset.manifest.version,
+            Operation::Append { fragments: vec![] },
+            None,
+        );
+        let appended = CommitBuilder::new(Arc::new(dataset.clone()))
+            .execute(append)
+            .await
+            .unwrap();
+
+        let (reserved_ds, reserved) = reserve_row_ids(&dataset, 64).await.unwrap();
+        assert!(reserved_ds.manifest.version > appended.manifest.version);
+        assert_eq!(reserved, 10..74);
+    }
+
+    /// An append that retries across a concurrent reserve must re-assign its
+    /// row ids from the rebased manifest rather than keep the ones its first
+    /// attempt computed -- otherwise it lands *inside* the reserved range.
+    ///
+    /// This holds because `build_manifest` assigns off a clone of the
+    /// transaction's fragments, so the transaction itself stays un-stamped. The
+    /// WAL's compaction path depends on the opposite property for fragments it
+    /// stamps itself, and the two only coexist because of that clone.
+    #[tokio::test]
+    async fn an_append_retrying_across_a_reserve_lands_above_the_reserved_range() {
+        let batch = sequence_batch(0..10);
+        let reader = RecordBatchIterator::new(vec![Ok(batch.clone())], batch.schema());
+        let temp_dir = lance_core::utils::tempfile::TempStrDir::default();
+        let tmp_path = &temp_dir;
+        let dataset = Dataset::write(
+            reader,
+            tmp_path,
+            Some(WriteParams {
+                enable_stable_row_ids: true,
+                ..Default::default()
+            }),
+        )
+        .await
+        .unwrap();
+        assert_eq!(dataset.manifest().next_row_id, 10);
+
+        // Stage an append against the current version, then slip a reserve in
+        // underneath it so the append has to rebase.
+        let append = crate::dataset::InsertBuilder::new(Arc::new(dataset.clone()))
+            .with_params(&WriteParams {
+                mode: WriteMode::Append,
+                ..Default::default()
+            })
+            .execute_uncommitted_stream(RecordBatchIterator::new(
+                vec![Ok(batch.clone())],
+                batch.schema(),
+            ))
+            .await
+            .unwrap();
+
+        let (_, reserved) = reserve_row_ids(&dataset, 500).await.unwrap();
+        assert_eq!(reserved, 10..510);
+
+        let appended = CommitBuilder::new(Arc::new(dataset.clone()))
+            .execute(append)
+            .await
+            .unwrap();
+
+        assert_eq!(appended.manifest().next_row_id, 520);
+        let index = get_row_id_index(&appended).await.unwrap().unwrap();
+        for id in reserved {
+            assert!(
+                index.get(id).unwrap().is_none(),
+                "retried append kept a stale id inside the reserved range"
+            );
+        }
+        for id in 510..520 {
+            assert!(index.get(id).unwrap().is_some());
+        }
     }
 
     #[tokio::test]

--- a/rust/lance/src/dataset/take.rs
+++ b/rust/lance/src/dataset/take.rs
@@ -484,10 +484,18 @@ pub struct TakeBuilder {
     missing_row_policy: MissingRowPolicy,
 }
 
+/// What a take does with a row id it cannot resolve to a live row.
+///
+/// Only consulted on a dataset that uses stable row ids: without them
+/// [`TakeBuilder::get_row_addrs`] reinterprets the ids as addresses verbatim
+/// and never looks at the policy, so setting `Error` there promises a check
+/// that does not happen.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
-pub(super) enum MissingRowPolicy {
+pub enum MissingRowPolicy {
+    /// Drop it, returning fewer rows than were asked for.
     #[default]
     Ignore,
+    /// Fail the take, naming the first id that could not be resolved.
     Error,
 }
 
@@ -530,7 +538,9 @@ impl TakeBuilder {
         self
     }
 
-    pub(super) fn with_missing_row_policy(mut self, policy: MissingRowPolicy) -> Self {
+    /// How to handle a row id that resolves to no live row. See
+    /// [`MissingRowPolicy`].
+    pub fn with_missing_row_policy(mut self, policy: MissingRowPolicy) -> Self {
         self.missing_row_policy = policy;
         self
     }

--- a/rust/lance/src/io/commit/conflict_resolver.rs
+++ b/rust/lance/src/io/commit/conflict_resolver.rs
@@ -105,6 +105,7 @@ impl<'a> TransactionRebase<'a> {
             | Operation::Overwrite { .. }
             | Operation::CreateIndex { .. }
             | Operation::ReserveFragments { .. }
+            | Operation::ReserveRowIds { .. }
             | Operation::Project { .. }
             | Operation::UpdateConfig { .. }
             | Operation::UpdateMemWalState { .. }
@@ -329,8 +330,8 @@ impl<'a> TransactionRebase<'a> {
             }
             Operation::Merge { .. } => self.check_merge_txn(other_transaction, other_version),
             Operation::Restore { .. } => self.check_restore_txn(other_transaction, other_version),
-            Operation::ReserveFragments { .. } => {
-                self.check_reserve_fragments_txn(other_transaction, other_version)
+            Operation::ReserveFragments { .. } | Operation::ReserveRowIds { .. } => {
+                self.check_reservation_txn(other_transaction, other_version)
             }
             Operation::Project { .. } => self.check_project_txn(other_transaction, other_version),
             Operation::UpdateConfig { .. } => {
@@ -355,6 +356,7 @@ impl<'a> TransactionRebase<'a> {
             match &other_transaction.operation {
                 Operation::CreateIndex { .. }
                 | Operation::ReserveFragments { .. }
+| Operation::ReserveRowIds { .. }
                 | Operation::Clone { .. }
                 | Operation::Project { .. }
                 | Operation::Append { .. }
@@ -511,6 +513,7 @@ impl<'a> TransactionRebase<'a> {
             match &other_transaction.operation {
                 Operation::CreateIndex { .. }
                 | Operation::ReserveFragments { .. }
+                | Operation::ReserveRowIds { .. }
                 | Operation::Project { .. }
                 | Operation::Clone { .. }
                 | Operation::UpdateConfig { .. }
@@ -808,7 +811,8 @@ impl<'a> TransactionRebase<'a> {
                         Ok(())
                     }
                 }
-                Operation::ReserveFragments { .. } => Ok(()),
+                Operation::ReserveFragments { .. }
+| Operation::ReserveRowIds { .. } => Ok(()),
                 Operation::Project { .. } => Ok(()),
                 // Should be compatible with rewrite if it didn't move the rows
                 // we indexed. If it did, we could retry.
@@ -945,6 +949,7 @@ impl<'a> TransactionRebase<'a> {
                 // existing fragments or update fragments we don't touch.
                 Operation::Append { .. }
                 | Operation::ReserveFragments { .. }
+                | Operation::ReserveRowIds { .. }
                 | Operation::Project { .. }
                 | Operation::Clone { .. }
                 | Operation::UpdateConfig { .. }
@@ -1168,6 +1173,7 @@ impl<'a> TransactionRebase<'a> {
             | Operation::Merge { .. }
             | Operation::Restore { .. }
             | Operation::ReserveFragments { .. }
+            | Operation::ReserveRowIds { .. }
             | Operation::Update { .. }
             | Operation::Project { .. }
             | Operation::UpdateBases { .. } => Ok(()),
@@ -1193,6 +1199,7 @@ impl<'a> TransactionRebase<'a> {
             | Operation::Delete { .. }
             | Operation::Update { .. }
             | Operation::ReserveFragments { .. }
+            | Operation::ReserveRowIds { .. }
             | Operation::Project { .. }
             | Operation::UpdateBases { .. }
             | Operation::Merge { .. }
@@ -1214,6 +1221,7 @@ impl<'a> TransactionRebase<'a> {
                 | Operation::Clone { .. }
                 | Operation::UpdateConfig { .. }
                 | Operation::ReserveFragments { .. }
+| Operation::ReserveRowIds { .. }
                 // Both a column replacement and an overlay preserve physical row
                 // addresses; the overlay is newer and wins its covered cells.
                 | Operation::DataOverlay { .. }
@@ -1392,6 +1400,7 @@ impl<'a> TransactionRebase<'a> {
             Operation::Append { .. }
             | Operation::CreateIndex { .. }
             | Operation::ReserveFragments { .. }
+            | Operation::ReserveRowIds { .. }
             | Operation::Project { .. }
             | Operation::UpdateConfig { .. }
             | Operation::UpdateBases { .. }
@@ -1496,6 +1505,7 @@ impl<'a> TransactionRebase<'a> {
                 }
             }
             Operation::ReserveFragments { .. }
+            | Operation::ReserveRowIds { .. }
             | Operation::Clone { .. }
             | Operation::UpdateConfig { .. }
             | Operation::UpdateBases { .. } => Ok(()),
@@ -1534,6 +1544,7 @@ impl<'a> TransactionRebase<'a> {
             | Operation::Merge { .. }
             | Operation::Restore { .. }
             | Operation::ReserveFragments { .. }
+            | Operation::ReserveRowIds { .. }
             | Operation::UpdateBases { .. }
             | Operation::Update { .. }
             | Operation::Project { .. }
@@ -1545,7 +1556,10 @@ impl<'a> TransactionRebase<'a> {
         }
     }
 
-    fn check_reserve_fragments_txn(
+    /// Covers both `ReserveFragments` and `ReserveRowIds`: each only bumps a
+    /// counter in the manifest, so the rules are identical -- conflict-free
+    /// against everything that does not replace the manifest wholesale.
+    fn check_reservation_txn(
         &mut self,
         other_transaction: &Transaction,
         other_version: u64,
@@ -1562,6 +1576,7 @@ impl<'a> TransactionRebase<'a> {
             | Operation::DataOverlay { .. }
             | Operation::Merge { .. }
             | Operation::ReserveFragments { .. }
+            | Operation::ReserveRowIds { .. }
             | Operation::Update { .. }
             | Operation::Project { .. }
             | Operation::Clone { .. }
@@ -1588,6 +1603,7 @@ impl<'a> TransactionRebase<'a> {
             | Operation::Rewrite { .. }
             | Operation::Clone { .. }
             | Operation::ReserveFragments { .. }
+            | Operation::ReserveRowIds { .. }
             | Operation::UpdateBases { .. } => Ok(()),
             Operation::Merge { .. } | Operation::Project { .. } => {
                 // Need to recompute the schema
@@ -1653,6 +1669,7 @@ impl<'a> TransactionRebase<'a> {
                 | Operation::Merge { .. }
                 | Operation::Restore { .. }
                 | Operation::ReserveFragments { .. }
+                | Operation::ReserveRowIds { .. }
                 | Operation::Update { .. }
                 | Operation::Project { .. }
                 | Operation::UpdateMemWalState { .. }
@@ -1721,6 +1738,7 @@ impl<'a> TransactionRebase<'a> {
                 Operation::UpdateConfig { .. }
                 | Operation::Rewrite { .. }
                 | Operation::ReserveFragments { .. }
+                | Operation::ReserveRowIds { .. }
                 | Operation::UpdateBases { .. } => Ok(()),
                 Operation::Append { .. }
                 | Operation::Overwrite { .. }
@@ -1825,6 +1843,7 @@ impl<'a> TransactionRebase<'a> {
             | Operation::Merge { .. }
             | Operation::Restore { .. }
             | Operation::ReserveFragments { .. }
+            | Operation::ReserveRowIds { .. }
             | Operation::Project { .. }
             | Operation::Clone { .. }
             | Operation::UpdateConfig { .. }
@@ -4957,6 +4976,7 @@ mod tests {
             | Operation::Overwrite { .. }
             | Operation::CreateIndex { .. }
             | Operation::ReserveFragments { .. }
+            | Operation::ReserveRowIds { .. }
             | Operation::Project { .. }
             | Operation::UpdateConfig { .. }
             | Operation::UpdateBases { .. }


### PR DESCRIPTION
Gives a WAL-backed table's rows a stable `_rowid` from the moment they are written, rather than from the moment they compact into base. Materialized views are the driver: `lancedb`'s MV path requires stable row ids, so a WAL table cannot source one today.

**Ids are assigned at insert, not at flush.** A row's id is resolved on the write path, injected as a physical `__wal_row_id` column before the WAL append, and carried unchanged through the memtable, the log, the SSTable and finally into the base fragment compaction writes. Nothing downstream of `put` ever mints. That is what makes replay deterministic (the log entry holds the id), makes `_rowid` answerable over not-yet-flushed rows without a special case, and reduces compaction to "these ids are already correct, don't touch them".

The resolver itself lives in the consumer (LanceDB's WAL service), not here. This PR is the format and the primitives it needs.

## What's in it

**`Operation::ReserveRowIds`** — advances `manifest.next_row_id` by `num_row_ids` with no fragments, so a writer can hold a range before committing rows. Mirrors `ReserveFragments` field for field, including its conflict set (conflict-free against everything but an overwrite or a restore).

The bump advances `build_manifest`'s *local* `next_row_id`, not `manifest.next_row_id`: the latter is overwritten from the local unconditionally at the end of the build, so a bump written there is clobbered four lines later.

**`ShardManifest.row_id_reservation`** — the half-open range a WAL shard is currently drawing from, written before any id is issued from it. Bound to the `writer_epoch` that took it, so a successor re-reserves rather than resuming a range two writers would both issue from.

**`__wal_row_id`** — a physical mem_wal column behind `ShardWriterConfig::enable_row_ids`, following `_tombstone` for every piece of schema plumbing. Nullable, because a tombstone carries no id: a delete sentinel exists only to shadow a primary key, and compaction resolves the base row it supersedes by key rather than by id. That also keeps `build_tombstone_batch` and `relax_non_pk_nullability` untouched.

At scan egress the column is renamed to `_rowid` on every WAL arm, and the base arm opts into `with_row_id()` so the union lines up. **Order matters**: the active-memtable and vector arms use the scanner's own `_rowid` as a recency sort key — it is a batch-store position, not an identity — so the rename runs *after* `null_columns` has cleared it.

`_rowid` over a shard that predates the column is rejected rather than NULL-filled. A null there is indistinguishable from a row that legitimately has no id, so a take routed by it would silently return base's stale copy.

**`commit_preassigned_rows`** — compaction with the ids the rows already carry. `merge_insert` cannot serve this: it preserves the id of a key already in base but *mints* one for a key that does not, and a key arriving from the WAL is exactly that case, so its id would change the moment it compacted. One `Operation::Update` replaces the two merge passes: new fragments whose `row_id_meta` already holds their ids (which `assign_row_ids` then skips), deletion vectors masking every superseded base row — tombstones included, which is why there is no separate delete pass — and the compacted-SSTable watermark, all on one commit.

`RowIdMeta::Inline`, not `External`: `assign_row_ids` reads an `External` fragment's existing row count as zero and would append a second set of ids on top.

Two ways to give one id two live rows are rejected outright, because nothing downstream catches them: an id repeated within the commit, and an id still live in base at an address the commit does not supersede. The check deliberately says nothing about any reservation — it has to hold in a job process, where there is none.

**`MissingRowPolicy` and `TakeBuilder::with_missing_row_policy` are public**, so a consumer can opt a take into naming an unresolvable id instead of surfacing it as a column-length mismatch.

## Process note

Per `protos/AGENTS.md` this should land as **two** PRs: the persisted-format proto change (`transaction.proto`, `table.proto`) plus the matching `docs/src/format/` text on its own, for the PMC vote, and the implementation as a follow-up. It is one branch here because it was built end to end against a downstream consumer; splitting it along that line is straightforward — commit 1 is the format, commits 2-4 the implementation, commit 5 the docs. Happy to split before this leaves draft.

## Tests

- A reserve commit advances `next_row_id`; a later append starts above the reserved range; a concurrent append does not conflict.
- An append that **retries across a reserve** re-assigns from the rebased manifest rather than keeping ids that now fall inside the reserved range. This holds because `build_manifest` assigns off a *clone* of the transaction's fragments — and the compaction design above depends on the opposite property for fragments it stamps itself, so the two only coexist because of that clone. Asserted explicitly.
- Ids survive a flush and an SSTable round-trip, and surface as `_rowid` from the base, SSTable and active-memtable arms.
- A tombstone carries no id and never reaches the output.
- `put` and `put_with_row_ids` are mutually exclusive per shard, so a row cannot reach storage without an id.
- A key new to base keeps the id it arrived with; an updated key keeps its own and loses its old copy; a superseded key with no replacement is deleted.
- A repeated id, an id live in base that is not superseded, and a dataset without stable row ids are each rejected.

`cargo clippy --tests -- -D warnings` and `cargo fmt --check` are clean on the touched crates; `lance-table` 393/393 and `lance` 3397/3398 pass (the one failure is a pre-existing IVF recall flake that passes on re-run and is untouched by this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0157WZkXSPWn4Fnycj7JaZP6