### PR TITLE
feat(fts): add with_index_limit to the indexed FTS leaf execs

### DIFF
--- a/rust/lance/src/dataset/mem_wal/index/fts.rs
+++ b/rust/lance/src/dataset/mem_wal/index/fts.rs
@@ -167,8 +167,11 @@ pub enum FtsQueryExpr {
         positive: Box<Self>,
         /// Optional query whose matches are demoted.
         negative: Option<Box<Self>>,
-        /// Multiplier applied to documents matching `negative` (typically
-        /// `< 1.0` to demote).
+        /// How strongly a document matching `negative` is demoted: its score
+        /// becomes `positive - negative_boost * negative_score`. `0.0` is no
+        /// demotion, and larger values demote harder — the same contract the
+        /// compound scorer applies to committed data, so both tiers rank a
+        /// boost query identically. Scores may go negative.
         negative_boost: f32,
     },
 }
@@ -2394,12 +2397,12 @@ impl FtsMemIndex {
         if options.wand_factor < 1.0 {
             if let Some(limit) = options.limit {
                 if results.len() > limit {
-                    let top_k_score = results[limit - 1].score;
-                    let threshold = top_k_score * options.wand_factor;
+                    let threshold =
+                        relaxed_score_threshold(results[limit - 1].score, options.wand_factor);
                     results.retain(|e| e.score >= threshold);
                 }
             } else if let Some(max_entry) = results.first() {
-                let threshold = max_entry.score * options.wand_factor;
+                let threshold = relaxed_score_threshold(max_entry.score, options.wand_factor);
                 results.retain(|e| e.score >= threshold);
             }
         }
@@ -2422,11 +2425,21 @@ impl FtsMemIndex {
             return results;
         };
         let negative_results = self.search_query_with_state(neg, st, None, include_tail, true);
-        let negative_set: HashSet<DocumentKey> =
-            negative_results.iter().map(FtsEntry::key).collect();
+        // Subtractive, matching the compound scorer's contract exactly:
+        // `positive - negative_boost * negative_score` for a document the
+        // negative clause also matches, `positive` otherwise
+        // (`BoostScorer::score`). The negative *score* is needed, not just
+        // membership, which is why this keeps a map rather than a set.
+        //
+        // Scores may go negative; only non-finite values are an error upstream
+        // (`checked_score`), so nothing is clamped here.
+        let negative_scores: HashMap<DocumentKey, f32> = negative_results
+            .iter()
+            .map(|entry| (entry.key(), entry.score))
+            .collect();
         for entry in &mut results {
-            if negative_set.contains(&entry.key()) {
-                entry.score *= negative_boost;
+            if let Some(negative) = negative_scores.get(&entry.key()) {
+                entry.score -= negative_boost * negative;
             }
         }
         results
@@ -3244,6 +3257,19 @@ fn phrase_from_position<T: AsRef<[u32]>>(positions: &[T], first_pos: u32, slop: 
         }
     }
     true
+}
+
+/// Loosen `anchor` by `factor`, in the direction that admits *more* results
+/// whatever the sign.
+///
+/// For a non-negative anchor this is exactly `anchor * factor`, the form this
+/// has always used — `|x| == x` there, so `anchor - (1 - f) * anchor == anchor *
+/// f`. The two only diverge once scores can be negative, which a boost query's
+/// `positive - negative_boost * negative` makes reachable: multiplying a
+/// negative anchor by a factor below one moves the threshold *up*, tightening
+/// the filter rather than loosening it, and can then discard the entire top-k.
+fn relaxed_score_threshold(anchor: f32, factor: f32) -> f32 {
+    anchor - (1.0 - factor) * anchor.abs()
 }
 
 fn apply_boost(results: &mut [FtsEntry], boost: f32) {
@@ -5940,7 +5966,7 @@ mod tests {
         let batch = create_boost_test_batch(&schema);
         index.insert(&batch, 0).unwrap();
 
-        let query_no_demote = FtsQueryExpr::boosting_with_negative(
+        let query_full_demote = FtsQueryExpr::boosting_with_negative(
             FtsQueryExpr::match_query("programming"),
             FtsQueryExpr::match_query("python"),
             1.0,
@@ -5956,7 +5982,7 @@ mod tests {
             0.0,
         );
 
-        let r_no = index.search_query(&query_no_demote);
+        let r_no = index.search_query(&query_full_demote);
         let r_half = index.search_query(&query_half_demote);
         let r_zero = index.search_query(&query_zero_demote);
 
@@ -5964,8 +5990,28 @@ mod tests {
         let s_half = r_half.iter().find(|e| e.row_position == 1).unwrap().score;
         let s_zero = r_zero.iter().find(|e| e.row_position == 1).unwrap().score;
 
-        assert!((s_half - s_no * 0.5).abs() < 0.001);
-        assert!(s_zero.abs() < 0.001);
+        // Subtractive: `positive - negative_boost * negative`. `0.0` leaves the
+        // positive score untouched and larger factors demote further, so the
+        // three are evenly spaced by the negative score.
+        let positive = index
+            .search_query(&FtsQueryExpr::match_query("programming"))
+            .into_iter()
+            .find(|e| e.row_position == 1)
+            .unwrap()
+            .score;
+        let negative = index
+            .search_query(&FtsQueryExpr::match_query("python"))
+            .into_iter()
+            .find(|e| e.row_position == 1)
+            .unwrap()
+            .score;
+        assert!((s_zero - positive).abs() < 0.001, "0.0 must not demote");
+        assert!((s_half - (positive - 0.5 * negative)).abs() < 0.001);
+        assert!((s_no - (positive - negative)).abs() < 0.001);
+        assert!(
+            s_no < s_half && s_half < s_zero,
+            "larger factor demotes more"
+        );
     }
 
     #[test]
@@ -6066,6 +6112,61 @@ mod tests {
         full.sort_by(|a, b| b.score.partial_cmp(&a.score).unwrap());
         assert_eq!(results[0].row_position, full[0].row_position);
         assert_eq!(results[1].row_position, full[1].row_position);
+    }
+
+    /// Boost makes negative scores reachable, and the factor threshold has to
+    /// stay a *relaxation* at that point. Multiplying a negative k-th score by a
+    /// factor below one moves the threshold toward zero — tightening the filter
+    /// — which can drop every result including the actual top-k.
+    #[test]
+    fn boost_negative_scores_preserve_top_k_with_wand_factor() {
+        let schema = create_test_schema();
+        let index = FtsMemIndex::new(1, "description".to_string());
+        let batch = create_boost_test_batch(&schema);
+        index.insert(&batch, 0).unwrap();
+
+        // Same clause on both sides with a factor above 1 drives every match
+        // negative: `positive - 2.0 * positive`.
+        let query = FtsQueryExpr::boosting_with_negative(
+            FtsQueryExpr::match_query("programming"),
+            FtsQueryExpr::match_query("programming"),
+            2.0,
+        );
+        let exhaustive = index.search_with_options(&query, SearchOptions::default());
+        assert!(
+            exhaustive.iter().all(|entry| entry.score < 0.0),
+            "fixture must actually produce negative scores"
+        );
+
+        let limited = index.search_with_options(
+            &query,
+            SearchOptions::new().with_limit(1).with_wand_factor(0.5),
+        );
+        assert_eq!(limited.len(), 1, "factor pruning removed the actual top-k");
+        // Compare scores, not keys: the fixture's two best documents tie, so
+        // which one a stable sort surfaces is not a property of pruning.
+        assert_eq!(
+            limited[0].score, exhaustive[0].score,
+            "the surviving result must be a best-scoring one"
+        );
+    }
+
+    /// The relaxation is bit-identical to the old `anchor * factor` wherever
+    /// scores are non-negative, which is every query but boost.
+    #[test]
+    fn relaxed_score_threshold_matches_multiplication_when_non_negative() {
+        for anchor in [0.0f32, 0.25, 1.0, 12.5] {
+            for factor in [0.0f32, 0.25, 0.5, 0.99] {
+                assert_eq!(
+                    relaxed_score_threshold(anchor, factor),
+                    anchor * factor,
+                    "anchor={anchor} factor={factor}"
+                );
+            }
+        }
+        // Negative anchors relax downward instead of upward.
+        assert!(relaxed_score_threshold(-0.3, 0.5) < -0.3);
+        assert_eq!(relaxed_score_threshold(-0.3, 1.0), -0.3);
     }
 
     #[test]

--- a/rust/lance/src/dataset/mem_wal/memtable/scanner/builder.rs
+++ b/rust/lance/src/dataset/mem_wal/memtable/scanner/builder.rs
@@ -17,7 +17,7 @@ use lance_core::{Error, ROW_ID, Result};
 use lance_datafusion::expr::safe_coerce_scalar;
 use lance_datafusion::planner::Planner;
 use lance_index::scalar::FullTextSearchQuery;
-use lance_index::scalar::inverted::query::{FtsQuery as IndexFtsQuery, Operator};
+use lance_index::scalar::inverted::query::{FtsQuery as IndexFtsQuery, FtsQueryNode, Operator};
 use lance_index::scalar::inverted::{DOC_INDEX_FIELD, DocumentGranularity};
 use lance_linalg::distance::DistanceType;
 
@@ -25,7 +25,7 @@ use super::exec::{
     BTreeIndexExec, FtsIndexExec, MemTableBruteForceVectorExec, MemTableDedupScanExec,
     MemTableScanExec, SCORE_COLUMN, VectorIndexExec,
 };
-use crate::dataset::mem_wal::index::MemTableVisibility;
+use crate::dataset::mem_wal::index::{FtsQueryExpr, MemTableVisibility};
 use crate::dataset::mem_wal::scanner::{exec::validate_pk_types, parse_filter_expr};
 use crate::dataset::mem_wal::write::{BatchStore, IndexStore};
 
@@ -56,57 +56,20 @@ pub struct VectorQuery {
     pub distance_upper_bound: Option<f32>,
 }
 
-/// Full-text search query type.
-#[derive(Debug, Clone)]
-pub enum FtsQueryType {
-    /// Simple term match.
-    Match {
-        /// The search query string.
-        query: String,
-        /// The operator used to combine tokenized query terms.
-        operator: Operator,
-        /// Boost factor applied to the score.
-        boost: f32,
-    },
-    /// Phrase query with slop.
-    Phrase {
-        /// The phrase to search for.
-        query: String,
-        /// Maximum allowed distance between consecutive tokens.
-        slop: u32,
-    },
-    /// Boolean query with MUST/SHOULD/MUST_NOT.
-    Boolean {
-        /// Terms that must match and contribute to the score.
-        must: Vec<String>,
-        /// Terms that should match (adds to score).
-        should: Vec<String>,
-        /// Terms that must not match.
-        must_not: Vec<String>,
-    },
-    /// Fuzzy match query with typo tolerance.
-    Fuzzy {
-        /// The search query string.
-        query: String,
-        /// Maximum edit distance (Levenshtein distance).
-        /// None means auto-fuzziness based on token length.
-        fuzziness: Option<u32>,
-        /// Number of initial characters that must match exactly.
-        prefix_length: u32,
-        /// Maximum number of terms to expand to.
-        max_expansions: usize,
-        /// Boost factor applied to the score.
-        boost: f32,
-    },
-}
-
 /// Full-text search query parameters.
+///
+/// The query itself is an [`FtsQueryExpr`] — the same tree the in-memory
+/// inverted index evaluates — so every shape the index supports (nested
+/// boolean, boost with a negative clause, phrase, fuzzy) reaches it without a
+/// lossy intermediate form. Everything outside the tree here is execution
+/// policy rather than the query: which column, which document unit, and the
+/// recall/latency knobs.
 #[derive(Debug, Clone)]
 pub struct FtsQuery {
     /// Column name to search.
     pub column: String,
-    /// Query type.
-    pub query_type: FtsQueryType,
+    /// The query tree, evaluated as given by the memtable's inverted index.
+    pub expr: FtsQueryExpr,
     /// Logical document unit. Defaults to one document per dataset row.
     pub document_granularity: DocumentGranularity,
     /// WAND factor for early termination (0.0 to 1.0).
@@ -121,16 +84,25 @@ pub struct FtsQuery {
     pub include_tail: bool,
 }
 
-/// Default maximum number of fuzzy expansions.
-pub const DEFAULT_MAX_EXPANSIONS: usize = 50;
-
 /// Default WAND factor for full recall (no early termination).
 pub const DEFAULT_WAND_FACTOR: f32 = 1.0;
 
 impl FtsQuery {
+    /// Wrap an already-built query tree.
+    pub fn new(column: impl Into<String>, expr: FtsQueryExpr) -> Self {
+        Self {
+            column: column.into(),
+            expr,
+            document_granularity: DocumentGranularity::Row,
+            wand_factor: DEFAULT_WAND_FACTOR,
+            limit: None,
+            include_tail: true,
+        }
+    }
+
     /// Create a simple term match query.
     pub fn match_query(column: impl Into<String>, query: impl Into<String>) -> Self {
-        Self::match_query_with_operator(column, query, Operator::Or)
+        Self::new(column, FtsQueryExpr::match_query(query))
     }
 
     pub fn match_query_with_operator(
@@ -138,54 +110,36 @@ impl FtsQuery {
         query: impl Into<String>,
         operator: Operator,
     ) -> Self {
-        Self {
-            column: column.into(),
-            query_type: FtsQueryType::Match {
-                query: query.into(),
-                operator,
-                boost: 1.0,
-            },
-            document_granularity: DocumentGranularity::Row,
-            wand_factor: DEFAULT_WAND_FACTOR,
-            limit: None,
-            include_tail: true,
-        }
+        Self::new(
+            column,
+            FtsQueryExpr::match_query_with_operator(query, operator),
+        )
     }
 
     /// Create a phrase query.
     pub fn phrase(column: impl Into<String>, query: impl Into<String>, slop: u32) -> Self {
-        Self {
-            column: column.into(),
-            query_type: FtsQueryType::Phrase {
-                query: query.into(),
-                slop,
-            },
-            document_granularity: DocumentGranularity::Row,
-            wand_factor: DEFAULT_WAND_FACTOR,
-            limit: None,
-            include_tail: true,
-        }
+        Self::new(column, FtsQueryExpr::phrase_with_slop(query, slop))
     }
 
-    /// Create a Boolean query.
+    /// Create a Boolean query over plain terms. Nested clauses go through
+    /// [`Self::new`] with a tree built on [`FtsQueryExpr::boolean`].
     pub fn boolean(
         column: impl Into<String>,
         must: Vec<String>,
         should: Vec<String>,
         must_not: Vec<String>,
     ) -> Self {
-        Self {
-            column: column.into(),
-            query_type: FtsQueryType::Boolean {
-                must,
-                should,
-                must_not,
-            },
-            document_granularity: DocumentGranularity::Row,
-            wand_factor: DEFAULT_WAND_FACTOR,
-            limit: None,
-            include_tail: true,
+        let mut builder = FtsQueryExpr::boolean();
+        for term in must {
+            builder = builder.must(FtsQueryExpr::match_query(term));
         }
+        for term in should {
+            builder = builder.should(FtsQueryExpr::match_query(term));
+        }
+        for term in must_not {
+            builder = builder.must_not(FtsQueryExpr::match_query(term));
+        }
+        Self::new(column, builder.build())
     }
 
     /// Create a fuzzy match query with auto-fuzziness.
@@ -195,20 +149,7 @@ impl FtsQuery {
     /// - 3-5 chars: 1 edit allowed
     /// - 6+ chars: 2 edits allowed
     pub fn fuzzy(column: impl Into<String>, query: impl Into<String>) -> Self {
-        Self {
-            column: column.into(),
-            query_type: FtsQueryType::Fuzzy {
-                query: query.into(),
-                fuzziness: None,
-                prefix_length: 0,
-                max_expansions: DEFAULT_MAX_EXPANSIONS,
-                boost: 1.0,
-            },
-            document_granularity: DocumentGranularity::Row,
-            wand_factor: DEFAULT_WAND_FACTOR,
-            limit: None,
-            include_tail: true,
-        }
+        Self::new(column, FtsQueryExpr::fuzzy(query))
     }
 
     /// Create a fuzzy match query with specified edit distance.
@@ -217,20 +158,7 @@ impl FtsQuery {
         query: impl Into<String>,
         fuzziness: u32,
     ) -> Self {
-        Self {
-            column: column.into(),
-            query_type: FtsQueryType::Fuzzy {
-                query: query.into(),
-                fuzziness: Some(fuzziness),
-                prefix_length: 0,
-                max_expansions: DEFAULT_MAX_EXPANSIONS,
-                boost: 1.0,
-            },
-            document_granularity: DocumentGranularity::Row,
-            wand_factor: DEFAULT_WAND_FACTOR,
-            limit: None,
-            include_tail: true,
-        }
+        Self::new(column, FtsQueryExpr::fuzzy_with_distance(query, fuzziness))
     }
 
     /// Create a fuzzy match query with full options.
@@ -241,20 +169,10 @@ impl FtsQuery {
         prefix_length: u32,
         max_expansions: usize,
     ) -> Self {
-        Self {
-            column: column.into(),
-            query_type: FtsQueryType::Fuzzy {
-                query: query.into(),
-                fuzziness,
-                prefix_length,
-                max_expansions,
-                boost: 1.0,
-            },
-            document_granularity: DocumentGranularity::Row,
-            wand_factor: DEFAULT_WAND_FACTOR,
-            limit: None,
-            include_tail: true,
-        }
+        Self::new(
+            column,
+            FtsQueryExpr::fuzzy_with_options(query, fuzziness, prefix_length, max_expansions),
+        )
     }
 
     /// Set the WAND factor for early termination.
@@ -283,24 +201,16 @@ impl FtsQuery {
         self.document_granularity = document_granularity;
         self
     }
-
-    fn with_boost(mut self, boost: f32) -> Self {
-        match &mut self.query_type {
-            FtsQueryType::Match { boost: b, .. } | FtsQueryType::Fuzzy { boost: b, .. } => {
-                *b = boost;
-            }
-            FtsQueryType::Phrase { .. } | FtsQueryType::Boolean { .. } => {}
-        }
-        self
-    }
 }
 
 /// Convert an index-level [`FullTextSearchQuery`] into the MemTable's local
 /// [`FtsQuery`], so the MemTable scanner shares the dataset `Scanner`'s FTS
-/// entry type. Supports match (exact `fuzziness == Some(0)` and fuzzy) and
-/// phrase leaf queries; the column must be bound on the query. Compound queries
-/// (boolean / boost / multi-match) cannot be modeled by the MemTable path and
-/// return a `not_supported` error rather than failing deep in planning.
+/// entry type.
+///
+/// Every shape the in-memory inverted index can evaluate is carried across:
+/// match (exact and fuzzy), phrase, boolean and boost, nested to any depth.
+/// Multi-match is the exception — it spans columns, and the memtable's indexes
+/// are per-column, so it has no single tree to evaluate and is refused.
 fn resolve_memtable_document_granularity(
     column: &str,
     requested: Option<DocumentGranularity>,
@@ -347,46 +257,125 @@ fn local_fts_query(query: FullTextSearchQuery, indexes: Option<&IndexStore>) -> 
             )
         })
     };
-    let local = match query.query {
-        IndexFtsQuery::Match(m) => {
-            let column = require_column(m.column)?;
-            let document_granularity =
-                resolve_memtable_document_granularity(&column, m.document_granularity, indexes)?;
-            let local = match m.fuzziness {
-                // Some(0) is an exact match in the index model.
-                Some(0) => FtsQuery::match_query_with_operator(column, m.terms, m.operator)
-                    .with_boost(m.boost),
-                _ if m.operator != Operator::Or => {
-                    return Err(Error::not_supported(
-                        "MemTable fuzzy full-text search only supports OR match operators"
-                            .to_string(),
-                    ));
+    let column = require_column(single_query_column(&query.query)?)?;
+    let document_granularity = resolve_memtable_document_granularity(
+        &column,
+        requested_document_granularity(&query.query)?,
+        indexes,
+    )?;
+    let expr = to_local_expr(&query.query)?;
+    Ok(FtsQuery::new(column, expr)
+        .with_document_granularity(document_granularity)
+        .with_wand_factor(wand_factor)
+        .with_limit(limit))
+}
+
+/// The single column the query targets, or `None` when it binds none. A query
+/// spanning several columns is refused before this — the memtable holds one
+/// inverted index per column, so there is no single index to evaluate against.
+fn single_query_column(query: &IndexFtsQuery) -> Result<Option<String>> {
+    let mut columns = query.columns().into_iter();
+    let first = columns.next();
+    if columns.next().is_some() {
+        return Err(Error::not_supported(
+            "MemTable full-text search is single-column; a query spanning several \
+             columns has no single in-memory index to evaluate against"
+                .to_string(),
+        ));
+    }
+    Ok(first)
+}
+
+/// The document granularity the query asks for, erroring if its leaves disagree
+/// — the memtable evaluates one index, so one granularity.
+fn requested_document_granularity(query: &IndexFtsQuery) -> Result<Option<DocumentGranularity>> {
+    fn visit(query: &IndexFtsQuery, current: &mut Option<DocumentGranularity>) -> Result<()> {
+        let requested = match query {
+            IndexFtsQuery::Match(m) => m.document_granularity,
+            IndexFtsQuery::Phrase(p) => p.document_granularity,
+            IndexFtsQuery::Boost(b) => {
+                visit(&b.positive, current)?;
+                return visit(&b.negative, current);
+            }
+            IndexFtsQuery::Boolean(b) => {
+                for child in b.must.iter().chain(&b.should).chain(&b.must_not) {
+                    visit(child, current)?;
                 }
-                fuzziness => FtsQuery::fuzzy_with_options(
-                    column,
-                    m.terms,
-                    fuzziness,
-                    m.prefix_length,
-                    m.max_expansions,
-                )
+                return Ok(());
+            }
+            IndexFtsQuery::MultiMatch(_) => {
+                return Err(Error::not_supported(
+                    "MemTable full-text search does not support multi-match queries".to_string(),
+                ));
+            }
+        };
+        match (*current, requested) {
+            (_, None) => {}
+            (None, Some(requested)) => *current = Some(requested),
+            (Some(current), Some(requested)) if current != requested => {
+                return Err(Error::invalid_input(
+                    "FTS queries cannot mix Row and ListElement document granularities".to_string(),
+                ));
+            }
+            _ => {}
+        }
+        Ok(())
+    }
+    let mut granularity = None;
+    visit(query, &mut granularity)?;
+    Ok(granularity)
+}
+
+/// Map an index-level query onto the tree the in-memory index evaluates.
+///
+/// Structural only — the column and document granularity are resolved once for
+/// the whole query by the caller, because the memtable searches a single index.
+fn to_local_expr(query: &IndexFtsQuery) -> Result<FtsQueryExpr> {
+    Ok(match query {
+        IndexFtsQuery::Match(m) => match m.fuzziness {
+            // `Some(0)` is an exact match in the index model.
+            Some(0) => FtsQueryExpr::match_query_with_operator(m.terms.clone(), m.operator)
                 .with_boost(m.boost),
-            };
-            local.with_document_granularity(document_granularity)
+            // The fuzzy path expands each term independently and unions the
+            // expansions, so it cannot also require every term to match.
+            _ if m.operator != Operator::Or => {
+                return Err(Error::not_supported(
+                    "MemTable fuzzy full-text search only supports OR match operators".to_string(),
+                ));
+            }
+            fuzziness => FtsQueryExpr::fuzzy_with_options(
+                m.terms.clone(),
+                fuzziness,
+                m.prefix_length,
+                m.max_expansions,
+            )
+            .with_boost(m.boost),
+        },
+        IndexFtsQuery::Phrase(p) => FtsQueryExpr::phrase_with_slop(p.terms.clone(), p.slop),
+        IndexFtsQuery::Boost(b) => FtsQueryExpr::boosting_with_negative(
+            to_local_expr(&b.positive)?,
+            to_local_expr(&b.negative)?,
+            b.negative_boost,
+        ),
+        IndexFtsQuery::Boolean(b) => {
+            let mut builder = FtsQueryExpr::boolean();
+            for child in &b.must {
+                builder = builder.must(to_local_expr(child)?);
+            }
+            for child in &b.should {
+                builder = builder.should(to_local_expr(child)?);
+            }
+            for child in &b.must_not {
+                builder = builder.must_not(to_local_expr(child)?);
+            }
+            builder.build()
         }
-        IndexFtsQuery::Phrase(p) => {
-            let column = require_column(p.column)?;
-            let document_granularity =
-                resolve_memtable_document_granularity(&column, p.document_granularity, indexes)?;
-            FtsQuery::phrase(column, p.terms, p.slop)
-                .with_document_granularity(document_granularity)
+        IndexFtsQuery::MultiMatch(_) => {
+            return Err(Error::not_supported(
+                "MemTable full-text search does not support multi-match queries".to_string(),
+            ));
         }
-        other => {
-            return Err(Error::not_supported(format!(
-                "MemTable full-text search supports match and phrase queries, got: {other}"
-            )));
-        }
-    };
-    Ok(local.with_wand_factor(wand_factor).with_limit(limit))
+    })
 }
 
 /// Scalar predicate for BTree index queries.
@@ -1801,10 +1790,66 @@ mod tests {
     /// `full_text_search` now takes a structured `FullTextSearchQuery` (matching
     /// the dataset `Scanner`); `local_fts_query` maps the supported leaf shapes
     /// and rejects compound queries and missing columns.
+    /// A boost query routed through the public entry point has to score the way
+    /// the compound scorer does — `positive - negative_boost * negative` — or
+    /// active rows rank differently from committed rows for the same query, and
+    /// can even differ in sign. Pins the formula, not just the ordering.
+    #[test]
+    fn public_boost_query_keeps_subtractive_scoring_in_memtable() {
+        use crate::dataset::mem_wal::index::FtsMemIndex;
+        use lance_index::scalar::inverted::query::{BoostQuery, MatchQuery};
+
+        let schema = Arc::new(arrow_schema::Schema::new(vec![
+            Field::new("id", DataType::Int32, false),
+            Field::new("text", DataType::Utf8, true),
+        ]));
+        let batch = RecordBatch::try_new(
+            schema,
+            vec![
+                Arc::new(arrow_array::Int32Array::from(vec![0, 1])),
+                Arc::new(arrow_array::StringArray::from(vec!["alpha", "alpha beta"])),
+            ],
+        )
+        .unwrap();
+        let index = FtsMemIndex::new(1, "text".to_string());
+        index.insert(&batch, 0).unwrap();
+
+        let leaf = |terms: &str| {
+            IndexFtsQuery::Match(
+                MatchQuery::new(terms.to_string()).with_column(Some("text".to_string())),
+            )
+        };
+        let negative_boost = 0.5;
+        let query = FullTextSearchQuery::new_query(IndexFtsQuery::Boost(BoostQuery::new(
+            leaf("alpha"),
+            leaf("beta"),
+            Some(negative_boost),
+        )));
+        let local = local_fts_query(query, None).unwrap();
+
+        let score_of = |expr: &FtsQueryExpr| {
+            index
+                .search_query(expr)
+                .into_iter()
+                .find(|entry| entry.row_position == 1)
+                .unwrap()
+                .score
+        };
+        // Row 1 matches both clauses, so it is the one the demotion applies to.
+        let actual = score_of(&local.expr);
+        let positive = score_of(&FtsQueryExpr::match_query("alpha"));
+        let negative = score_of(&FtsQueryExpr::match_query("beta"));
+        assert!(
+            (actual - (positive - negative_boost * negative)).abs() < 1e-5,
+            "expected positive - {negative_boost} * negative = {}, got {actual}",
+            positive - negative_boost * negative
+        );
+    }
+
     #[test]
     fn local_fts_query_maps_leaf_shapes_and_rejects_the_rest() {
         use lance_index::scalar::inverted::query::{
-            BooleanQuery, MatchQuery, Occur, Operator, PhraseQuery,
+            BooleanQuery, BoostQuery, MatchQuery, MultiMatchQuery, Occur, Operator, PhraseQuery,
         };
 
         // Exact match (default fuzziness Some(0)) -> local Match, preserving the
@@ -1815,7 +1860,7 @@ mod tests {
         let local = local_fts_query(q, None).unwrap();
         assert_eq!(local.column, "text");
         assert!(
-            matches!(local.query_type, FtsQueryType::Match { query, operator, .. }
+            matches!(local.expr, FtsQueryExpr::Match { query, operator, .. }
                 if query == "hello" && operator == Operator::Or)
         );
 
@@ -1874,7 +1919,7 @@ mod tests {
         ));
         let local = local_fts_query(exact_and, None).unwrap();
         assert!(
-            matches!(local.query_type, FtsQueryType::Match { query, operator, boost }
+            matches!(local.expr, FtsQueryExpr::Match { query, operator, boost }
                 if query == "hello world" && operator == Operator::And && boost == 3.0)
         );
 
@@ -1888,7 +1933,7 @@ mod tests {
         ));
         let local = local_fts_query(fuzzy, None).unwrap();
         assert!(
-            matches!(local.query_type, FtsQueryType::Fuzzy { fuzziness, prefix_length, boost, .. }
+            matches!(local.expr, FtsQueryExpr::Fuzzy { fuzziness, prefix_length, boost, .. }
                 if fuzziness == Some(2) && prefix_length == 2 && boost == 2.5)
         );
 
@@ -1908,19 +1953,88 @@ mod tests {
             PhraseQuery::new("quick fox".to_string()).with_column(Some("text".to_string())),
         ));
         let local = local_fts_query(phrase, None).unwrap();
-        assert!(matches!(local.query_type, FtsQueryType::Phrase { .. }));
+        assert!(matches!(local.expr, FtsQueryExpr::Phrase { .. }));
 
-        // Compound (boolean) -> not supported.
+        // Compound (boolean) -> mapped onto the index's own tree, clause for
+        // clause, rather than refused.
+        let leaf = |terms: &str| {
+            IndexFtsQuery::Match(
+                MatchQuery::new(terms.to_string()).with_column(Some("text".to_string())),
+            )
+        };
         let boolean =
+            FullTextSearchQuery::new_query(IndexFtsQuery::Boolean(BooleanQuery::new(vec![
+                (Occur::Must, leaf("x")),
+                (Occur::MustNot, leaf("y")),
+            ])));
+        let local = local_fts_query(boolean, None).unwrap();
+        let FtsQueryExpr::Boolean {
+            must,
+            should,
+            must_not,
+        } = &local.expr
+        else {
+            panic!("expected a Boolean expr, got {:?}", local.expr);
+        };
+        assert!(should.is_empty());
+        assert!(
+            matches!(&must[..], [FtsQueryExpr::Match { query, .. }] if query == "x"),
+            "MUST clause lost: {must:?}"
+        );
+        assert!(
+            matches!(&must_not[..], [FtsQueryExpr::Match { query, .. }] if query == "y"),
+            "MUST_NOT clause lost: {must_not:?}"
+        );
+
+        // Boost -> positive and negative both carried, with the demotion factor.
+        let boost = FullTextSearchQuery::new_query(IndexFtsQuery::Boost(BoostQuery::new(
+            leaf("keep"),
+            leaf("demote"),
+            Some(0.25),
+        )));
+        let local = local_fts_query(boost, None).unwrap();
+        let FtsQueryExpr::Boost {
+            positive,
+            negative,
+            negative_boost,
+        } = &local.expr
+        else {
+            panic!("expected a Boost expr, got {:?}", local.expr);
+        };
+        assert!(matches!(positive.as_ref(), FtsQueryExpr::Match { query, .. } if query == "keep"));
+        let negative = negative.as_ref().expect("negative clause carried");
+        assert!(
+            matches!(negative.as_ref(), FtsQueryExpr::Match { query, .. } if query == "demote")
+        );
+        assert_eq!(*negative_boost, 0.25);
+
+        // Nested: a boolean whose clause is itself a boolean.
+        let nested =
             FullTextSearchQuery::new_query(IndexFtsQuery::Boolean(BooleanQuery::new(vec![(
                 Occur::Must,
-                IndexFtsQuery::Match(
-                    MatchQuery::new("x".to_string()).with_column(Some("text".to_string())),
-                ),
+                IndexFtsQuery::Boolean(BooleanQuery::new(vec![(Occur::Should, leaf("deep"))])),
             )])));
+        let local = local_fts_query(nested, None).unwrap();
+        let FtsQueryExpr::Boolean { must, .. } = &local.expr else {
+            panic!("expected a Boolean expr, got {:?}", local.expr);
+        };
         assert!(
-            local_fts_query(boolean, None).is_err(),
-            "boolean must be rejected"
+            matches!(&must[..], [FtsQueryExpr::Boolean { .. }]),
+            "nesting flattened: {must:?}"
+        );
+
+        // Multi-match spans columns -> still refused; the memtable holds one
+        // inverted index per column.
+        let multi = FullTextSearchQuery::new_query(IndexFtsQuery::MultiMatch(
+            MultiMatchQuery::try_new(
+                "x".to_string(),
+                vec!["text".to_string(), "other".to_string()],
+            )
+            .unwrap(),
+        ));
+        assert!(
+            local_fts_query(multi, None).is_err(),
+            "multi-match must be rejected"
         );
 
         // Missing column -> error.

--- a/rust/lance/src/dataset/mem_wal/memtable/scanner/exec/fts.rs
+++ b/rust/lance/src/dataset/mem_wal/memtable/scanner/exec/fts.rs
@@ -25,9 +25,9 @@ use futures::stream::{self, StreamExt};
 use lance_core::{Error, Result};
 use lance_index::scalar::inverted::DOC_INDEX_FIELD;
 
-use super::super::builder::{FtsQuery, FtsQueryType};
+use super::super::builder::FtsQuery;
 use super::newest_pk_positions;
-use crate::dataset::mem_wal::index::{FtsQueryExpr, SearchOptions};
+use crate::dataset::mem_wal::index::SearchOptions;
 use crate::dataset::mem_wal::scanner::exec::resolve_pk_indices;
 use crate::dataset::mem_wal::write::{BatchStore, IndexStore};
 
@@ -80,7 +80,7 @@ impl Debug for FtsIndexExec {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("FtsIndexExec")
             .field("column", &self.query.column)
-            .field("query_type", &self.query.query_type)
+            .field("expr", &self.query.expr)
             .field("readable_count", &self.readable_count)
             .field("with_row_id", &self.with_row_id)
             .finish()
@@ -223,42 +223,9 @@ impl FtsIndexExec {
             return vec![];
         };
 
-        // Convert FtsQueryType to FtsQueryExpr
-        let query_expr = match &self.query.query_type {
-            FtsQueryType::Match {
-                query,
-                operator,
-                boost,
-            } => FtsQueryExpr::match_query_with_operator(query, *operator).with_boost(*boost),
-            FtsQueryType::Phrase { query, slop } => FtsQueryExpr::phrase_with_slop(query, *slop),
-            FtsQueryType::Boolean {
-                must,
-                should,
-                must_not,
-            } => {
-                let mut builder = FtsQueryExpr::boolean();
-                for term in must {
-                    builder = builder.must(FtsQueryExpr::match_query(term));
-                }
-                for term in should {
-                    builder = builder.should(FtsQueryExpr::match_query(term));
-                }
-                for term in must_not {
-                    builder = builder.must_not(FtsQueryExpr::match_query(term));
-                }
-                builder.build()
-            }
-            FtsQueryType::Fuzzy {
-                query,
-                fuzziness,
-                prefix_length,
-                max_expansions,
-                boost,
-            } => {
-                FtsQueryExpr::fuzzy_with_options(query, *fuzziness, *prefix_length, *max_expansions)
-                    .with_boost(*boost)
-            }
-        };
+        // The scanner carries the tree the index evaluates, so there is nothing
+        // to translate here.
+        let query_expr = self.query.expr.clone();
 
         let all_rows_visible = self.batch_ranges.last().is_none_or(|last| {
             self.max_readable_row
@@ -612,14 +579,14 @@ impl DisplayAs for FtsIndexExec {
                 write!(
                     f,
                     "FtsIndexExec: column={}, query_type={:?}, with_row_id={}",
-                    self.query.column, self.query.query_type, self.with_row_id
+                    self.query.column, self.query.expr, self.with_row_id
                 )
             }
             DisplayFormatType::TreeRender => {
                 write!(
                     f,
                     "FtsIndexExec\ncolumn={}\nquery_type={:?}\nwith_row_id={}",
-                    self.query.column, self.query.query_type, self.with_row_id
+                    self.query.column, self.query.expr, self.with_row_id
                 )
             }
         }

--- a/rust/lance/src/dataset/mem_wal/scanner/exec.rs
+++ b/rust/lance/src/dataset/mem_wal/scanner/exec.rs
@@ -9,11 +9,13 @@
 //! - [`MemtableGenTagExec`]: Wraps a scan to add `_memtable_gen` column
 //! - [`BloomFilterGuardExec`]: Guards child execution with bloom filter check
 //! - [`CoalesceFirstExec`]: Returns first non-empty result with short-circuit
+//! - [`FirstByPkExec`]: Keeps the first row per PK from an ordered stream (the cross-column collapse)
 //! - [`PkBlockFilterExec`]: Drops rows whose PK was superseded by a newer generation (the cross-generation block-list)
 //! - [`SchemaRelabelExec`]: Re-labels batches to an exact schema (the logical/storage nullability boundary)
 
 mod bloom_guard;
 mod coalesce_first;
+mod first_by_pk;
 mod generation_tag;
 mod pk;
 mod pk_block_filter;
@@ -21,6 +23,7 @@ mod schema_relabel;
 
 pub use bloom_guard::{BloomFilterGuardExec, compute_pk_hash_from_scalars};
 pub use coalesce_first::CoalesceFirstExec;
+pub use first_by_pk::FirstByPkExec;
 pub use generation_tag::{MEMTABLE_GEN_COLUMN, MemtableGenTagExec};
 pub use pk::{
     ROW_ADDRESS_COLUMN, compute_pk_hash, is_supported_pk_type, resolve_pk_indices,

--- a/rust/lance/src/dataset/mem_wal/scanner/exec/first_by_pk.rs
+++ b/rust/lance/src/dataset/mem_wal/scanner/exec/first_by_pk.rs
@@ -1,0 +1,165 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+//! Keep the first row per primary key from an ordered stream.
+//!
+//! Collapses the duplicates a cross-column full-text search produces: a row
+//! whose text matches in two columns is scored once per column, so it arrives
+//! twice. A cross-column `MultiMatch` scores each field independently and takes
+//! the **maximum** per row (`DisjunctionScore::Max` on the base-table path), and
+//! over an input already sorted by `_score` descending, "first wins" *is* that
+//! maximum — which is why this is a filter rather than a grouped aggregate, and
+//! why it keeps the streaming top-k shape the FTS planner is built around.
+//!
+//! The input ordering is load-bearing. Feeding this an unordered stream keeps an
+//! arbitrary duplicate instead of the best-scoring one.
+
+use std::collections::HashSet;
+use std::fmt;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::task::{Context, Poll};
+
+use arrow::compute::filter_record_batch;
+use arrow_array::{BooleanArray, RecordBatch};
+use arrow_schema::SchemaRef;
+use datafusion::common::ScalarValue;
+use datafusion::error::{DataFusionError, Result as DFResult};
+use datafusion::execution::TaskContext;
+use datafusion::physical_expr::EquivalenceProperties;
+use datafusion::physical_plan::{
+    DisplayAs, DisplayFormatType, ExecutionPlan, ExecutionPlanProperties, PlanProperties,
+    SendableRecordBatchStream,
+};
+use futures::{Stream, StreamExt};
+
+use super::pk::resolve_pk_indices;
+
+/// Emits the first row seen for each primary key, preserving input order.
+#[derive(Debug)]
+pub struct FirstByPkExec {
+    input: Arc<dyn ExecutionPlan>,
+    pk_columns: Vec<String>,
+    properties: Arc<PlanProperties>,
+}
+
+impl FirstByPkExec {
+    pub fn new(input: Arc<dyn ExecutionPlan>, pk_columns: Vec<String>) -> Self {
+        // A filter: same schema, same partitioning, and the input's ordering
+        // survives because rows are only dropped.
+        let properties = Arc::new(PlanProperties::new(
+            EquivalenceProperties::new(input.schema()),
+            input.output_partitioning().clone(),
+            input.pipeline_behavior(),
+            input.boundedness(),
+        ));
+        Self {
+            input,
+            pk_columns,
+            properties,
+        }
+    }
+}
+
+impl DisplayAs for FirstByPkExec {
+    fn fmt_as(&self, t: DisplayFormatType, f: &mut fmt::Formatter) -> fmt::Result {
+        match t {
+            DisplayFormatType::Default | DisplayFormatType::Verbose => {
+                write!(f, "FirstByPk: pk={:?}", self.pk_columns)
+            }
+            DisplayFormatType::TreeRender => write!(f, "FirstByPk"),
+        }
+    }
+}
+
+impl ExecutionPlan for FirstByPkExec {
+    fn name(&self) -> &str {
+        "FirstByPkExec"
+    }
+
+    fn properties(&self) -> &Arc<PlanProperties> {
+        &self.properties
+    }
+
+    fn children(&self) -> Vec<&Arc<dyn ExecutionPlan>> {
+        vec![&self.input]
+    }
+
+    fn with_new_children(
+        self: Arc<Self>,
+        children: Vec<Arc<dyn ExecutionPlan>>,
+    ) -> DFResult<Arc<dyn ExecutionPlan>> {
+        let input = children.into_iter().next().ok_or_else(|| {
+            DataFusionError::Internal("FirstByPkExec requires one child".to_string())
+        })?;
+        Ok(Arc::new(Self::new(input, self.pk_columns.clone())))
+    }
+
+    fn execute(
+        &self,
+        partition: usize,
+        context: Arc<TaskContext>,
+    ) -> DFResult<SendableRecordBatchStream> {
+        Ok(Box::pin(FirstByPkStream {
+            input: self.input.execute(partition, context)?,
+            pk_columns: self.pk_columns.clone(),
+            schema: self.schema(),
+            seen: HashSet::new(),
+        }))
+    }
+}
+
+struct FirstByPkStream {
+    input: SendableRecordBatchStream,
+    pk_columns: Vec<String>,
+    schema: SchemaRef,
+    seen: HashSet<Vec<ScalarValue>>,
+}
+
+impl FirstByPkStream {
+    /// Mask out rows whose PK was already emitted. Sequential by construction:
+    /// the first occurrence in input order wins, so the mask depends on every
+    /// row before it.
+    fn keep_first(&mut self, batch: &RecordBatch) -> DFResult<RecordBatch> {
+        if self.pk_columns.is_empty() || batch.num_rows() == 0 {
+            return Ok(batch.clone());
+        }
+        let pk_indices = resolve_pk_indices(batch, &self.pk_columns)
+            .map_err(|e| DataFusionError::Execution(e.to_string()))?;
+        let mut keep = Vec::with_capacity(batch.num_rows());
+        for row in 0..batch.num_rows() {
+            let key = pk_indices
+                .iter()
+                .map(|&col| ScalarValue::try_from_array(batch.column(col), row))
+                .collect::<DFResult<Vec<_>>>()?;
+            keep.push(self.seen.insert(key));
+        }
+        filter_record_batch(batch, &BooleanArray::from(keep)).map_err(DataFusionError::from)
+    }
+}
+
+impl Stream for FirstByPkStream {
+    type Item = DFResult<RecordBatch>;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        loop {
+            match futures::ready!(self.input.poll_next_unpin(cx)) {
+                Some(Ok(batch)) => {
+                    let filtered = self.keep_first(&batch)?;
+                    // An all-duplicate batch yields nothing; keep polling rather
+                    // than emitting empties.
+                    if filtered.num_rows() > 0 {
+                        return Poll::Ready(Some(Ok(filtered)));
+                    }
+                }
+                other => return Poll::Ready(other),
+            }
+        }
+    }
+}
+
+impl datafusion::physical_plan::RecordBatchStream for FirstByPkStream {
+    fn schema(&self) -> SchemaRef {
+        self.schema.clone()
+    }
+}

--- a/rust/lance/src/dataset/mem_wal/scanner/fts_search.rs
+++ b/rust/lance/src/dataset/mem_wal/scanner/fts_search.rs
@@ -41,6 +41,7 @@ use arrow_schema::{DataType, Field, Schema, SchemaRef, SortOptions};
 use datafusion::physical_expr::expressions::Column;
 use datafusion::physical_expr::{LexOrdering, PhysicalSortExpr};
 use datafusion::physical_plan::ExecutionPlan;
+use datafusion::physical_plan::limit::GlobalLimitExec;
 use datafusion::physical_plan::sorts::sort::SortExec;
 use datafusion::physical_plan::sorts::sort_preserving_merge::SortPreservingMergeExec;
 use datafusion::physical_plan::union::UnionExec;
@@ -48,14 +49,14 @@ use datafusion::prelude::Expr;
 use lance_core::{Error, Result, is_system_column};
 use lance_index::scalar::FullTextSearchQuery;
 use lance_index::scalar::InvertedIndexParams;
-use lance_index::scalar::inverted::query::{FtsQuery as IndexFtsQuery, Operator};
+use lance_index::scalar::inverted::query::{FtsQuery as IndexFtsQuery, FtsQueryNode, Operator};
 use lance_index::scalar::inverted::{DOC_INDEX_COL, DOC_INDEX_FIELD, DocumentGranularity};
 use tracing::instrument;
 
 use super::block_list::compute_source_block_lists;
 use super::collector::LsmDataSourceCollector;
 use super::data_source::LsmDataSource;
-use super::exec::PkBlockFilterExec;
+use super::exec::{FirstByPkExec, PkBlockFilterExec};
 use super::projection::{project_to_canonical, validate_projection_names};
 use super::sstable_cache::{DatasetCache, SsTableWarmer, open_sstable};
 use crate::dataset::mem_wal::memtable::scanner::MemTableScanner;
@@ -361,6 +362,52 @@ fn transient_fts_index_store(
     Ok(Some(Arc::new(store)))
 }
 
+/// Split a query targeting several columns into one sub-query per column, or
+/// `None` when it targets at most one and takes the single-column path unchanged.
+///
+/// Only a top-level multi-match decomposes. Its leaves are independent
+/// per-column matches, which is exactly what the base-table path scores
+/// separately before taking the best per row. A boolean or boost spanning
+/// columns is one predicate over several fields — `must: [a in title, b in
+/// body]` is a conjunction, not a union of per-column results — so unioning
+/// per-column plans would answer a different query, and it is refused instead.
+fn cross_column_targets(query: &IndexFtsQuery) -> Result<Option<Vec<(String, IndexFtsQuery)>>> {
+    if query.columns().len() <= 1 {
+        return Ok(None);
+    }
+    // The on-disk cross-column path accepts Row documents only
+    // (`validate_row_leaf_granularities`); match that contract rather than
+    // inventing a broader one here.
+    if requested_query_document_granularity(query)?
+        .is_some_and(|granularity| granularity.is_list_element())
+    {
+        return Err(Error::not_supported(
+            "cross-column full-text search supports row documents only, not list elements"
+                .to_string(),
+        ));
+    }
+    let IndexFtsQuery::MultiMatch(multi) = query else {
+        return Err(Error::not_supported(format!(
+            "LSM full-text search cannot evaluate this query across several columns; only \
+             multi-match decomposes into independent per-column searches: {query}"
+        )));
+    };
+    multi
+        .match_queries
+        .iter()
+        .map(|leaf| {
+            let column = leaf.column.clone().ok_or_else(|| {
+                Error::invalid_input(
+                    "multi-match leaf has no bound column; they are bound at construction"
+                        .to_string(),
+                )
+            })?;
+            Ok((column, IndexFtsQuery::Match(leaf.clone())))
+        })
+        .collect::<Result<Vec<_>>>()
+        .map(Some)
+}
+
 /// Plans local-scoring FTS queries over LSM data.
 pub struct LsmFtsSearchPlanner {
     collector: LsmDataSourceCollector,
@@ -465,6 +512,123 @@ impl LsmFtsSearchPlanner {
         fields(column = %column, limit)
     )]
     pub async fn plan_search(
+        &self,
+        column: &str,
+        query: FullTextSearchQuery,
+        limit: Option<usize>,
+        projection: Option<&[String]>,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        let Some(per_column) = cross_column_targets(&query.query)? else {
+            return self
+                .plan_single_column_search(column, query, limit, projection)
+                .await;
+        };
+
+        // Collapsing field hits needs a row identity to collapse *by*. Without
+        // one every matching field contributes its own row, which is not a
+        // partial answer to a multi-match — it is a different one, with inflated
+        // counts and a ranking that double-counts rows matching in two fields.
+        if self.pk_columns.is_empty() {
+            return Err(Error::not_supported(
+                "cross-column full-text search requires a primary key: a row matching in \
+                 several columns is scored once per column, and collapsing those hits to \
+                 one row needs a stable identity to collapse by"
+                    .to_string(),
+            ));
+        }
+
+        // One single-column plan per field, unioned and collapsed. Each field is
+        // scored independently and a row takes its best field's score, which is
+        // what the base-table path does for a cross-column MultiMatch
+        // (`DisjunctionScore::Max`). Reusing the single-column planner per field
+        // keeps every per-source behavior — granularity resolution, prefilter,
+        // the cross-generation block-list — identical to a single-column search,
+        // at the cost of one pass over the sources per field.
+        //
+        // Each arm is cut at `k * fields` rather than `k`: the final top-k is
+        // over *rows*, and a row can occupy up to one slot per field, so a
+        // tighter per-arm cut could leave fewer than `k` rows after the collapse
+        // even when more matching rows exist.
+        let candidate_limit = limit.map(|k| k.saturating_mul(per_column.len().max(1)));
+        let mut per_column_plans = Vec::with_capacity(per_column.len());
+        for (field, sub_query) in per_column {
+            let mut bounded = FullTextSearchQuery::new_query(sub_query);
+            bounded.limit = query.limit;
+            bounded.wand_factor = query.wand_factor;
+            per_column_plans.push(
+                Box::pin(self.plan_single_column_search(
+                    &field,
+                    bounded,
+                    candidate_limit,
+                    projection,
+                ))
+                .await?,
+            );
+        }
+
+        // Enforce the row-only contract on what each arm *resolved*, not on what
+        // the query asked for. A default multi-match requests no granularity, so
+        // the check in `cross_column_targets` sees nothing to reject; if every
+        // column happens to carry a list-element index, each arm resolves to
+        // `ListElement` independently and their schemas agree, so a
+        // schema-equality check passes too. The result would be element hits
+        // collapsed by row primary key — which silently discards every matching
+        // element of a row but one, because a row PK is not an element identity.
+        //
+        // `_doc_index` in the output is the observable form of that resolution,
+        // so key on it rather than re-deriving the granularity.
+        if per_column_plans
+            .iter()
+            .any(|plan| plan.schema().column_with_name(DOC_INDEX_COL).is_some())
+        {
+            return Err(Error::not_supported(
+                "cross-column full-text search supports row documents only: element hits \
+                 carry a per-element coordinate that a row primary key cannot collapse by, \
+                 so matching elements would be silently dropped"
+                    .to_string(),
+            ));
+        }
+
+        // Any remaining schema divergence would panic inside `UnionExec::new`
+        // rather than erroring, so this is the last point where it is still a
+        // query error instead of a process failure.
+        if let Some((first, rest)) = per_column_plans.split_first()
+            && let Some(mismatch) = rest.iter().find(|plan| plan.schema() != first.schema())
+        {
+            return Err(Error::not_supported(format!(
+                "cross-column full-text search requires every column to produce the same \
+                 schema; got {:?} and {:?}",
+                first.schema(),
+                mismatch.schema()
+            )));
+        }
+
+        let merged: Arc<dyn ExecutionPlan> = if per_column_plans.len() == 1 {
+            per_column_plans.into_iter().next().unwrap()
+        } else {
+            #[allow(deprecated)]
+            Arc::new(UnionExec::new(per_column_plans))
+        };
+        // Order the candidates, collapse duplicates, *then* cut to k. Cutting
+        // before the collapse spends the budget on repeat hits of the same row.
+        // The input is sorted by `_score` descending, so keeping the first
+        // occurrence per primary key takes the maximum — see `FirstByPkExec`.
+        let sorted = self.sort_by_score(merged, candidate_limit)?;
+        let collapsed: Arc<dyn ExecutionPlan> =
+            Arc::new(FirstByPkExec::new(sorted, self.pk_columns.clone()));
+        Ok(match limit {
+            Some(k) => Arc::new(GlobalLimitExec::new(collapsed, 0, Some(k))),
+            None => collapsed,
+        })
+    }
+
+    #[instrument(
+        name = "lsm_fts_search_column",
+        level = "info",
+        skip_all,
+        fields(column = %column, limit)
+    )]
+    async fn plan_single_column_search(
         &self,
         column: &str,
         mut query: FullTextSearchQuery,
@@ -649,6 +813,19 @@ impl LsmFtsSearchPlanner {
             Arc::new(UnionExec::new(per_source_plans))
         };
 
+        self.sort_by_score(merged, limit)
+    }
+
+    /// Order a merged FTS result by `_score` descending, capped at `limit`.
+    ///
+    /// Per-partition sort with `fetch=k` so each upstream partition can
+    /// early-terminate at k; the preserving merge then does a K-way heap merge
+    /// also capped at k. Same pattern as `LsmVectorSearchPlanner`.
+    fn sort_by_score(
+        &self,
+        merged: Arc<dyn ExecutionPlan>,
+        limit: Option<usize>,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
         let score_idx = merged.schema().index_of(SCORE_COLUMN).map_err(|_| {
             Error::internal(format!(
                 "{SCORE_COLUMN} missing from canonical FTS schema after merge"
@@ -666,20 +843,14 @@ impl LsmFtsSearchPlanner {
             Error::internal("Failed to build LexOrdering for FTS _score sort".to_string())
         })?;
 
-        // Per-partition sort with `fetch=k` so each upstream partition
-        // can early-terminate at k; the preserving merge then does a
-        // K-way heap merge also capped at k. Same pattern as
-        // LsmVectorSearchPlanner.
         let per_partition_sorted: Arc<dyn ExecutionPlan> = Arc::new(
             SortExec::new(lex_ordering.clone(), merged)
                 .with_preserve_partitioning(true)
                 .with_fetch(limit),
         );
-        let merged_sorted: Arc<dyn ExecutionPlan> = Arc::new(
+        Ok(Arc::new(
             SortPreservingMergeExec::new(lex_ordering, per_partition_sorted).with_fetch(limit),
-        );
-
-        Ok(merged_sorted)
+        ))
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -907,6 +1078,39 @@ mod tests {
             id_field,
             Field::new("text", DataType::Utf8, true),
         ]))
+    }
+
+    /// Two independently searchable text columns, for cross-column queries.
+    fn two_column_fts_schema() -> Arc<ArrowSchema> {
+        let mut id_meta = HashMap::new();
+        id_meta.insert(
+            "lance-schema:unenforced-primary-key".to_string(),
+            "true".to_string(),
+        );
+        let id_field = Field::new("id", DataType::Int32, false).with_metadata(id_meta);
+        Arc::new(ArrowSchema::new(vec![
+            id_field,
+            Field::new("title", DataType::Utf8, true),
+            Field::new("body", DataType::Utf8, true),
+        ]))
+    }
+
+    fn make_two_column_batch(schema: &ArrowSchema, rows: &[(i32, &str, &str)]) -> RecordBatch {
+        RecordBatch::try_new(
+            Arc::new(schema.clone()),
+            vec![
+                Arc::new(Int32Array::from(
+                    rows.iter().map(|(id, _, _)| *id).collect::<Vec<_>>(),
+                )),
+                Arc::new(StringArray::from(
+                    rows.iter().map(|(_, t, _)| *t).collect::<Vec<_>>(),
+                )),
+                Arc::new(StringArray::from(
+                    rows.iter().map(|(_, _, b)| *b).collect::<Vec<_>>(),
+                )),
+            ],
+        )
+        .unwrap()
     }
 
     fn fts_tombstone_schema() -> Arc<ArrowSchema> {
@@ -2166,57 +2370,6 @@ mod tests {
         );
     }
 
-    /// Multi-match spans columns and the memtable holds one inverted index per
-    /// column, so it stays refused rather than silently searching one of them.
-    #[tokio::test]
-    async fn multi_match_query_is_refused_by_the_active_memtable() {
-        use lance_index::scalar::inverted::query::{FtsQuery as IndexFtsQuery, MultiMatchQuery};
-
-        let schema = fts_schema();
-        let batch_store = Arc::new(BatchStore::with_capacity(16));
-        let mut indexes = IndexStore::new();
-        indexes.enable_pk_index(&[("id".to_string(), 0)]);
-        indexes.add_fts("text_fts".to_string(), 1, "text".to_string());
-        let active_batch = make_batch(&schema, &[1], &["lance memwal"]);
-        let (_, row_offset, batch_position) = batch_store.append(active_batch.clone()).unwrap();
-        indexes
-            .insert_with_batch_position(&active_batch, row_offset, Some(batch_position))
-            .unwrap();
-        let indexes = Arc::new(indexes);
-        let tmp = tempfile::tempdir().unwrap();
-        let base_uri = format!("{}/base", tmp.path().to_str().unwrap());
-        let collector = LsmDataSourceCollector::without_base_table(base_uri, vec![])
-            .with_in_memory_memtables(
-                uuid::Uuid::new_v4(),
-                InMemoryMemTables {
-                    active: InMemoryMemTableRef {
-                        batch_store,
-                        index_store: indexes,
-                        schema: schema.clone(),
-                        generation: 1,
-                    },
-                    frozen: vec![],
-                },
-            );
-        let planner = LsmFtsSearchPlanner::new(collector, vec!["id".to_string()], schema);
-
-        let query = FullTextSearchQuery::new_query(IndexFtsQuery::MultiMatch(
-            MultiMatchQuery::try_new(
-                "lance".to_string(),
-                vec!["text".to_string(), "other".to_string()],
-            )
-            .unwrap(),
-        ));
-        let err = planner
-            .plan_search("text", query, Some(10), Some(&["id".to_string()]))
-            .await
-            .unwrap_err();
-        assert!(
-            err.to_string().contains("multi-match"),
-            "unexpected error for multi-match query: {err}"
-        );
-    }
-
     /// An FTS index the write spec does not maintain used to make the active
     /// memtable contribute nothing — `empty_plan()`, not an error — so the query
     /// returned a base-only answer under a plan that said it consulted the
@@ -2592,8 +2745,370 @@ mod tests {
         assert_eq!(batches.iter().map(|b| b.num_rows()).sum::<usize>(), 0);
     }
 
+    /// A multi-match reaches the active memtable across every queried column,
+    /// and a row matching in more than one is returned once rather than per
+    /// column.
+    #[tokio::test]
+    async fn multi_match_searches_every_column_and_collapses_duplicates() {
+        use lance_index::scalar::inverted::query::MultiMatchQuery;
+
+        let schema = two_column_fts_schema();
+        let batch_store = Arc::new(BatchStore::with_capacity(16));
+        let mut indexes = IndexStore::new();
+        indexes.enable_pk_index(&[("id".to_string(), 0)]);
+        indexes.add_fts("title_fts".to_string(), 1, "title".to_string());
+        indexes.add_fts("body_fts".to_string(), 2, "body".to_string());
+        let active_batch = make_two_column_batch(
+            &schema,
+            &[
+                (1, "lance title", "unrelated body"), // title only
+                (2, "unrelated title", "lance body"), // body only
+                (3, "lance title", "lance body"),     // both -> must appear once
+                (4, "nothing", "nothing"),            // neither
+            ],
+        );
+        let (_, row_offset, batch_position) = batch_store.append(active_batch.clone()).unwrap();
+        indexes
+            .insert_with_batch_position(&active_batch, row_offset, Some(batch_position))
+            .unwrap();
+        let indexes = Arc::new(indexes);
+
+        let tmp = tempfile::tempdir().unwrap();
+        let base_uri = format!("{}/base", tmp.path().to_str().unwrap());
+        let collector = LsmDataSourceCollector::without_base_table(base_uri, vec![])
+            .with_in_memory_memtables(
+                uuid::Uuid::new_v4(),
+                InMemoryMemTables {
+                    active: InMemoryMemTableRef {
+                        batch_store,
+                        index_store: indexes,
+                        schema: schema.clone(),
+                        generation: 1,
+                    },
+                    frozen: vec![],
+                },
+            );
+        let planner = LsmFtsSearchPlanner::new(collector, vec!["id".to_string()], schema);
+
+        let query = FullTextSearchQuery::new_query(IndexFtsQuery::MultiMatch(
+            MultiMatchQuery::try_new(
+                "lance".to_string(),
+                vec!["title".to_string(), "body".to_string()],
+            )
+            .unwrap(),
+        ));
+        let plan = planner
+            .plan_search("title", query, Some(10), Some(&["id".to_string()]))
+            .await
+            .expect("a cross-column multi-match must plan");
+        let ctx = datafusion::prelude::SessionContext::new();
+        let stream = plan.execute(0, ctx.task_ctx()).unwrap();
+        let batches: Vec<RecordBatch> = stream.try_collect().await.unwrap();
+        let ids: Vec<i32> = batches
+            .iter()
+            .flat_map(|batch| {
+                batch
+                    .column_by_name("id")
+                    .unwrap()
+                    .as_any()
+                    .downcast_ref::<Int32Array>()
+                    .unwrap()
+                    .values()
+                    .to_vec()
+            })
+            .collect();
+        let mut sorted = ids.clone();
+        sorted.sort_unstable();
+        assert_eq!(
+            sorted,
+            vec![1, 2, 3],
+            "every column must be searched; id=4 matches neither"
+        );
+        assert_eq!(
+            ids.len(),
+            3,
+            "id=3 matches in both columns and must collapse to one row, got {ids:?}"
+        );
+    }
+
+    /// The top-k is over *rows*, so the cut has to happen after duplicates
+    /// collapse. Cutting the union to `k` field hits first lets one row that
+    /// ranks highly in several fields spend the whole budget on itself, and the
+    /// query returns fewer than `k` rows while more matching rows exist.
+    #[tokio::test]
+    async fn cross_column_limit_counts_rows_not_field_hits() {
+        use lance_index::scalar::inverted::query::MultiMatchQuery;
+
+        let schema = two_column_fts_schema();
+        let batch_store = Arc::new(BatchStore::with_capacity(16));
+        let mut indexes = IndexStore::new();
+        indexes.enable_pk_index(&[("id".to_string(), 0)]);
+        indexes.add_fts("title_fts".to_string(), 1, "title".to_string());
+        indexes.add_fts("body_fts".to_string(), 2, "body".to_string());
+        let active_batch = make_two_column_batch(
+            &schema,
+            &[
+                // Ranks top in both fields, so it occupies two of the union's
+                // slots on its own.
+                (3, "lance lance lance", "lance lance lance"),
+                (1, "lance title", "unrelated body"),
+                (2, "unrelated title", "lance body"),
+            ],
+        );
+        let (_, row_offset, batch_position) = batch_store.append(active_batch.clone()).unwrap();
+        indexes
+            .insert_with_batch_position(&active_batch, row_offset, Some(batch_position))
+            .unwrap();
+        let indexes = Arc::new(indexes);
+
+        let tmp = tempfile::tempdir().unwrap();
+        let base_uri = format!("{}/base", tmp.path().to_str().unwrap());
+        let collector = LsmDataSourceCollector::without_base_table(base_uri, vec![])
+            .with_in_memory_memtables(
+                uuid::Uuid::new_v4(),
+                InMemoryMemTables {
+                    active: InMemoryMemTableRef {
+                        batch_store,
+                        index_store: indexes,
+                        schema: schema.clone(),
+                        generation: 1,
+                    },
+                    frozen: vec![],
+                },
+            );
+        let planner = LsmFtsSearchPlanner::new(collector, vec!["id".to_string()], schema);
+        let query = FullTextSearchQuery::new_query(IndexFtsQuery::MultiMatch(
+            MultiMatchQuery::try_new(
+                "lance".to_string(),
+                vec!["title".to_string(), "body".to_string()],
+            )
+            .unwrap(),
+        ));
+        let plan = planner
+            .plan_search("title", query, Some(2), Some(&["id".to_string()]))
+            .await
+            .unwrap();
+        let ctx = datafusion::prelude::SessionContext::new();
+        let stream = plan.execute(0, ctx.task_ctx()).unwrap();
+        let batches: Vec<RecordBatch> = stream.try_collect().await.unwrap();
+        let ids: Vec<i32> = batches
+            .iter()
+            .flat_map(|batch| {
+                batch
+                    .column_by_name("id")
+                    .unwrap()
+                    .as_any()
+                    .downcast_ref::<Int32Array>()
+                    .unwrap()
+                    .values()
+                    .to_vec()
+            })
+            .collect();
+        assert_eq!(
+            ids.len(),
+            2,
+            "limit 2 must return two distinct rows, got {ids:?}"
+        );
+        let mut distinct = ids.clone();
+        distinct.sort_unstable();
+        distinct.dedup();
+        assert_eq!(distinct.len(), 2, "rows must be distinct, got {ids:?}");
+    }
+
+    /// Without a primary key there is no identity to collapse field hits by, so
+    /// the query is refused rather than returning one row per matching field.
+    #[tokio::test]
+    async fn cross_column_without_a_primary_key_is_refused() {
+        use lance_index::scalar::inverted::query::MultiMatchQuery;
+
+        let schema = two_column_fts_schema();
+        let tmp = tempfile::tempdir().unwrap();
+        let base_uri = format!("{}/base", tmp.path().to_str().unwrap());
+        let collector = LsmDataSourceCollector::without_base_table(base_uri, vec![]);
+        let planner = LsmFtsSearchPlanner::new(collector, vec![], schema);
+        let query = FullTextSearchQuery::new_query(IndexFtsQuery::MultiMatch(
+            MultiMatchQuery::try_new(
+                "lance".to_string(),
+                vec!["title".to_string(), "body".to_string()],
+            )
+            .unwrap(),
+        ));
+        let err = planner
+            .plan_search("title", query, Some(10), Some(&["id".to_string()]))
+            .await
+            .unwrap_err();
+        assert!(
+            err.to_string().contains("requires a primary key"),
+            "unexpected error: {err}"
+        );
+    }
+
+    /// A list-element leaf makes one arm carry `_doc_index` and the other not,
+    /// which `UnionExec::new` panics on rather than erroring. Refuse first: the
+    /// on-disk cross-column contract is row documents only.
+    #[tokio::test]
+    async fn cross_column_list_element_granularity_is_refused() {
+        use lance_index::scalar::inverted::query::{MatchQuery, MultiMatchQuery};
+
+        let schema = two_column_fts_schema();
+        let tmp = tempfile::tempdir().unwrap();
+        let base_uri = format!("{}/base", tmp.path().to_str().unwrap());
+        let collector = LsmDataSourceCollector::without_base_table(base_uri, vec![]);
+        let planner = LsmFtsSearchPlanner::new(collector, vec!["id".to_string()], schema);
+
+        let mut multi = MultiMatchQuery::try_new(
+            "lance".to_string(),
+            vec!["title".to_string(), "body".to_string()],
+        )
+        .unwrap();
+        multi.match_queries[1] = MatchQuery::new("lance".to_string())
+            .with_column(Some("body".to_string()))
+            .with_document_granularity(DocumentGranularity::ListElement);
+        let query = FullTextSearchQuery::new_query(IndexFtsQuery::MultiMatch(multi));
+        let err = planner
+            .plan_search("title", query, Some(10), Some(&["id".to_string()]))
+            .await
+            .unwrap_err();
+        assert!(
+            err.to_string().contains("row documents only"),
+            "unexpected error: {err}"
+        );
+    }
+
+    /// The implicit case the explicit-request guard cannot see: a default
+    /// multi-match names no granularity, so nothing is rejected up front, and
+    /// if every column carries a list-element index each arm resolves to
+    /// `ListElement` on its own. Their schemas then *agree*, so a
+    /// schema-equality check passes too — and the collapse would key element
+    /// hits by row primary key, dropping every matching element of a row but
+    /// one.
+    #[tokio::test]
+    async fn cross_column_implicit_list_element_granularity_is_refused() {
+        use lance_index::scalar::inverted::InvertedIndexParams;
+        use lance_index::scalar::inverted::query::MultiMatchQuery;
+
+        let mut id_meta = HashMap::new();
+        id_meta.insert(
+            "lance-schema:unenforced-primary-key".to_string(),
+            "true".to_string(),
+        );
+        let id_field = Field::new("id", DataType::Int32, false).with_metadata(id_meta);
+        let list_type = DataType::List(Arc::new(Field::new("item", DataType::Utf8, true)));
+        let schema = Arc::new(ArrowSchema::new(vec![
+            id_field,
+            Field::new("tags", list_type.clone(), true),
+            Field::new("notes", list_type, true),
+        ]));
+
+        let mut tags = ListBuilder::new(StringBuilder::new());
+        tags.values().append_value("lance");
+        tags.append(true);
+        let mut notes = ListBuilder::new(StringBuilder::new());
+        notes.values().append_value("lance");
+        notes.append(true);
+        let active_batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(Int32Array::from(vec![1])),
+                Arc::new(tags.finish()),
+                Arc::new(notes.finish()),
+            ],
+        )
+        .unwrap();
+
+        let batch_store = Arc::new(BatchStore::with_capacity(16));
+        let mut indexes = IndexStore::new();
+        indexes.enable_pk_index(&[("id".to_string(), 0)]);
+        for (name, field_id, column) in [
+            ("tags_element_fts", 1, "tags"),
+            ("notes_element_fts", 2, "notes"),
+        ] {
+            indexes
+                .add_fts_with_params(
+                    name.to_string(),
+                    field_id,
+                    column.to_string(),
+                    InvertedIndexParams::default()
+                        .document_granularity(DocumentGranularity::ListElement),
+                )
+                .unwrap();
+        }
+        let (_, row_offset, batch_position) = batch_store.append(active_batch.clone()).unwrap();
+        indexes
+            .insert_with_batch_position(&active_batch, row_offset, Some(batch_position))
+            .unwrap();
+        let indexes = Arc::new(indexes);
+
+        let tmp = tempfile::tempdir().unwrap();
+        let base_uri = format!("{}/base", tmp.path().to_str().unwrap());
+        let collector = LsmDataSourceCollector::without_base_table(base_uri, vec![])
+            .with_in_memory_memtables(
+                uuid::Uuid::new_v4(),
+                InMemoryMemTables {
+                    active: InMemoryMemTableRef {
+                        batch_store,
+                        index_store: indexes,
+                        schema: schema.clone(),
+                        generation: 1,
+                    },
+                    frozen: vec![],
+                },
+            );
+        let planner = LsmFtsSearchPlanner::new(collector, vec!["id".to_string()], schema);
+
+        // No explicit granularity: both arms resolve to ListElement themselves.
+        let query = FullTextSearchQuery::new_query(IndexFtsQuery::MultiMatch(
+            MultiMatchQuery::try_new(
+                "lance".to_string(),
+                vec!["tags".to_string(), "notes".to_string()],
+            )
+            .unwrap(),
+        ));
+        let err = planner
+            .plan_search("tags", query, Some(10), Some(&["id".to_string()]))
+            .await
+            .unwrap_err();
+        assert!(
+            err.to_string().contains("row documents only"),
+            "unexpected error: {err}"
+        );
+    }
+
+    /// A boolean spanning columns is one predicate over several fields, not a
+    /// union of per-column results, so it is refused rather than decomposed
+    /// into an answer to a different question.
+    #[tokio::test]
+    async fn cross_column_boolean_is_refused() {
+        use lance_index::scalar::inverted::query::{BooleanQuery, MatchQuery, Occur};
+
+        let schema = two_column_fts_schema();
+        let tmp = tempfile::tempdir().unwrap();
+        let base_uri = format!("{}/base", tmp.path().to_str().unwrap());
+        let collector = LsmDataSourceCollector::without_base_table(base_uri, vec![]);
+        let planner = LsmFtsSearchPlanner::new(collector, vec!["id".to_string()], schema);
+
+        let leaf = |terms: &str, column: &str| {
+            IndexFtsQuery::Match(
+                MatchQuery::new(terms.to_string()).with_column(Some(column.to_string())),
+            )
+        };
+        let query =
+            FullTextSearchQuery::new_query(IndexFtsQuery::Boolean(BooleanQuery::new(vec![
+                (Occur::Must, leaf("alpha", "title")),
+                (Occur::Must, leaf("beta", "body")),
+            ])));
+        let err = planner
+            .plan_search("title", query, Some(10), Some(&["id".to_string()]))
+            .await
+            .unwrap_err();
+        assert!(
+            err.to_string().contains("across several columns"),
+            "unexpected error for a cross-column boolean: {err}"
+        );
+    }
+
     /// The base arm must apply the filter as a true *prefilter*, not a
-    /// post-filter on the BM25 top-k."""""" With `k = 1` and the higher-scoring base
+    /// post-filter on the BM25 top-k.""""""""" With `k = 1` and the higher-scoring base
     /// doc failing the predicate, a post-filter would return zero rows; a
     /// prefilter restricts BM25 to matching rows and returns the lower-scoring
     /// match. Regression for a missing `scanner.prefilter(true)` on the base arm.

--- a/rust/lance/src/dataset/mem_wal/scanner/fts_search.rs
+++ b/rust/lance/src/dataset/mem_wal/scanner/fts_search.rs
@@ -206,21 +206,43 @@ fn validate_source_document_granularities(
     Ok(())
 }
 
+/// Reject the query shapes the active memtable arm cannot evaluate.
+///
+/// Only two remain. A fuzzy Match cannot also require every term: the fuzzy
+/// path expands each term independently and unions the expansions. And
+/// multi-match spans columns, while the memtable holds one inverted index per
+/// column, so there is no single index to search.
 fn validate_lsm_fts_query(query: &FullTextSearchQuery) -> Result<()> {
-    match &query.query {
-        IndexFtsQuery::Match(m) => {
-            if m.fuzziness != Some(0) && m.operator != Operator::Or {
-                return Err(Error::not_supported(
-                    "LSM fuzzy full-text search only supports OR match operators".to_string(),
-                ));
+    fn visit(query: &IndexFtsQuery) -> Result<()> {
+        match query {
+            IndexFtsQuery::Match(m) => {
+                if m.fuzziness != Some(0) && m.operator != Operator::Or {
+                    return Err(Error::not_supported(
+                        "LSM fuzzy full-text search only supports OR match operators".to_string(),
+                    ));
+                }
+                Ok(())
             }
-            Ok(())
+            IndexFtsQuery::Phrase(_) => Ok(()),
+            IndexFtsQuery::Boost(b) => {
+                visit(&b.positive)?;
+                visit(&b.negative)
+            }
+            IndexFtsQuery::Boolean(b) => {
+                for child in b.must.iter().chain(&b.should).chain(&b.must_not) {
+                    visit(child)?;
+                }
+                Ok(())
+            }
+            IndexFtsQuery::MultiMatch(_) => Err(Error::not_supported(
+                "LSM full-text search does not support multi-match queries: the memtable \
+                 holds one inverted index per column, so a cross-column query has no single \
+                 index to search"
+                    .to_string(),
+            )),
         }
-        IndexFtsQuery::Phrase(_) => Ok(()),
-        _ => Err(Error::not_supported(
-            "LSM full-text search only supports match and phrase leaf queries".to_string(),
-        )),
     }
+    visit(&query.query)
 }
 
 fn active_source_can_execute_fts(
@@ -1894,8 +1916,160 @@ mod tests {
         assert_eq!(ids, vec![1]);
     }
 
+    /// A boolean query has to reach the active memtable, not just the base
+    /// table, and every clause has to survive the trip: the MUST clause selects
+    /// and the MUST_NOT clause excludes, on memtable rows as much as base rows.
+    ///
+    /// Before this, `local_fts_query` refused any compound query outright, so a
+    /// memtable holding an FTS index on the searched column made the whole
+    /// query fail — and the LSM validator rejected it one layer up.
+    #[tokio::test]
+    async fn boolean_query_reaches_the_active_memtable() {
+        use crate::index::DatasetIndexExt;
+        use lance_index::IndexType;
+        use lance_index::scalar::inverted::query::{
+            BooleanQuery, FtsQuery as IndexFtsQuery, MatchQuery, Occur,
+        };
+        use lance_index::scalar::inverted::tokenizer::InvertedIndexParams;
+
+        let schema = fts_schema();
+        let tmp = tempfile::tempdir().unwrap();
+        let base_uri = format!("{}/base", tmp.path().to_str().unwrap());
+        let mut base_ds = write_dataset(
+            &base_uri,
+            vec![make_batch(
+                &schema,
+                &[1, 2],
+                &["lance rocks", "unrelated text"],
+            )],
+        )
+        .await;
+        base_ds
+            .create_index(
+                &["text"],
+                IndexType::Inverted,
+                Some("text_fts".to_string()),
+                &InvertedIndexParams::default(),
+                false,
+            )
+            .await
+            .unwrap();
+        let base_ds = Arc::new(Dataset::open(&base_uri).await.unwrap());
+
+        // Active memtable with its own FTS index on the searched column: one
+        // row the query should keep, one the MUST_NOT clause should drop.
+        let batch_store = Arc::new(BatchStore::with_capacity(16));
+        let mut indexes = IndexStore::new();
+        indexes.enable_pk_index(&[("id".to_string(), 0)]);
+        indexes.add_fts("text_fts".to_string(), 1, "text".to_string());
+        let active_batch = make_batch(&schema, &[10, 11], &["lance memwal", "lance beta"]);
+        let (_, row_offset, batch_position) = batch_store.append(active_batch.clone()).unwrap();
+        indexes
+            .insert_with_batch_position(&active_batch, row_offset, Some(batch_position))
+            .unwrap();
+        let indexes = Arc::new(indexes);
+        let collector = LsmDataSourceCollector::new(base_ds, vec![]).with_in_memory_memtables(
+            uuid::Uuid::new_v4(),
+            InMemoryMemTables {
+                active: InMemoryMemTableRef {
+                    batch_store,
+                    index_store: indexes,
+                    schema: schema.clone(),
+                    generation: 1,
+                },
+                frozen: vec![],
+            },
+        );
+        let planner = LsmFtsSearchPlanner::new(collector, vec!["id".to_string()], schema);
+
+        let leaf = |terms: &str| IndexFtsQuery::from(MatchQuery::new(terms.to_string()));
+        let query =
+            FullTextSearchQuery::new_query(IndexFtsQuery::Boolean(BooleanQuery::new(vec![
+                (Occur::Must, leaf("lance")),
+                (Occur::MustNot, leaf("beta")),
+            ])));
+        let plan = planner
+            .plan_search("text", query, Some(10), Some(&["id".to_string()]))
+            .await
+            .expect("an active memtable with an FTS index must serve a boolean query");
+        let ctx = datafusion::prelude::SessionContext::new();
+        let stream = plan.execute(0, ctx.task_ctx()).unwrap();
+        let batches: Vec<RecordBatch> = stream.try_collect().await.unwrap();
+        let mut ids: Vec<i32> = batches
+            .iter()
+            .flat_map(|batch| {
+                batch
+                    .column_by_name("id")
+                    .unwrap()
+                    .as_any()
+                    .downcast_ref::<Int32Array>()
+                    .unwrap()
+                    .values()
+                    .to_vec()
+            })
+            .collect();
+        ids.sort_unstable();
+        assert_eq!(
+            ids,
+            vec![1, 10],
+            "id=1 from base and id=10 from the memtable match MUST 'lance'; \
+             id=2 lacks it and id=11 is excluded by MUST_NOT 'beta'"
+        );
+    }
+
+    /// Multi-match spans columns and the memtable holds one inverted index per
+    /// column, so it stays refused rather than silently searching one of them.
+    #[tokio::test]
+    async fn multi_match_query_is_refused_by_the_active_memtable() {
+        use lance_index::scalar::inverted::query::{FtsQuery as IndexFtsQuery, MultiMatchQuery};
+
+        let schema = fts_schema();
+        let batch_store = Arc::new(BatchStore::with_capacity(16));
+        let mut indexes = IndexStore::new();
+        indexes.enable_pk_index(&[("id".to_string(), 0)]);
+        indexes.add_fts("text_fts".to_string(), 1, "text".to_string());
+        let active_batch = make_batch(&schema, &[1], &["lance memwal"]);
+        let (_, row_offset, batch_position) = batch_store.append(active_batch.clone()).unwrap();
+        indexes
+            .insert_with_batch_position(&active_batch, row_offset, Some(batch_position))
+            .unwrap();
+        let indexes = Arc::new(indexes);
+        let tmp = tempfile::tempdir().unwrap();
+        let base_uri = format!("{}/base", tmp.path().to_str().unwrap());
+        let collector = LsmDataSourceCollector::without_base_table(base_uri, vec![])
+            .with_in_memory_memtables(
+                uuid::Uuid::new_v4(),
+                InMemoryMemTables {
+                    active: InMemoryMemTableRef {
+                        batch_store,
+                        index_store: indexes,
+                        schema: schema.clone(),
+                        generation: 1,
+                    },
+                    frozen: vec![],
+                },
+            );
+        let planner = LsmFtsSearchPlanner::new(collector, vec!["id".to_string()], schema);
+
+        let query = FullTextSearchQuery::new_query(IndexFtsQuery::MultiMatch(
+            MultiMatchQuery::try_new(
+                "lance".to_string(),
+                vec!["text".to_string(), "other".to_string()],
+            )
+            .unwrap(),
+        ));
+        let err = planner
+            .plan_search("text", query, Some(10), Some(&["id".to_string()]))
+            .await
+            .unwrap_err();
+        assert!(
+            err.to_string().contains("multi-match"),
+            "unexpected error for multi-match query: {err}"
+        );
+    }
+
     /// The base arm must apply the filter as a true *prefilter*, not a
-    /// post-filter on the BM25 top-k. With `k = 1` and the higher-scoring base
+    /// post-filter on the BM25 top-k.""" With `k = 1` and the higher-scoring base
     /// doc failing the predicate, a post-filter would return zero rows; a
     /// prefilter restricts BM25 to matching rows and returns the lower-scoring
     /// match. Regression for a missing `scanner.prefilter(true)` on the base arm.

--- a/rust/lance/src/dataset/mem_wal/scanner/fts_search.rs
+++ b/rust/lance/src/dataset/mem_wal/scanner/fts_search.rs
@@ -47,6 +47,7 @@ use datafusion::physical_plan::union::UnionExec;
 use datafusion::prelude::Expr;
 use lance_core::{Error, Result, is_system_column};
 use lance_index::scalar::FullTextSearchQuery;
+use lance_index::scalar::InvertedIndexParams;
 use lance_index::scalar::inverted::query::{FtsQuery as IndexFtsQuery, Operator};
 use lance_index::scalar::inverted::{DOC_INDEX_COL, DOC_INDEX_FIELD, DocumentGranularity};
 use tracing::instrument;
@@ -58,7 +59,10 @@ use super::exec::PkBlockFilterExec;
 use super::projection::{project_to_canonical, validate_projection_names};
 use super::sstable_cache::{DatasetCache, SsTableWarmer, open_sstable};
 use crate::dataset::mem_wal::memtable::scanner::MemTableScanner;
-use crate::index::scalar::inverted::{indexed_fts_document_granularities, resolve_fts_field};
+use crate::dataset::mem_wal::write::{BatchStore, IndexStore};
+use crate::index::scalar::inverted::{
+    indexed_fts_document_granularities, indexed_fts_index_params, resolve_fts_field,
+};
 use crate::session::Session;
 use lance_io::object_store::ObjectStoreParams;
 
@@ -267,6 +271,96 @@ fn active_source_can_execute_fts(
     }
 }
 
+/// Build a throwaway [`IndexStore`] carrying an inverted index on `column`,
+/// populated from the memtable's visible prefix.
+///
+/// The active memtable indexes only the columns in the write spec's maintained
+/// set, and that set is fixed when the spec is installed — an FTS index created
+/// afterwards can never join it. Without this, the arm for such a column is
+/// `empty_plan()`: the query succeeds, the plan says it consulted the memtable,
+/// and every matching row still in memory is missing from the answer.
+///
+/// Indexing at query time costs a tokenize pass over the visible rows, which is
+/// what any brute-force scoring would cost anyway — and going through a real
+/// index means every query shape works here exactly as it does on a maintained
+/// column, compound trees included, rather than a hand-written subset.
+///
+/// Returns `None` when the memtable has no visible rows, so an empty memtable
+/// pays nothing.
+fn transient_fts_index_store(
+    batch_store: &Arc<BatchStore>,
+    source: &IndexStore,
+    schema: &SchemaRef,
+    column: &str,
+    document_granularity: DocumentGranularity,
+    pk_columns: &[String],
+    index_params: Option<&InvertedIndexParams>,
+) -> Result<Option<Arc<IndexStore>>> {
+    let visible_batches = source.visible_count();
+    if visible_batches == 0 {
+        return Ok(None);
+    }
+
+    let field_id = schema.index_of(column).map_err(|_| {
+        Error::invalid_input(format!(
+            "FTS query column '{column}' is not in the MemWAL schema"
+        ))
+    })? as i32;
+
+    // PK columns first: `enable_pk_index` refuses to run once a search index
+    // holds rows, and the FTS exec needs the PK index to drop superseded
+    // postings before it applies the query limit.
+    let mut store = IndexStore::new();
+    if !pk_columns.is_empty() {
+        let resolved = pk_columns
+            .iter()
+            .map(|name| {
+                schema
+                    .index_of(name)
+                    .map(|idx| (name.clone(), idx as i32))
+                    .map_err(|_| {
+                        Error::invalid_input(format!(
+                            "primary-key column '{name}' is not in the MemWAL schema"
+                        ))
+                    })
+            })
+            .collect::<Result<Vec<_>>>()?;
+        store.enable_pk_index(&resolved);
+    }
+    // Inherit the persisted index's analyzer and positional settings. They are
+    // part of the query contract: a phrase query needs positions, and a
+    // stemming or n-gram tokenizer changes which terms a document produces, so
+    // defaults here would have the active rows disagree with base and SSTable
+    // rows about what matches — silently, by returning fewer rows. Defaults are
+    // right only when no persisted index covers the column, where there is no
+    // contract to match.
+    let params = index_params
+        .cloned()
+        .unwrap_or_default()
+        .document_granularity(document_granularity);
+    store.add_fts_with_params(
+        format!("__transient_fts_{column}"),
+        field_id,
+        column.to_string(),
+        params,
+    )?;
+
+    // Exactly the prefix the real store publishes. A bare `IndexStore` carries
+    // no durability cursors, so its own `visible_count` is its indexed prefix —
+    // indexing this many batches makes the two agree.
+    for position in 0..visible_batches {
+        let Some(stored) = batch_store.get(position) else {
+            break;
+        };
+        store.insert_with_batch_position(
+            &stored.data,
+            stored.row_offset,
+            Some(stored.batch_position),
+        )?;
+    }
+    Ok(Some(Arc::new(store)))
+}
+
 /// Plans local-scoring FTS queries over LSM data.
 pub struct LsmFtsSearchPlanner {
     collector: LsmDataSourceCollector,
@@ -381,9 +475,18 @@ impl LsmFtsSearchPlanner {
         let requested = requested_query_document_granularity(&query.query)?;
         let mut available = Vec::new();
         let mut source_granularities = Vec::with_capacity(sources.len());
+        // The analyzer/positional contract each granularity's persisted index
+        // was built with. Which one applies is only known once the query's
+        // granularity is resolved below — row and list-element indexes may
+        // coexist on a column with different settings, so choosing early would
+        // rebuild the transient arm against the wrong one.
+        let mut index_params: Vec<(DocumentGranularity, InvertedIndexParams)> = Vec::new();
         for source in &sources {
             let granularities = match source {
                 LsmDataSource::BaseTable { dataset } => {
+                    if index_params.is_empty() {
+                        index_params = indexed_fts_index_params(dataset, column).await?;
+                    }
                     indexed_fts_document_granularities(dataset, column)
                         .await?
                         .into_iter()
@@ -399,6 +502,9 @@ impl LsmFtsSearchPlanner {
                         self.warmer.as_ref(),
                     )
                     .await?;
+                    if index_params.is_empty() {
+                        index_params = indexed_fts_index_params(&dataset, column).await?;
+                    }
                     indexed_fts_document_granularities(&dataset, column)
                         .await?
                         .into_iter()
@@ -419,6 +525,13 @@ impl LsmFtsSearchPlanner {
             document_granularity,
             &source_granularities,
         )?;
+        // Now that the granularity is settled, take the settings of the index
+        // the query actually selects — `load_segments` picks the persisted index
+        // the same way.
+        let index_params = index_params
+            .into_iter()
+            .find(|(granularity, _)| *granularity == document_granularity)
+            .map(|(_, params)| params);
         let schema = lance_core::datatypes::Schema::try_from(self.base_schema.as_ref())?;
         resolve_fts_field(&schema, column, document_granularity)?;
         set_query_document_granularity(&mut query.query, document_granularity);
@@ -486,7 +599,14 @@ impl LsmFtsSearchPlanner {
             .collect();
         let built =
             futures::future::try_join_all(arm_inputs.iter().map(|(source, _, _, fetch_limit)| {
-                Box::pin(self.build_source_plan(source, column, &query, *fetch_limit, projection))
+                Box::pin(self.build_source_plan(
+                    source,
+                    column,
+                    &query,
+                    *fetch_limit,
+                    projection,
+                    index_params.as_ref(),
+                ))
             }))
             .await?;
 
@@ -562,6 +682,7 @@ impl LsmFtsSearchPlanner {
         Ok(merged_sorted)
     }
 
+    #[allow(clippy::too_many_arguments)]
     async fn build_source_plan(
         &self,
         source: &LsmDataSource,
@@ -569,6 +690,7 @@ impl LsmFtsSearchPlanner {
         query: &FullTextSearchQuery,
         limit: Option<usize>,
         projection: Option<&[String]>,
+        index_params: Option<&InvertedIndexParams>,
     ) -> Result<Arc<dyn ExecutionPlan>> {
         match source {
             LsmDataSource::BaseTable { dataset } => {
@@ -625,13 +747,36 @@ impl LsmFtsSearchPlanner {
                 ..
             } => {
                 let document_granularity = query_document_granularity(query)?;
-                if !active_source_can_execute_fts(source, column, document_granularity) {
-                    return self
-                        .empty_plan(&self.canonical_fts_schema(projection, document_granularity));
-                }
+                // A column outside the write spec's maintained set has no
+                // in-memory inverted index, so the memtable cannot be searched
+                // through `index_store`. Build one over the visible prefix for
+                // this query rather than contributing nothing: an empty arm is a
+                // silently short answer, since those rows are present and do
+                // match. `None` means there is nothing to index.
+                let index_store =
+                    if active_source_can_execute_fts(source, column, document_granularity) {
+                        index_store.clone()
+                    } else {
+                        match transient_fts_index_store(
+                            batch_store,
+                            index_store,
+                            schema,
+                            column,
+                            document_granularity,
+                            &self.pk_columns,
+                            index_params,
+                        )? {
+                            Some(store) => store,
+                            None => {
+                                return self.empty_plan(
+                                    &self.canonical_fts_schema(projection, document_granularity),
+                                );
+                            }
+                        }
+                    };
                 validate_lsm_fts_query(query)?;
                 let mut scanner =
-                    MemTableScanner::new(batch_store.clone(), index_store.clone(), schema.clone());
+                    MemTableScanner::new(batch_store.clone(), index_store, schema.clone());
                 let cols = self.fts_scanner_projection(projection);
                 scanner.project(&cols.iter().map(|s| s.as_str()).collect::<Vec<_>>())?;
                 if let Some(ref filter) = self.filter {
@@ -1834,8 +1979,12 @@ mod tests {
         assert_eq!(ids, vec![1]);
     }
 
+    /// An active memtable with no FTS index on the column is now indexed for
+    /// the query rather than skipped, so a boolean query reaches it. This
+    /// memtable's row carries none of the query's terms, so the answer is
+    /// unchanged — what changed is that it was actually searched.
     #[tokio::test]
-    async fn boolean_query_ignores_active_memtable_without_relevant_fts_index() {
+    async fn boolean_query_searches_active_memtable_without_a_maintained_fts_index() {
         use crate::index::DatasetIndexExt;
         use lance_index::IndexType;
         use lance_index::scalar::inverted::query::{
@@ -1896,7 +2045,7 @@ mod tests {
         let plan = planner
             .plan_search("text", query, Some(10), Some(&["id".to_string()]))
             .await
-            .expect("irrelevant active memtable must not reject base-supported boolean query");
+            .expect("an unmaintained column must be indexed for the query, not skipped");
         let ctx = datafusion::prelude::SessionContext::new();
         let stream = plan.execute(0, ctx.task_ctx()).unwrap();
         let batches: Vec<RecordBatch> = stream.try_collect().await.unwrap();
@@ -2068,8 +2217,383 @@ mod tests {
         );
     }
 
+    /// An FTS index the write spec does not maintain used to make the active
+    /// memtable contribute nothing — `empty_plan()`, not an error — so the query
+    /// returned a base-only answer under a plan that said it consulted the
+    /// memtable. Index the visible prefix for the query instead.
+    #[tokio::test]
+    async fn unmaintained_column_is_indexed_for_the_query() {
+        use crate::index::DatasetIndexExt;
+        use lance_index::IndexType;
+        use lance_index::scalar::inverted::tokenizer::InvertedIndexParams;
+
+        let schema = fts_schema();
+        let tmp = tempfile::tempdir().unwrap();
+        let base_uri = format!("{}/base", tmp.path().to_str().unwrap());
+        let mut base_ds = write_dataset(
+            &base_uri,
+            vec![make_batch(&schema, &[1, 2], &["lance rocks", "unrelated"])],
+        )
+        .await;
+        base_ds
+            .create_index(
+                &["text"],
+                IndexType::Inverted,
+                Some("text_fts".to_string()),
+                &InvertedIndexParams::default(),
+                false,
+            )
+            .await
+            .unwrap();
+        let base_ds = Arc::new(Dataset::open(&base_uri).await.unwrap());
+
+        // PK index maintained, FTS index not — the shape you get when the FTS
+        // index is built after `set_lsm_write_spec`.
+        let batch_store = Arc::new(BatchStore::with_capacity(16));
+        let mut indexes = IndexStore::new();
+        indexes.enable_pk_index(&[("id".to_string(), 0)]);
+        let active_batch = make_batch(&schema, &[10, 11], &["lance in memtable", "no match here"]);
+        let (_, row_offset, batch_position) = batch_store.append(active_batch.clone()).unwrap();
+        indexes
+            .insert_with_batch_position(&active_batch, row_offset, Some(batch_position))
+            .unwrap();
+        let indexes = Arc::new(indexes);
+        assert!(
+            indexes
+                .fts_document_granularities_by_column("text")
+                .is_empty(),
+            "precondition: the memtable maintains no FTS index on the column"
+        );
+
+        let collector = LsmDataSourceCollector::new(base_ds, vec![]).with_in_memory_memtables(
+            uuid::Uuid::new_v4(),
+            InMemoryMemTables {
+                active: InMemoryMemTableRef {
+                    batch_store,
+                    index_store: indexes,
+                    schema: schema.clone(),
+                    generation: 1,
+                },
+                frozen: vec![],
+            },
+        );
+        let planner = LsmFtsSearchPlanner::new(collector, vec!["id".to_string()], schema);
+        let query = FullTextSearchQuery::new_query(IndexFtsQuery::Match(MatchQuery::new(
+            "lance".to_string(),
+        )));
+        let plan = planner
+            .plan_search("text", query, Some(10), Some(&["id".to_string()]))
+            .await
+            .unwrap();
+        let ctx = datafusion::prelude::SessionContext::new();
+        let stream = plan.execute(0, ctx.task_ctx()).unwrap();
+        let batches: Vec<RecordBatch> = stream.try_collect().await.unwrap();
+        let mut ids: Vec<i32> = batches
+            .iter()
+            .flat_map(|batch| {
+                batch
+                    .column_by_name("id")
+                    .unwrap()
+                    .as_any()
+                    .downcast_ref::<Int32Array>()
+                    .unwrap()
+                    .values()
+                    .to_vec()
+            })
+            .collect();
+        ids.sort_unstable();
+        assert_eq!(
+            ids,
+            vec![1, 10],
+            "id=10 lives only in the memtable and matches 'lance'; without a \
+             transient index the arm contributes nothing and only id=1 comes back"
+        );
+    }
+
+    /// The transient index has to inherit the persisted index's analyzer and
+    /// positional settings, not defaults. Positions are the sharpest case:
+    /// `InvertedIndexParams::default()` has `with_position = false`, so a phrase
+    /// that matches in base silently matches nothing in the active prefix —
+    /// fewer rows, no error. Tokenizer settings diverge the same way.
+    #[tokio::test]
+    async fn transient_index_inherits_persisted_index_params() {
+        use crate::index::DatasetIndexExt;
+        use lance_index::IndexType;
+        use lance_index::scalar::inverted::query::PhraseQuery;
+        use lance_index::scalar::inverted::tokenizer::InvertedIndexParams;
+
+        let schema = fts_schema();
+        let tmp = tempfile::tempdir().unwrap();
+        let base_uri = format!("{}/base", tmp.path().to_str().unwrap());
+        let mut base_ds = write_dataset(
+            &base_uri,
+            vec![make_batch(&schema, &[1, 2], &["lance rocks", "unrelated"])],
+        )
+        .await;
+        // Built *with* positions, so phrase is a supported query on this table.
+        base_ds
+            .create_index(
+                &["text"],
+                IndexType::Inverted,
+                Some("text_fts".to_string()),
+                &InvertedIndexParams::default().with_position(true),
+                false,
+            )
+            .await
+            .unwrap();
+        let base_ds = Arc::new(Dataset::open(&base_uri).await.unwrap());
+
+        let batch_store = Arc::new(BatchStore::with_capacity(16));
+        let mut indexes = IndexStore::new();
+        indexes.enable_pk_index(&[("id".to_string(), 0)]);
+        let active_batch = make_batch(&schema, &[10], &["lance rocks in memtable"]);
+        let (_, row_offset, batch_position) = batch_store.append(active_batch.clone()).unwrap();
+        indexes
+            .insert_with_batch_position(&active_batch, row_offset, Some(batch_position))
+            .unwrap();
+        let indexes = Arc::new(indexes);
+
+        let collector = LsmDataSourceCollector::new(base_ds, vec![]).with_in_memory_memtables(
+            uuid::Uuid::new_v4(),
+            InMemoryMemTables {
+                active: InMemoryMemTableRef {
+                    batch_store,
+                    index_store: indexes,
+                    schema: schema.clone(),
+                    generation: 1,
+                },
+                frozen: vec![],
+            },
+        );
+        let planner = LsmFtsSearchPlanner::new(collector, vec!["id".to_string()], schema);
+        let query = FullTextSearchQuery::new_query(IndexFtsQuery::Phrase(PhraseQuery::new(
+            "lance rocks".to_string(),
+        )));
+        let plan = planner
+            .plan_search("text", query, Some(10), Some(&["id".to_string()]))
+            .await
+            .unwrap();
+        let ctx = datafusion::prelude::SessionContext::new();
+        let stream = plan.execute(0, ctx.task_ctx()).unwrap();
+        let batches: Vec<RecordBatch> = stream.try_collect().await.unwrap();
+        let mut ids: Vec<i32> = batches
+            .iter()
+            .flat_map(|batch| {
+                batch
+                    .column_by_name("id")
+                    .unwrap()
+                    .as_any()
+                    .downcast_ref::<Int32Array>()
+                    .unwrap()
+                    .values()
+                    .to_vec()
+            })
+            .collect();
+        ids.sort_unstable();
+        assert_eq!(
+            ids,
+            vec![1, 10],
+            "id=10 carries the phrase in the memtable; a default-params transient \
+             index has no positions and drops it"
+        );
+    }
+
+    /// Row and list-element indexes may coexist on one column with *different*
+    /// settings, and the query selects between them by its resolved
+    /// granularity. Taking whichever index came first would rebuild the
+    /// transient arm against the wrong contract — here the row index has no
+    /// positions, so a list-element phrase query would analyze the active rows
+    /// positionlessly and silently match nothing.
+    #[tokio::test]
+    async fn transient_index_uses_params_for_selected_granularity() {
+        use crate::index::DatasetIndexExt;
+        use lance_index::IndexType;
+        use lance_index::scalar::inverted::InvertedIndexParams;
+        use lance_index::scalar::inverted::query::PhraseQuery;
+
+        let mut id_meta = HashMap::new();
+        id_meta.insert(
+            "lance-schema:unenforced-primary-key".to_string(),
+            "true".to_string(),
+        );
+        let id_field = Field::new("id", DataType::Int32, false).with_metadata(id_meta);
+        let list_type = DataType::List(Arc::new(Field::new("item", DataType::Utf8, true)));
+        let schema = Arc::new(ArrowSchema::new(vec![
+            id_field,
+            Field::new("tags", list_type, true),
+        ]));
+
+        let mut base_tags = ListBuilder::new(StringBuilder::new());
+        base_tags.values().append_value("lance rocks");
+        base_tags.append(true);
+        let base_batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(Int32Array::from(vec![1])),
+                Arc::new(base_tags.finish()),
+            ],
+        )
+        .unwrap();
+        let tmp = tempfile::tempdir().unwrap();
+        let base_uri = format!("{}/base", tmp.path().to_str().unwrap());
+        let mut base_ds = Dataset::write(
+            RecordBatchIterator::new(vec![Ok(base_batch)], schema.clone()),
+            &base_uri,
+            None,
+        )
+        .await
+        .unwrap();
+        // Row index first, without positions; list-element index second, with.
+        // Order matters: a first-match lookup picks the positionless one.
+        base_ds
+            .create_index(
+                &["tags"],
+                IndexType::Inverted,
+                Some("tags_row_fts".to_string()),
+                &InvertedIndexParams::default(),
+                false,
+            )
+            .await
+            .unwrap();
+        base_ds
+            .create_index(
+                &["tags"],
+                IndexType::Inverted,
+                Some("tags_element_fts".to_string()),
+                &InvertedIndexParams::default()
+                    .with_position(true)
+                    .document_granularity(DocumentGranularity::ListElement),
+                false,
+            )
+            .await
+            .unwrap();
+        let base_ds = Arc::new(Dataset::open(&base_uri).await.unwrap());
+
+        // Precondition: both granularities really do coexist, with different
+        // positional settings, or this test proves nothing.
+        let params = indexed_fts_index_params(&base_ds, "tags").await.unwrap();
+        let row = params
+            .iter()
+            .find(|(g, _)| *g == DocumentGranularity::Row)
+            .expect("row index");
+        let element = params
+            .iter()
+            .find(|(g, _)| *g == DocumentGranularity::ListElement)
+            .expect("list-element index");
+        assert!(!row.1.has_positions(), "row index must lack positions");
+        assert!(
+            element.1.has_positions(),
+            "element index must have positions"
+        );
+
+        // Active memtable with no maintained FTS index on the column.
+        let mut active_tags = ListBuilder::new(StringBuilder::new());
+        active_tags.values().append_value("lance rocks");
+        active_tags.append(true);
+        let active_batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(Int32Array::from(vec![10])),
+                Arc::new(active_tags.finish()),
+            ],
+        )
+        .unwrap();
+        let batch_store = Arc::new(BatchStore::with_capacity(16));
+        let mut indexes = IndexStore::new();
+        indexes.enable_pk_index(&[("id".to_string(), 0)]);
+        let (_, row_offset, batch_position) = batch_store.append(active_batch.clone()).unwrap();
+        indexes
+            .insert_with_batch_position(&active_batch, row_offset, Some(batch_position))
+            .unwrap();
+        let indexes = Arc::new(indexes);
+
+        let collector = LsmDataSourceCollector::new(base_ds, vec![]).with_in_memory_memtables(
+            uuid::Uuid::new_v4(),
+            InMemoryMemTables {
+                active: InMemoryMemTableRef {
+                    batch_store,
+                    index_store: indexes,
+                    schema: schema.clone(),
+                    generation: 1,
+                },
+                frozen: vec![],
+            },
+        );
+        let planner = LsmFtsSearchPlanner::new(collector, vec!["id".to_string()], schema);
+        let query = FullTextSearchQuery::new_query(IndexFtsQuery::Phrase(
+            PhraseQuery::new("lance rocks".to_string())
+                .with_document_granularity(DocumentGranularity::ListElement),
+        ));
+        let plan = planner
+            .plan_search("tags", query, Some(10), Some(&["id".to_string()]))
+            .await
+            .unwrap();
+        let ctx = datafusion::prelude::SessionContext::new();
+        let stream = plan.execute(0, ctx.task_ctx()).unwrap();
+        let batches: Vec<RecordBatch> = stream.try_collect().await.unwrap();
+        let mut ids: Vec<i32> = batches
+            .iter()
+            .flat_map(|batch| {
+                batch
+                    .column_by_name("id")
+                    .unwrap()
+                    .as_any()
+                    .downcast_ref::<Int32Array>()
+                    .unwrap()
+                    .values()
+                    .to_vec()
+            })
+            .collect();
+        ids.sort_unstable();
+        ids.dedup();
+        assert_eq!(
+            ids,
+            vec![1, 10],
+            "id=10 is in the memtable; rebuilding against the row index's \
+             positionless settings drops it"
+        );
+    }
+
+    /// An empty memtable pays nothing: there is nothing to index, so the arm
+    /// stays empty rather than building a tokenizer pool over no rows.""""""
+    #[tokio::test]
+    async fn empty_memtable_builds_no_transient_index() {
+        let schema = fts_schema();
+        let batch_store = Arc::new(BatchStore::with_capacity(16));
+        let mut indexes = IndexStore::new();
+        indexes.enable_pk_index(&[("id".to_string(), 0)]);
+        let indexes = Arc::new(indexes);
+        let tmp = tempfile::tempdir().unwrap();
+        let base_uri = format!("{}/base", tmp.path().to_str().unwrap());
+        let collector = LsmDataSourceCollector::without_base_table(base_uri, vec![])
+            .with_in_memory_memtables(
+                uuid::Uuid::new_v4(),
+                InMemoryMemTables {
+                    active: InMemoryMemTableRef {
+                        batch_store,
+                        index_store: indexes,
+                        schema: schema.clone(),
+                        generation: 1,
+                    },
+                    frozen: vec![],
+                },
+            );
+        let planner = LsmFtsSearchPlanner::new(collector, vec!["id".to_string()], schema);
+        let query = FullTextSearchQuery::new_query(IndexFtsQuery::Match(MatchQuery::new(
+            "lance".to_string(),
+        )));
+        let plan = planner
+            .plan_search("text", query, Some(10), Some(&["id".to_string()]))
+            .await
+            .unwrap();
+        let ctx = datafusion::prelude::SessionContext::new();
+        let stream = plan.execute(0, ctx.task_ctx()).unwrap();
+        let batches: Vec<RecordBatch> = stream.try_collect().await.unwrap();
+        assert_eq!(batches.iter().map(|b| b.num_rows()).sum::<usize>(), 0);
+    }
+
     /// The base arm must apply the filter as a true *prefilter*, not a
-    /// post-filter on the BM25 top-k.""" With `k = 1` and the higher-scoring base
+    /// post-filter on the BM25 top-k."""""" With `k = 1` and the higher-scoring base
     /// doc failing the predicate, a post-filter would return zero rows; a
     /// prefilter restricts BM25 to matching rows and returns the lower-scoring
     /// match. Regression for a missing `scanner.prefilter(true)` on the base arm.

--- a/rust/lance/src/index/scalar/inverted.rs
+++ b/rust/lance/src/index/scalar/inverted.rs
@@ -582,6 +582,53 @@ pub(crate) async fn indexed_fts_document_granularities(
     Ok(by_name.into_iter().collect())
 }
 
+/// The effective [`InvertedIndexParams`] of every persisted FTS index on
+/// `column`, paired with the document granularity it was built for.
+///
+/// The analyzer and positional settings are part of the query contract, not an
+/// implementation detail: a phrase query needs positions, and a stemming or
+/// n-gram tokenizer changes which terms a document produces. Anything that
+/// evaluates the same query over rows an index does not cover — an unindexed
+/// fragment, or a MemWAL active memtable — has to analyze them the same way or
+/// the two disagree about what matches.
+///
+/// Keyed by granularity rather than flattened, because row and list-element
+/// indexes may coexist on one column with *different* settings, and
+/// `load_segments` selects between them by the query's resolved granularity.
+/// Picking the first match instead would rebuild against the wrong contract —
+/// a list-element phrase query could be analyzed with the row index's
+/// positionless settings and silently match nothing.
+pub(crate) async fn indexed_fts_index_params(
+    dataset: &Dataset,
+    column: &str,
+) -> Result<Vec<(DocumentGranularity, InvertedIndexParams)>> {
+    let resolved = resolve_fts_field(dataset.schema(), column, DocumentGranularity::Row)?;
+    let mut found = Vec::new();
+    for index in dataset.load_indices().await?.iter() {
+        if index.keyed_field() != Some(resolved.final_field_id) {
+            continue;
+        }
+        let details_any = fetch_index_details(dataset, &resolved.canonical_path, index).await?;
+        if !details_any.type_url.ends_with("InvertedIndexDetails") {
+            continue;
+        }
+        let details =
+            InvertedIndexDetails::decode(details_any.value.as_slice()).map_err(|error| {
+                Error::corrupt_file(
+                    dataset.indices_dir().join(index.uuid.to_string()),
+                    format!(
+                        "failed to decode InvertedIndexDetails for FTS index '{}': {error}",
+                        index.name
+                    ),
+                )
+            })?;
+        let document_granularity = DocumentGranularity::try_from(details.document_granularity)?;
+        let params = InvertedIndexParams::try_from(&details)?;
+        found.push((document_granularity, params));
+    }
+    Ok(found)
+}
+
 /// Resolve an optional query granularity against persisted FTS index metadata.
 ///
 /// A unique indexed granularity is authoritative and also controls flat search

--- a/rust/lance/src/io/exec/fts.rs
+++ b/rust/lance/src/io/exec/fts.rs
@@ -794,6 +794,38 @@ impl CompoundQueryExec {
     pub fn explicit_segment_uuids(&self) -> Option<Vec<Uuid>> {
         self.segment_selection.explicit_segment_uuids()
     }
+
+    /// The same leaf with a different index-level top-k.
+    ///
+    /// Over-fetching a bounded FTS arm changes exactly one thing —
+    /// `FtsSearchParams::limit` — but these nodes have no `with_fetch`, because
+    /// the cut lives in the index params rather than in a fetch node. Callers
+    /// have therefore rebuilt through a public constructor, which silently
+    /// drops whatever that constructor does not take: the segment selection,
+    /// the overlay block, the external mask, the prepared and shared scorers.
+    /// Widening a leaf's segment or mask domain re-admits documents this plan
+    /// deliberately excluded, so the copy has to be total — and has to stay
+    /// total as fields are added, which a constructor call cannot promise.
+    ///
+    /// Metrics start fresh; the tokenized-query cache carries over because it
+    /// is a pure function of `query`, which is unchanged.
+    pub fn with_index_limit(&self, limit: usize) -> Self {
+        let mut params = self.params.clone();
+        params.limit = Some(limit);
+        Self {
+            dataset: self.dataset.clone(),
+            query: self.query.clone(),
+            tokenized_query: self.tokenized_query.clone(),
+            params,
+            prefilter_source: self.prefilter_source.clone(),
+            base_scorer: self.base_scorer.clone(),
+            prepared_match: self.prepared_match.clone(),
+            segment_selection: self.segment_selection.clone(),
+            external_mask: self.external_mask.clone(),
+            properties: self.properties.clone(),
+            metrics: ExecutionPlanMetricsSet::new(),
+        }
+    }
 }
 
 #[derive(Debug)]
@@ -2769,6 +2801,42 @@ impl MatchQueryExec {
     pub fn explicit_segment_uuids(&self) -> Option<Vec<Uuid>> {
         self.segment_selection.explicit_segment_uuids()
     }
+
+    /// The same leaf with a different index-level top-k.
+    ///
+    /// Over-fetching a bounded FTS arm changes exactly one thing —
+    /// `FtsSearchParams::limit` — but these nodes have no `with_fetch`, because
+    /// the cut lives in the index params rather than in a fetch node. Callers
+    /// have therefore rebuilt through a public constructor, which silently
+    /// drops whatever that constructor does not take: the segment selection,
+    /// the overlay block, the external mask, the prepared and shared scorers.
+    /// Widening a leaf's segment or mask domain re-admits documents this plan
+    /// deliberately excluded, so the copy has to be total — and has to stay
+    /// total as fields are added, which a constructor call cannot promise.
+    ///
+    /// Metrics start fresh; the tokenized-query cache carries over because it
+    /// is a pure function of `query`, which is unchanged.
+    pub fn with_index_limit(&self, limit: usize) -> Self {
+        let mut params = self.params.clone();
+        params.limit = Some(limit);
+        Self {
+            dataset: self.dataset.clone(),
+            query: self.query.clone(),
+            tokenized_query: self.tokenized_query.clone(),
+            params,
+            prefilter_source: self.prefilter_source.clone(),
+            base_scorer: self.base_scorer.clone(),
+            prepared_query: self.prepared_query.clone(),
+            shared_scorer: self.shared_scorer.clone(),
+            segment_selection: self.segment_selection.clone(),
+            overlay_block: self.overlay_block.clone(),
+            document_granularity: self.document_granularity,
+            schema: self.schema.clone(),
+            external_mask: self.external_mask.clone(),
+            properties: self.properties.clone(),
+            metrics: ExecutionPlanMetricsSet::new(),
+        }
+    }
 }
 
 impl ExecutionPlan for MatchQueryExec {
@@ -4082,6 +4150,41 @@ impl PhraseQueryExec {
     /// Pre-resolved selections preserve the supplied metadata order.
     pub fn explicit_segment_uuids(&self) -> Option<Vec<Uuid>> {
         self.segment_selection.explicit_segment_uuids()
+    }
+
+    /// The same leaf with a different index-level top-k.
+    ///
+    /// Over-fetching a bounded FTS arm changes exactly one thing —
+    /// `FtsSearchParams::limit` — but these nodes have no `with_fetch`, because
+    /// the cut lives in the index params rather than in a fetch node. Callers
+    /// have therefore rebuilt through a public constructor, which silently
+    /// drops whatever that constructor does not take: the segment selection,
+    /// the overlay block, the external mask, the prepared and shared scorers.
+    /// Widening a leaf's segment or mask domain re-admits documents this plan
+    /// deliberately excluded, so the copy has to be total — and has to stay
+    /// total as fields are added, which a constructor call cannot promise.
+    ///
+    /// Metrics start fresh; the tokenized-query cache carries over because it
+    /// is a pure function of `query`, which is unchanged.
+    pub fn with_index_limit(&self, limit: usize) -> Self {
+        let mut params = self.params.clone();
+        params.limit = Some(limit);
+        Self {
+            dataset: self.dataset.clone(),
+            query: self.query.clone(),
+            tokenized_query: self.tokenized_query.clone(),
+            params,
+            prefilter_source: self.prefilter_source.clone(),
+            base_scorer: self.base_scorer.clone(),
+            shared_scorer: self.shared_scorer.clone(),
+            segment_selection: self.segment_selection.clone(),
+            overlay_block: self.overlay_block.clone(),
+            document_granularity: self.document_granularity,
+            schema: self.schema.clone(),
+            external_mask: self.external_mask.clone(),
+            properties: self.properties.clone(),
+            metrics: ExecutionPlanMetricsSet::new(),
+        }
     }
 }
 
@@ -5588,6 +5691,63 @@ mod tests {
         assert!(
             compound_line.contains(&format!("{PARTITIONS_SEARCHED_METRIC}={expected_total}")),
             "compound FTS scorer metrics missing partitions_searched: {compound_line}"
+        );
+    }
+
+    /// Changing the top-k must not change *what* a leaf searches. The hazard is
+    /// specific: rebuilding through a public constructor drops the segment
+    /// selection, so an explicitly-scoped leaf silently widens to all committed
+    /// segments and re-admits documents the plan excluded as superseded.
+    #[tokio::test]
+    async fn with_index_limit_preserves_the_execution_domain() {
+        let (dataset, segments, _fragment_ids) = create_segment_selection_fixture().await;
+        let query = MatchQuery::new("quick".to_string())
+            .with_column(Some("text".to_string()))
+            .with_document_granularity(DocumentGranularity::Row);
+        let params = FtsSearchParams::default().with_limit(Some(5));
+        let scoped_uuids = vec![segments[0].uuid];
+
+        let scoped = MatchQueryExec::new_with_segment_uuids(
+            dataset.clone(),
+            query.clone(),
+            params.clone(),
+            PreFilterSource::None,
+            scoped_uuids.clone(),
+        )
+        .unwrap();
+        assert_eq!(scoped.explicit_segment_uuids(), Some(scoped_uuids.clone()));
+        assert_eq!(scoped.params().limit, Some(5));
+
+        let inflated = scoped.with_index_limit(20);
+        assert_eq!(inflated.params().limit, Some(20), "limit must change");
+        assert_eq!(
+            inflated.explicit_segment_uuids(),
+            Some(scoped_uuids),
+            "segment selection must survive the limit change"
+        );
+        assert_eq!(
+            inflated.query().terms,
+            scoped.query().terms,
+            "the query itself is untouched"
+        );
+
+        // A leaf resolved to explicit segment metadata keeps that form too.
+        let preset = MatchQueryExec::new_with_segments(
+            dataset,
+            query,
+            params,
+            PreFilterSource::None,
+            segments,
+        )
+        .unwrap();
+        let preset_len = preset.preset_segments().map(<[_]>::len);
+        assert_eq!(
+            preset
+                .with_index_limit(20)
+                .preset_segments()
+                .map(<[_]>::len),
+            preset_len,
+            "preset segments must survive the limit change"
         );
     }
 


### PR DESCRIPTION
**Stacked on #9172** (chain: #9160 → #9167 → #9172 → this).

## The problem is the pattern, not a field

Over-fetching a bounded FTS arm changes exactly one thing — `FtsSearchParams::limit` — but these nodes have no `with_fetch`, because the cut lives in the index params rather than in a fetch node. So callers rebuild the leaf through a public constructor, which silently drops whatever that constructor does not take.

For `MatchQueryExec` that is five things:

| State | Taken by `new`? |
| --- | :-: |
| `segment_selection` | ❌ |
| `overlay_block` | ❌ |
| `external_mask` | ❌ |
| `prepared_query` | ❌ |
| `shared_scorer` | ❌ |

Losing the first three is not a recall detail. A leaf scoped to explicit segments widens to `AllCommitted`, re-admitting documents the plan excluded as superseded — so a caller asking only for *more candidates* gets a **different answer**.

This has already broken twice in review on downstream work (once for `MatchQueryExec`, once for `PhraseQueryExec`), which is the argument for fixing the shape rather than the instances: reconstruct-to-edit re-breaks every time a field is added to one of these execs, and the compiler cannot see it because the constructor call still type-checks.

## The change

`with_index_limit(&self, limit)` copies the node whole and changes the limit. Nothing to forget, and nothing to re-forget when a field is added.

Metrics start fresh, since a new exec owns its own. The tokenized-query cache carries over — it is a pure function of `query`, which is unchanged, so re-tokenizing would be pure waste.

Added to `MatchQueryExec`, `PhraseQueryExec` and `CompoundQueryExec`. `HybridCompoundQueryExec` needs the same, but it is still `pub(crate)`; its builder belongs with #9166, which makes the type public.

## Test

`with_index_limit_preserves_the_execution_domain` targets the hazard directly rather than the happy path: a leaf built with `new_with_segment_uuids` keeps its explicit UUIDs after the limit changes, and one built with `new_with_segments` keeps its preset metadata. Both would silently widen under the reconstruct pattern.

24 `io::exec::fts` tests pass, clippy clean.

## Downstream

Lets sophon's WAL over-fetch stop reconstructing leaves. It also restores over-fetch for shapes that had to give it up for exactly this reason: phrase leaves are currently pinned at `k` (lancedb/sophon#7830) and `CompoundQueryExec` never had it, both because neither could be rebuilt safely. With this they get real over-fetch, so the base arm stops under-delivering on those shapes once the PK block-list drops superseded rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QBv2WLSq5oy6kR2gVrfFDh