### PR TITLE
perf(fts): drive skewed AND from the rare posting list

### DIFF
--- a/rust/lance-index/src/scalar/inverted/wand.rs
+++ b/rust/lance-index/src/scalar/inverted/wand.rs
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright The Lance Authors
 
+#[cfg(test)]
+use std::cell::Cell;
 use std::sync::atomic::{AtomicU32, Ordering};
 use std::sync::{Arc, LazyLock};
 use std::{
@@ -2314,6 +2316,8 @@ pub struct Wand<'a, S: Scorer, D: WandDocuments> {
     maxscore_single_essential_windows: usize,
     #[cfg(test)]
     maxscore_general_windows: usize,
+    #[cfg(test)]
+    phrase_position_checks: Cell<usize>,
     documents: &'a D,
     scorer: S,
     // Shared cross-partition top-k floor. Each partition publishes its local
@@ -2420,6 +2424,8 @@ impl<'a, S: Scorer, D: WandDocuments> Wand<'a, S, D> {
             maxscore_single_essential_windows: 0,
             #[cfg(test)]
             maxscore_general_windows: 0,
+            #[cfg(test)]
+            phrase_position_checks: Cell::new(0),
             documents,
             scorer,
             shared_threshold: None,
@@ -2593,21 +2599,57 @@ impl<'a, S: Scorer, D: WandDocuments> Wand<'a, S, D> {
 
             let score = if self.operator == Operator::Or {
                 self.advance_all_tail(doc.doc_id(), None, None);
-                if params.phrase_slop.is_some()
-                    && !self.check_positions(params.phrase_slop.unwrap() as i32)?
-                {
-                    self.push_back_leads(doc.doc_id() + 1);
-                    continue;
+                if let Some(slop) = params.phrase_slop {
+                    // Only front-load the BM25 total when a floor exists: with
+                    // no floor the skip cannot fire, and scoring before
+                    // position confirmation would make every position-failing
+                    // candidate pay for a score it never uses.
+                    let early_score =
+                        (self.threshold > 0.0).then(|| self.score_in_query_order(doc_length));
+                    if early_score
+                        .is_some_and(|score| self.exclusive_score_cannot_beat_floor(score))
+                    {
+                        self.push_back_leads(doc.doc_id() + 1);
+                        continue;
+                    }
+                    if !self.check_positions(slop as i32)? {
+                        self.push_back_leads(doc.doc_id() + 1);
+                        continue;
+                    }
+                    early_score.unwrap_or_else(|| self.score_in_query_order(doc_length))
+                } else {
+                    self.score_in_query_order(doc_length)
                 }
-                self.score_in_query_order(doc_length)
             } else {
                 self.advance_all_tail(doc.doc_id(), None, None);
-                if params.phrase_slop.is_some()
-                    && !self.check_positions(params.phrase_slop.unwrap() as i32)?
-                {
-                    continue;
-                }
-                if self.and_candidate_score.is_some() {
+                if let Some(slop) = params.phrase_slop {
+                    // Only front-load the BM25 total when a floor exists: with
+                    // no floor the skip cannot fire, and scoring before
+                    // position confirmation would make every position-failing
+                    // candidate pay for a score it never uses.
+                    let early_score = (self.threshold > 0.0).then(|| {
+                        if self.and_candidate_score.is_some() {
+                            and_score
+                        } else {
+                            self.score_in_query_order(doc_length)
+                        }
+                    });
+                    if early_score
+                        .is_some_and(|score| self.exclusive_score_cannot_beat_floor(score))
+                    {
+                        continue;
+                    }
+                    if !self.check_positions(slop as i32)? {
+                        continue;
+                    }
+                    early_score.unwrap_or_else(|| {
+                        if self.and_candidate_score.is_some() {
+                            and_score
+                        } else {
+                            self.score_in_query_order(doc_length)
+                        }
+                    })
+                } else if self.and_candidate_score.is_some() {
                     and_score
                 } else {
                     self.score_in_query_order(doc_length)
@@ -2680,14 +2722,6 @@ impl<'a, S: Scorer, D: WandDocuments> Wand<'a, S, D> {
                 continue;
             }
 
-            // check positions
-            if params.phrase_slop.is_some()
-                && !self.check_positions(params.phrase_slop.unwrap() as i32)?
-            {
-                self.advance_lead_to_head(doc_id + 1);
-                continue;
-            }
-
             // score the doc
             let doc_length = self
                 .documents
@@ -2702,7 +2736,22 @@ impl<'a, S: Scorer, D: WandDocuments> Wand<'a, S, D> {
             }
 
             self.collect_tail_matches(doc_id);
-            let score = self.score_in_query_order(doc_length);
+            // Only front-load the BM25 total when a floor exists: with no floor
+            // the skip cannot fire, and scoring before position confirmation
+            // would make every position-failing candidate pay for a score it
+            // never uses.
+            let early_score = (self.threshold > 0.0).then(|| self.score_in_query_order(doc_length));
+            if let Some(slop) = params.phrase_slop {
+                if early_score.is_some_and(|score| self.exclusive_score_cannot_beat_floor(score)) {
+                    self.advance_lead_to_head(doc_id + 1);
+                    continue;
+                }
+                if !self.check_positions(slop as i32)? {
+                    self.advance_lead_to_head(doc_id + 1);
+                    continue;
+                }
+            }
+            let score = early_score.unwrap_or_else(|| self.score_in_query_order(doc_length));
 
             if candidates.insert(
                 ScoredDoc::new(document_key, score),
@@ -3302,6 +3351,19 @@ impl<'a, S: Scorer, D: WandDocuments> Wand<'a, S, D> {
         candidates.into_candidates(|key| self.documents.candidate_from_key(key))
     }
 
+    /// Exclusive top-k floor: a finite complete score at or below `threshold`
+    /// cannot enter the heap, so phrase confirmation is wasted work.
+    ///
+    /// The score is the same query-order f32 the heap compares, so this uses
+    /// `accepts_score` rather than the inflated partial-sum bound. Fail-closed:
+    /// `threshold == 0` (heap not full) never skips.
+    #[inline]
+    fn exclusive_score_cannot_beat_floor(&self, score: f32) -> bool {
+        self.threshold > 0.0
+            && score.is_finite()
+            && !self.floor_mode.accepts_score(score, self.threshold)
+    }
+
     /// Calculate the current document's score in query order.
     ///
     /// WAND deliberately reorders postings by doc id, cost, and score bound.
@@ -3781,6 +3843,33 @@ impl<'a, S: Scorer, D: WandDocuments> Wand<'a, S, D> {
             end: usize,
             // Absolute posting index of the block's first entry.
             block_start: usize,
+        }
+
+        /// Sum one bulk-AND candidate's per-clause BM25 contributions in score
+        /// order. Nested so it can name the block-local `WindowList`; the
+        /// caller may run it before or after position confirmation.
+        #[inline]
+        fn window_bm25_score<S: Scorer + ?Sized>(
+            lead: &[Box<PostingIterator>],
+            wins: &[WindowList],
+            offs: &[u8],
+            score_order: &[usize],
+            scorer: &S,
+            norm_addend: Option<f32>,
+            doc_length: u32,
+        ) -> f32 {
+            let mut score = 0.0_f32;
+            for &clause_index in score_order {
+                let win = &wins[clause_index];
+                let posting = &lead[clause_index];
+                let off = offs[clause_index];
+                let freq = unsafe { *win.freqs.add(off as usize) };
+                score += match norm_addend {
+                    Some(addend) => posting.query_weight * bm25_doc_weight_with_norm(freq, addend),
+                    None => posting.score(scorer, freq, doc_length),
+                };
+            }
+            score
         }
 
         // Merge kernels: intersect the window's per-clause slices and record
@@ -4453,7 +4542,30 @@ impl<'a, S: Scorer, D: WandDocuments> Wand<'a, S, D> {
                         continue;
                     };
 
+                    // Only front-load the BM25 total when a floor exists: the
+                    // skip below can only fire then, and scoring before
+                    // position confirmation would otherwise make every
+                    // position-failing candidate pay for a score it never uses.
+                    let early_score = (self.threshold > 0.0).then(|| {
+                        window_bm25_score(
+                            &self.lead,
+                            &wins,
+                            offs,
+                            &score_order,
+                            &self.scorer,
+                            norm_addend,
+                            doc_length,
+                        )
+                    });
                     if let Some(slop) = phrase_slop {
+                        // Lance phrase score is term-frequency BM25, so this
+                        // total is exact. Skip position decode when it cannot
+                        // enter the exclusive top-k heap.
+                        if early_score
+                            .is_some_and(|score| self.exclusive_score_cannot_beat_floor(score))
+                        {
+                            continue;
+                        }
                         // Park every clause's iterator on this doc so
                         // `position_cursor` reads the right posting entry. The
                         // window block is already decompressed; position blocks
@@ -4476,19 +4588,17 @@ impl<'a, S: Scorer, D: WandDocuments> Wand<'a, S, D> {
                             continue;
                         }
                     }
-                    let mut score = 0.0_f32;
-                    for &clause_index in &score_order {
-                        let win = &wins[clause_index];
-                        let posting = &self.lead[clause_index];
-                        let off = offs[clause_index];
-                        let freq = unsafe { *win.freqs.add(off as usize) };
-                        score += match norm_addend {
-                            Some(addend) => {
-                                posting.query_weight * bm25_doc_weight_with_norm(freq, addend)
-                            }
-                            None => posting.score(&self.scorer, freq, doc_length),
-                        };
-                    }
+                    let score = early_score.unwrap_or_else(|| {
+                        window_bm25_score(
+                            &self.lead,
+                            &wins,
+                            offs,
+                            &score_order,
+                            &self.scorer,
+                            norm_addend,
+                            doc_length,
+                        )
+                    });
 
                     if candidates.insert(
                         ScoredDoc::new(document_key, score),
@@ -5136,6 +5246,11 @@ impl<'a, S: Scorer, D: WandDocuments> Wand<'a, S, D> {
     }
 
     fn check_positions(&self, slop: i32) -> Result<bool> {
+        #[cfg(test)]
+        {
+            self.phrase_position_checks
+                .set(self.phrase_position_checks.get() + 1);
+        }
         if slop == 0 {
             return self.check_exact_positions();
         }
@@ -5185,6 +5300,11 @@ impl<'a, S: Scorer, D: WandDocuments> Wand<'a, S, D> {
     /// clauses at their query offsets — without the per-candidate cursor vec
     /// and sort.
     fn check_exact_positions_bulk(&self) -> Result<bool> {
+        #[cfg(test)]
+        {
+            self.phrase_position_checks
+                .set(self.phrase_position_checks.get() + 1);
+        }
         const MAX_INLINE_CLAUSES: usize = 16;
         let num_clauses = self.lead.len();
         if num_clauses > MAX_INLINE_CLAUSES {
@@ -10156,6 +10276,81 @@ mod tests {
         let classic = run(BulkAndMode::Off);
         assert_eq!(run(BulkAndMode::On), classic);
         assert_eq!(run(BulkAndMode::Auto), classic);
+    }
+
+    #[rstest]
+    fn phrase_skips_position_confirm_when_complete_score_cannot_beat_floor(
+        #[values(BulkAndMode::Off, BulkAndMode::On)] mode: BulkAndMode,
+        #[values(0_u32, 3)] phrase_slop: u32,
+        #[values(true, false)] phrase_first: bool,
+        #[values(1_usize, 32)] limit: usize,
+    ) {
+        let num_docs = 32_usize;
+        let phrase_doc = if phrase_first { 0 } else { num_docs - 1 };
+        let mut docs = DocSet::default();
+        for doc in 0..num_docs {
+            docs.append(doc as u64, 1);
+        }
+        let postings = (0..2_u32)
+            .map(|term| {
+                let mut list = generate_impact_posting_list_with_freqs_and_block_size(
+                    (0..num_docs as u32).collect(),
+                    vec![1; num_docs],
+                    vec![1; num_docs],
+                    MAX_POSTING_BLOCK_SIZE,
+                );
+                let positions = (0..num_docs as u32)
+                    .map(|doc| {
+                        if term == 0 {
+                            0
+                        } else if doc == phrase_doc as u32 {
+                            1
+                        } else {
+                            50
+                        }
+                    })
+                    .collect::<Vec<_>>();
+                let mut bytes = Vec::new();
+                encode_position_stream_block_into(
+                    &positions,
+                    &vec![1; num_docs],
+                    PositionStreamCodec::VarintDocDelta,
+                    &mut bytes,
+                )
+                .unwrap();
+                if let PostingList::Compressed(list) = &mut list {
+                    list.positions = Some(CompressedPositionStorage::SharedStream(
+                        SharedPositionStream::new(
+                            PositionStreamCodec::VarintDocDelta,
+                            vec![0],
+                            bytes.into(),
+                        ),
+                    ));
+                }
+                PostingIterator::with_query_weight(
+                    format!("t{term}"),
+                    term,
+                    term,
+                    1.0,
+                    list,
+                    docs.len(),
+                )
+            })
+            .collect::<Vec<_>>();
+        let mut wand = Wand::new(Operator::And, postings.into_iter(), &docs, UnitScorer)
+            .with_bulk_and_mode(mode);
+        let mut params = FtsSearchParams::default().with_limit(Some(limit));
+        params.phrase_slop = Some(phrase_slop);
+        let hits = wand.search(&params, &NoOpMetricsCollector).unwrap();
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].posting_doc_id, phrase_doc as u64);
+        assert_eq!(wand.bulk_and_searches, usize::from(mode == BulkAndMode::On));
+        let expected_checks = if phrase_first && limit == 1 {
+            1
+        } else {
+            num_docs
+        };
+        assert_eq!(wand.phrase_position_checks.get(), expected_checks);
     }
 
     #[rstest]

--- a/rust/lance-index/src/scalar/inverted/wand.rs
+++ b/rust/lance-index/src/scalar/inverted/wand.rs
@@ -24,6 +24,8 @@ use crate::metrics::MetricsCollector;
 
 #[path = "wand_intersection.rs"]
 mod intersection;
+#[path = "wand_lead_stream.rs"]
+mod lead_stream;
 #[path = "wand_maxscore.rs"]
 mod maxscore;
 
@@ -260,7 +262,13 @@ impl CompetitiveFloorMode {
 // skipping plus a slice-level merge over decompressed blocks, replacing the
 // per-doc `next()` leapfrog. Results are identical to the classic AND loop.
 // LANCE_FTS_BULK_AND accepts auto (default), on/1, or off/0. Auto enables the
-// bulk path for two and three clauses and for wider current-format conjunctions.
+// bulk path for two and three clauses and for wider current-format conjunctions
+// whose posting lengths stay within `lead_stream::AND_SKEW_RATIO`. A stopword
+// paired with a rare term stays off N-way bulk: the merge would decompress
+// the dense list in every window. Skewed Auto conjunctions with three or more
+// clauses use a lead-stream instead; a skewed pair keeps classic leapfrog. The
+// lead-stream is separately switchable via LANCE_FTS_LEAD_STREAM=0, which sends
+// those conjunctions back to classic leapfrog.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 enum BulkAndMode {
     #[default]
@@ -291,6 +299,15 @@ impl BulkAndMode {
         }
     }
 }
+
+// Lead-stream path for skewed Auto conjunctions of three or more clauses: the
+// rare list drives the walk and dense followers only seek to it, instead of
+// N-way bulk decompressing the dense list in every window. This is a third
+// execution mode rather than a variant of bulk or classic, so it has its own
+// switch: LANCE_FTS_LEAD_STREAM=0 sends those conjunctions down the classic
+// leapfrog instead. Results are identical either way; only the cost differs.
+static USE_LEAD_STREAM_SEARCH: LazyLock<bool> =
+    LazyLock::new(|| std::env::var("LANCE_FTS_LEAD_STREAM").as_deref() != Ok("0"));
 
 fn bulk_and_mode_from_env() -> BulkAndMode {
     match std::env::var("LANCE_FTS_BULK_AND") {
@@ -2338,6 +2355,8 @@ pub struct Wand<'a, S: Scorer, D: WandDocuments> {
     #[cfg(test)]
     bulk_and_searches: usize,
     #[cfg(test)]
+    lead_stream_and_searches: usize,
+    #[cfg(test)]
     maxscore_single_essential_windows: usize,
     #[cfg(test)]
     maxscore_general_windows: usize,
@@ -2447,6 +2466,8 @@ impl<'a, S: Scorer, D: WandDocuments> Wand<'a, S, D> {
             bulk_and_mode_override: None,
             #[cfg(test)]
             bulk_and_searches: 0,
+            #[cfg(test)]
+            lead_stream_and_searches: 0,
             #[cfg(test)]
             maxscore_single_essential_windows: 0,
             #[cfg(test)]
@@ -2577,34 +2598,53 @@ impl<'a, S: Scorer, D: WandDocuments> Wand<'a, S, D> {
             return self.maxscore_search(params, metrics);
         }
 
-        // Top-k conjunctions (AND and phrase) over compressed lists use the
-        // bulk path: the same block-max window pruning, but candidates come
-        // from a slice-level merge over decompressed blocks instead of per-doc
-        // `next()` leapfrogging through boxed iterators.
+        // Top-k conjunctions (AND and phrase) over compressed lists: N-way
+        // bulk when Auto/On selects a balanced shape; leftover Auto (skewed
+        // 3+, including Wikipedia block-128 4+) uses a lead-stream so the
+        // rare list drives and dense followers only seek. Explicit Off and
+        // skewed pairs keep the classic per-doc leapfrog.
         if self.operator == Operator::And
             && !self.lead.is_empty()
             && self
                 .lead
                 .iter()
                 .all(|posting| posting.is_compressed() && !posting.has_grouped_terms())
-            && {
-                let mode = self
-                    .bulk_and_mode_override
-                    .unwrap_or_else(|| *BULK_AND_MODE);
-                mode.enabled_for(self.lead.len())
-                    || (mode == BulkAndMode::Auto
-                        && self.lead.len() >= 4
-                        && self.lead.iter().all(|posting| {
-                            matches!(&posting.list, PostingList::Compressed(list)
-                                if list.block_size == MAX_POSTING_BLOCK_SIZE && list.impacts.is_some())
-                        }))
-            }
         {
-            #[cfg(test)]
-            {
-                self.bulk_and_searches += 1;
+            let mode = self
+                .bulk_and_mode_override
+                .unwrap_or_else(|| *BULK_AND_MODE);
+            let num_clauses = self.lead.len();
+            let min_cost = self.lead[0].cost();
+            let max_cost = self.lead.last().map(|posting| posting.cost()).unwrap_or(0);
+            let is_skewed = lead_stream::conjunction_lists_are_skewed(min_cost, max_cost);
+            let auto_wide_modern = mode == BulkAndMode::Auto
+                && num_clauses >= 4
+                && self.lead.iter().all(|posting| {
+                    matches!(&posting.list, PostingList::Compressed(list)
+                        if list.block_size == MAX_POSTING_BLOCK_SIZE && list.impacts.is_some())
+                });
+            let use_bulk = match mode {
+                BulkAndMode::On => true,
+                BulkAndMode::Off => false,
+                BulkAndMode::Auto => {
+                    !is_skewed && (mode.enabled_for(num_clauses) || auto_wide_modern)
+                }
+            };
+            if use_bulk {
+                #[cfg(test)]
+                {
+                    self.bulk_and_searches += 1;
+                }
+                return self.and_bulk_search(params, metrics);
             }
-            return self.and_bulk_search(params, metrics);
+            if *USE_LEAD_STREAM_SEARCH && mode == BulkAndMode::Auto && is_skewed && num_clauses >= 3
+            {
+                #[cfg(test)]
+                {
+                    self.lead_stream_and_searches += 1;
+                }
+                return self.and_lead_stream_search(params, metrics);
+            }
         }
 
         let mut candidates = TopKCollector::new(limit, std::cmp::min(limit, BLOCK_SIZE * 10));
@@ -10714,6 +10754,465 @@ mod tests {
         assert!(!bulk.0.is_empty(), "test corpus should produce matches");
         assert_eq!(bulk, classic);
         assert_eq!(auto, classic);
+    }
+
+    fn compressed_and_clause(
+        token: &str,
+        term_pos: u32,
+        query_weight: f32,
+        doc_ids: Vec<u32>,
+        num_docs: usize,
+    ) -> PostingIterator {
+        PostingIterator::with_query_weight(
+            token.to_owned(),
+            term_pos,
+            term_pos,
+            query_weight,
+            generate_posting_list(doc_ids, 8.0, None, true),
+            num_docs,
+        )
+    }
+
+    fn phrase_and_clause(
+        token: &str,
+        term_pos: u32,
+        query_weight: f32,
+        doc_ids: Vec<u32>,
+        num_docs: usize,
+    ) -> PostingIterator {
+        let positions = doc_ids
+            .iter()
+            .map(|&doc| {
+                if doc % 2 == 0 {
+                    vec![5 + term_pos, 40 + (doc % 3)]
+                } else {
+                    vec![20 + term_pos * 4]
+                }
+            })
+            .collect::<Vec<_>>();
+        PostingIterator::with_query_weight(
+            token.to_owned(),
+            term_pos,
+            term_pos,
+            query_weight,
+            generate_posting_list_with_positions(doc_ids, positions, 8.0, true),
+            num_docs,
+        )
+    }
+
+    #[derive(Debug, PartialEq, Eq, PartialOrd, Ord)]
+    struct AndHit {
+        document: u64,
+        posting_doc_id: u64,
+        doc_length: u32,
+        freqs: Vec<(u32, u32)>,
+    }
+
+    struct AndSearchDump {
+        rows: Vec<AndHit>,
+        bulk_searches: usize,
+        lead_stream_searches: usize,
+        kth_bits: u32,
+    }
+
+    fn run_and_search(
+        mode: BulkAndMode,
+        postings: Vec<PostingIterator>,
+        docs: &DocSet,
+        params: &FtsSearchParams,
+    ) -> AndSearchDump {
+        run_and_search_with_scorer(mode, postings, docs, params, UnitScorer)
+    }
+
+    /// Same as [`run_and_search`] but with a caller-supplied scorer, so a case
+    /// can use a length-dependent one instead of the length-blind `UnitScorer`.
+    fn run_and_search_with_scorer<S: Scorer>(
+        mode: BulkAndMode,
+        postings: Vec<PostingIterator>,
+        docs: &DocSet,
+        params: &FtsSearchParams,
+        scorer: S,
+    ) -> AndSearchDump {
+        let shared_floor = Arc::new(AtomicU32::new(0.0_f32.to_bits()));
+        let mut wand = Wand::new(Operator::And, postings.into_iter(), docs, scorer)
+            .with_bulk_and_mode(mode)
+            .with_shared_threshold(shared_floor.clone());
+        let mut rows = wand
+            .search(params, &NoOpMetricsCollector)
+            .unwrap()
+            .into_iter()
+            .map(|hit| AndHit {
+                document: hit.document,
+                posting_doc_id: hit.posting_doc_id,
+                doc_length: hit.doc_length,
+                freqs: hit.freqs,
+            })
+            .collect::<Vec<_>>();
+        rows.sort_unstable();
+        AndSearchDump {
+            rows,
+            bulk_searches: wand.bulk_and_searches,
+            lead_stream_searches: wand.lead_stream_and_searches,
+            kth_bits: shared_floor.load(Ordering::Relaxed),
+        }
+    }
+
+    fn every_nth_docs(num_docs: u32, stride: u32) -> Vec<u32> {
+        (0..num_docs).step_by(stride as usize).collect()
+    }
+
+    /// Conjunction clause with explicit per-document frequencies. The plain
+    /// `compressed_and_clause` sets every frequency to 1, which makes the
+    /// frequency-bound LUT and the frequency pruning no-ops.
+    fn compressed_and_clause_with_freqs(
+        token: &str,
+        term_pos: u32,
+        query_weight: f32,
+        doc_ids: Vec<u32>,
+        freqs: Vec<u32>,
+        num_docs: usize,
+    ) -> PostingIterator {
+        PostingIterator::with_query_weight(
+            token.to_owned(),
+            term_pos,
+            term_pos,
+            query_weight,
+            generate_posting_list_with_freqs(doc_ids, freqs, 8.0, None, true),
+            num_docs,
+        )
+    }
+
+    #[test]
+    fn auto_keeps_bulk_when_cost_ratio_is_just_below_skew() {
+        // 496/16 = 31 < 32: balanced Auto 3-AND must stay on community bulk.
+        let num_docs = 496_u32;
+        let mut docs = DocSet::default();
+        for doc_id in 0..num_docs {
+            docs.append(u64::from(doc_id), 8);
+        }
+        let rare = every_nth_docs(num_docs, 31);
+        assert_eq!(num_docs as usize / rare.len(), 31);
+        let dense: Vec<u32> = (0..num_docs).collect();
+        let mid: Vec<u32> = (0..num_docs).filter(|doc| doc % 2 == 0).collect();
+        let build = || {
+            vec![
+                compressed_and_clause("rare", 0, 3.0, rare.clone(), docs.len()),
+                compressed_and_clause("mid", 1, 2.0, mid.clone(), docs.len()),
+                compressed_and_clause("dense", 2, 1.0, dense.clone(), docs.len()),
+            ]
+        };
+        let params = FtsSearchParams::default().with_limit(Some(10));
+        let classic = run_and_search(BulkAndMode::Off, build(), &docs, &params);
+        let auto = run_and_search(BulkAndMode::Auto, build(), &docs, &params);
+        let on = run_and_search(BulkAndMode::On, build(), &docs, &params);
+        assert!(!classic.rows.is_empty());
+        assert_eq!(classic.bulk_searches, 0);
+        assert_eq!(classic.lead_stream_searches, 0);
+        assert_eq!(auto.bulk_searches, 1);
+        assert_eq!(auto.lead_stream_searches, 0);
+        assert_eq!(on.bulk_searches, 1);
+        assert_eq!(on.lead_stream_searches, 0);
+        assert_eq!(auto.rows, classic.rows);
+        assert_eq!(on.rows, classic.rows);
+        assert_eq!(auto.kth_bits, classic.kth_bits);
+        assert_eq!(on.kth_bits, classic.kth_bits);
+    }
+
+    #[rstest]
+    #[case::three(3)]
+    #[case::six(6)]
+    fn auto_uses_lead_stream_for_skewed_and_and_matches_classic(#[case] num_clauses: usize) {
+        // 512/16 = 32: Auto n>=3 leaves bulk. On still forces bulk for parity.
+        let num_docs = 512_u32;
+        let mut docs = DocSet::default();
+        for doc_id in 0..num_docs {
+            docs.append(u64::from(doc_id), 8 + doc_id % 5);
+        }
+        let rare = every_nth_docs(num_docs, 32);
+        assert_eq!(num_docs as usize / rare.len(), 32);
+        let dense: Vec<u32> = (0..num_docs).collect();
+        let mid: Vec<u32> = (0..num_docs).filter(|doc| doc % 2 == 0).collect();
+        let build = || {
+            let mut postings = vec![
+                compressed_and_clause("rare", 0, 4.0, rare.clone(), docs.len()),
+                compressed_and_clause("mid", 1, 2.0, mid.clone(), docs.len()),
+            ];
+            for term in 2..num_clauses {
+                postings.push(compressed_and_clause(
+                    &format!("d{term}"),
+                    term as u32,
+                    1.0,
+                    dense.clone(),
+                    docs.len(),
+                ));
+            }
+            postings
+        };
+        let params = FtsSearchParams::default().with_limit(Some(10));
+        let classic = run_and_search(BulkAndMode::Off, build(), &docs, &params);
+        let auto = run_and_search(BulkAndMode::Auto, build(), &docs, &params);
+        let on = run_and_search(BulkAndMode::On, build(), &docs, &params);
+        assert!(!classic.rows.is_empty());
+        assert_eq!(classic.bulk_searches, 0);
+        assert_eq!(classic.lead_stream_searches, 0);
+        assert_eq!(auto.bulk_searches, 0);
+        assert_eq!(auto.lead_stream_searches, 1);
+        assert_eq!(on.bulk_searches, 1);
+        assert_eq!(on.lead_stream_searches, 0);
+        assert_eq!(auto.rows, classic.rows);
+        assert_eq!(on.rows, classic.rows);
+        assert_eq!(auto.kth_bits, classic.kth_bits);
+        assert_eq!(on.kth_bits, classic.kth_bits);
+    }
+
+    #[test]
+    fn auto_keeps_classic_leapfrog_for_skewed_pair() {
+        let num_docs = 512_u32;
+        let mut docs = DocSet::default();
+        for doc_id in 0..num_docs {
+            docs.append(u64::from(doc_id), 8);
+        }
+        let rare = every_nth_docs(num_docs, 32);
+        let dense: Vec<u32> = (0..num_docs).collect();
+        let build = || {
+            vec![
+                compressed_and_clause("rare", 0, 3.0, rare.clone(), docs.len()),
+                compressed_and_clause("dense", 1, 1.0, dense.clone(), docs.len()),
+            ]
+        };
+        let params = FtsSearchParams::default().with_limit(Some(10));
+        let classic = run_and_search(BulkAndMode::Off, build(), &docs, &params);
+        let auto = run_and_search(BulkAndMode::Auto, build(), &docs, &params);
+        assert!(!classic.rows.is_empty());
+        assert_eq!(auto.bulk_searches, 0);
+        assert_eq!(auto.lead_stream_searches, 0);
+        assert_eq!(classic.lead_stream_searches, 0);
+        assert_eq!(auto.rows, classic.rows);
+        assert_eq!(auto.kth_bits, classic.kth_bits);
+    }
+
+    #[test]
+    fn lead_stream_follower_leap_matches_classic() {
+        // `mid` deliberately skips half of the rare documents, so
+        // `seek_lead_followers` has to return `Leap` and `skip_lead_docs` has to
+        // discard buffered lead documents. That branch is the only one that can
+        // silently drop or duplicate a document, and the other lead-stream cases
+        // never reach it: their followers land exactly on every lead document.
+        let num_docs = 512_u32;
+        let mut docs = DocSet::default();
+        for doc_id in 0..num_docs {
+            docs.append(u64::from(doc_id), 8 + doc_id % 5);
+        }
+        let rare = every_nth_docs(num_docs, 32);
+        let mid: Vec<u32> = (0..num_docs)
+            .filter(|doc| doc % 2 == 0 && (doc / 32) % 2 == 0)
+            .collect();
+        let dense: Vec<u32> = (0..num_docs).collect();
+        assert!(
+            rare.iter().any(|doc| !mid.contains(doc)),
+            "the fixture must leave some rare documents out of `mid` so the follower leaps"
+        );
+        assert!(
+            rare.iter().any(|doc| mid.contains(doc)),
+            "the fixture must keep some rare documents in `mid` so the follower also matches"
+        );
+        let build = || {
+            vec![
+                compressed_and_clause("rare", 0, 3.0, rare.clone(), docs.len()),
+                compressed_and_clause("mid", 1, 2.0, mid.clone(), docs.len()),
+                compressed_and_clause("dense", 2, 1.0, dense.clone(), docs.len()),
+            ]
+        };
+        let params = FtsSearchParams::default().with_limit(Some(10));
+        let classic = run_and_search(BulkAndMode::Off, build(), &docs, &params);
+        let auto = run_and_search(BulkAndMode::Auto, build(), &docs, &params);
+        assert_eq!(auto.lead_stream_searches, 1);
+        assert_eq!(auto.bulk_searches, 0);
+        assert!(!classic.rows.is_empty());
+        assert_eq!(auto.rows, classic.rows);
+        assert_eq!(auto.kth_bits, classic.kth_bits);
+    }
+
+    #[rstest]
+    #[case::three(3)]
+    #[case::four(4)]
+    fn lead_stream_matches_classic_with_length_dependent_scorer(#[case] num_clauses: usize) {
+        // The other lead-stream cases use `UnitScorer`, which ignores document
+        // length, and unit frequencies. Together those turn the frequency-bound
+        // LUT into a constant and leave the frequency pruning unreachable, so
+        // `freq_cannot_beat` and `matched_pair_cannot_beat_floor` never decide
+        // anything. This case scores real BM25 shapes over varied lengths and
+        // frequencies, and fills the heap (16 matches against a limit of 10) so a
+        // live floor actually drives those branches -- while still comparing the
+        // result against the classic walk.
+        let num_docs = 512_u32;
+        let mut docs = DocSet::default();
+        for doc_id in 0..num_docs {
+            docs.append(u64::from(doc_id), 4 + doc_id % 23);
+        }
+        let rare = every_nth_docs(num_docs, 32);
+        let dense = (0..num_docs).collect::<Vec<_>>();
+        let half = (0..num_docs).step_by(2).collect::<Vec<_>>();
+        let quarter = (0..num_docs).step_by(4).collect::<Vec<_>>();
+        // Costs 16 / 512 / 256 (/ 128): the densest clause is 32x the rarest, so
+        // Auto routes to the lead-stream.
+        let build = || {
+            let mut postings = vec![
+                compressed_and_clause_with_freqs(
+                    "rare",
+                    0,
+                    3.0,
+                    rare.clone(),
+                    rare.iter().map(|doc| 20 + doc % 7).collect(),
+                    docs.len(),
+                ),
+                compressed_and_clause_with_freqs(
+                    "dense",
+                    1,
+                    1.0,
+                    dense.clone(),
+                    dense.iter().map(|doc| 2 + doc % 5).collect(),
+                    docs.len(),
+                ),
+                compressed_and_clause_with_freqs(
+                    "half",
+                    2,
+                    1.5,
+                    half.clone(),
+                    half.iter().map(|doc| 3 + doc % 4).collect(),
+                    docs.len(),
+                ),
+            ];
+            if num_clauses == 4 {
+                postings.push(compressed_and_clause_with_freqs(
+                    "quarter",
+                    3,
+                    1.2,
+                    quarter.clone(),
+                    quarter.iter().map(|doc| 4 + doc % 3).collect(),
+                    docs.len(),
+                ));
+            }
+            postings
+        };
+        let params = FtsSearchParams::default().with_limit(Some(10));
+        let classic = run_and_search_with_scorer(
+            BulkAndMode::Off,
+            build(),
+            &docs,
+            &params,
+            VariedBm25ShapeScorer,
+        );
+        let auto = run_and_search_with_scorer(
+            BulkAndMode::Auto,
+            build(),
+            &docs,
+            &params,
+            VariedBm25ShapeScorer,
+        );
+        assert_eq!(auto.lead_stream_searches, 1);
+        assert_eq!(auto.bulk_searches, 0);
+        assert_eq!(classic.rows.len(), 10);
+        assert_eq!(auto.rows, classic.rows);
+        assert_eq!(auto.kth_bits, classic.kth_bits);
+    }
+
+    /// The dispatch heuristic is a single threshold: at or above
+    /// `AND_SKEW_RATIO` (32x) a conjunction of three or more clauses takes the
+    /// lead-stream. Walk the ratio across that threshold for several clause
+    /// counts, checking both the routing and that the result still matches the
+    /// classic walk -- the flip point has to be a pure cost decision.
+    #[rstest]
+    #[case::r8(8_usize, 2)]
+    #[case::r16(16, 2)]
+    #[case::r32(32, 2)]
+    #[case::r64(64, 2)]
+    #[case::r8_n3(8, 3)]
+    #[case::r16_n3(16, 3)]
+    #[case::r32_n3(32, 3)]
+    #[case::r64_n3(64, 3)]
+    #[case::r128_n3(128, 3)]
+    #[case::r32_n4(32, 4)]
+    #[case::r128_n4(128, 4)]
+    fn lead_stream_dispatch_follows_the_skew_ratio(
+        #[case] ratio: usize,
+        #[case] num_clauses: usize,
+    ) {
+        // Always include the rarest clause (stride `ratio`, so 8 documents) and
+        // the densest (`num_docs`), which pins max/min at exactly `ratio` for
+        // every clause count. Extra clauses sit between them.
+        let num_docs = (8 * ratio) as u32;
+        let mut docs = DocSet::default();
+        for doc_id in 0..num_docs {
+            docs.append(u64::from(doc_id), 8 + doc_id % 5);
+        }
+        let mut strides = vec![ratio, 1];
+        for extra in [2_usize, 4] {
+            if strides.len() < num_clauses {
+                strides.push(extra);
+            }
+        }
+        let build = || {
+            (0..num_clauses)
+                .map(|clause| {
+                    let doc_ids = (0..num_docs).step_by(strides[clause]).collect::<Vec<_>>();
+                    compressed_and_clause(
+                        &format!("c{clause}"),
+                        clause as u32,
+                        1.0,
+                        doc_ids,
+                        docs.len(),
+                    )
+                })
+                .collect::<Vec<_>>()
+        };
+        let params = FtsSearchParams::default().with_limit(Some(10));
+        let classic = run_and_search(BulkAndMode::Off, build(), &docs, &params);
+        let auto = run_and_search(BulkAndMode::Auto, build(), &docs, &params);
+
+        let expects_lead_stream = ratio >= 32 && num_clauses >= 3;
+        assert_eq!(
+            auto.lead_stream_searches,
+            usize::from(expects_lead_stream),
+            "ratio {ratio} with {num_clauses} clauses"
+        );
+        assert!(!classic.rows.is_empty());
+        assert_eq!(auto.rows, classic.rows);
+        assert_eq!(auto.kth_bits, classic.kth_bits);
+    }
+
+    #[rstest]
+    #[case::slop0(0_u32)]
+    #[case::slop3(3)]
+    fn lead_stream_phrase_matches_classic_and_bulk(#[case] slop: u32) {
+        let num_docs = 512_u32;
+        let mut docs = DocSet::default();
+        for doc_id in 0..num_docs {
+            docs.append(u64::from(doc_id), 8);
+        }
+        let rare = every_nth_docs(num_docs, 32);
+        let dense: Vec<u32> = (0..num_docs).collect();
+        let mid: Vec<u32> = (0..num_docs).filter(|doc| doc % 2 == 0).collect();
+        let build = || {
+            vec![
+                phrase_and_clause("rare", 0, 3.0, rare.clone(), docs.len()),
+                phrase_and_clause("mid", 1, 2.0, mid.clone(), docs.len()),
+                phrase_and_clause("dense", 2, 1.0, dense.clone(), docs.len()),
+            ]
+        };
+        let mut params = FtsSearchParams::default().with_limit(Some(10));
+        params.phrase_slop = Some(slop);
+        let classic = run_and_search(BulkAndMode::Off, build(), &docs, &params);
+        let auto = run_and_search(BulkAndMode::Auto, build(), &docs, &params);
+        let on = run_and_search(BulkAndMode::On, build(), &docs, &params);
+        assert!(!classic.rows.is_empty());
+        assert_eq!(auto.bulk_searches, 0);
+        assert_eq!(auto.lead_stream_searches, 1);
+        assert_eq!(on.bulk_searches, 1);
+        assert_eq!(auto.rows, classic.rows);
+        assert_eq!(on.rows, classic.rows);
+        assert_eq!(auto.kth_bits, classic.kth_bits);
+        assert_eq!(on.kth_bits, classic.kth_bits);
     }
 
     #[rstest]

--- a/rust/lance-index/src/scalar/inverted/wand.rs
+++ b/rust/lance-index/src/scalar/inverted/wand.rs
@@ -24,6 +24,8 @@ use crate::metrics::MetricsCollector;
 
 #[path = "wand_intersection.rs"]
 mod intersection;
+#[path = "wand_maxscore.rs"]
+mod maxscore;
 
 use super::{
     CompressedPositionStorage,
@@ -168,6 +170,16 @@ impl TopKCollector {
         self.heap
             .push(Reverse((doc, doc_length, posting_doc_id, frequency_slot)));
         Ok(true)
+    }
+
+    fn rejects_score(&self, score: f32) -> bool {
+        if self.heap.len() < self.limit {
+            return false;
+        }
+        let Some(kth_score) = self.heap.peek().map(|entry| entry.0.0.score.0) else {
+            return false;
+        };
+        score.partial_cmp(&kth_score) != Some(std::cmp::Ordering::Greater)
     }
 
     fn kth_score_if_full(&self) -> Option<f32> {
@@ -1818,6 +1830,15 @@ fn score_contributions_in_query_order(mut contributions: SmallVec<[ScoreContribu
         .fold(0.0_f32, |score, (_, contribution)| score + contribution)
 }
 
+/// One MAXSCORE clause: posting plus the current window bound / prefix used
+/// to pick essential vs optional and to complete scores in query order.
+struct MaxScoreClause {
+    posting: Box<PostingIterator>,
+    query_rank: usize,
+    bound: f32,
+    prefix_bound: f64,
+}
+
 /// Per-window score/frequency accumulator for the bulk MAXSCORE path. Slot i
 /// covers doc id `window_min + i`; `freqs` is laid out clause-major so accept
 /// paths can recover (term, freq) pairs of the essential clauses.
@@ -2321,6 +2342,8 @@ pub struct Wand<'a, S: Scorer, D: WandDocuments> {
     #[cfg(test)]
     maxscore_general_windows: usize,
     #[cfg(test)]
+    maxscore_essential_blocks_skipped: usize,
+    #[cfg(test)]
     phrase_position_checks: Cell<usize>,
     documents: &'a D,
     scorer: S,
@@ -2428,6 +2451,8 @@ impl<'a, S: Scorer, D: WandDocuments> Wand<'a, S, D> {
             maxscore_single_essential_windows: 0,
             #[cfg(test)]
             maxscore_general_windows: 0,
+            #[cfg(test)]
+            maxscore_essential_blocks_skipped: 0,
             #[cfg(test)]
             phrase_position_checks: Cell::new(0),
             documents,
@@ -2788,13 +2813,6 @@ impl<'a, S: Scorer, D: WandDocuments> Wand<'a, S, D> {
         params: &FtsSearchParams,
         metrics: &dyn MetricsCollector,
     ) -> Result<Vec<DocCandidate<D::Candidate>>> {
-        struct MaxScoreClause {
-            posting: Box<PostingIterator>,
-            query_rank: usize,
-            bound: f32,
-            prefix_bound: f64,
-        }
-
         let limit = params.limit.unwrap_or(usize::MAX);
         let mut clauses = std::mem::take(&mut self.head)
             .into_vec()
@@ -2817,6 +2835,8 @@ impl<'a, S: Scorer, D: WandDocuments> Wand<'a, S, D> {
         let total_sum_upper_bound_factor = score_sum_upper_bound_factor(num_query_terms);
 
         let mut acc = WindowAccumulator::new(clauses.len());
+        let mut essential_chunk = Vec::with_capacity(128);
+        let mut soa_scratch = maxscore::MaxScoreSoaScratch::new();
         let mut candidates = TopKCollector::new(limit, std::cmp::min(limit, BLOCK_SIZE * 10));
         let norm_k = self.norm_k_cache();
         let norm_k_ref = norm_k
@@ -2958,12 +2978,50 @@ impl<'a, S: Scorer, D: WandDocuments> Wand<'a, S, D> {
             };
 
             // Single essential clause (the common case once the threshold is
-            // competitive): stream it directly against the non-essential
-            // prefix, skipping the accumulator entirely.
+            // competitive): skip dead blocks, take one posting block at a
+            // time, and complete ≤2 optionals in SoA buffers. More optionals
+            // keep the per-doc LiveHit completion below.
             if first_essential + 1 == clauses.len() {
                 #[cfg(test)]
                 {
                     self.maxscore_single_essential_windows += 1;
+                }
+                if first_essential <= 2 {
+                    let essential_query_rank = clauses[first_essential].query_rank;
+                    let essential_term = clauses[first_essential].posting.term_index();
+                    let essential_weight = clauses[first_essential].posting.query_weight;
+                    let essential_window_bound = clauses[first_essential].bound;
+                    if clauses[first_essential]
+                        .posting
+                        .doc()
+                        .is_some_and(|doc| doc.doc_id() < window_min)
+                    {
+                        clauses[first_essential].posting.next(window_min);
+                    }
+                    self.score_single_essential_upto(
+                        &mut clauses,
+                        first_essential,
+                        first_essential,
+                        window_max,
+                        essential_query_rank,
+                        essential_term,
+                        essential_weight,
+                        essential_window_bound,
+                        num_query_terms,
+                        total_non_essential_bound,
+                        total_sum_upper_bound_factor,
+                        norm_k_ref,
+                        &mut essential_chunk,
+                        &mut soa_scratch,
+                        &mut candidates,
+                        &mut num_comparisons,
+                        params.wand_factor,
+                    )?;
+                    window_min = match window_max {
+                        TERMINATED_DOC_ID => TERMINATED_DOC_ID,
+                        max => max + 1,
+                    };
+                    continue;
                 }
                 let (non_essential, essential) = clauses.split_at_mut(first_essential);
                 let essential_query_rank = essential[0].query_rank;
@@ -3174,6 +3232,71 @@ impl<'a, S: Scorer, D: WandDocuments> Wand<'a, S, D> {
                 inner_min = inner_min.max(next_essential_doc);
                 if inner_min == TERMINATED_DOC_ID || inner_min > window_max {
                     break;
+                }
+                // Lucene `scoreInnerWindow`: when the second essential is at
+                // least INNER_WINDOW/2 ahead of the first, the prefix matches
+                // a single clause. Complete it with the SoA path instead of
+                // scattering two sparse lists into a 4096-slot accumulator.
+                let mut top_idx = None;
+                let mut top_doc = TERMINATED_DOC_ID;
+                let mut top2_doc = TERMINATED_DOC_ID;
+                for (idx, clause) in clauses.iter().enumerate().skip(first_essential) {
+                    let Some(doc) = clause.posting.doc() else {
+                        continue;
+                    };
+                    let id = doc.doc_id();
+                    if id < top_doc {
+                        top2_doc = top_doc;
+                        top_doc = id;
+                        top_idx = Some(idx);
+                    } else if id < top2_doc {
+                        top2_doc = id;
+                    }
+                }
+                if let Some(ess_idx) = top_idx
+                    && top2_doc.saturating_sub(top_doc) >= (MAXSCORE_INNER_WINDOW / 2) as u64
+                    && first_essential <= 2
+                {
+                    let upto = window_max.min(top2_doc.saturating_sub(1));
+                    if clauses[ess_idx]
+                        .posting
+                        .doc()
+                        .is_some_and(|doc| doc.doc_id() < inner_min)
+                    {
+                        clauses[ess_idx].posting.next(inner_min);
+                    }
+                    let essential_query_rank = clauses[ess_idx].query_rank;
+                    let essential_term = clauses[ess_idx].posting.term_index();
+                    let essential_weight = clauses[ess_idx].posting.query_weight;
+                    let essential_window_bound = clauses[ess_idx].bound;
+                    #[cfg(test)]
+                    {
+                        self.maxscore_single_essential_windows += 1;
+                    }
+                    self.score_single_essential_upto(
+                        &mut clauses,
+                        first_essential,
+                        ess_idx,
+                        upto,
+                        essential_query_rank,
+                        essential_term,
+                        essential_weight,
+                        essential_window_bound,
+                        num_query_terms,
+                        total_non_essential_bound,
+                        total_sum_upper_bound_factor,
+                        norm_k_ref,
+                        &mut essential_chunk,
+                        &mut soa_scratch,
+                        &mut candidates,
+                        &mut num_comparisons,
+                        params.wand_factor,
+                    )?;
+                    inner_min = match upto {
+                        TERMINATED_DOC_ID => TERMINATED_DOC_ID,
+                        max => max + 1,
+                    };
+                    continue;
                 }
                 let inner_max =
                     window_max.min(inner_min.saturating_add(MAXSCORE_INNER_WINDOW as u64 - 1));
@@ -6370,10 +6493,470 @@ mod tests {
 
         assert_eq!(hits.len(), 1);
         assert_eq!(hits[0].document, 0);
+        let mut terms = hits[0]
+            .freqs
+            .iter()
+            .map(|(term_index, freq)| {
+                assert_eq!(*freq, 1);
+                *term_index
+            })
+            .collect::<Vec<_>>();
+        terms.sort_unstable();
+        assert_eq!(terms, vec![0, 1, 2]);
         assert_eq!(shared_floor.load(Ordering::Relaxed), 0x3be0_094c);
         assert_eq!(scored.load(Ordering::Relaxed), contributions.len());
         assert_eq!(wand.maxscore_single_essential_windows > 0, single_essential);
         assert_eq!(wand.maxscore_general_windows > 0, !single_essential);
+    }
+
+    #[test]
+    fn maxscore_skips_essential_blocks_below_the_floor() {
+        // Lucene ImpactsEnum.setMinCompetitiveScore: a single-essential
+        // block whose impact bound plus the optional remainder cannot
+        // enter the heap is skipped without decoding.
+        let block = crate::scalar::inverted::LEGACY_BLOCK_SIZE as u32;
+        let hot: Vec<u32> = (0..block).collect();
+        let cold: Vec<u32> = (block..2 * block).collect();
+        let ess_docs: Vec<u32> = hot.iter().copied().chain(cold.iter().copied()).collect();
+        let ess_freqs: Vec<u32> = std::iter::repeat_n(200, block as usize)
+            .chain(std::iter::repeat_n(1, block as usize))
+            .collect();
+        let opt_docs = ess_docs.clone();
+        let essential = PostingIterator::with_query_weight(
+            "ess".to_owned(),
+            0,
+            0,
+            1.0,
+            generate_impact_posting_list_with_freqs_and_block_size(
+                ess_docs,
+                ess_freqs,
+                vec![1; 2 * block as usize],
+                crate::scalar::inverted::LEGACY_BLOCK_SIZE,
+            ),
+            2 * block as usize,
+        );
+        let optional = PostingIterator::with_query_weight(
+            "opt".to_owned(),
+            1,
+            1,
+            0.01,
+            generate_impact_posting_list_with_freqs_and_block_size(
+                opt_docs,
+                vec![1; 2 * block as usize],
+                vec![1; 2 * block as usize],
+                crate::scalar::inverted::LEGACY_BLOCK_SIZE,
+            ),
+            2 * block as usize,
+        );
+        let mut docs = DocSet::default();
+        for doc in 0..2 * block {
+            docs.append(doc.into(), 1);
+        }
+        let shared_floor = Arc::new(AtomicU32::new(5.0_f32.to_bits()));
+        let mut wand = Wand::new(
+            Operator::Or,
+            [essential, optional].into_iter(),
+            &docs,
+            InverseDocLengthScorer,
+        )
+        .with_shared_threshold(shared_floor);
+        let hits = wand
+            .maxscore_search(
+                &FtsSearchParams::default().with_limit(Some(10)),
+                &NoOpMetricsCollector,
+            )
+            .unwrap();
+        assert!(!hits.is_empty());
+        for hit in &hits {
+            assert!(
+                hit.posting_doc_id < u64::from(block),
+                "cold-block doc {} should not enter the heap",
+                hit.posting_doc_id
+            );
+        }
+        // NOTE: this scenario never reaches the whole-block skip. With
+        // `InverseDocLengthScorer` there is no finite `doc_weight_upper_bound`,
+        // so `block_max_score` falls back to infinity and no block can be
+        // proven dead; with a BM25-shaped scorer the test helpers emit
+        // zeroed `block_max_scores`, so `block_max_score` falls back to the
+        // global scorer bound instead of a per-block one. Either way the skip
+        // branch stays uncovered by a unit test -- the assertion below only
+        // pins that the single-essential path ran.
+        assert!(
+            wand.maxscore_essential_blocks_skipped > 0
+                || wand.maxscore_single_essential_windows > 0,
+            "the hot block must take the single-essential path"
+        );
+    }
+
+    #[test]
+    fn maxscore_does_not_skip_past_the_current_window() {
+        // Optional starts in block 1. Window 0's optional remainder is 0, so
+        // the essential's next block cannot compete *in this window*. Skip
+        // must leave the cursor on that block for window 1, where the
+        // optional is live.
+        let block = crate::scalar::inverted::LEGACY_BLOCK_SIZE as u32;
+        let ess_docs: Vec<u32> = (0..2 * block).collect();
+        let opt_docs: Vec<u32> = (block..2 * block).collect();
+        let essential = PostingIterator::with_query_weight(
+            "ess".to_owned(),
+            0,
+            0,
+            0.4,
+            generate_impact_posting_list_with_freqs_and_block_size(
+                ess_docs,
+                vec![1; 2 * block as usize],
+                vec![1; 2 * block as usize],
+                crate::scalar::inverted::LEGACY_BLOCK_SIZE,
+            ),
+            2 * block as usize,
+        );
+        let optional = PostingIterator::with_query_weight(
+            "opt".to_owned(),
+            1,
+            1,
+            0.3,
+            generate_impact_posting_list_with_freqs_and_block_size(
+                opt_docs,
+                vec![1; block as usize],
+                vec![1; block as usize],
+                crate::scalar::inverted::LEGACY_BLOCK_SIZE,
+            ),
+            2 * block as usize,
+        );
+        let mut docs = DocSet::default();
+        for doc in 0..2 * block {
+            docs.append(doc.into(), 1);
+        }
+        let shared_floor = Arc::new(AtomicU32::new(0.5_f32.to_bits()));
+        let mut wand = Wand::new(
+            Operator::Or,
+            [essential, optional].into_iter(),
+            &docs,
+            InverseDocLengthScorer,
+        )
+        .with_shared_threshold(shared_floor);
+        let hits = wand
+            .maxscore_search(
+                &FtsSearchParams::default().with_limit(Some(10)),
+                &NoOpMetricsCollector,
+            )
+            .unwrap();
+        assert_eq!(hits.len(), 10);
+        assert!(
+            hits.iter()
+                .all(|hit| hit.posting_doc_id >= u64::from(block)),
+            "only the optional-overlap block can beat the exclusive floor"
+        );
+    }
+
+    #[test]
+    fn merge_optional_freqs_matches_per_doc_next() {
+        let posting_docs = vec![1u32, 2, 4, 7, 11, 20, 21, 40];
+        let freqs = vec![3u32, 1, 5, 2, 9, 4, 1, 8];
+        let targets = [0u64, 2, 5, 7, 10, 11, 20, 21, 30, 40];
+        let build = || {
+            PostingIterator::new(
+                "hotels".to_owned(),
+                0,
+                0,
+                generate_posting_list_with_freqs(
+                    posting_docs.clone(),
+                    freqs.clone(),
+                    1.0,
+                    None,
+                    true,
+                ),
+                64,
+            )
+        };
+        let mut merged = build();
+        let mut out = vec![0u32; targets.len()];
+        merged.merge_optional_freqs(&targets, &mut out);
+
+        let mut probe = build();
+        let mut expected = vec![0u32; targets.len()];
+        for (i, &doc) in targets.iter().enumerate() {
+            if probe.doc().is_some_and(|cur| cur.doc_id() < doc) {
+                probe.next(doc);
+            }
+            if let Some(cur) = probe.doc()
+                && cur.doc_id() == doc
+            {
+                expected[i] = cur.frequency();
+            }
+        }
+        assert_eq!(out, expected);
+        assert_eq!(out, vec![0, 1, 0, 2, 0, 9, 4, 1, 0, 8]);
+    }
+
+    #[test]
+    fn maxscore_top2_gap_completes_isolated_essentials() {
+        // Two essentials 3000 docs apart: Lucene scores each stretch as a
+        // single-essential window. The optional sits on both ends so the
+        // floor can demote it without dropping either essential's hits.
+        let left: Vec<u32> = (0..32).collect();
+        let right: Vec<u32> = (3000..3032).collect();
+        let optional: Vec<u32> = left.iter().copied().chain(right.iter().copied()).collect();
+        let build = |token: &str, rank: u32, docs: Vec<u32>, weight: f32| {
+            PostingIterator::with_query_weight(
+                token.to_owned(),
+                rank,
+                rank,
+                weight,
+                generate_posting_list(docs, weight, None, true),
+                4096,
+            )
+        };
+        let mut docs = DocSet::default();
+        for doc in 0..4096u64 {
+            docs.append(doc, 1);
+        }
+        let shared_floor = Arc::new(AtomicU32::new(0.15_f32.to_bits()));
+        let mut wand = Wand::new(
+            Operator::Or,
+            [
+                build("left", 0, left, 2.0),
+                build("right", 1, right, 2.0),
+                build("opt", 2, optional, 0.1),
+            ]
+            .into_iter(),
+            &docs,
+            InverseDocLengthScorer,
+        )
+        .with_shared_threshold(shared_floor);
+        let hits = wand
+            .maxscore_search(
+                &FtsSearchParams::default().with_limit(Some(10)),
+                &NoOpMetricsCollector,
+            )
+            .unwrap();
+        assert_eq!(hits.len(), 10);
+        assert!(
+            wand.maxscore_single_essential_windows > 0,
+            "a 2048+ gap between essentials must take the Lucene single-clause inner window"
+        );
+    }
+
+    #[test]
+    fn maxscore_first_required_keeps_winners_on_the_buffer() {
+        // Optional is non-essential once the floor sits between its bound and
+        // the essential bound. Promoting it to required must still keep the
+        // document that has both terms; the essential posting is not the
+        // leapfrog driver.
+        let postings = [
+            (0_u32, 0.3_f32, vec![0_u32]),
+            (1_u32, 0.4_f32, vec![0_u32, 1]),
+        ]
+        .into_iter()
+        .map(|(position, query_weight, docs)| {
+            PostingIterator::with_query_weight(
+                format!("t{position}"),
+                position,
+                position,
+                query_weight,
+                generate_posting_list(docs, query_weight, None, true),
+                2,
+            )
+        })
+        .collect::<Vec<_>>();
+        let mut docs = DocSet::default();
+        docs.append(0, 1);
+        docs.append(1, 1);
+        let mut wand = Wand::new(
+            Operator::Or,
+            postings.into_iter(),
+            &docs,
+            CountingScorer {
+                scored: Arc::new(AtomicUsize::new(0)),
+            },
+        );
+        wand.threshold = 0.45;
+        let hits = wand
+            .maxscore_search(
+                &FtsSearchParams::default().with_limit(Some(10)),
+                &NoOpMetricsCollector,
+            )
+            .unwrap();
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].document, 0);
+        assert!(hits[0].freqs.iter().any(|(term, _)| *term == 0));
+        assert!(wand.maxscore_single_essential_windows > 0);
+    }
+
+    /// Oracle: `maxscore_search` must publish the same top-k as an exhaustive
+    /// fold over every document, scored in query order. The fold shares no code
+    /// with MAXSCORE, so it pins the hit set, the order, and the k-th score
+    /// without needing a second search path to compare against.
+    #[rstest]
+    fn maxscore_matches_an_exhaustive_query_order_fold(
+        #[values(2_usize, 3_usize)] num_terms: usize,
+        #[values(4_usize, 10_usize)] limit: usize,
+    ) {
+        let block = MAX_POSTING_BLOCK_SIZE as u32;
+        let total_docs = 3 * block;
+        let mut docs = DocSet::default();
+        for doc in 0..total_docs {
+            docs.append(u64::from(doc), doc % 17 + 1);
+        }
+
+        // Clause `term` covers `term, term+num_terms, term+2*num_terms, ...`,
+        // so membership is a closed form instead of a posting-list walk.
+        let covered =
+            |doc: u32, term: u32| doc >= term && (doc - term).is_multiple_of(num_terms as u32);
+        let freq_of = |doc: u32, term: u32| (doc + term) % 5 + 1;
+
+        let mut expected = (0..total_docs)
+            .map(|doc| {
+                let norm = 0.3 + docs.scoring_num_tokens(doc) as f32 * 0.1;
+                let score = (0..num_terms as u32)
+                    .filter(|term| covered(doc, *term))
+                    .fold(0.0_f32, |sum, term| {
+                        sum + bm25_doc_weight_with_norm(freq_of(doc, term), norm)
+                    });
+                (u64::from(doc), score)
+            })
+            .filter(|(_, score)| *score > 0.0)
+            .collect::<Vec<_>>();
+        expected.sort_unstable_by(|left, right| {
+            right
+                .1
+                .total_cmp(&left.1)
+                .then_with(|| left.0.cmp(&right.0))
+        });
+        // Lengths and frequencies are quantized, so many documents tie on
+        // score. Which tied documents fill the last slots is not observable,
+        // so pin the strict winners and the tie set instead of one arbitrary
+        // ordering.
+        let kth = expected[limit - 1].1;
+        let strictly_better = expected
+            .iter()
+            .filter(|(_, score)| *score > kth)
+            .map(|(doc, _)| *doc)
+            .collect::<Vec<_>>();
+        let tying = expected
+            .iter()
+            .filter(|(_, score)| *score == kth)
+            .map(|(doc, _)| *doc)
+            .collect::<Vec<_>>();
+
+        let postings = (0..num_terms as u32)
+            .map(|term| {
+                let doc_ids = (term..total_docs).step_by(num_terms).collect::<Vec<_>>();
+                let freqs = doc_ids
+                    .iter()
+                    .map(|doc| freq_of(*doc, term))
+                    .collect::<Vec<_>>();
+                let lengths = doc_ids.iter().map(|doc| doc % 17 + 1).collect::<Vec<_>>();
+                PostingIterator::with_query_weight(
+                    format!("t{term}"),
+                    term,
+                    term,
+                    1.0,
+                    generate_impact_posting_list_with_freqs_and_block_size(
+                        doc_ids,
+                        freqs,
+                        lengths,
+                        MAX_POSTING_BLOCK_SIZE,
+                    ),
+                    docs.len(),
+                )
+            })
+            .collect::<Vec<_>>();
+        let shared_floor = Arc::new(AtomicU32::new(0.0_f32.to_bits()));
+        let mut wand = Wand::new(
+            Operator::Or,
+            postings.into_iter(),
+            &docs,
+            VariedBm25ShapeScorer,
+        )
+        .with_shared_threshold(shared_floor.clone());
+        let hits = wand
+            .maxscore_search(
+                &FtsSearchParams::default().with_limit(Some(limit)),
+                &NoOpMetricsCollector,
+            )
+            .unwrap();
+
+        let got = hits
+            .iter()
+            .map(|hit| hit.posting_doc_id)
+            .collect::<Vec<_>>();
+        assert_eq!(got.len(), limit);
+        for doc in &strictly_better {
+            assert!(
+                got.contains(doc),
+                "doc {doc} scores above the k-th ({kth}) and must be in the top {limit}"
+            );
+        }
+        for doc in &got {
+            assert!(
+                strictly_better.contains(doc) || tying.contains(doc),
+                "doc {doc} is not a top-{limit} candidate (k-th = {kth})"
+            );
+        }
+        // The published floor is the k-th best score, so it pins the value and
+        // not just the membership.
+        assert_eq!(shared_floor.load(Ordering::Relaxed), kth.to_bits());
+    }
+
+    /// The gap that hands a stretch to the single-essential inner window is
+    /// `MAXSCORE_INNER_WINDOW / 2`. Pin the boundary from both sides instead of
+    /// only testing a comfortable distance away from it.
+    #[rstest]
+    fn maxscore_top2_gap_boundary(#[values(2047_u32, 2048_u32, 2049_u32)] gap: u32) {
+        let left = (0..32_u32).collect::<Vec<_>>();
+        let right = (gap..gap + 32).collect::<Vec<_>>();
+        let num_docs = (gap + 64) as usize;
+        let build = |token: &str, rank: u32, doc_ids: Vec<u32>, weight: f32| {
+            PostingIterator::with_query_weight(
+                token.to_owned(),
+                rank,
+                rank,
+                weight,
+                generate_posting_list(doc_ids, weight, None, true),
+                num_docs,
+            )
+        };
+        let mut docs = DocSet::default();
+        for doc in 0..num_docs as u64 {
+            docs.append(doc, 1);
+        }
+        let mut wand = Wand::new(
+            Operator::Or,
+            // Distinct weights: every document of "left" outranks every document
+            // of "right", so the top ten is a known set instead of an arbitrary
+            // pick out of 64 tied documents.
+            [build("left", 0, left, 3.0), build("right", 1, right, 1.0)].into_iter(),
+            &docs,
+            InverseDocLengthScorer,
+        );
+        let hits = wand
+            .maxscore_search(
+                &FtsSearchParams::default().with_limit(Some(10)),
+                &NoOpMetricsCollector,
+            )
+            .unwrap();
+
+        assert_eq!(hits.len(), 10);
+        assert!(
+            hits.iter().all(|hit| hit.posting_doc_id < 32),
+            "the heavier clause must fill the top ten, got {:?}",
+            hits.iter()
+                .map(|hit| hit.posting_doc_id)
+                .collect::<Vec<_>>()
+        );
+        if gap >= (MAXSCORE_INNER_WINDOW / 2) as u32 {
+            assert!(
+                wand.maxscore_single_essential_windows > 0,
+                "gap {gap} must take the single-essential inner window"
+            );
+        } else {
+            assert!(
+                wand.maxscore_general_windows > 0,
+                "gap {gap} must stay on the general window path"
+            );
+        }
     }
 
     #[rstest]

--- a/rust/lance-index/src/scalar/inverted/wand.rs
+++ b/rust/lance-index/src/scalar/inverted/wand.rs
@@ -1185,6 +1185,10 @@ impl PostingIterator {
     }
 
     fn position_cursor(&self) -> Result<PositionCursor<'_>> {
+        #[cfg(test)]
+        {
+            POSITION_CURSOR_CALLS.with(|calls| calls.set(calls.get() + 1));
+        }
         match self.list {
             PostingList::Plain(ref list) => {
                 let positions = list.positions.as_ref().ok_or_else(|| {
@@ -5294,106 +5298,134 @@ impl<'a, S: Scorer, D: WandDocuments> Wand<'a, S, D> {
         }
     }
 
-    /// Allocation-free exact-phrase check for the bulk conjunction path,
-    /// where every clause is a parked `lead` iterator. Semantically identical
-    /// to [`Self::check_exact_positions`] — some base position must align all
-    /// clauses at their query offsets — without the per-candidate cursor vec
-    /// and sort.
+    /// Exact-phrase check for the bulk conjunction path, where every clause
+    /// is a parked `lead` iterator. Semantically identical to
+    /// [`Self::check_exact_positions`].
     fn check_exact_positions_bulk(&self) -> Result<bool> {
         #[cfg(test)]
         {
             self.phrase_position_checks
                 .set(self.phrase_position_checks.get() + 1);
         }
-        const MAX_INLINE_CLAUSES: usize = 16;
-        let num_clauses = self.lead.len();
-        if num_clauses > MAX_INLINE_CLAUSES {
-            return self.check_exact_positions();
-        }
-        // Cursors stay alive in the stack array so owned position buffers
-        // (legacy per-doc storage) remain valid while we scan.
-        let mut cursors: [Option<PositionCursor<'_>>; MAX_INLINE_CLAUSES] =
-            std::array::from_fn(|_| None);
-        let mut anchor_idx = 0usize;
-        let mut anchor_len = usize::MAX;
-        for (index, (slot, posting)) in cursors.iter_mut().zip(self.lead.iter()).enumerate() {
-            let cursor = posting.position_cursor()?;
-            if cursor.len() < anchor_len {
-                anchor_len = cursor.len();
-                anchor_idx = index;
-            }
-            *slot = Some(cursor);
-        }
-
-        let anchor = cursors[anchor_idx]
-            .as_ref()
-            .expect("anchor cursor was just populated");
-        let anchor_offset = anchor.position_in_query as u32;
-        'anchor: for &anchor_position in anchor.positions.as_slice() {
-            let Some(base) = anchor_position.checked_sub(anchor_offset) else {
-                continue;
-            };
-            for (index, slot) in cursors[..num_clauses].iter().enumerate() {
-                if index == anchor_idx {
-                    continue;
-                }
-                let cursor = slot.as_ref().expect("clause cursor was just populated");
-                let Some(target) = base.checked_add(cursor.position_in_query as u32) else {
-                    return Ok(false);
-                };
-                if cursor.positions.as_slice().binary_search(&target).is_err() {
-                    continue 'anchor;
-                }
-            }
-            return Ok(true);
-        }
-        Ok(false)
+        exact_phrase_positions_match(
+            self.lead.len(),
+            |index| {
+                self.lead[index]
+                    .doc()
+                    .map(|doc| doc.frequency())
+                    .unwrap_or(u32::MAX)
+            },
+            |index| self.lead[index].position_cursor(),
+        )
     }
 
     fn check_exact_positions(&self) -> Result<bool> {
-        let mut position_iters = self
-            .current_doc_postings()
-            .into_iter()
-            .map(PostingIterator::position_cursor)
-            .collect::<Result<Vec<_>>>()?;
-        position_iters.sort_unstable_by_key(|iter| iter.len());
-        let Some(lead) = position_iters.first() else {
-            return Ok(false);
-        };
-        let lead_position = lead.position_in_query;
+        let postings = self.current_doc_postings();
+        exact_phrase_positions_match(
+            postings.len(),
+            |index| {
+                postings[index]
+                    .doc()
+                    .map(|doc| doc.frequency())
+                    .unwrap_or(u32::MAX)
+            },
+            |index| postings[index].position_cursor(),
+        )
+    }
+}
 
-        loop {
-            let Some(anchor) = position_iters[0].absolute_position() else {
+/// Decode exact-phrase position lists in current-doc frequency order.
+///
+/// Term frequency equals the position count, so a stopword on this document
+/// is decoded last. If the two rarest lists share no phrase base, the rest
+/// (typically `"the"` / `"of"`) are never unpacked.
+fn exact_phrase_positions_match<'a>(
+    num_clauses: usize,
+    frequency: impl Fn(usize) -> u32,
+    decode: impl FnMut(usize) -> Result<PositionCursor<'a>>,
+) -> Result<bool> {
+    const MAX_INLINE_CLAUSES: usize = 16;
+    if num_clauses == 0 {
+        return Ok(false);
+    }
+    if num_clauses > MAX_INLINE_CLAUSES {
+        let mut order: Vec<usize> = (0..num_clauses).collect();
+        order.sort_unstable_by_key(|&index| frequency(index));
+        let mut cursors: Vec<Option<PositionCursor<'a>>> = (0..num_clauses).map(|_| None).collect();
+        return exact_phrase_scan(&order, &mut cursors, decode);
+    }
+    let mut order = [0usize; MAX_INLINE_CLAUSES];
+    for (index, slot) in order.iter_mut().enumerate().take(num_clauses) {
+        *slot = index;
+    }
+    order[..num_clauses].sort_unstable_by_key(|&index| frequency(index));
+    let mut cursors: [Option<PositionCursor<'a>>; MAX_INLINE_CLAUSES] =
+        std::array::from_fn(|_| None);
+    exact_phrase_scan(&order[..num_clauses], &mut cursors, decode)
+}
+
+fn exact_phrase_scan<'a>(
+    order: &[usize],
+    cursors: &mut [Option<PositionCursor<'a>>],
+    mut decode: impl FnMut(usize) -> Result<PositionCursor<'a>>,
+) -> Result<bool> {
+    let num_clauses = order.len();
+    if num_clauses == 0 {
+        return Ok(false);
+    }
+    let rarest = order[0];
+    cursors[rarest] = Some(decode(rarest)?);
+    let (n_pos, anchor_offset) = {
+        let cursor = cursors[rarest]
+            .as_ref()
+            .expect("rarest clause cursor was just populated");
+        (cursor.len(), cursor.position_in_query as u32)
+    };
+    if num_clauses == 1 {
+        return Ok(n_pos > 0);
+    }
+
+    for pos_i in 0..n_pos {
+        let anchor_position = {
+            let cursor = cursors[rarest]
+                .as_ref()
+                .expect("rarest clause cursor was just populated");
+            cursor.positions.as_slice()[pos_i]
+        };
+        let Some(base) = anchor_position.checked_sub(anchor_offset) else {
+            continue;
+        };
+        let mut matched = true;
+        for &index in &order[1..num_clauses] {
+            if cursors[index].is_none() {
+                cursors[index] = Some(decode(index)?);
+            }
+            let cursor = cursors[index]
+                .as_ref()
+                .expect("phrase clause cursor was just populated");
+            let Some(target) = base.checked_add(cursor.position_in_query as u32) else {
                 return Ok(false);
             };
-            let Some(base) = anchor.checked_sub(lead_position as u32) else {
-                position_iters[0].advance_next();
-                continue;
-            };
-
-            let mut next_lead_relative = None;
-            let mut matched = true;
-            for follower in position_iters.iter_mut().skip(1) {
-                let Some(target) = base.checked_add(follower.position_in_query as u32) else {
-                    return Ok(false);
-                };
-                let Some(position) = follower.advance_to_absolute(target) else {
-                    return Ok(false);
-                };
-                if position != target {
-                    next_lead_relative = Some(position as i32 - follower.position_in_query);
-                    matched = false;
-                    break;
-                }
+            if cursor.positions.as_slice().binary_search(&target).is_err() {
+                matched = false;
+                break;
             }
-
-            if matched {
-                return Ok(true);
-            }
-
-            position_iters[0].advance_to_relative(next_lead_relative.unwrap());
+        }
+        if matched {
+            return Ok(true);
         }
     }
+    Ok(false)
+}
+
+#[cfg(test)]
+thread_local! {
+    static POSITION_CURSOR_CALLS: Cell<usize> = const { Cell::new(0) };
+}
+
+#[cfg(test)]
+fn take_position_cursor_calls() -> usize {
+    POSITION_CURSOR_CALLS.with(|calls| calls.replace(0))
 }
 
 #[derive(Debug)]
@@ -5469,10 +5501,6 @@ impl<'a> PositionCursor<'a> {
         self.positions.len()
     }
 
-    fn absolute_position(&self) -> Option<u32> {
-        self.positions.as_slice().get(self.index).copied()
-    }
-
     fn relative_position(&self) -> Option<i32> {
         self.positions
             .as_slice()
@@ -5488,19 +5516,6 @@ impl<'a> PositionCursor<'a> {
         let least_pos = least_pos.max(0) as u32;
         let values = self.positions.as_slice();
         self.index += values[self.index..].partition_point(|&pos| pos < least_pos);
-    }
-
-    fn advance_to_absolute(&mut self, least_pos: u32) -> Option<u32> {
-        if self.index >= self.len() {
-            return None;
-        }
-        let values = self.positions.as_slice();
-        self.index += values[self.index..].partition_point(|&pos| pos < least_pos);
-        self.absolute_position()
-    }
-
-    fn advance_next(&mut self) {
-        self.index = self.index.saturating_add(1).min(self.len());
     }
 }
 
@@ -9788,6 +9803,195 @@ mod tests {
         let second = wand.next().unwrap().unwrap();
         assert_eq!(second.0.doc_id(), 1);
         assert!(wand.check_positions(0).unwrap());
+    }
+
+    #[rstest]
+    fn exact_phrase_skips_stopword_decode_when_rare_pair_misses(
+        #[values(false, true)] is_compressed: bool,
+    ) {
+        let mut docs = DocSet::default();
+        docs.append(0, 16);
+
+        let postings = vec![
+            PostingIterator::new(
+                String::from("the"),
+                0,
+                0,
+                generate_posting_list_with_positions(
+                    vec![0],
+                    vec![(0..100_u32).collect()],
+                    1.0,
+                    is_compressed,
+                ),
+                docs.len(),
+            ),
+            PostingIterator::new(
+                String::from("news"),
+                1,
+                1,
+                generate_posting_list_with_positions(
+                    vec![0],
+                    vec![vec![50_u32]],
+                    1.0,
+                    is_compressed,
+                ),
+                docs.len(),
+            ),
+            PostingIterator::new(
+                String::from("journal"),
+                2,
+                2,
+                generate_posting_list_with_positions(
+                    vec![0],
+                    vec![vec![99_u32]],
+                    1.0,
+                    is_compressed,
+                ),
+                docs.len(),
+            ),
+        ];
+        let bm25 = IndexBM25Scorer::new(std::iter::empty());
+        let wand = Wand::new(Operator::And, postings.into_iter(), &docs, bm25);
+        let _ = take_position_cursor_calls();
+        assert!(!wand.check_exact_positions().unwrap());
+        assert_eq!(take_position_cursor_calls(), 2);
+        assert!(!wand.check_exact_positions_bulk().unwrap());
+        assert_eq!(take_position_cursor_calls(), 2);
+    }
+
+    #[rstest]
+    fn exact_phrase_decodes_stopword_when_rare_pair_aligns(
+        #[values(false, true)] is_compressed: bool,
+    ) {
+        let mut docs = DocSet::default();
+        docs.append(0, 16);
+
+        let hit_the: Vec<u32> = (0..100).collect();
+        let postings = vec![
+            PostingIterator::new(
+                String::from("the"),
+                0,
+                0,
+                generate_posting_list_with_positions(vec![0], vec![hit_the], 1.0, is_compressed),
+                docs.len(),
+            ),
+            PostingIterator::new(
+                String::from("news"),
+                1,
+                1,
+                generate_posting_list_with_positions(
+                    vec![0],
+                    vec![vec![11_u32]],
+                    1.0,
+                    is_compressed,
+                ),
+                docs.len(),
+            ),
+            PostingIterator::new(
+                String::from("journal"),
+                2,
+                2,
+                generate_posting_list_with_positions(
+                    vec![0],
+                    vec![vec![12_u32]],
+                    1.0,
+                    is_compressed,
+                ),
+                docs.len(),
+            ),
+        ];
+        let bm25 = IndexBM25Scorer::new(std::iter::empty());
+        let wand = Wand::new(Operator::And, postings.into_iter(), &docs, bm25);
+        let _ = take_position_cursor_calls();
+        assert!(wand.check_exact_positions().unwrap());
+        assert_eq!(take_position_cursor_calls(), 3);
+        assert!(wand.check_exact_positions_bulk().unwrap());
+        assert_eq!(take_position_cursor_calls(), 3);
+    }
+
+    #[rstest]
+    fn exact_phrase_rejects_when_stopword_misses_aligned_pair(
+        #[values(false, true)] is_compressed: bool,
+    ) {
+        let mut docs = DocSet::default();
+        docs.append(0, 16);
+
+        // "news journal" aligns at base 10, but "the" has no position 10.
+        let the_positions: Vec<u32> = (0..10).chain(11..100).collect();
+        let postings = vec![
+            PostingIterator::new(
+                String::from("the"),
+                0,
+                0,
+                generate_posting_list_with_positions(
+                    vec![0],
+                    vec![the_positions],
+                    1.0,
+                    is_compressed,
+                ),
+                docs.len(),
+            ),
+            PostingIterator::new(
+                String::from("news"),
+                1,
+                1,
+                generate_posting_list_with_positions(
+                    vec![0],
+                    vec![vec![11_u32]],
+                    1.0,
+                    is_compressed,
+                ),
+                docs.len(),
+            ),
+            PostingIterator::new(
+                String::from("journal"),
+                2,
+                2,
+                generate_posting_list_with_positions(
+                    vec![0],
+                    vec![vec![12_u32]],
+                    1.0,
+                    is_compressed,
+                ),
+                docs.len(),
+            ),
+        ];
+        let bm25 = IndexBM25Scorer::new(std::iter::empty());
+        let wand = Wand::new(Operator::And, postings.into_iter(), &docs, bm25);
+        let _ = take_position_cursor_calls();
+        assert!(!wand.check_exact_positions().unwrap());
+        assert_eq!(take_position_cursor_calls(), 3);
+        assert!(!wand.check_exact_positions_bulk().unwrap());
+        assert_eq!(take_position_cursor_calls(), 3);
+    }
+
+    #[rstest]
+    fn exact_phrase_heap_path_matches_wide_clause_count(
+        #[values(false, true)] is_compressed: bool,
+    ) {
+        let mut docs = DocSet::default();
+        docs.append(0, 32);
+        let num_clauses = 17usize;
+        let postings = (0..num_clauses)
+            .map(|index| {
+                PostingIterator::new(
+                    format!("t{index}"),
+                    index as u32,
+                    index as u32,
+                    generate_posting_list_with_positions(
+                        vec![0],
+                        vec![vec![index as u32]],
+                        1.0,
+                        is_compressed,
+                    ),
+                    docs.len(),
+                )
+            })
+            .collect::<Vec<_>>();
+        let bm25 = IndexBM25Scorer::new(std::iter::empty());
+        let wand = Wand::new(Operator::And, postings.into_iter(), &docs, bm25);
+        assert!(wand.check_exact_positions().unwrap());
+        assert!(wand.check_exact_positions_bulk().unwrap());
     }
 
     /// The bulk conjunction path must return exactly the classic loop's

--- a/rust/lance-index/src/scalar/inverted/wand_lead_stream.rs
+++ b/rust/lance-index/src/scalar/inverted/wand_lead_stream.rs
@@ -1,0 +1,428 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+//! Skewed conjunction search: the rare list's decompressed block is the
+//! buffer, dense followers only `next(target)`.
+//!
+//! Community Auto still uses N-way bulk for balanced 2/3 (and modern 4+).
+//! When `max_cost / min_cost >= AND_SKEW_RATIO`, bulk would decompress the
+//! stopword in every window the rare term barely touches. Three or more
+//! skewed clauses therefore take this lead-stream; a skewed pair stays on
+//! classic leapfrog (Lucene `ConjunctionDISI` — one follower makes the
+//! buffer pure overhead).
+//!
+//! Inner score-first is not a dispatch table: with three or more clauses
+//! whose second list is at least `AND_SCORE_FIRST_COST_RATIO` times the
+//! lead, the rare BM25 is scored before seeking dense followers. Phrase
+//! confirmation stays on the existing score-then-positions path.
+
+use lance_core::Result;
+use smallvec::SmallVec;
+
+use super::super::builder::ScoredDoc;
+use super::super::encoding::MAX_POSTING_BLOCK_SIZE;
+use super::super::query::FtsSearchParams;
+use super::super::scorer::Scorer;
+use super::{
+    BLOCK_SIZE, CompetitiveFloorMode, DocCandidate, DocInfo, PostingIterator, PostingList,
+    RawDocInfo, TERMINATED_DOC_ID, TopKCollector, Wand, WandDocuments, conservative_score_sum,
+    score_sum_cannot_compete, score_sum_upper_bound_factor,
+};
+use crate::metrics::MetricsCollector;
+
+/// Cost ratio at which Auto leaves N-way bulk. Same 32× Wikipedia number
+/// the analysis tree used for n≤3; not a term-count bucket.
+pub(super) const AND_SKEW_RATIO: usize = 32;
+
+/// Score the rare lead before seeking followers when the second list is
+/// at least this many times longer. Same 3× shape as IU promotion.
+const AND_SCORE_FIRST_COST_RATIO: usize = 3;
+
+const FREQ_LUT_BUCKETS: usize = 64;
+
+enum LeadFollowerSeek {
+    Match,
+    Leap(u64),
+    Exhausted,
+}
+
+pub(super) fn conjunction_lists_are_skewed(min_cost: usize, max_cost: usize) -> bool {
+    min_cost > 0 && max_cost / min_cost >= AND_SKEW_RATIO
+}
+
+fn and_score_first_for(num_lists: usize, lead_cost: usize, second_cost: usize) -> bool {
+    num_lists >= 3 && second_cost >= lead_cost.saturating_mul(AND_SCORE_FIRST_COST_RATIO)
+}
+
+impl PostingIterator {
+    /// Copy remaining docs in the current decompressed block at or before
+    /// `window_max` without moving the cursor. Returns the absolute posting
+    /// index of the first copied doc.
+    fn peek_remaining_block_docs_upto(
+        &mut self,
+        window_max: u64,
+        docs: &mut Vec<u32>,
+        freqs: &mut Vec<u32>,
+    ) -> Option<usize> {
+        docs.clear();
+        freqs.clear();
+        let PostingList::Compressed(ref list) = self.list else {
+            return None;
+        };
+        let cur = self.current_doc?;
+        if cur.doc_id() > window_max {
+            return None;
+        }
+        let shift = list.block_shift();
+        let block_idx = self.index >> shift;
+        let block_offset = self.index & list.block_mask();
+        // SAFETY: `ensure_compressed_block_ptr` hands back a pointer into this
+        // iterator's own `UnsafeCell` compressed state for `block_idx`, which it
+        // guarantees is populated. We hold `&mut self`, and the reads below
+        // complete before the state is touched again, so no second reference to
+        // it is live across them. Same contract as the other call sites.
+        let compressed = unsafe { &mut *self.ensure_compressed_block_ptr(list, block_idx) };
+        for offset in block_offset..compressed.doc_ids.len() {
+            let doc_id = compressed.doc_ids[offset];
+            if u64::from(doc_id) > window_max {
+                break;
+            }
+            docs.push(doc_id);
+            freqs.push(compressed.freqs[offset]);
+        }
+        if docs.is_empty() {
+            None
+        } else {
+            Some((block_idx << shift) + block_offset)
+        }
+    }
+}
+
+impl<'a, S: Scorer, D: WandDocuments> Wand<'a, S, D> {
+    /// Seek `lead[from..to]` onto `doc`.
+    fn seek_lead_followers(&mut self, from: usize, to: usize, doc: u32) -> LeadFollowerSeek {
+        for posting in self.lead.iter_mut().take(to).skip(from) {
+            if posting
+                .doc()
+                .is_none_or(|cur| cur.doc_id() < u64::from(doc))
+            {
+                posting.next(u64::from(doc));
+            }
+            match posting.doc() {
+                None => return LeadFollowerSeek::Exhausted,
+                Some(cur) if cur.doc_id() > u64::from(doc) => {
+                    return LeadFollowerSeek::Leap(cur.doc_id());
+                }
+                Some(_) => {}
+            }
+        }
+        LeadFollowerSeek::Match
+    }
+
+    /// After the two rarest lists sit on `doc`, skip remaining dense
+    /// followers when even a conservative Exclusive upper cannot enter
+    /// the heap. `rest_block_max` is `lead[2..]` over the current window.
+    fn matched_pair_cannot_beat_floor(
+        &self,
+        lead_freq: u32,
+        doc_length: u32,
+        rest_block_max: f64,
+        num_lists: usize,
+    ) -> bool {
+        if self.threshold <= 0.0 || num_lists < 3 {
+            return false;
+        }
+        let Some(second) = self.lead.get(1).and_then(|posting| posting.doc()) else {
+            return false;
+        };
+        score_sum_cannot_compete(
+            self.lead[0].score(&self.scorer, lead_freq, doc_length),
+            f64::from(self.lead[1].score(&self.scorer, second.frequency(), doc_length))
+                + rest_block_max,
+            self.threshold,
+            score_sum_upper_bound_factor(num_lists),
+            CompetitiveFloorMode::Exclusive,
+        )
+    }
+
+    fn park_lead_at(&mut self, index: usize, doc: u32, freq: u32) {
+        self.lead[0].index = index;
+        if let PostingList::Compressed(ref list) = self.lead[0].list {
+            self.lead[0].block_idx = index >> list.block_shift();
+        }
+        self.lead[0].current_doc = Some(DocInfo::Raw(RawDocInfo {
+            doc_id: doc,
+            frequency: freq,
+        }));
+    }
+
+    /// Skewed conjunction: the rare lead's decompressed block is the buffer,
+    /// followers only `next(target)`. Scoring, phrase confirm, and heap
+    /// semantics match the classic loop.
+    pub(super) fn and_lead_stream_search(
+        &mut self,
+        params: &FtsSearchParams,
+        metrics: &dyn MetricsCollector,
+    ) -> Result<Vec<DocCandidate<D::Candidate>>> {
+        let limit = params.limit.unwrap_or(usize::MAX);
+        if limit == 0 {
+            return Ok(vec![]);
+        }
+        let phrase_slop = params.phrase_slop;
+        let num_lists = self.lead.len();
+        let mut freq_bound_lut = [f32::INFINITY; FREQ_LUT_BUCKETS];
+        for (freq, slot) in freq_bound_lut
+            .iter_mut()
+            .enumerate()
+            .take(FREQ_LUT_BUCKETS - 1)
+        {
+            *slot = self.lead[0].score(&self.scorer, freq as u32, 0);
+        }
+        // Every LUT entry is consumed as an upper bound for any document
+        // length, which only holds while the BM25 document weight is
+        // non-increasing in length. Lock that premise down here. Use `>=`:
+        // scorers that ignore document length (e.g. `UnitScorer`) tie.
+        #[cfg(debug_assertions)]
+        for freq in [1_usize, FREQ_LUT_BUCKETS / 2, FREQ_LUT_BUCKETS - 2] {
+            let upper = freq_bound_lut[freq];
+            for doc_length in [1_u32, 64, 4096] {
+                debug_assert!(
+                    upper >= self.lead[0].score(&self.scorer, freq as u32, doc_length),
+                    "freq LUT entry {freq} is not an upper bound at doc length {doc_length}"
+                );
+            }
+        }
+        freq_bound_lut[FREQ_LUT_BUCKETS - 1] =
+            self.lead[0].frequency_clamp_upper_bound(&self.scorer);
+
+        let score_first = and_score_first_for(
+            num_lists,
+            self.lead[0].cost(),
+            self.lead.get(1).map(|posting| posting.cost()).unwrap_or(0),
+        );
+
+        let mut candidates = TopKCollector::new(limit, std::cmp::min(limit, BLOCK_SIZE * 10));
+        let mut num_comparisons: usize = 0;
+        let mut lead_docs: Vec<u32> = Vec::with_capacity(MAX_POSTING_BLOCK_SIZE);
+        let mut lead_freqs: Vec<u32> = Vec::with_capacity(MAX_POSTING_BLOCK_SIZE);
+
+        let mut target: u64 = 0;
+        for posting in &self.lead {
+            match posting.doc() {
+                Some(doc) => target = target.max(doc.doc_id()),
+                None => return Ok(vec![]),
+            }
+        }
+
+        'window: loop {
+            self.raise_to_shared_floor(params.wand_factor);
+            self.lead[0].next(target);
+            let Some(lead_doc) = self.lead[0].doc() else {
+                break;
+            };
+            target = target.max(lead_doc.doc_id());
+            let win_end = Self::posting_block_up_to(&self.lead[0], target);
+
+            if self.threshold > 0.0 {
+                for posting in &mut self.lead {
+                    posting.shallow_next(target);
+                }
+                let wide_max = conservative_score_sum(self.lead.iter().map(|posting| {
+                    posting
+                        .block_max_score_up_to_with_stats(win_end, &self.scorer)
+                        .score
+                }));
+                if wide_max < self.threshold {
+                    if win_end == TERMINATED_DOC_ID {
+                        break;
+                    }
+                    target = win_end + 1;
+                    continue;
+                }
+            }
+
+            let Some(first_index) = self.lead[0].peek_remaining_block_docs_upto(
+                win_end,
+                &mut lead_docs,
+                &mut lead_freqs,
+            ) else {
+                if win_end == TERMINATED_DOC_ID {
+                    break;
+                }
+                target = win_end + 1;
+                continue;
+            };
+
+            // These bounds must be computed even when the floor is zero at
+            // window entry: the floor can become live part-way through the
+            // window, and `freq_cannot_beat` below consumes them as an upper
+            // bound. Skipping the computation would under-estimate that bound
+            // and prune documents that can still compete.
+            let others_bounds: SmallVec<[f64; 8]> = self.lead[1..]
+                .iter()
+                .map(|posting| {
+                    f64::from(
+                        posting
+                            .block_max_score_up_to_with_stats(win_end, &self.scorer)
+                            .score,
+                    )
+                })
+                .collect();
+            let others_block_max = others_bounds.iter().copied().sum::<f64>();
+            let rest_block_max = others_bounds.iter().skip(1).copied().sum::<f64>();
+            let freq_cannot_beat = if self.threshold > 0.0 && num_lists >= 2 {
+                std::array::from_fn(|frequency| {
+                    score_sum_cannot_compete(
+                        freq_bound_lut[frequency],
+                        others_block_max,
+                        self.threshold,
+                        score_sum_upper_bound_factor(num_lists),
+                        CompetitiveFloorMode::Exclusive,
+                    )
+                })
+            } else {
+                [false; FREQ_LUT_BUCKETS]
+            };
+
+            let mut pos = 0;
+            while pos < lead_docs.len() {
+                let doc = lead_docs[pos];
+                let freq = lead_freqs[pos];
+                let freq_bucket = (freq as usize).min(FREQ_LUT_BUCKETS - 1);
+                if freq_cannot_beat[freq_bucket] {
+                    pos += 1;
+                    continue;
+                }
+
+                self.park_lead_at(first_index + pos, doc, freq);
+                let Some(parked) = self.lead[0].doc() else {
+                    pos += 1;
+                    continue;
+                };
+                let Some(document_key) = self.documents.document_key(&parked) else {
+                    pos += 1;
+                    continue;
+                };
+                let doc_length = self.documents.doc_length(&parked);
+
+                if score_first
+                    && self.threshold > 0.0
+                    && score_sum_cannot_compete(
+                        self.lead[0].score(&self.scorer, freq, doc_length),
+                        others_block_max,
+                        self.threshold,
+                        score_sum_upper_bound_factor(num_lists),
+                        CompetitiveFloorMode::Exclusive,
+                    )
+                {
+                    pos += 1;
+                    continue;
+                }
+
+                let split_followers = num_lists >= 3 && self.threshold > 0.0;
+                let first_followers = if split_followers { 2 } else { num_lists };
+                match self.seek_lead_followers(1, first_followers, doc) {
+                    LeadFollowerSeek::Exhausted => break 'window,
+                    LeadFollowerSeek::Leap(next) => {
+                        pos = skip_lead_docs(&lead_docs, pos, next);
+                        if next > win_end {
+                            target = next;
+                            continue 'window;
+                        }
+                        continue;
+                    }
+                    LeadFollowerSeek::Match => {}
+                }
+
+                if self.matched_pair_cannot_beat_floor(freq, doc_length, rest_block_max, num_lists)
+                {
+                    pos += 1;
+                    continue;
+                }
+
+                if split_followers {
+                    match self.seek_lead_followers(2, num_lists, doc) {
+                        LeadFollowerSeek::Exhausted => break 'window,
+                        LeadFollowerSeek::Leap(next) => {
+                            pos = skip_lead_docs(&lead_docs, pos, next);
+                            if next > win_end {
+                                target = next;
+                                continue 'window;
+                            }
+                            continue;
+                        }
+                        LeadFollowerSeek::Match => {}
+                    }
+                }
+
+                let score = self.score_in_query_order(doc_length);
+                num_comparisons += 1;
+                if let Some(slop) = phrase_slop {
+                    if self.exclusive_score_cannot_beat_floor(score) {
+                        pos += 1;
+                        continue;
+                    }
+                    if !self.check_positions(slop as i32)? {
+                        pos += 1;
+                        continue;
+                    }
+                }
+
+                if candidates.insert(
+                    ScoredDoc::new(document_key, score),
+                    doc_length,
+                    u64::from(doc),
+                    self.iter_term_freqs(),
+                )? && let Some(kth) = candidates.kth_score_if_full()
+                {
+                    self.update_threshold(kth, params.wand_factor);
+                }
+                pos += 1;
+            }
+
+            if win_end == TERMINATED_DOC_ID {
+                break;
+            }
+            target = win_end + 1;
+        }
+
+        metrics.record_comparisons(num_comparisons);
+        candidates.into_candidates(|key| self.documents.candidate_from_key(key))
+    }
+}
+
+fn skip_lead_docs(lead_docs: &[u32], pos: usize, next: u64) -> usize {
+    let next32 = u32::try_from(next).unwrap_or(u32::MAX);
+    pos + lead_docs[pos + 1..].partition_point(|&id| id < next32) + 1
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        AND_SKEW_RATIO, and_score_first_for, conjunction_lists_are_skewed, skip_lead_docs,
+    };
+
+    #[test]
+    fn skew_gate_uses_integer_max_over_min() {
+        assert!(!conjunction_lists_are_skewed(0, 1_000_000));
+        assert!(!conjunction_lists_are_skewed(16, 16 * (AND_SKEW_RATIO - 1)));
+        assert!(conjunction_lists_are_skewed(16, 16 * AND_SKEW_RATIO));
+        assert!(conjunction_lists_are_skewed(1, AND_SKEW_RATIO));
+    }
+
+    #[test]
+    fn score_first_needs_three_clauses_and_a_3x_second() {
+        assert!(!and_score_first_for(2, 100, 10_000));
+        assert!(!and_score_first_for(3, 100, 299));
+        assert!(and_score_first_for(3, 100, 300));
+        assert!(and_score_first_for(6, 10, 30));
+    }
+
+    #[test]
+    fn skip_lead_docs_advances_to_the_first_id_at_or_after_next() {
+        let docs = [10, 20, 30, 40];
+        assert_eq!(skip_lead_docs(&docs, 0, 30), 2);
+        assert_eq!(skip_lead_docs(&docs, 0, 25), 2);
+        assert_eq!(skip_lead_docs(&docs, 1, 50), 4);
+    }
+}

--- a/rust/lance-index/src/scalar/inverted/wand_maxscore.rs
+++ b/rust/lance-index/src/scalar/inverted/wand_maxscore.rs
@@ -1,0 +1,683 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+//! Inner-window work for MAXSCORE: block skip, two-pointer optional freqs,
+//! and SoA completion for one essential plus at most two optionals.
+//!
+//! Lucene's `scoreInnerWindowSingleEssentialClause`. Two-essential compact
+//! union is intentionally not ported.
+
+use smallvec::SmallVec;
+
+use lance_core::Result;
+
+use super::super::builder::ScoredDoc;
+use super::super::scorer::{Scorer, bm25_doc_weight_with_norm};
+use super::{
+    CompetitiveFloorMode, DocInfo, MaxScoreClause, PostingIterator, PostingList, RawDocInfo,
+    TopKCollector, Wand, WandDocuments, score_sum_cannot_compete,
+};
+
+#[inline]
+pub(super) fn exclusive_cannot_compete(
+    partial: f32,
+    remaining_upper_bound: f64,
+    floor: f32,
+    upper_bound_factor: f64,
+) -> bool {
+    floor > 0.0
+        && score_sum_cannot_compete(
+            partial,
+            remaining_upper_bound,
+            floor,
+            upper_bound_factor,
+            CompetitiveFloorMode::Exclusive,
+        )
+}
+
+fn bm25_tf_from_caches(
+    query_weight: f32,
+    freq: u32,
+    doc: u32,
+    quantized: Option<(&[u8], &[f32; 256])>,
+) -> Option<f32> {
+    let (norms, cache) = quantized?;
+    Some(query_weight * bm25_doc_weight_with_norm(freq, cache[norms[doc as usize] as usize]))
+}
+
+fn bulk_bm25_tf(
+    query_weight: f32,
+    hits: &[(u64, u32)],
+    quantized: Option<(&[u8], &[f32; 256])>,
+    fallback: impl Fn(u64, u32) -> f32,
+    out: &mut Vec<f32>,
+) {
+    out.clear();
+    out.reserve(hits.len());
+    if let Some((norms, cache)) = quantized {
+        for &(doc, freq) in hits {
+            out.push(
+                query_weight * bm25_doc_weight_with_norm(freq, cache[norms[doc as usize] as usize]),
+            );
+        }
+        return;
+    }
+    for &(doc, freq) in hits {
+        out.push(fallback(doc, freq));
+    }
+}
+
+/// Lucene `DocAndScoreAccBuffer`: SoA vectors reused across essential blocks.
+pub(super) struct MaxScoreSoaScratch {
+    docs: Vec<u64>,
+    ess_scores: Vec<f32>,
+    ess_freqs: Vec<u32>,
+    raw_scores: Vec<f32>,
+    opt_scores: Vec<f32>,
+    opt_freqs: Vec<u32>,
+    opt_s: [Vec<f32>; 2],
+    opt_f: [Vec<u32>; 2],
+    partial: Vec<f32>,
+}
+
+impl MaxScoreSoaScratch {
+    pub(super) fn new() -> Self {
+        Self {
+            docs: Vec::with_capacity(128),
+            ess_scores: Vec::with_capacity(128),
+            ess_freqs: Vec::with_capacity(128),
+            raw_scores: Vec::with_capacity(128),
+            opt_scores: Vec::with_capacity(128),
+            opt_freqs: Vec::with_capacity(128),
+            opt_s: [Vec::with_capacity(128), Vec::with_capacity(128)],
+            opt_f: [Vec::with_capacity(128), Vec::with_capacity(128)],
+            partial: Vec::with_capacity(128),
+        }
+    }
+}
+
+impl PostingIterator {
+    /// Lucene `ScorerUtil.applyOptionalClause`: fill `out_freqs[i]` with this
+    /// clause's frequency at sorted `docs[i]`, or 0 on a miss.
+    pub(super) fn merge_optional_freqs(&mut self, docs: &[u64], out_freqs: &mut [u32]) {
+        debug_assert_eq!(docs.len(), out_freqs.len());
+        out_freqs.fill(0);
+        if docs.is_empty() {
+            return;
+        }
+        if self.doc().is_some_and(|cur| cur.doc_id() < docs[0]) {
+            self.next(docs[0]);
+        }
+        if matches!(self.list, PostingList::Plain(_)) {
+            for (i, &doc) in docs.iter().enumerate() {
+                if self.doc().is_some_and(|cur| cur.doc_id() < doc) {
+                    self.next(doc);
+                }
+                if let Some(cur) = self.doc()
+                    && cur.doc_id() == doc
+                {
+                    out_freqs[i] = cur.frequency();
+                }
+            }
+            return;
+        }
+        let shift = match &self.list {
+            PostingList::Compressed(list) => list.block_shift(),
+            PostingList::Plain(_) => return,
+        };
+        let length = match &self.list {
+            PostingList::Compressed(list) => list.length as usize,
+            PostingList::Plain(_) => return,
+        };
+        let mut i = 0usize;
+        while i < docs.len() {
+            let Some(cur) = self.current_doc else {
+                return;
+            };
+            let cur_id = cur.doc_id();
+            while i < docs.len() && docs[i] < cur_id {
+                i += 1;
+            }
+            if i >= docs.len() {
+                return;
+            }
+            if docs[i] > cur_id {
+                self.next(docs[i]);
+                continue;
+            }
+            let block_idx = self.index >> shift;
+            let mask = match &self.list {
+                PostingList::Compressed(list) => list.block_mask(),
+                PostingList::Plain(_) => return,
+            };
+            let (stay, end_of_block) = match &self.list {
+                PostingList::Compressed(list) => {
+                    let compressed = unsafe { &*self.ensure_compressed_block_ptr(list, block_idx) };
+                    let mut j = self.index & mask;
+                    let n = compressed.doc_ids.len();
+                    while i < docs.len() && j < n {
+                        let block_doc = u64::from(compressed.doc_ids[j]);
+                        if block_doc < docs[i] {
+                            j += 1;
+                        } else if block_doc == docs[i] {
+                            out_freqs[i] = compressed.freqs[j];
+                            i += 1;
+                            j += 1;
+                        } else {
+                            i += 1;
+                        }
+                    }
+                    let stay = (j < n).then(|| (compressed.doc_ids[j], compressed.freqs[j]));
+                    (stay, j)
+                }
+                PostingList::Plain(_) => return,
+            };
+            if let Some((doc_id, frequency)) = stay {
+                self.index = (block_idx << shift) + end_of_block;
+                self.block_idx = block_idx;
+                self.current_doc = Some(DocInfo::Raw(RawDocInfo { doc_id, frequency }));
+            } else {
+                let next_start = (block_idx + 1) << shift;
+                if next_start >= length {
+                    self.index = length;
+                    self.block_idx = self.index >> shift;
+                    self.current_doc = None;
+                } else {
+                    self.index = next_start;
+                    self.block_idx = block_idx + 1;
+                    let next_doc = match &self.list {
+                        PostingList::Compressed(list) => {
+                            let next =
+                                unsafe { &*self.ensure_compressed_block_ptr(list, block_idx + 1) };
+                            (next.doc_ids[0], next.freqs[0])
+                        }
+                        PostingList::Plain(_) => return,
+                    };
+                    self.current_doc = Some(DocInfo::Raw(RawDocInfo {
+                        doc_id: next_doc.0,
+                        frequency: next_doc.1,
+                    }));
+                }
+            }
+        }
+    }
+
+    /// Copy one decompressed posting block (or a 128-doc Plain slice) with
+    /// `doc_id <= window_max` into `out`. Leaves the cursor on the first doc
+    /// beyond that chunk.
+    pub(super) fn take_docs_one_block_upto(&mut self, window_max: u64, out: &mut Vec<(u64, u32)>) {
+        out.clear();
+        match self.list {
+            PostingList::Compressed(ref list) => {
+                let Some(cur) = self.current_doc else {
+                    return;
+                };
+                if cur.doc_id() > window_max {
+                    return;
+                }
+                let shift = list.block_shift();
+                let mask = list.block_mask();
+                let block_idx = self.index >> shift;
+                let block_offset = self.index & mask;
+                let compressed = unsafe { &mut *self.ensure_compressed_block_ptr(list, block_idx) };
+                for offset in block_offset..compressed.doc_ids.len() {
+                    let doc_id = compressed.doc_ids[offset];
+                    if u64::from(doc_id) > window_max {
+                        self.index = (block_idx << shift) + offset;
+                        self.block_idx = block_idx;
+                        self.current_doc = Some(DocInfo::Raw(RawDocInfo {
+                            doc_id,
+                            frequency: compressed.freqs[offset],
+                        }));
+                        return;
+                    }
+                    out.push((u64::from(doc_id), compressed.freqs[offset]));
+                }
+                let next_start = (block_idx + 1) << shift;
+                if next_start >= list.length as usize {
+                    self.index = list.length as usize;
+                    self.block_idx = self.index >> shift;
+                    self.current_doc = None;
+                    return;
+                }
+                self.index = next_start;
+                self.block_idx = block_idx + 1;
+                let compressed =
+                    unsafe { &mut *self.ensure_compressed_block_ptr(list, block_idx + 1) };
+                self.current_doc = Some(DocInfo::Raw(RawDocInfo {
+                    doc_id: compressed.doc_ids[0],
+                    frequency: compressed.freqs[0],
+                }));
+            }
+            PostingList::Plain(_) => {
+                while let Some(cur) = self.doc() {
+                    let doc = cur.doc_id();
+                    if doc > window_max {
+                        break;
+                    }
+                    out.push((doc, cur.frequency()));
+                    self.next(doc + 1);
+                    if out.len() >= 128 {
+                        break;
+                    }
+                }
+            }
+        }
+    }
+
+    /// Advance to the first doc of the next posting block, or exhaust.
+    pub(super) fn skip_current_block(&mut self) -> bool {
+        match self.next_block_first_doc() {
+            Some(doc) => {
+                self.next(doc);
+                self.current_doc.is_some()
+            }
+            None => {
+                if let PostingList::Compressed(ref list) = self.list {
+                    self.index = list.length as usize;
+                    self.block_idx = self.index >> list.block_shift();
+                }
+                self.current_doc = None;
+                false
+            }
+        }
+    }
+}
+
+impl<'a, S: Scorer, D: WandDocuments> Wand<'a, S, D> {
+    /// Skip dead essential blocks and complete surviving docs with at most
+    /// two optional clauses via SoA buffers.
+    #[allow(clippy::too_many_arguments)]
+    pub(super) fn score_single_essential_upto(
+        &mut self,
+        clauses: &mut [MaxScoreClause],
+        first_essential: usize,
+        ess_idx: usize,
+        upto: u64,
+        essential_query_rank: usize,
+        essential_term: u32,
+        essential_weight: f32,
+        essential_window_bound: f32,
+        num_query_terms: usize,
+        total_non_essential_bound: f64,
+        total_sum_upper_bound_factor: f64,
+        norm_k_ref: Option<(&[u8], &[f32; 256])>,
+        essential_chunk: &mut Vec<(u64, u32)>,
+        scratch: &mut MaxScoreSoaScratch,
+        candidates: &mut TopKCollector,
+        num_comparisons: &mut usize,
+        wand_factor: f32,
+    ) -> Result<()> {
+        loop {
+            // Lucene `nextPostings(upTo)`: do not advance past this call's
+            // exclusive end. After `take_docs` the cursor already sits on the
+            // first doc of the next block, which may belong to a later window
+            // whose optional remainder is larger.
+            if clauses[ess_idx]
+                .posting
+                .doc()
+                .is_none_or(|doc| doc.doc_id() > upto)
+            {
+                break;
+            }
+            if self.threshold > 0.0 {
+                let block_max = clauses[ess_idx].posting.block_max_score(&self.scorer);
+                if exclusive_cannot_compete(
+                    block_max,
+                    total_non_essential_bound,
+                    self.threshold,
+                    total_sum_upper_bound_factor,
+                ) {
+                    #[cfg(test)]
+                    {
+                        self.maxscore_essential_blocks_skipped += 1;
+                    }
+                    let more = clauses[ess_idx].posting.skip_current_block();
+                    if !more
+                        || clauses[ess_idx]
+                            .posting
+                            .doc()
+                            .is_none_or(|doc| doc.doc_id() > upto)
+                    {
+                        break;
+                    }
+                    continue;
+                }
+            }
+            clauses[ess_idx]
+                .posting
+                .take_docs_one_block_upto(upto, essential_chunk);
+            if essential_chunk.is_empty() {
+                break;
+            }
+            let (non_essential, _) = clauses.split_at_mut(first_essential);
+            self.complete_maxscore_single_essential(
+                essential_chunk,
+                non_essential,
+                essential_query_rank,
+                essential_term,
+                essential_weight,
+                essential_window_bound,
+                num_query_terms,
+                total_non_essential_bound,
+                total_sum_upper_bound_factor,
+                norm_k_ref,
+                scratch,
+                candidates,
+                num_comparisons,
+                wand_factor,
+            )?;
+        }
+        Ok(())
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn complete_maxscore_single_essential(
+        &mut self,
+        hits: &[(u64, u32)],
+        non_essential: &mut [MaxScoreClause],
+        essential_query_rank: usize,
+        essential_term: u32,
+        essential_weight: f32,
+        essential_window_bound: f32,
+        num_query_terms: usize,
+        total_non_essential_bound: f64,
+        total_sum_upper_bound_factor: f64,
+        norm_k_ref: Option<(&[u8], &[f32; 256])>,
+        scratch: &mut MaxScoreSoaScratch,
+        candidates: &mut TopKCollector,
+        num_comparisons: &mut usize,
+        wand_factor: f32,
+    ) -> Result<()> {
+        debug_assert!(non_essential.len() <= 2);
+        scratch.docs.clear();
+        scratch.ess_scores.clear();
+        scratch.ess_freqs.clear();
+        scratch.opt_scores.clear();
+        scratch.opt_freqs.clear();
+        bulk_bm25_tf(
+            essential_weight,
+            hits,
+            norm_k_ref,
+            |doc, freq| {
+                essential_weight
+                    * self
+                        .scorer
+                        .doc_weight(freq, self.documents.scoring_num_tokens(doc as u32))
+            },
+            &mut scratch.raw_scores,
+        );
+        for (hit, &score) in hits.iter().zip(scratch.raw_scores.iter()) {
+            *num_comparisons += 1;
+            if exclusive_cannot_compete(
+                score,
+                total_non_essential_bound,
+                self.threshold,
+                total_sum_upper_bound_factor,
+            ) {
+                continue;
+            }
+            scratch.docs.push(hit.0);
+            scratch.ess_scores.push(score);
+            scratch.ess_freqs.push(hit.1);
+        }
+        if scratch.docs.is_empty() {
+            return Ok(());
+        }
+
+        let mut opt_term = 0u32;
+        let mut opt_rank = 0usize;
+
+        if non_essential.len() == 1 {
+            let optional = &mut non_essential[0];
+            opt_term = optional.posting.term_index();
+            opt_rank = optional.query_rank;
+            let require_best = essential_window_bound.is_finite()
+                && essential_window_bound > 0.0
+                && exclusive_cannot_compete(
+                    essential_window_bound,
+                    0.0,
+                    self.threshold,
+                    total_sum_upper_bound_factor,
+                );
+            let query_weight = optional.posting.query_weight;
+            // With a single optional clause `total_non_essential_bound` is that
+            // clause's own `prefix_bound`, so the entry filter above already
+            // applied this predicate; re-running it here was a no-op pass.
+            scratch.opt_scores.clear();
+            scratch.opt_scores.resize(scratch.docs.len(), 0.0);
+            scratch.opt_freqs.clear();
+            scratch.opt_freqs.resize(scratch.docs.len(), 0);
+            let probe = &mut optional.posting;
+            probe.merge_optional_freqs(&scratch.docs, &mut scratch.opt_freqs);
+            let mut w = 0usize;
+            for r in 0..scratch.docs.len() {
+                let freq = scratch.opt_freqs[r];
+                if freq == 0 && require_best {
+                    continue;
+                }
+                let contribution = if freq == 0 {
+                    0.0
+                } else {
+                    bm25_tf_from_caches(query_weight, freq, scratch.docs[r] as u32, norm_k_ref)
+                        .unwrap_or_else(|| {
+                            probe.score(
+                                &self.scorer,
+                                freq,
+                                self.documents.scoring_num_tokens(scratch.docs[r] as u32),
+                            )
+                        })
+                };
+                scratch.docs[w] = scratch.docs[r];
+                scratch.ess_scores[w] = scratch.ess_scores[r];
+                scratch.ess_freqs[w] = scratch.ess_freqs[r];
+                scratch.opt_scores[w] = contribution;
+                scratch.opt_freqs[w] = freq;
+                w += 1;
+            }
+            scratch.docs.truncate(w);
+            scratch.ess_scores.truncate(w);
+            scratch.ess_freqs.truncate(w);
+            scratch.opt_scores.truncate(w);
+            scratch.opt_freqs.truncate(w);
+        } else if non_essential.len() == 2 {
+            let n_live = scratch.docs.len();
+            for slot in 0..2 {
+                scratch.opt_s[slot].clear();
+                scratch.opt_s[slot].resize(n_live, 0.0);
+                scratch.opt_f[slot].clear();
+                scratch.opt_f[slot].resize(n_live, 0);
+            }
+            scratch.partial.clear();
+            scratch.partial.extend_from_slice(&scratch.ess_scores);
+            let opt_term = [
+                non_essential[0].posting.term_index(),
+                non_essential[1].posting.term_index(),
+            ];
+            let opt_rank = [non_essential[0].query_rank, non_essential[1].query_rank];
+            let remaining_without_best = non_essential[0].prefix_bound;
+            let require_best = essential_window_bound.is_finite()
+                && essential_window_bound > 0.0
+                && remaining_without_best.is_finite()
+                && exclusive_cannot_compete(
+                    essential_window_bound,
+                    remaining_without_best,
+                    self.threshold,
+                    total_sum_upper_bound_factor,
+                );
+            let apply = [1usize, 0];
+            for (step, &idx) in apply.iter().enumerate() {
+                let required = require_best && step == 0;
+                let query_weight = non_essential[idx].posting.query_weight;
+                // Step 0 probes the second optional, whose `prefix_bound` is
+                // `total_non_essential_bound`; the entry filter already applied
+                // that predicate while `partial` still equalled the essential
+                // score, so re-filtering here would be a no-op pass.
+                if !required && step > 0 {
+                    let prefix_bound = non_essential[idx].prefix_bound;
+                    let mut w = 0usize;
+                    for r in 0..scratch.docs.len() {
+                        if exclusive_cannot_compete(
+                            scratch.partial[r],
+                            prefix_bound,
+                            self.threshold,
+                            total_sum_upper_bound_factor,
+                        ) {
+                            continue;
+                        }
+                        scratch.docs[w] = scratch.docs[r];
+                        scratch.ess_scores[w] = scratch.ess_scores[r];
+                        scratch.ess_freqs[w] = scratch.ess_freqs[r];
+                        scratch.opt_s[0][w] = scratch.opt_s[0][r];
+                        scratch.opt_s[1][w] = scratch.opt_s[1][r];
+                        scratch.opt_f[0][w] = scratch.opt_f[0][r];
+                        scratch.opt_f[1][w] = scratch.opt_f[1][r];
+                        scratch.partial[w] = scratch.partial[r];
+                        w += 1;
+                    }
+                    scratch.docs.truncate(w);
+                    scratch.ess_scores.truncate(w);
+                    scratch.ess_freqs.truncate(w);
+                    scratch.partial.truncate(w);
+                    scratch.opt_s[0].truncate(w);
+                    scratch.opt_s[1].truncate(w);
+                    scratch.opt_f[0].truncate(w);
+                    scratch.opt_f[1].truncate(w);
+                    if scratch.docs.is_empty() {
+                        return Ok(());
+                    }
+                }
+                let n = scratch.docs.len();
+                scratch.opt_f[idx].clear();
+                scratch.opt_f[idx].resize(n, 0);
+                let probe = &mut non_essential[idx].posting;
+                probe.merge_optional_freqs(&scratch.docs, &mut scratch.opt_f[idx]);
+                let mut w = 0usize;
+                for r in 0..n {
+                    let freq = scratch.opt_f[idx][r];
+                    if freq == 0 && required {
+                        continue;
+                    }
+                    let contribution = if freq == 0 {
+                        0.0
+                    } else {
+                        bm25_tf_from_caches(query_weight, freq, scratch.docs[r] as u32, norm_k_ref)
+                            .unwrap_or_else(|| {
+                                probe.score(
+                                    &self.scorer,
+                                    freq,
+                                    self.documents.scoring_num_tokens(scratch.docs[r] as u32),
+                                )
+                            })
+                    };
+                    scratch.docs[w] = scratch.docs[r];
+                    scratch.ess_scores[w] = scratch.ess_scores[r];
+                    scratch.ess_freqs[w] = scratch.ess_freqs[r];
+                    scratch.opt_s[0][w] = scratch.opt_s[0][r];
+                    scratch.opt_s[1][w] = scratch.opt_s[1][r];
+                    scratch.opt_f[0][w] = scratch.opt_f[0][r];
+                    scratch.opt_f[1][w] = scratch.opt_f[1][r];
+                    scratch.opt_s[idx][w] = contribution;
+                    scratch.opt_f[idx][w] = freq;
+                    scratch.partial[w] = scratch.partial[r] + contribution;
+                    w += 1;
+                }
+                scratch.docs.truncate(w);
+                scratch.ess_scores.truncate(w);
+                scratch.ess_freqs.truncate(w);
+                scratch.partial.truncate(w);
+                scratch.opt_s[0].truncate(w);
+                scratch.opt_s[1].truncate(w);
+                scratch.opt_f[0].truncate(w);
+                scratch.opt_f[1].truncate(w);
+                if scratch.docs.is_empty() {
+                    return Ok(());
+                }
+            }
+            for i in 0..scratch.docs.len() {
+                let mut by_rank = SmallVec::<[f32; 8]>::from_elem(0.0, num_query_terms);
+                by_rank[essential_query_rank] = scratch.ess_scores[i];
+                for (o, &rank) in opt_rank.iter().enumerate() {
+                    if scratch.opt_f[o][i] > 0 {
+                        by_rank[rank] = scratch.opt_s[o][i];
+                    }
+                }
+                let canonical = by_rank
+                    .into_iter()
+                    .fold(0.0_f32, |sum, contribution| sum + contribution);
+                if canonical <= self.threshold || candidates.rejects_score(canonical) {
+                    continue;
+                }
+                let Some(document_key) = self
+                    .documents
+                    .document_key_for_doc_id(scratch.docs[i] as u32)
+                else {
+                    continue;
+                };
+                let doc_length = self.documents.scoring_num_tokens(scratch.docs[i] as u32);
+                let mut freqs = SmallVec::<[(u32, u32); 3]>::new();
+                freqs.push((essential_term, scratch.ess_freqs[i]));
+                for (o, &term) in opt_term.iter().enumerate() {
+                    if scratch.opt_f[o][i] > 0 {
+                        freqs.push((term, scratch.opt_f[o][i]));
+                    }
+                }
+                if candidates.insert(
+                    ScoredDoc::new(document_key, canonical),
+                    doc_length,
+                    scratch.docs[i],
+                    freqs.into_iter(),
+                )? && let Some(kth) = candidates.kth_score_if_full()
+                {
+                    self.update_threshold(kth, wand_factor);
+                }
+            }
+            return Ok(());
+        }
+
+        for i in 0..scratch.docs.len() {
+            let opt_freq = if non_essential.len() == 1 {
+                scratch.opt_freqs.get(i).copied().unwrap_or(0)
+            } else {
+                0
+            };
+            let canonical = if non_essential.is_empty() {
+                scratch.ess_scores[i]
+            } else {
+                let mut by_rank = SmallVec::<[f32; 8]>::from_elem(0.0, num_query_terms);
+                by_rank[essential_query_rank] = scratch.ess_scores[i];
+                if opt_freq > 0 {
+                    by_rank[opt_rank] = scratch.opt_scores[i];
+                }
+                by_rank
+                    .into_iter()
+                    .fold(0.0_f32, |sum, contribution| sum + contribution)
+            };
+            if canonical <= self.threshold || candidates.rejects_score(canonical) {
+                continue;
+            }
+            let Some(document_key) = self
+                .documents
+                .document_key_for_doc_id(scratch.docs[i] as u32)
+            else {
+                continue;
+            };
+            let doc_length = self.documents.scoring_num_tokens(scratch.docs[i] as u32);
+            let mut freqs = SmallVec::<[(u32, u32); 2]>::new();
+            freqs.push((essential_term, scratch.ess_freqs[i]));
+            if opt_freq > 0 {
+                freqs.push((opt_term, opt_freq));
+            }
+            if candidates.insert(
+                ScoredDoc::new(document_key, canonical),
+                doc_length,
+                scratch.docs[i],
+                freqs.into_iter(),
+            )? && let Some(kth) = candidates.kth_score_if_full()
+            {
+                self.update_threshold(kth, wand_factor);
+            }
+        }
+        Ok(())
+    }
+}


### PR DESCRIPTION
## What this does

Under `BulkAndMode::Auto`, a skewed conjunction (costliest/cheapest clause ratio
at least `AND_SKEW_RATIO`) used to take the same N-way bulk path as a balanced
one. Bulk decompresses the dense clause's posting blocks in every window, so a
stopword paired with a rare term paid for the dense list in windows the rare
term barely touches.

This adds `rust/lance-index/src/scalar/inverted/wand_lead_stream.rs`, which walks
the conjunction from the rare clause:

- the rare clause's decompressed block is the buffer;
- dense followers only seek to it, instead of stepping every document;
- the aligned pair is confirmed first, and only then is the rest of the window
  scored.

Conjunctions of three or more skewed clauses take this path. A skewed pair keeps
classic leapfrog: with a single follower the buffer is pure overhead, the same
reason Lucene's `ConjunctionDISI` does not batch a pair. Balanced clauses and the
`On`/`Off` modes are unchanged.

The conjunction dispatch does not look at `params.phrase_slop`, so phrase queries
follow the same routing; phrase confirmation stays on the existing
score-then-positions path.

`LANCE_FTS_LEAD_STREAM=0` (process-wide, like `LANCE_FTS_MAXSCORE`) sends these
conjunctions back to classic leapfrog. It gates only the lead-stream branch, so
`On`/`Off` and balanced routing are unaffected, and results are identical either
way — only the cost differs.

## Measurements

Incremental, against the tip of the stack below (which already contains the two
phrase PRs and the MAXSCORE inner-window change). Wikipedia SBG 943-query set, A1
`TOP_10`, best of 10, 3 repetitions, one pinned core, time-weighted per shape:

  shape                  n     before      after    delta
  intersection         300   633191us   499397us   -21.1%
  phrase               300   851832us   759439us   -10.8%
  union                301   629435us   627748us    -0.3%
  intersection_union    40  1111378us  1124069us    +1.1%

Per-repetition spread was 0.7-1.9% for the baseline and 2.0-3.1% after, so both
target shapes move far outside the noise. Result counts are identical (943/943)
and the overall total improves 6.7%.

Two notes on the shape of this change.

Most of the intersection gain does not come from the new walk. The previous
dispatch sent every conjunction to bulk unconditionally, so a skewed query
already wins just by leaving bulk: with `LANCE_FTS_LEAD_STREAM=0` the same run
measures intersection -15.8% and phrase -10.2%. The lead-stream contributes the
last quarter of the intersection gain, and a smaller share of the phrase gain.
That comparison is also the evidence for the 32x threshold on real data — on the
skewed conjunctions this corpus contains, the flip is a further win, not a
regression.

`intersection_union` is +1.1% here and +2.3% with the switch off, so the
difference is inside the noise of those 40 queries (a dedicated five-repetition
run of them measured -0.12%). It is reported rather than dropped so it is not
read as supporting evidence either way.

## Validation

- `cargo test -p lance-index --lib`: 1557 passed, 0 failed.
- `cargo fmt --all --check` and
  `cargo clippy -p lance-index --all-targets -- -D warnings`: clean.
- New coverage:
  - `lead_stream_follower_leap_matches_classic` exercises the leap-and-discard
    branch (the only one that could silently drop or duplicate a document) and
    checks it against the classic walk.
  - `lead_stream_matches_classic_with_length_dependent_scorer` scores a
    BM25-shaped scorer over varied document lengths and frequencies with a full
    heap, so the frequency pruning actually decides something. Every other case
    in this area uses `UnitScorer` with unit frequencies, which makes that
    pruning a no-op.
  - `lead_stream_dispatch_follows_the_skew_ratio` walks the clause-cost ratio
    across the threshold (8/16/32/64/128 x 2/3/4 clauses) and checks both the
    routing decision and result equality with the classic walk.

## Stack

Depends on #9153 (skip phrase position decode when the BM25 score cannot enter
the heap), #9170 (decode exact-phrase positions from the rarest term first) and
the MAXSCORE inner-window PR (complete MaxScore inner windows with SoA and
top2-gap). This PR's diff currently contains all three; it reduces to this change
alone once they merge.

Stack, 4/4: #9153 -> #9170 -> #<maxscore> -> **this PR**. Base: #<maxscore>.
Merge in stack order; retarget/restack the remaining PRs after their parent merges.