### PR TITLE
feat(transaction): stamp only the replaced offsets on DataReplacement

### DIFF
--- a/docs/src/format/table/transaction.md
+++ b/docs/src/format/table/transaction.md
@@ -466,6 +466,29 @@ The following operations are retryable conflicts with DataReplacement:
 A concurrent Delete or Update that only adds a deletion vector to a target fragment (without removing it) is compatible: the
 positional column file stays aligned and the rebase preserves the deletion vector.
 
+#### Replaced Offsets
+
+A replacement rewrites a whole column file, but its values may differ from the previous file on only some rows: a partial
+refresh, or a fill of rows that were null. `replaced_offset_bitmaps` lets the writer say which. It maps a replaced fragment's
+id to the physical row offsets whose values changed, encoded as a portable-serialized Roaring bitmap.
+
+When stable row ids are enabled, committing a replacement stamps `last_updated_at_version` (see
+[Row ID Lineage](row_id_lineage.md)) on each replaced fragment:
+
+- Absent, or absent for a fragment, or an empty bitmap: every row of that fragment takes the new version. This is what every
+  writer before this field produced.
+- Present for a fragment that already carries a `last_updated_at_version` sequence: only the listed offsets take the new
+  version; the other rows keep theirs.
+- Present for a fragment with no sequence to keep: every row takes the new version, since there is nothing to preserve.
+
+A writer must list every row whose value changed, including a row written as null that previously held a value. Listing
+rows that did not change is allowed and only over-stamps. Consumers must reject as invalid a transaction whose keys name a
+fragment that is not in `replacements`, whose bitmaps are not valid portable Roaring bitmaps, or whose offsets reach the
+fragment's physical row count.
+
+The field is additive: absent decodes as a full stamp, and readers that predate it ignore it, so no existing transaction
+changes meaning.
+
 ### DataOverlay
 
 Attaches [overlay files](data_overlay_file.md) to fragments, supplying new values

--- a/java/lance-jni/src/transaction.rs
+++ b/java/lance-jni/src/transaction.rs
@@ -1125,7 +1125,7 @@ fn convert_to_java_operation_inner<'local>(
             )?;
             Ok(java_operation)
         }
