### PR TITLE
feat(format): record the requested IVF partition count on a vector index

### DIFF
--- a/docs/src/format/index/vector/index.md
+++ b/docs/src/format/index/vector/index.md
@@ -61,17 +61,19 @@ message. These are the parameters an engine needs to rebuild the index without
 reading the index files: the distance metric, the quantization scheme, and the
 partitioning the index was asked for.
 
-`num_partitions` records the IVF partition count the index was asked to train. It
-is absent when no count was requested, in which case the partitioning was derived
-from the data and an engine rebuilding the index derives it again. When present, a
-rebuild starts from that count, and may still train fewer partitions when the data
-cannot support them. A segment that covers no fragments carries these details with
-no index files, so a recorded count is the only statement of the partitioning the
-index is to be built with once its column holds enough vectors to train.
+`target_num_partitions` records the IVF partition count the index was asked to
+train. It is a request, not a description of the index that was built: a build
+trains fewer partitions when the data cannot support the count asked for, so the
+number of partitions an index holds is read from the index itself and not from
+here. It is absent when no count was requested, in which case the partitioning was
+derived from the data and an engine rebuilding the index derives it again. A
+segment that covers no fragments carries these details with no index files, so a
+recorded count is the only statement of the partitioning the index is to be built
+with once its column holds enough vectors to train.
 
 `target_partition_size` records the target number of vectors per partition, and is
-0 when unset. An engine that is given neither value derives the partitioning from
-the data alone.
+0 when unset. `target_num_partitions` takes precedence when both are set. An engine
+given neither derives the partitioning from the data alone.
 
 `runtime_hints` carries optional build preferences that do not affect index
 structure, keyed by reverse-DNS name. Unrecognized keys must be silently ignored.

