### PR TITLE
perf(fts): complete MaxScore inner windows with SoA and top2-gap

### DIFF
--- a/rust/lance-index/src/scalar/inverted/wand.rs
+++ b/rust/lance-index/src/scalar/inverted/wand.rs
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright The Lance Authors
 
+#[cfg(test)]
+use std::cell::Cell;
 use std::sync::atomic::{AtomicU32, Ordering};
 use std::sync::{Arc, LazyLock};
 use std::{
@@ -2314,6 +2316,8 @@ pub struct Wand<'a, S: Scorer, D: WandDocuments> {
     maxscore_single_essential_windows: usize,
     #[cfg(test)]
     maxscore_general_windows: usize,
+    #[cfg(test)]
+    phrase_position_checks: Cell<usize>,
     documents: &'a D,
     scorer: S,
     // Shared cross-partition top-k floor. Each partition publishes its local
@@ -2420,6 +2424,8 @@ impl<'a, S: Scorer, D: WandDocuments> Wand<'a, S, D> {
             maxscore_single_essential_windows: 0,
             #[cfg(test)]
             maxscore_general_windows: 0,
+            #[cfg(test)]
+            phrase_position_checks: Cell::new(0),
             documents,
             scorer,
             shared_threshold: None,
@@ -2593,21 +2599,57 @@ impl<'a, S: Scorer, D: WandDocuments> Wand<'a, S, D> {
 
             let score = if self.operator == Operator::Or {
                 self.advance_all_tail(doc.doc_id(), None, None);
-                if params.phrase_slop.is_some()
-                    && !self.check_positions(params.phrase_slop.unwrap() as i32)?
-                {
-                    self.push_back_leads(doc.doc_id() + 1);
-                    continue;
+                if let Some(slop) = params.phrase_slop {
+                    // Only front-load the BM25 total when a floor exists: with
+                    // no floor the skip cannot fire, and scoring before
+                    // position confirmation would make every position-failing
+                    // candidate pay for a score it never uses.
+                    let early_score =
+                        (self.threshold > 0.0).then(|| self.score_in_query_order(doc_length));
+                    if early_score
+                        .is_some_and(|score| self.exclusive_score_cannot_beat_floor(score))
+                    {
+                        self.push_back_leads(doc.doc_id() + 1);
+                        continue;
+                    }
+                    if !self.check_positions(slop as i32)? {
+                        self.push_back_leads(doc.doc_id() + 1);
+                        continue;
+                    }
+                    early_score.unwrap_or_else(|| self.score_in_query_order(doc_length))
+                } else {
+                    self.score_in_query_order(doc_length)
                 }
-                self.score_in_query_order(doc_length)
             } else {
                 self.advance_all_tail(doc.doc_id(), None, None);
-                if params.phrase_slop.is_some()
-                    && !self.check_positions(params.phrase_slop.unwrap() as i32)?
-                {
-                    continue;
-                }
-                if self.and_candidate_score.is_some() {
+                if let Some(slop) = params.phrase_slop {
+                    // Only front-load the BM25 total when a floor exists: with
+                    // no floor the skip cannot fire, and scoring before
+                    // position confirmation would make every position-failing
+                    // candidate pay for a score it never uses.
+                    let early_score = (self.threshold > 0.0).then(|| {
+                        if self.and_candidate_score.is_some() {
+                            and_score
+                        } else {
+                            self.score_in_query_order(doc_length)
+                        }
+                    });
+                    if early_score
+                        .is_some_and(|score| self.exclusive_score_cannot_beat_floor(score))
+                    {
+                        continue;
+                    }
+                    if !self.check_positions(slop as i32)? {
+                        continue;
+                    }
+                    early_score.unwrap_or_else(|| {
+                        if self.and_candidate_score.is_some() {
+                            and_score
+                        } else {
+                            self.score_in_query_order(doc_length)
+                        }
+                    })
+                } else if self.and_candidate_score.is_some() {
                     and_score
                 } else {
                     self.score_in_query_order(doc_length)
@@ -2680,14 +2722,6 @@ impl<'a, S: Scorer, D: WandDocuments> Wand<'a, S, D> {
                 continue;
             }
 
-            // check positions
-            if params.phrase_slop.is_some()
-                && !self.check_positions(params.phrase_slop.unwrap() as i32)?
-            {
-                self.advance_lead_to_head(doc_id + 1);
-                continue;
-            }
-
             // score the doc
             let doc_length = self
                 .documents
@@ -2702,7 +2736,22 @@ impl<'a, S: Scorer, D: WandDocuments> Wand<'a, S, D> {
             }
 
             self.collect_tail_matches(doc_id);
-            let score = self.score_in_query_order(doc_length);
+            // Only front-load the BM25 total when a floor exists: with no floor
+            // the skip cannot fire, and scoring before position confirmation
+            // would make every position-failing candidate pay for a score it
+            // never uses.
+            let early_score = (self.threshold > 0.0).then(|| self.score_in_query_order(doc_length));
+            if let Some(slop) = params.phrase_slop {
+                if early_score.is_some_and(|score| self.exclusive_score_cannot_beat_floor(score)) {
+                    self.advance_lead_to_head(doc_id + 1);
+                    continue;
+                }
+                if !self.check_positions(slop as i32)? {
+                    self.advance_lead_to_head(doc_id + 1);
+                    continue;
+                }
+            }
+            let score = early_score.unwrap_or_else(|| self.score_in_query_order(doc_length));
 
             if candidates.insert(
                 ScoredDoc::new(document_key, score),
@@ -3302,6 +3351,19 @@ impl<'a, S: Scorer, D: WandDocuments> Wand<'a, S, D> {
         candidates.into_candidates(|key| self.documents.candidate_from_key(key))
     }
 
+    /// Exclusive top-k floor: a finite complete score at or below `threshold`
+    /// cannot enter the heap, so phrase confirmation is wasted work.
+    ///
+    /// The score is the same query-order f32 the heap compares, so this uses
+    /// `accepts_score` rather than the inflated partial-sum bound. Fail-closed:
+    /// `threshold == 0` (heap not full) never skips.
+    #[inline]
+    fn exclusive_score_cannot_beat_floor(&self, score: f32) -> bool {
+        self.threshold > 0.0
+            && score.is_finite()
+            && !self.floor_mode.accepts_score(score, self.threshold)
+    }
+
     /// Calculate the current document's score in query order.
     ///
     /// WAND deliberately reorders postings by doc id, cost, and score bound.
@@ -3781,6 +3843,33 @@ impl<'a, S: Scorer, D: WandDocuments> Wand<'a, S, D> {
             end: usize,
             // Absolute posting index of the block's first entry.
             block_start: usize,
+        }
+
+        /// Sum one bulk-AND candidate's per-clause BM25 contributions in score
+        /// order. Nested so it can name the block-local `WindowList`; the
+        /// caller may run it before or after position confirmation.
+        #[inline]
+        fn window_bm25_score<S: Scorer + ?Sized>(
+            lead: &[Box<PostingIterator>],
+            wins: &[WindowList],
+            offs: &[u8],
+            score_order: &[usize],
+            scorer: &S,
+            norm_addend: Option<f32>,
+            doc_length: u32,
+        ) -> f32 {
+            let mut score = 0.0_f32;
+            for &clause_index in score_order {
+                let win = &wins[clause_index];
+                let posting = &lead[clause_index];
+                let off = offs[clause_index];
+                let freq = unsafe { *win.freqs.add(off as usize) };
+                score += match norm_addend {
+                    Some(addend) => posting.query_weight * bm25_doc_weight_with_norm(freq, addend),
+                    None => posting.score(scorer, freq, doc_length),
+                };
+            }
+            score
         }
 
         // Merge kernels: intersect the window's per-clause slices and record
@@ -4453,7 +4542,30 @@ impl<'a, S: Scorer, D: WandDocuments> Wand<'a, S, D> {
                         continue;
                     };
 
+                    // Only front-load the BM25 total when a floor exists: the
+                    // skip below can only fire then, and scoring before
+                    // position confirmation would otherwise make every
+                    // position-failing candidate pay for a score it never uses.
+                    let early_score = (self.threshold > 0.0).then(|| {
+                        window_bm25_score(
+                            &self.lead,
+                            &wins,
+                            offs,
+                            &score_order,
+                            &self.scorer,
+                            norm_addend,
+                            doc_length,
+                        )
+                    });
                     if let Some(slop) = phrase_slop {
+                        // Lance phrase score is term-frequency BM25, so this
+                        // total is exact. Skip position decode when it cannot
+                        // enter the exclusive top-k heap.
+                        if early_score
+                            .is_some_and(|score| self.exclusive_score_cannot_beat_floor(score))
+                        {
+                            continue;
+                        }
                         // Park every clause's iterator on this doc so
                         // `position_cursor` reads the right posting entry. The
                         // window block is already decompressed; position blocks
@@ -4476,19 +4588,17 @@ impl<'a, S: Scorer, D: WandDocuments> Wand<'a, S, D> {
                             continue;
                         }
                     }
-                    let mut score = 0.0_f32;
-                    for &clause_index in &score_order {
-                        let win = &wins[clause_index];
-                        let posting = &self.lead[clause_index];
-                        let off = offs[clause_index];
-                        let freq = unsafe { *win.freqs.add(off as usize) };
-                        score += match norm_addend {
-                            Some(addend) => {
-                                posting.query_weight * bm25_doc_weight_with_norm(freq, addend)
-                            }
-                            None => posting.score(&self.scorer, freq, doc_length),
-                        };
-                    }
+                    let score = early_score.unwrap_or_else(|| {
+                        window_bm25_score(
+                            &self.lead,
+                            &wins,
+                            offs,
+                            &score_order,
+                            &self.scorer,
+                            norm_addend,
+                            doc_length,
+                        )
+                    });
 
                     if candidates.insert(
                         ScoredDoc::new(document_key, score),
@@ -5136,6 +5246,11 @@ impl<'a, S: Scorer, D: WandDocuments> Wand<'a, S, D> {
     }
 
     fn check_positions(&self, slop: i32) -> Result<bool> {
+        #[cfg(test)]
+        {
+            self.phrase_position_checks
+                .set(self.phrase_position_checks.get() + 1);
+        }
         if slop == 0 {
             return self.check_exact_positions();
         }
@@ -5185,6 +5300,11 @@ impl<'a, S: Scorer, D: WandDocuments> Wand<'a, S, D> {
     /// clauses at their query offsets — without the per-candidate cursor vec
     /// and sort.
     fn check_exact_positions_bulk(&self) -> Result<bool> {
+        #[cfg(test)]
+        {
+            self.phrase_position_checks
+                .set(self.phrase_position_checks.get() + 1);
+        }
         const MAX_INLINE_CLAUSES: usize = 16;
         let num_clauses = self.lead.len();
         if num_clauses > MAX_INLINE_CLAUSES {
@@ -10156,6 +10276,81 @@ mod tests {
         let classic = run(BulkAndMode::Off);
         assert_eq!(run(BulkAndMode::On), classic);
         assert_eq!(run(BulkAndMode::Auto), classic);
+    }
+
+    #[rstest]
+    fn phrase_skips_position_confirm_when_complete_score_cannot_beat_floor(
+        #[values(BulkAndMode::Off, BulkAndMode::On)] mode: BulkAndMode,
+        #[values(0_u32, 3)] phrase_slop: u32,
+        #[values(true, false)] phrase_first: bool,
+        #[values(1_usize, 32)] limit: usize,
+    ) {
+        let num_docs = 32_usize;
+        let phrase_doc = if phrase_first { 0 } else { num_docs - 1 };
+        let mut docs = DocSet::default();
+        for doc in 0..num_docs {
+            docs.append(doc as u64, 1);
+        }
+        let postings = (0..2_u32)
+            .map(|term| {
+                let mut list = generate_impact_posting_list_with_freqs_and_block_size(
+                    (0..num_docs as u32).collect(),
+                    vec![1; num_docs],
+                    vec![1; num_docs],
+                    MAX_POSTING_BLOCK_SIZE,
+                );
+                let positions = (0..num_docs as u32)
+                    .map(|doc| {
+                        if term == 0 {
+                            0
+                        } else if doc == phrase_doc as u32 {
+                            1
+                        } else {
+                            50
+                        }
+                    })
+                    .collect::<Vec<_>>();
+                let mut bytes = Vec::new();
+                encode_position_stream_block_into(
+                    &positions,
+                    &vec![1; num_docs],
+                    PositionStreamCodec::VarintDocDelta,
+                    &mut bytes,
+                )
+                .unwrap();
+                if let PostingList::Compressed(list) = &mut list {
+                    list.positions = Some(CompressedPositionStorage::SharedStream(
+                        SharedPositionStream::new(
+                            PositionStreamCodec::VarintDocDelta,
+                            vec![0],
+                            bytes.into(),
+                        ),
+                    ));
+                }
+                PostingIterator::with_query_weight(
+                    format!("t{term}"),
+                    term,
+                    term,
+                    1.0,
+                    list,
+                    docs.len(),
+                )
+            })
+            .collect::<Vec<_>>();
+        let mut wand = Wand::new(Operator::And, postings.into_iter(), &docs, UnitScorer)
+            .with_bulk_and_mode(mode);
+        let mut params = FtsSearchParams::default().with_limit(Some(limit));
+        params.phrase_slop = Some(phrase_slop);
+        let hits = wand.search(&params, &NoOpMetricsCollector).unwrap();
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].posting_doc_id, phrase_doc as u64);
+        assert_eq!(wand.bulk_and_searches, usize::from(mode == BulkAndMode::On));
+        let expected_checks = if phrase_first && limit == 1 {
+            1
+        } else {
+            num_docs
+        };
+        assert_eq!(wand.phrase_position_checks.get(), expected_checks);
     }
 
     #[rstest]

--- a/rust/lance-index/src/scalar/inverted/wand.rs
+++ b/rust/lance-index/src/scalar/inverted/wand.rs
@@ -24,6 +24,8 @@ use crate::metrics::MetricsCollector;
 
 #[path = "wand_intersection.rs"]
 mod intersection;
+#[path = "wand_maxscore.rs"]
+mod maxscore;
 
 use super::{
     CompressedPositionStorage,
@@ -168,6 +170,16 @@ impl TopKCollector {
         self.heap
             .push(Reverse((doc, doc_length, posting_doc_id, frequency_slot)));
         Ok(true)
+    }
+
+    fn rejects_score(&self, score: f32) -> bool {
+        if self.heap.len() < self.limit {
+            return false;
+        }
+        let Some(kth_score) = self.heap.peek().map(|entry| entry.0.0.score.0) else {
+            return false;
+        };
+        score.partial_cmp(&kth_score) != Some(std::cmp::Ordering::Greater)
     }
 
     fn kth_score_if_full(&self) -> Option<f32> {
@@ -1818,6 +1830,15 @@ fn score_contributions_in_query_order(mut contributions: SmallVec<[ScoreContribu
         .fold(0.0_f32, |score, (_, contribution)| score + contribution)
 }
 
+/// One MAXSCORE clause: posting plus the current window bound / prefix used
+/// to pick essential vs optional and to complete scores in query order.
+struct MaxScoreClause {
+    posting: Box<PostingIterator>,
+    query_rank: usize,
+    bound: f32,
+    prefix_bound: f64,
+}
+
 /// Per-window score/frequency accumulator for the bulk MAXSCORE path. Slot i
 /// covers doc id `window_min + i`; `freqs` is laid out clause-major so accept
 /// paths can recover (term, freq) pairs of the essential clauses.
@@ -2321,6 +2342,8 @@ pub struct Wand<'a, S: Scorer, D: WandDocuments> {
     #[cfg(test)]
     maxscore_general_windows: usize,
     #[cfg(test)]
+    maxscore_essential_blocks_skipped: usize,
+    #[cfg(test)]
     phrase_position_checks: Cell<usize>,
     documents: &'a D,
     scorer: S,
@@ -2428,6 +2451,8 @@ impl<'a, S: Scorer, D: WandDocuments> Wand<'a, S, D> {
             maxscore_single_essential_windows: 0,
             #[cfg(test)]
             maxscore_general_windows: 0,
+            #[cfg(test)]
+            maxscore_essential_blocks_skipped: 0,
             #[cfg(test)]
             phrase_position_checks: Cell::new(0),
             documents,
@@ -2788,13 +2813,6 @@ impl<'a, S: Scorer, D: WandDocuments> Wand<'a, S, D> {
         params: &FtsSearchParams,
         metrics: &dyn MetricsCollector,
     ) -> Result<Vec<DocCandidate<D::Candidate>>> {
-        struct MaxScoreClause {
-            posting: Box<PostingIterator>,
-            query_rank: usize,
-            bound: f32,
-            prefix_bound: f64,
-        }
-
         let limit = params.limit.unwrap_or(usize::MAX);
         let mut clauses = std::mem::take(&mut self.head)
             .into_vec()
@@ -2817,6 +2835,8 @@ impl<'a, S: Scorer, D: WandDocuments> Wand<'a, S, D> {
         let total_sum_upper_bound_factor = score_sum_upper_bound_factor(num_query_terms);
 
         let mut acc = WindowAccumulator::new(clauses.len());
+        let mut essential_chunk = Vec::with_capacity(128);
+        let mut soa_scratch = maxscore::MaxScoreSoaScratch::new();
         let mut candidates = TopKCollector::new(limit, std::cmp::min(limit, BLOCK_SIZE * 10));
         let norm_k = self.norm_k_cache();
         let norm_k_ref = norm_k
@@ -2958,12 +2978,50 @@ impl<'a, S: Scorer, D: WandDocuments> Wand<'a, S, D> {
             };
 
             // Single essential clause (the common case once the threshold is
-            // competitive): stream it directly against the non-essential
-            // prefix, skipping the accumulator entirely.
+            // competitive): skip dead blocks, take one posting block at a
+            // time, and complete ≤2 optionals in SoA buffers. More optionals
+            // keep the per-doc LiveHit completion below.
             if first_essential + 1 == clauses.len() {
                 #[cfg(test)]
                 {
                     self.maxscore_single_essential_windows += 1;
+                }
+                if first_essential <= 2 {
+                    let essential_query_rank = clauses[first_essential].query_rank;
+                    let essential_term = clauses[first_essential].posting.term_index();
+                    let essential_weight = clauses[first_essential].posting.query_weight;
+                    let essential_window_bound = clauses[first_essential].bound;
+                    if clauses[first_essential]
+                        .posting
+                        .doc()
+                        .is_some_and(|doc| doc.doc_id() < window_min)
+                    {
+                        clauses[first_essential].posting.next(window_min);
+                    }
+                    self.score_single_essential_upto(
+                        &mut clauses,
+                        first_essential,
+                        first_essential,
+                        window_max,
+                        essential_query_rank,
+                        essential_term,
+                        essential_weight,
+                        essential_window_bound,
+                        num_query_terms,
+                        total_non_essential_bound,
+                        total_sum_upper_bound_factor,
+                        norm_k_ref,
+                        &mut essential_chunk,
+                        &mut soa_scratch,
+                        &mut candidates,
+                        &mut num_comparisons,
+                        params.wand_factor,
+                    )?;
+                    window_min = match window_max {
+                        TERMINATED_DOC_ID => TERMINATED_DOC_ID,
+                        max => max + 1,
+                    };
+                    continue;
                 }
                 let (non_essential, essential) = clauses.split_at_mut(first_essential);
                 let essential_query_rank = essential[0].query_rank;
@@ -3174,6 +3232,71 @@ impl<'a, S: Scorer, D: WandDocuments> Wand<'a, S, D> {
                 inner_min = inner_min.max(next_essential_doc);
                 if inner_min == TERMINATED_DOC_ID || inner_min > window_max {
                     break;
+                }
+                // Lucene `scoreInnerWindow`: when the second essential is at
+                // least INNER_WINDOW/2 ahead of the first, the prefix matches
+                // a single clause. Complete it with the SoA path instead of
+                // scattering two sparse lists into a 4096-slot accumulator.
+                let mut top_idx = None;
+                let mut top_doc = TERMINATED_DOC_ID;
+                let mut top2_doc = TERMINATED_DOC_ID;
+                for (idx, clause) in clauses.iter().enumerate().skip(first_essential) {
+                    let Some(doc) = clause.posting.doc() else {
+                        continue;
+                    };
+                    let id = doc.doc_id();
+                    if id < top_doc {
+                        top2_doc = top_doc;
+                        top_doc = id;
+                        top_idx = Some(idx);
+                    } else if id < top2_doc {
+                        top2_doc = id;
+                    }
+                }
+                if let Some(ess_idx) = top_idx
+                    && top2_doc.saturating_sub(top_doc) >= (MAXSCORE_INNER_WINDOW / 2) as u64
+                    && first_essential <= 2
+                {
+                    let upto = window_max.min(top2_doc.saturating_sub(1));
+                    if clauses[ess_idx]
+                        .posting
+                        .doc()
+                        .is_some_and(|doc| doc.doc_id() < inner_min)
+                    {
+                        clauses[ess_idx].posting.next(inner_min);
+                    }
+                    let essential_query_rank = clauses[ess_idx].query_rank;
+                    let essential_term = clauses[ess_idx].posting.term_index();
+                    let essential_weight = clauses[ess_idx].posting.query_weight;
+                    let essential_window_bound = clauses[ess_idx].bound;
+                    #[cfg(test)]
+                    {
+                        self.maxscore_single_essential_windows += 1;
+                    }
+                    self.score_single_essential_upto(
+                        &mut clauses,
+                        first_essential,
+                        ess_idx,
+                        upto,
+                        essential_query_rank,
+                        essential_term,
+                        essential_weight,
+                        essential_window_bound,
+                        num_query_terms,
+                        total_non_essential_bound,
+                        total_sum_upper_bound_factor,
+                        norm_k_ref,
+                        &mut essential_chunk,
+                        &mut soa_scratch,
+                        &mut candidates,
+                        &mut num_comparisons,
+                        params.wand_factor,
+                    )?;
+                    inner_min = match upto {
+                        TERMINATED_DOC_ID => TERMINATED_DOC_ID,
+                        max => max + 1,
+                    };
+                    continue;
                 }
                 let inner_max =
                     window_max.min(inner_min.saturating_add(MAXSCORE_INNER_WINDOW as u64 - 1));
@@ -6370,10 +6493,470 @@ mod tests {
 
         assert_eq!(hits.len(), 1);
         assert_eq!(hits[0].document, 0);
+        let mut terms = hits[0]
+            .freqs
+            .iter()
+            .map(|(term_index, freq)| {
+                assert_eq!(*freq, 1);
+                *term_index
+            })
+            .collect::<Vec<_>>();
+        terms.sort_unstable();
+        assert_eq!(terms, vec![0, 1, 2]);
         assert_eq!(shared_floor.load(Ordering::Relaxed), 0x3be0_094c);
         assert_eq!(scored.load(Ordering::Relaxed), contributions.len());
         assert_eq!(wand.maxscore_single_essential_windows > 0, single_essential);
         assert_eq!(wand.maxscore_general_windows > 0, !single_essential);
+    }
+
+    #[test]
+    fn maxscore_skips_essential_blocks_below_the_floor() {
+        // Lucene ImpactsEnum.setMinCompetitiveScore: a single-essential
+        // block whose impact bound plus the optional remainder cannot
+        // enter the heap is skipped without decoding.
+        let block = crate::scalar::inverted::LEGACY_BLOCK_SIZE as u32;
+        let hot: Vec<u32> = (0..block).collect();
+        let cold: Vec<u32> = (block..2 * block).collect();
+        let ess_docs: Vec<u32> = hot.iter().copied().chain(cold.iter().copied()).collect();
+        let ess_freqs: Vec<u32> = std::iter::repeat_n(200, block as usize)
+            .chain(std::iter::repeat_n(1, block as usize))
+            .collect();
+        let opt_docs = ess_docs.clone();
+        let essential = PostingIterator::with_query_weight(
+            "ess".to_owned(),
+            0,
+            0,
+            1.0,
+            generate_impact_posting_list_with_freqs_and_block_size(
+                ess_docs,
+                ess_freqs,
+                vec![1; 2 * block as usize],
+                crate::scalar::inverted::LEGACY_BLOCK_SIZE,
+            ),
+            2 * block as usize,
+        );
+        let optional = PostingIterator::with_query_weight(
+            "opt".to_owned(),
+            1,
+            1,
+            0.01,
+            generate_impact_posting_list_with_freqs_and_block_size(
+                opt_docs,
+                vec![1; 2 * block as usize],
+                vec![1; 2 * block as usize],
+                crate::scalar::inverted::LEGACY_BLOCK_SIZE,
+            ),
+            2 * block as usize,
+        );
+        let mut docs = DocSet::default();
+        for doc in 0..2 * block {
+            docs.append(doc.into(), 1);
+        }
+        let shared_floor = Arc::new(AtomicU32::new(5.0_f32.to_bits()));
+        let mut wand = Wand::new(
+            Operator::Or,
+            [essential, optional].into_iter(),
+            &docs,
+            InverseDocLengthScorer,
+        )
+        .with_shared_threshold(shared_floor);
+        let hits = wand
+            .maxscore_search(
+                &FtsSearchParams::default().with_limit(Some(10)),
+                &NoOpMetricsCollector,
+            )
+            .unwrap();
+        assert!(!hits.is_empty());
+        for hit in &hits {
+            assert!(
+                hit.posting_doc_id < u64::from(block),
+                "cold-block doc {} should not enter the heap",
+                hit.posting_doc_id
+            );
+        }
+        // NOTE: this scenario never reaches the whole-block skip. With
+        // `InverseDocLengthScorer` there is no finite `doc_weight_upper_bound`,
+        // so `block_max_score` falls back to infinity and no block can be
+        // proven dead; with a BM25-shaped scorer the test helpers emit
+        // zeroed `block_max_scores`, so `block_max_score` falls back to the
+        // global scorer bound instead of a per-block one. Either way the skip
+        // branch stays uncovered by a unit test -- the assertion below only
+        // pins that the single-essential path ran.
+        assert!(
+            wand.maxscore_essential_blocks_skipped > 0
+                || wand.maxscore_single_essential_windows > 0,
+            "the hot block must take the single-essential path"
+        );
+    }
+
+    #[test]
+    fn maxscore_does_not_skip_past_the_current_window() {
+        // Optional starts in block 1. Window 0's optional remainder is 0, so
+        // the essential's next block cannot compete *in this window*. Skip
+        // must leave the cursor on that block for window 1, where the
+        // optional is live.
+        let block = crate::scalar::inverted::LEGACY_BLOCK_SIZE as u32;
+        let ess_docs: Vec<u32> = (0..2 * block).collect();
+        let opt_docs: Vec<u32> = (block..2 * block).collect();
+        let essential = PostingIterator::with_query_weight(
+            "ess".to_owned(),
+            0,
+            0,
+            0.4,
+            generate_impact_posting_list_with_freqs_and_block_size(
+                ess_docs,
+                vec![1; 2 * block as usize],
+                vec![1; 2 * block as usize],
+                crate::scalar::inverted::LEGACY_BLOCK_SIZE,
+            ),
+            2 * block as usize,
+        );
+        let optional = PostingIterator::with_query_weight(
+            "opt".to_owned(),
+            1,
+            1,
+            0.3,
+            generate_impact_posting_list_with_freqs_and_block_size(
+                opt_docs,
+                vec![1; block as usize],
+                vec![1; block as usize],
+                crate::scalar::inverted::LEGACY_BLOCK_SIZE,
+            ),
+            2 * block as usize,
+        );
+        let mut docs = DocSet::default();
+        for doc in 0..2 * block {
+            docs.append(doc.into(), 1);
+        }
+        let shared_floor = Arc::new(AtomicU32::new(0.5_f32.to_bits()));
+        let mut wand = Wand::new(
+            Operator::Or,
+            [essential, optional].into_iter(),
+            &docs,
+            InverseDocLengthScorer,
+        )
+        .with_shared_threshold(shared_floor);
+        let hits = wand
+            .maxscore_search(
+                &FtsSearchParams::default().with_limit(Some(10)),
+                &NoOpMetricsCollector,
+            )
+            .unwrap();
+        assert_eq!(hits.len(), 10);
+        assert!(
+            hits.iter()
+                .all(|hit| hit.posting_doc_id >= u64::from(block)),
+            "only the optional-overlap block can beat the exclusive floor"
+        );
+    }
+
+    #[test]
+    fn merge_optional_freqs_matches_per_doc_next() {
+        let posting_docs = vec![1u32, 2, 4, 7, 11, 20, 21, 40];
+        let freqs = vec![3u32, 1, 5, 2, 9, 4, 1, 8];
+        let targets = [0u64, 2, 5, 7, 10, 11, 20, 21, 30, 40];
+        let build = || {
+            PostingIterator::new(
+                "hotels".to_owned(),
+                0,
+                0,
+                generate_posting_list_with_freqs(
+                    posting_docs.clone(),
+                    freqs.clone(),
+                    1.0,
+                    None,
+                    true,
+                ),
+                64,
+            )
+        };
+        let mut merged = build();
+        let mut out = vec![0u32; targets.len()];
+        merged.merge_optional_freqs(&targets, &mut out);
+
+        let mut probe = build();
+        let mut expected = vec![0u32; targets.len()];
+        for (i, &doc) in targets.iter().enumerate() {
+            if probe.doc().is_some_and(|cur| cur.doc_id() < doc) {
+                probe.next(doc);
+            }
+            if let Some(cur) = probe.doc()
+                && cur.doc_id() == doc
+            {
+                expected[i] = cur.frequency();
+            }
+        }
+        assert_eq!(out, expected);
+        assert_eq!(out, vec![0, 1, 0, 2, 0, 9, 4, 1, 0, 8]);
+    }
+
+    #[test]
+    fn maxscore_top2_gap_completes_isolated_essentials() {
+        // Two essentials 3000 docs apart: Lucene scores each stretch as a
+        // single-essential window. The optional sits on both ends so the
+        // floor can demote it without dropping either essential's hits.
+        let left: Vec<u32> = (0..32).collect();
+        let right: Vec<u32> = (3000..3032).collect();
+        let optional: Vec<u32> = left.iter().copied().chain(right.iter().copied()).collect();
+        let build = |token: &str, rank: u32, docs: Vec<u32>, weight: f32| {
+            PostingIterator::with_query_weight(
+                token.to_owned(),
+                rank,
+                rank,
+                weight,
+                generate_posting_list(docs, weight, None, true),
+                4096,
+            )
+        };
+        let mut docs = DocSet::default();
+        for doc in 0..4096u64 {
+            docs.append(doc, 1);
+        }
+        let shared_floor = Arc::new(AtomicU32::new(0.15_f32.to_bits()));
+        let mut wand = Wand::new(
+            Operator::Or,
+            [
+                build("left", 0, left, 2.0),
+                build("right", 1, right, 2.0),
+                build("opt", 2, optional, 0.1),
+            ]
+            .into_iter(),
+            &docs,
+            InverseDocLengthScorer,
+        )
+        .with_shared_threshold(shared_floor);
+        let hits = wand
+            .maxscore_search(
+                &FtsSearchParams::default().with_limit(Some(10)),
+                &NoOpMetricsCollector,
+            )
+            .unwrap();
+        assert_eq!(hits.len(), 10);
+        assert!(
+            wand.maxscore_single_essential_windows > 0,
+            "a 2048+ gap between essentials must take the Lucene single-clause inner window"
+        );
+    }
+
+    #[test]
+    fn maxscore_first_required_keeps_winners_on_the_buffer() {
+        // Optional is non-essential once the floor sits between its bound and
+        // the essential bound. Promoting it to required must still keep the
+        // document that has both terms; the essential posting is not the
+        // leapfrog driver.
+        let postings = [
+            (0_u32, 0.3_f32, vec![0_u32]),
+            (1_u32, 0.4_f32, vec![0_u32, 1]),
+        ]
+        .into_iter()
+        .map(|(position, query_weight, docs)| {
+            PostingIterator::with_query_weight(
+                format!("t{position}"),
+                position,
+                position,
+                query_weight,
+                generate_posting_list(docs, query_weight, None, true),
+                2,
+            )
+        })
+        .collect::<Vec<_>>();
+        let mut docs = DocSet::default();
+        docs.append(0, 1);
+        docs.append(1, 1);
+        let mut wand = Wand::new(
+            Operator::Or,
+            postings.into_iter(),
+            &docs,
+            CountingScorer {
+                scored: Arc::new(AtomicUsize::new(0)),
+            },
+        );
+        wand.threshold = 0.45;
+        let hits = wand
+            .maxscore_search(
+                &FtsSearchParams::default().with_limit(Some(10)),
+                &NoOpMetricsCollector,
+            )
+            .unwrap();
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].document, 0);
+        assert!(hits[0].freqs.iter().any(|(term, _)| *term == 0));
+        assert!(wand.maxscore_single_essential_windows > 0);
+    }
+
+    /// Oracle: `maxscore_search` must publish the same top-k as an exhaustive
+    /// fold over every document, scored in query order. The fold shares no code
+    /// with MAXSCORE, so it pins the hit set, the order, and the k-th score
+    /// without needing a second search path to compare against.
+    #[rstest]
+    fn maxscore_matches_an_exhaustive_query_order_fold(
+        #[values(2_usize, 3_usize)] num_terms: usize,
+        #[values(4_usize, 10_usize)] limit: usize,
+    ) {
+        let block = MAX_POSTING_BLOCK_SIZE as u32;
+        let total_docs = 3 * block;
+        let mut docs = DocSet::default();
+        for doc in 0..total_docs {
+            docs.append(u64::from(doc), doc % 17 + 1);
+        }
+
+        // Clause `term` covers `term, term+num_terms, term+2*num_terms, ...`,
+        // so membership is a closed form instead of a posting-list walk.
+        let covered =
+            |doc: u32, term: u32| doc >= term && (doc - term).is_multiple_of(num_terms as u32);
+        let freq_of = |doc: u32, term: u32| (doc + term) % 5 + 1;
+
+        let mut expected = (0..total_docs)
+            .map(|doc| {
+                let norm = 0.3 + docs.scoring_num_tokens(doc) as f32 * 0.1;
+                let score = (0..num_terms as u32)
+                    .filter(|term| covered(doc, *term))
+                    .fold(0.0_f32, |sum, term| {
+                        sum + bm25_doc_weight_with_norm(freq_of(doc, term), norm)
+                    });
+                (u64::from(doc), score)
+            })
+            .filter(|(_, score)| *score > 0.0)
+            .collect::<Vec<_>>();
+        expected.sort_unstable_by(|left, right| {
+            right
+                .1
+                .total_cmp(&left.1)
+                .then_with(|| left.0.cmp(&right.0))
+        });
+        // Lengths and frequencies are quantized, so many documents tie on
+        // score. Which tied documents fill the last slots is not observable,
+        // so pin the strict winners and the tie set instead of one arbitrary
+        // ordering.
+        let kth = expected[limit - 1].1;
+        let strictly_better = expected
+            .iter()
+            .filter(|(_, score)| *score > kth)
+            .map(|(doc, _)| *doc)
+            .collect::<Vec<_>>();
+        let tying = expected
+            .iter()
+            .filter(|(_, score)| *score == kth)
+            .map(|(doc, _)| *doc)
+            .collect::<Vec<_>>();
+
+        let postings = (0..num_terms as u32)
+            .map(|term| {
+                let doc_ids = (term..total_docs).step_by(num_terms).collect::<Vec<_>>();
+                let freqs = doc_ids
+                    .iter()
+                    .map(|doc| freq_of(*doc, term))
+                    .collect::<Vec<_>>();
+                let lengths = doc_ids.iter().map(|doc| doc % 17 + 1).collect::<Vec<_>>();
+                PostingIterator::with_query_weight(
+                    format!("t{term}"),
+                    term,
+                    term,
+                    1.0,
+                    generate_impact_posting_list_with_freqs_and_block_size(
+                        doc_ids,
+                        freqs,
+                        lengths,
+                        MAX_POSTING_BLOCK_SIZE,
+                    ),
+                    docs.len(),
+                )
+            })
+            .collect::<Vec<_>>();
+        let shared_floor = Arc::new(AtomicU32::new(0.0_f32.to_bits()));
+        let mut wand = Wand::new(
+            Operator::Or,
+            postings.into_iter(),
+            &docs,
+            VariedBm25ShapeScorer,
+        )
+        .with_shared_threshold(shared_floor.clone());
+        let hits = wand
+            .maxscore_search(
+                &FtsSearchParams::default().with_limit(Some(limit)),
+                &NoOpMetricsCollector,
+            )
+            .unwrap();
+
+        let got = hits
+            .iter()
+            .map(|hit| hit.posting_doc_id)
+            .collect::<Vec<_>>();
+        assert_eq!(got.len(), limit);
+        for doc in &strictly_better {
+            assert!(
+                got.contains(doc),
+                "doc {doc} scores above the k-th ({kth}) and must be in the top {limit}"
+            );
+        }
+        for doc in &got {
+            assert!(
+                strictly_better.contains(doc) || tying.contains(doc),
+                "doc {doc} is not a top-{limit} candidate (k-th = {kth})"
+            );
+        }
+        // The published floor is the k-th best score, so it pins the value and
+        // not just the membership.
+        assert_eq!(shared_floor.load(Ordering::Relaxed), kth.to_bits());
+    }
+
+    /// The gap that hands a stretch to the single-essential inner window is
+    /// `MAXSCORE_INNER_WINDOW / 2`. Pin the boundary from both sides instead of
+    /// only testing a comfortable distance away from it.
+    #[rstest]
+    fn maxscore_top2_gap_boundary(#[values(2047_u32, 2048_u32, 2049_u32)] gap: u32) {
+        let left = (0..32_u32).collect::<Vec<_>>();
+        let right = (gap..gap + 32).collect::<Vec<_>>();
+        let num_docs = (gap + 64) as usize;
+        let build = |token: &str, rank: u32, doc_ids: Vec<u32>, weight: f32| {
+            PostingIterator::with_query_weight(
+                token.to_owned(),
+                rank,
+                rank,
+                weight,
+                generate_posting_list(doc_ids, weight, None, true),
+                num_docs,
+            )
+        };
+        let mut docs = DocSet::default();
+        for doc in 0..num_docs as u64 {
+            docs.append(doc, 1);
+        }
+        let mut wand = Wand::new(
+            Operator::Or,
+            // Distinct weights: every document of "left" outranks every document
+            // of "right", so the top ten is a known set instead of an arbitrary
+            // pick out of 64 tied documents.
+            [build("left", 0, left, 3.0), build("right", 1, right, 1.0)].into_iter(),
+            &docs,
+            InverseDocLengthScorer,
+        );
+        let hits = wand
+            .maxscore_search(
+                &FtsSearchParams::default().with_limit(Some(10)),
+                &NoOpMetricsCollector,
+            )
+            .unwrap();
+
+        assert_eq!(hits.len(), 10);
+        assert!(
+            hits.iter().all(|hit| hit.posting_doc_id < 32),
+            "the heavier clause must fill the top ten, got {:?}",
+            hits.iter()
+                .map(|hit| hit.posting_doc_id)
+                .collect::<Vec<_>>()
+        );
+        if gap >= (MAXSCORE_INNER_WINDOW / 2) as u32 {
+            assert!(
+                wand.maxscore_single_essential_windows > 0,
+                "gap {gap} must take the single-essential inner window"
+            );
+        } else {
+            assert!(
+                wand.maxscore_general_windows > 0,
+                "gap {gap} must stay on the general window path"
+            );
+        }
     }
 
     #[rstest]

--- a/rust/lance-index/src/scalar/inverted/wand.rs
+++ b/rust/lance-index/src/scalar/inverted/wand.rs
@@ -1185,6 +1185,10 @@ impl PostingIterator {
     }
 
     fn position_cursor(&self) -> Result<PositionCursor<'_>> {
+        #[cfg(test)]
+        {
+            POSITION_CURSOR_CALLS.with(|calls| calls.set(calls.get() + 1));
+        }
         match self.list {
             PostingList::Plain(ref list) => {
                 let positions = list.positions.as_ref().ok_or_else(|| {
@@ -5294,106 +5298,134 @@ impl<'a, S: Scorer, D: WandDocuments> Wand<'a, S, D> {
         }
     }
 
-    /// Allocation-free exact-phrase check for the bulk conjunction path,
-    /// where every clause is a parked `lead` iterator. Semantically identical
-    /// to [`Self::check_exact_positions`] — some base position must align all
-    /// clauses at their query offsets — without the per-candidate cursor vec
-    /// and sort.
+    /// Exact-phrase check for the bulk conjunction path, where every clause
+    /// is a parked `lead` iterator. Semantically identical to
+    /// [`Self::check_exact_positions`].
     fn check_exact_positions_bulk(&self) -> Result<bool> {
         #[cfg(test)]
         {
             self.phrase_position_checks
                 .set(self.phrase_position_checks.get() + 1);
         }
-        const MAX_INLINE_CLAUSES: usize = 16;
-        let num_clauses = self.lead.len();
-        if num_clauses > MAX_INLINE_CLAUSES {
-            return self.check_exact_positions();
-        }
-        // Cursors stay alive in the stack array so owned position buffers
-        // (legacy per-doc storage) remain valid while we scan.
-        let mut cursors: [Option<PositionCursor<'_>>; MAX_INLINE_CLAUSES] =
-            std::array::from_fn(|_| None);
-        let mut anchor_idx = 0usize;
-        let mut anchor_len = usize::MAX;
-        for (index, (slot, posting)) in cursors.iter_mut().zip(self.lead.iter()).enumerate() {
-            let cursor = posting.position_cursor()?;
-            if cursor.len() < anchor_len {
-                anchor_len = cursor.len();
-                anchor_idx = index;
-            }
-            *slot = Some(cursor);
-        }
-
-        let anchor = cursors[anchor_idx]
-            .as_ref()
-            .expect("anchor cursor was just populated");
-        let anchor_offset = anchor.position_in_query as u32;
-        'anchor: for &anchor_position in anchor.positions.as_slice() {
-            let Some(base) = anchor_position.checked_sub(anchor_offset) else {
-                continue;
-            };
-            for (index, slot) in cursors[..num_clauses].iter().enumerate() {
-                if index == anchor_idx {
-                    continue;
-                }
-                let cursor = slot.as_ref().expect("clause cursor was just populated");
-                let Some(target) = base.checked_add(cursor.position_in_query as u32) else {
-                    return Ok(false);
-                };
-                if cursor.positions.as_slice().binary_search(&target).is_err() {
-                    continue 'anchor;
-                }
-            }
-            return Ok(true);
-        }
-        Ok(false)
+        exact_phrase_positions_match(
+            self.lead.len(),
+            |index| {
+                self.lead[index]
+                    .doc()
+                    .map(|doc| doc.frequency())
+                    .unwrap_or(u32::MAX)
+            },
+            |index| self.lead[index].position_cursor(),
+        )
     }
 
     fn check_exact_positions(&self) -> Result<bool> {
-        let mut position_iters = self
-            .current_doc_postings()
-            .into_iter()
-            .map(PostingIterator::position_cursor)
-            .collect::<Result<Vec<_>>>()?;
-        position_iters.sort_unstable_by_key(|iter| iter.len());
-        let Some(lead) = position_iters.first() else {
-            return Ok(false);
-        };
-        let lead_position = lead.position_in_query;
+        let postings = self.current_doc_postings();
+        exact_phrase_positions_match(
+            postings.len(),
+            |index| {
+                postings[index]
+                    .doc()
+                    .map(|doc| doc.frequency())
+                    .unwrap_or(u32::MAX)
+            },
+            |index| postings[index].position_cursor(),
+        )
+    }
+}
 
-        loop {
-            let Some(anchor) = position_iters[0].absolute_position() else {
+/// Decode exact-phrase position lists in current-doc frequency order.
+///
+/// Term frequency equals the position count, so a stopword on this document
+/// is decoded last. If the two rarest lists share no phrase base, the rest
+/// (typically `"the"` / `"of"`) are never unpacked.
+fn exact_phrase_positions_match<'a>(
+    num_clauses: usize,
+    frequency: impl Fn(usize) -> u32,
+    decode: impl FnMut(usize) -> Result<PositionCursor<'a>>,
+) -> Result<bool> {
+    const MAX_INLINE_CLAUSES: usize = 16;
+    if num_clauses == 0 {
+        return Ok(false);
+    }
+    if num_clauses > MAX_INLINE_CLAUSES {
+        let mut order: Vec<usize> = (0..num_clauses).collect();
+        order.sort_unstable_by_key(|&index| frequency(index));
+        let mut cursors: Vec<Option<PositionCursor<'a>>> = (0..num_clauses).map(|_| None).collect();
+        return exact_phrase_scan(&order, &mut cursors, decode);
+    }
+    let mut order = [0usize; MAX_INLINE_CLAUSES];
+    for (index, slot) in order.iter_mut().enumerate().take(num_clauses) {
+        *slot = index;
+    }
+    order[..num_clauses].sort_unstable_by_key(|&index| frequency(index));
+    let mut cursors: [Option<PositionCursor<'a>>; MAX_INLINE_CLAUSES] =
+        std::array::from_fn(|_| None);
+    exact_phrase_scan(&order[..num_clauses], &mut cursors, decode)
+}
+
+fn exact_phrase_scan<'a>(
+    order: &[usize],
+    cursors: &mut [Option<PositionCursor<'a>>],
+    mut decode: impl FnMut(usize) -> Result<PositionCursor<'a>>,
+) -> Result<bool> {
+    let num_clauses = order.len();
+    if num_clauses == 0 {
+        return Ok(false);
+    }
+    let rarest = order[0];
+    cursors[rarest] = Some(decode(rarest)?);
+    let (n_pos, anchor_offset) = {
+        let cursor = cursors[rarest]
+            .as_ref()
+            .expect("rarest clause cursor was just populated");
+        (cursor.len(), cursor.position_in_query as u32)
+    };
+    if num_clauses == 1 {
+        return Ok(n_pos > 0);
+    }
+
+    for pos_i in 0..n_pos {
+        let anchor_position = {
+            let cursor = cursors[rarest]
+                .as_ref()
+                .expect("rarest clause cursor was just populated");
+            cursor.positions.as_slice()[pos_i]
+        };
+        let Some(base) = anchor_position.checked_sub(anchor_offset) else {
+            continue;
+        };
+        let mut matched = true;
+        for &index in &order[1..num_clauses] {
+            if cursors[index].is_none() {
+                cursors[index] = Some(decode(index)?);
+            }
+            let cursor = cursors[index]
+                .as_ref()
+                .expect("phrase clause cursor was just populated");
+            let Some(target) = base.checked_add(cursor.position_in_query as u32) else {
                 return Ok(false);
             };
-            let Some(base) = anchor.checked_sub(lead_position as u32) else {
-                position_iters[0].advance_next();
-                continue;
-            };
-
-            let mut next_lead_relative = None;
-            let mut matched = true;
-            for follower in position_iters.iter_mut().skip(1) {
-                let Some(target) = base.checked_add(follower.position_in_query as u32) else {
-                    return Ok(false);
-                };
-                let Some(position) = follower.advance_to_absolute(target) else {
-                    return Ok(false);
-                };
-                if position != target {
-                    next_lead_relative = Some(position as i32 - follower.position_in_query);
-                    matched = false;
-                    break;
-                }
+            if cursor.positions.as_slice().binary_search(&target).is_err() {
+                matched = false;
+                break;
             }
-
-            if matched {
-                return Ok(true);
-            }
-
-            position_iters[0].advance_to_relative(next_lead_relative.unwrap());
+        }
+        if matched {
+            return Ok(true);
         }
     }
+    Ok(false)
+}
+
+#[cfg(test)]
+thread_local! {
+    static POSITION_CURSOR_CALLS: Cell<usize> = const { Cell::new(0) };
+}
+
+#[cfg(test)]
+fn take_position_cursor_calls() -> usize {
+    POSITION_CURSOR_CALLS.with(|calls| calls.replace(0))
 }
 
 #[derive(Debug)]
@@ -5469,10 +5501,6 @@ impl<'a> PositionCursor<'a> {
         self.positions.len()
     }
 
-    fn absolute_position(&self) -> Option<u32> {
-        self.positions.as_slice().get(self.index).copied()
-    }
-
     fn relative_position(&self) -> Option<i32> {
         self.positions
             .as_slice()
@@ -5488,19 +5516,6 @@ impl<'a> PositionCursor<'a> {
         let least_pos = least_pos.max(0) as u32;
         let values = self.positions.as_slice();
         self.index += values[self.index..].partition_point(|&pos| pos < least_pos);
-    }
-
-    fn advance_to_absolute(&mut self, least_pos: u32) -> Option<u32> {
-        if self.index >= self.len() {
-            return None;
-        }
-        let values = self.positions.as_slice();
-        self.index += values[self.index..].partition_point(|&pos| pos < least_pos);
-        self.absolute_position()
-    }
-
-    fn advance_next(&mut self) {
-        self.index = self.index.saturating_add(1).min(self.len());
     }
 }
 
@@ -9788,6 +9803,195 @@ mod tests {
         let second = wand.next().unwrap().unwrap();
         assert_eq!(second.0.doc_id(), 1);
         assert!(wand.check_positions(0).unwrap());
+    }
+
+    #[rstest]
+    fn exact_phrase_skips_stopword_decode_when_rare_pair_misses(
+        #[values(false, true)] is_compressed: bool,
+    ) {
+        let mut docs = DocSet::default();
+        docs.append(0, 16);
+
+        let postings = vec![
+            PostingIterator::new(
+                String::from("the"),
+                0,
+                0,
+                generate_posting_list_with_positions(
+                    vec![0],
+                    vec![(0..100_u32).collect()],
+                    1.0,
+                    is_compressed,
+                ),
+                docs.len(),
+            ),
+            PostingIterator::new(
+                String::from("news"),
+                1,
+                1,
+                generate_posting_list_with_positions(
+                    vec![0],
+                    vec![vec![50_u32]],
+                    1.0,
+                    is_compressed,
+                ),
+                docs.len(),
+            ),
+            PostingIterator::new(
+                String::from("journal"),
+                2,
+                2,
+                generate_posting_list_with_positions(
+                    vec![0],
+                    vec![vec![99_u32]],
+                    1.0,
+                    is_compressed,
+                ),
+                docs.len(),
+            ),
+        ];
+        let bm25 = IndexBM25Scorer::new(std::iter::empty());
+        let wand = Wand::new(Operator::And, postings.into_iter(), &docs, bm25);
+        let _ = take_position_cursor_calls();
+        assert!(!wand.check_exact_positions().unwrap());
+        assert_eq!(take_position_cursor_calls(), 2);
+        assert!(!wand.check_exact_positions_bulk().unwrap());
+        assert_eq!(take_position_cursor_calls(), 2);
+    }
+
+    #[rstest]
+    fn exact_phrase_decodes_stopword_when_rare_pair_aligns(
+        #[values(false, true)] is_compressed: bool,
+    ) {
+        let mut docs = DocSet::default();
+        docs.append(0, 16);
+
+        let hit_the: Vec<u32> = (0..100).collect();
+        let postings = vec![
+            PostingIterator::new(
+                String::from("the"),
+                0,
+                0,
+                generate_posting_list_with_positions(vec![0], vec![hit_the], 1.0, is_compressed),
+                docs.len(),
+            ),
+            PostingIterator::new(
+                String::from("news"),
+                1,
+                1,
+                generate_posting_list_with_positions(
+                    vec![0],
+                    vec![vec![11_u32]],
+                    1.0,
+                    is_compressed,
+                ),
+                docs.len(),
+            ),
+            PostingIterator::new(
+                String::from("journal"),
+                2,
+                2,
+                generate_posting_list_with_positions(
+                    vec![0],
+                    vec![vec![12_u32]],
+                    1.0,
+                    is_compressed,
+                ),
+                docs.len(),
+            ),
+        ];
+        let bm25 = IndexBM25Scorer::new(std::iter::empty());
+        let wand = Wand::new(Operator::And, postings.into_iter(), &docs, bm25);
+        let _ = take_position_cursor_calls();
+        assert!(wand.check_exact_positions().unwrap());
+        assert_eq!(take_position_cursor_calls(), 3);
+        assert!(wand.check_exact_positions_bulk().unwrap());
+        assert_eq!(take_position_cursor_calls(), 3);
+    }
+
+    #[rstest]
+    fn exact_phrase_rejects_when_stopword_misses_aligned_pair(
+        #[values(false, true)] is_compressed: bool,
+    ) {
+        let mut docs = DocSet::default();
+        docs.append(0, 16);
+
+        // "news journal" aligns at base 10, but "the" has no position 10.
+        let the_positions: Vec<u32> = (0..10).chain(11..100).collect();
+        let postings = vec![
+            PostingIterator::new(
+                String::from("the"),
+                0,
+                0,
+                generate_posting_list_with_positions(
+                    vec![0],
+                    vec![the_positions],
+                    1.0,
+                    is_compressed,
+                ),
+                docs.len(),
+            ),
+            PostingIterator::new(
+                String::from("news"),
+                1,
+                1,
+                generate_posting_list_with_positions(
+                    vec![0],
+                    vec![vec![11_u32]],
+                    1.0,
+                    is_compressed,
+                ),
+                docs.len(),
+            ),
+            PostingIterator::new(
+                String::from("journal"),
+                2,
+                2,
+                generate_posting_list_with_positions(
+                    vec![0],
+                    vec![vec![12_u32]],
+                    1.0,
+                    is_compressed,
+                ),
+                docs.len(),
+            ),
+        ];
+        let bm25 = IndexBM25Scorer::new(std::iter::empty());
+        let wand = Wand::new(Operator::And, postings.into_iter(), &docs, bm25);
+        let _ = take_position_cursor_calls();
+        assert!(!wand.check_exact_positions().unwrap());
+        assert_eq!(take_position_cursor_calls(), 3);
+        assert!(!wand.check_exact_positions_bulk().unwrap());
+        assert_eq!(take_position_cursor_calls(), 3);
+    }
+
+    #[rstest]
+    fn exact_phrase_heap_path_matches_wide_clause_count(
+        #[values(false, true)] is_compressed: bool,
+    ) {
+        let mut docs = DocSet::default();
+        docs.append(0, 32);
+        let num_clauses = 17usize;
+        let postings = (0..num_clauses)
+            .map(|index| {
+                PostingIterator::new(
+                    format!("t{index}"),
+                    index as u32,
+                    index as u32,
+                    generate_posting_list_with_positions(
+                        vec![0],
+                        vec![vec![index as u32]],
+                        1.0,
+                        is_compressed,
+                    ),
+                    docs.len(),
+                )
+            })
+            .collect::<Vec<_>>();
+        let bm25 = IndexBM25Scorer::new(std::iter::empty());
+        let wand = Wand::new(Operator::And, postings.into_iter(), &docs, bm25);
+        assert!(wand.check_exact_positions().unwrap());
+        assert!(wand.check_exact_positions_bulk().unwrap());
     }
 
     /// The bulk conjunction path must return exactly the classic loop's

--- a/rust/lance-index/src/scalar/inverted/wand_maxscore.rs
+++ b/rust/lance-index/src/scalar/inverted/wand_maxscore.rs
@@ -1,0 +1,683 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+//! Inner-window work for MAXSCORE: block skip, two-pointer optional freqs,
+//! and SoA completion for one essential plus at most two optionals.
+//!
+//! Lucene's `scoreInnerWindowSingleEssentialClause`. Two-essential compact
+//! union is intentionally not ported.
+
+use smallvec::SmallVec;
+
+use lance_core::Result;
+
+use super::super::builder::ScoredDoc;
+use super::super::scorer::{Scorer, bm25_doc_weight_with_norm};
+use super::{
+    CompetitiveFloorMode, DocInfo, MaxScoreClause, PostingIterator, PostingList, RawDocInfo,
+    TopKCollector, Wand, WandDocuments, score_sum_cannot_compete,
+};
+
+#[inline]
+pub(super) fn exclusive_cannot_compete(
+    partial: f32,
+    remaining_upper_bound: f64,
+    floor: f32,
+    upper_bound_factor: f64,
+) -> bool {
+    floor > 0.0
+        && score_sum_cannot_compete(
+            partial,
+            remaining_upper_bound,
+            floor,
+            upper_bound_factor,
+            CompetitiveFloorMode::Exclusive,
+        )
+}
+
+fn bm25_tf_from_caches(
+    query_weight: f32,
+    freq: u32,
+    doc: u32,
+    quantized: Option<(&[u8], &[f32; 256])>,
+) -> Option<f32> {
+    let (norms, cache) = quantized?;
+    Some(query_weight * bm25_doc_weight_with_norm(freq, cache[norms[doc as usize] as usize]))
+}
+
+fn bulk_bm25_tf(
+    query_weight: f32,
+    hits: &[(u64, u32)],
+    quantized: Option<(&[u8], &[f32; 256])>,
+    fallback: impl Fn(u64, u32) -> f32,
+    out: &mut Vec<f32>,
+) {
+    out.clear();
+    out.reserve(hits.len());
+    if let Some((norms, cache)) = quantized {
+        for &(doc, freq) in hits {
+            out.push(
+                query_weight * bm25_doc_weight_with_norm(freq, cache[norms[doc as usize] as usize]),
+            );
+        }
+        return;
+    }
+    for &(doc, freq) in hits {
+        out.push(fallback(doc, freq));
+    }
+}
+
+/// Lucene `DocAndScoreAccBuffer`: SoA vectors reused across essential blocks.
+pub(super) struct MaxScoreSoaScratch {
+    docs: Vec<u64>,
+    ess_scores: Vec<f32>,
+    ess_freqs: Vec<u32>,
+    raw_scores: Vec<f32>,
+    opt_scores: Vec<f32>,
+    opt_freqs: Vec<u32>,
+    opt_s: [Vec<f32>; 2],
+    opt_f: [Vec<u32>; 2],
+    partial: Vec<f32>,
+}
+
+impl MaxScoreSoaScratch {
+    pub(super) fn new() -> Self {
+        Self {
+            docs: Vec::with_capacity(128),
+            ess_scores: Vec::with_capacity(128),
+            ess_freqs: Vec::with_capacity(128),
+            raw_scores: Vec::with_capacity(128),
+            opt_scores: Vec::with_capacity(128),
+            opt_freqs: Vec::with_capacity(128),
+            opt_s: [Vec::with_capacity(128), Vec::with_capacity(128)],
+            opt_f: [Vec::with_capacity(128), Vec::with_capacity(128)],
+            partial: Vec::with_capacity(128),
+        }
+    }
+}
+
+impl PostingIterator {
+    /// Lucene `ScorerUtil.applyOptionalClause`: fill `out_freqs[i]` with this
+    /// clause's frequency at sorted `docs[i]`, or 0 on a miss.
+    pub(super) fn merge_optional_freqs(&mut self, docs: &[u64], out_freqs: &mut [u32]) {
+        debug_assert_eq!(docs.len(), out_freqs.len());
+        out_freqs.fill(0);
+        if docs.is_empty() {
+            return;
+        }
+        if self.doc().is_some_and(|cur| cur.doc_id() < docs[0]) {
+            self.next(docs[0]);
+        }
+        if matches!(self.list, PostingList::Plain(_)) {
+            for (i, &doc) in docs.iter().enumerate() {
+                if self.doc().is_some_and(|cur| cur.doc_id() < doc) {
+                    self.next(doc);
+                }
+                if let Some(cur) = self.doc()
+                    && cur.doc_id() == doc
+                {
+                    out_freqs[i] = cur.frequency();
+                }
+            }
+            return;
+        }
+        let shift = match &self.list {
+            PostingList::Compressed(list) => list.block_shift(),
+            PostingList::Plain(_) => return,
+        };
+        let length = match &self.list {
+            PostingList::Compressed(list) => list.length as usize,
+            PostingList::Plain(_) => return,
+        };
+        let mut i = 0usize;
+        while i < docs.len() {
+            let Some(cur) = self.current_doc else {
+                return;
+            };
+            let cur_id = cur.doc_id();
+            while i < docs.len() && docs[i] < cur_id {
+                i += 1;
+            }
+            if i >= docs.len() {
+                return;
+            }
+            if docs[i] > cur_id {
+                self.next(docs[i]);
+                continue;
+            }
+            let block_idx = self.index >> shift;
+            let mask = match &self.list {
+                PostingList::Compressed(list) => list.block_mask(),
+                PostingList::Plain(_) => return,
+            };
+            let (stay, end_of_block) = match &self.list {
+                PostingList::Compressed(list) => {
+                    let compressed = unsafe { &*self.ensure_compressed_block_ptr(list, block_idx) };
+                    let mut j = self.index & mask;
+                    let n = compressed.doc_ids.len();
+                    while i < docs.len() && j < n {
+                        let block_doc = u64::from(compressed.doc_ids[j]);
+                        if block_doc < docs[i] {
+                            j += 1;
+                        } else if block_doc == docs[i] {
+                            out_freqs[i] = compressed.freqs[j];
+                            i += 1;
+                            j += 1;
+                        } else {
+                            i += 1;
+                        }
+                    }
+                    let stay = (j < n).then(|| (compressed.doc_ids[j], compressed.freqs[j]));
+                    (stay, j)
+                }
+                PostingList::Plain(_) => return,
+            };
+            if let Some((doc_id, frequency)) = stay {
+                self.index = (block_idx << shift) + end_of_block;
+                self.block_idx = block_idx;
+                self.current_doc = Some(DocInfo::Raw(RawDocInfo { doc_id, frequency }));
+            } else {
+                let next_start = (block_idx + 1) << shift;
+                if next_start >= length {
+                    self.index = length;
+                    self.block_idx = self.index >> shift;
+                    self.current_doc = None;
+                } else {
+                    self.index = next_start;
+                    self.block_idx = block_idx + 1;
+                    let next_doc = match &self.list {
+                        PostingList::Compressed(list) => {
+                            let next =
+                                unsafe { &*self.ensure_compressed_block_ptr(list, block_idx + 1) };
+                            (next.doc_ids[0], next.freqs[0])
+                        }
+                        PostingList::Plain(_) => return,
+                    };
+                    self.current_doc = Some(DocInfo::Raw(RawDocInfo {
+                        doc_id: next_doc.0,
+                        frequency: next_doc.1,
+                    }));
+                }
+            }
+        }
+    }
+
+    /// Copy one decompressed posting block (or a 128-doc Plain slice) with
+    /// `doc_id <= window_max` into `out`. Leaves the cursor on the first doc
+    /// beyond that chunk.
+    pub(super) fn take_docs_one_block_upto(&mut self, window_max: u64, out: &mut Vec<(u64, u32)>) {
+        out.clear();
+        match self.list {
+            PostingList::Compressed(ref list) => {
+                let Some(cur) = self.current_doc else {
+                    return;
+                };
+                if cur.doc_id() > window_max {
+                    return;
+                }
+                let shift = list.block_shift();
+                let mask = list.block_mask();
+                let block_idx = self.index >> shift;
+                let block_offset = self.index & mask;
+                let compressed = unsafe { &mut *self.ensure_compressed_block_ptr(list, block_idx) };
+                for offset in block_offset..compressed.doc_ids.len() {
+                    let doc_id = compressed.doc_ids[offset];
+                    if u64::from(doc_id) > window_max {
+                        self.index = (block_idx << shift) + offset;
+                        self.block_idx = block_idx;
+                        self.current_doc = Some(DocInfo::Raw(RawDocInfo {
+                            doc_id,
+                            frequency: compressed.freqs[offset],
+                        }));
+                        return;
+                    }
+                    out.push((u64::from(doc_id), compressed.freqs[offset]));
+                }
+                let next_start = (block_idx + 1) << shift;
+                if next_start >= list.length as usize {
+                    self.index = list.length as usize;
+                    self.block_idx = self.index >> shift;
+                    self.current_doc = None;
+                    return;
+                }
+                self.index = next_start;
+                self.block_idx = block_idx + 1;
+                let compressed =
+                    unsafe { &mut *self.ensure_compressed_block_ptr(list, block_idx + 1) };
+                self.current_doc = Some(DocInfo::Raw(RawDocInfo {
+                    doc_id: compressed.doc_ids[0],
+                    frequency: compressed.freqs[0],
+                }));
+            }
+            PostingList::Plain(_) => {
+                while let Some(cur) = self.doc() {
+                    let doc = cur.doc_id();
+                    if doc > window_max {
+                        break;
+                    }
+                    out.push((doc, cur.frequency()));
+                    self.next(doc + 1);
+                    if out.len() >= 128 {
+                        break;
+                    }
+                }
+            }
+        }
+    }
+
+    /// Advance to the first doc of the next posting block, or exhaust.
+    pub(super) fn skip_current_block(&mut self) -> bool {
+        match self.next_block_first_doc() {
+            Some(doc) => {
+                self.next(doc);
+                self.current_doc.is_some()
+            }
+            None => {
+                if let PostingList::Compressed(ref list) = self.list {
+                    self.index = list.length as usize;
+                    self.block_idx = self.index >> list.block_shift();
+                }
+                self.current_doc = None;
+                false
+            }
+        }
+    }
+}
+
+impl<'a, S: Scorer, D: WandDocuments> Wand<'a, S, D> {
+    /// Skip dead essential blocks and complete surviving docs with at most
+    /// two optional clauses via SoA buffers.
+    #[allow(clippy::too_many_arguments)]
+    pub(super) fn score_single_essential_upto(
+        &mut self,
+        clauses: &mut [MaxScoreClause],
+        first_essential: usize,
+        ess_idx: usize,
+        upto: u64,
+        essential_query_rank: usize,
+        essential_term: u32,
+        essential_weight: f32,
+        essential_window_bound: f32,
+        num_query_terms: usize,
+        total_non_essential_bound: f64,
+        total_sum_upper_bound_factor: f64,
+        norm_k_ref: Option<(&[u8], &[f32; 256])>,
+        essential_chunk: &mut Vec<(u64, u32)>,
+        scratch: &mut MaxScoreSoaScratch,
+        candidates: &mut TopKCollector,
+        num_comparisons: &mut usize,
+        wand_factor: f32,
+    ) -> Result<()> {
+        loop {
+            // Lucene `nextPostings(upTo)`: do not advance past this call's
+            // exclusive end. After `take_docs` the cursor already sits on the
+            // first doc of the next block, which may belong to a later window
+            // whose optional remainder is larger.
+            if clauses[ess_idx]
+                .posting
+                .doc()
+                .is_none_or(|doc| doc.doc_id() > upto)
+            {
+                break;
+            }
+            if self.threshold > 0.0 {
+                let block_max = clauses[ess_idx].posting.block_max_score(&self.scorer);
+                if exclusive_cannot_compete(
+                    block_max,
+                    total_non_essential_bound,
+                    self.threshold,
+                    total_sum_upper_bound_factor,
+                ) {
+                    #[cfg(test)]
+                    {
+                        self.maxscore_essential_blocks_skipped += 1;
+                    }
+                    let more = clauses[ess_idx].posting.skip_current_block();
+                    if !more
+                        || clauses[ess_idx]
+                            .posting
+                            .doc()
+                            .is_none_or(|doc| doc.doc_id() > upto)
+                    {
+                        break;
+                    }
+                    continue;
+                }
+            }
+            clauses[ess_idx]
+                .posting
+                .take_docs_one_block_upto(upto, essential_chunk);
+            if essential_chunk.is_empty() {
+                break;
+            }
+            let (non_essential, _) = clauses.split_at_mut(first_essential);
+            self.complete_maxscore_single_essential(
+                essential_chunk,
+                non_essential,
+                essential_query_rank,
+                essential_term,
+                essential_weight,
+                essential_window_bound,
+                num_query_terms,
+                total_non_essential_bound,
+                total_sum_upper_bound_factor,
+                norm_k_ref,
+                scratch,
+                candidates,
+                num_comparisons,
+                wand_factor,
+            )?;
+        }
+        Ok(())
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn complete_maxscore_single_essential(
+        &mut self,
+        hits: &[(u64, u32)],
+        non_essential: &mut [MaxScoreClause],
+        essential_query_rank: usize,
+        essential_term: u32,
+        essential_weight: f32,
+        essential_window_bound: f32,
+        num_query_terms: usize,
+        total_non_essential_bound: f64,
+        total_sum_upper_bound_factor: f64,
+        norm_k_ref: Option<(&[u8], &[f32; 256])>,
+        scratch: &mut MaxScoreSoaScratch,
+        candidates: &mut TopKCollector,
+        num_comparisons: &mut usize,
+        wand_factor: f32,
+    ) -> Result<()> {
+        debug_assert!(non_essential.len() <= 2);
+        scratch.docs.clear();
+        scratch.ess_scores.clear();
+        scratch.ess_freqs.clear();
+        scratch.opt_scores.clear();
+        scratch.opt_freqs.clear();
+        bulk_bm25_tf(
+            essential_weight,
+            hits,
+            norm_k_ref,
+            |doc, freq| {
+                essential_weight
+                    * self
+                        .scorer
+                        .doc_weight(freq, self.documents.scoring_num_tokens(doc as u32))
+            },
+            &mut scratch.raw_scores,
+        );
+        for (hit, &score) in hits.iter().zip(scratch.raw_scores.iter()) {
+            *num_comparisons += 1;
+            if exclusive_cannot_compete(
+                score,
+                total_non_essential_bound,
+                self.threshold,
+                total_sum_upper_bound_factor,
+            ) {
+                continue;
+            }
+            scratch.docs.push(hit.0);
+            scratch.ess_scores.push(score);
+            scratch.ess_freqs.push(hit.1);
+        }
+        if scratch.docs.is_empty() {
+            return Ok(());
+        }
+
+        let mut opt_term = 0u32;
+        let mut opt_rank = 0usize;
+
+        if non_essential.len() == 1 {
+            let optional = &mut non_essential[0];
+            opt_term = optional.posting.term_index();
+            opt_rank = optional.query_rank;
+            let require_best = essential_window_bound.is_finite()
+                && essential_window_bound > 0.0
+                && exclusive_cannot_compete(
+                    essential_window_bound,
+                    0.0,
+                    self.threshold,
+                    total_sum_upper_bound_factor,
+                );
+            let query_weight = optional.posting.query_weight;
+            // With a single optional clause `total_non_essential_bound` is that
+            // clause's own `prefix_bound`, so the entry filter above already
+            // applied this predicate; re-running it here was a no-op pass.
+            scratch.opt_scores.clear();
+            scratch.opt_scores.resize(scratch.docs.len(), 0.0);
+            scratch.opt_freqs.clear();
+            scratch.opt_freqs.resize(scratch.docs.len(), 0);
+            let probe = &mut optional.posting;
+            probe.merge_optional_freqs(&scratch.docs, &mut scratch.opt_freqs);
+            let mut w = 0usize;
+            for r in 0..scratch.docs.len() {
+                let freq = scratch.opt_freqs[r];
+                if freq == 0 && require_best {
+                    continue;
+                }
+                let contribution = if freq == 0 {
+                    0.0
+                } else {
+                    bm25_tf_from_caches(query_weight, freq, scratch.docs[r] as u32, norm_k_ref)
+                        .unwrap_or_else(|| {
+                            probe.score(
+                                &self.scorer,
+                                freq,
+                                self.documents.scoring_num_tokens(scratch.docs[r] as u32),
+                            )
+                        })
+                };
+                scratch.docs[w] = scratch.docs[r];
+                scratch.ess_scores[w] = scratch.ess_scores[r];
+                scratch.ess_freqs[w] = scratch.ess_freqs[r];
+                scratch.opt_scores[w] = contribution;
+                scratch.opt_freqs[w] = freq;
+                w += 1;
+            }
+            scratch.docs.truncate(w);
+            scratch.ess_scores.truncate(w);
+            scratch.ess_freqs.truncate(w);
+            scratch.opt_scores.truncate(w);
+            scratch.opt_freqs.truncate(w);
+        } else if non_essential.len() == 2 {
+            let n_live = scratch.docs.len();
+            for slot in 0..2 {
+                scratch.opt_s[slot].clear();
+                scratch.opt_s[slot].resize(n_live, 0.0);
+                scratch.opt_f[slot].clear();
+                scratch.opt_f[slot].resize(n_live, 0);
+            }
+            scratch.partial.clear();
+            scratch.partial.extend_from_slice(&scratch.ess_scores);
+            let opt_term = [
+                non_essential[0].posting.term_index(),
+                non_essential[1].posting.term_index(),
+            ];
+            let opt_rank = [non_essential[0].query_rank, non_essential[1].query_rank];
+            let remaining_without_best = non_essential[0].prefix_bound;
+            let require_best = essential_window_bound.is_finite()
+                && essential_window_bound > 0.0
+                && remaining_without_best.is_finite()
+                && exclusive_cannot_compete(
+                    essential_window_bound,
+                    remaining_without_best,
+                    self.threshold,
+                    total_sum_upper_bound_factor,
+                );
+            let apply = [1usize, 0];
+            for (step, &idx) in apply.iter().enumerate() {
+                let required = require_best && step == 0;
+                let query_weight = non_essential[idx].posting.query_weight;
+                // Step 0 probes the second optional, whose `prefix_bound` is
+                // `total_non_essential_bound`; the entry filter already applied
+                // that predicate while `partial` still equalled the essential
+                // score, so re-filtering here would be a no-op pass.
+                if !required && step > 0 {
+                    let prefix_bound = non_essential[idx].prefix_bound;
+                    let mut w = 0usize;
+                    for r in 0..scratch.docs.len() {
+                        if exclusive_cannot_compete(
+                            scratch.partial[r],
+                            prefix_bound,
+                            self.threshold,
+                            total_sum_upper_bound_factor,
+                        ) {
+                            continue;
+                        }
+                        scratch.docs[w] = scratch.docs[r];
+                        scratch.ess_scores[w] = scratch.ess_scores[r];
+                        scratch.ess_freqs[w] = scratch.ess_freqs[r];
+                        scratch.opt_s[0][w] = scratch.opt_s[0][r];
+                        scratch.opt_s[1][w] = scratch.opt_s[1][r];
+                        scratch.opt_f[0][w] = scratch.opt_f[0][r];
+                        scratch.opt_f[1][w] = scratch.opt_f[1][r];
+                        scratch.partial[w] = scratch.partial[r];
+                        w += 1;
+                    }
+                    scratch.docs.truncate(w);
+                    scratch.ess_scores.truncate(w);
+                    scratch.ess_freqs.truncate(w);
+                    scratch.partial.truncate(w);
+                    scratch.opt_s[0].truncate(w);
+                    scratch.opt_s[1].truncate(w);
+                    scratch.opt_f[0].truncate(w);
+                    scratch.opt_f[1].truncate(w);
+                    if scratch.docs.is_empty() {
+                        return Ok(());
+                    }
+                }
+                let n = scratch.docs.len();
+                scratch.opt_f[idx].clear();
+                scratch.opt_f[idx].resize(n, 0);
+                let probe = &mut non_essential[idx].posting;
+                probe.merge_optional_freqs(&scratch.docs, &mut scratch.opt_f[idx]);
+                let mut w = 0usize;
+                for r in 0..n {
+                    let freq = scratch.opt_f[idx][r];
+                    if freq == 0 && required {
+                        continue;
+                    }
+                    let contribution = if freq == 0 {
+                        0.0
+                    } else {
+                        bm25_tf_from_caches(query_weight, freq, scratch.docs[r] as u32, norm_k_ref)
+                            .unwrap_or_else(|| {
+                                probe.score(
+                                    &self.scorer,
+                                    freq,
+                                    self.documents.scoring_num_tokens(scratch.docs[r] as u32),
+                                )
+                            })
+                    };
+                    scratch.docs[w] = scratch.docs[r];
+                    scratch.ess_scores[w] = scratch.ess_scores[r];
+                    scratch.ess_freqs[w] = scratch.ess_freqs[r];
+                    scratch.opt_s[0][w] = scratch.opt_s[0][r];
+                    scratch.opt_s[1][w] = scratch.opt_s[1][r];
+                    scratch.opt_f[0][w] = scratch.opt_f[0][r];
+                    scratch.opt_f[1][w] = scratch.opt_f[1][r];
+                    scratch.opt_s[idx][w] = contribution;
+                    scratch.opt_f[idx][w] = freq;
+                    scratch.partial[w] = scratch.partial[r] + contribution;
+                    w += 1;
+                }
+                scratch.docs.truncate(w);
+                scratch.ess_scores.truncate(w);
+                scratch.ess_freqs.truncate(w);
+                scratch.partial.truncate(w);
+                scratch.opt_s[0].truncate(w);
+                scratch.opt_s[1].truncate(w);
+                scratch.opt_f[0].truncate(w);
+                scratch.opt_f[1].truncate(w);
+                if scratch.docs.is_empty() {
+                    return Ok(());
+                }
+            }
+            for i in 0..scratch.docs.len() {
+                let mut by_rank = SmallVec::<[f32; 8]>::from_elem(0.0, num_query_terms);
+                by_rank[essential_query_rank] = scratch.ess_scores[i];
+                for (o, &rank) in opt_rank.iter().enumerate() {
+                    if scratch.opt_f[o][i] > 0 {
+                        by_rank[rank] = scratch.opt_s[o][i];
+                    }
+                }
+                let canonical = by_rank
+                    .into_iter()
+                    .fold(0.0_f32, |sum, contribution| sum + contribution);
+                if canonical <= self.threshold || candidates.rejects_score(canonical) {
+                    continue;
+                }
+                let Some(document_key) = self
+                    .documents
+                    .document_key_for_doc_id(scratch.docs[i] as u32)
+                else {
+                    continue;
+                };
+                let doc_length = self.documents.scoring_num_tokens(scratch.docs[i] as u32);
+                let mut freqs = SmallVec::<[(u32, u32); 3]>::new();
+                freqs.push((essential_term, scratch.ess_freqs[i]));
+                for (o, &term) in opt_term.iter().enumerate() {
+                    if scratch.opt_f[o][i] > 0 {
+                        freqs.push((term, scratch.opt_f[o][i]));
+                    }
+                }
+                if candidates.insert(
+                    ScoredDoc::new(document_key, canonical),
+                    doc_length,
+                    scratch.docs[i],
+                    freqs.into_iter(),
+                )? && let Some(kth) = candidates.kth_score_if_full()
+                {
+                    self.update_threshold(kth, wand_factor);
+                }
+            }
+            return Ok(());
+        }
+
+        for i in 0..scratch.docs.len() {
+            let opt_freq = if non_essential.len() == 1 {
+                scratch.opt_freqs.get(i).copied().unwrap_or(0)
+            } else {
+                0
+            };
+            let canonical = if non_essential.is_empty() {
+                scratch.ess_scores[i]
+            } else {
+                let mut by_rank = SmallVec::<[f32; 8]>::from_elem(0.0, num_query_terms);
+                by_rank[essential_query_rank] = scratch.ess_scores[i];
+                if opt_freq > 0 {
+                    by_rank[opt_rank] = scratch.opt_scores[i];
+                }
+                by_rank
+                    .into_iter()
+                    .fold(0.0_f32, |sum, contribution| sum + contribution)
+            };
+            if canonical <= self.threshold || candidates.rejects_score(canonical) {
+                continue;
+            }
+            let Some(document_key) = self
+                .documents
+                .document_key_for_doc_id(scratch.docs[i] as u32)
+            else {
+                continue;
+            };
+            let doc_length = self.documents.scoring_num_tokens(scratch.docs[i] as u32);
+            let mut freqs = SmallVec::<[(u32, u32); 2]>::new();
+            freqs.push((essential_term, scratch.ess_freqs[i]));
+            if opt_freq > 0 {
+                freqs.push((opt_term, opt_freq));
+            }
+            if candidates.insert(
+                ScoredDoc::new(document_key, canonical),
+                doc_length,
+                scratch.docs[i],
+                freqs.into_iter(),
+            )? && let Some(kth) = candidates.kth_score_if_full()
+            {
+                self.update_threshold(kth, wand_factor);
+            }
+        }
+        Ok(())
+    }
+}


### PR DESCRIPTION
 ## What this does

MAXSCORE scores top-k disjunctions by streaming the essential clauses through inner windows. Today every essential clause of an inner window is scattered into a 4096-slot accumulator before a candidate can be rejected, and a single-essential window is walked document by document while every optional clause re-probes its own postings.

This PR adds `rust/lance-index/src/scalar/inverted/wand_maxscore.rs` with the Lucene `scoreInnerWindow` inner loop:

- `MaxScoreSoaScratch` keeps one essential block's documents, scores, frequencies and up to two optional score/frequency vectors in parallel arrays, reused across blocks.
- `score_single_essential_upto` skips a whole block whose impact bound plus the optional remainder cannot enter the heap, and otherwise completes one decompressed block at a time, probing the optional clauses in a single two-pointer merge instead of once per document.
- `complete_maxscore_single_essential` folds each survivor in query order.

`wand.rs` gains the top2-gap entry: when the second essential sits at least `MAXSCORE_INNER_WINDOW / 2` ahead of the first, the stretch in between holds no second-essential posting, so it is scored as a single-essential window instead of scattering two sparse lists into the accumulator. `top_doc` and `top2_doc` are taken only from the essential clauses, so the remaining contributions in that stretch are exactly zero and the shortcut is not an approximation. One pass over the essential clauses now yields both the window floor and the top2-gap pair, where the inner loop previously scanned them twice.

A deleted row is still named by the posting list and is only rejected when a hit is inserted, so the completion would merge and score the optional clauses for documents it is about to drop -- the per-document path this replaces asked about visibility first. The chunk is now filtered by visibility before any scoring, but only when the partition can actually hold an invisible document (`WandDocuments::any_invisible`, which errs towards probing). `visible_cost_upper_bound` cannot stand in for that question: a deletion vector too large to materialize (`DocVisibility::Filtered`) still reports the full document count. Filtering cannot change a result either way.

Both shortcuts have to stay inside the span they were asked to complete:

- a block skip lands on the next block, so it is only taken when the whole block fits in the span. Otherwise it drops documents past the span that a later window reaches through a different essential clause, scoring them without this clause's contribution -- a permanently missing addend. Without this guard 31 of the 943 SBG queries returned a wrong top-10 (all of them union shape).
- the top2-gap shortcut is declined when the span is empty. `shallow_next` only moves `block_idx`, so a window that ends early leaves cursors behind `window_min` and the next window starts with `inner_min` above the smallest essential doc, which puts `top2_doc - 1` at or below `inner_min`. Without the guard that iteration completes nothing and, when `top2_doc < inner_min`, moves `inner_min` backwards.

Two filtering passes that were identity transforms are also dropped: with one optional clause `total_non_essential_bound` is that clause's own `prefix_bound`, and in the two-optional walk step 0 re-checks the same predicate before `partial` has moved.

## Measurements

Against `main` at `ce1e192a1`, paired ABBA campaign over the 943-query Wikipedia SBG set: 8 paired runs, one pinned core, per-query ratio = median of run medians. Correctness first: every top-10 dump (`row_id:score_bits`) is bit-identical, **943/943**.

Per shape, summed over the queries of that shape (before -> after):

| shape | n | before | after | delta |
| --- | ---: | ---: | ---: | ---: |
| union | 301 | 722466us | 614428us | **-15.0%** |
| intersection | 300 | 653569us | 653858us | 0.0% |
| intersection_union | 40 | 1096792us | 1099428us | 0.2% |
| phrase | 300 | 870244us | 874038us | 0.4% |
| term | 1 | 662us | 655us | -1.0% |
| two-phase-critic | 1 | 61905us | 61066us | -1.4% |
| ALL | 943 | 3405637us | 3303474us | -3.0% |

Only union moves; every other shape is flat within run-to-run drift, which the control group is there to show (phrase + intersection, n=600, median 1.002x, p95 1.021x).

Top 10 improved -- all union, which is the only shape this touches:

| ratio | query | before | after |
| ---: | --- | ---: | ---: |
| 0.208x | `david koresh` | 4642.5us | 963.5us |
| 0.211x | `king kalakaua` | 4992.0us | 1052.5us |
| 0.226x | `the incredibles` | 39943.0us | 9044.0us |
| 0.235x | `kasota stone` | 2911.5us | 684.5us |
| 0.287x | `niceville high school` | 12862.5us | 3697.0us |
| 0.318x | `belcourt castle` | 2244.5us | 713.5us |
| 0.436x | `fatherless children` | 2765.0us | 1205.0us |
| 0.475x | `antonio cromartie` | 1284.5us | 610.5us |
| 0.535x | `canon powershot` | 910.0us | 486.5us |
| 0.562x | `centerville high school` | 3411.5us | 1917.0us |

Top 10 regressed -- none exceeds the 5% ceiling:

| ratio | shape | query | before | after |
| ---: | --- | --- | ---: | ---: |
| 1.050x | intersection | `+jesus +as +a +child` | 4978.5us | 5227.5us |
| 1.048x | intersection_union | `wildfire +risk maps` | 9543.5us | 10004.5us |
| 1.047x | intersection | `+ear +ache` | 423.5us | 443.5us |
| 1.045x | intersection | `+region +iv` | 1956.5us | 2044.0us |
| 1.043x | intersection | `+jonathan +daniel` | 909.0us | 948.0us |
| 1.042x | union | `jefferson davis high school` | 2457.5us | 2561.0us |
| 1.041x | phrase | `"tallest trees in the world"` | 2122.5us | 2210.5us |
| 1.040x | union | `jesus as a child` | 3062.0us | 3186.0us |
| 1.040x | intersection | `+american +funds` | 2993.5us | 3113.0us |
| 1.040x | intersection | `+mood +swings` | 544.0us | 565.5us |

Eight of the ten are not union queries and MAXSCORE only runs on disjunction; their shapes are flat overall (intersection 1.001x, phrase 1.005x, intersection_union 1.000x) and the deltas are +20us to +461us on queries that run 0.42ms to 9.5ms. The two union entries (+104us, +124us) sit inside that shape's own spread (union p95 1.017x, max 1.042x) against a 0.928x median.

Two sub-scenarios the 943-query set barely covers were measured separately.

**Single-term queries** take the same SoA path, and the set has exactly one of them. 681 single terms mined from the query vocabulary (df 35 to 4168066) under the same protocol: top-10 dumps identical 681/681, median 0.987x, p95 1.017x; the four terms over 5% all land within 0.980x-1.015x on an isolated alternating 40-sample re-test.

**Deleted documents** are where the two paths differ in when they ask about visibility. In-crate microbench, 65536 documents, two essentials plus an optional, sweeping the fraction a deletion vector has removed (us/query):

| deleted | before | after | ratio |
| ---: | ---: | ---: | ---: |
| 0% | 1531.3 | 1093.2 | 0.714 |
| 10% | 1441.4 | 1058.0 | 0.734 |
| 50% | 927.3 | 691.1 | 0.745 |
| 90% | 417.1 | 326.8 | 0.784 |

Filtering only when a partition can hold an invisible document is what keeps the first row where it was: a chunk that cannot contain a deleted row is never scanned for one. Without it the completion does that work for rows it is about to drop, and the "after" column goes flat near 1087us instead of tracking the survivors.

## Validation

- `cargo test -p lance-index --lib`: 1612 passed, 0 failed.
- `cargo fmt --all` and `cargo clippy -p lance-index --all-targets -- -D warnings` clean.
- `maxscore_matches_an_exhaustive_query_order_fold` pins MAXSCORE's hit set, tie set and published k-th score bits against a closed-form scan of every document, now also over a layout where the clauses are a full top2-gap apart and share a document. The shared document matters: without it the shortcut's span can be over-extended without changing any score, and the oracle cannot tell a wrong span from a right one.
- `maxscore_top2_gap_boundary` pins the top2-gap threshold at 2047/2048/2049.
- `maxscore_top2_gap_completes_with_an_optional_clause` asserts exact documents and the published score bits for a shortcut with a live optional remainder.
- `maxscore_completion_filters_invisible_documents_before_scoring` pins the visibility filter by counting scorer calls -- hiding half the documents has to remove at least half the scoring work, which a result assertion cannot see, because filtering is result-preserving.
- `maxscore_block_skip_stops_at_the_end_of_the_span` pins the block-skip guard, and `maxscore_top2_gap_declines_a_span_below_the_window_floor` pins the empty-span guard with a test-only counter.