### PR TITLE
perf: check table deregistration status concurrently in list_directory_tables

### DIFF
--- a/rust/lance-namespace-impls/src/dir.rs
+++ b/rust/lance-namespace-impls/src/dir.rs
@@ -1159,7 +1159,6 @@ impl DirectoryNamespace {
 
     /// List tables using directory scanning (fallback method)
     async fn list_directory_tables(&self) -> Result<Vec<String>> {
-        let mut tables = Vec::new();
         let entries = self
             .object_store
             .read_dir(self.base_path.clone())
@@ -1170,21 +1169,31 @@ impl DirectoryNamespace {
                 })
             })?;
 
-        for entry in entries {
-            let path = entry.trim_end_matches('/');
-            if !path.ends_with(".lance") {
-                continue;
+        let candidates: Vec<String> = entries
+            .iter()
+            .filter_map(|entry| {
+                entry
+                    .trim_end_matches('/')
+                    .strip_suffix(".lance")
+                    .map(|name| name.to_string())
+            })
+            .collect();
+
+        // Each candidate needs its own `check_table_status` round trip (a `read_dir` probe
+        // for a deregistration marker), so this is linear in the number of listed entries;
+        // run a bounded number concurrently rather than one at a time.
+        let mut stream =
+            futures::stream::iter(candidates.into_iter().map(|table_name| async move {
+                let status = self.check_table_status(&table_name).await?;
+                Ok::<Option<String>, Error>((!status.is_deregistered).then_some(table_name))
+            }))
+            .buffered(manifest::DECLARED_FILTER_CONCURRENCY);
+
+        let mut tables = Vec::new();
+        while let Some(result) = stream.next().await {
+            if let Some(table_name) = result? {
+                tables.push(table_name);
             }
-
-            let table_name = &path[..path.len() - 6];
-
-            // Use atomic check to skip deregistered tables.
-            let status = self.check_table_status(table_name).await?;
-            if status.is_deregistered {
-                continue;
-            }
-
-            tables.push(table_name.to_string());
         }
 
         Ok(tables)


### PR DESCRIPTION
`DirectoryNamespace::list_directory_tables` lists a namespace's tables by scanning the directory, then calls `check_table_status` once per candidate table to check for a deregistration marker — sequentially, one table at a time. For a namespace with many tables this becomes N sequential round trips on every `list_tables` call, and pagination doesn't help: `limit`/`page_token` are applied afterward, in memory, over the fully-scanned result, so the sequential cost is paid regardless of page size. This PR parallelizes those status checks, reusing the same bounded-concurrency pattern (`buffered(16)`) that `filter_declared_tables` already uses elsewhere in this file.

This was accomplished with the following changes:
- `list_directory_tables` now collects candidate table names from the directory scan up front, then runs `check_table_status` on each through a `futures::stream::iter(...).buffered(DECLARED_FILTER_CONCURRENCY)` pipeline instead of a sequential `for` loop.
- No change to filtering semantics or return type — deregistered tables are still excluded, and only `.lance`-suffixed entries are considered candidates.

### Testing
- `cargo test -p lance-namespace-impls --lib`: 313 passed, 0 failed, including `test_list_tables`, `test_list_tables_pagination`, `test_list_tables_pagination_limit_zero`, `test_list_tables_skips_deregistered_v1`, and `test_list_all_tables`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)