--- a/docs/src/format/index/vector/index.md
+++ b/docs/src/format/index/vector/index.md
@@ -53,6 +53,38 @@ The Lance vector index format has gone through 3 versions so far.
 This document currently only records version 3 which is the latest version.
 The specific version of the vector index is recorded in the `index_version` field of the generic [index metadata](../index.md#loading-an-index).
 
+### Index Details
+
+An index segment records its build parameters in the `index_details` field of the
+generic [index metadata](../index.md#loading-an-index), as a `VectorIndexDetails`
+message. These are the parameters an engine needs to rebuild the index without
+reading the index files: the distance metric, the quantization scheme, and the
+partitioning the index was asked for.
+
+`num_partitions` records the IVF partition count the index was asked to train. It
+is absent when no count was requested, in which case the partitioning was derived
+from the data and an engine rebuilding the index derives it again. When present, a
+rebuild starts from that count, and may still train fewer partitions when the data
+cannot support them. A segment that covers no fragments carries these details with
+no index files, so a recorded count is the only statement of the partitioning the
+index is to be built with once its column holds enough vectors to train.
+
+`target_partition_size` records the target number of vectors per partition, and is
+0 when unset. An engine that is given neither value derives the partitioning from
+the data alone.
+
+`runtime_hints` carries optional build preferences that do not affect index
+structure, keyed by reverse-DNS name. Unrecognized keys must be silently ignored.
+
+<details>
+  <summary>Full protobuf definition</summary>
+
+```protobuf
+%%% proto.message.VectorIndexDetails %%%
+```
+
+</details>
+
 ## Storage Layout (V3)
 
 Each vector index is stored as 2 regular Lance files - index file and auxiliary file.

--- a/docs/src/format/index/vector/index.md
+++ b/docs/src/format/index/vector/index.md
@@ -71,6 +71,10 @@ segment that covers no fragments carries these details with no index files, so a
 recorded count is the only statement of the partitioning the index is to be built
 with once its column holds enough vectors to train.
 
+A recorded count is at least 1. A writer that cannot represent the count it was
+given records nothing rather than a truncated value, and a reader treats 0 as no
+request, so a partitioning is never derived from a count of zero.
+
 `target_partition_size` records the target number of vectors per partition, and is
 0 when unset. `target_num_partitions` takes precedence when both are set. An engine
 given neither derives the partitioning from the data alone.

--- a/docs/src/format/index/vector/index.md
+++ b/docs/src/format/index/vector/index.md
@@ -66,10 +66,10 @@ train. It is a request, not a description of the index that was built: a build
 trains fewer partitions when the data cannot support the count asked for, so the
 number of partitions an index holds is read from the index itself and not from
 here. It is absent when no count was requested, in which case the partitioning was
-derived from the data and an engine rebuilding the index derives it again. A
-segment that covers no fragments carries these details with no index files, so a
-recorded count is the only statement of the partitioning the index is to be built
-with once its column holds enough vectors to train.
+derived from the data and an engine rebuilding the index derives it again. Where
+a segment covers no fragments and carries no index files, a recorded count is the
+only statement of the partitioning the index is to be built with once its column
+holds enough vectors to train.
 
 A recorded count is at least 1. A writer that cannot represent the count it was
 given records nothing rather than a truncated value, and a reader treats 0 as no

--- a/docs/src/format/index/vector/index.md
+++ b/docs/src/format/index/vector/index.md
@@ -61,23 +61,21 @@ message. These are the parameters an engine needs to rebuild the index without
 reading the index files: the distance metric, the quantization scheme, and the
 partitioning the index was asked for.
 
-`target_num_partitions` records the IVF partition count the index was asked to
-train. It is a request, not a description of the index that was built: a build
-trains fewer partitions when the data cannot support the count asked for, so the
-number of partitions an index holds is read from the index itself and not from
-here. It is absent when no count was requested, in which case the partitioning was
-derived from the data and an engine rebuilding the index derives it again. Where
-a segment covers no fragments and carries no index files, a recorded count is the
-only statement of the partitioning the index is to be built with once its column
-holds enough vectors to train.
-
-A recorded count is at least 1. A writer that cannot represent the count it was
-given records nothing rather than a truncated value, and a reader treats 0 as no
-request, so a partitioning is never derived from a count of zero.
+`target_num_partitions` records the IVF partition count requested for building or
+rebuilding the index. The count an index actually holds may differ from it and is
+read from the index files. Where a segment covers no fragments and carries no
+index files, this field preserves an explicit partition-count request that has no
+built index to read it from.
 
 `target_partition_size` records the target number of vectors per partition, and is
-0 when unset. `target_num_partitions` takes precedence when both are set. An engine
-given neither derives the partitioning from the data alone.
+0 when unset. A positive `target_num_partitions` takes precedence over it. Absent
+or zero means no explicit count is available: a rebuild uses
+`target_partition_size` when that is positive, and the engine's own sizing
+otherwise. Absence does not imply the original build used automatic sizing, since
+a writer that predates this field records no count either way.
+
+Writers record only positive, representable counts, and omit a count they cannot
+represent rather than truncating it.
 
 `runtime_hints` carries optional build preferences that do not affect index
 structure, keyed by reverse-DNS name. Unrecognized keys must be silently ignored.

--- a/protos/index.proto
+++ b/protos/index.proto
@@ -229,6 +229,15 @@ message VectorIndexDetails {
    * Unrecognized keys must be silently ignored by all runtimes.
    */
   map<string, string> runtime_hints = 9;
+
+  /* The number of IVF partitions this index was asked to train.
+   *
+   * Absent when no count was requested, in which case the partitioning was
+   * derived from the data and a rebuild derives it again. Present when a caller
+   * named a count: a rebuild starts from that count, and may still train fewer
+   * partitions when the data cannot support them.
+   */
+  optional uint32 num_partitions = 10;
 }
 
 // Hierarchical Navigable Small World (HNSW) parameters, used as an optional configuration for IVF indexes.

--- a/protos/index.proto
+++ b/protos/index.proto
@@ -232,12 +232,15 @@ message VectorIndexDetails {
 
   /* The number of IVF partitions this index was asked to train.
    *
+   * A request, not a description of the index that was built: a build trains
+   * fewer partitions when the data cannot support the count asked for, so the
+   * partitions an index holds are read from the index itself.
+   *
    * Absent when no count was requested, in which case the partitioning was
-   * derived from the data and a rebuild derives it again. Present when a caller
-   * named a count: a rebuild starts from that count, and may still train fewer
-   * partitions when the data cannot support them.
+   * derived from the data and a rebuild derives it again. Takes precedence over
+   * `target_partition_size` when both are set.
    */
-  optional uint32 num_partitions = 10;
+  optional uint32 target_num_partitions = 10;
 }
 
 // Hierarchical Navigable Small World (HNSW) parameters, used as an optional configuration for IVF indexes.

--- a/protos/index.proto
+++ b/protos/index.proto
@@ -239,6 +239,10 @@ message VectorIndexDetails {
    * Absent when no count was requested, in which case the partitioning was
    * derived from the data and a rebuild derives it again. Takes precedence over
    * `target_partition_size` when both are set.
+   *
+   * A recorded count is at least 1, and a writer that cannot represent the
+   * count it was given records nothing rather than a truncated value. Readers
+   * treat 0 as no request.
    */
   optional uint32 target_num_partitions = 10;
 }

--- a/protos/index.proto
+++ b/protos/index.proto
@@ -230,19 +230,19 @@ message VectorIndexDetails {
    */
   map<string, string> runtime_hints = 9;
 
-  /* The number of IVF partitions this index was asked to train.
+  /* Requested IVF partition count for building or rebuilding this index.
    *
-   * A request, not a description of the index that was built: a build trains
-   * fewer partitions when the data cannot support the count asked for, so the
-   * partitions an index holds are read from the index itself.
+   * The actual partition count may differ from this target and is read from the
+   * index files.
    *
-   * Absent when no count was requested, in which case the partitioning was
-   * derived from the data and a rebuild derives it again. Takes precedence over
-   * `target_partition_size` when both are set.
+   * A positive value takes precedence over `target_partition_size`. Absent or
+   * zero means no explicit count is available: a rebuild uses
+   * `target_partition_size` when positive, and the engine's own sizing
+   * otherwise. Absence does not imply the original build used automatic sizing,
+   * since a writer that predates this field records no count either way.
    *
-   * A recorded count is at least 1, and a writer that cannot represent the
-   * count it was given records nothing rather than a truncated value. Readers
-   * treat 0 as no request.
+   * Writers record only positive, representable counts, and omit a count they
+   * cannot represent rather than truncating it.
    */
   optional uint32 target_num_partitions = 10;
 }

--- a/rust/lance/src/index/vector/details.rs
+++ b/rust/lance/src/index/vector/details.rs
@@ -162,6 +162,7 @@ pub fn vector_index_details(params: &VectorIndexParams) -> prost_types::Any {
         hnsw_index_config,
         compression,
         runtime_hints,
+        num_partitions: None,
     };
     prost_types::Any::from_msg(&details).unwrap()
 }
@@ -564,6 +565,7 @@ fn convert_legacy_proto_to_details(proto: &pb::Index) -> Result<prost_types::Any
         hnsw_index_config: None,
         compression,
         runtime_hints: Default::default(),
+        num_partitions: None,
     };
     Ok(prost_types::Any::from_msg(&details).unwrap())
 }
