### PR TITLE
fix(mem_wal): honor the query's distance type and ef in fresh-tier vector search

### DIFF
--- a/rust/lance/src/dataset/mem_wal/memtable/scanner/builder.rs
+++ b/rust/lance/src/dataset/mem_wal/memtable/scanner/builder.rs
@@ -1177,7 +1177,7 @@ impl MemTableScanner {
         let exec: Arc<dyn ExecutionPlan> = if filter_predicate.is_none()
             && hnsw_safe_with_pk
             && hnsw_safe_with_bounds
-            && self.has_vector_index(&query.column)
+            && self.has_vector_index(&query.column, query.distance_type)
         {
             Arc::new(VectorIndexExec::new(
                 self.batch_store.clone(),
@@ -1482,8 +1482,17 @@ impl MemTableScanner {
     }
 
     /// Check if a vector index exists for a column.
-    fn has_vector_index(&self, column: &str) -> bool {
-        self.indexes.get_hnsw_by_column(column).is_some()
+    /// Whether an HNSW index on `column` can answer a query in `distance_type`.
+    ///
+    /// The graph's metric is baked into its structure, so a query asking for a
+    /// different one has to brute-force instead — the same fallback
+    /// `Scanner::vector_search` applies when a requested metric disagrees with
+    /// a base index. `None` means "use the index's metric", which always
+    /// matches.
+    fn has_vector_index(&self, column: &str, distance_type: Option<DistanceType>) -> bool {
+        self.indexes
+            .get_hnsw_by_column(column)
+            .is_some_and(|hnsw| distance_type.is_none_or(|dt| dt == hnsw.distance_type()))
     }
 
     /// Check if an FTS index exists for a column.
@@ -2681,6 +2690,74 @@ mod tests {
             "plan output schema missing `{DISTANCE_COLUMN}` — got {:?}",
             out_schema
         );
+    }
+
+    /// The HNSW graph's metric is baked into its structure, so a query asking
+    /// for a different one must brute-force rather than traverse it. Without
+    /// this the memtable silently answers in the graph's metric while the base
+    /// arm answers in the requested one, and the union merges two scales.
+    #[tokio::test]
+    async fn vector_search_routes_to_brute_force_on_a_metric_mismatch() {
+        use lance_linalg::distance::DistanceType;
+        use std::sync::Arc;
+
+        let schema: SchemaRef = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int32, false),
+            Field::new(
+                "vector",
+                DataType::FixedSizeList(Arc::new(Field::new("item", DataType::Float32, true)), 2),
+                true,
+            ),
+        ]));
+
+        let plan_rendering_for = |requested: Option<DistanceType>| {
+            let schema = schema.clone();
+            async move {
+                let batch_store = Arc::new(BatchStore::with_capacity(4));
+                let mut indexes = IndexStore::new();
+                indexes.add_hnsw(
+                    "vector_hnsw".to_string(),
+                    1,
+                    "vector".to_string(),
+                    DistanceType::Cosine,
+                    64,
+                    8,
+                );
+                let mut scanner =
+                    MemTableScanner::new(batch_store, Arc::new(indexes), schema.clone());
+                let query: Arc<dyn arrow_array::Array> =
+                    Arc::new(arrow_array::Float32Array::from(vec![0.0_f32, 0.0_f32]));
+                scanner.nearest("vector", query.as_ref(), 5).unwrap();
+                if let Some(metric) = requested {
+                    scanner.distance_metric(metric);
+                }
+                let plan = scanner.create_plan().await.unwrap();
+                // The chosen exec sits under `apply_post_index_ops`'s wrappers,
+                // so match on the rendered tree rather than the root node.
+                format!(
+                    "{}",
+                    datafusion::physical_plan::displayable(plan.as_ref()).indent(false)
+                )
+            }
+        };
+
+        let uses_graph = |rendered: &str| rendered.contains("VectorIndex");
+        let uses_brute_force = |rendered: &str| rendered.contains("MemTableBruteForceVector");
+
+        // Unset means "use the index's metric", so the graph is still usable.
+        let unset = plan_rendering_for(None).await;
+        assert!(uses_graph(&unset), "{unset}");
+        // Matching the graph's own metric keeps the graph.
+        let matching = plan_rendering_for(Some(DistanceType::Cosine)).await;
+        assert!(uses_graph(&matching), "{matching}");
+        // Disagreeing with it must not.
+        for mismatched in [DistanceType::Dot, DistanceType::L2] {
+            let rendered = plan_rendering_for(Some(mismatched)).await;
+            assert!(
+                uses_brute_force(&rendered) && !uses_graph(&rendered),
+                "{mismatched:?} query must not traverse a cosine graph: {rendered}"
+            );
+        }
     }
 
     #[tokio::test]

