### PR TITLE
refactor(fts): make HybridCompoundQueryExec public

### DIFF
--- a/rust/lance/src/io/exec/fts.rs
+++ b/rust/lance/src/io/exec/fts.rs
@@ -965,7 +965,7 @@ fn residual_bm25_scorer(
 /// flat-search approximation without rescanning the residual input or rebuilding
 /// exact corpus statistics.
 #[derive(Debug)]
-pub(crate) struct HybridCompoundQueryExec {
+pub struct HybridCompoundQueryExec {
     dataset: Arc<Dataset>,
     query: FtsQuery,
     params: FtsSearchParams,
@@ -977,7 +977,7 @@ pub(crate) struct HybridCompoundQueryExec {
 }
 
 impl HybridCompoundQueryExec {
-    pub(crate) fn new(
+    pub fn new(
         dataset: Arc<Dataset>,
         query: FtsQuery,
         params: FtsSearchParams,
@@ -1000,6 +1000,35 @@ impl HybridCompoundQueryExec {
             )),
             metrics: ExecutionPlanMetricsSet::new(),
         }
+    }
+
+    pub fn dataset(&self) -> &Arc<Dataset> {
+        &self.dataset
+    }
+
+    pub fn query(&self) -> &FtsQuery {
+        &self.query
+    }
+
+    pub fn params(&self) -> &FtsSearchParams {
+        &self.params
+    }
+
+    pub fn column(&self) -> &str {
+        &self.column
+    }
+
+    /// The indexed segments this scorer reads. Paired with
+    /// [`Self::residual_input`] and [`Self::new`], this is what lets a caller
+    /// rebuild the node — the FTS top-k lives in [`Self::params`], not in a
+    /// fetch node, so changing it means reconstruction.
+    pub fn segments(&self) -> &[IndexMetadata] {
+        &self.segments
+    }
+
+    /// The scan over the fragments no segment covers.
+    pub fn residual_input(&self) -> &Arc<dyn ExecutionPlan> {
+        &self.residual_input
     }
 }
 


### PR DESCRIPTION
`HybridCompoundQueryExec` is the plan node a **bounded** full-text query over a **partially-indexed** column produces — indexed segments scored together with a scan of the fragments no segment covers.

Both of its siblings are already public:

| | visibility | constructor | accessors |
| --- | --- | --- | --- |
| `CompoundQueryExec` | `pub` | `pub fn new_with_segments` | `query`, `params`, `dataset`, `prefilter_source`, … |
| `CrossColumnCompoundQueryExec` | `pub` | `pub fn new_with_segments` | same |
| `HybridCompoundQueryExec` | `pub(crate)` | `pub(crate) fn new` | **none** |

So this is the odd one out rather than a deliberate boundary.

## Why it matters

A caller walking a physical plan can't downcast it, so the shape is invisible and reads as "no full-text query here". Sophon's WAL read-union hits exactly this: it matches every other FTS exec, finds no Match leaf under this one (its children are the residual scan), and falls through to a base-only answer with no way to detect that it did.

## What's exposed

The type, its constructor, and read accessors mirroring the siblings: `dataset()`, `query()`, `params()`, `column()`, plus `segments()` and `residual_input()`.

The last two are what make the node **rebuildable**, which is the part that isn't obvious. The FTS top-k lives in `FtsSearchParams.limit` rather than in a fetch node, and there's no `with_fetch` impl, so a caller that needs a different limit has to reconstruct — which needs the segment list and the residual plan back out.

No behavior change. `cargo check` clean, 23 `io::exec::fts` tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QBv2WLSq5oy6kR2gVrfFDh