@@ -703,6 +705,7 @@ async fn convert_v3_metadata_to_details(
         hnsw_index_config,
         compression,
         runtime_hints: Default::default(),
+        num_partitions: None,
     };
     Ok(prost_types::Any::from_msg(&details).unwrap())
 }
@@ -752,6 +755,7 @@ mod tests {
             hnsw_index_config: hnsw,
             compression,
             runtime_hints: Default::default(),
+            num_partitions: None,
         };
         prost_types::Any::from_msg(&details).unwrap()
     }
@@ -901,6 +905,7 @@ mod tests {
                 hnsw_index_config: None,
                 compression: None,
                 runtime_hints: Default::default(),
+                num_partitions: None,
             };
             prost_types::Any::from_msg(&d).unwrap()
         };

--- a/rust/lance/src/index/vector/details.rs
+++ b/rust/lance/src/index/vector/details.rs
@@ -162,7 +162,7 @@ pub fn vector_index_details(params: &VectorIndexParams) -> prost_types::Any {
         hnsw_index_config,
         compression,
         runtime_hints,
-        num_partitions: None,
+        target_num_partitions: None,
     };
     prost_types::Any::from_msg(&details).unwrap()
 }
@@ -565,7 +565,7 @@ fn convert_legacy_proto_to_details(proto: &pb::Index) -> Result<prost_types::Any
         hnsw_index_config: None,
         compression,
         runtime_hints: Default::default(),