--- a/rust/lance/src/dataset/mem_wal/scanner/vector_search.rs
+++ b/rust/lance/src/dataset/mem_wal/scanner/vector_search.rs
@@ -106,6 +106,11 @@ pub struct LsmVectorSearchPlanner {
     /// Optional `lower <= _distance < upper` bound, applied inside every source
     /// arm's KNN so an out-of-range row never consumes a top-k slot.
     distance_range: (Option<f32>, Option<f32>),
+    /// Optional HNSW search-list size, forwarded to every arm. It bites on the
+    /// HNSW-backed ones — the active memtable's graph and each flushed
+    /// generation's `IVF_HNSW_SQ` — and is ignored by an arm whose index is not
+    /// a graph. `None` leaves each arm at its own default.
+    ef: Option<usize>,
 }
 
 impl LsmVectorSearchPlanner {
@@ -138,6 +143,7 @@ impl LsmVectorSearchPlanner {
             warmer: None,
             filter: None,
             distance_range: (None, None),
+            ef: None,
         }
     }
 
@@ -155,6 +161,16 @@ impl LsmVectorSearchPlanner {
     /// row can't displace an in-range one.
     pub fn with_distance_range(mut self, lower: Option<f32>, upper: Option<f32>) -> Self {
         self.distance_range = (lower, upper);
+        self
+    }
+
+    /// Set the HNSW search-list size — the fresh tier's recall/latency knob.
+    ///
+    /// Not `nprobes`: flushed generations are written as single-partition IVF
+    /// and the memtable graph has no partitions at all, so a probe count has
+    /// nothing to probe on the fresh tier. `ef` is what widens the search.
+    pub fn with_ef(mut self, ef: Option<usize>) -> Self {
+        self.ef = ef;
         self
     }
 
@@ -457,6 +473,9 @@ impl LsmVectorSearchPlanner {
                 scanner.distance_range(self.distance_range.0, self.distance_range.1);
                 scanner.nprobes(nprobes);
                 scanner.distance_metric(self.distance_type);
+                if let Some(ef) = self.ef {
+                    scanner.ef(ef);
+                }
                 // Memtables cover unindexed rows; only search indexed data here.
                 scanner.fast_search();
                 // Re-rank base candidates with exact distances so they're
@@ -491,6 +510,9 @@ impl LsmVectorSearchPlanner {
                 scanner.distance_range(self.distance_range.0, self.distance_range.1);
                 scanner.nprobes(nprobes);
                 scanner.distance_metric(self.distance_type);
+                if let Some(ef) = self.ef {
+                    scanner.ef(ef);
+                }
                 scanner.fast_search();
                 scanner.create_plan().await
             }
@@ -521,6 +543,9 @@ impl LsmVectorSearchPlanner {
                 scanner.distance_range(self.distance_range.0, self.distance_range.1);
                 scanner.nprobes(nprobes);
                 scanner.distance_metric(self.distance_type);
+                if let Some(ef) = self.ef {
+                    scanner.ef(ef);
+                }
                 scanner.create_plan().await
             }
         }
@@ -793,6 +818,93 @@ mod tests {
 
         assert!(cols.contains(&"vector".to_string()));
         assert!(cols.contains(&"id".to_string()));
+    }
+
+    /// `ef` is the fresh tier's only meaningful recall knob — its arms are
+    /// HNSW-backed, and probe counts have nothing to probe here. Before
+    /// `with_ef` the planner had no way to express it at all, so every
+    /// fresh-tier search ran at the graph default while the base arm honored
+    /// whatever the caller asked for.
+    #[tokio::test]
+    async fn with_ef_reaches_the_memtable_arm() {
+        use crate::dataset::mem_wal::scanner::collector::{InMemoryMemTableRef, InMemoryMemTables};
+        use crate::dataset::mem_wal::write::{BatchStore, IndexStore};
+
+        let schema = create_vector_schema();
+        let temp_dir = tempfile::tempdir().unwrap();
+        let base_uri = format!("{}/base", temp_dir.path().to_str().unwrap());
+        let base_dataset =
+            Arc::new(create_dataset(&base_uri, vec![create_test_batch(&schema, &[10, 20])]).await);
+
+        let build_planner = || {
+            let batch_store = Arc::new(BatchStore::with_capacity(16));
+            let mut index_store = IndexStore::new();
+            index_store.enable_pk_index(&[("id".to_string(), 0)]);
+            index_store.add_hnsw(
+                "vector_hnsw".to_string(),
+                1,
+                "vector".to_string(),
+                lance_linalg::distance::DistanceType::L2,
+                64,
+                8,
+            );
+            let batch = create_test_batch(&schema, &[1, 2, 3, 4]);
+            batch_store.append(batch.clone()).unwrap();
+            index_store
+                .insert_with_batch_position(&batch, 0, Some(0))
+                .unwrap();
+            let collector = LsmDataSourceCollector::new(base_dataset.clone(), vec![])
+                .with_in_memory_memtables(
+                    uuid::Uuid::new_v4(),
+                    InMemoryMemTables {
+                        active: InMemoryMemTableRef {
+                            batch_store,
+                            index_store: Arc::new(index_store),
+                            schema: schema.clone(),
+                            generation: 1,
+                        },
+                        frozen: vec![],
+                    },
+                );
+            LsmVectorSearchPlanner::new(
+                collector,
+                vec!["id".to_string()],
+                schema.clone(),
+                "vector".to_string(),
+                lance_linalg::distance::DistanceType::L2,
+            )
+        };
+
+        let query = create_query_vector();
+        let render = |plan: Arc<dyn ExecutionPlan>| {
+            format!(
+                "{}",
+                datafusion::physical_plan::displayable(plan.as_ref()).indent(false)
+            )
+        };
+
+        let defaulted = render(
+            build_planner()
+                .plan_search(&query, 3, 1, None, false, 1.0)
+                .await
+                .unwrap(),
+        );
+        assert!(
+            !defaulted.contains("ef="),
+            "unset ef must leave each arm at its own default: {defaulted}"
+        );
+
+        let widened = render(
+            build_planner()
+                .with_ef(Some(97))
+                .plan_search(&query, 3, 1, None, false, 1.0)
+                .await
+                .unwrap(),
+        );
+        assert!(
+            widened.contains("ef=97"),
+            "with_ef must reach the memtable HNSW arm: {widened}"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
Two gaps in the MemWAL fresh-tier vector path that only bite once a caller can express either knob. They ship together because the caller-side plumbing that will send them (in LanceDB Enterprise) is blocked on both.

## The metric guard

`has_vector_index` gated the memtable's HNSW on presence alone and never compared the query's distance type against the metric the graph was built with — even though `HnswMemIndex::distance_type()` was right there.

That is invisible today because callers always pass the graph's own metric, so the two cannot disagree. But a graph's metric is baked into its structure: traversing a cosine graph for a dot query returns cosine-ranked rows labelled `_distance`. It now falls through to `MemTableBruteForceVectorExec` on a mismatch — the same fallback `Scanner::vector_search` already applies when a requested metric disagrees with a base index (`scanner.rs:5381`). `None` still means "use the index's metric" and always matches.

This is the prerequisite half: a caller that starts sending a real metric without it would turn an invisible non-issue into a live wrong answer.

## The ef knob

`LsmVectorSearchPlanner` had no notion of `ef` anywhere, so every fresh-tier search ran at the graph default while the base arm honored whatever the caller asked for. `with_ef` threads it to all three arms.

Deliberately `ef` and not `nprobes`: flushed generations are written as single-partition IVF (`memtable/flush.rs`) and the memtable graph has no partitions at all, so a probe count has nothing to probe on the fresh tier. `ef` is what actually widens the search.

## Tests

- `vector_search_routes_to_brute_force_on_a_metric_mismatch` — a cosine-built graph keeps the graph for an unset or cosine query and routes to brute force for dot and l2.
- `with_ef_reaches_the_memtable_arm` — unset leaves each arm at its own default; `with_ef(Some(97))` shows up in the memtable HNSW arm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ddu6oGeAqPsmsCwR3FnQoZ