-        Operation::DataReplacement { replacements } => {
+        Operation::DataReplacement { replacements, .. } => {
             let java_replacements = export_vec(env, &replacements)?;
 
             Ok(env.new_object(
@@ -1998,7 +1998,10 @@ fn convert_to_rust_operation(
                 import_vec_from_method(env, java_operation, "replacements", |env, replacement| {
                     replacement.extract_object(env)
                 })?;
-            Operation::DataReplacement { replacements }
+            Operation::DataReplacement {
+                replacements,
+                replaced_offsets: None,
+            }
         }
         "DataOverlay" => {
             let groups = import_vec_from_method(env, java_operation, "getGroups", |env, group| {

--- a/protos/transaction.proto
+++ b/protos/transaction.proto
@@ -365,6 +365,14 @@ message Transaction {
   // An operation that replaces the data in a region of the table with new data.
   message DataReplacement {
     repeated DataReplacementGroup replacements = 1;
+    /* Per replaced fragment, the physical row offsets whose values changed,
+     * as portable RoaringBitmap bytes. Drives row-level last_updated_at_version
+     * stamping: only the listed offsets take the new version, the rest keep
+     * theirs. Absent, or absent for a fragment, stamps every row of it.
+     * Keys must name fragments in `replacements`; offsets must be below the
+     * fragment's physical row count.
+     */
+    map<uint64, bytes> replaced_offset_bitmaps = 2;
   }
 
   /* Overlay files to append to a single fragment, in order (the last entry is

--- a/python/src/transaction.rs
+++ b/python/src/transaction.rs
@@ -514,7 +514,10 @@ impl FromPyObject<'_, '_> for PyLance<Operation> {
             "DataReplacement" => {
                 let replacements = extract_vec(&ob.getattr("replacements")?)?;
 
-                let op = Operation::DataReplacement { replacements };
+                let op = Operation::DataReplacement {
+                    replacements,
+                    replaced_offsets: None,
+                };
 
                 Ok(Self(op))
             }
@@ -681,7 +684,7 @@ impl<'py> IntoPyObject<'py> for PyLance<&Operation> {
                     updated_fragment_offsets,
                 ))
             }
-            Operation::DataReplacement { replacements } => {
+            Operation::DataReplacement { replacements, .. } => {
                 let replacements = export_vec(py, replacements.as_slice())?;
                 let cls = namespace
                     .getattr("DataReplacement")

--- a/rust/lance-table/src/transaction/conflicts.rs
+++ b/rust/lance-table/src/transaction/conflicts.rs
@@ -198,9 +198,18 @@ impl PartialEq for Operation {
                     && a_field == b_field
             }
             (
-                Self::DataReplacement { replacements: a },
-                Self::DataReplacement { replacements: b },
-            ) => a.len() == b.len() && a.iter().all(|r| b.contains(r)),
+                Self::DataReplacement {
+                    replacements: a,
+                    replaced_offsets: a_offsets,
+                },
+                Self::DataReplacement {
+                    replacements: b,
+                    replaced_offsets: b_offsets,
+                },
+            ) => {
+                compare_vec(a, b)
+                    && a_offsets.as_ref().map(|o| &o.0) == b_offsets.as_ref().map(|o| &o.0)
+            }
             // Handle all remaining combinations.
             // We spell out all combinations explicitly to prevent
             // us accidentally handling a new case in the wrong way.

--- a/rust/lance-table/src/transaction/manifest_build.rs
+++ b/rust/lance-table/src/transaction/manifest_build.rs
@@ -943,7 +943,11 @@ impl Transaction {
             Operation::Restore { .. } => {
                 unreachable!()
             }
-            Operation::DataReplacement { replacements } => {
+            Operation::DataReplacement {
+                replacements,
+                replaced_offsets,
+                ..
+            } => {
                 log::warn!(
                     "Building manifest with DataReplacement operation. This operation is not stable yet, please use with caution."
                 );
@@ -1144,16 +1148,45 @@ impl Transaction {
 
                 // A replacement changes what its rows read as, so stamp them
                 // updated. Without this, get_updated_rows never reports them and
-                // an incremental consumer skips them for good.
+                // an incremental consumer skips them for good. A caller that
+                // changed only some rows says which; a fragment with no stamps
+                // to keep takes a full one.
                 if next_row_id.is_some() {
                     let new_version = current_manifest.map_or(1, |m| m.version + 1);
+                    let prev_version = current_manifest.map_or(0, |m| m.version);
                     for fragment in final_fragments
                         .iter_mut()
                         .filter(|f| fragments_changed.contains(&f.id))
                     {
-                        crate::rowids::version::refresh_row_latest_update_meta_for_full_frag_rewrite_cols(
+                        let partial = replaced_offsets
+                            .as_ref()
+                            .and_then(|UpdatedFragmentOffsets(m)| m.get(&fragment.id))
+                            .filter(|bitmap| !bitmap.is_empty())
+                            .filter(|_| fragment.last_updated_at_version_meta.is_some());
+                        let Some(bitmap) = partial else {
+                            crate::rowids::version::refresh_row_latest_update_meta_for_full_frag_rewrite_cols(
+                                fragment,
+                                new_version,
+                            )?;
+                            continue;
+                        };
+                        let physical_rows = fragment.physical_rows.unwrap_or(1 << 24);
+                        if bitmap.len() as usize > physical_rows
+                            || bitmap
+                                .max()
+                                .is_some_and(|max| max as usize >= physical_rows)
+                        {
+                            return Err(Error::invalid_input(format!(
+                                "replacedOffsets for fragment {} exceed its {} physical rows",
+                                fragment.id, physical_rows
+                            )));
+                        }
+                        let offsets: Vec<usize> = bitmap.iter().map(|o| o as usize).collect();
+                        crate::rowids::version::refresh_row_latest_update_meta_for_partial_frag_rewrite_cols(
                             fragment,
+                            &offsets,
                             new_version,
+                            prev_version,
                         )?;
                     }
                 }
@@ -1866,6 +1899,157 @@ mod tests {
         assert!(
             out.fragments[0].last_updated_at_version_meta.is_none(),
             "fragment with no prior version metadata must not have fabricated prev_version stamped on unmatched rows"
+        );
+    }
+
+    /// A replacement that says which rows it changed stamps only those; the
+    /// rest keep the version that last touched them. Without offsets, or on a
+    /// fragment with no stamps to keep, every row takes the new version.
+    #[test]
+    fn test_data_replacement_stamps_only_replaced_offsets() {
+        let stamped_at = |meta: &Option<RowDatasetVersionMeta>| -> Vec<u64> {
+            meta.as_ref()
+                .expect("stamped")
+                .load_sequence()
+                .unwrap()
+                .versions()
+                .collect()
+        };
+        let fragment_with = |version_meta: Option<RowDatasetVersionMeta>| {
+            let row_ids = RowIdSequence::from([10u64, 11, 12, 13, 14].as_slice());
+            Fragment {
+                id: 1,
+                files: vec![DataFile::new(
+                    "data.lance",
+                    vec![0],
+                    vec![0],
+                    LanceFileVersion::Stable.resolve(),
+                    None,
+                    None,
+                )],
+                overlays: vec![],
+                deletion_file: None,
+                row_id_meta: Some(RowIdMeta::Inline(write_row_ids(&row_ids).into())),
+                physical_rows: Some(5),
+                last_updated_at_version_meta: version_meta.clone(),
+                created_at_version_meta: version_meta,
+            }
+        };
+        let replacement = || {
+            DataReplacementGroup(
+                1,
+                DataFile::new(
+                    "replaced.lance",
+                    vec![0],
+                    vec![0],
+                    LanceFileVersion::Stable.resolve(),
+                    None,
+                    None,
+                ),
+            )
+        };
+        let build = |fragment: Fragment, replaced_offsets: Option<UpdatedFragmentOffsets>| {
+            let manifest = make_stable_row_id_manifest(vec![fragment]);
+            let tx = Transaction::new(
+                manifest.version,
+                Operation::DataReplacement {
+                    replacements: vec![replacement()],
+                    replaced_offsets,
+                },
+                None,
+            );
+            let (out, _) = tx
+                .build_manifest(Some(&manifest), vec![], "txn", &default_build_config())
+                .unwrap();
+            (out, manifest.version + 1)
+        };
+        let stamped_v1 = Some(
+            RowDatasetVersionMeta::from_sequence(
+                &RowDatasetVersionSequence::from_uniform_row_count(5, 1),
+            )
+            .unwrap(),
+        );
+        let partial = || {
+            Some(UpdatedFragmentOffsets(HashMap::from([(
+                1u64,
+                RoaringBitmap::from_iter([1u32, 3]),
+            )])))
+        };
+
+        let (out, new_version) = build(fragment_with(stamped_v1.clone()), partial());
+        assert_eq!(
+            stamped_at(&out.fragments[0].last_updated_at_version_meta),
+            vec![1, new_version, 1, new_version, 1],
+            "only the replaced offsets take the new version"
+        );
+
+        let (out, new_version) = build(fragment_with(stamped_v1), None);
+        assert_eq!(
+            stamped_at(&out.fragments[0].last_updated_at_version_meta),
+            vec![new_version; 5],
+            "no offsets means the whole fragment was replaced"
+        );
+
+        let (out, new_version) = build(fragment_with(None), partial());
+        assert_eq!(
+            stamped_at(&out.fragments[0].last_updated_at_version_meta),
+            vec![new_version; 5],
+            "a fragment with no stamps cannot keep any, so it takes a full one"
+        );
+    }
+
+    #[test]
+    fn test_data_replacement_offsets_past_the_fragment_are_rejected() {
+        let row_ids = RowIdSequence::from([10u64, 11, 12, 13, 14].as_slice());
+        let version_meta = RowDatasetVersionMeta::from_sequence(
+            &RowDatasetVersionSequence::from_uniform_row_count(5, 1),
+        )
+        .unwrap();
+        let fragment = Fragment {
+            id: 1,
+            files: vec![DataFile::new(
+                "data.lance",
+                vec![0],
+                vec![0],
+                LanceFileVersion::Stable.resolve(),
+                None,
+                None,
+            )],
+            overlays: vec![],
+            deletion_file: None,
+            row_id_meta: Some(RowIdMeta::Inline(write_row_ids(&row_ids).into())),
+            physical_rows: Some(5),
+            last_updated_at_version_meta: Some(version_meta.clone()),
+            created_at_version_meta: Some(version_meta),
+        };
+        let manifest = make_stable_row_id_manifest(vec![fragment]);
+        let tx = Transaction::new(
+            manifest.version,
+            Operation::DataReplacement {
+                replacements: vec![DataReplacementGroup(
+                    1,
+                    DataFile::new(
+                        "replaced.lance",
+                        vec![0],
+                        vec![0],
+                        LanceFileVersion::Stable.resolve(),
+                        None,
+                        None,
+                    ),
+                )],
+                replaced_offsets: Some(UpdatedFragmentOffsets(HashMap::from([(
+                    1u64,
+                    RoaringBitmap::from_iter([7u32]),
+                )]))),
+            },
+            None,
+        );
+        let error = tx
+            .build_manifest(Some(&manifest), vec![], "txn", &default_build_config())
+            .unwrap_err();
+        assert!(
+            error.to_string().contains("exceed its 5 physical rows"),
+            "{error}"
         );
     }
 
@@ -2742,6 +2926,7 @@ mod tests {
                     0,
                     DataFile::new_legacy_from_fields("f5-new.lance", vec![5], None),
                 )],
+                replaced_offsets: None,
             },
             None,
         );
@@ -2802,6 +2987,7 @@ mod tests {
                         None,
                     ),
                 )],
+                replaced_offsets: None,
             },
             None,
         );

--- a/rust/lance-table/src/transaction/operation.rs
+++ b/rust/lance-table/src/transaction/operation.rs
@@ -107,6 +107,9 @@ pub enum Operation {
     /// with a new column A, the operation is not allowed.
     DataReplacement {
         replacements: Vec<DataReplacementGroup>,
+        /// Rows whose values changed, for row-level `last_updated` stamping.
+        /// `None` stamps every row.
+        replaced_offsets: Option<UpdatedFragmentOffsets>,
     },
     /// Attach overlay files to fragments, supplying new values for a subset of
     /// `(physical offset, field)` cells without rewriting the fragments' base

--- a/rust/lance-table/src/transaction/proto.rs
+++ b/rust/lance-table/src/transaction/proto.rs
@@ -25,6 +25,40 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use uuid::Uuid;
 
+/// Per-fragment offsets as RoaringBitmap bytes, the `Update` encoding.
+fn offset_bitmaps_to_proto(offsets: Option<&UpdatedFragmentOffsets>) -> HashMap<u64, Vec<u8>> {
+    offsets
+        .map(|UpdatedFragmentOffsets(m)| {
+            m.iter()
+                .filter(|(_, b)| !b.is_empty())
+                .map(|(frag_id, b)| {
+                    let mut buf = Vec::new();
+                    b.serialize_into(&mut buf)
+                        .expect("RoaringBitmap serialization cannot fail");
+                    (*frag_id, buf)
+                })
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+fn offset_bitmaps_from_proto(
+    bitmaps: HashMap<u64, Vec<u8>>,
+    what: &str,
+) -> Result<Option<UpdatedFragmentOffsets>> {
+    let m = bitmaps
+        .into_iter()
+        .filter(|(_, bytes)| !bytes.is_empty())
+        .map(|(id, bytes)| {
+            let bitmap = RoaringBitmap::deserialize_from(bytes.as_slice()).map_err(|e| {
+                Error::invalid_input(format!("invalid {what} for fragment {id}: {e}"))
+            })?;
+            Ok((id, bitmap))
+        })
+        .collect::<Result<HashMap<_, _>>>()?;
+    Ok((!m.is_empty()).then_some(UpdatedFragmentOffsets(m)))
+}
+
 impl From<&DataReplacementGroup> for pb::transaction::DataReplacementGroup {
     fn from(DataReplacementGroup(fragment_id, new_file): &DataReplacementGroup) -> Self {
         Self {
@@ -373,12 +407,19 @@ impl TryFrom<pb::Transaction> for Transaction {
                 }
             }
             Some(pb::transaction::Operation::DataReplacement(
-                pb::transaction::DataReplacement { replacements, .. },
+                pb::transaction::DataReplacement {
+                    replacements,
+                    replaced_offset_bitmaps,
+                },
             )) => Operation::DataReplacement {
                 replacements: replacements
                     .into_iter()
                     .map(DataReplacementGroup::try_from)
                     .collect::<Result<Vec<_>>>()?,
+                replaced_offsets: offset_bitmaps_from_proto(
+                    replaced_offset_bitmaps,
+                    "replaced_offset_bitmaps",
+                )?,
             },
             Some(pb::transaction::Operation::UpdateMemWalState(
                 pb::transaction::UpdateMemWalState { compacted_sstables },
@@ -673,15 +714,16 @@ impl From<&Transaction> for pb::Transaction {
                 schema_metadata: Default::default(),
                 field_metadata: Default::default(),
             }),
-            Operation::DataReplacement { replacements } => {
-                pb::transaction::Operation::DataReplacement(pb::transaction::DataReplacement {
-                    replacements: replacements
-                        .iter()
-                        .map(pb::transaction::DataReplacementGroup::from)
-                        .collect(),
-                    replaced_offset_bitmaps: Default::default(),
-                })
-            }
+            Operation::DataReplacement {
+                replacements,
+                replaced_offsets,
+            } => pb::transaction::Operation::DataReplacement(pb::transaction::DataReplacement {
+                replacements: replacements
+                    .iter()
+                    .map(pb::transaction::DataReplacementGroup::from)
+                    .collect(),
+                replaced_offset_bitmaps: offset_bitmaps_to_proto(replaced_offsets.as_ref()),
+            }),
             Operation::DataOverlay { groups } => {
                 pb::transaction::Operation::DataOverlay(pb::transaction::DataOverlay {
                     groups: groups
@@ -811,6 +853,50 @@ mod tests {
     use super::*;
     use crate::format::DataFile;
     use crate::format::overlay::OverlayCoverage;
+
+    /// A DataReplacement's source fields and replaced offsets survive the
+    /// protobuf round-trip; absent on the wire, they read back as no
+    /// dependencies and no offsets, which is what every older writer produced.
+    #[test]
+    fn test_data_replacement_dependencies_roundtrip() {
+        let operation = Operation::DataReplacement {
+            replacements: vec![DataReplacementGroup(
+                4,
+                DataFile::new_legacy_from_fields("replacement.lance", vec![7], None),
+            )],
+            replaced_offsets: Some(UpdatedFragmentOffsets(HashMap::from([(
+                4,
+                roaring::RoaringBitmap::from_iter([2u32, 5, 9]),
+            )]))),
+        };
+        let transaction = Transaction::new(1, operation.clone(), None);
+        let message = pb::Transaction::from(&transaction);
+        let read_back = Transaction::try_from(message).unwrap();
+        assert_eq!(read_back.operation, operation);
+
+        let legacy = pb::Transaction {
+            read_version: 1,
+            uuid: Uuid::new_v4().to_string(),
+            operation: Some(pb::transaction::Operation::DataReplacement(
+                pb::transaction::DataReplacement {
+                    replacements: vec![pb::transaction::DataReplacementGroup::from(
+                        &DataReplacementGroup(
+                            4,
+                            DataFile::new_legacy_from_fields("replacement.lance", vec![7], None),
+                        ),
+                    )],
+                    ..Default::default()
+                },
+            )),
+            ..Default::default()
+        };
+        match Transaction::try_from(legacy).unwrap().operation {
+            Operation::DataReplacement {
+                replaced_offsets, ..
+            } => assert!(replaced_offsets.is_none()),
+            other => panic!("expected DataReplacement, got {other:?}"),
+        }
+    }
 
     #[test]
     fn test_data_overlay_operation_roundtrips() {

--- a/rust/lance-table/src/transaction/proto.rs
+++ b/rust/lance-table/src/transaction/proto.rs
@@ -373,7 +373,7 @@ impl TryFrom<pb::Transaction> for Transaction {
                 }
             }
             Some(pb::transaction::Operation::DataReplacement(
-                pb::transaction::DataReplacement { replacements },
+                pb::transaction::DataReplacement { replacements, .. },
             )) => Operation::DataReplacement {
                 replacements: replacements
                     .into_iter()
@@ -679,6 +679,7 @@ impl From<&Transaction> for pb::Transaction {
                         .iter()
                         .map(pb::transaction::DataReplacementGroup::from)
                         .collect(),
+                    replaced_offset_bitmaps: Default::default(),
                 })
             }
             Operation::DataOverlay { groups } => {

--- a/rust/lance-table/src/transaction/validate.rs
+++ b/rust/lance-table/src/transaction/validate.rs
@@ -94,6 +94,24 @@ pub fn validate_operation(manifest: Option<&Manifest>, operation: &Operation) ->
             }
             Ok(())
         }
+        // The offsets stamp version metadata by fragment id, so a key outside
+        // the replacements would corrupt an unrelated fragment's metadata.
+        Operation::DataReplacement {
+            replacements,
+            replaced_offsets: Some(UpdatedFragmentOffsets(off_map)),
+            ..
+        } => {
+            let replaced_ids: HashSet<u64> = replacements.iter().map(|r| r.0).collect();
+            for &frag_id in off_map.keys() {
+                if !replaced_ids.contains(&frag_id) {
+                    return Err(Error::invalid_input(format!(
+                        "replacedOffsets key {frag_id} is not in replacements; \
+                         offsets must reference only fragments being replaced"
+                    )));
+                }
+            }
+            Ok(())
+        }
         _ => Ok(()),
     }
 }
@@ -425,6 +443,35 @@ mod tests {
     use roaring::RoaringBitmap;
     use std::collections::HashMap;
     use std::sync::Arc;
+
+    /// An offsets key outside the replacements would stamp an unrelated
+    /// fragment's version metadata.
+    #[test]
+    fn test_data_replacement_offsets_must_name_a_replaced_fragment() {
+        use crate::format::DataFile;
+        use crate::transaction::DataReplacementGroup;
+        use roaring::RoaringBitmap;
+        use std::collections::HashMap;
+        let replacement = DataReplacementGroup(
+            3,
+            DataFile::new_legacy_from_fields("replacement.lance", vec![0], None),
+        );
+        let manifest =
+            crate::transaction::test_support::make_stable_row_id_manifest(vec![Fragment::new(3)]);
+        let with_offsets = |fragment_id: u64| Operation::DataReplacement {
+            replacements: vec![replacement.clone()],
+            replaced_offsets: Some(UpdatedFragmentOffsets(HashMap::from([(
+                fragment_id,
+                RoaringBitmap::from_iter([0u32]),
+            )]))),
+        };
+        assert!(validate_operation(Some(&manifest), &with_offsets(3)).is_ok());
+        let error = validate_operation(Some(&manifest), &with_offsets(4)).unwrap_err();
+        assert!(
+            error.to_string().contains("is not in replacements"),
+            "{error}"
+        );
+    }
 
     #[test]
     fn test_merge_fragments_valid() {

--- a/rust/lance/src/dataset/blob.rs
+++ b/rust/lance/src/dataset/blob.rs
@@ -5986,6 +5986,7 @@ mod tests {
             uuid: Uuid::new_v4().hyphenated().to_string(),
             operation: Operation::DataReplacement {
                 replacements: vec![DataReplacementGroup(0, data_file)],
+                replaced_offsets: None,
             },
             tag: None,
             transaction_properties: None,
@@ -6169,6 +6170,7 @@ mod tests {
             uuid: Uuid::new_v4().hyphenated().to_string(),
             operation: Operation::DataReplacement {
                 replacements: vec![DataReplacementGroup(0, data_file)],
+                replaced_offsets: None,
             },
             tag: None,
             transaction_properties: None,

--- a/rust/lance/src/dataset/tests/data_file_part.rs
+++ b/rust/lance/src/dataset/tests/data_file_part.rs
@@ -93,6 +93,7 @@ async fn commit(dataset: &Dataset, replacement: DataReplacementGroup) -> Result<
         WriteDestination::Dataset(Arc::new(dataset.clone())),
         Operation::DataReplacement {
             replacements: vec![replacement],
+            replaced_offsets: None,
         },
         Some(dataset.version_id()),
         None,

--- a/rust/lance/src/dataset/tests/dataset_index.rs
+++ b/rust/lance/src/dataset/tests/dataset_index.rs
@@ -2976,6 +2976,7 @@ async fn test_partial_compound_hybrid_prunes_same_path_different_base_rewrite() 
         WriteDestination::Dataset(Arc::new(dataset)),
         Operation::DataReplacement {
             replacements: vec![DataReplacementGroup(1, replacement_file)],
+            replaced_offsets: None,
         },
         Some(read_version),
         None,

--- a/rust/lance/src/dataset/tests/dataset_merge_update.rs
+++ b/rust/lance/src/dataset/tests/dataset_merge_update.rs
@@ -690,6 +690,7 @@ async fn test_datafile_replacement() {
         WriteDestination::Dataset(dataset.clone()),
         Operation::DataReplacement {
             replacements: vec![],
+            replaced_offsets: None,
         },
         Some(1),
         None,
@@ -719,6 +720,7 @@ async fn test_datafile_replacement() {
         WriteDestination::Dataset(Arc::new(dataset)),
         Operation::DataReplacement {
             replacements: vec![],
+            replaced_offsets: None,
         },
         Some(3),
         None,
@@ -773,6 +775,7 @@ async fn test_datafile_replacement() {
         WriteDestination::Dataset(Arc::new(dataset)),
         Operation::DataReplacement {
             replacements: vec![DataReplacementGroup(0, new_data_file)],
+            replaced_offsets: None,
         },
         Some(4),
         None,
@@ -890,6 +893,7 @@ async fn test_datafile_partial_replacement() {
         WriteDestination::Dataset(Arc::new(dataset)),
         Operation::DataReplacement {
             replacements: vec![DataReplacementGroup(0, new_data_file)],
+            replaced_offsets: None,
         },
         Some(3),
         None,
@@ -951,6 +955,7 @@ async fn test_datafile_partial_replacement() {
         WriteDestination::Dataset(Arc::new(dataset)),
         Operation::DataReplacement {
             replacements: vec![DataReplacementGroup(0, new_data_file)],
+            replaced_offsets: None,
         },
         Some(4),
         None,
@@ -1056,6 +1061,7 @@ async fn test_datafile_replacement_error() {
         WriteDestination::Dataset(Arc::new(dataset.clone())),
         Operation::DataReplacement {
             replacements: vec![DataReplacementGroup(0, new_data_file)],
+            replaced_offsets: None,
         },
         // read at the current version (after the Merge above)
         Some(dataset.manifest.version),
@@ -2621,6 +2627,7 @@ async fn test_data_replacement_advances_row_lineage() {
         WriteDestination::Dataset(Arc::new(dataset)),
         Operation::DataReplacement {
             replacements: vec![DataReplacementGroup(0, new_data_file)],
+            replaced_offsets: None,
         },
         Some(read_version),
         None,
@@ -2730,6 +2737,7 @@ async fn test_data_replacement_invalidates_index_bitmap() {
         WriteDestination::Dataset(Arc::new(dataset)),
         Operation::DataReplacement {
             replacements: vec![DataReplacementGroup(0, new_data_file)],
+            replaced_offsets: None,
         },
         Some(read_version),
         None,
@@ -3014,6 +3022,7 @@ async fn test_data_replacement_populates_invalidated_bitmap() {
         WriteDestination::Dataset(Arc::new(dataset)),
         Operation::DataReplacement {
             replacements: vec![DataReplacementGroup(0, new_data_file)],
+            replaced_offsets: None,
         },
         Some(read_version),
         None,
@@ -3133,6 +3142,7 @@ async fn test_fts_stale_entries_after_data_replacement() {
         WriteDestination::Dataset(Arc::new(dataset)),
         Operation::DataReplacement {
             replacements: vec![DataReplacementGroup(1, new_data_file)],
+            replaced_offsets: None,
         },
         Some(read_version),
         None,
@@ -3273,6 +3283,7 @@ async fn test_cross_column_fast_search_blocks_column_local_stale_postings() {
         WriteDestination::Dataset(Arc::new(dataset)),
         Operation::DataReplacement {
             replacements: vec![DataReplacementGroup(1, replacement_file)],
+            replaced_offsets: None,
         },
         Some(read_version),
         None,
@@ -3444,6 +3455,7 @@ async fn test_vector_index_after_data_replacement() {
         WriteDestination::Dataset(Arc::new(dataset)),
         Operation::DataReplacement {
             replacements: vec![DataReplacementGroup(frag1_id, new_data_file)],
+            replaced_offsets: None,
         },
         Some(read_version),
         None,

--- a/rust/lance/src/dataset/tests/fragment_write_columns.rs
+++ b/rust/lance/src/dataset/tests/fragment_write_columns.rs
@@ -97,7 +97,10 @@ async fn commit(dataset: &Dataset, replacements: Vec<DataReplacementGroup>) -> R
     let read_version = dataset.manifest.version;
     Dataset::commit(
         WriteDestination::Dataset(Arc::new(dataset.clone())),
-        Operation::DataReplacement { replacements },
+        Operation::DataReplacement {
+            replacements,
+            replaced_offsets: None,
+        },
         Some(read_version),
         None,
         None,

--- a/rust/lance/src/io/commit/conflict_resolver.rs
+++ b/rust/lance/src/io/commit/conflict_resolver.rs
@@ -178,7 +178,7 @@ impl<'a> TransactionRebase<'a> {
                     conflicting_mem_wal_compacted_sstables: Vec::new(),
                 })
             }
-            Operation::DataReplacement { replacements } => {
+            Operation::DataReplacement { replacements, .. } => {
                 let modified_fragment_ids =
                     replacements.iter().map(|r| r.0).collect::<HashSet<_>>();
                 let initial_fragments =
@@ -886,7 +886,7 @@ impl<'a> TransactionRebase<'a> {
                     }
                 }
                 Operation::UpdateConfig { .. } => Ok(()),
-                Operation::DataReplacement { replacements } => {
+                Operation::DataReplacement { replacements, .. } => {
                     // A data replacement only conflicts if it is updating a field the
                     // index depends on -- whether keyed on or merely carried, since
                     // `fields` lists both (see `IndexMetadata::covering_fields`).
@@ -1006,7 +1006,7 @@ impl<'a> TransactionRebase<'a> {
                         Ok(())
                     }
                 }
-                Operation::DataReplacement { replacements } => {
+                Operation::DataReplacement { replacements, .. } => {
                     // These conflict if the rewrite touches any of the fragments being replaced.
                     for replacement in replacements {
                         for group in groups {
@@ -1208,14 +1208,12 @@ impl<'a> TransactionRebase<'a> {
         other_transaction: &Transaction,
         other_version: u64,
     ) -> Result<()> {
-        if let Operation::DataReplacement { replacements } = &self.transaction.operation {
+        if let Operation::DataReplacement { replacements, .. } = &self.transaction.operation {
             match &other_transaction.operation {
                 Operation::Append { .. }
                 | Operation::Clone { .. }
                 | Operation::UpdateConfig { .. }
                 | Operation::ReserveFragments { .. }
-                // Both a column replacement and an overlay preserve physical row
-                // addresses; the overlay is newer and wins its covered cells.
                 | Operation::DataOverlay { .. }
                 | Operation::UpdateBases { .. } => Ok(()),
                 Operation::Project { schema, .. } => {
@@ -1339,6 +1337,7 @@ impl<'a> TransactionRebase<'a> {
                 }
                 Operation::DataReplacement {
                     replacements: other_replacements,
+                    ..
                 } => {
                     // These conflict if there is overlap in fragment id && fields.
                     for replacement in replacements {
@@ -3657,6 +3656,7 @@ mod tests {
                         1,
                         DataFile::new_legacy_from_fields("r.lance", vec![0], None),
                     )],
+                    replaced_offsets: None,
                 },
                 Compatible,
             ),
@@ -4025,6 +4025,7 @@ mod tests {
                 "replacement",
                 Operation::DataReplacement {
                     replacements: vec![DataReplacementGroup(0, file())],
+                    replaced_offsets: None,
                 },
             ),
             (
@@ -4988,7 +4989,7 @@ mod tests {
                     .map(|f| f.id)
                     .chain(removed_fragment_ids.iter().copied()),
             ),
-            Operation::DataReplacement { replacements } => {
+            Operation::DataReplacement { replacements, .. } => {
                 Box::new(replacements.iter().map(|r| r.0))
             }
             Operation::DataOverlay { groups } => Box::new(groups.iter().map(|g| g.fragment_id)),
@@ -5014,9 +5015,11 @@ mod tests {
                 "Different fragments",
                 Operation::DataReplacement {
                     replacements: vec![DataReplacementGroup(0, data_file_frag0_fields01.clone())],
+                    replaced_offsets: None,
                 },
                 Operation::DataReplacement {
                     replacements: vec![DataReplacementGroup(1, data_file_frag1_fields01)],
+                    replaced_offsets: None,
                 },
                 Compatible,
             ),
@@ -5024,9 +5027,11 @@ mod tests {
                 "Same fragment, different fields",
                 Operation::DataReplacement {
                     replacements: vec![DataReplacementGroup(0, data_file_frag0_fields01.clone())],
+                    replaced_offsets: None,
                 },
                 Operation::DataReplacement {
                     replacements: vec![DataReplacementGroup(0, data_file_frag0_fields23)],
+                    replaced_offsets: None,
                 },
                 Compatible,
             ),
@@ -5034,9 +5039,11 @@ mod tests {
                 "Same fragment, same fields",
                 Operation::DataReplacement {
                     replacements: vec![DataReplacementGroup(0, data_file_frag0_fields01.clone())],
+                    replaced_offsets: None,
                 },
                 Operation::DataReplacement {
                     replacements: vec![DataReplacementGroup(0, data_file_frag0_fields01.clone())],
+                    replaced_offsets: None,
                 },
                 Retryable,
             ),
@@ -5044,12 +5051,14 @@ mod tests {
                 "Same fragment, overlapping fields",
                 Operation::DataReplacement {
                     replacements: vec![DataReplacementGroup(0, data_file_frag0_fields01.clone())],
+                    replaced_offsets: None,
                 },
                 Operation::DataReplacement {
                     replacements: vec![DataReplacementGroup(
                         0,
                         DataFile::new_legacy_from_fields("path0_12", vec![1, 2], None),
                     )],
+                    replaced_offsets: None,
                 },
                 Retryable,
             ),
@@ -5057,6 +5066,7 @@ mod tests {
                 "DataReplacement vs Rewrite on same fragment",
                 Operation::DataReplacement {
                     replacements: vec![DataReplacementGroup(0, data_file_frag0_fields01.clone())],
+                    replaced_offsets: None,
                 },
                 Operation::Rewrite {
                     groups: vec![RewriteGroup {
@@ -5072,6 +5082,7 @@ mod tests {
                 "DataReplacement vs Rewrite on different fragment",
                 Operation::DataReplacement {
                     replacements: vec![DataReplacementGroup(0, data_file_frag0_fields01.clone())],
+                    replaced_offsets: None,
                 },
                 Operation::Rewrite {
                     groups: vec![RewriteGroup {
@@ -5090,6 +5101,7 @@ mod tests {
                 "DataReplacement vs Update (RewriteColumns) on a different field",
                 Operation::DataReplacement {
                     replacements: vec![DataReplacementGroup(0, data_file_frag0_fields01.clone())],
+                    replaced_offsets: None,
                 },
                 Operation::Update {
                     updated_fragments: vec![Fragment::new(0)],
@@ -5109,6 +5121,7 @@ mod tests {
                 "DataReplacement vs Update (RewriteColumns) with inserts on a different field",
                 Operation::DataReplacement {
                     replacements: vec![DataReplacementGroup(0, data_file_frag0_fields01.clone())],
+                    replaced_offsets: None,
                 },
                 Operation::Update {
                     updated_fragments: vec![Fragment::new(0)],
@@ -5127,6 +5140,7 @@ mod tests {
                 "DataReplacement vs Update (RewriteColumns) that rewrote one of our fields",
                 Operation::DataReplacement {
                     replacements: vec![DataReplacementGroup(0, data_file_frag0_fields01.clone())],
+                    replaced_offsets: None,
                 },
                 Operation::Update {
                     updated_fragments: vec![Fragment::new(0)],
@@ -5145,6 +5159,7 @@ mod tests {
                 "DataReplacement vs Update (RewriteRows) that moved our rows",
                 Operation::DataReplacement {
                     replacements: vec![DataReplacementGroup(0, data_file_frag0_fields01.clone())],
+                    replaced_offsets: None,
                 },
                 Operation::Update {
                     updated_fragments: vec![Fragment::new(0)],
@@ -5163,6 +5178,7 @@ mod tests {
                 "DataReplacement vs Update that removed our fragment",
                 Operation::DataReplacement {
                     replacements: vec![DataReplacementGroup(0, data_file_frag0_fields01.clone())],
+                    replaced_offsets: None,
                 },
                 Operation::Update {
                     updated_fragments: vec![],
@@ -5181,6 +5197,7 @@ mod tests {
                 "DataReplacement vs Update (RewriteRows) that moved a different fragment's rows",
                 Operation::DataReplacement {
                     replacements: vec![DataReplacementGroup(0, data_file_frag0_fields01.clone())],
+                    replaced_offsets: None,
                 },
                 Operation::Update {
                     updated_fragments: vec![Fragment::new(1)],
@@ -5199,6 +5216,7 @@ mod tests {
                 "DataReplacement vs Delete (deletion-vector only) on same fragment",
                 Operation::DataReplacement {
                     replacements: vec![DataReplacementGroup(0, data_file_frag0_fields01.clone())],
+                    replaced_offsets: None,
                 },
                 Operation::Delete {
                     deleted_fragment_ids: vec![],
@@ -5211,6 +5229,7 @@ mod tests {
                 "DataReplacement vs Delete that removes the fragment",
                 Operation::DataReplacement {
                     replacements: vec![DataReplacementGroup(0, data_file_frag0_fields01.clone())],
+                    replaced_offsets: None,
                 },
                 Operation::Delete {
                     deleted_fragment_ids: vec![0],
@@ -5224,6 +5243,7 @@ mod tests {
                 "DataReplacement vs Merge",
                 Operation::DataReplacement {
                     replacements: vec![DataReplacementGroup(0, data_file_frag0_fields01)],
+                    replaced_offsets: None,
                 },
                 Operation::Merge {
                     fragments: vec![Fragment::new(0)],
@@ -5264,6 +5284,7 @@ mod tests {
                         0,
                         DataFile::new_legacy_from_fields("path0_3", vec![3], None),
                     )],
+                    replaced_offsets: None,
                 },
                 Retryable,
             ),


### PR DESCRIPTION
Stacked on #9138, which adds the field; the first commit here is that spec change and the second is this implementation.

The manifest build stamps `last_updated_at_version` on the listed offsets of each replaced fragment and leaves the rest at their previous version, falling back to a full stamp for a fragment with no sequence to keep. Offsets past the fragment's physical rows are rejected at build time, and keys naming a fragment outside the replacements at validation, so a bad bitmap cannot corrupt an unrelated fragment's metadata. Absent offsets stamp every row, which is what every existing writer produced.

The Python and Java bindings construct the operation without offsets, as before; exposing the field there is a follow-up.