-        num_partitions: None,
+        target_num_partitions: None,
     };
     Ok(prost_types::Any::from_msg(&details).unwrap())
 }
@@ -705,7 +705,7 @@ async fn convert_v3_metadata_to_details(
         hnsw_index_config,
         compression,
         runtime_hints: Default::default(),
-        num_partitions: None,
+        target_num_partitions: None,
     };
     Ok(prost_types::Any::from_msg(&details).unwrap())
 }
@@ -755,7 +755,7 @@ mod tests {
             hnsw_index_config: hnsw,
             compression,
             runtime_hints: Default::default(),
-            num_partitions: None,
+            target_num_partitions: None,
         };
         prost_types::Any::from_msg(&details).unwrap()
     }
@@ -905,7 +905,7 @@ mod tests {
                 hnsw_index_config: None,
                 compression: None,
                 runtime_hints: Default::default(),
-                num_partitions: None,
+                target_num_partitions: None,
             };
             prost_types::Any::from_msg(&d).unwrap()
         };


### PR DESCRIPTION
Proposes recording the IVF partition count a vector index was asked to train, as `target_num_partitions` on `VectorIndexDetails`.

A vector index segment records its build parameters in `index_details` so an engine can rebuild the index without reading the index files. The partition count is not among them: `target_partition_size` records a target size per partition, and nothing records a requested count. An index rebuilt from its details is therefore auto-sized from the data, so an index created as IVF-8 comes back with whatever count the data suggests.

This matters most for a segment that covers no fragments. Such a segment carries its details with no index files at all, so the recorded parameters are the only statement of what the index is to become once its column holds enough vectors to train — and without the count it cannot reliably preserve the requested shape however far the table grows. That is the case behind #4034, where creating a vector index on a table too small to train its quantizer records the definition and fills it in later.

The field is a request, not a description of the index that was built. A build trains fewer partitions when the data cannot support the count asked for, so the partitions an index holds are read from the index itself. The name pairs with `target_partition_size`, the other way of asking for a partitioning, and the spec states that an explicit count wins when both are set. Absent means no count was requested, and a rebuild derives the partitioning from the data again.

`runtime_hints` is not the place for this. It is specified as optional build preferences that do not affect index structure, and requires that unrecognized keys be silently ignored. A partition count is exactly index structure — it is the number that defines the index's shape — so recording it there would contradict the field's stated contract and make an ignorable key load-bearing for readers that do recognize it.

A recorded count is at least 1. Zero partitions already fails badly on the build
path — KMeans indexes into an empty cluster list and panics — and a count is
easy to compute as zero, since `rows / target` is zero on a small table. What a
recorded count would add is distance: a definition writes no index, so nothing
rejects the count before the details record it, and the failure would surface on
a later rebuild instead of at the call that set it. The spec therefore requires a
reader to treat zero as no request, and a writer to record nothing rather than a
truncated value.

Field number 10 rather than 9's successor 7: the existing `compression` oneof skips 7 and the message carries no `reserved` statement, so I left the gap alone rather than assume it is free.

The new field is set nowhere in this PR; the five exhaustive struct literals updated are the minimum needed to compile. Reading and writing it lands in a follow-up alongside #9134.



