### PR TITLE
feat(index): support cloning tagged fragment reuse histories

### DIFF
--- a/rust/lance-table/src/system_index/frag_reuse/metadata.rs
+++ b/rust/lance-table/src/system_index/frag_reuse/metadata.rs
@@ -32,9 +32,13 @@ pub fn validate_flags(manifest: &Manifest, indices: &[IndexMetadata]) -> Result<
     Ok(())
 }
 
-/// Cloning requires relocation of external mappings, which is not implemented yet.
+/// Deep-cloning a tagged history would need every referenced row-map file
+/// copied and its stable-partition references relocated, which no writer
+/// implements. Shallow clone does not consult this: it relocates the
+/// references in the `lance` crate instead (the decode machinery lives
+/// there), rejecting on its own any content it cannot fully interpret.
 /// A sticky flag alone need not mean that a mapping still exists.
-pub async fn ensure_clone_supported(
+pub async fn ensure_deep_clone_supported(
     store: &ObjectStore,
     location: &ManifestLocation,
     manifest: &Manifest,
@@ -45,7 +49,7 @@ pub async fn ensure_clone_supported(
     let indices = read_manifest_indexes(store, location, manifest).await?;
     if indices.iter().any(is_tagged) {
         return Err(Error::not_supported(
-            "Cloning tagged FRI requires row-map reference relocation. Please upgrade to a version supporting FRI clone",
+            "Deep-cloning tagged FRI requires copying row maps and relocating their references. Please upgrade to a version supporting FRI deep clone",
         ));
     }
     Ok(())

--- a/rust/lance/src/dataset.rs
+++ b/rust/lance/src/dataset.rs
@@ -3320,7 +3320,7 @@ impl Dataset {
         // Resolve source dataset and its manifest using checkout_version
         let src_ds = self.checkout_version(version).await?;
         ensure_can_write_manifest(&src_ds.manifest)?;
-        lance_table::system_index::frag_reuse::metadata::ensure_clone_supported(
+        lance_table::system_index::frag_reuse::metadata::ensure_deep_clone_supported(
             &src_ds.object_store,
             &src_ds.manifest_location,
             &src_ds.manifest,

--- a/rust/lance/src/dataset.rs
+++ b/rust/lance/src/dataset.rs
@@ -3265,6 +3265,23 @@ impl Dataset {
         version: impl Into<refs::Ref>,
         store_params: Option<ObjectStoreParams>,
     ) -> Result<Self> {
+        // Prevent cloning into an existing target dataset (parity with
+        // `deep_clone`) before anything is written there: a tagged clone
+        // stages its relocated FRI details in the target's `_indices/`
+        // ahead of the manifest commit, which must not pollute a live
+        // dataset. The check goes through the same store and commit handler
+        // the commit below writes through.
+        let target_base =
+            ObjectStore::extract_path_from_uri(self.session.store_registry(), target_path)?;
+        if self
+            .commit_handler
+            .resolve_latest_location(&target_base, &self.object_store)
+            .await
+            .is_ok()
+        {
+            return Err(Error::dataset_already_exists(target_path.to_string()));
+        }
+
         let (ref_name, version_number) = self.resolve_reference(version.into()).await?;
         let source_location = self.branch_location().find_branch(ref_name.as_deref())?;
         let clone_op = Operation::Clone {

--- a/rust/lance/src/dataset.rs
+++ b/rust/lance/src/dataset.rs
@@ -3270,16 +3270,27 @@ impl Dataset {
         // stages its relocated FRI details in the target's `_indices/`
         // ahead of the manifest commit, which must not pollute a live
         // dataset. The check goes through the same store and commit handler
-        // the commit below writes through.
+        // the commit below writes through. Only a definitive "no dataset
+        // here" permits the clone: any other resolver failure (storage,
+        // auth, corrupt manifest listing) propagates instead of letting the
+        // clone write into a target it failed to inspect.
         let target_base =
             ObjectStore::extract_path_from_uri(self.session.store_registry(), target_path)?;
-        if self
+        match self
             .commit_handler
             .resolve_latest_location(&target_base, &self.object_store)
             .await
-            .is_ok()
         {
-            return Err(Error::dataset_already_exists(target_path.to_string()));
+            Ok(_) => {
+                return Err(Error::dataset_already_exists(target_path.to_string()));
+            }
+            // The codebase-wide "dataset absent" pair: the built-in resolver
+            // reports an empty `_versions/` listing as `NotFound`, while
+            // handlers with an external source of truth use
+            // `DatasetNotFound` (the same discrimination the write path's
+            // destination probe applies).
+            Err(Error::NotFound { .. } | Error::DatasetNotFound { .. }) => {}
+            Err(error) => return Err(error),
         }
 
         let (ref_name, version_number) = self.resolve_reference(version.into()).await?;

--- a/rust/lance/src/dataset/cleanup.rs
+++ b/rust/lance/src/dataset/cleanup.rs
@@ -321,6 +321,14 @@ struct CleanupInspection {
     /// entry uuid so each is decoded at most once; the flag records whether
     /// some retained (working-set) manifest carries the entry.
     frag_reuse_entries: HashMap<uuid::Uuid, (IndexMetadata, bool)>,
+    /// Tagged FRI entry uuids per manifest version, so a branch rescue that
+    /// retains a parent manifest can flip its entries into the working set
+    /// (their row maps become referenced instead of merely verified).
+    frag_reuse_entry_versions: HashMap<u64, Vec<uuid::Uuid>>,
+    /// Set when a branch manifest's FRI history could not be interpreted:
+    /// `_fri/` garbage collection is skipped for the run rather than risking
+    /// row maps the branch references invisibly.
+    skip_frag_reuse_gc: bool,
     /// The earliest timestamp of all retained manifests.
     earliest_retained_manifest_time: Option<DateTime<Utc>>,
     /// The latest timestamp of all manifests that will be removed.
@@ -682,6 +690,11 @@ impl<'a> CleanupTask<'a> {
                     .entry(index.uuid)
                     .or_insert_with(|| (index.clone(), false));
                 entry.1 |= in_working_set;
+                inspection
+                    .frag_reuse_entry_versions
+                    .entry(manifest.version)
+                    .or_default()
+                    .push(index.uuid);
             }
         }
         Ok(())
@@ -764,7 +777,8 @@ impl<'a> CleanupTask<'a> {
         &self,
         mut inspection: CleanupInspection,
     ) -> Result<CleanupRunResult> {
-        let collect_frag_reuse_maps = self.resolve_frag_reuse_map_ids(&mut inspection).await;
+        let collect_frag_reuse_maps = !inspection.skip_frag_reuse_gc
+            && self.resolve_frag_reuse_map_ids(&mut inspection).await;
         let inspection = inspection;
         let cleanup_result = Mutex::new(CleanupRunResult::default());
         let deletes_files = self.action.deletes_files();
@@ -1355,6 +1369,7 @@ impl<'a> CleanupTask<'a> {
                 })
                 .try_for_each_concurrent(self.dataset.object_store.io_parallelism(), |location| {
                     self.process_branch_referenced_manifests(
+                        &branch_location.path,
                         location,
                         *root_version_number,
                         &inspection,
@@ -1365,8 +1380,107 @@ impl<'a> CleanupTask<'a> {
         Ok(inspection.into_inner().unwrap())
     }
 
+    /// The `_fri/<map_id>/` row maps a branch manifest's tagged FRI entry
+    /// resolves into THIS dataset's base: stable-partition mappings whose
+    /// `base_id` names the parent (a branch clone's relocated entry keeps
+    /// reading the parent's row maps in place). The entry's own details are
+    /// read base-aware, exactly as a reader on the branch would.
+    async fn branch_frag_reuse_parent_map_ids(
+        &self,
+        branch_root: &Path,
+        manifest: &Manifest,
+        entry: &IndexMetadata,
+    ) -> Result<Vec<String>> {
+        use lance_table::system_index::frag_reuse::ledger::Mapping;
+
+        let details = entry
+            .index_details
+            .as_ref()
+            .filter(|details| details.type_url.ends_with("FragmentReuseIndexDetails"))
+            .ok_or_else(|| Error::index("Index details is not for the fragment reuse index"))?;
+        let content =
+            crate::index::frag_reuse::extract_raw_frag_reuse_content(details, |file| async move {
+                let end = file
+                    .offset
+                    .checked_add(file.size)
+                    .and_then(|n| usize::try_from(n).ok())
+                    .ok_or_else(|| {
+                        Error::corrupt_file_named("FRI details", "external FRI range overflow")
+                    })?;
+                let (store, indices_dir) = match entry.base_id {
+                    None => (None, branch_root.clone().join(crate::dataset::INDICES_DIR)),
+                    Some(id) => {
+                        let base_path = manifest.base_paths.get(&id).ok_or_else(|| {
+                            Error::invalid_input(format!(
+                                "base_path id {} not found for index {}",
+                                id, entry.uuid
+                            ))
+                        })?;
+                        let path = base_path.extract_path(self.dataset.session.store_registry())?;
+                        let dir = if base_path.is_dataset_root {
+                            path.join(crate::dataset::INDICES_DIR)
+                        } else {
+                            path
+                        };
+                        let store = if base_path.path == self.dataset.uri {
+                            None
+                        } else {
+                            // Foreign bases are opened with default store
+                            // params; per-base credentials are not plumbed
+                            // through cleanup (see
+                            // <https://github.com/lance-format/lance/issues/6093>).
+                            Some(
+                                lance_io::object_store::ObjectStore::from_uri_and_params(
+                                    self.dataset.session.store_registry(),
+                                    &base_path.path,
+                                    &Default::default(),
+                                )
+                                .await?
+                                .0,
+                            )
+                        };
+                        (store, dir)
+                    }
+                };
+                let path = indices_dir
+                    .join(entry.uuid.to_string())
+                    .join(file.path.as_str());
+                let store = store.as_deref().unwrap_or(&self.dataset.object_store);
+                store
+                    .open(&path)
+                    .await?
+                    .get_range(file.offset as usize..end)
+                    .await
+                    .map_err(Error::from)
+            })
+            .await?;
+        let ledger = crate::index::frag_reuse::decode_frag_reuse_ledger_from_content(
+            entry.index_version,
+            &content,
+        )
+        .await?;
+        if ledger.has_unsupported_transitions() {
+            return Err(Error::not_supported(
+                "the branch's tagged FRI history carries transitions this client cannot interpret",
+            ));
+        }
+        Ok(ledger
+            .transitions()
+            .iter()
+            .filter_map(|transition| match transition.mapping() {
+                Mapping::StablePartition(partition) => partition
+                    .base_id
+                    .and_then(|id| manifest.base_paths.get(&id))
+                    .filter(|base_path| base_path.path == self.dataset.uri)
+                    .map(|_| partition.map_id.clone()),
+                _ => None,
+            })
+            .collect())
+    }
+
     async fn process_branch_referenced_manifests(
         &self,
+        branch_root: &Path,
         location: ManifestLocation,
         referenced_version: u64,
         inspection: &Mutex<CleanupInspection>,
@@ -1375,6 +1489,35 @@ impl<'a> CleanupTask<'a> {
             read_manifest(&self.dataset.object_store, &location.path, location.size).await?;
         let indexes =
             read_manifest_indexes(&self.dataset.object_store, &location, &manifest).await?;
+
+        // Resolve tagged FRI references into the parent before taking the
+        // lock (content reads are async). A history this client cannot
+        // interpret disables `_fri/` GC for the whole run: it may reference
+        // parent row maps invisibly.
+        let mut branch_parent_map_ids: Vec<String> = Vec::new();
+        let mut fri_unresolvable = false;
+        for index in indexes.iter() {
+            if index.name == lance_index::frag_reuse::FRAG_REUSE_INDEX_NAME
+                && index.index_version != 0
+            {
+                match self
+                    .branch_frag_reuse_parent_map_ids(branch_root, &manifest, index)
+                    .await
+                {
+                    Ok(map_ids) => branch_parent_map_ids.extend(map_ids),
+                    Err(error) => {
+                        warn!(
+                            entry_uuid = %index.uuid,
+                            error = %error,
+                            "Cannot resolve the row-map references of a branch's fragment \
+                             reuse index entry; skipping _fri garbage collection for this run"
+                        );
+                        fri_unresolvable = true;
+                    }
+                }
+            }
+        }
+
         let mut inspection = inspection.lock().unwrap();
         let mut is_referenced = false;
 
@@ -1439,12 +1582,39 @@ impl<'a> CleanupTask<'a> {
                 }
             }
         }
+        if fri_unresolvable {
+            inspection.skip_frag_reuse_gc = true;
+        }
+        // The branch's relocated FRI entry keeps translating through row
+        // maps that live in the parent's `_fri/`; those maps are part of the
+        // working set for as long as the branch's history references them.
+        for map_id in branch_parent_map_ids {
+            inspection.verified_files.frag_reuse_map_ids.remove(&map_id);
+            inspection
+                .referenced_files
+                .frag_reuse_map_ids
+                .insert(map_id);
+            is_referenced = true;
+        }
         if is_referenced {
             inspection
                 .old_manifests
                 .retain(|_path, version_number| *version_number != referenced_version);
             // Kept on disk, so its record stays too.
             inspection.retired_records.remove(&referenced_version);
+            // The rescued parent manifest's own FRI entries join the working
+            // set with it: their row maps become referenced, not merely
+            // verified, when `resolve_frag_reuse_map_ids` decodes them.
+            if let Some(uuids) = inspection
+                .frag_reuse_entry_versions
+                .get(&referenced_version)
+            {
+                for uuid in uuids.clone() {
+                    if let Some(entry) = inspection.frag_reuse_entries.get_mut(&uuid) {
+                        entry.1 = true;
+                    }
+                }
+            }
         }
 
         Ok(())
@@ -3105,6 +3275,7 @@ mod tests {
                 .insert(root_version, "root-identity".to_string());
         }
         task.process_branch_referenced_manifests(
+            &branch.base,
             branch.manifest_location.clone(),
             root_version,
             &inspection,

--- a/rust/lance/src/index/frag_reuse.rs
+++ b/rust/lance/src/index/frag_reuse.rs
@@ -11,10 +11,14 @@ use lance_index::frag_reuse::{
     FRAG_REUSE_INDEX_NAME, FragReuseGroup, FragReuseIndexDetails, FragReuseVersion,
 };
 use lance_index::scalar::{BatchRowIdRemapper, MetricsCollector, RowIdRemapper};
-use lance_table::format::IndexMetadata;
-use lance_table::format::pb::fragment_reuse_index_details::{Content, InlineContent};
+use lance_io::object_store::{ObjectStore, ObjectStoreRegistry};
+use lance_table::format::pb::fragment_reuse_index_details::{
+    self as pb_fri, Content, InlineContent,
+};
 use lance_table::format::pb::{ExternalFile, FragmentReuseIndexDetails};
+use lance_table::format::{IndexMetadata, Manifest};
 use lance_table::transaction::{FragmentReuseRewrite, RewriteGroup};
+use object_store::path::Path;
 use prost::Message;
 use roaring::RoaringBitmap;
 use std::collections::{HashMap, HashSet};
@@ -539,15 +543,30 @@ pub(crate) async fn load_raw_frag_reuse_content(
     dataset: &Dataset,
     index: &IndexMetadata,
 ) -> lance_core::Result<Vec<u8>> {
-    use bytes::Buf;
-    use prost::encoding::{DecodeContext, WireType, decode_key, decode_varint, skip_field};
-
-    let corrupt = |message: &str| Error::corrupt_file_named("FRI details", message);
     let details = index
         .index_details
         .as_ref()
         .filter(|details| details.type_url.ends_with("FragmentReuseIndexDetails"))
         .ok_or_else(|| Error::index("Index details is not for the fragment reuse index"))?;
+    extract_raw_frag_reuse_content(details, |file| read_fri_external_file(dataset, index, file))
+        .await
+}
+
+/// [`load_raw_frag_reuse_content`] with the external read abstracted: callers
+/// outside a live `Dataset` (the shallow-clone relocation reads the SOURCE
+/// dataset's entry before the clone exists) supply their own resolution.
+async fn extract_raw_frag_reuse_content<F, Fut>(
+    details: &prost_types::Any,
+    read_external: F,
+) -> lance_core::Result<Vec<u8>>
+where
+    F: FnOnce(ExternalFile) -> Fut,
+    Fut: std::future::Future<Output = lance_core::Result<bytes::Bytes>>,
+{
+    use bytes::Buf;
+    use prost::encoding::{DecodeContext, WireType, decode_key, decode_varint, skip_field};
+
+    let corrupt = |message: &str| Error::corrupt_file_named("FRI details", message);
     let mut wire = bytes::Bytes::copy_from_slice(&details.value);
     let mut content: Option<(u32, bytes::Bytes)> = None;
     while wire.has_remaining() {
@@ -573,7 +592,7 @@ pub(crate) async fn load_raw_frag_reuse_content(
             let external_file =
                 ExternalFile::decode(external).map_err(|e| corrupt(&e.to_string()))?;
             let expected = external_file.size;
-            let data = read_fri_external_file(dataset, index, external_file).await?;
+            let data = read_external(external_file).await?;
             if data.len() as u64 != expected {
                 return Err(corrupt(&format!(
                     "external FRI size mismatch: expected {expected}, received {}",
@@ -875,23 +894,13 @@ pub(crate) async fn build_tagged_frag_reuse_entry(
     fragment_bitmap: RoaringBitmap,
 ) -> lance_core::Result<IndexMetadata> {
     let index_id = Uuid::new_v4();
-    let details_value = if content.len() > 204800 {
-        let file_path = dataset
-            .indices_dir()
-            .join(index_id.to_string())
-            .join(FRAG_REUSE_DETAILS_FILE_NAME);
-        let mut writer = dataset.object_store.create(&file_path).await?;
-        writer.write_all(&content).await?;
-        writer.shutdown().await?;
-        let external_file = ExternalFile {
-            path: FRAG_REUSE_DETAILS_FILE_NAME.to_owned(),
-            offset: 0,
-            size: content.len() as u64,
-        };
-        encode_length_delimited_field(2, &external_file.encode_to_vec())
-    } else {
-        encode_length_delimited_field(1, &content)
-    };
+    let details_value = encode_tagged_frag_reuse_details(
+        &dataset.object_store,
+        dataset.indices_dir(),
+        index_id,
+        content,
+    )
+    .await?;
 
     Ok(IndexMetadata {
         uuid: index_id,
@@ -910,6 +919,234 @@ pub(crate) async fn build_tagged_frag_reuse_entry(
         // The row-map files live in their own directories referenced from the
         // transitions, not under this entry's uuid.
         files: None,
+    })
+}
+
+/// Encode validated tagged FRI content bytes as an `index_details` value,
+/// spilling to `<indices_dir>/<index_id>/details.binpb` above the inline
+/// threshold.
+async fn encode_tagged_frag_reuse_details(
+    object_store: &ObjectStore,
+    indices_dir: Path,
+    index_id: Uuid,
+    content: Vec<u8>,
+) -> lance_core::Result<Vec<u8>> {
+    if content.len() > 204800 {
+        let file_path = indices_dir
+            .join(index_id.to_string())
+            .join(FRAG_REUSE_DETAILS_FILE_NAME);
+        let mut writer = object_store.create(&file_path).await?;
+        writer.write_all(&content).await?;
+        writer.shutdown().await?;
+        let external_file = ExternalFile {
+            path: FRAG_REUSE_DETAILS_FILE_NAME.to_owned(),
+            offset: 0,
+            size: content.len() as u64,
+        };
+        Ok(encode_length_delimited_field(
+            2,
+            &external_file.encode_to_vec(),
+        ))
+    } else {
+        Ok(encode_length_delimited_field(1, &content))
+    }
+}
+
+/// Rewrite each stable-partition mapping's `base_id` through `remap`, leaving
+/// every record it does not rewrite in its exact wire form (legacy versions
+/// and ordered-compaction transitions carry no base references). An unknown
+/// envelope record is refused: it may participate in base resolution in ways
+/// this writer cannot see, so a history it cannot fully parse must not be
+/// relocated (mirrors the trim's obligation).
+fn relocate_stable_partition_bases(
+    content: &[u8],
+    remap: impl Fn(Option<u32>) -> lance_core::Result<Option<u32>>,
+) -> lance_core::Result<Vec<u8>> {
+    use bytes::Buf;
+    use prost::encoding::{WireType, decode_key, decode_varint};
+
+    let corrupt = |message: String| Error::corrupt_file_named("FRI details", message);
+    let total = content.len();
+    let mut buf = bytes::Bytes::copy_from_slice(content);
+    let mut output = Vec::with_capacity(content.len());
+    while buf.has_remaining() {
+        let start = total - buf.remaining();
+        let (tag, wire_type) = decode_key(&mut buf).map_err(|e| corrupt(e.to_string()))?;
+        if wire_type != WireType::LengthDelimited || !matches!(tag, 1 | 2) {
+            return Err(Error::not_supported(format!(
+                "the tagged FRI history carries an unknown record (field {tag}); \
+                 upgrade to a newer version of Lance before cloning this table"
+            )));
+        }
+        let length = decode_varint(&mut buf).map_err(|e| corrupt(e.to_string()))?;
+        if length > buf.remaining() as u64 {
+            return Err(corrupt(format!(
+                "field {tag} length {length} exceeds remaining {} bytes",
+                buf.remaining()
+            )));
+        }
+        let payload = buf.split_to(length as usize);
+        let end = total - buf.remaining();
+        if tag == 1 {
+            // Legacy versions reference no bases; verbatim.
+            output.extend_from_slice(&content[start..end]);
+            continue;
+        }
+        let mut transition =
+            pb_fri::Transition::decode(payload).map_err(|e| corrupt(e.to_string()))?;
+        match &mut transition.mapping {
+            Some(pb_fri::transition::Mapping::StablePartition(partition)) => {
+                partition.base_id = remap(partition.base_id)?;
+                output.extend_from_slice(&encode_length_delimited_field(
+                    2,
+                    &transition.encode_to_vec(),
+                ));
+            }
+            // No base references; keep the exact wire form.
+            Some(pb_fri::transition::Mapping::OrderedCompaction(_)) => {
+                output.extend_from_slice(&content[start..end]);
+            }
+            // The ledger validation run before relocation rejects these.
+            None => return Err(corrupt("transition has no mapping".into())),
+        }
+    }
+    Ok(output)
+}
+
+/// Relocate a tagged FRI entry for a shallow clone.
+///
+/// The source entry's content is resolved base-aware (a chained clone's entry
+/// or details file may live in one of the source's own bases), its
+/// stable-partition references are restamped through the clone's base mapping
+/// (`Manifest::shallow_clone` carries the source's `base_paths` ids over
+/// verbatim and adds `new_base_id` for the source's own base, so `None`
+/// becomes `Some(new_base_id)` and `Some(id)` stays `id`), and the relocated
+/// content is written into the CLONE under a fresh uuid with `base_id: None`.
+/// Row-map files are NOT copied: the relocated references keep resolving them
+/// from the bases they live in.
+///
+/// A history this writer cannot fully interpret (unsupported transitions or
+/// unknown records) is refused with `NotSupported` before anything is
+/// written, per the spec's writer obligation.
+#[allow(clippy::too_many_arguments)]
+pub(crate) async fn relocate_tagged_entry_for_shallow_clone(
+    source_store: &ObjectStore,
+    source_base: &Path,
+    source_manifest: &Manifest,
+    store_registry: Arc<ObjectStoreRegistry>,
+    entry: &IndexMetadata,
+    new_base_id: u32,
+    target_store: &ObjectStore,
+    target_base: &Path,
+) -> lance_core::Result<IndexMetadata> {
+    let details = entry
+        .index_details
+        .as_ref()
+        .filter(|details| details.type_url.ends_with("FragmentReuseIndexDetails"))
+        .ok_or_else(|| Error::index("Index details is not for the fragment reuse index"))?;
+    // Base-aware resolution of the entry's external details without a live
+    // `Dataset`: the same rule as `read_fri_external_file`, against the
+    // source manifest's `base_paths`.
+    let registry = store_registry.clone();
+    let content = extract_raw_frag_reuse_content(details, |file| async move {
+        let end = file
+            .offset
+            .checked_add(file.size)
+            .and_then(|n| usize::try_from(n).ok())
+            .ok_or_else(|| {
+                Error::corrupt_file_named("FRI details", "external FRI range overflow")
+            })?;
+        let (store, indices_dir) = match entry.base_id {
+            None => (None, source_base.clone().join(crate::dataset::INDICES_DIR)),
+            Some(id) => {
+                let base_path = source_manifest.base_paths.get(&id).ok_or_else(|| {
+                    Error::invalid_input(format!(
+                        "base_path id {} not found for index {}",
+                        id, entry.uuid
+                    ))
+                })?;
+                let path = base_path.extract_path(registry.clone())?;
+                let dir = if base_path.is_dataset_root {
+                    path.join(crate::dataset::INDICES_DIR)
+                } else {
+                    path
+                };
+                let (store, _) = ObjectStore::from_uri_and_params(
+                    registry,
+                    &base_path.path,
+                    &Default::default(),
+                )
+                .await?;
+                (Some(store), dir)
+            }
+        };
+        let path = indices_dir
+            .join(entry.uuid.to_string())
+            .join(file.path.as_str());
+        let store = store.as_deref().unwrap_or(source_store);
+        store
+            .open(&path)
+            .await?
+            .get_range(file.offset as usize..end)
+            .await
+            .map_err(Error::from)
+    })
+    .await?;
+
+    // Full ledger validation before interpreting anything; reader semantics
+    // skip unknown mappings, and a writer must not relocate a history it
+    // cannot fully interpret.
+    let ledger = decode_frag_reuse_ledger_from_content(entry.index_version, &content).await?;
+    if ledger.has_unsupported_transitions() {
+        return Err(Error::not_supported(
+            "the fragment reuse history contains mappings this writer cannot relocate; \
+             upgrade to a newer version of Lance before cloning this table",
+        ));
+    }
+
+    let relocated = relocate_stable_partition_bases(&content, |base_id| match base_id {
+        // The source's own base gets the id the clone assigned to it.
+        None => Ok(Some(new_base_id)),
+        // The clone carries the source's `base_paths` entries over under the
+        // same ids, so a foreign-base reference keeps its id; it must exist.
+        Some(id) => {
+            if source_manifest.base_paths.contains_key(&id) {
+                Ok(Some(id))
+            } else {
+                Err(Error::corrupt_file_named(
+                    "FRI details",
+                    format!("stable partition mapping references missing base {id}"),
+                ))
+            }
+        }
+    })?;
+    // The relocated history must still decode as a well-formed ledger.
+    decode_frag_reuse_ledger_from_content(entry.index_version, &relocated).await?;
+
+    let index_id = Uuid::new_v4();
+    let details_value = encode_tagged_frag_reuse_details(
+        target_store,
+        target_base.clone().join(crate::dataset::INDICES_DIR),
+        index_id,
+        relocated,
+    )
+    .await?;
+    Ok(IndexMetadata {
+        uuid: index_id,
+        name: entry.name.clone(),
+        fields: entry.fields.clone(),
+        covering_fields: entry.covering_fields.clone(),
+        dataset_version: entry.dataset_version,
+        fragment_bitmap: entry.fragment_bitmap.clone(),
+        index_details: Some(Arc::new(prost_types::Any {
+            type_url: "/lance.table.FragmentReuseIndexDetails".into(),
+            value: details_value,
+        })),
+        index_version: entry.index_version,
+        created_at: entry.created_at,
+        // The relocated entry lives in the clone.
+        base_id: None,
+        files: entry.files.clone(),
     })
 }
 
@@ -1672,6 +1909,12 @@ mod tests {
         let stored = crate::index::load_all_indices(&clone).await.unwrap();
         let cloned_entry = stored_fri(&stored);
         assert!(cloned_entry.base_id.is_some());
+        // A v0 entry is carried exactly as before relocation existed: same
+        // uuid and details bytes, base-stamped to the source, never lifted.
+        assert_eq!(cloned_entry.index_version, 0);
+        assert_eq!(cloned_entry.uuid, source_entry.uuid);
+        assert_eq!(cloned_entry.index_details, source_entry.index_details);
+        assert_eq!(cloned_entry.base_id, Some(0));
 
         // First rewrite on the clone: assembly must read the source's
         // external details through the entry's base.
@@ -2192,5 +2435,557 @@ mod tests {
         assert_eq!(dataset.count_rows(None).await.unwrap(), 9);
         assert_eq!(filtered_values(&dataset, "i = 8").await, vec![8]);
         assert_eq!(filtered_values(&dataset, "i >= 9").await, Vec::<i32>::new());
+    }
+
+    /// Shallow-cloning tagged histories. All fixtures are on-disk: base-path
+    /// resolution must reach the SOURCE dataset's store, which `memory://`
+    /// fixtures cannot demonstrate (each URI is its own store).
+    mod shallow_clone {
+        use super::*;
+        use futures::TryStreamExt;
+
+        /// An on-disk two-fragment dataset with a committed scalar index.
+        async fn disk_fixture(uri: &str) -> Dataset {
+            let mut dataset = lance_datagen::gen_batch()
+                .col("i", lance_datagen::array::step::<Int32Type>())
+                .into_dataset(
+                    uri,
+                    crate::utils::test::FragmentCount::from(2),
+                    crate::utils::test::FragmentRowCount::from(4),
+                )
+                .await
+                .unwrap();
+            dataset
+                .create_index(
+                    &["i"],
+                    lance_index::IndexType::Scalar,
+                    Some("i_idx".into()),
+                    &lance_index::scalar::ScalarIndexParams::default(),
+                    false,
+                )
+                .await
+                .unwrap();
+            dataset
+        }
+
+        /// Commit one stable-partition rewrite over `source_ids`, writing its
+        /// row map into the dataset's own `_fri/`.
+        async fn commit_stable_partition(
+            dataset: Dataset,
+            source_ids: &[u64],
+            dest_base_id: u64,
+        ) -> Dataset {
+            let old_fragments: Vec<Fragment> = source_ids
+                .iter()
+                .map(|id| {
+                    dataset
+                        .fragments()
+                        .iter()
+                        .find(|f| f.id == *id)
+                        .unwrap()
+                        .clone()
+                })
+                .collect();
+            let (transition, destinations) =
+                reader_tests::prepare_partition(&dataset, source_ids, dest_base_id).await;
+            let read_version = dataset.manifest.version;
+            crate::dataset::write::CommitBuilder::new(Arc::new(dataset))
+                .execute(Transaction::new(
+                    read_version,
+                    Operation::Rewrite {
+                        groups: vec![RewriteGroup {
+                            old_fragments,
+                            new_fragments: destinations,
+                        }],
+                        rewritten_indices: vec![],
+                        frag_reuse_index: None,
+                        frag_reuse_rewrite: Some(FragmentReuseRewrite {
+                            transitions: vec![transition],
+                            base_entry_version: None,
+                        }),
+                    },
+                    None,
+                ))
+                .await
+                .unwrap()
+        }
+
+        /// The `_fri/<map_id>/` directories under the dataset's own base.
+        async fn list_fri_map_dirs(dataset: &Dataset) -> Vec<String> {
+            let prefix = dataset.base.clone().join("_fri");
+            let mut ids = HashSet::new();
+            let mut stream = dataset.object_store.read_dir_all(&prefix, None);
+            loop {
+                match stream.try_next().await {
+                    Ok(Some(meta)) => {
+                        let relative = meta
+                            .location
+                            .as_ref()
+                            .strip_prefix(prefix.as_ref())
+                            .unwrap()
+                            .trim_start_matches('/');
+                        ids.insert(relative.split('/').next().unwrap().to_string());
+                    }
+                    Ok(None) => break,
+                    Err(Error::NotFound { .. }) => break,
+                    Err(e) => panic!("{e}"),
+                }
+            }
+            let mut ids: Vec<String> = ids.into_iter().collect();
+            ids.sort();
+            ids
+        }
+
+        /// The stable-partition `base_id`s of the entry's transitions, in
+        /// lineage order.
+        fn stable_partition_bases(ledger: &FragReuseLedger) -> Vec<Option<u32>> {
+            ledger
+                .transitions()
+                .iter()
+                .filter_map(|transition| match transition.mapping() {
+                    Mapping::StablePartition(partition) => Some(partition.base_id),
+                    _ => None,
+                })
+                .collect()
+        }
+
+        /// Commit a v0 entry big enough (>200KB) that its lifted tagged form
+        /// spills details to an external file. Returns the v0 content bytes.
+        async fn commit_big_v0_entry(dataset: &mut Dataset) -> Vec<u8> {
+            let digest = |id: u64| FragDigest {
+                id,
+                physical_rows: 4,
+                num_deleted_rows: 0,
+            };
+            let mut versions = Vec::new();
+            for i in 0..3500u64 {
+                let old_id = 1_000 + i;
+                let mut addrs = RoaringTreemap::new();
+                for offset in 0..4u64 {
+                    addrs.insert((old_id << 32) + offset);
+                }
+                let mut serialized = Vec::new();
+                addrs.serialize_into(&mut serialized).unwrap();
+                versions.push(FragReuseVersion {
+                    dataset_version: i + 1,
+                    groups: vec![FragReuseGroup {
+                        changed_row_addrs: serialized,
+                        old_frags: vec![digest(old_id)],
+                        new_frags: vec![digest(100_000 + i)],
+                    }],
+                });
+            }
+            let details = FragReuseIndexDetails { versions };
+            let bitmap: RoaringBitmap = (0..3500u32).map(|i| 100_000 + i).collect();
+            let entry = build_frag_reuse_index_metadata(dataset, None, details, bitmap)
+                .await
+                .unwrap();
+            dataset
+                .apply_commit(
+                    Transaction::new(
+                        dataset.manifest.version,
+                        Operation::CreateIndex {
+                            new_indices: vec![entry],
+                            removed_indices: vec![],
+                        },
+                        None,
+                    ),
+                    &Default::default(),
+                    &Default::default(),
+                )
+                .await
+                .unwrap();
+            let stored = crate::index::load_all_indices(dataset).await.unwrap();
+            load_raw_frag_reuse_content(dataset, &stored_fri(&stored))
+                .await
+                .unwrap()
+        }
+
+        /// Test 1: cloning a tagged table relocates the row-map references
+        /// into the clone's base mapping instead of rejecting. Queries on the
+        /// clone translate through row maps read from the SOURCE's `_fri/`.
+        #[rstest::rstest]
+        #[case::inline(false)]
+        #[case::external(true)]
+        #[tokio::test]
+        async fn clone_relocates_row_map_references(#[case] external: bool) {
+            let source_dir = lance_core::utils::tempfile::TempStrDir::default();
+            let clone_dir = lance_core::utils::tempfile::TempStrDir::default();
+            let clone_uri = format!("{}/clone", clone_dir.as_str());
+            let mut dataset = disk_fixture(source_dir.as_str()).await;
+            let v0_content = if external {
+                commit_big_v0_entry(&mut dataset).await
+            } else {
+                Vec::new()
+            };
+            reserve_fragments(&mut dataset, 20).await;
+            let before = sorted_values(&dataset).await;
+            let source_ids: Vec<u64> = dataset.fragments().iter().map(|f| f.id).collect();
+            let mut dataset = commit_stable_partition(dataset, &source_ids, 10).await;
+            let stored = crate::index::load_all_indices(&dataset).await.unwrap();
+            let source_entry = stored_fri(&stored);
+            assert_eq!(source_entry.index_version, 1);
+            let source_content = load_raw_frag_reuse_content(&dataset, &source_entry)
+                .await
+                .unwrap();
+            assert_eq!(source_content.len() > 204800, external);
+
+            let version = dataset.manifest.version;
+            let clone = dataset
+                .shallow_clone(clone_uri.as_str(), version, None)
+                .await
+                .unwrap();
+
+            // The relocated entry lives in the clone under a fresh uuid; the
+            // rest of its metadata is carried over.
+            let stored = crate::index::load_all_indices(&clone).await.unwrap();
+            let entry = stored_fri(&stored);
+            assert!(is_tagged(&entry));
+            assert_ne!(entry.uuid, source_entry.uuid);
+            assert_eq!(entry.base_id, None);
+            assert_eq!(entry.index_version, 1);
+            assert_eq!(entry.fragment_bitmap, source_entry.fragment_bitmap);
+            assert_eq!(entry.dataset_version, source_entry.dataset_version);
+            let proto = FragmentReuseIndexDetails::decode(
+                entry.index_details.as_ref().unwrap().value.as_slice(),
+            )
+            .unwrap();
+            if external {
+                // Spilled to the CLONE's own `_indices/<new uuid>/`.
+                assert!(matches!(proto.content, Some(Content::External(_))));
+            } else {
+                assert!(matches!(proto.content, Some(Content::Inline(_))));
+            }
+
+            // The source's own base got the clone's freshly assigned id;
+            // records without base references are carried verbatim.
+            let clone_content = load_raw_frag_reuse_content(&clone, &entry).await.unwrap();
+            assert!(clone_content.starts_with(&v0_content));
+            assert_ne!(clone_content, source_content);
+            let ledger = decode_entry(&clone, &entry).await;
+            assert_eq!(ledger.transitions().len(), if external { 3501 } else { 1 });
+            assert_eq!(stable_partition_bases(&ledger), vec![Some(0)]);
+            assert!(clone.manifest.base_paths[&0].is_dataset_root);
+
+            // The row-map files were NOT copied: the clone has no `_fri/` of
+            // its own and reads the source's.
+            assert!(list_fri_map_dirs(&clone).await.is_empty());
+            assert_eq!(list_fri_map_dirs(&dataset).await.len(), 1);
+            assert_eq!(sorted_values(&clone).await, before);
+            assert_eq!(filtered_values(&clone, "i = 3").await, vec![3]);
+            assert_eq!(filtered_values(&clone, "i >= 4").await, vec![4, 5, 6, 7]);
+            // The source is untouched and still answers identically.
+            assert_eq!(sorted_values(&dataset).await, before);
+            assert_eq!(filtered_values(&dataset, "i = 3").await, vec![3]);
+        }
+
+        /// Test 2: a new stable-partition rewrite on the CLONE appends onto
+        /// the relocated entry, mixing a source-base mapping with a
+        /// clone-base one; both translation hops resolve correctly.
+        #[tokio::test]
+        async fn stable_partition_on_clone_mixes_bases() {
+            let source_dir = lance_core::utils::tempfile::TempStrDir::default();
+            let clone_dir = lance_core::utils::tempfile::TempStrDir::default();
+            let clone_uri = format!("{}/clone", clone_dir.as_str());
+            let mut dataset = disk_fixture(source_dir.as_str()).await;
+            reserve_fragments(&mut dataset, 40).await;
+            let before = sorted_values(&dataset).await;
+            let source_ids: Vec<u64> = dataset.fragments().iter().map(|f| f.id).collect();
+            let mut dataset = commit_stable_partition(dataset, &source_ids, 10).await;
+            let source_map_dirs = list_fri_map_dirs(&dataset).await;
+
+            let version = dataset.manifest.version;
+            let mut clone = dataset
+                .shallow_clone(clone_uri.as_str(), version, None)
+                .await
+                .unwrap();
+            let stored = crate::index::load_all_indices(&clone).await.unwrap();
+            let relocated_content = load_raw_frag_reuse_content(&clone, &stored_fri(&stored))
+                .await
+                .unwrap();
+
+            reserve_fragments(&mut clone, 40).await;
+            let clone = commit_stable_partition(clone, &[10, 11], 20).await;
+
+            let stored = crate::index::load_all_indices(&clone).await.unwrap();
+            let entry = stored_fri(&stored);
+            assert_eq!(entry.base_id, None);
+            // Appended onto the relocated entry, its bytes verbatim.
+            let content = load_raw_frag_reuse_content(&clone, &entry).await.unwrap();
+            assert!(content.starts_with(&relocated_content));
+            let ledger = decode_entry(&clone, &entry).await;
+            assert_eq!(ledger.transitions().len(), 2);
+            assert_eq!(stable_partition_bases(&ledger), vec![Some(0), None]);
+
+            // The new row map lives in the clone's own `_fri/`; the first
+            // hop's map is still only in the source's.
+            let clone_map_dirs = list_fri_map_dirs(&clone).await;
+            assert_eq!(clone_map_dirs.len(), 1);
+            assert!(!source_map_dirs.contains(&clone_map_dirs[0]));
+            assert_eq!(list_fri_map_dirs(&dataset).await, source_map_dirs);
+
+            // Queries translate through both hops (source-base then
+            // clone-base row map).
+            assert_eq!(sorted_values(&clone).await, before);
+            assert_eq!(filtered_values(&clone, "i = 3").await, vec![3]);
+            assert_eq!(filtered_values(&clone, "i >= 4").await, vec![4, 5, 6, 7]);
+        }
+
+        /// Test 3: clone of a clone. The first hop's mapping keeps its
+        /// carried-over base id, the second hop's own-base mapping gets the
+        /// freshly assigned one.
+        #[tokio::test]
+        async fn chained_clone_remaps_both_hops() {
+            let source_dir = lance_core::utils::tempfile::TempStrDir::default();
+            let clone_dir = lance_core::utils::tempfile::TempStrDir::default();
+            let clone1_uri = format!("{}/clone1", clone_dir.as_str());
+            let clone2_uri = format!("{}/clone2", clone_dir.as_str());
+            let mut dataset = disk_fixture(source_dir.as_str()).await;
+            reserve_fragments(&mut dataset, 40).await;
+            let before = sorted_values(&dataset).await;
+            let source_ids: Vec<u64> = dataset.fragments().iter().map(|f| f.id).collect();
+            let mut dataset = commit_stable_partition(dataset, &source_ids, 10).await;
+
+            let version = dataset.manifest.version;
+            let mut clone1 = dataset
+                .shallow_clone(clone1_uri.as_str(), version, None)
+                .await
+                .unwrap();
+            reserve_fragments(&mut clone1, 40).await;
+            let mut clone1 = commit_stable_partition(clone1, &[10, 11], 20).await;
+
+            let version = clone1.manifest.version;
+            let clone2 = clone1
+                .shallow_clone(clone2_uri.as_str(), version, None)
+                .await
+                .unwrap();
+
+            // Both hops' bases are present under their expected ids.
+            assert_eq!(clone2.manifest.base_paths.len(), 2);
+            assert!(
+                clone2.manifest.base_paths[&0]
+                    .path
+                    .ends_with(source_dir.as_str())
+            );
+            assert!(clone2.manifest.base_paths[&1].path.ends_with("clone1"));
+
+            let stored = crate::index::load_all_indices(&clone2).await.unwrap();
+            let entry = stored_fri(&stored);
+            assert_eq!(entry.base_id, None);
+            let ledger = decode_entry(&clone2, &entry).await;
+            assert_eq!(stable_partition_bases(&ledger), vec![Some(0), Some(1)]);
+
+            // Nothing was copied; both row maps are read from their homes.
+            assert!(list_fri_map_dirs(&clone2).await.is_empty());
+            assert_eq!(sorted_values(&clone2).await, before);
+            assert_eq!(filtered_values(&clone2, "i = 3").await, vec![3]);
+            assert_eq!(filtered_values(&clone2, "i >= 4").await, vec![4, 5, 6, 7]);
+        }
+
+        /// Test 4a: trim on the clone splices retained records verbatim, so a
+        /// retained source-base mapping keeps its stamped base id while a
+        /// drained record is dropped.
+        #[tokio::test]
+        #[serial_test::serial(frag_reuse_maintenance)]
+        async fn trim_on_clone_preserves_relocated_bases() {
+            let source_dir = lance_core::utils::tempfile::TempStrDir::default();
+            let clone_dir = lance_core::utils::tempfile::TempStrDir::default();
+            let clone_uri = format!("{}/clone", clone_dir.as_str());
+            let mut dataset = disk_fixture(source_dir.as_str()).await;
+
+            // A v0 legacy version over synthetic fragments: after the clone
+            // it is trimmable (disjoint from every index) while the
+            // stable-partition transition is still pinned by `i_idx`.
+            let mut addrs = RoaringTreemap::new();
+            for offset in 0..4u64 {
+                addrs.insert((100 << 32) + offset);
+            }
+            let mut changed_row_addrs = Vec::new();
+            addrs.serialize_into(&mut changed_row_addrs).unwrap();
+            let digest = |id: u64| FragDigest {
+                id,
+                physical_rows: 4,
+                num_deleted_rows: 0,
+            };
+            let details = FragReuseIndexDetails {
+                versions: vec![FragReuseVersion {
+                    dataset_version: 1,
+                    groups: vec![FragReuseGroup {
+                        changed_row_addrs,
+                        old_frags: vec![digest(100)],
+                        new_frags: vec![digest(110)],
+                    }],
+                }],
+            };
+            let v0_entry = build_frag_reuse_index_metadata(
+                &dataset,
+                None,
+                details,
+                RoaringBitmap::from_iter([110u32]),
+            )
+            .await
+            .unwrap();
+            dataset
+                .apply_commit(
+                    Transaction::new(
+                        dataset.manifest.version,
+                        Operation::CreateIndex {
+                            new_indices: vec![v0_entry],
+                            removed_indices: vec![],
+                        },
+                        None,
+                    ),
+                    &Default::default(),
+                    &Default::default(),
+                )
+                .await
+                .unwrap();
+
+            reserve_fragments(&mut dataset, 20).await;
+            let before = sorted_values(&dataset).await;
+            let source_ids: Vec<u64> = dataset.fragments().iter().map(|f| f.id).collect();
+            let mut dataset = commit_stable_partition(dataset, &source_ids, 10).await;
+
+            let version = dataset.manifest.version;
+            let mut clone = dataset
+                .shallow_clone(clone_uri.as_str(), version, None)
+                .await
+                .unwrap();
+            let stored = crate::index::load_all_indices(&clone).await.unwrap();
+            let pre_trim_entry = stored_fri(&stored);
+            let pre_trim_content = load_raw_frag_reuse_content(&clone, &pre_trim_entry)
+                .await
+                .unwrap();
+
+            crate::dataset::index::frag_reuse::cleanup_frag_reuse_index(&mut clone)
+                .await
+                .unwrap();
+            let stored = crate::index::load_all_indices(&clone).await.unwrap();
+            let entry = stored_fri(&stored);
+            assert_ne!(entry.uuid, pre_trim_entry.uuid);
+            let trimmed_content = load_raw_frag_reuse_content(&clone, &entry).await.unwrap();
+            // The legacy version is gone; the retained transition is the
+            // exact byte suffix of the relocated entry, base stamp included.
+            assert!(pre_trim_content.ends_with(&trimmed_content));
+            assert!(trimmed_content.len() < pre_trim_content.len());
+            let ledger = decode_entry(&clone, &entry).await;
+            assert_eq!(ledger.transitions().len(), 1);
+            assert_eq!(stable_partition_bases(&ledger), vec![Some(0)]);
+            assert_eq!(sorted_values(&clone).await, before);
+            assert_eq!(filtered_values(&clone, "i = 3").await, vec![3]);
+        }
+
+        /// Test 4b: the clone's `_fri/` garbage collection enumerates only
+        /// its own directory, so draining and cleaning the clone never
+        /// deletes the source's row-map files.
+        #[tokio::test]
+        #[serial_test::serial(frag_reuse_maintenance)]
+        async fn clone_fri_gc_spares_source_row_maps() {
+            let source_dir = lance_core::utils::tempfile::TempStrDir::default();
+            let clone_dir = lance_core::utils::tempfile::TempStrDir::default();
+            let clone_uri = format!("{}/clone", clone_dir.as_str());
+            let mut dataset = disk_fixture(source_dir.as_str()).await;
+            reserve_fragments(&mut dataset, 40).await;
+            let before = sorted_values(&dataset).await;
+            let source_ids: Vec<u64> = dataset.fragments().iter().map(|f| f.id).collect();
+            let mut dataset = commit_stable_partition(dataset, &source_ids, 10).await;
+            let source_map_dirs = list_fri_map_dirs(&dataset).await;
+            assert_eq!(source_map_dirs.len(), 1);
+
+            let version = dataset.manifest.version;
+            let mut clone = dataset
+                .shallow_clone(clone_uri.as_str(), version, None)
+                .await
+                .unwrap();
+            reserve_fragments(&mut clone, 40).await;
+            let mut clone = commit_stable_partition(clone, &[10, 11], 20).await;
+            assert_eq!(list_fri_map_dirs(&clone).await.len(), 1);
+
+            // Drain: rebuild the index over the final destinations, trim the
+            // entry away entirely.
+            clone
+                .create_index(
+                    &["i"],
+                    lance_index::IndexType::Scalar,
+                    Some("i_idx".into()),
+                    &lance_index::scalar::ScalarIndexParams::default(),
+                    true,
+                )
+                .await
+                .unwrap();
+            crate::dataset::index::frag_reuse::cleanup_frag_reuse_index(&mut clone)
+                .await
+                .unwrap();
+            let stored = crate::index::load_all_indices(&clone).await.unwrap();
+            assert!(!stored.iter().any(|idx| idx.name == FRAG_REUSE_INDEX_NAME));
+
+            // Expire every old clone version and collect aggressively.
+            crate::dataset::cleanup::cleanup_old_versions(
+                &clone,
+                crate::dataset::cleanup::CleanupPolicyBuilder::default()
+                    .before_timestamp(
+                        chrono::Utc::now() + chrono::TimeDelta::try_seconds(10).unwrap(),
+                    )
+                    .delete_unverified(true)
+                    .error_if_tagged_old_versions(false)
+                    .build(),
+            )
+            .await
+            .unwrap();
+
+            // The clone's own released map is collected; the source's map is
+            // outside the clone's `_fri/` and survives untouched.
+            assert!(list_fri_map_dirs(&clone).await.is_empty());
+            assert_eq!(list_fri_map_dirs(&dataset).await, source_map_dirs);
+            assert_eq!(sorted_values(&dataset).await, before);
+            assert_eq!(filtered_values(&dataset, "i = 3").await, vec![3]);
+            assert_eq!(sorted_values(&clone).await, before);
+        }
+
+        /// Test 5: a history this writer cannot fully interpret is not
+        /// relocated: the clone is rejected whether the opacity sits inside a
+        /// transition (unknown mapping fields) or beside the known records
+        /// (unknown envelope field).
+        #[rstest::rstest]
+        #[case::unknown_transition_field(false)]
+        #[case::unknown_envelope_record(true)]
+        #[tokio::test]
+        async fn clone_rejects_uninterpretable_history(#[case] envelope: bool) {
+            let source_dir = lance_core::utils::tempfile::TempStrDir::default();
+            let clone_dir = lance_core::utils::tempfile::TempStrDir::default();
+            let clone_uri = format!("{}/clone", clone_dir.as_str());
+            let mut dataset = disk_fixture(source_dir.as_str()).await;
+            let (transition, destinations) = reader_tests::prepare(&dataset).await;
+            let content = if envelope {
+                let mut content = reader_tests::field(2, &transition.encode_to_vec());
+                content.extend(reader_tests::field(3, b"future record"));
+                content
+            } else {
+                let mut raw = transition.encode_to_vec();
+                raw.extend(reader_tests::field(9, b"future mapping payload"));
+                reader_tests::field(2, &raw)
+            };
+            reader_tests::install(&mut dataset, content, destinations, false).await;
+            let indices = crate::index::load_all_indices(&dataset)
+                .await
+                .unwrap()
+                .as_ref()
+                .clone();
+            reader_tests::persist_fixture(&mut dataset, indices).await;
+
+            let version = dataset.manifest.version;
+            let error = dataset
+                .shallow_clone(clone_uri.as_str(), version, None)
+                .await
+                .unwrap_err();
+            assert!(matches!(error, Error::NotSupported { .. }), "{error}");
+            assert!(
+                error.to_string().to_lowercase().contains("upgrade"),
+                "{error}"
+            );
+            // Nothing was created at the target.
+            assert!(Dataset::open(clone_uri.as_str()).await.is_err());
+            assert_eq!(dataset.manifest.version, version);
+        }
     }
 }

--- a/rust/lance/src/index/frag_reuse.rs
+++ b/rust/lance/src/index/frag_reuse.rs
@@ -3353,6 +3353,101 @@ mod tests {
             assert_eq!(reopened.manifest.version, occupied_version);
         }
 
+        /// The target preflight only lets a definitive "no dataset here"
+        /// resolution permit the clone: any other resolver failure (storage,
+        /// auth, corrupt listing) aborts before anything is written, instead
+        /// of treating an uninspectable target as absent.
+        #[tokio::test]
+        async fn clone_preflight_propagates_resolver_errors() {
+            use lance_table::io::commit::{
+                CommitError, CommitHandler, ManifestLocation, ManifestNamingScheme, ManifestWriter,
+                RenameCommitHandler,
+            };
+
+            /// Delegates everything except latest-location resolution, which
+            /// fails with a non-NotFound error for the poisoned target path.
+            #[derive(Debug)]
+            struct FailingResolver {
+                inner: RenameCommitHandler,
+                fail_suffix: &'static str,
+            }
+
+            #[async_trait::async_trait]
+            impl CommitHandler for FailingResolver {
+                async fn resolve_latest_location(
+                    &self,
+                    base_path: &Path,
+                    object_store: &ObjectStore,
+                ) -> lance_core::Result<ManifestLocation> {
+                    if base_path.as_ref().ends_with(self.fail_suffix) {
+                        return Err(Error::io("injected resolver outage"));
+                    }
+                    self.inner
+                        .resolve_latest_location(base_path, object_store)
+                        .await
+                }
+
+                async fn commit(
+                    &self,
+                    manifest: &mut Manifest,
+                    indices: Option<Vec<IndexMetadata>>,
+                    base_path: &Path,
+                    object_store: &ObjectStore,
+                    manifest_writer: ManifestWriter,
+                    naming_scheme: ManifestNamingScheme,
+                    transaction: Option<lance_table::format::Transaction>,
+                ) -> std::result::Result<ManifestLocation, CommitError> {
+                    self.inner
+                        .commit(
+                            manifest,
+                            indices,
+                            base_path,
+                            object_store,
+                            manifest_writer,
+                            naming_scheme,
+                            transaction,
+                        )
+                        .await
+                }
+            }
+
+            let source_dir = lance_core::utils::tempfile::TempStrDir::default();
+            let clone_dir = lance_core::utils::tempfile::TempStrDir::default();
+            let clone_uri = format!("{}/flaky-target", clone_dir.as_str());
+            // Build the tagged source normally, then reopen it with the
+            // failing resolver installed as its commit handler.
+            let mut dataset = disk_fixture(source_dir.as_str()).await;
+            reserve_fragments(&mut dataset, 20).await;
+            let source_ids: Vec<u64> = dataset.fragments().iter().map(|f| f.id).collect();
+            let dataset = commit_stable_partition(dataset, &source_ids, 10).await;
+            let version = dataset.manifest.version;
+            drop(dataset);
+            let mut dataset =
+                crate::dataset::builder::DatasetBuilder::from_uri(source_dir.as_str())
+                    .with_read_params(crate::dataset::ReadParams {
+                        commit_handler: Some(Arc::new(FailingResolver {
+                            inner: RenameCommitHandler,
+                            fail_suffix: "flaky-target",
+                        })),
+                        ..Default::default()
+                    })
+                    .load()
+                    .await
+                    .unwrap();
+
+            let error = dataset
+                .shallow_clone(clone_uri.as_str(), version, None)
+                .await
+                .unwrap_err();
+            assert!(matches!(error, Error::IO { .. }), "{error}");
+            assert!(
+                error.to_string().contains("injected resolver outage"),
+                "{error}"
+            );
+            // The clone did not proceed: nothing was written to the target.
+            assert!(!std::path::Path::new(clone_uri.as_str()).exists());
+        }
+
         /// A clone commit that conclusively fails must delete the details
         /// file it staged in the target, alongside its transaction file.
         /// Driven through the internal commit path: the public

--- a/rust/lance/src/index/frag_reuse.rs
+++ b/rust/lance/src/index/frag_reuse.rs
@@ -12,9 +12,7 @@ use lance_index::frag_reuse::{
 };
 use lance_index::scalar::{BatchRowIdRemapper, MetricsCollector, RowIdRemapper};
 use lance_io::object_store::{ObjectStore, ObjectStoreRegistry};
-use lance_table::format::pb::fragment_reuse_index_details::{
-    self as pb_fri, Content, InlineContent,
-};
+use lance_table::format::pb::fragment_reuse_index_details::{Content, InlineContent};
 use lance_table::format::pb::{ExternalFile, FragmentReuseIndexDetails};
 use lance_table::format::{IndexMetadata, Manifest};
 use lance_table::transaction::{FragmentReuseRewrite, RewriteGroup};
@@ -381,7 +379,7 @@ pub(crate) async fn build_frag_reuse_index_metadata(
 ) -> lance_core::Result<IndexMetadata> {
     let index_id = uuid::Uuid::new_v4();
     let new_index_details_proto = InlineContent::from(&new_index_details);
-    let proto = if new_index_details_proto.encoded_len() > 204800 {
+    let proto = if new_index_details_proto.encoded_len() > FRAG_REUSE_INLINE_DETAILS_LIMIT {
         let file_path = dataset
             .indices_dir()
             .join(index_id.to_string())
@@ -554,8 +552,9 @@ pub(crate) async fn load_raw_frag_reuse_content(
 
 /// [`load_raw_frag_reuse_content`] with the external read abstracted: callers
 /// outside a live `Dataset` (the shallow-clone relocation reads the SOURCE
-/// dataset's entry before the clone exists) supply their own resolution.
-async fn extract_raw_frag_reuse_content<F, Fut>(
+/// dataset's entry before the clone exists; the parent's cleanup reads a
+/// BRANCH manifest's entry) supply their own resolution.
+pub(crate) async fn extract_raw_frag_reuse_content<F, Fut>(
     details: &prost_types::Any,
     read_external: F,
 ) -> lance_core::Result<Vec<u8>>
@@ -931,7 +930,7 @@ async fn encode_tagged_frag_reuse_details(
     index_id: Uuid,
     content: Vec<u8>,
 ) -> lance_core::Result<Vec<u8>> {
-    if content.len() > 204800 {
+    if content.len() > FRAG_REUSE_INLINE_DETAILS_LIMIT {
         let file_path = indices_dir
             .join(index_id.to_string())
             .join(FRAG_REUSE_DETAILS_FILE_NAME);
@@ -952,12 +951,24 @@ async fn encode_tagged_frag_reuse_details(
     }
 }
 
+/// Details above this size spill to an external `details.binpb` file.
+pub(crate) const FRAG_REUSE_INLINE_DETAILS_LIMIT: usize = 204800;
+
+/// `InlineContent.Transition.stable_partition` (proto field 4).
+const STABLE_PARTITION_FIELD: u32 = 4;
+/// `StablePartition.base_id` (proto field 3, varint).
+const STABLE_PARTITION_BASE_ID_FIELD: u32 = 3;
+
 /// Rewrite each stable-partition mapping's `base_id` through `remap`, leaving
-/// every record it does not rewrite in its exact wire form (legacy versions
-/// and ordered-compaction transitions carry no base references). An unknown
-/// envelope record is refused: it may participate in base resolution in ways
+/// every other byte in its exact wire form. The rewrite is a surgical
+/// wire-level patch (no protobuf decode/re-encode), so unknown NESTED fields
+/// -- extensions of `StablePartition` or `FragmentDigest` this writer does
+/// not know, exactly the shape `base_id` itself was added in -- survive
+/// byte-identically instead of being silently stripped. An unknown envelope
+/// record is still refused: it may participate in base resolution in ways
 /// this writer cannot see, so a history it cannot fully parse must not be
-/// relocated (mirrors the trim's obligation).
+/// relocated (mirrors the trim's obligation). Unknown fields INSIDE a
+/// transition are refused earlier, by the ledger gate the caller runs.
 fn relocate_stable_partition_bases(
     content: &[u8],
     remap: impl Fn(Option<u32>) -> lance_core::Result<Option<u32>>,
@@ -987,28 +998,134 @@ fn relocate_stable_partition_bases(
         }
         let payload = buf.split_to(length as usize);
         let end = total - buf.remaining();
-        if tag == 1 {
-            // Legacy versions reference no bases; verbatim.
+        if tag == 2
+            && let Some(patched) = patch_transition_stable_partition(&payload, &remap)?
+        {
+            output.extend_from_slice(&encode_length_delimited_field(2, &patched));
+        } else {
+            // Legacy versions and transitions without a stable-partition
+            // mapping (ordered compaction) reference no bases; verbatim.
             output.extend_from_slice(&content[start..end]);
-            continue;
         }
-        let mut transition =
-            pb_fri::Transition::decode(payload).map_err(|e| corrupt(e.to_string()))?;
-        match &mut transition.mapping {
-            Some(pb_fri::transition::Mapping::StablePartition(partition)) => {
-                partition.base_id = remap(partition.base_id)?;
-                output.extend_from_slice(&encode_length_delimited_field(
-                    2,
-                    &transition.encode_to_vec(),
+    }
+    Ok(output)
+}
+
+/// Patch a transition's stable-partition submessage in place, copying every
+/// other field's bytes verbatim (whatever their field number or wire type).
+/// Returns `None` when the transition carries no stable-partition mapping.
+fn patch_transition_stable_partition(
+    raw: &[u8],
+    remap: &impl Fn(Option<u32>) -> lance_core::Result<Option<u32>>,
+) -> lance_core::Result<Option<Vec<u8>>> {
+    use bytes::Buf;
+    use prost::encoding::{DecodeContext, WireType, decode_key, decode_varint, skip_field};
+
+    let corrupt = |message: String| Error::corrupt_file_named("FRI details", message);
+    let total = raw.len();
+    let mut buf = bytes::Bytes::copy_from_slice(raw);
+    let mut output = Vec::with_capacity(raw.len() + 8);
+    let mut found = false;
+    while buf.has_remaining() {
+        let start = total - buf.remaining();
+        let (tag, wire_type) = decode_key(&mut buf).map_err(|e| corrupt(e.to_string()))?;
+        if tag == STABLE_PARTITION_FIELD {
+            if wire_type != WireType::LengthDelimited {
+                return Err(corrupt("stable partition mapping must be a message".into()));
+            }
+            let length = decode_varint(&mut buf).map_err(|e| corrupt(e.to_string()))?;
+            if length > buf.remaining() as u64 {
+                return Err(corrupt(format!(
+                    "stable partition length {length} exceeds remaining {} bytes",
+                    buf.remaining()
+                )));
+            }
+            let payload = buf.split_to(length as usize);
+            if found {
+                // The ledger gate rejects this before relocation runs.
+                return Err(corrupt(
+                    "transition contains multiple stable-partition mappings".into(),
                 ));
             }
-            // No base references; keep the exact wire form.
-            Some(pb_fri::transition::Mapping::OrderedCompaction(_)) => {
-                output.extend_from_slice(&content[start..end]);
+            found = true;
+            let patched = patch_stable_partition_base(&payload, remap)?;
+            output.extend_from_slice(&encode_length_delimited_field(
+                STABLE_PARTITION_FIELD,
+                &patched,
+            ));
+        } else {
+            if wire_type == WireType::LengthDelimited {
+                let length = decode_varint(&mut buf).map_err(|e| corrupt(e.to_string()))?;
+                if length > buf.remaining() as u64 {
+                    return Err(corrupt(format!(
+                        "field {tag} length {length} exceeds remaining {} bytes",
+                        buf.remaining()
+                    )));
+                }
+                buf.advance(length as usize);
+            } else {
+                skip_field(wire_type, tag, &mut buf, DecodeContext::default())
+                    .map_err(|e| corrupt(e.to_string()))?;
             }
-            // The ledger validation run before relocation rejects these.
-            None => return Err(corrupt("transition has no mapping".into())),
+            let end = total - buf.remaining();
+            output.extend_from_slice(&raw[start..end]);
         }
+    }
+    Ok(found.then_some(output))
+}
+
+/// Drop the submessage's `base_id` field wherever it occurs (proto3
+/// last-one-wins yields the effective current value) and re-emit the
+/// remapped value at the end; every other byte is preserved verbatim.
+fn patch_stable_partition_base(
+    raw: &[u8],
+    remap: &impl Fn(Option<u32>) -> lance_core::Result<Option<u32>>,
+) -> lance_core::Result<Vec<u8>> {
+    use bytes::Buf;
+    use prost::encoding::{DecodeContext, WireType, decode_key, decode_varint, skip_field};
+
+    let corrupt = |message: String| Error::corrupt_file_named("FRI details", message);
+    let total = raw.len();
+    let mut buf = bytes::Bytes::copy_from_slice(raw);
+    let mut output = Vec::with_capacity(raw.len() + 8);
+    let mut existing = None;
+    while buf.has_remaining() {
+        let start = total - buf.remaining();
+        let (tag, wire_type) = decode_key(&mut buf).map_err(|e| corrupt(e.to_string()))?;
+        if tag == STABLE_PARTITION_BASE_ID_FIELD {
+            if wire_type != WireType::Varint {
+                return Err(corrupt("stable partition base_id must be a varint".into()));
+            }
+            let value = decode_varint(&mut buf).map_err(|e| corrupt(e.to_string()))?;
+            existing =
+                Some(u32::try_from(value).map_err(|_| {
+                    corrupt(format!("stable partition base_id {value} overflows u32"))
+                })?);
+        } else {
+            if wire_type == WireType::LengthDelimited {
+                let length = decode_varint(&mut buf).map_err(|e| corrupt(e.to_string()))?;
+                if length > buf.remaining() as u64 {
+                    return Err(corrupt(format!(
+                        "field {tag} length {length} exceeds remaining {} bytes",
+                        buf.remaining()
+                    )));
+                }
+                buf.advance(length as usize);
+            } else {
+                skip_field(wire_type, tag, &mut buf, DecodeContext::default())
+                    .map_err(|e| corrupt(e.to_string()))?;
+            }
+            let end = total - buf.remaining();
+            output.extend_from_slice(&raw[start..end]);
+        }
+    }
+    if let Some(base_id) = remap(existing)? {
+        prost::encoding::encode_key(
+            STABLE_PARTITION_BASE_ID_FIELD,
+            WireType::Varint,
+            &mut output,
+        );
+        prost::encoding::encode_varint(u64::from(base_id), &mut output);
     }
     Ok(output)
 }
@@ -1028,6 +1145,10 @@ fn relocate_stable_partition_bases(
 /// A history this writer cannot fully interpret (unsupported transitions or
 /// unknown records) is refused with `NotSupported` before anything is
 /// written, per the spec's writer obligation.
+///
+/// Returns the relocated entry and, when the details spilled to an external
+/// file in the target, that file's path so a failed clone commit can delete
+/// it again.
 #[allow(clippy::too_many_arguments)]
 pub(crate) async fn relocate_tagged_entry_for_shallow_clone(
     source_store: &ObjectStore,
@@ -1038,7 +1159,7 @@ pub(crate) async fn relocate_tagged_entry_for_shallow_clone(
     new_base_id: u32,
     target_store: &ObjectStore,
     target_base: &Path,
-) -> lance_core::Result<IndexMetadata> {
+) -> lance_core::Result<(IndexMetadata, Option<Path>)> {
     let details = entry
         .index_details
         .as_ref()
@@ -1071,6 +1192,11 @@ pub(crate) async fn relocate_tagged_entry_for_shallow_clone(
                 } else {
                     path
                 };
+                // Foreign bases are opened with default store params:
+                // per-base source credentials are not plumbed through the
+                // clone commit path. Documented limitation shared with deep
+                // clone's base reads (see
+                // <https://github.com/lance-format/lance/issues/6093>).
                 let (store, _) = ObjectStore::from_uri_and_params(
                     registry,
                     &base_path.path,
@@ -1124,30 +1250,36 @@ pub(crate) async fn relocate_tagged_entry_for_shallow_clone(
     decode_frag_reuse_ledger_from_content(entry.index_version, &relocated).await?;
 
     let index_id = Uuid::new_v4();
-    let details_value = encode_tagged_frag_reuse_details(
-        target_store,
-        target_base.clone().join(crate::dataset::INDICES_DIR),
-        index_id,
-        relocated,
-    )
-    .await?;
-    Ok(IndexMetadata {
-        uuid: index_id,
-        name: entry.name.clone(),
-        fields: entry.fields.clone(),
-        covering_fields: entry.covering_fields.clone(),
-        dataset_version: entry.dataset_version,
-        fragment_bitmap: entry.fragment_bitmap.clone(),
-        index_details: Some(Arc::new(prost_types::Any {
-            type_url: "/lance.table.FragmentReuseIndexDetails".into(),
-            value: details_value,
-        })),
-        index_version: entry.index_version,
-        created_at: entry.created_at,
-        // The relocated entry lives in the clone.
-        base_id: None,
-        files: entry.files.clone(),
-    })
+    let target_indices_dir = target_base.clone().join(crate::dataset::INDICES_DIR);
+    let spilled = (relocated.len() > FRAG_REUSE_INLINE_DETAILS_LIMIT).then(|| {
+        target_indices_dir
+            .clone()
+            .join(index_id.to_string())
+            .join(FRAG_REUSE_DETAILS_FILE_NAME)
+    });
+    let details_value =
+        encode_tagged_frag_reuse_details(target_store, target_indices_dir, index_id, relocated)
+            .await?;
+    Ok((
+        IndexMetadata {
+            uuid: index_id,
+            name: entry.name.clone(),
+            fields: entry.fields.clone(),
+            covering_fields: entry.covering_fields.clone(),
+            dataset_version: entry.dataset_version,
+            fragment_bitmap: entry.fragment_bitmap.clone(),
+            index_details: Some(Arc::new(prost_types::Any {
+                type_url: "/lance.table.FragmentReuseIndexDetails".into(),
+                value: details_value,
+            })),
+            index_version: entry.index_version,
+            created_at: entry.created_at,
+            // The relocated entry lives in the clone.
+            base_id: None,
+            files: entry.files.clone(),
+        },
+        spilled,
+    ))
 }
 
 #[cfg(test)]
@@ -2986,6 +3118,297 @@ mod tests {
             // Nothing was created at the target.
             assert!(Dataset::open(clone_uri.as_str()).await.is_err());
             assert_eq!(dataset.manifest.version, version);
+        }
+
+        /// The `_indices/<uuid>/` directories under the dataset's own base.
+        async fn list_index_dirs(dataset: &Dataset) -> Vec<String> {
+            let prefix = dataset.base.clone().join(crate::dataset::INDICES_DIR);
+            let mut ids = HashSet::new();
+            let mut stream = dataset.object_store.read_dir_all(&prefix, None);
+            loop {
+                match stream.try_next().await {
+                    Ok(Some(meta)) => {
+                        let relative = meta
+                            .location
+                            .as_ref()
+                            .strip_prefix(prefix.as_ref())
+                            .unwrap()
+                            .trim_start_matches('/');
+                        ids.insert(relative.split('/').next().unwrap().to_string());
+                    }
+                    Ok(None) => break,
+                    Err(Error::NotFound { .. }) => break,
+                    Err(e) => panic!("{e}"),
+                }
+            }
+            let mut ids: Vec<String> = ids.into_iter().collect();
+            ids.sort();
+            ids
+        }
+
+        /// Owner-required regression: the PARENT's cleanup must not delete
+        /// `_fri/` row maps a branch still translates through.
+        ///
+        /// 1. Tagged source (stable-partition mapping), `create_branch` a
+        ///    child (the branch carries a relocated entry stamped to the
+        ///    parent base).
+        /// 2. The source rebuilds its index and trims its FRI history away.
+        /// 3. The source's cleanup expires the older versions.
+        /// 4. The child's indexed queries still succeed, opening the
+        ///    source's row map. Retaining the branch-point manifest alone is
+        ///    not enough: the map ids must be collected into the referenced
+        ///    set explicitly.
+        ///
+        /// The control case runs the same drain without a branch: nothing
+        /// references the map and cleanup collects it.
+        #[rstest::rstest]
+        #[case::branch_pins_the_map(true)]
+        #[case::no_branch_releases_the_map(false)]
+        #[tokio::test]
+        #[serial_test::serial(frag_reuse_maintenance)]
+        async fn parent_cleanup_spares_row_maps_a_branch_translates_through(
+            #[case] with_branch: bool,
+        ) {
+            let source_dir = lance_core::utils::tempfile::TempStrDir::default();
+            let mut parent = disk_fixture(source_dir.as_str()).await;
+            reserve_fragments(&mut parent, 20).await;
+            let before = sorted_values(&parent).await;
+            let source_ids: Vec<u64> = parent.fragments().iter().map(|f| f.id).collect();
+            let mut parent = commit_stable_partition(parent, &source_ids, 10).await;
+            let map_dirs = list_fri_map_dirs(&parent).await;
+            assert_eq!(map_dirs.len(), 1);
+
+            let child_uri = if with_branch {
+                let version = parent.manifest.version;
+                let child = parent.create_branch("child", version, None).await.unwrap();
+                // The branch's relocated entry reads the parent's row map in
+                // place, through the base stamped at branch creation.
+                let stored = crate::index::load_all_indices(&child).await.unwrap();
+                let entry = stored_fri(&stored);
+                assert_eq!(entry.base_id, None);
+                let ledger = decode_entry(&child, &entry).await;
+                assert_eq!(stable_partition_bases(&ledger), vec![Some(0)]);
+                Some(child.uri().to_string())
+            } else {
+                None
+            };
+
+            // The parent drains: index rebuilt over the destinations, tagged
+            // history trimmed away entirely.
+            parent
+                .create_index(
+                    &["i"],
+                    lance_index::IndexType::Scalar,
+                    Some("i_idx".into()),
+                    &lance_index::scalar::ScalarIndexParams::default(),
+                    true,
+                )
+                .await
+                .unwrap();
+            crate::dataset::index::frag_reuse::cleanup_frag_reuse_index(&mut parent)
+                .await
+                .unwrap();
+            let stored = crate::index::load_all_indices(&parent).await.unwrap();
+            assert!(!stored.iter().any(|idx| idx.name == FRAG_REUSE_INDEX_NAME));
+
+            // Expire every old parent version.
+            crate::dataset::cleanup::cleanup_old_versions(
+                &parent,
+                crate::dataset::cleanup::CleanupPolicyBuilder::default()
+                    .before_timestamp(
+                        chrono::Utc::now() + chrono::TimeDelta::try_seconds(10).unwrap(),
+                    )
+                    .delete_unverified(true)
+                    .error_if_tagged_old_versions(false)
+                    .build(),
+            )
+            .await
+            .unwrap();
+
+            if let Some(child_uri) = child_uri {
+                // The branch pins the row map, and the child (opened fresh,
+                // no warm caches) still translates through it.
+                assert_eq!(list_fri_map_dirs(&parent).await, map_dirs);
+                let child = Dataset::open(child_uri.as_str()).await.unwrap();
+                assert_eq!(sorted_values(&child).await, before);
+                assert_eq!(filtered_values(&child, "i = 3").await, vec![3]);
+                assert_eq!(filtered_values(&child, "i >= 4").await, vec![4, 5, 6, 7]);
+            } else {
+                // Control: nothing references the map; the same cleanup
+                // collects it.
+                assert!(list_fri_map_dirs(&parent).await.is_empty());
+            }
+        }
+
+        /// The relocation must not silently strip nested unknown fields:
+        /// `base_id` is patched at the wire level, so extensions inside the
+        /// stable-partition submessage or a fragment digest (exactly the
+        /// shape `base_id` itself was added in) survive byte-identically.
+        #[tokio::test]
+        async fn clone_preserves_unknown_nested_wire_fields() {
+            let source_dir = lance_core::utils::tempfile::TempStrDir::default();
+            let clone_dir = lance_core::utils::tempfile::TempStrDir::default();
+            let clone_uri = format!("{}/clone", clone_dir.as_str());
+            let mut dataset = disk_fixture(source_dir.as_str()).await;
+            let before = sorted_values(&dataset).await;
+            let (transition, destinations) = reader_tests::prepare(&dataset).await;
+
+            // Re-encode the transition by hand, planting unknown subfields
+            // inside the first source digest and the stable-partition
+            // submessage.
+            let Some(transition::Mapping::StablePartition(partition)) = &transition.mapping else {
+                unreachable!()
+            };
+            let mut partition_bytes = partition.encode_to_vec();
+            partition_bytes.extend(reader_tests::field(9, b"stable-partition-extension"));
+            let build_transition = |partition_bytes: &[u8]| {
+                let mut raw = Vec::new();
+                for (position, digest) in transition.sources.iter().enumerate() {
+                    let mut digest_bytes = digest.encode_to_vec();
+                    if position == 0 {
+                        digest_bytes.extend(reader_tests::field(9, b"digest-extension"));
+                    }
+                    raw.extend(reader_tests::field(1, &digest_bytes));
+                }
+                for digest in transition.destinations.iter() {
+                    raw.extend(reader_tests::field(2, &digest.encode_to_vec()));
+                }
+                raw.extend(reader_tests::field(4, partition_bytes));
+                reader_tests::field(2, &raw)
+            };
+            let content = build_transition(&partition_bytes);
+            reader_tests::install(&mut dataset, content, destinations, false).await;
+            let indices = crate::index::load_all_indices(&dataset)
+                .await
+                .unwrap()
+                .as_ref()
+                .clone();
+            reader_tests::persist_fixture(&mut dataset, indices).await;
+
+            let version = dataset.manifest.version;
+            let clone = dataset
+                .shallow_clone(clone_uri.as_str(), version, None)
+                .await
+                .unwrap();
+
+            // Byte-exact expectation: everything identical except the
+            // stable-partition submessage gains `base_id = 0` (field 3,
+            // varint) appended after its preserved unknown field.
+            let mut expected_partition = partition_bytes.clone();
+            expected_partition.extend([0x18, 0x00]);
+            let expected = build_transition(&expected_partition);
+            let stored = crate::index::load_all_indices(&clone).await.unwrap();
+            let entry = stored_fri(&stored);
+            let clone_content = load_raw_frag_reuse_content(&clone, &entry).await.unwrap();
+            assert_eq!(clone_content, expected);
+
+            // The relocated history still resolves and translates.
+            let ledger = decode_entry(&clone, &entry).await;
+            assert_eq!(stable_partition_bases(&ledger), vec![Some(0)]);
+            assert_eq!(sorted_values(&clone).await, before);
+            assert_eq!(filtered_values(&clone, "i = 3").await, vec![3]);
+        }
+
+        /// Parity with `deep_clone`: shallow-cloning onto a URI where a
+        /// dataset already lives fails before anything is written there, so
+        /// a tagged clone cannot pollute a live dataset's `_indices/` with
+        /// staged details.
+        #[tokio::test]
+        async fn clone_onto_existing_dataset_rejected() {
+            let source_dir = lance_core::utils::tempfile::TempStrDir::default();
+            let target_dir = lance_core::utils::tempfile::TempStrDir::default();
+            let target_uri = format!("{}/occupied", target_dir.as_str());
+            let mut dataset = disk_fixture(source_dir.as_str()).await;
+            // External details: without the pre-check, the relocation would
+            // stage a spilled details file into the occupied target.
+            commit_big_v0_entry(&mut dataset).await;
+            reserve_fragments(&mut dataset, 20).await;
+            let source_ids: Vec<u64> = dataset.fragments().iter().map(|f| f.id).collect();
+            let mut dataset = commit_stable_partition(dataset, &source_ids, 10).await;
+
+            let occupied = lance_datagen::gen_batch()
+                .col("j", lance_datagen::array::step::<Int32Type>())
+                .into_dataset(
+                    target_uri.as_str(),
+                    crate::utils::test::FragmentCount::from(1),
+                    crate::utils::test::FragmentRowCount::from(4),
+                )
+                .await
+                .unwrap();
+            let occupied_version = occupied.manifest.version;
+            assert!(list_index_dirs(&occupied).await.is_empty());
+
+            let version = dataset.manifest.version;
+            let error = dataset
+                .shallow_clone(target_uri.as_str(), version, None)
+                .await
+                .unwrap_err();
+            assert!(
+                matches!(error, Error::DatasetAlreadyExists { .. }),
+                "{error}"
+            );
+            // Nothing was staged in the occupied dataset.
+            assert!(list_index_dirs(&occupied).await.is_empty());
+            let reopened = Dataset::open(target_uri.as_str()).await.unwrap();
+            assert_eq!(reopened.manifest.version, occupied_version);
+        }
+
+        /// A clone commit that conclusively fails must delete the details
+        /// file it staged in the target, alongside its transaction file.
+        /// Driven through the internal commit path: the public
+        /// `shallow_clone` rejects an occupied target before staging, so the
+        /// racing case is simulated by committing the same clone twice.
+        #[tokio::test]
+        async fn failed_clone_commit_cleans_staged_details() {
+            let source_dir = lance_core::utils::tempfile::TempStrDir::default();
+            let clone_dir = lance_core::utils::tempfile::TempStrDir::default();
+            let clone_uri = format!("{}/clone", clone_dir.as_str());
+            let mut dataset = disk_fixture(source_dir.as_str()).await;
+            commit_big_v0_entry(&mut dataset).await;
+            reserve_fragments(&mut dataset, 20).await;
+            let source_ids: Vec<u64> = dataset.fragments().iter().map(|f| f.id).collect();
+            let mut dataset = commit_stable_partition(dataset, &source_ids, 10).await;
+
+            let version = dataset.manifest.version;
+            let clone = dataset
+                .shallow_clone(clone_uri.as_str(), version, None)
+                .await
+                .unwrap();
+            // Exactly the relocated entry's spilled details dir.
+            let staged = list_index_dirs(&clone).await;
+            assert_eq!(staged.len(), 1);
+
+            let transaction = Transaction::new(
+                version,
+                Operation::Clone {
+                    is_shallow: true,
+                    ref_name: None,
+                    ref_version: version,
+                    ref_path: dataset.uri().to_string(),
+                    branch_name: None,
+                },
+                None,
+            );
+            let error = crate::io::commit::commit_new_dataset(
+                &dataset.object_store,
+                None,
+                dataset.commit_handler.as_ref(),
+                &clone.base,
+                &transaction,
+                &Default::default(),
+                clone.manifest_location.naming_scheme,
+                dataset.metadata_cache.as_ref(),
+                dataset.session.store_registry(),
+            )
+            .await
+            .unwrap_err();
+            assert!(
+                matches!(error, Error::DatasetAlreadyExists { .. }),
+                "{error}"
+            );
+            // The retry's staged details file was deleted again; only the
+            // committed clone's remains.
+            assert_eq!(list_index_dirs(&clone).await, staged);
         }
     }
 }

--- a/rust/lance/src/index/frag_reuse_reader.rs
+++ b/rust/lance/src/index/frag_reuse_reader.rs
@@ -716,11 +716,12 @@ pub mod tests {
     // chained end-to-end test in `crate::index::frag_reuse`). Cleanup is no
     // longer in this list either: tagged trim is implemented (see
     // `crate::dataset::index::frag_reuse::tests::tagged_trim`), and on this
-    // fixture it is a retaining no-op.
+    // fixture it is a retaining no-op. Shallow clone is no longer in this
+    // list: it relocates the entry's row-map references (see the clone tests
+    // in `crate::index::frag_reuse`).
     #[rstest::rstest]
     #[case::eager_compaction("eager")]
     #[case::statistics("statistics")]
-    #[case::shallow_clone("shallow")]
     #[case::deep_clone("deep")]
     #[tokio::test]
     async fn unsupported_maintenance_preserves_snapshot(#[case] operation: &str) {
@@ -752,10 +753,6 @@ pub mod tests {
             .unwrap_err(),
             "statistics" => dataset
                 .index_statistics(FRAG_REUSE_INDEX_NAME)
-                .await
-                .unwrap_err(),
-            "shallow" => dataset
-                .shallow_clone("memory://fri-shallow", version, None)
                 .await
                 .unwrap_err(),
             "deep" => dataset
@@ -907,7 +904,7 @@ pub mod tests {
         let dataset = fixture().await;
         let mut location = dataset.manifest_location.clone();
         location.path = dataset.base.clone().join("missing.manifest");
-        lance_table::system_index::frag_reuse::metadata::ensure_clone_supported(
+        lance_table::system_index::frag_reuse::metadata::ensure_deep_clone_supported(
             &dataset.object_store,
             &location,
             &dataset.manifest,
@@ -1705,18 +1702,20 @@ pub mod tests {
             .unwrap_err();
         assert!(matches!(error, Error::NotSupported { .. }));
         assert!(error.to_string().contains("Tagged FRI"));
+        // Shallow clone would have to relocate references inside content it
+        // cannot interpret; the version gate rejects it before any decode.
         let error = dataset
             .shallow_clone("memory://fri-shallow", version, None)
             .await
             .unwrap_err();
         assert!(matches!(error, Error::NotSupported { .. }));
-        assert!(error.to_string().contains("relocation"));
+        assert!(error.to_string().contains("index_version 2"), "{error}");
         let error = dataset
             .deep_clone("memory://fri-deep", version, None)
             .await
             .unwrap_err();
         assert!(matches!(error, Error::NotSupported { .. }));
-        assert!(error.to_string().contains("relocation"));
+        assert!(error.to_string().contains("Deep-cloning"), "{error}");
         let error = crate::dataset::index::frag_reuse::cleanup_frag_reuse_index(&mut dataset)
             .await
             .unwrap_err();

--- a/rust/lance/src/io/commit.rs
+++ b/rust/lance/src/io/commit.rs
@@ -364,6 +364,7 @@ async fn do_commit_new_dataset(
     let may_change_schema = operation_may_change_schema(&pb_transaction);
 
     let clone_source = if let Operation::Clone {
+        is_shallow,
         ref_version,
         ref_path,
         ..
@@ -374,7 +375,7 @@ async fn do_commit_new_dataset(
         // back to the destination store for same-store clones.
         let source_store = source_store.unwrap_or(object_store);
         let source_base_path =
-            ObjectStore::extract_path_from_uri(store_registry, ref_path.as_str())?;
+            ObjectStore::extract_path_from_uri(store_registry.clone(), ref_path.as_str())?;
         let source_manifest_location = commit_handler
             .resolve_version_location(&source_base_path, *ref_version, &source_store.inner)
             .await?;
@@ -386,13 +387,77 @@ async fn do_commit_new_dataset(
         )
         .await?;
         ensure_can_write_manifest(&source_manifest)?;
-        lance_table::system_index::frag_reuse::metadata::ensure_clone_supported(
-            source_store,
-            &source_manifest_location,
-            &source_manifest,
-        )
-        .await?;
-        Some((source_store, source_manifest_location, source_manifest))
+        if !*is_shallow {
+            // Deep clone copies files without relocating row-map references;
+            // shallow clone relocates tagged FRI entries below instead.
+            lance_table::system_index::frag_reuse::metadata::ensure_deep_clone_supported(
+                source_store,
+                &source_manifest_location,
+                &source_manifest,
+            )
+            .await?;
+        }
+
+        // Prepare the cloned index metadata now: an uncloneable tagged FRI
+        // history must be rejected before anything is written to the target.
+        let indices = if let Some(index_section_pos) = source_manifest.index_section {
+            let reader = source_store.open(&source_manifest_location.path).await?;
+            let section: pb::IndexSection =
+                lance_io::utils::read_message(reader.as_ref(), index_section_pos).await?;
+            section
+                .indices
+                .into_iter()
+                .map(IndexMetadata::try_from)
+                .collect::<Result<Vec<_>>>()?
+        } else {
+            vec![]
+        };
+        let new_base_id = source_manifest
+            .base_paths
+            .keys()
+            .max()
+            .map(|id| *id + 1)
+            .unwrap_or(0);
+        let updated_indices = if *is_shallow {
+            let mut updated = Vec::with_capacity(indices.len());
+            for mut index in indices {
+                if lance_table::system_index::frag_reuse::metadata::is_tagged(&index) {
+                    // Restamp the entry's row-map references through the
+                    // clone's base mapping and move the entry itself into the
+                    // clone; the row-map files stay where they are.
+                    index = crate::index::frag_reuse::relocate_tagged_entry_for_shallow_clone(
+                        source_store,
+                        &source_base_path,
+                        &source_manifest,
+                        store_registry.clone(),
+                        &index,
+                        new_base_id,
+                        object_store,
+                        base_path,
+                    )
+                    .await?;
+                } else if index.base_id.is_none() {
+                    // Same rule as the data files in `Manifest::shallow_clone`:
+                    // only the source's own entries get the new base; entries
+                    // already stamped keep their ids, which carry over into
+                    // the clone's `base_paths` verbatim (a chained clone must
+                    // not restamp an origin-based index onto the middle hop).
+                    index.base_id = Some(new_base_id);
+                }
+                updated.push(index);
+            }
+            updated
+        } else {
+            // Deep clone: keep metadata but normalize base to local.
+            indices
+                .into_iter()
+                .map(|mut index| {
+                    index.base_id = None;
+                    index
+                })
+                .collect()
+        };
+        Some((source_manifest, new_base_id, updated_indices))
     } else {
         None
     };
@@ -411,16 +476,10 @@ async fn do_commit_new_dataset(
             branch_name,
             ..
         },
-        Some((source_store, source_manifest_location, source_manifest)),
+        Some((source_manifest, new_base_id, updated_indices)),
     ) = (&transaction.operation, clone_source)
     {
         if *is_shallow {
-            let new_base_id = source_manifest
-                .base_paths
-                .keys()
-                .max()
-                .map(|id| *id + 1)
-                .unwrap_or(0);
             let new_manifest = source_manifest.shallow_clone(
                 ref_name.clone(),
                 ref_path.clone(),
@@ -428,27 +487,10 @@ async fn do_commit_new_dataset(
                 branch_name.clone(),
                 transaction_file.clone(),
             );
-
-            let updated_indices = if let Some(index_section_pos) = source_manifest.index_section {
-                let reader = source_store.open(&source_manifest_location.path).await?;
-                let section: pb::IndexSection =
-                    lance_io::utils::read_message(reader.as_ref(), index_section_pos).await?;
-                section
-                    .indices
-                    .into_iter()
-                    .map(|index_pb| {
-                        let mut index = IndexMetadata::try_from(index_pb)?;
-                        index.base_id = Some(new_base_id);
-                        Ok(index)
-                    })
-                    .collect::<Result<Vec<_>>>()?
-            } else {
-                vec![]
-            };
             (new_manifest, updated_indices)
         } else {
             // Deep clone: build a manifest that references local files (no external bases)
-            let mut new_manifest = source_manifest.clone();
+            let mut new_manifest = source_manifest;
             new_manifest.base_paths.clear();
             new_manifest.branch = None;
             new_manifest.tag = None;
@@ -466,22 +508,6 @@ async fn do_commit_new_dataset(
             }
             new_manifest.fragments = Arc::new(new_frags);
 
-            // Indices: keep metadata but normalize base to local
-            let mut updated_indices = Vec::new();
-            if let Some(index_section_pos) = source_manifest.index_section {
-                let reader = source_store.open(&source_manifest_location.path).await?;
-                let section: pb::IndexSection =
-                    lance_io::utils::read_message(reader.as_ref(), index_section_pos).await?;
-                updated_indices = section
-                    .indices
-                    .into_iter()
-                    .map(|index_pb| {
-                        let mut index = IndexMetadata::try_from(index_pb)?;
-                        index.base_id = None;
-                        Ok(index)
-                    })
-                    .collect::<Result<Vec<_>>>()?;
-            }
             (new_manifest, updated_indices)
         }
     } else {

--- a/rust/lance/src/io/commit.rs
+++ b/rust/lance/src/io/commit.rs
@@ -167,6 +167,18 @@ async fn cleanup_transaction_file(
     }
 }
 
+/// Best-effort removal of files a shallow clone staged in the target before
+/// its commit conclusively failed (the relocated FRI entry's spilled
+/// `details.binpb`). Never called when the commit outcome is unknown: the
+/// clone may have landed and still need them.
+async fn cleanup_spilled_clone_files(object_store: &ObjectStore, spilled_files: &[Path]) {
+    for path in spilled_files {
+        if let Err(e) = object_store.delete(path).await {
+            log::warn!("Failed to clean up staged clone file '{}': {}", path, e);
+        }
+    }
+}
+
 /// Who owns the manifest at a version, checked after a failed commit attempt.
 #[derive(Debug)]
 enum CommitOutcome {
@@ -363,6 +375,9 @@ async fn do_commit_new_dataset(
     // copy would tie the verdict to the payload size instead.
     let may_change_schema = operation_may_change_schema(&pb_transaction);
 
+    // Files a shallow clone writes into the target before the manifest
+    // commit; deleted again when the commit conclusively fails.
+    let mut spilled_clone_files: Vec<Path> = Vec::new();
     let clone_source = if let Operation::Clone {
         is_shallow,
         ref_version,
@@ -425,17 +440,20 @@ async fn do_commit_new_dataset(
                     // Restamp the entry's row-map references through the
                     // clone's base mapping and move the entry itself into the
                     // clone; the row-map files stay where they are.
-                    index = crate::index::frag_reuse::relocate_tagged_entry_for_shallow_clone(
-                        source_store,
-                        &source_base_path,
-                        &source_manifest,
-                        store_registry.clone(),
-                        &index,
-                        new_base_id,
-                        object_store,
-                        base_path,
-                    )
-                    .await?;
+                    let (relocated, spilled) =
+                        crate::index::frag_reuse::relocate_tagged_entry_for_shallow_clone(
+                            source_store,
+                            &source_base_path,
+                            &source_manifest,
+                            store_registry.clone(),
+                            &index,
+                            new_base_id,
+                            object_store,
+                            base_path,
+                        )
+                        .await?;
+                    index = relocated;
+                    spilled_clone_files.extend(spilled);
                 } else if index.base_id.is_none() {
                     // Same rule as the data files in `Manifest::shallow_clone`:
                     // only the source's own entries get the new base; entries
@@ -463,7 +481,13 @@ async fn do_commit_new_dataset(
     };
 
     let transaction_file = if !write_config.disable_transaction_file() {
-        write_transaction_file(object_store, base_path, &pb_transaction).await?
+        match write_transaction_file(object_store, base_path, &pb_transaction).await {
+            Ok(transaction_file) => transaction_file,
+            Err(err) => {
+                cleanup_spilled_clone_files(object_store, &spilled_clone_files).await;
+                return Err(err);
+            }
+        }
     } else {
         String::new()
     };
@@ -585,6 +609,7 @@ async fn do_commit_new_dataset(
                 }
             }
             cleanup_transaction_file(object_store, base_path, &transaction_file).await;
+            cleanup_spilled_clone_files(object_store, &spilled_clone_files).await;
             Err(crate::Error::dataset_already_exists(base_path.to_string()))
         }
         Err(CommitError::OtherError(err)) => {
@@ -623,6 +648,7 @@ async fn do_commit_new_dataset(
                 }
             }
             cleanup_transaction_file(object_store, base_path, &transaction_file).await;
+            cleanup_spilled_clone_files(object_store, &spilled_clone_files).await;
             Err(err)
         }
     }


### PR DESCRIPTION
Clones of datasets carrying tagged fragment reuse histories: shallow clones relocate references instead of copying data; deep clones copy the row maps and become fully independent.

## Shallow clone: relocation

Cloning decodes the source's FRI entry base-aware and rewrites it into the clone under a fresh UUID (spilling to the clone's own `_indices/<uuid>/details.binpb` above 200KB). Stable-partition mappings restamp their `base_id`: an unset base (files owned by the source) becomes the clone's new base-path entry, an already-set base is carried verbatim through the base-path carry-over. Row-map files are not copied; they stay where they are and remain readable through `Manifest.base_paths`. Chained clones compose.

The `base_id` edit happens at the protobuf wire level: every other field, including unknown nested fields a future writer may have added, survives byte-identically. Histories the clone cannot fully interpret are rejected before anything is written to the target.

## Deep clone: materialization

A deep clone copies every `_fri/<map_id>/` directory the entry references into its own tree (resolving through `Manifest.base_paths`, so a deep clone of a shallow clone materializes ancestor-owned row maps too), then rewrites the entry with every `base_id` unset. The same wire-level patch machinery is used, so unknown nested fields survive. The result carries no reference to any ancestor: deleting the source leaves the clone fully queryable, translation included. Version-0 entries keep today's deep-clone behavior byte-identically.

Both clone kinds reject a history containing records they cannot fully interpret (unknown envelope records or mapping kinds), since unknown kinds may reference artifacts that cannot be enumerated for copying or safe sharing.

## Safety around the commit

- Target preflight passes only on definitive absence (`NotFound`); an occupied target fails with `DatasetAlreadyExists`, and any other resolver error (storage, auth) propagates instead of being treated as absence. Shallow and deep clone share one preflight helper, so the two rules cannot drift.
- A conclusively failed clone commit deletes its staged details spill; an outcome-unknown failure leaves it, since the clone may have landed.

## Cleanup in both directions

- Clone-side GC derives `_fri` paths from the clone's own base, so it can never delete source-owned row maps.
- Source-side cleanup now protects row maps a child branch still translates through: branch manifests' FRI entries are decoded and every map id resolving to the parent base joins the referenced set explicitly (manifest retention alone was not enough). Regression test drives the exact failing sequence: branch, then source rebuild + trim + version expiry, then the child still answers indexed queries.

## Related fix

Committing a chained shallow clone used to restamp every index entry's `base_id`, breaking inherited indices of all types. The fix (stamp only when `base_id` is unset) is included here and also extracted as standalone #9176 against main; this branch rebases mechanically when that merges.

## Validation

Combined tree with the synchronized stack (including the FragReuseUpdate refactor and the sticky-flag authority fix from #9139): `lance` lib 3624 green (frag_reuse 173, clone 53, cleanup 87), `lance-table` 459+; fmt and clippy clean; python and java bindings compile. v0 clone behavior is test-guarded byte-identical for both clone kinds.

Stack: 9 of 11, follows #9161 (synchronized), #9187 builds on this.

