### PR TITLE
feat: fragment metadata trees behind the tree manifest layout

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5100,6 +5100,7 @@ dependencies = [
  "lance-arrow",
  "lance-core",
  "lance-datagen",
+ "lance-encoding",
  "lance-file",
  "lance-io",
  "lance-select",

--- a/docs/src/format/table/.pages
+++ b/docs/src/format/table/.pages
@@ -7,4 +7,5 @@ nav:
   - Branch & Tag: branch_tag.md
   - Row ID & Lineage: row_id_lineage.md
   - Data Overlay Files: data_overlay_file.md
+  - Fragment Metadata Tree: fragment_metadata.md
   - MemTable & WAL: mem_wal.md

--- a/docs/src/format/table/fragment_metadata.md
+++ b/docs/src/format/table/fragment_metadata.md
@@ -4,7 +4,8 @@
 
     This layout is unstable. Readers and writers may change it without
     keeping compatibility with earlier unstable revisions. Flat manifests
-    remain the default.
+    remain the default. Use disposable datasets. Do not keep tree tables
+    you cannot rebuild.
 
 **This page specifies a proposed on-disk format for storing fragment state.
 Support for creating or reading tree tables is not yet available in released

--- a/docs/src/format/table/fragment_metadata.md
+++ b/docs/src/format/table/fragment_metadata.md
@@ -1,0 +1,409 @@
+# Fragment Metadata Tree
+
+!!! warning "Experimental"
+
+    This layout is unstable. Readers and writers may change it without
+    keeping compatibility with earlier unstable revisions. Flat manifests
+    remain the default.
+
+**This page specifies a proposed on-disk format for storing fragment state.
+Support for creating or reading tree tables is not yet available in released
+Lance versions.**
+
+!!! note "Tree tables require feature flag 512, `FLAG_FRAGMENT_METADATA`"
+
+    A reader or writer that does not understand this layout must refuse the
+    dataset. The flat `fragments` list is empty on a tree table, so a reader
+    that ignored the flag would see an empty table.
+
+In the flat format, each Version Manifest carries the complete fragment list.
+Committing a change and opening a dataset both process that whole list, even
+when the change touches only a few fragments.
+
+The fragment metadata tree stores those records in immutable Lance leaves
+keyed by fragment ID. Validated changes may remain above the leaves as
+mutations until enough work accumulates to rewrite them.
+
+The Version Manifest defines table-version state. Committing it makes that
+version visible.
+
+![Fragment metadata tree](fragment_metadata_tree.svg)
+
+*A shallow tree is shown. Larger trees may insert interior routing nodes between
+the root and leaves.*
+
+### At a glance
+
+| | |
+|---|---|
+| Read | Read the leaf record, if any, then apply newer mutations for that fragment. |
+| Write | Native Lance validates the change. The tree stores the resulting mutation. |
+| Publish | Write immutable tree objects first, then commit the Version Manifest. |
+
+Protobuf messages are in `protos/table.proto`. Operation semantics, conflict
+rules, and native validation stay with [transactions](transaction.md). A
+storage action is the result of a successful native transaction.
+
+Readers must treat a violation of any requirement on this page as a corrupt
+snapshot.
+
+## Snapshot
+
+A tree table must set `Manifest.fragment_metadata`, leave `Manifest.fragments`
+empty, and set flag 512 in both `reader_feature_flags` and
+`writer_feature_flags`. These fields must agree. When `FLAG_FRAGMENT_METADATA`
+is set, `FragmentMetadata.layout` must select exactly one recognized layout.
+
+A `FragmentMetadataTree` must contain exactly one of an inline root or a
+`root_path`.
+
+An inline root carries the complete `FragmentMetadataRoot` in the Version
+Manifest. `mutations_since_root` must be empty.
+
+An external root named by `root_path` belongs to the current dataset.
+`mutations_since_root` contains every mutation in this version that is not
+represented by that root. Readers must not follow a mutation chain.
+
+```
+Version Manifest N
+├─ root_path ──────────► Root R
+└─ mutations_since_root
+
+fragment state N = Root R + mutations_since_root
+```
+
+Opening a version requires its Version Manifest and at most one external root.
+Version history is not consulted.
+
+`buffer` on a root or interior holds mutations already in the tree that have
+not been pushed to that node's children.
+
+## Tree objects
+
+Tree objects are immutable and stored under `_bt/` relative to a dataset root.
+Tree object paths must begin with `_bt/`. Readers must reject absolute paths
+and paths outside `_bt/`.
+
+```
+{dataset_root}/
+    _bt/
+        root/{uuid}.root     FragmentMetadataRoot protobuf
+        node/{uuid}.node     FragmentMetadataNode protobuf
+        leaf/{uuid}.lance    Lance file of complete fragment records
+```
+
+A `.root` file is a raw `FragmentMetadataRoot` protobuf. A `.node` file is a
+raw `FragmentMetadataNode` protobuf. Neither has an extra header or footer.
+
+`FragmentMetadataRoot` holds its children, buffer, and `next_action_sequence`.
+
+`FragmentMetadataNode` holds the child list and a mutation buffer for that
+subtree.
+
+Child `path` values must be non-empty. Resolved child locations within a child
+list must be unique.
+
+A leaf is a Lance file of complete fragment records for one fragment-ID range.
+
+## Object references
+
+The Version Manifest root belongs to the current dataset. It is either an
+inline `FragmentMetadataRoot` or a `root_path` in the current dataset.
+
+A `FragmentMetadataChild` contains a `path` relative to its resolved dataset
+and an optional `base_id`.
+
+When `base_id` is set, it must identify a `BasePath` in the Version Manifest
+with `is_dataset_root` set to true. When `base_id` is absent, the reference
+inherits the resolved dataset of the containing tree object.
+
+A child object resolves to `{resolved_dataset}/{path}`. Tree object paths must
+begin with `_bt/` and must not be resolved under `data/`.
+
+A reference with `base_id` set may name an immutable tree object in another
+dataset. Descendant references with no `base_id` inherit that object's resolved
+dataset.
+
+New tree objects must belong to the current dataset. Tree objects owned by
+another dataset must not be modified.
+
+A shallow clone's root must belong to the clone dataset. Unchanged source
+subtrees may be referenced through `base_id`. The clone's `base_paths` must
+contain a `BasePath` for the source dataset root and preserve every `BasePath`
+entry referenced by a shared tree object at the same id. New base paths must
+use previously unused ids.
+
+When a tree object is copied into another dataset, references that inherited
+the source dataset must be rewritten with a `base_id` naming that dataset.
+Existing explicit `base_id` values must continue to resolve to the same
+`BasePath` entries.
+
+An `ExternalFile` embedded in `DataFragment` has no `base_id`. Its path is
+relative to the resolved dataset of the tree object or Version Manifest that
+contains the fragment state.
+
+When fragment state is written to a different dataset, each referenced
+`ExternalFile` must be copied to that dataset and its path rewritten before
+publication. The write must fail if any such reference cannot be preserved.
+
+## Leaf format
+
+A leaf is a Lance file with this schema. The tree does not require a specific
+Lance file version.
+
+```python
+import pyarrow as pa
+
+leaf_schema = pa.schema([
+    pa.field("row_kind", pa.uint8(), nullable=False),
+    pa.field("frag_id", pa.uint64(), nullable=False),
+    pa.field("fragment_meta", pa.binary(), nullable=True),
+    pa.field("path", pa.utf8(), nullable=False),
+    pa.field("field_ids", pa.list_(pa.field("item", pa.int32(), nullable=False)), nullable=False),
+    pa.field("column_indices", pa.list_(pa.field("item", pa.int32(), nullable=False)), nullable=False),
+    pa.field("major_version", pa.uint32(), nullable=False),
+    pa.field("minor_version", pa.uint32(), nullable=False),
+    pa.field("file_size_bytes", pa.uint64(), nullable=False),
+    pa.field("base_id", pa.uint32(), nullable=True),
+])
+```
+
+The schema must match exactly. Readers must reject different fields, types, or
+nullability. Non-nullable columns and list elements must not hold nulls.
+
+`row_kind` is 0 for a FRAGMENT row and 1 for a DATA_FILE row. Readers must
+reject an unknown `row_kind`.
+
+Rows are grouped by fragment. A group is one FRAGMENT row followed by its
+DATA_FILE rows, in file order. Every row in the group must carry that
+`frag_id`. The FRAGMENT row's `frag_id` must equal the `id` inside
+`fragment_meta`. A fragment with no files is a group of one FRAGMENT row.
+Groups must be ordered by strictly increasing `frag_id`. A fragment must not
+be split across leaves. `frag_id` is stored as `uint64`. Valid fragment IDs
+fit in `u32`.
+
+A FRAGMENT row carries `fragment_meta`, the `DataFragment` protobuf with
+`files` cleared. Its remaining columns are sentinels: empty `path`, empty
+`field_ids` and `column_indices`, version and size 0, and a null `base_id`.
+A DATA_FILE row carries one `DataFile` across those columns and a null
+`fragment_meta`. `file_size_bytes` of 0 means unknown. A null `base_id`
+inherits the leaf object's resolved dataset. A set `base_id` indexes this
+Version Manifest's `base_paths`. The same rule applies to deletion files,
+overlays, and other fragment-owned files.
+
+A null `base_id` in a buffered mutation inherits the resolved dataset of the
+structure containing that mutation.
+
+Counts in a leaf are known. `physical_rows` of 0 is zero rows. A deletion file
+must carry `num_deleted_rows`, which must not exceed `physical_rows`.
+
+After decoding a leaf, readers must verify the following fields against its
+parent `FragmentMetadataChild`:
+
+- `num_keys` equals the number of fragment groups
+- `total_rows` and `visible_rows` equal the counts recomputed from the
+  fragment records
+- `height` is 0
+- `num_children` is 0
+
+`min_key` is an inherited routing bound. `object_size` is the stored byte
+length of the fetched object. `materialized_through_action_sequence` is stored
+on the child reference. Readers must validate those fields by the rules in
+Routing and Sequence numbers, not by recomputing them from the leaf file.
+
+## Routing
+
+A root may have zero or more children. With no children, mutations may remain
+in the root `buffer` or `FragmentMetadataTree.mutations_since_root`. Fragment
+resolution must not descend to a leaf. Once children exist, they route
+fragment IDs as follows.
+
+Interior nodes must have at least two children. The root may have zero, one,
+or more.
+
+Children are ordered by `min_key`. A child's `min_key` is the inclusive lower
+bound of its range. The next child's `min_key` is the exclusive upper bound.
+The first child of the root must have `min_key` 0. An interior node's first
+child must begin at the lower bound assigned by its parent. Together, the
+children must partition the parent range. Routing a key selects the
+rightmost child whose `min_key` is at most that key.
+
+Ranges must not overlap. Each mutation buffered by an interior must belong to
+exactly one child range. The same rule applies to a root once it has children.
+
+`height` is the number of edges from the referenced object to its leaves.
+Leaves have height 0. Every child of an interior must have height one less
+than that interior, so all leaves in a subtree occur at the same depth.
+
+A leaf must contain at least one fragment record and have `num_children` 0.
+Writers must not retain an empty child.
+
+`num_children` is the number of direct children in the referenced object. It
+is 0 for leaves and at least 2 for interiors. After an interior is decoded,
+readers must verify that this value equals `children.len()`.
+
+`num_keys` is the number of fragment records in the referenced subtree,
+including that object's own buffer. Mutations held by ancestors are excluded.
+After a leaf is decoded, it must equal the number of fragment groups. After an
+interior is decoded, it must equal the sum of the children's `num_keys` plus
+the buffer `fragment_count_delta`s.
+
+`total_rows` is the physical-row count in that subtree, including deleted
+rows. `visible_rows` is that count minus deleted rows. Both include that
+object's own buffer and exclude ancestor mutations. `visible_rows` must not
+exceed `total_rows`. After a leaf is decoded, both must equal the counts
+recomputed from fragment records. After an interior is decoded, both must
+equal the sum of the children's values plus the corresponding buffer deltas.
+
+`object_size` is the stored byte length of the child object. It must be
+nonzero. It is known before the child is fetched and must equal the fetched
+object's byte length.
+
+A child's inherited range is `min_key` inclusive to the next sibling's
+`min_key` exclusive. The last child of the root uses `2^32` as that exclusive
+end. The last child of an interior uses the exclusive end assigned by its
+parent. `min_key` must be at most `2^32 - 1`.
+
+Every fragment ID decoded from a leaf must lie in that leaf's inherited
+range. Every mutation target decoded from a root or interior buffer must lie
+in that node's inherited range. Every descendant child range must be contained
+in its parent's range. Readers apply these checks as objects are decoded. The
+checks do not require opening the rest of the tree.
+
+## Mutations
+
+`FragmentMetadataMutation` wraps one `FragmentAction` with a sequence number
+and three count deltas. Every mutation must contain an action. The action must
+select exactly one recognized variant, and any message payload required by
+that variant must be present.
+
+`fragment_count_delta` is 1 when the action creates a record, minus 1 when it
+removes one, and 0 otherwise. `total_rows_delta` and `visible_rows_delta` are
+the record after the action minus the record before it. An absent record
+counts as zero.
+
+When the prior fragment is available, readers must recompute the mutation
+deltas and verify that they match the stored values. Ancestor summaries are
+maintained from these deltas. After materialization, readers must recompute
+leaf summaries from records. Writers must not publish a materialization whose
+recomputed summaries disagree with the derived version totals.
+
+File and deletion-file actions must leave all other `DataFragment` fields
+unchanged. Changes to overlays, row-ID state, lineage, or other
+fragment-level metadata must use `add_fragment`.
+
+Removal actions are idempotent. Removing an absent fragment, file, or deletion
+file is a no-op where specified below. Actions that modify an existing
+fragment require that fragment to exist.
+
+| Action | Precondition | Effect |
+|---|---|---|
+| `add_fragment` | None | Install the complete record, replacing anything at that id |
+| `remove_fragment` | None | Remove the record at that id. An absent id is a no-op |
+| `add_data_file` | Record present, else reject | Append the file to the end of the ordered file list |
+| `remove_data_file` | Record present, else reject | Remove every file whose path matches, keeping survivor order. No match is a no-op |
+| `add_deletion_file` | Record present, else reject | Set the deletion file, replacing any existing one |
+| `clear_deletion_file` | Record present, else reject | Clear the deletion file. No deletion file is a no-op |
+| `replace_data_file` | Record present and a file whose path equals `expected_path`, else reject | On the first such file set `path`, `file_size_bytes`, and `base_id`. Keep its field ids, column indices, and file version |
+
+`Fragment.files` is an ordered list and paths may repeat. `replace_data_file`
+edits a slot, not a path. Writers must not fold two replacements that chain
+through a renamed path into one. Starting from files `[A, B]`, renaming B to
+A and then replacing the first A with C yields `[C, A]`. Folding them into
+one replacement of B with C yields `[A, C]`.
+
+To resolve a fragment, collect every mutation for its id from
+`mutations_since_root`, the root buffer, and each interior buffer on its
+routing path. Sort by sequence and apply in order to the leaf record, or to
+nothing if there is no leaf or the leaf has no record.
+
+Version fragment count, physical-row count, and visible-row count are derived
+from the root child summaries plus the root buffer deltas, then plus the
+`mutations_since_root` deltas. They are not stored on `FragmentMetadataTree`.
+Derived `visible_rows` must not exceed derived `total_rows`.
+
+## Sequence numbers
+
+Mutation sequences must be nonzero and unique.
+Each tree has one sequence namespace. Writers must not reuse a sequence number
+anywhere in the tree.
+
+- `FragmentMetadataRoot.next_action_sequence` is at least 1. Every sequence in
+  the root buffer, in every interior buffer below it, and every leaf watermark
+  below it must be less than this value.
+- `FragmentMetadataTree.next_action_sequence` is at least the root's value.
+  Every `mutations_since_root` sequence must be at or above the root's value
+  and below `FragmentMetadataTree.next_action_sequence`.
+- A leaf watermark of 0 means the leaf has applied nothing, so every mutation
+  routed to it replays.
+
+Readers must verify uniqueness across every mutation source decoded for the
+operation. Uniqueness across unread subtrees is a writer invariant.
+
+`materialized_through_action_sequence` records how far a leaf has been
+materialized. It is not part of the leaf contents. The same leaf may
+therefore be referenced with different watermarks. It must be 0 on an
+interior child.
+
+A leaf watermark `N` means every mutation for that leaf's range with a
+sequence at or below `N` has been incorporated into the leaf's records, with
+no holes, and no buffer above the leaf holds a mutation for its range with a
+sequence at or below `N`. Readers must reject a collected mutation whose
+sequence is at or below the owning leaf's
+`materialized_through_action_sequence`.
+
+## Fragment IDs
+
+`Manifest.max_fragment_id` is authoritative for fragment ID allocation. The
+tree has no separate allocator.
+
+`max_fragment_id` is absent only when no fragment ID has ever been allocated or
+reserved in the lineage. It must not decrease. Deletion does not make fragment
+IDs reusable, and restore must not lower the value.
+
+The first allocated fragment ID is 0. Otherwise, allocation uses
+`max_fragment_id + 1`. `ReserveFragments` advances the value. A value of
+`2^32 - 1` exhausts the fragment-ID space.
+
+Every fragment ID stored or targeted by the tree must be at most
+`Manifest.max_fragment_id`. If `max_fragment_id` is absent, the tree must
+contain no fragment records or fragment-targeting mutations.
+
+## Validation
+
+Readers must validate every structure they decode before using it. They must
+not treat a corrupt snapshot as empty.
+
+| Object | Additional checks |
+|---|---|
+| Manifest | Feature flags set, `fragments` empty, `fragment_metadata` present, layout selected |
+| `FragmentMetadataTree` | Exactly one root representation, sequence range valid, tree object references valid, no target above `max_fragment_id` |
+| Root | Children and buffer valid, derived visible rows at most derived total rows |
+| Node / leaf | Fetched byte length equals parent `object_size`. Shape and aggregate fields that can be recomputed from the object agree with the parent child reference. Routing bounds and the leaf watermark follow Routing and Sequence numbers. |
+
+## Publication and cleanup
+
+Every tree object reachable from a Version Manifest must be durable before that
+manifest is committed. The manifest commit is the visibility boundary.
+
+A failed attempt leaves unreachable objects that are eligible for cleanup.
+
+Whether to inline the root or publish a new external root is writer policy and
+may change between versions.
+
+Unchanged immutable subtrees may be reused. New tree objects must belong to
+the current dataset. Reused references must preserve their resolved dataset.
+
+Cleanup computes reachability from the fragment state of every
+retained manifest, applying buffers and `mutations_since_root`. The reachable
+set is the `root_path` if any, every `.node` and `.lance` reachable from that
+root after resolving child references, and every data file, deletion file, and
+related object that state names.
+A file named only by a pending mutation is reachable through that resolved
+state. A file named only by a mutation that a later mutation in the same
+snapshot supersedes is not. Objects under this dataset's `_bt/` outside the
+set follow the same age and in-progress rules as data files.
+
+An object reachable from any retained manifest of this dataset must not be
+removed. Tree object lifetime across datasets follows the same contract as
+data files named through `base_paths`.

--- a/docs/src/format/table/fragment_metadata_tree.svg
+++ b/docs/src/format/table/fragment_metadata_tree.svg
@@ -1,0 +1,67 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 420" role="img" aria-labelledby="title desc">
+  <title id="title">Fragment metadata tree</title>
+  <desc id="desc">A Version Manifest holds mutations_since_root and points at an external root. The root holds a buffer and routes fragment-id ranges to Lance leaves. Interior nodes may sit between the root and leaves.</desc>
+  <defs>
+    <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto">
+      <path class="arrowhead" d="M 0 1 L 10 5 L 0 9 Z"/>
+    </marker>
+  </defs>
+  <style>
+    text { font-family: Helvetica, Arial, sans-serif; fill: #172a38; }
+    .rail { font-size: 12px; font-weight: 700; fill: #526575; }
+    .title { font-size: 16px; font-weight: 700; }
+    .sub { font-size: 13px; }
+    .box { stroke: #afbcc7; stroke-width: 1.2; }
+    .arrowhead { fill: #526575; }
+    .line { stroke: #526575; stroke-width: 1.5; }
+    .manifest { fill: #deeef8; }
+    .mutation { fill: #fff0d5; }
+    .root { fill: #f5f8fa; }
+    .leaf { fill: #e3f2ea; }
+
+    @media (prefers-color-scheme: dark) {
+      text { fill: #e8eef4; }
+      .rail { fill: #9bb0c2; }
+      .box { stroke: #6c8ebf; }
+      .arrowhead { fill: #9bb0c2; }
+      .line { stroke: #9bb0c2; }
+      .manifest { fill: #1d293b; }
+      .mutation { fill: #3d3420; }
+      .root { fill: #1a222c; }
+      .leaf { fill: #1f2f1e; }
+    }
+  </style>
+
+  <text class="rail" x="16" y="48">VERSION</text>
+  <text class="rail" x="16" y="64">MANIFEST</text>
+  <rect class="box manifest" x="140" y="16" width="420" height="118" rx="6"/>
+  <text class="title" x="156" y="42">Version Manifest</text>
+  <text class="sub" x="156" y="62">snapshot authority, schema, version</text>
+  <rect class="box mutation" x="156" y="74" width="388" height="48" rx="5"/>
+  <text class="title" x="172" y="94">mutations_since_root</text>
+  <text class="sub" x="172" y="112">not in the referenced root yet</text>
+
+  <line class="line" x1="350" y1="134" x2="350" y2="168" marker-end="url(#arrow)"/>
+  <text class="sub" x="362" y="156">root_path</text>
+
+  <text class="rail" x="16" y="210">EXTERNAL</text>
+  <text class="rail" x="16" y="226">ROOT</text>
+  <rect class="box root" x="140" y="172" width="420" height="118" rx="6"/>
+  <text class="title" x="156" y="198">Root R</text>
+  <text class="sub" x="156" y="218">child ranges</text>
+  <rect class="box mutation" x="156" y="230" width="388" height="48" rx="5"/>
+  <text class="title" x="172" y="250">buffer</text>
+  <text class="sub" x="172" y="268">in the tree, not in children or leaves yet</text>
+
+  <line class="line" x1="250" y1="290" x2="210" y2="332" marker-end="url(#arrow)"/>
+  <line class="line" x1="450" y1="290" x2="490" y2="332" marker-end="url(#arrow)"/>
+  <text class="sub" x="292" y="318">fragment-id ranges</text>
+
+  <text class="rail" x="16" y="372">LEAVES</text>
+  <rect class="box leaf" x="80" y="336" width="200" height="72" rx="6"/>
+  <text class="title" x="96" y="364">Lance leaf</text>
+  <text class="sub" x="96" y="386">fragments 0..999</text>
+  <rect class="box leaf" x="360" y="336" width="200" height="72" rx="6"/>
+  <text class="title" x="376" y="364">Lance leaf</text>
+  <text class="sub" x="376" y="386">fragments 1000..1999</text>
+</svg>

--- a/docs/src/format/table/layout.md
+++ b/docs/src/format/table/layout.md
@@ -35,6 +35,8 @@ A Lance dataset in its basic form stores all files within the dataset root direc
             *.json        -- Tag metadata
         branches/
             *.json        -- Branch metadata
+    _bt/
+        ...               -- fragment metadata tree objects (see Fragment Metadata Tree)
     tree/
         {branch_name}/
             ...           -- Branch dataset
@@ -71,6 +73,8 @@ Three types of files can specify alternative base paths: data files, deletion fi
 Each of these file types includes an optional `base_id` field in their metadata that references a base path entry by its numeric identifier.
 When a file's `base_id` is absent, the file is located relative to the dataset root.
 When a file's `base_id` is present, readers must look up the corresponding base path entry in the manifest's `base_paths` array to determine where the file is stored.
+
+Tree children and fragment files stored in the tree also carry optional `base_id`. Resolution is specified in [Fragment Metadata Tree](fragment_metadata.md#object-references).
 
 At read time, path resolution follows a two-step process.
 First, the reader determines the base path: if `base_id` is absent, the base path is the dataset root; otherwise, the reader looks up the base path entry using the `base_id` to obtain the path and its `is_dataset_root` flag.

--- a/docs/src/format/table/versioning.md
+++ b/docs/src/format/table/versioning.md
@@ -31,7 +31,8 @@ they should return an "unsupported" error on any read or write operation.
 | 32       | `FLAG_DISABLE_TRANSACTION_FILE` | No              | Yes             | Transactions are recorded in the manifest rather than in a separate transaction file.                       |
 | 64       | `FLAG_UNSTABLE_DATA_OVERLAY_FILES` | Yes          | Yes             | Fragments may carry data overlay files. Unstable: release builds reject it unless explicitly opted in.      |
 | 128      | `FLAG_COVERED_INDEX_METADATA`   | Yes             | Yes             | Some index declares covering columns (`IndexMetadata.covering_fields`), so `fields` means keyed columns followed by carried ones. An implementation without this flag selects an index by membership of `fields` and would answer a query on a merely-carried column with an index keyed on a different one. |
+| 512      | `FLAG_FRAGMENT_METADATA`        | Yes             | Yes             | Fragment records live in a [fragment metadata tree](fragment_metadata.md). `Manifest.fragments` is empty. |
 
 </div>
 
-Flags with bit values 256 and above are unknown and will cause implementations to reject the dataset with an "unsupported" error.
+Flags with bit values not listed above are unknown and will cause implementations to reject the dataset with an "unsupported" error.

--- a/java/lance-jni/Cargo.lock
+++ b/java/lance-jni/Cargo.lock
@@ -4391,6 +4391,7 @@ dependencies = [
  "futures",
  "lance-arrow",
  "lance-core",
+ "lance-encoding",
  "lance-file",
  "lance-io",
  "lance-select",

--- a/protos/table.proto
+++ b/protos/table.proto
@@ -32,6 +32,135 @@ message UUID {
   bytes uuid = 1;
 }
 
+// fragment metadata layout for this version.
+message FragmentMetadata {
+  oneof layout {
+    FragmentMetadataTree tree = 1;
+  }
+}
+
+// fragment state for one Version Manifest.
+message FragmentMetadataTree {
+  oneof root {
+    FragmentMetadataRoot inline_root = 1;
+    // External root path relative to this dataset.
+    string root_path = 2;
+  }
+
+  // Mutations not represented by the selected root.
+  repeated FragmentMetadataMutation mutations_since_root = 3;
+
+  // Next unused action sequence for this version.
+  uint64 next_action_sequence = 4;
+}
+
+// Inline or external root state.
+message FragmentMetadataRoot {
+  repeated FragmentMetadataChild children = 1;
+  repeated FragmentMetadataMutation buffer = 2;
+
+  // First action sequence not represented by this root.
+  uint64 next_action_sequence = 3;
+}
+
+/* Children are ordered by min_key. A child owns [min_key, next min_key);
+ * the last child inherits its parent's upper bound.
+ */
+message FragmentMetadataChild {
+  // Tree object path relative to its resolved dataset.
+  string path = 1;
+
+  // Absent inherits the containing object's dataset. Otherwise indexes Manifest.base_paths.
+  optional uint32 base_id = 2;
+
+  // Inclusive lower bound of this child's range.
+  uint64 min_key = 3;
+
+  // Fragment count in this subtree, including this object's buffer.
+  uint64 num_keys = 4;
+
+  // Edges from this object to its leaves. Zero for a leaf.
+  uint32 height = 5;
+
+  // Direct child count. Zero for a leaf.
+  uint32 num_children = 6;
+
+  // Physical rows in this subtree, including this object's buffer.
+  uint64 total_rows = 7;
+
+  // Stored byte length of the child object.
+  uint64 object_size = 8;
+
+  /* Every mutation for this leaf's range at or below this value has been
+   * applied, and none remain buffered above it. Zero means none. Must be 0
+   * for interiors.
+   */
+  uint64 materialized_through_action_sequence = 9;
+
+  // Visible rows in this subtree, including this object's buffer.
+  uint64 visible_rows = 10;
+}
+
+// Interior routing node.
+message FragmentMetadataNode {
+  repeated FragmentMetadataChild children = 1;
+  repeated FragmentMetadataMutation buffer = 2;
+}
+
+// Validated mutation with exact after-minus-before aggregate deltas.
+message FragmentMetadataMutation {
+  uint64 action_sequence = 1;
+  FragmentAction action = 2;
+  sint64 fragment_count_delta = 3;
+  sint64 total_rows_delta = 4;
+  sint64 visible_rows_delta = 5;
+}
+
+// Use add_fragment when no other action can represent the result.
+message FragmentAction {
+  oneof action {
+    DataFragment add_fragment = 1;
+    uint64 remove_fragment = 2;
+    AddDataFile add_data_file = 3;
+    RemoveDataFile remove_data_file = 4;
+    AddDeletionFile add_deletion_file = 5;
+    ClearDeletionFile clear_deletion_file = 6;
+    ReplaceDataFile replace_data_file = 7;
+  }
+}
+
+// Append to the ordered file list.
+message AddDataFile {
+  uint64 frag_id = 1;
+  DataFile file = 2;
+}
+
+// Remove every matching path, preserving order.
+message RemoveDataFile {
+  uint64 frag_id = 1;
+  string path = 2;
+}
+
+message AddDeletionFile {
+  uint64 frag_id = 1;
+  DeletionFile deletion_file = 2;
+}
+
+message ClearDeletionFile {
+  uint64 frag_id = 1;
+}
+
+/* On the first expected_path match, replace path, file_size_bytes, and base_id.
+ * Preserve its column mapping and file version.
+ */
+message ReplaceDataFile {
+  uint64 frag_id = 1;
+  string expected_path = 2;
+  string path = 3;
+  uint64 file_size_bytes = 4;
+  // Absent means the file lives under the dataset root.
+  optional uint32 base_id = 5;
+}
 // Manifest is a global section shared between all the files.
 message Manifest {
   // All fields of the dataset, including the nested fields.
@@ -42,6 +171,11 @@ message Manifest {
 
   // Fragments of the dataset.
   repeated DataFragment fragments = 2;
+
+  /* Tree tables set this, leave fragments empty, and set bit 9 on both flag
+   * fields. Old readers skip unknown fields and would otherwise see an empty table.
+   */
+  FragmentMetadata fragment_metadata = 22;
 
   // Snapshot version number.
   uint64 version = 3;
@@ -133,6 +267,8 @@ message Manifest {
    * * 1 << 8: reserved for datasets that may reference recognized V2 data files
    *   with different exact versions. Implementations that do not support the
    *   per-file exact-version contract must treat this bit as unknown.
+   * * 1 << 9: fragment records live in fragment_metadata. The fragments list
+   *   must be empty. Readers that do not know this bit must refuse the dataset.
    */
   uint64 reader_feature_flags = 9;
 
@@ -147,12 +283,9 @@ message Manifest {
    */
   uint64 writer_feature_flags = 10;
 
-  /* The highest fragment ID that has been used so far.
-   *
-   * This ID is not guaranteed to be present in the current version, but it may
-   * have been used in previous versions.
-   *
-   * For a single fragment, will be zero. For no fragments, will be absent.
+  /* Highest fragment id ever allocated or reserved in this lineage.
+   * Absent only before the first allocation or reservation. Never decreases.
+   * u32::MAX means the fragment-id space is exhausted.
    */
   optional uint32 max_fragment_id = 11;
 

--- a/python/Cargo.lock
+++ b/python/Cargo.lock
@@ -4540,6 +4540,7 @@ dependencies = [
  "futures",
  "lance-arrow",
  "lance-core",
+ "lance-encoding",
  "lance-file",
  "lance-io",
  "lance-select",

--- a/rust/lance-io/src/utils.rs
+++ b/rust/lance-io/src/utils.rs
@@ -13,6 +13,8 @@ use serde::{Deserialize, Serialize};
 use crate::traits::{ProtoStruct, Reader};
 use lance_core::{Error, Result};
 
+#[cfg(feature = "test-util")]
+pub mod failpoint;
 pub mod tracking_store;
 
 /// Chunk size for splitting a large metadata read into concurrent range requests.

--- a/rust/lance-io/src/utils/failpoint.rs
+++ b/rust/lance-io/src/utils/failpoint.rs
@@ -1,0 +1,245 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+//! Test-only object store wrapper that fails the Nth matching request, either
+//! before it reaches storage (the write never happened) or after it succeeded
+//! (the write happened but the writer never learned). Used to simulate crashes
+//! at exact points of a fragment metadata tree commit.
+
+use std::fmt;
+use std::sync::{Arc, Mutex};
+
+use crate::object_store::WrappingObjectStore;
+use async_trait::async_trait;
+use futures::stream::BoxStream;
+use futures::{StreamExt, TryStreamExt};
+use object_store::path::Path;
+use object_store::{
+    CopyOptions, Error as OSError, GetOptions, GetResult, ListResult, MultipartUpload, ObjectMeta,
+    ObjectStore as OSObjectStore, PutMode, PutMultipartOptions, PutOptions, PutPayload, PutResult,
+    Result as OSResult,
+};
+
+/// Which request class a failpoint targets.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FailOn {
+    /// Any `put_opts` whose path contains the substring.
+    Put,
+    /// Only create-only puts (root and transaction publication).
+    CreateOnly,
+    Get,
+    Delete,
+}
+
+/// Whether the failure is reported before or after the underlying request.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FailWhen {
+    Before,
+    After,
+}
+
+#[derive(Debug, Clone)]
+pub struct Failpoint {
+    pub on: FailOn,
+    pub when: FailWhen,
+    /// Path substring filter, empty matches every path of that class.
+    pub path_contains: String,
+    /// Fail the Nth matching request (1-based).
+    pub nth: usize,
+}
+
+#[derive(Debug, Default)]
+struct State {
+    failpoint: Option<Failpoint>,
+    matched: usize,
+    tripped: bool,
+    /// Simulated per-request latency, a stand-in for remote round trips.
+    latency: Option<std::time::Duration>,
+}
+
+/// Shared failpoint controller, cloned into every wrapped store.
+#[derive(Debug, Clone, Default)]
+pub struct FailpointController {
+    state: Arc<Mutex<State>>,
+}
+
+impl FailpointController {
+    pub fn arm(&self, failpoint: Failpoint) {
+        let mut state = self.state.lock().unwrap();
+        state.failpoint = Some(failpoint);
+        state.matched = 0;
+        state.tripped = false;
+    }
+
+    /// Delay every GET by `latency`, simulating a remote round trip.
+    pub fn set_get_latency(&self, latency: std::time::Duration) {
+        self.state.lock().unwrap().latency = Some(latency);
+    }
+
+    fn get_latency(&self) -> Option<std::time::Duration> {
+        self.state.lock().unwrap().latency
+    }
+
+    pub fn disarm(&self) {
+        let mut state = self.state.lock().unwrap();
+        state.failpoint = None;
+    }
+
+    /// Whether the armed failpoint fired.
+    pub fn tripped(&self) -> bool {
+        self.state.lock().unwrap().tripped
+    }
+
+    /// Decide whether this request must fail, and when.
+    fn check(&self, on: FailOn, path: &Path, create_only: bool) -> Option<FailWhen> {
+        let mut state = self.state.lock().unwrap();
+        let failpoint = state.failpoint.clone()?;
+        if state.tripped {
+            return None;
+        }
+        let class_matches = match failpoint.on {
+            FailOn::Put => on == FailOn::Put || on == FailOn::CreateOnly,
+            FailOn::CreateOnly => on == FailOn::CreateOnly && create_only,
+            other => other == on,
+        };
+        if !class_matches || !path.as_ref().contains(&failpoint.path_contains) {
+            return None;
+        }
+        state.matched += 1;
+        if state.matched == failpoint.nth {
+            state.tripped = true;
+            Some(failpoint.when)
+        } else {
+            None
+        }
+    }
+}
+
+impl WrappingObjectStore for FailpointController {
+    fn wrap_paginated(
+        &self,
+        _store_prefix: &str,
+        _original: Arc<dyn object_store::list::PaginatedListStore>,
+    ) -> Option<Arc<dyn object_store::list::PaginatedListStore>> {
+        None
+    }
+    fn wrap(
+        &self,
+        _store_prefix: &str,
+        original: Arc<dyn OSObjectStore>,
+    ) -> Arc<dyn OSObjectStore> {
+        Arc::new(FailpointStore {
+            target: original,
+            controller: self.clone(),
+        })
+    }
+}
+
+fn injected(path: &Path) -> OSError {
+    OSError::Generic {
+        store: "failpoint",
+        source: format!("injected failure at {path}").into(),
+    }
+}
+
+#[derive(Debug)]
+struct FailpointStore {
+    target: Arc<dyn OSObjectStore>,
+    controller: FailpointController,
+}
+
+impl fmt::Display for FailpointStore {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "FailpointStore({})", self.target)
+    }
+}
+
+#[async_trait]
+impl OSObjectStore for FailpointStore {
+    async fn put_opts(
+        &self,
+        location: &Path,
+        bytes: PutPayload,
+        opts: PutOptions,
+    ) -> OSResult<PutResult> {
+        let create_only = matches!(opts.mode, PutMode::Create);
+        let class = if create_only {
+            FailOn::CreateOnly
+        } else {
+            FailOn::Put
+        };
+        match self.controller.check(class, location, create_only) {
+            Some(FailWhen::Before) => Err(injected(location)),
+            Some(FailWhen::After) => {
+                self.target.put_opts(location, bytes, opts).await?;
+                Err(injected(location))
+            }
+            None => self.target.put_opts(location, bytes, opts).await,
+        }
+    }
+
+    async fn put_multipart_opts(
+        &self,
+        location: &Path,
+        opts: PutMultipartOptions,
+    ) -> OSResult<Box<dyn MultipartUpload>> {
+        // Leaf Lance files are written through a multipart upload; treat the
+        // upload start as the write for failpoint purposes.
+        match self.controller.check(FailOn::Put, location, false) {
+            Some(FailWhen::Before) => Err(injected(location)),
+            Some(FailWhen::After) | None => self.target.put_multipart_opts(location, opts).await,
+        }
+    }
+
+    async fn get_opts(&self, location: &Path, options: GetOptions) -> OSResult<GetResult> {
+        if let Some(latency) = self.controller.get_latency() {
+            tokio::time::sleep(latency).await;
+        }
+        match self.controller.check(FailOn::Get, location, false) {
+            Some(_) => Err(injected(location)),
+            None => self.target.get_opts(location, options).await,
+        }
+    }
+
+    fn delete_stream(
+        &self,
+        locations: BoxStream<'static, OSResult<Path>>,
+    ) -> BoxStream<'static, OSResult<Path>> {
+        let controller = self.controller.clone();
+        let target = self.target.clone();
+        locations
+            .then(move |location| {
+                let controller = controller.clone();
+                let target = target.clone();
+                async move {
+                    let location = location?;
+                    let verdict = controller.check(FailOn::Delete, &location, false);
+                    if verdict == Some(FailWhen::Before) {
+                        return Err(injected(&location));
+                    }
+                    let once = location.clone();
+                    let deleted = target
+                        .delete_stream(futures::stream::once(async move { Ok(once) }).boxed())
+                        .try_collect::<Vec<_>>()
+                        .await?;
+                    match verdict {
+                        Some(FailWhen::After) => Err(injected(&location)),
+                        _ => Ok(deleted.into_iter().next().unwrap_or(location)),
+                    }
+                }
+            })
+            .boxed()
+    }
+
+    fn list(&self, prefix: Option<&Path>) -> BoxStream<'static, OSResult<ObjectMeta>> {
+        self.target.list(prefix)
+    }
+
+    async fn list_with_delimiter(&self, prefix: Option<&Path>) -> OSResult<ListResult> {
+        self.target.list_with_delimiter(prefix).await
+    }
+
+    async fn copy_opts(&self, from: &Path, to: &Path, opts: CopyOptions) -> OSResult<()> {
+        self.target.copy_opts(from, to, opts).await
+    }
+}

--- a/rust/lance-io/src/utils/tracking_store.rs
+++ b/rust/lance-io/src/utils/tracking_store.rs
@@ -430,15 +430,24 @@ impl ObjectStore for IoTrackingStore {
 
     async fn get_opts(&self, location: &Path, options: GetOptions) -> OSResult<GetResult> {
         let _guard = self.stage_guard();
+        let is_head = options.head;
         let range = match &options.range {
             Some(GetRange::Bounded(range)) => Some(range.clone()),
             _ => None, // TODO: fill in other options.
         };
         let result = self.target.get_opts(location, options).await;
         if let Ok(result) = &result {
-            let num_bytes = result.range.end - result.range.start;
-
-            self.record_read("get_opts", location.to_owned(), num_bytes, range);
+            let num_bytes = if is_head {
+                0
+            } else {
+                result.range.end - result.range.start
+            };
+            self.record_read(
+                if is_head { "head" } else { "get_opts" },
+                location.to_owned(),
+                num_bytes,
+                range,
+            );
         }
         result
     }
@@ -590,5 +599,31 @@ impl Drop for StageGuard {
             let mut stats = self.stats.lock().unwrap();
             stats.num_stages += 1;
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use object_store::{ObjectStoreExt, memory::InMemory};
+
+    #[tokio::test]
+    async fn head_counts_a_request_without_reading_the_object_body() {
+        let tracker = IOTracker::default();
+        let store = tracker.wrap("", Arc::new(InMemory::new()));
+        let path = Path::from("payload");
+        store.put(&path, vec![7u8; 4096].into()).await.unwrap();
+        tracker.incremental_stats();
+        store.head(&path).await.unwrap();
+        let stats = tracker.incremental_stats();
+        assert_eq!(stats.read_iops, 1);
+        assert_eq!(stats.read_bytes, 0);
+        #[cfg(feature = "test-util")]
+        assert_eq!(stats.requests[0].method, "head");
+        assert_eq!(
+            store.get(&path).await.unwrap().bytes().await.unwrap().len(),
+            4096
+        );
+        assert_eq!(tracker.incremental_stats().read_bytes, 4096);
     }
 }

--- a/rust/lance-table/Cargo.toml
+++ b/rust/lance-table/Cargo.toml
@@ -14,6 +14,7 @@ rust-version.workspace = true
 [dependencies]
 lance-arrow.workspace = true
 lance-core.workspace = true
+lance-encoding.workspace = true
 lance-file.workspace = true
 lance-select.workspace = true
 lance-io.workspace = true
@@ -49,6 +50,7 @@ uuid.workspace = true
 [dev-dependencies]
 lance-datagen.workspace = true
 lance-testing.workspace = true
+lance-io = { workspace = true, features = ["test-util"] }
 arrow-schema.workspace = true
 criterion.workspace = true
 pretty_assertions.workspace = true
@@ -60,6 +62,7 @@ prost-build.workspace = true
 protobuf-src = { workspace = true, optional = true }
 
 [features]
+test-util = []
 dynamodb = ["dep:aws-sdk-dynamodb", "dep:aws-credential-types", "lance-io/aws"]
 protoc = ["dep:protobuf-src"]
 

--- a/rust/lance-table/build.rs
+++ b/rust/lance-table/build.rs
@@ -4,7 +4,12 @@
 use std::io::Result;
 
 fn main() -> Result<()> {
-    println!("cargo:rerun-if-changed=protos");
+    // Watch each proto file explicitly. `protos/` is a symlink to the repo
+    // root; directory-level rerun-if-changed can miss content updates and leave
+    // release builds on a stale generated `lance.table` module.
+    println!("cargo:rerun-if-changed=protos/table.proto");
+    println!("cargo:rerun-if-changed=protos/transaction.proto");
+    println!("cargo:rerun-if-changed=protos/rowids.proto");
 
     #[cfg(feature = "protoc")]
     // Use vendored protobuf compiler if requested.
@@ -16,6 +21,29 @@ fn main() -> Result<()> {
     prost_build.extern_path(".lance.file", "::lance_file::format::pb");
     prost_build.protoc_arg("--experimental_allow_proto3_optional");
     prost_build.enable_type_names();
+    for name in [
+        "FragmentMetadataTree",
+        "FragmentMetadataRoot",
+        "FragmentMetadataChild",
+        "FragmentMetadataMutation",
+        "FragmentAction",
+        "AddDataFile",
+        "RemoveDataFile",
+        "ReplaceDataFile",
+        "AddDeletionFile",
+        "ClearDeletionFile",
+        "DataFragment",
+        "DataFile",
+        "DataOverlayFile",
+        "FieldCoverage",
+        "DeletionFile",
+        "ExternalFile",
+    ] {
+        prost_build.type_attribute(
+            format!(".lance.table.{name}"),
+            "#[derive(lance_core::deepsize::DeepSizeOf)]",
+        );
+    }
     prost_build.compile_protos(
         &[
             "./protos/table.proto",

--- a/rust/lance-table/src/feature_flags.rs
+++ b/rust/lance-table/src/feature_flags.rs
@@ -53,11 +53,14 @@ pub const FLAG_COVERED_INDEX_METADATA: u64 = 1 << 7;
 /// Reserved for datasets that reference recognized V2 data files with
 /// different exact versions.
 pub const FLAG_MIXED_DATA_FILE_VERSIONS: u64 = 1 << 8;
+/// Fragment records are stored outside the manifest in immutable tree objects.
+/// Bit 7 belongs to covering indices and bit 8 is reserved for file versions.
+pub const FLAG_FRAGMENT_METADATA: u64 = 1 << 9;
 /// The first bit that is unknown as a feature flag
 pub const FLAG_UNKNOWN: u64 = 1 << 8;
 
-// Supported flags stay below the unknown boundary; the mixed-version bit is
-// reserved at the boundary until its storage contract lands.
+// The contiguous supported range ends before the reserved mixed-version bit.
+// Later capabilities, including external metadata, are listed explicitly.
 const _: () = assert!(FLAG_COVERED_INDEX_METADATA < FLAG_UNKNOWN);
 // The fence needs a bit the current released build already refuses, which means
 // at or above the boundary that build shipped with (bit 7).
@@ -85,9 +88,22 @@ pub fn apply_feature_flags(
         & FLAG_COVERED_INDEX_METADATA;
     let sticky_paired_flags = validated_sticky_paired_flags(manifest)?;
 
+    // Untouched external fragment records still contribute these requirements.
+    let fragment_flags = if manifest.fragment_metadata.is_some() {
+        (manifest.reader_feature_flags | manifest.writer_feature_flags)
+            & (FLAG_DELETION_FILES | FLAG_STABLE_ROW_IDS | FLAG_UNSTABLE_DATA_OVERLAY_FILES)
+    } else {
+        0
+    };
+
     // Reset flags
-    manifest.reader_feature_flags = 0;
-    manifest.writer_feature_flags = 0;
+    manifest.reader_feature_flags = fragment_flags;
+    manifest.writer_feature_flags = fragment_flags;
+
+    if manifest.fragment_metadata.is_some() {
+        manifest.reader_feature_flags |= FLAG_FRAGMENT_METADATA;
+        manifest.writer_feature_flags |= FLAG_FRAGMENT_METADATA;
+    }
 
     let has_deletion_files = manifest
         .fragments
@@ -187,7 +203,7 @@ fn mark_supported(flags: &mut u64, flag: u64, feature_enabled: bool) {
 /// is enabled. Split out from [`supported_flags`] so the policy is testable
 /// without toggling the build profile or environment.
 fn supported_flags_when(overlay_enabled: bool) -> u64 {
-    let mut supported = FLAG_UNKNOWN - 1;
+    let mut supported = (FLAG_UNKNOWN - 1) | FLAG_FRAGMENT_METADATA;
     mark_supported(
         &mut supported,
         FLAG_UNSTABLE_DATA_OVERLAY_FILES,
@@ -294,6 +310,28 @@ mod tests {
 
     use super::*;
     use crate::format::BasePath;
+
+    #[test]
+    fn lazy_fragment_metadata_preserves_fragment_feature_requirements() {
+        let mut manifest = Manifest::new(
+            Default::default(),
+            std::sync::Arc::new(Vec::new()),
+            Default::default(),
+            Default::default(),
+        );
+        manifest.fragment_metadata = Some(std::sync::Arc::new(Default::default()));
+        let features = FLAG_DELETION_FILES | FLAG_STABLE_ROW_IDS | FLAG_UNSTABLE_DATA_OVERLAY_FILES;
+        manifest.reader_feature_flags = features;
+        apply_feature_flags(&mut manifest, false, false).unwrap();
+        assert_eq!(
+            manifest.reader_feature_flags,
+            features | FLAG_FRAGMENT_METADATA
+        );
+        assert_eq!(
+            manifest.writer_feature_flags,
+            features | FLAG_FRAGMENT_METADATA
+        );
+    }
 
     #[test]
     fn test_read_check() {

--- a/rust/lance-table/src/format/fragment.rs
+++ b/rust/lance-table/src/format/fragment.rs
@@ -274,15 +274,19 @@ impl<T: Eq + std::hash::Hash + Clone> Default for InternCache<T> {
 }
 
 impl<T: Eq + std::hash::Hash + Clone> InternCache<T> {
-    fn intern(&mut self, v: Vec<T>) -> Arc<[T]> {
+    fn get(&self, v: &[T]) -> Option<Arc<[T]>> {
+        match self {
+            Self::Small(entries) => entries
+                .iter()
+                .find(|existing| existing.as_ref() == v)
+                .cloned(),
+            Self::Large(map) => map.get_key_value(v).map(|(existing, _)| existing.clone()),
+        }
+    }
+
+    fn insert(&mut self, arc: Arc<[T]>) -> Arc<[T]> {
         match self {
             Self::Small(entries) => {
-                for existing in entries.iter() {
-                    if existing.as_ref() == v.as_slice() {
-                        return existing.clone();
-                    }
-                }
-                let arc: Arc<[T]> = Arc::from(v);
                 entries.push(arc.clone());
                 if entries.len() > INTERN_CACHE_UPGRADE_THRESHOLD {
                     let mut map = HashMap::with_capacity(entries.len());
@@ -294,15 +298,24 @@ impl<T: Eq + std::hash::Hash + Clone> InternCache<T> {
                 arc
             }
             Self::Large(map) => {
-                if let Some((existing, _)) = map.get_key_value(v.as_slice()) {
-                    existing.clone()
-                } else {
-                    let arc: Arc<[T]> = Arc::from(v);
-                    map.insert(arc.clone(), ());
-                    arc
-                }
+                map.insert(arc.clone(), ());
+                arc
             }
         }
+    }
+
+    fn intern(&mut self, v: Vec<T>) -> Arc<[T]> {
+        if let Some(existing) = self.get(v.as_slice()) {
+            return existing;
+        }
+        self.insert(Arc::from(v))
+    }
+
+    fn intern_slice(&mut self, v: &[T]) -> Arc<[T]> {
+        if let Some(existing) = self.get(v) {
+            return existing;
+        }
+        self.insert(Arc::from(v))
     }
 }
 
@@ -345,6 +358,16 @@ impl DataFileFieldInterner {
                 }))
             }
         }
+    }
+
+    /// Share one allocation for an already-decoded field-id or column-index list.
+    pub fn intern_field_ids(&mut self, ids: &[i32]) -> Arc<[i32]> {
+        self.fields.intern_slice(ids)
+    }
+
+    /// Share one allocation for an already-decoded column-index list.
+    pub fn intern_column_indices(&mut self, ids: &[i32]) -> Arc<[i32]> {
+        self.column_indices.intern_slice(ids)
     }
 
     /// Convert a protobuf `DataFile`, interning `fields` and `column_indices`.
@@ -1018,5 +1041,27 @@ mod tests {
         data_file
             .validate(&base_path)
             .expect("validation should allow extra columns without field ids");
+    }
+
+    #[test]
+    fn intern_slice_reuses_the_same_allocation() {
+        let mut intern = DataFileFieldInterner::default();
+        let first = intern.intern_field_ids(&[0, 1, 2]);
+        let second = intern.intern_field_ids(&[0, 1, 2]);
+        assert!(Arc::ptr_eq(&first, &second));
+        let other = intern.intern_field_ids(&[0, 1]);
+        assert!(!Arc::ptr_eq(&first, &other));
+        let from_vec = intern
+            .intern_data_file(pb::DataFile {
+                path: "a.lance".into(),
+                fields: vec![0, 1, 2],
+                column_indices: vec![0, 1, 2],
+                file_major_version: MAJOR_VERSION as u32,
+                file_minor_version: MINOR_VERSION as u32,
+                file_size_bytes: 0,
+                base_id: None,
+            })
+            .unwrap();
+        assert!(Arc::ptr_eq(&first, &from_vec.fields));
     }
 }

--- a/rust/lance-table/src/format/manifest.rs
+++ b/rust/lance-table/src/format/manifest.rs
@@ -18,7 +18,9 @@ use std::ops::Range;
 use std::sync::Arc;
 
 use super::Fragment;
-use crate::feature_flags::{FLAG_COVERED_INDEX_METADATA, STICKY_PAIRED_FLAGS};
+use crate::feature_flags::{
+    FLAG_COVERED_INDEX_METADATA, FLAG_FRAGMENT_METADATA, STICKY_PAIRED_FLAGS,
+};
 use crate::feature_flags::{FLAG_STABLE_ROW_IDS, has_deprecated_v2_feature_flag};
 use crate::format::fragment::DataFileFieldInterner;
 use crate::format::pb;
@@ -53,6 +55,11 @@ pub struct Manifest {
     /// This list is stored in order, sorted by fragment id.  However, the fragment id
     /// sequence may have gaps.
     pub fragments: Arc<Vec<Fragment>>,
+
+    /// Fragment metadata tree descriptor when fragment records are external.
+    /// `None` means [`Self::fragments`] is the complete state. This unstable
+    /// representation requires the fragment metadata reader/writer feature flag.
+    pub fragment_metadata: Option<Arc<pb::FragmentMetadataTree>>,
 
     /// The file position of the version aux data.
     pub version_aux_data: usize,
@@ -170,6 +177,12 @@ impl From<ManifestSummary> for BTreeMap<String, String> {
 }
 
 impl Manifest {
+    /// Replace resident fragments and rebuild row offsets, preserving the ID allocator.
+    pub fn set_fragments(&mut self, fragments: Vec<Fragment>) {
+        self.fragment_offsets = compute_fragment_offsets(&fragments);
+        self.fragments = Arc::new(fragments);
+    }
+
     pub fn new(
         schema: Schema,
         fragments: Arc<Vec<Fragment>>,
@@ -199,6 +212,7 @@ impl Manifest {
             config: HashMap::new(),
             table_metadata: HashMap::new(),
             base_paths,
+            fragment_metadata: None,
         }
     }
 
@@ -230,6 +244,7 @@ impl Manifest {
             config: previous.config.clone(),
             table_metadata: previous.table_metadata.clone(),
             base_paths: previous.base_paths.clone(),
+            fragment_metadata: previous.fragment_metadata.clone(),
         }
     }
 
@@ -286,13 +301,14 @@ impl Manifest {
             // Sticky capabilities are also retained because the clone keeps the
             // source file identities that require them.
             reader_feature_flags: self.reader_feature_flags
-                & (FLAG_COVERED_INDEX_METADATA | STICKY_PAIRED_FLAGS),
+                & (FLAG_COVERED_INDEX_METADATA | FLAG_FRAGMENT_METADATA | STICKY_PAIRED_FLAGS),
             writer_feature_flags: self.writer_feature_flags
-                & (FLAG_COVERED_INDEX_METADATA | STICKY_PAIRED_FLAGS),
+                & (FLAG_COVERED_INDEX_METADATA | FLAG_FRAGMENT_METADATA | STICKY_PAIRED_FLAGS),
             max_fragment_id: self.max_fragment_id,
             transaction_file: Some(transaction_file),
             transaction_section: None,
             fragment_offsets: self.fragment_offsets.clone(),
+            fragment_metadata: self.fragment_metadata.clone(),
             next_row_id: self.next_row_id,
             data_storage_format: self.data_storage_format.clone(),
             config: self.config.clone(),
@@ -926,6 +942,31 @@ impl TryFrom<pb::Manifest> for Manifest {
     type Error = Error;
 
     fn try_from(p: pb::Manifest) -> Result<Self> {
+        let has_tree = p.fragment_metadata.is_some();
+        let tree_flag = p.reader_feature_flags & crate::feature_flags::FLAG_FRAGMENT_METADATA != 0;
+        let writer_tree_flag =
+            p.writer_feature_flags & crate::feature_flags::FLAG_FRAGMENT_METADATA != 0;
+        if has_tree != tree_flag
+            || has_tree != writer_tree_flag
+            || (has_tree && !p.fragments.is_empty())
+        {
+            return Err(Error::invalid_input(format!(
+                "Manifest version {} has inconsistent fragment metadata: descriptor={}, reader_flag={}, flat_fragments={}",
+                p.version,
+                has_tree,
+                tree_flag,
+                p.fragments.len()
+            )));
+        }
+        if p.fragment_metadata
+            .as_ref()
+            .is_some_and(|metadata| metadata.layout.is_none())
+        {
+            return Err(Error::invalid_input(format!(
+                "Manifest version {} has an empty fragment metadata encoding",
+                p.version
+            )));
+        }
         let timestamp_nanos = p.timestamp.map(|ts| {
             let sec = ts.seconds as u128 * 1e9 as u128;
             let nanos = ts.nanos as u128;
@@ -1005,6 +1046,12 @@ impl TryFrom<pb::Manifest> for Manifest {
             transaction_section: p.transaction_section.map(|i| i as usize),
             fragment_offsets,
             next_row_id: p.next_row_id,
+            fragment_metadata: p
+                .fragment_metadata
+                .and_then(|metadata| metadata.layout)
+                .map(|encoding| match encoding {
+                    pb::fragment_metadata::Layout::Tree(snapshot) => Arc::new(snapshot),
+                }),
             data_storage_format,
             config: p.config,
             table_metadata: p.table_metadata,
@@ -1049,7 +1096,11 @@ impl From<&Manifest> for pb::Manifest {
                     prerelease: wv.prerelease.clone(),
                     build_metadata: wv.build_metadata.clone(),
                 }),
-            fragments: m.fragments.iter().map(pb::DataFragment::from).collect(),
+            fragments: if m.fragment_metadata.is_some() {
+                Vec::new()
+            } else {
+                m.fragments.iter().map(pb::DataFragment::from).collect()
+            },
             table_metadata: m.table_metadata.clone(),
             version_aux_data: m.version_aux_data as u64,
             index_section: m.index_section.map(|i| i as u64),
@@ -1080,6 +1131,12 @@ impl From<&Manifest> for pb::Manifest {
                 })
                 .collect(),
             transaction_section: m.transaction_section.map(|i| i as u64),
+            fragment_metadata: m
+                .fragment_metadata
+                .as_ref()
+                .map(|bytes| pb::FragmentMetadata {
+                    layout: Some(pb::fragment_metadata::Layout::Tree(bytes.as_ref().clone())),
+                }),
         }
     }
 }
@@ -1154,6 +1211,60 @@ mod tests {
     use arrow_schema::{Field as ArrowField, Schema as ArrowSchema};
     use lance_core::datatypes::Field;
     use roaring::RoaringBitmap;
+
+    #[rstest::rstest]
+    #[case::flat(false, false, false, false, true)]
+    #[case::tree(true, true, true, false, true)]
+    #[case::reader_missing(true, false, true, false, false)]
+    #[case::writer_missing(true, true, false, false, false)]
+    #[case::descriptor_missing(false, true, true, false, false)]
+    #[case::two_layouts(true, true, true, true, false)]
+    fn fragment_metadata_requires_paired_flags(
+        #[case] descriptor: bool,
+        #[case] reader: bool,
+        #[case] writer: bool,
+        #[case] flat_records: bool,
+        #[case] accepted: bool,
+    ) {
+        let flag = crate::feature_flags::FLAG_FRAGMENT_METADATA;
+        let mut manifest = pb::Manifest::from(&Manifest::new(
+            Default::default(),
+            Arc::new(Vec::new()),
+            Default::default(),
+            Default::default(),
+        ));
+        manifest.fragment_metadata = descriptor.then(|| pb::FragmentMetadata {
+            layout: Some(pb::fragment_metadata::Layout::Tree(Default::default())),
+        });
+        manifest.reader_feature_flags = if reader { flag } else { 0 };
+        manifest.writer_feature_flags = if writer { flag } else { 0 };
+        if flat_records {
+            manifest.fragments.push(Default::default());
+        }
+        let decoded = Manifest::try_from(manifest);
+        assert_eq!(decoded.is_ok(), accepted);
+        if !accepted {
+            assert!(matches!(decoded, Err(Error::InvalidInput { .. })));
+        }
+    }
+
+    #[test]
+    fn resident_tree_fragments_are_not_duplicated_in_the_manifest() {
+        let mut manifest = Manifest::new(
+            Default::default(),
+            Arc::new(Vec::new()),
+            Default::default(),
+            Default::default(),
+        );
+        manifest.fragment_metadata = Some(Arc::new(Default::default()));
+        manifest.set_fragments(vec![Fragment {
+            id: 0,
+            physical_rows: Some(7),
+            ..Fragment::new(0)
+        }]);
+        assert_eq!(manifest.fragments_by_offset_range(0..7).len(), 1);
+        assert!(pb::Manifest::from(&manifest).fragments.is_empty());
+    }
 
     /// A shallow clone points every local file at the parent through `base_id`.
     /// An overlay's data file lives in the parent too, so it needs the same

--- a/rust/lance-table/src/fragment_metadata/action.rs
+++ b/rust/lance-table/src/fragment_metadata/action.rs
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+//! Storage-action constructors and routing keys.
+//!
+//! Every action here is an already-validated storage mutation with one
+//! unambiguous leaf application in action sequence order (see
+//! [`crate::fragment_metadata::node::apply_actions`]). Transaction intent is validated
+//! and translated into these in [`crate::fragment_metadata::commit`].
+
+use crate::format::pb::{self, fragment_action::Action};
+use crate::format::{DataFile, DeletionFile, DeletionFileType, Fragment};
+
+/// Attach `file` to fragment `frag_id` (the validated add-column case).
+pub fn add_data_file(frag_id: u64, file: &DataFile) -> pb::FragmentAction {
+    pb::FragmentAction {
+        action: Some(Action::AddDataFile(pb::AddDataFile {
+            frag_id,
+            file: Some(pb::DataFile::from(file)),
+        })),
+    }
+}
+
+/// Drop the data file at `path` from `frag_id`.
+pub fn remove_data_file(frag_id: u64, path: impl Into<String>) -> pb::FragmentAction {
+    pb::FragmentAction {
+        action: Some(Action::RemoveDataFile(pb::RemoveDataFile {
+            frag_id,
+            path: path.into(),
+        })),
+    }
+}
+
+/// Swap the data file at `expected_path` on `frag_id` for `file`. Only
+/// [`crate::fragment_metadata::commit::data_replacement`] should build this, after
+/// checking the fragment's current state.
+pub fn replace_data_file(frag_id: u64, expected_path: &str, file: &DataFile) -> pb::FragmentAction {
+    pb::FragmentAction {
+        action: Some(Action::ReplaceDataFile(pb::ReplaceDataFile {
+            frag_id,
+            expected_path: expected_path.to_string(),
+            path: file.path.clone(),
+            file_size_bytes: file.file_size_bytes.get().map_or(0, |v| v.get()),
+            base_id: file.base_id,
+        })),
+    }
+}
+
+/// Insert a fragment, or replace the whole record of an existing one.
+pub fn add_fragment(fragment: &Fragment) -> pb::FragmentAction {
+    pb::FragmentAction {
+        action: Some(Action::AddFragment(pb::DataFragment::from(fragment))),
+    }
+}
+
+/// Remove a whole fragment (tombstone).
+pub fn remove_fragment(frag_id: u64) -> pb::FragmentAction {
+    pb::FragmentAction {
+        action: Some(Action::RemoveFragment(frag_id)),
+    }
+}
+
+/// Attach or replace the deletion file for `frag_id`.
+pub fn add_deletion_file(frag_id: u64, deletion_file: &DeletionFile) -> pb::FragmentAction {
+    let file_type = match deletion_file.file_type {
+        DeletionFileType::Array => pb::deletion_file::DeletionFileType::ArrowArray,
+        DeletionFileType::Bitmap => pb::deletion_file::DeletionFileType::Bitmap,
+    };
+    pb::FragmentAction {
+        action: Some(Action::AddDeletionFile(pb::AddDeletionFile {
+            frag_id,
+            deletion_file: Some(pb::DeletionFile {
+                read_version: deletion_file.read_version,
+                id: deletion_file.id,
+                file_type: file_type.into(),
+                num_deleted_rows: deletion_file.num_deleted_rows.unwrap_or_default() as u64,
+                base_id: deletion_file.base_id,
+            }),
+        })),
+    }
+}
+
+/// Clear the deletion file attached to `frag_id`.
+pub fn clear_deletion_file(frag_id: u64) -> pb::FragmentAction {
+    pb::FragmentAction {
+        action: Some(Action::ClearDeletionFile(pb::ClearDeletionFile { frag_id })),
+    }
+}
+
+/// The fragment id an action targets, used to route it to the owning child.
+pub fn target_frag_id(action: &pb::FragmentAction) -> Option<u64> {
+    match action.action.as_ref()? {
+        Action::AddFragment(f) => Some(f.id),
+        Action::RemoveFragment(id) => Some(*id),
+        Action::AddDataFile(a) => Some(a.frag_id),
+        Action::RemoveDataFile(a) => Some(a.frag_id),
+        Action::ReplaceDataFile(a) => Some(a.frag_id),
+        Action::AddDeletionFile(a) => Some(a.frag_id),
+        Action::ClearDeletionFile(a) => Some(a.frag_id),
+    }
+}

--- a/rust/lance-table/src/fragment_metadata/bulk.rs
+++ b/rust/lance-table/src/fragment_metadata/bulk.rs
@@ -1,0 +1,166 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+//! Ordered bulk materialization at any height. Keep one pending leaf across
+//! routing boundaries so split/coalesce is decided before writing final leaves.
+
+use std::collections::BTreeMap;
+
+use lance_core::{Error, Result};
+
+use super::node::{self, FragmentMetadataTreeConfig};
+use super::store::NodeStore;
+use crate::format::{Fragment, pb};
+
+#[derive(Default)]
+pub(super) struct BulkResult {
+    pub children: Vec<pb::FragmentMetadataChild>,
+    pub io_bytes: u64,
+    pub flushes: u64,
+    pub splits: u64,
+    pub merges: u64,
+    pub materialized: u64,
+    pub max_flush_depth: u32,
+}
+
+enum PendingLeaf {
+    Unchanged(pb::FragmentMetadataChild),
+    Changed(Vec<Fragment>),
+}
+
+impl PendingLeaf {
+    async fn bytes(&self, store: &NodeStore) -> Result<u64> {
+        Ok(match self {
+            Self::Unchanged(child) => child.object_size,
+            Self::Changed(fragments) => store.encode_leaf(fragments).await?.len() as u64,
+        })
+    }
+
+    async fn load(self, store: &NodeStore) -> Result<Vec<Fragment>> {
+        match self {
+            Self::Unchanged(child) => store.read_leaf(&child).await,
+            Self::Changed(fragments) => Ok(fragments),
+        }
+    }
+
+    async fn write(
+        self,
+        store: &NodeStore,
+        config: &FragmentMetadataTreeConfig,
+        watermark: u64,
+        output: &mut BulkResult,
+    ) -> Result<()> {
+        match self {
+            Self::Unchanged(child) => output.children.push(child),
+            Self::Changed(fragments) => {
+                let written = store.write_leaves(&fragments, watermark, config).await?;
+                output.splits += written.len().saturating_sub(1) as u64;
+                for written in written {
+                    output.io_bytes += written.io_bytes;
+                    output.children.push(written.child_ref);
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+/// Visit old routing in order, carrying each ancestor's actions to its owning
+/// leaf. Defer the last output leaf across parent boundaries so a later sparse
+/// sibling cannot force a read/rewrite of an already emitted replacement.
+/// Unchanged leaves are reused unless coalescing needs them. The caller builds
+/// final routing over the returned leaf references, without intermediate nodes.
+pub(super) async fn materialize(
+    store: &NodeStore,
+    config: &FragmentMetadataTreeConfig,
+    children: Vec<pb::FragmentMetadataChild>,
+    buffer: Vec<pb::FragmentMetadataMutation>,
+    watermark: u64,
+) -> Result<BulkResult> {
+    let mut output = BulkResult::default();
+    let mut pending: Option<PendingLeaf> = None;
+    if children.is_empty() {
+        let mut fragments = BTreeMap::new();
+        output.materialized = buffer.len() as u64;
+        store.apply_verified(&mut fragments, buffer)?;
+        if !fragments.is_empty() {
+            PendingLeaf::Changed(fragments.into_values().collect())
+                .write(store, config, watermark, &mut output)
+                .await?;
+        }
+        return Ok(output);
+    }
+    let buckets = node::partition_buffer_by_child(&children, buffer);
+    node::validate_routed(&children, &buckets, node::ROOT_EXCLUSIVE_END)?;
+    let mut stack: Vec<_> = children
+        .into_iter()
+        .zip(buckets)
+        .map(|(child, actions)| (child, actions, 0))
+        .rev()
+        .collect();
+    while let Some((child, actions, depth)) = stack.pop() {
+        if child.height > 0 {
+            let mut internal = store.read_internal(&child).await?;
+            if internal.children.is_empty() {
+                return Err(Error::invalid_input(format!(
+                    "fragment metadata bulk encountered childless interior {} at height {}",
+                    child.path, child.height
+                )));
+            }
+            internal.buffer.extend(actions);
+            let buckets = node::partition_buffer_by_child(&internal.children, internal.buffer);
+            node::validate_routed(&internal.children, &buckets, node::ROOT_EXCLUSIVE_END)?;
+            stack.extend(
+                internal
+                    .children
+                    .into_iter()
+                    .zip(buckets)
+                    .map(|(child, actions)| (child, actions, depth + 1))
+                    .rev(),
+            );
+            continue;
+        }
+        let current = if actions.is_empty() {
+            PendingLeaf::Unchanged(child)
+        } else {
+            output.flushes += 1;
+            output.max_flush_depth = output.max_flush_depth.max(depth);
+            output.materialized += actions.len() as u64;
+            let mut fragments: BTreeMap<_, _> = store
+                .read_leaf(&child)
+                .await?
+                .into_iter()
+                .map(|f| (f.id, f))
+                .collect();
+            store.apply_verified(&mut fragments, actions)?;
+            if fragments.is_empty() {
+                continue;
+            }
+            PendingLeaf::Changed(fragments.into_values().collect())
+        };
+        if let Some(previous) = pending.take() {
+            let previous_bytes = previous.bytes(store).await?;
+            let current_bytes = current.bytes(store).await?;
+            let small = previous_bytes <= config.leaf_merge_floor()
+                || current_bytes <= config.leaf_merge_floor();
+            let fits = previous_bytes
+                .checked_add(current_bytes)
+                .is_some_and(|bytes| bytes <= config.leaf_coalesce_ceiling());
+            if small && fits {
+                let mut fragments = previous.load(store).await?;
+                fragments.extend(current.load(store).await?);
+                pending = Some(PendingLeaf::Changed(fragments));
+                output.merges += 1;
+                continue;
+            }
+            previous
+                .write(store, config, watermark, &mut output)
+                .await?;
+        }
+        pending = Some(current);
+    }
+    if let Some(leaf) = pending {
+        leaf.write(store, config, watermark, &mut output).await?;
+    }
+    Ok(output)
+}

--- a/rust/lance-table/src/fragment_metadata/commit.rs
+++ b/rust/lance-table/src/fragment_metadata/commit.rs
@@ -1,0 +1,365 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+//! Validation inputs and storage-action semantics.
+//!
+//! Native transactions are validated against current fragment state before
+//! lowering. The tree only replays the resulting state changes.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use crate::format::pb::{self, fragment_action::Action};
+use crate::format::{DataFile, Fragment};
+use crate::fragment_metadata::action;
+use lance_core::{Error, Result};
+
+/// The current state of the fragments one commit touches, and nothing else.
+///
+/// `ids` records every id that was resolved, so an id that is absent from
+/// `fragments` is known to be missing rather than unresolved. A commit may
+/// only mutate ids in this set, or append ids the tree has never assigned.
+#[derive(Debug, Clone, Default)]
+pub struct TouchedFragments {
+    pub ids: BTreeSet<u64>,
+    pub fragments: BTreeMap<u64, Fragment>,
+}
+
+impl TouchedFragments {
+    pub fn get(&self, fragment_id: u64) -> Option<&Fragment> {
+        self.fragments.get(&fragment_id)
+    }
+
+    pub fn resolved(&self, fragment_id: u64) -> bool {
+        self.ids.contains(&fragment_id)
+    }
+}
+
+/// A commit whose every action has been validated against
+/// [`TouchedFragments`] and is safe to store.
+#[derive(Debug, Clone)]
+pub struct ValidatedCommit {
+    /// Advance the ID allocator, including reservations; never decrease it.
+    pub next_fragment_id: Option<u64>,
+    pub fragment_actions: Vec<pb::FragmentAction>,
+}
+
+impl ValidatedCommit {
+    pub fn fragment_actions(fragment_actions: Vec<pb::FragmentAction>) -> Self {
+        Self {
+            next_fragment_id: None,
+            fragment_actions,
+        }
+    }
+}
+
+/// Production `Operation::DataReplacement` for one fragment, decided against
+/// the fragment's current state:
+///
+/// * a data file with the same fields and file version is swapped in place,
+///   which becomes a [`pb::ReplaceDataFile`] naming the file it replaces;
+/// * a replacement whose fields the fragment does not cover at all is the
+///   add-column case and becomes an [`pb::AddDataFile`];
+/// * a missing fragment, a partial field overlap, or a replacement identical
+///   to the existing file is rejected, as the flat commit rejects them.
+pub fn data_replacement(
+    current: Option<&Fragment>,
+    fragment_id: u64,
+    replacement: &DataFile,
+) -> Result<Vec<pb::FragmentAction>> {
+    let fragment = current.ok_or_else(|| {
+        Error::invalid_input(format!(
+            "DataReplacement targets fragment {fragment_id} which does not exist"
+        ))
+    })?;
+    let matching: Vec<&DataFile> = fragment
+        .files
+        .iter()
+        .filter(|file| {
+            file.fields == replacement.fields
+                && file.file_major_version == replacement.file_major_version
+                && file.file_minor_version == replacement.file_minor_version
+        })
+        .collect();
+    let actions = if !matching.is_empty() {
+        let unchanged = matching.iter().all(|file| {
+            file.path == replacement.path
+                && file.file_size_bytes == replacement.file_size_bytes
+                && file.base_id == replacement.base_id
+        });
+        if unchanged {
+            return Err(Error::invalid_input(format!(
+                "DataReplacement for fragment {fragment_id} made no changes: the replacement \
+                 matches the existing data file {} exactly",
+                replacement.path
+            )));
+        }
+        matching
+            .iter()
+            .map(|file| action::replace_data_file(fragment_id, &file.path, replacement))
+            .collect::<Vec<_>>()
+    } else {
+        let covered = fragment
+            .files
+            .iter()
+            .flat_map(|file| file.fields.iter())
+            .any(|field_id| replacement.fields.contains(field_id));
+        if covered {
+            return Err(Error::invalid_input(format!(
+                "DataReplacement for fragment {fragment_id} partially overlaps existing fields: \
+                 replacement fields={:?}",
+                replacement.fields
+            )));
+        }
+        vec![action::add_data_file(fragment_id, replacement)]
+    };
+
+    let mut paths = BTreeSet::new();
+    let aliases = fragment.files.iter().any(|file| !paths.insert(&file.path));
+    let rename_collision =
+        matching.len() > 1 && matching.iter().any(|file| file.path == replacement.path);
+    let mut overlays = fragment.overlays.clone();
+    let fields: Vec<u32> = replacement
+        .fields
+        .iter()
+        .filter_map(|field| u32::try_from(*field).ok())
+        .collect();
+    crate::format::overlay::tombstone_overlay_fields(&mut overlays, &fields);
+    if overlays == fragment.overlays && !(aliases || rename_collision) {
+        return Ok(actions);
+    }
+
+    // Validation selects by fields/version, while a storage replacement selects
+    // by first path. A whole-state update retains that decision when aliases,
+    // rename collisions, or overlay tombstones cannot be expressed by the
+    // smaller location-only action language.
+    let mut updated = fragment.clone();
+    updated.overlays = overlays;
+    if matching.is_empty() {
+        updated.files.push(replacement.clone());
+    } else {
+        for file in &mut updated.files {
+            if file.fields == replacement.fields
+                && file.file_major_version == replacement.file_major_version
+                && file.file_minor_version == replacement.file_minor_version
+            {
+                file.path = replacement.path.clone();
+                file.file_size_bytes = replacement.file_size_bytes.clone();
+                file.base_id = replacement.base_id;
+            }
+        }
+    }
+    Ok(vec![action::add_fragment(&updated)])
+}
+
+/// Check that every storage action targets a fragment the commit resolved,
+/// or appends an id the tree has never assigned, then apply the actions to
+/// the touched snapshot to derive each action's fragment-count and row-count
+/// contribution. Application errors here are storage invariant violations,
+/// not user errors: a validated action must always apply.
+pub(crate) fn aggregate_deltas(
+    actions: &[pb::FragmentAction],
+    touched: &TouchedFragments,
+    next_fragment_id: u64,
+) -> Result<Vec<ActionDeltas>> {
+    let mut snapshot = touched.fragments.clone();
+    let mut created = BTreeSet::new();
+    let mut deltas = Vec::with_capacity(actions.len());
+    for (offset, fragment_action) in actions.iter().enumerate() {
+        let fragment_id = action::target_frag_id(fragment_action).ok_or_else(|| {
+            Error::invalid_input("fragment metadata tree commit contains an empty fragment action")
+        })?;
+        let fresh_append = matches!(
+            fragment_action.action,
+            Some(Action::AddFragment(_)) if fragment_id >= next_fragment_id
+        );
+        if !fresh_append && !touched.resolved(fragment_id) && !created.contains(&fragment_id) {
+            return Err(Error::invalid_input(format!(
+                "fragment metadata tree commit mutates fragment {fragment_id} without resolving it first"
+            )));
+        }
+        let before = snapshot.get(&fragment_id).cloned();
+        crate::fragment_metadata::node::apply_actions(
+            &mut snapshot,
+            vec![pb::FragmentMetadataMutation {
+                action_sequence: offset as u64,
+                action: Some(fragment_action.clone()),
+                fragment_count_delta: 0,
+                total_rows_delta: 0,
+                visible_rows_delta: 0,
+            }],
+        )?;
+        if fresh_append {
+            created.insert(fragment_id);
+        }
+        let after = snapshot.get(&fragment_id);
+        if let Some(after) = after {
+            require_known_counts(after)?;
+        }
+        deltas.push(ActionDeltas {
+            fragment_count: i64::from(after.is_some()) - i64::from(before.is_some()),
+            physical_rows: physical_rows(after)? - physical_rows(before.as_ref())?,
+            visible_rows: visible_rows(after)? - visible_rows(before.as_ref())?,
+        });
+    }
+    Ok(deltas)
+}
+
+/// The writer invariant behind exact visible-row aggregates: every fragment
+/// stored in the tree has a known physical row count, and every deletion
+/// file a known deleted count. Production writers always produce both;
+/// conversion of older data must compute the missing count or refuse.
+pub fn require_known_counts(fragment: &Fragment) -> Result<()> {
+    if fragment.id > u64::from(u32::MAX) {
+        return Err(Error::invalid_input(format!(
+            "Fragment ID {} exceeds u32",
+            fragment.id
+        )));
+    }
+    if fragment.physical_rows.is_none() {
+        return Err(Error::invalid_input(format!(
+            "fragment {} has no physical row count; the fragment metadata tree requires known counts",
+            fragment.id
+        )));
+    }
+    if let Some(deletion_file) = &fragment.deletion_file
+        && deletion_file.num_deleted_rows.is_none()
+    {
+        return Err(Error::invalid_input(format!(
+            "fragment {} has a deletion file without a deleted-row count; the fragment metadata tree requires known counts",
+            fragment.id
+        )));
+    }
+    if let (Some(rows), Some(deleted)) = (
+        fragment.physical_rows,
+        fragment
+            .deletion_file
+            .as_ref()
+            .and_then(|file| file.num_deleted_rows),
+    ) && deleted > rows
+    {
+        return Err(Error::invalid_input(format!(
+            "fragment {} has {deleted} deleted rows but only {rows} physical rows",
+            fragment.id
+        )));
+    }
+    Ok(())
+}
+
+/// One action's contribution to the tree aggregates, derived by applying it
+/// to the touched snapshot.
+#[derive(Debug, Clone, Copy)]
+pub struct ActionDeltas {
+    pub fragment_count: i64,
+    pub physical_rows: i64,
+    /// Physical minus deleted rows, exact by [`require_known_counts`].
+    pub visible_rows: i64,
+}
+
+/// A fragment's visible rows. An absent fragment contributes zero; counts
+/// are known by [`require_known_counts`], enforced before this is read.
+fn visible_rows(fragment: Option<&Fragment>) -> Result<i64> {
+    let Some(fragment) = fragment else {
+        return Ok(0);
+    };
+    let rows = fragment.num_rows().ok_or_else(|| {
+        Error::internal(format!(
+            "fragment {} reached visible-row accounting with unknown counts; \
+             require_known_counts must run first",
+            fragment.id
+        ))
+    })?;
+    to_i64(rows)
+}
+
+fn to_i64(rows: usize) -> Result<i64> {
+    i64::try_from(rows).map_err(|_| {
+        Error::invalid_input(format!(
+            "row count does not fit aggregate delta: rows={rows}"
+        ))
+    })
+}
+
+fn physical_rows(fragment: Option<&Fragment>) -> Result<i64> {
+    let rows = fragment
+        .and_then(|fragment| fragment.physical_rows)
+        .unwrap_or(0);
+    i64::try_from(rows).map_err(|_| {
+        Error::invalid_input(format!(
+            "fragment physical_rows does not fit aggregate delta: physical_rows={rows}"
+        ))
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::fragment_metadata::support::{
+        make_backfill_data_file, make_fragment, make_replacement_data_file,
+    };
+
+    #[test]
+    fn data_replacement_swaps_appends_or_rejects_like_production() {
+        let fragment = make_fragment(7);
+
+        // Exact fields and file version: swap the named file in place.
+        let matching = make_replacement_data_file(7, 0);
+        let actions = data_replacement(Some(&fragment), 7, &matching).unwrap();
+        assert_eq!(actions.len(), 1);
+        match actions[0].action.as_ref().unwrap() {
+            Action::ReplaceDataFile(replace) => {
+                assert_eq!(replace.expected_path, fragment.files[0].path);
+                assert_eq!(replace.path, matching.path);
+            }
+            other => panic!("expected ReplaceDataFile, got {other:?}"),
+        }
+
+        // Disjoint fields: the all-NULL add-column case appends verbatim.
+        let disjoint = make_backfill_data_file(7, 0);
+        let actions = data_replacement(Some(&fragment), 7, &disjoint).unwrap();
+        assert!(matches!(
+            actions[0].action.as_ref().unwrap(),
+            Action::AddDataFile(add) if add.frag_id == 7
+        ));
+
+        // Identical file: rejected as a no-op.
+        let error = data_replacement(Some(&fragment), 7, &fragment.files[0]).unwrap_err();
+        assert!(error.to_string().contains("no changes"), "{error}");
+
+        // Partial field overlap: rejected.
+        let mut overlapping = make_replacement_data_file(7, 1);
+        overlapping.fields = vec![1, 99].into();
+        let error = data_replacement(Some(&fragment), 7, &overlapping).unwrap_err();
+        assert!(error.to_string().contains("partially overlaps"), "{error}");
+
+        // Missing fragment: rejected.
+        let error = data_replacement(None, 99, &matching).unwrap_err();
+        assert!(error.to_string().contains("fragment 99"), "{error}");
+    }
+
+    #[test]
+    fn aggregate_deltas_reject_unresolved_mutations_and_stale_appends() {
+        let touched = TouchedFragments::default();
+        let error = aggregate_deltas(&[action::remove_fragment(3)], &touched, 10).unwrap_err();
+        assert!(error.to_string().contains("without resolving"), "{error}");
+
+        let error =
+            aggregate_deltas(&[action::add_fragment(&make_fragment(3))], &touched, 10).unwrap_err();
+        assert!(error.to_string().contains("without resolving"), "{error}");
+
+        let deltas =
+            aggregate_deltas(&[action::add_fragment(&make_fragment(10))], &touched, 10).unwrap();
+        assert_eq!(deltas.len(), 1);
+        assert_eq!(deltas[0].fragment_count, 1);
+        assert_eq!(deltas[0].physical_rows, 1);
+        assert_eq!(deltas[0].visible_rows, 1);
+
+        // The writer invariant: unknown counts are rejected at the door.
+        let mut unknown_physical = make_fragment(10);
+        unknown_physical.physical_rows = None;
+        let error = require_known_counts(&unknown_physical).unwrap_err();
+        assert!(error.to_string().contains("physical row count"), "{error}");
+        let empty = make_fragment(10).with_physical_rows(0);
+        let deltas = aggregate_deltas(&[action::add_fragment(&empty)], &touched, 10).unwrap();
+        assert_eq!(deltas[0].physical_rows, 0);
+    }
+}

--- a/rust/lance-table/src/fragment_metadata/dict_decode_compare.rs
+++ b/rust/lance-table/src/fragment_metadata/dict_decode_compare.rs
@@ -1,0 +1,445 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+//! Arrow reconstruct of synthetic fragment records.
+//!
+//! Compares dictionary-of-lists intern against copy-then-intern on in-process
+//! Arrow batches. Not a Lance file decode. Dictionary-of-lists is not a
+//! Lance file type. Reports Arrow batch memory, interned fragment heap, and
+//! copy-then-intern temporary allocations separately. Does not measure
+//! dataset-open memory.
+
+#![allow(clippy::print_stdout)]
+
+use std::sync::Arc;
+use std::time::Instant;
+
+use arrow_array::cast::AsArray;
+use arrow_array::types::{Int32Type, UInt32Type, UInt64Type};
+use arrow_array::{Array, RecordBatch};
+use lance_core::deepsize::DeepSizeOf;
+use lance_io::utils::CachedFileSize;
+use serde_json::json;
+
+use super::leaf_layout_compare::{
+    EncodeSpec, Layout, Mapping, batch_memory, data_file_from_parts, encode_flat, env_u64,
+    fragment_from_header, list_i32_at, unique_field_lists, wide_fragment,
+};
+use crate::format::pb;
+use crate::format::{DataFile, DataFileFieldInterner, Fragment};
+
+const ROW_KIND_FRAGMENT: u8 = 0;
+
+#[derive(Default)]
+struct CopyMeter {
+    copied_bytes: usize,
+    copy_count: usize,
+    live_bytes: usize,
+    peak_live_bytes: usize,
+}
+
+impl CopyMeter {
+    fn copy_row(&mut self, list: Vec<i32>) -> Vec<i32> {
+        let bytes = list.len() * std::mem::size_of::<i32>();
+        self.copied_bytes += bytes;
+        self.copy_count += 1;
+        self.live_bytes += bytes;
+        self.peak_live_bytes = self.peak_live_bytes.max(self.live_bytes);
+        list
+    }
+
+    fn release_row(&mut self, len: usize) {
+        self.live_bytes = self
+            .live_bytes
+            .saturating_sub(len * std::mem::size_of::<i32>());
+    }
+}
+
+fn intern_i32s(
+    interner: &mut DataFileFieldInterner,
+    list: Vec<i32>,
+    as_fields: bool,
+) -> Arc<[i32]> {
+    if as_fields {
+        interner
+            .intern_data_file(pb::DataFile {
+                path: String::new(),
+                fields: list,
+                column_indices: Vec::new(),
+                file_major_version: 0,
+                file_minor_version: 0,
+                file_size_bytes: 0,
+                base_id: None,
+            })
+            .expect("dummy data file intern")
+            .fields
+    } else {
+        interner
+            .intern_data_file(pb::DataFile {
+                path: String::new(),
+                fields: Vec::new(),
+                column_indices: list,
+                file_major_version: 0,
+                file_minor_version: 0,
+                file_size_bytes: 0,
+                base_id: None,
+            })
+            .expect("dummy data file intern")
+            .column_indices
+    }
+}
+
+fn dictionary_column_parts(array: &dyn Array) -> serde_json::Value {
+    match array.data_type() {
+        arrow_schema::DataType::Dictionary(_, _) => {
+            let dictionary = array.as_dictionary::<Int32Type>();
+            json!({
+                "kind": "dictionary",
+                "rows": array.len(),
+                "unique_values": dictionary.values().len(),
+                "column_bytes": array.get_array_memory_size(),
+                "buffer_bytes": array.get_buffer_memory_size(),
+                "keys_bytes": dictionary.keys().get_array_memory_size(),
+                "values_bytes": dictionary.values().get_array_memory_size(),
+                "keys_plus_values_bytes": dictionary.keys().get_array_memory_size()
+                    + dictionary.values().get_array_memory_size(),
+            })
+        }
+        _ => json!({
+            "kind": "list",
+            "rows": array.len(),
+            "column_bytes": array.get_array_memory_size(),
+            "buffer_bytes": array.get_buffer_memory_size(),
+        }),
+    }
+}
+
+fn interned_dictionary_values(
+    array: &dyn Array,
+    interner: &mut DataFileFieldInterner,
+    as_fields: bool,
+    meter: &mut CopyMeter,
+) -> Option<Vec<Arc<[i32]>>> {
+    let arrow_schema::DataType::Dictionary(_, _) = array.data_type() else {
+        return None;
+    };
+    let dictionary = array.as_dictionary::<Int32Type>();
+    let values = dictionary.values();
+    let mut interned = Vec::with_capacity(values.len());
+    for row in 0..values.len() {
+        let list = meter.copy_row(list_i32_at(values, row));
+        let len = list.len();
+        interned.push(intern_i32s(interner, list, as_fields));
+        meter.release_row(len);
+    }
+    Some(interned)
+}
+
+fn reconstruct_list_then_intern(
+    batch: &RecordBatch,
+    interner: &mut DataFileFieldInterner,
+    meter: &mut CopyMeter,
+) -> Vec<Fragment> {
+    let row_kinds = batch["row_kind"].as_primitive::<arrow_array::types::UInt8Type>();
+    let fragment_meta = batch["fragment_meta"].as_binary::<i32>();
+    let paths = batch["path"].as_string::<i32>();
+    let field_ids = batch["field_ids"].as_ref();
+    let column_indices = batch["column_indices"].as_ref();
+    let major = batch["major_version"].as_primitive::<UInt32Type>();
+    let minor = batch["minor_version"].as_primitive::<UInt32Type>();
+    let sizes = batch["file_size_bytes"].as_primitive::<UInt64Type>();
+    let base_ids = batch["base_id"].as_primitive::<UInt32Type>();
+    let mut fragments = Vec::new();
+    for row in 0..batch.num_rows() {
+        if row_kinds.value(row) == ROW_KIND_FRAGMENT {
+            fragments.push(fragment_from_header(
+                fragment_meta.value(row),
+                Vec::new(),
+                Some(interner),
+            ));
+            continue;
+        }
+        let fields = meter.copy_row(list_i32_at(field_ids, row));
+        let field_len = fields.len();
+        let cols = meter.copy_row(list_i32_at(column_indices, row));
+        let col_len = cols.len();
+        let file = data_file_from_parts(
+            pb::DataFile {
+                path: paths.value(row).to_string(),
+                fields,
+                column_indices: cols,
+                file_major_version: major.value(row),
+                file_minor_version: minor.value(row),
+                file_size_bytes: sizes.value(row),
+                base_id: (!base_ids.is_null(row)).then(|| base_ids.value(row)),
+            },
+            Some(interner),
+        );
+        meter.release_row(field_len);
+        meter.release_row(col_len);
+        fragments
+            .last_mut()
+            .expect("DATA_FILE follows a FRAGMENT row")
+            .files
+            .push(file);
+    }
+    fragments
+}
+
+fn reconstruct_dictionary_then_intern(
+    batch: &RecordBatch,
+    interner: &mut DataFileFieldInterner,
+    meter: &mut CopyMeter,
+) -> Vec<Fragment> {
+    let field_ids = batch["field_ids"].as_ref();
+    let column_indices = batch["column_indices"].as_ref();
+    let interned_fields = interned_dictionary_values(field_ids, interner, true, meter)
+        .expect("field_ids is a dictionary of lists");
+    let interned_cols = interned_dictionary_values(column_indices, interner, false, meter)
+        .expect("column_indices is a dictionary of lists");
+    let field_keys = field_ids.as_dictionary::<Int32Type>().keys();
+    let col_keys = column_indices.as_dictionary::<Int32Type>().keys();
+    let row_kinds = batch["row_kind"].as_primitive::<arrow_array::types::UInt8Type>();
+    let fragment_meta = batch["fragment_meta"].as_binary::<i32>();
+    let paths = batch["path"].as_string::<i32>();
+    let major = batch["major_version"].as_primitive::<UInt32Type>();
+    let minor = batch["minor_version"].as_primitive::<UInt32Type>();
+    let sizes = batch["file_size_bytes"].as_primitive::<UInt64Type>();
+    let base_ids = batch["base_id"].as_primitive::<UInt32Type>();
+    let mut fragments = Vec::new();
+    for row in 0..batch.num_rows() {
+        if row_kinds.value(row) == ROW_KIND_FRAGMENT {
+            fragments.push(fragment_from_header(
+                fragment_meta.value(row),
+                Vec::new(),
+                Some(interner),
+            ));
+            continue;
+        }
+        let file = DataFile {
+            path: paths.value(row).to_string(),
+            fields: interned_fields[field_keys.value(row) as usize].clone(),
+            column_indices: interned_cols[col_keys.value(row) as usize].clone(),
+            file_major_version: major.value(row),
+            file_minor_version: minor.value(row),
+            file_size_bytes: CachedFileSize::new(sizes.value(row)),
+            base_id: (!base_ids.is_null(row)).then(|| base_ids.value(row)),
+        };
+        fragments
+            .last_mut()
+            .expect("DATA_FILE follows a FRAGMENT row")
+            .files
+            .push(file);
+    }
+    fragments
+}
+
+fn mapping_vector(mapping_id: u64, columns: u32) -> Arc<[i32]> {
+    let mut values = Vec::with_capacity(columns as usize);
+    values.push(mapping_id as i32);
+    values.extend(1..columns as i32);
+    Arc::from(values)
+}
+
+fn fragments_with_mappings(
+    fragment_count: u64,
+    columns: u32,
+    distinct_mappings: u64,
+) -> Vec<Fragment> {
+    let distinct_mappings = distinct_mappings.max(1);
+    (0..fragment_count)
+        .map(|id| {
+            let mapping_id = id % distinct_mappings;
+            let fields = mapping_vector(mapping_id, columns);
+            wide_fragment(id, fields.clone(), fields, 0)
+        })
+        .collect()
+}
+
+fn split_leaves(fragments: &[Fragment], leaf_count: usize) -> Vec<Vec<Fragment>> {
+    let leaf_count = leaf_count.max(1);
+    let size = fragments.len().div_ceil(leaf_count);
+    fragments.chunks(size).map(|chunk| chunk.to_vec()).collect()
+}
+
+fn median_ns(mut times: Vec<u128>) -> u128 {
+    times.sort_unstable();
+    times[times.len() / 2]
+}
+
+fn unique_field_arcs(fragments: &[Fragment]) -> usize {
+    let mut pointers = std::collections::HashSet::new();
+    for fragment in fragments {
+        for file in &fragment.files {
+            pointers.insert(Arc::as_ptr(&file.fields));
+        }
+    }
+    pointers.len()
+}
+
+fn dict_spec() -> EncodeSpec {
+    EncodeSpec {
+        layout: Layout::Flat,
+        mapping: Mapping::DictionaryList,
+        physical_dictionary: true,
+    }
+}
+
+fn list_spec() -> EncodeSpec {
+    EncodeSpec {
+        layout: Layout::Flat,
+        mapping: Mapping::RepeatedList,
+        physical_dictionary: true,
+    }
+}
+
+fn measure_dictionary_reconstruct(name: &str, fragments: &[Fragment], leaf_count: usize) {
+    let leaves = split_leaves(fragments, leaf_count);
+    let list_batches: Vec<_> = leaves
+        .iter()
+        .map(|leaf| encode_flat(leaf, list_spec()).unwrap())
+        .collect();
+    let dict_batches: Vec<_> = leaves
+        .iter()
+        .map(|leaf| encode_flat(leaf, dict_spec()).unwrap())
+        .collect();
+
+    let list_arrow: usize = list_batches.iter().map(batch_memory).sum();
+    let dict_arrow: usize = dict_batches.iter().map(batch_memory).sum();
+
+    let mut list_meter = CopyMeter::default();
+    let mut dict_meter = CopyMeter::default();
+    let mut list_fragments = Vec::new();
+    let mut dict_fragments = Vec::new();
+    let mut list_times = Vec::new();
+    let mut dict_times = Vec::new();
+    for _ in 0..3 {
+        let mut meter = CopyMeter::default();
+        let mut intern = DataFileFieldInterner::default();
+        let started = Instant::now();
+        let mut decoded = Vec::new();
+        for batch in &list_batches {
+            decoded.extend(reconstruct_list_then_intern(batch, &mut intern, &mut meter));
+        }
+        list_times.push(started.elapsed().as_nanos());
+        list_meter = meter;
+        list_fragments = decoded;
+
+        let mut meter = CopyMeter::default();
+        let mut intern = DataFileFieldInterner::default();
+        let started = Instant::now();
+        let mut decoded = Vec::new();
+        for batch in &dict_batches {
+            decoded.extend(reconstruct_dictionary_then_intern(
+                batch,
+                &mut intern,
+                &mut meter,
+            ));
+        }
+        dict_times.push(started.elapsed().as_nanos());
+        dict_meter = meter;
+        dict_fragments = decoded;
+    }
+    assert_eq!(list_fragments, *fragments);
+    assert_eq!(dict_fragments, *fragments);
+
+    println!(
+        "DICT_JSON {}",
+        json!({
+            "kind": "reconstruct",
+            "workload": name,
+            "fragments": fragments.len(),
+            "files": fragments.iter().map(|fragment| fragment.files.len()).sum::<usize>(),
+            "unique_field_lists": unique_field_lists(fragments),
+            "leaves": leaf_count,
+            "list": {
+                "arrow_bytes": list_arrow,
+                "copied_bytes": list_meter.copied_bytes,
+                "copy_count": list_meter.copy_count,
+                "peak_live_copy_bytes": list_meter.peak_live_bytes,
+                "interned_fragment_bytes": list_fragments.deep_size_of(),
+                "interned_unique_arcs": unique_field_arcs(&list_fragments),
+                "resident_batch_plus_interned": list_arrow + list_fragments.deep_size_of(),
+                "reconstruct_ns": median_ns(list_times),
+            },
+            "dictionary": {
+                "arrow_bytes": dict_arrow,
+                "copied_bytes": dict_meter.copied_bytes,
+                "copy_count": dict_meter.copy_count,
+                "peak_live_copy_bytes": dict_meter.peak_live_bytes,
+                "interned_fragment_bytes": dict_fragments.deep_size_of(),
+                "interned_unique_arcs": unique_field_arcs(&dict_fragments),
+                "resident_batch_plus_interned": dict_arrow + dict_fragments.deep_size_of(),
+                "reconstruct_ns": median_ns(dict_times),
+            },
+            "field_ids": {
+                "list": dictionary_column_parts(list_batches[0].column_by_name("field_ids").unwrap()),
+                "dictionary": dictionary_column_parts(dict_batches[0].column_by_name("field_ids").unwrap()),
+            },
+        })
+    );
+}
+
+#[test]
+fn dictionary_batch_memory_includes_keys_and_values_and_matches_list_records() {
+    let fragments = fragments_with_mappings(12, 16, 4);
+    let list_batch = encode_flat(&fragments, list_spec()).unwrap();
+    let dict_batch = encode_flat(&fragments, dict_spec()).unwrap();
+    let mut list_intern = DataFileFieldInterner::default();
+    let mut dict_intern = DataFileFieldInterner::default();
+    let mut list_meter = CopyMeter::default();
+    let mut dict_meter = CopyMeter::default();
+    let from_list = reconstruct_list_then_intern(&list_batch, &mut list_intern, &mut list_meter);
+    let from_dict =
+        reconstruct_dictionary_then_intern(&dict_batch, &mut dict_intern, &mut dict_meter);
+    assert_eq!(from_list, fragments);
+    assert_eq!(from_dict, fragments);
+
+    let field_ids = dict_batch.column_by_name("field_ids").unwrap();
+    let dictionary = field_ids.as_dictionary::<Int32Type>();
+    let keys_bytes = dictionary.keys().get_array_memory_size();
+    let values_bytes = dictionary.values().get_array_memory_size();
+    let column_bytes = field_ids.get_array_memory_size();
+    assert!(
+        column_bytes >= keys_bytes + values_bytes,
+        "dictionary column {column_bytes} must include keys {keys_bytes} and values {values_bytes}"
+    );
+    assert!(keys_bytes > 0, "dictionary keys must occupy memory");
+    assert!(values_bytes > 0, "dictionary values must occupy memory");
+}
+
+#[ignore]
+#[tokio::test]
+async fn dictionary_reconstruct_vs_list_intern() {
+    let fragment_count = env_u64("LEAF_F", 20000);
+    let columns = env_u64("LEAF_C", 500) as u32;
+    let leaf_count = env_u64("LEAF_LEAVES", 4) as usize;
+    println!(
+        "DICT_JSON {}",
+        json!({
+            "kind": "config",
+            "records": "synthetic",
+            "storage": "in-process",
+            "fragments": fragment_count,
+            "columns": columns,
+            "leaves": leaf_count,
+            "build": if cfg!(debug_assertions) { "debug" } else { "release" },
+            "note": "Arrow reconstruct only. Dictionary-of-lists is not a Lance file type.",
+        })
+    );
+    measure_dictionary_reconstruct(
+        "homogeneous",
+        &fragments_with_mappings(fragment_count, columns, 1),
+        leaf_count,
+    );
+    measure_dictionary_reconstruct(
+        "partial_32",
+        &fragments_with_mappings(fragment_count, columns, 32),
+        leaf_count,
+    );
+    measure_dictionary_reconstruct(
+        "mostly_unique",
+        &fragments_with_mappings(fragment_count, columns, fragment_count),
+        leaf_count,
+    );
+}

--- a/rust/lance-table/src/fragment_metadata/layout.rs
+++ b/rust/lance-table/src/fragment_metadata/layout.rs
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+//! Creation-time layout selection. Manifest feature flags govern compatibility.
+//! This setting chooses which writer to use for a new dataset.
+
+use std::collections::HashMap;
+
+use lance_core::{Error, Result};
+
+/// Table config key selecting a manifest layout.
+pub const MANIFEST_LAYOUT_KEY: &str = "lance.manifest.layout";
+/// Config value selecting today's flat manifest, also the default.
+pub const MANIFEST_LAYOUT_FLAT: &str = "flat";
+/// Config value selecting the buffered fragment tree layout.
+pub const MANIFEST_LAYOUT_TREE: &str = "tree";
+
+/// The manifest layout a table's config selects.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ManifestLayout {
+    /// Single-protobuf manifest. The default when the key is unset.
+    Flat,
+    /// Buffered fragment metadata, selected by `lance.manifest.layout=tree`.
+    Tree,
+}
+
+impl ManifestLayout {
+    /// Select a layout from table config, treating an unset key as flat.
+    ///
+    /// Rejects unknown values instead of falling back, so a typo cannot
+    /// silently create a flat dataset.
+    pub fn from_config(config: &HashMap<String, String>) -> Result<Self> {
+        match config.get(MANIFEST_LAYOUT_KEY).map(String::as_str) {
+            None | Some(MANIFEST_LAYOUT_FLAT) => Ok(Self::Flat),
+            Some(MANIFEST_LAYOUT_TREE) => Ok(Self::Tree),
+            Some(other) => Err(Error::invalid_input(format!(
+                "unsupported {MANIFEST_LAYOUT_KEY} value: layout={other:?}, \
+                 expected={MANIFEST_LAYOUT_FLAT:?} or {MANIFEST_LAYOUT_TREE:?}"
+            ))),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn layout_defaults_to_flat_and_rejects_unknown_values() {
+        assert_eq!(
+            ManifestLayout::from_config(&HashMap::new()).unwrap(),
+            ManifestLayout::Flat
+        );
+        let flat = HashMap::from([(MANIFEST_LAYOUT_KEY.to_string(), "flat".to_string())]);
+        assert_eq!(
+            ManifestLayout::from_config(&flat).unwrap(),
+            ManifestLayout::Flat
+        );
+        let tree = HashMap::from([(MANIFEST_LAYOUT_KEY.to_string(), "tree".to_string())]);
+        assert_eq!(
+            ManifestLayout::from_config(&tree).unwrap(),
+            ManifestLayout::Tree
+        );
+        let unknown = HashMap::from([(MANIFEST_LAYOUT_KEY.to_string(), "tiered".to_string())]);
+        let error = ManifestLayout::from_config(&unknown).unwrap_err();
+        assert!(error.to_string().contains("layout=\"tiered\""), "{error}");
+    }
+}

--- a/rust/lance-table/src/fragment_metadata/leaf_layout_compare.rs
+++ b/rust/lance-table/src/fragment_metadata/leaf_layout_compare.rs
@@ -1,0 +1,923 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+//! Local in-memory Lance file encode and decode of synthetic fragment records.
+//!
+//! Compares flat and nested leaf layouts. Nested files are not a voted leaf
+//! format. Reports encoded bytes, encode-time Arrow batch memory, decoded
+//! Arrow batch memory, and interned fragment heap separately.
+
+#![allow(clippy::print_stdout)]
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Instant;
+
+use arrow_array::builder::{Int32Builder, ListBuilder};
+use arrow_array::cast::AsArray;
+use arrow_array::types::{Int32Type, UInt32Type, UInt64Type};
+use arrow_array::{
+    Array, ArrayRef, BinaryArray, DictionaryArray, Int32Array, RecordBatch, StringArray,
+    StructArray, UInt8Array, UInt32Array, UInt64Array,
+};
+use arrow_buffer::OffsetBuffer;
+use arrow_schema::{DataType, Field as ArrowField, Fields, Schema as ArrowSchema};
+use bytes::Bytes;
+use futures::TryStreamExt;
+use lance_core::Result;
+use lance_core::cache::LanceCache;
+use lance_core::datatypes::Schema as LanceSchema;
+use lance_core::deepsize::DeepSizeOf;
+use lance_encoding::constants::DICT_DIVISOR_META_KEY;
+use lance_encoding::decoder::{DecoderPlugins, FilterExpression};
+use lance_file::reader::{FileReader, FileReaderOptions};
+use lance_file::version::ConcreteFileVersion;
+use lance_file::versions::create_writer;
+use lance_file::writer::FileWriterOptions;
+use lance_io::ReadBatchParams;
+use lance_io::object_reader::SmallReader;
+use lance_io::object_store::ObjectStore;
+use lance_io::scheduler::{ScanScheduler, SchedulerConfig};
+use object_store::path::Path;
+use object_store::{PutOptions, PutPayload};
+use prost::Message;
+use serde_json::json;
+
+use crate::format::pb;
+use crate::format::{DataFile, DataFileFieldInterner, Fragment, RowDatasetVersionMeta};
+use crate::fragment_metadata::action;
+use crate::fragment_metadata::store::get_whole;
+use crate::fragment_metadata::support::{data_file_path, make_backfill_data_file};
+
+const FILE_VERSION: ConcreteFileVersion = ConcreteFileVersion::V2_1;
+const ROW_KIND_FRAGMENT: u8 = 0;
+const ROW_KIND_DATA_FILE: u8 = 1;
+const DISABLE_PHYSICAL_DICTIONARY: &str = "1000000000";
+
+#[derive(Clone, Copy)]
+pub(super) enum Layout {
+    Flat,
+    Nested,
+}
+
+#[derive(Clone, Copy)]
+pub(super) enum Mapping {
+    RepeatedList,
+    DictionaryList,
+}
+
+#[derive(Clone, Copy)]
+pub(super) struct EncodeSpec {
+    pub(super) layout: Layout,
+    pub(super) mapping: Mapping,
+    pub(super) physical_dictionary: bool,
+}
+
+impl EncodeSpec {
+    fn label(self) -> String {
+        format!(
+            "{} {} physical_dict={}",
+            match self.layout {
+                Layout::Flat => "flat",
+                Layout::Nested => "nested",
+            },
+            match self.mapping {
+                Mapping::RepeatedList => "list",
+                Mapping::DictionaryList => "arrow_dict",
+            },
+            self.physical_dictionary
+        )
+    }
+}
+
+pub(super) fn env_u64(name: &str, default: u64) -> u64 {
+    std::env::var(name)
+        .ok()
+        .and_then(|value| value.parse().ok())
+        .unwrap_or(default)
+}
+
+fn int_list_type() -> DataType {
+    DataType::List(Arc::new(ArrowField::new("item", DataType::Int32, false)))
+}
+
+fn mapped_list_type(mapping: Mapping) -> DataType {
+    match mapping {
+        Mapping::RepeatedList => int_list_type(),
+        Mapping::DictionaryList => {
+            DataType::Dictionary(Box::new(DataType::Int32), Box::new(int_list_type()))
+        }
+    }
+}
+
+fn stamp_physical_dictionary(field: ArrowField, physical_dictionary: bool) -> ArrowField {
+    if physical_dictionary {
+        return field;
+    }
+    let mut metadata = field.metadata().clone();
+    metadata.insert(
+        DICT_DIVISOR_META_KEY.to_string(),
+        DISABLE_PHYSICAL_DICTIONARY.to_string(),
+    );
+    let data_type = match field.data_type() {
+        DataType::List(item) => {
+            DataType::List(Arc::new(stamp_physical_dictionary((**item).clone(), false)))
+        }
+        DataType::Struct(fields) => DataType::Struct(
+            fields
+                .iter()
+                .map(|child| stamp_physical_dictionary((**child).clone(), false))
+                .collect(),
+        ),
+        DataType::Dictionary(key, value) => {
+            let value_field = stamp_physical_dictionary(
+                ArrowField::new("value", value.as_ref().clone(), true),
+                false,
+            );
+            DataType::Dictionary(key.clone(), Box::new(value_field.data_type().clone()))
+        }
+        other => other.clone(),
+    };
+    ArrowField::new(field.name(), data_type, field.is_nullable()).with_metadata(metadata)
+}
+
+fn list_item_field(physical_dictionary: bool) -> ArrowField {
+    stamp_physical_dictionary(
+        ArrowField::new("item", DataType::Int32, false),
+        physical_dictionary,
+    )
+}
+
+fn list_column(mapping: Mapping, lists: &[Vec<i32>], physical_dictionary: bool) -> ArrayRef {
+    let item = list_item_field(physical_dictionary);
+    match mapping {
+        Mapping::RepeatedList => {
+            let mut builder = ListBuilder::new(Int32Builder::new()).with_field(item);
+            for list in lists {
+                builder.values().append_slice(list);
+                builder.append(true);
+            }
+            Arc::new(builder.finish())
+        }
+        Mapping::DictionaryList => {
+            let mut unique: HashMap<Vec<i32>, i32> = HashMap::new();
+            let mut keys = Vec::with_capacity(lists.len());
+            let mut dictionary = Vec::new();
+            for list in lists {
+                if let Some(&key) = unique.get(list) {
+                    keys.push(key);
+                    continue;
+                }
+                let key = i32::try_from(dictionary.len()).expect("dictionary key fits i32");
+                unique.insert(list.clone(), key);
+                dictionary.push(list.clone());
+                keys.push(key);
+            }
+            let mut values = ListBuilder::new(Int32Builder::new()).with_field(item);
+            for list in &dictionary {
+                values.values().append_slice(list);
+                values.append(true);
+            }
+            Arc::new(
+                DictionaryArray::<Int32Type>::try_new(
+                    Int32Array::from(keys),
+                    Arc::new(values.finish()),
+                )
+                .expect("dictionary keys index values"),
+            )
+        }
+    }
+}
+
+pub(super) fn list_i32_at(array: &dyn Array, row: usize) -> Vec<i32> {
+    match array.data_type() {
+        DataType::Dictionary(_, _) => {
+            let dictionary = array.as_dictionary::<Int32Type>();
+            list_i32_at(
+                dictionary.values().as_ref(),
+                dictionary.keys().value(row) as usize,
+            )
+        }
+        _ => array
+            .as_list::<i32>()
+            .value(row)
+            .as_primitive::<Int32Type>()
+            .values()
+            .to_vec(),
+    }
+}
+
+fn header_proto(fragment: &Fragment) -> Vec<u8> {
+    let mut header = pb::DataFragment::from(fragment);
+    header.files.clear();
+    header.encode_to_vec()
+}
+
+pub(super) fn data_file_from_parts(
+    proto: pb::DataFile,
+    intern: Option<&mut DataFileFieldInterner>,
+) -> DataFile {
+    match intern {
+        Some(interner) => interner
+            .intern_data_file(proto)
+            .expect("data file proto is valid"),
+        None => DataFile::try_from(proto).expect("data file proto is valid"),
+    }
+}
+
+pub(super) fn fragment_from_header(
+    bytes: &[u8],
+    files: Vec<DataFile>,
+    intern: Option<&mut DataFileFieldInterner>,
+) -> Fragment {
+    let proto = pb::DataFragment::decode(bytes).expect("fragment_meta is a DataFragment");
+    let mut fragment = match intern {
+        Some(interner) => interner
+            .intern_fragment(proto)
+            .expect("fragment_meta is a DataFragment"),
+        None => crate::format::Fragment::try_from(proto).expect("fragment_meta is a DataFragment"),
+    };
+    fragment.files = files;
+    fragment
+}
+
+fn file_column_lists(fragments: &[Fragment]) -> (Vec<Vec<i32>>, Vec<Vec<i32>>) {
+    let mut field_ids = Vec::new();
+    let mut column_indices = Vec::new();
+    for fragment in fragments {
+        field_ids.push(Vec::new());
+        column_indices.push(Vec::new());
+        for file in &fragment.files {
+            field_ids.push(file.fields.to_vec());
+            column_indices.push(file.column_indices.to_vec());
+        }
+    }
+    (field_ids, column_indices)
+}
+
+pub(super) fn encode_flat(fragments: &[Fragment], spec: EncodeSpec) -> Result<RecordBatch> {
+    let num_rows: usize = fragments
+        .iter()
+        .map(|fragment| fragment.files.len() + 1)
+        .sum();
+    let mut row_kind = Vec::with_capacity(num_rows);
+    let mut frag_ids = Vec::with_capacity(num_rows);
+    let mut fragment_meta = Vec::with_capacity(num_rows);
+    let mut paths = Vec::with_capacity(num_rows);
+    let mut major = Vec::with_capacity(num_rows);
+    let mut minor = Vec::with_capacity(num_rows);
+    let mut sizes = Vec::with_capacity(num_rows);
+    let mut base_ids: Vec<Option<u32>> = Vec::with_capacity(num_rows);
+    for fragment in fragments {
+        row_kind.push(ROW_KIND_FRAGMENT);
+        frag_ids.push(fragment.id);
+        fragment_meta.push(Some(header_proto(fragment)));
+        paths.push(String::new());
+        major.push(0);
+        minor.push(0);
+        sizes.push(0);
+        base_ids.push(None);
+        for file in &fragment.files {
+            row_kind.push(ROW_KIND_DATA_FILE);
+            frag_ids.push(fragment.id);
+            fragment_meta.push(None);
+            paths.push(file.path.clone());
+            major.push(file.file_major_version);
+            minor.push(file.file_minor_version);
+            sizes.push(
+                file.file_size_bytes
+                    .get()
+                    .map(|size| size.get())
+                    .unwrap_or_default(),
+            );
+            base_ids.push(file.base_id);
+        }
+    }
+    let (field_ids, column_indices) = file_column_lists(fragments);
+    let schema = ArrowSchema::new(vec![
+        stamp_physical_dictionary(
+            ArrowField::new("row_kind", DataType::UInt8, false),
+            spec.physical_dictionary,
+        ),
+        stamp_physical_dictionary(
+            ArrowField::new("frag_id", DataType::UInt64, false),
+            spec.physical_dictionary,
+        ),
+        stamp_physical_dictionary(
+            ArrowField::new("fragment_meta", DataType::Binary, true),
+            spec.physical_dictionary,
+        ),
+        stamp_physical_dictionary(
+            ArrowField::new("path", DataType::Utf8, false),
+            spec.physical_dictionary,
+        ),
+        stamp_physical_dictionary(
+            ArrowField::new("field_ids", mapped_list_type(spec.mapping), false),
+            spec.physical_dictionary,
+        ),
+        stamp_physical_dictionary(
+            ArrowField::new("column_indices", mapped_list_type(spec.mapping), false),
+            spec.physical_dictionary,
+        ),
+        stamp_physical_dictionary(
+            ArrowField::new("major_version", DataType::UInt32, false),
+            spec.physical_dictionary,
+        ),
+        stamp_physical_dictionary(
+            ArrowField::new("minor_version", DataType::UInt32, false),
+            spec.physical_dictionary,
+        ),
+        stamp_physical_dictionary(
+            ArrowField::new("file_size_bytes", DataType::UInt64, false),
+            spec.physical_dictionary,
+        ),
+        stamp_physical_dictionary(
+            ArrowField::new("base_id", DataType::UInt32, true),
+            spec.physical_dictionary,
+        ),
+    ]);
+    Ok(RecordBatch::try_new(
+        Arc::new(schema),
+        vec![
+            Arc::new(UInt8Array::from(row_kind)),
+            Arc::new(UInt64Array::from(frag_ids)),
+            Arc::new(BinaryArray::from_opt_vec(
+                fragment_meta
+                    .iter()
+                    .map(|value| value.as_deref())
+                    .collect::<Vec<_>>(),
+            )),
+            Arc::new(StringArray::from(paths)),
+            list_column(spec.mapping, &field_ids, spec.physical_dictionary),
+            list_column(spec.mapping, &column_indices, spec.physical_dictionary),
+            Arc::new(UInt32Array::from(major)),
+            Arc::new(UInt32Array::from(minor)),
+            Arc::new(UInt64Array::from(sizes)),
+            Arc::new(UInt32Array::from(base_ids)),
+        ],
+    )?)
+}
+
+fn file_struct_fields(mapping: Mapping, physical_dictionary: bool) -> Fields {
+    Fields::from(vec![
+        stamp_physical_dictionary(
+            ArrowField::new("path", DataType::Utf8, false),
+            physical_dictionary,
+        ),
+        stamp_physical_dictionary(
+            ArrowField::new("field_ids", mapped_list_type(mapping), false),
+            physical_dictionary,
+        ),
+        stamp_physical_dictionary(
+            ArrowField::new("column_indices", mapped_list_type(mapping), false),
+            physical_dictionary,
+        ),
+        stamp_physical_dictionary(
+            ArrowField::new("major_version", DataType::UInt32, false),
+            physical_dictionary,
+        ),
+        stamp_physical_dictionary(
+            ArrowField::new("minor_version", DataType::UInt32, false),
+            physical_dictionary,
+        ),
+        stamp_physical_dictionary(
+            ArrowField::new("file_size_bytes", DataType::UInt64, false),
+            physical_dictionary,
+        ),
+        stamp_physical_dictionary(
+            ArrowField::new("base_id", DataType::UInt32, true),
+            physical_dictionary,
+        ),
+    ])
+}
+
+fn encode_nested(fragments: &[Fragment], spec: EncodeSpec) -> Result<RecordBatch> {
+    let mut ids = Vec::with_capacity(fragments.len());
+    let mut fragment_meta = Vec::with_capacity(fragments.len());
+    let mut offsets = Vec::with_capacity(fragments.len() + 1);
+    offsets.push(0i32);
+    let mut paths = Vec::new();
+    let mut field_ids = Vec::new();
+    let mut column_indices = Vec::new();
+    let mut major = Vec::new();
+    let mut minor = Vec::new();
+    let mut sizes = Vec::new();
+    let mut base_ids: Vec<Option<u32>> = Vec::new();
+    let mut file_count = 0i32;
+    for fragment in fragments {
+        ids.push(fragment.id);
+        fragment_meta.push(header_proto(fragment));
+        for file in &fragment.files {
+            paths.push(file.path.clone());
+            field_ids.push(file.fields.to_vec());
+            column_indices.push(file.column_indices.to_vec());
+            major.push(file.file_major_version);
+            minor.push(file.file_minor_version);
+            sizes.push(
+                file.file_size_bytes
+                    .get()
+                    .map(|size| size.get())
+                    .unwrap_or_default(),
+            );
+            base_ids.push(file.base_id);
+            file_count += 1;
+        }
+        offsets.push(file_count);
+    }
+    let struct_fields = file_struct_fields(spec.mapping, spec.physical_dictionary);
+    let files = StructArray::new(
+        struct_fields.clone(),
+        vec![
+            Arc::new(StringArray::from(paths)),
+            list_column(spec.mapping, &field_ids, spec.physical_dictionary),
+            list_column(spec.mapping, &column_indices, spec.physical_dictionary),
+            Arc::new(UInt32Array::from(major)),
+            Arc::new(UInt32Array::from(minor)),
+            Arc::new(UInt64Array::from(sizes)),
+            Arc::new(UInt32Array::from(base_ids)),
+        ],
+        None,
+    );
+    let files_list = arrow_array::ListArray::try_new(
+        Arc::new(ArrowField::new(
+            "item",
+            DataType::Struct(struct_fields),
+            false,
+        )),
+        OffsetBuffer::from_lengths(
+            offsets
+                .windows(2)
+                .map(|window| (window[1] - window[0]) as usize),
+        ),
+        Arc::new(files),
+        None,
+    )?;
+    let schema = ArrowSchema::new(vec![
+        stamp_physical_dictionary(
+            ArrowField::new("id", DataType::UInt64, false),
+            spec.physical_dictionary,
+        ),
+        stamp_physical_dictionary(
+            ArrowField::new("fragment_meta", DataType::Binary, false),
+            spec.physical_dictionary,
+        ),
+        ArrowField::new("files", files_list.data_type().clone(), false),
+    ]);
+    Ok(RecordBatch::try_new(
+        Arc::new(schema),
+        vec![
+            Arc::new(UInt64Array::from(ids)),
+            Arc::new(BinaryArray::from_iter_values(fragment_meta)),
+            Arc::new(files_list),
+        ],
+    )?)
+}
+
+pub(super) fn batch_memory(batch: &RecordBatch) -> usize {
+    batch
+        .columns()
+        .iter()
+        .map(|column| column.get_array_memory_size())
+        .sum()
+}
+
+async fn write_lance(batch: &RecordBatch) -> Result<Bytes> {
+    let lance_schema = LanceSchema::try_from(batch.schema().as_ref())?;
+    let memory = ObjectStore::memory();
+    let path = Path::from("encoded-leaf");
+    let writer = memory.create(&path).await?;
+    let mut file_writer = create_writer(
+        FILE_VERSION,
+        writer,
+        lance_schema,
+        FileWriterOptions::default(),
+    )?;
+    file_writer.write_batch(batch).await?;
+    file_writer.finish().await?;
+    get_whole(&memory, &path).await
+}
+
+async fn read_lance(bytes: Bytes, columns: Option<&[&str]>) -> Result<RecordBatch> {
+    let store = ObjectStore::memory();
+    let path = Path::from("encoded-leaf");
+    let size = bytes.len();
+    store
+        .inner
+        .put_opts(&path, PutPayload::from(bytes), PutOptions::default())
+        .await?;
+    let store = Arc::new(store);
+    let scheduler = ScanScheduler::new(store.clone(), SchedulerConfig::max_bandwidth(&store));
+    let object_reader = Arc::new(SmallReader::new(store.inner.clone(), path, 3, size));
+    let file_scheduler = scheduler.open_reader(object_reader);
+    let cache = LanceCache::with_capacity(64 * 1024 * 1024);
+    let reader = FileReader::try_open(
+        file_scheduler,
+        None,
+        Arc::<DecoderPlugins>::default(),
+        &cache,
+        FileReaderOptions::default(),
+    )
+    .await?;
+    let mut stream = match columns {
+        Some(names) => {
+            let projection = lance_file::versions::reader_projection_from_column_names(
+                FILE_VERSION,
+                reader.schema(),
+                names,
+            )?;
+            reader
+                .read_stream_projected(
+                    ReadBatchParams::RangeFull,
+                    16 * 1024,
+                    16,
+                    projection,
+                    FilterExpression::no_filter(),
+                )
+                .await?
+        }
+        None => {
+            reader
+                .read_stream(
+                    ReadBatchParams::RangeFull,
+                    16 * 1024,
+                    16,
+                    FilterExpression::no_filter(),
+                )
+                .await?
+        }
+    };
+    let mut batches = Vec::new();
+    while let Some(batch) = stream.try_next().await? {
+        batches.push(batch);
+    }
+    Ok(arrow::compute::concat_batches(
+        &batches[0].schema(),
+        &batches,
+    )?)
+}
+
+fn decode_flat(batch: &RecordBatch, intern: bool) -> Vec<Fragment> {
+    let mut interner = intern.then(DataFileFieldInterner::default);
+    let row_kinds = batch["row_kind"].as_primitive::<arrow_array::types::UInt8Type>();
+    let fragment_meta = batch["fragment_meta"].as_binary::<i32>();
+    let paths = batch["path"].as_string::<i32>();
+    let field_ids = batch["field_ids"].as_ref();
+    let column_indices = batch["column_indices"].as_ref();
+    let major = batch["major_version"].as_primitive::<UInt32Type>();
+    let minor = batch["minor_version"].as_primitive::<UInt32Type>();
+    let sizes = batch["file_size_bytes"].as_primitive::<UInt64Type>();
+    let base_ids = batch["base_id"].as_primitive::<UInt32Type>();
+    let mut fragments = Vec::new();
+    for row in 0..batch.num_rows() {
+        if row_kinds.value(row) == ROW_KIND_FRAGMENT {
+            fragments.push(fragment_from_header(
+                fragment_meta.value(row),
+                Vec::new(),
+                interner.as_mut(),
+            ));
+            continue;
+        }
+        let file = data_file_from_parts(
+            pb::DataFile {
+                path: paths.value(row).to_string(),
+                fields: list_i32_at(field_ids, row),
+                column_indices: list_i32_at(column_indices, row),
+                file_major_version: major.value(row),
+                file_minor_version: minor.value(row),
+                file_size_bytes: sizes.value(row),
+                base_id: (!base_ids.is_null(row)).then(|| base_ids.value(row)),
+            },
+            interner.as_mut(),
+        );
+        fragments
+            .last_mut()
+            .expect("DATA_FILE follows a FRAGMENT row")
+            .files
+            .push(file);
+    }
+    fragments
+}
+
+fn decode_nested(batch: &RecordBatch, intern: bool) -> Vec<Fragment> {
+    let mut interner = intern.then(DataFileFieldInterner::default);
+    let ids = batch["id"].as_primitive::<UInt64Type>();
+    let fragment_meta = batch["fragment_meta"].as_binary::<i32>();
+    let files = batch["files"].as_list::<i32>();
+    let mut fragments = Vec::with_capacity(batch.num_rows());
+    for row in 0..batch.num_rows() {
+        let struct_array = files.value(row);
+        let files_struct = struct_array.as_struct();
+        let paths = files_struct
+            .column_by_name("path")
+            .unwrap()
+            .as_string::<i32>();
+        let field_ids = files_struct.column_by_name("field_ids").unwrap();
+        let column_indices = files_struct.column_by_name("column_indices").unwrap();
+        let major = files_struct
+            .column_by_name("major_version")
+            .unwrap()
+            .as_primitive::<UInt32Type>();
+        let minor = files_struct
+            .column_by_name("minor_version")
+            .unwrap()
+            .as_primitive::<UInt32Type>();
+        let sizes = files_struct
+            .column_by_name("file_size_bytes")
+            .unwrap()
+            .as_primitive::<UInt64Type>();
+        let base_ids = files_struct
+            .column_by_name("base_id")
+            .unwrap()
+            .as_primitive::<UInt32Type>();
+        let mut decoded_files = Vec::with_capacity(files_struct.len());
+        for file_row in 0..files_struct.len() {
+            decoded_files.push(data_file_from_parts(
+                pb::DataFile {
+                    path: paths.value(file_row).to_string(),
+                    fields: list_i32_at(field_ids, file_row),
+                    column_indices: list_i32_at(column_indices, file_row),
+                    file_major_version: major.value(file_row),
+                    file_minor_version: minor.value(file_row),
+                    file_size_bytes: sizes.value(file_row),
+                    base_id: (!base_ids.is_null(file_row)).then(|| base_ids.value(file_row)),
+                },
+                interner.as_mut(),
+            ));
+        }
+        let mut fragment =
+            fragment_from_header(fragment_meta.value(row), decoded_files, interner.as_mut());
+        fragment.id = ids.value(row);
+        fragments.push(fragment);
+    }
+    fragments
+}
+
+pub(super) fn wide_fragment(
+    id: u64,
+    fields: Arc<[i32]>,
+    indices: Arc<[i32]>,
+    adds: u64,
+) -> Fragment {
+    let mut fragment = Fragment::new(id);
+    fragment.physical_rows = Some(2048);
+    fragment.files.push(DataFile {
+        path: data_file_path(id, 0),
+        fields,
+        column_indices: indices,
+        file_major_version: 2,
+        file_minor_version: 0,
+        file_size_bytes: std::num::NonZero::new(4096).into(),
+        base_id: None,
+    });
+    for add in 0..adds {
+        fragment.files.push(make_backfill_data_file(id, add as u32));
+    }
+    fragment
+}
+
+fn wide_fragments(fragment_count: u64, columns: u32, adds: u64) -> Vec<Fragment> {
+    let fields: Arc<[i32]> = (0..columns as i32).collect::<Vec<_>>().into();
+    let indices = fields.clone();
+    (0..fragment_count)
+        .map(|id| wide_fragment(id, fields.clone(), indices.clone(), adds))
+        .collect()
+}
+
+fn with_timestamp(fragments: &[Fragment]) -> Vec<Fragment> {
+    fragments
+        .iter()
+        .cloned()
+        .map(|mut fragment| {
+            fragment.last_updated_at_version_meta =
+                Some(RowDatasetVersionMeta::Inline(Arc::from([
+                    1u8, 2, 3, 4, 5, 6, 7, 8,
+                ])));
+            fragment
+        })
+        .collect()
+}
+
+fn one_add_columns_buffer_bytes(fragment_count: u64) -> usize {
+    (0..fragment_count)
+        .map(|id| {
+            let file = make_backfill_data_file(id, 0);
+            pb::FragmentMetadataMutation {
+                action_sequence: id + 1,
+                action: Some(action::add_data_file(id, &file)),
+                fragment_count_delta: 0,
+                total_rows_delta: 0,
+                visible_rows_delta: 0,
+            }
+            .encoded_len()
+        })
+        .sum()
+}
+
+fn build_batch(fragments: &[Fragment], spec: EncodeSpec) -> Result<RecordBatch> {
+    match spec.layout {
+        Layout::Flat => encode_flat(fragments, spec),
+        Layout::Nested => encode_nested(fragments, spec),
+    }
+}
+
+async fn encode_bytes(fragments: &[Fragment], spec: EncodeSpec) -> Result<(Bytes, u128, usize)> {
+    let started = Instant::now();
+    let batch = build_batch(fragments, spec)?;
+    let arrow_bytes = batch_memory(&batch);
+    let bytes = write_lance(&batch).await?;
+    Ok((bytes, started.elapsed().as_nanos(), arrow_bytes))
+}
+
+async fn reconstruct(
+    bytes: Bytes,
+    spec: EncodeSpec,
+    intern: bool,
+) -> Result<(Vec<Fragment>, u128, usize)> {
+    let started = Instant::now();
+    let batch = read_lance(bytes, None).await?;
+    let fragments = match spec.layout {
+        Layout::Flat => decode_flat(&batch, intern),
+        Layout::Nested => decode_nested(&batch, intern),
+    };
+    Ok((
+        fragments,
+        started.elapsed().as_nanos(),
+        batch_memory(&batch),
+    ))
+}
+
+async fn project(bytes: Bytes, spec: EncodeSpec) -> Result<(u128, usize, usize)> {
+    let columns: &[&str] = match spec.layout {
+        Layout::Flat => &["frag_id", "field_ids"],
+        Layout::Nested => &["files"],
+    };
+    let started = Instant::now();
+    let batch = read_lance(bytes, Some(columns)).await?;
+    Ok((
+        started.elapsed().as_nanos(),
+        batch_memory(&batch),
+        batch.num_rows(),
+    ))
+}
+
+fn specs() -> Vec<EncodeSpec> {
+    let mut specs = Vec::new();
+    for layout in [Layout::Flat, Layout::Nested] {
+        for mapping in [Mapping::RepeatedList, Mapping::DictionaryList] {
+            specs.push(EncodeSpec {
+                layout,
+                mapping,
+                physical_dictionary: true,
+            });
+            if matches!(mapping, Mapping::RepeatedList) {
+                specs.push(EncodeSpec {
+                    layout,
+                    mapping,
+                    physical_dictionary: false,
+                });
+            }
+        }
+    }
+    specs
+}
+
+fn writable_specs() -> Vec<EncodeSpec> {
+    specs()
+        .into_iter()
+        .filter(|spec| matches!(spec.mapping, Mapping::RepeatedList))
+        .collect()
+}
+
+pub(super) fn unique_field_lists(fragments: &[Fragment]) -> usize {
+    let mut unique = std::collections::HashSet::new();
+    for fragment in fragments {
+        for file in &fragment.files {
+            unique.insert(file.fields.to_vec());
+        }
+    }
+    unique.len()
+}
+
+async fn measure_workload(name: &str, fragments: &[Fragment]) -> Result<()> {
+    let buffer_bytes = one_add_columns_buffer_bytes(fragments.len() as u64);
+    println!(
+        "LEAF_JSON {}",
+        json!({
+            "kind": "workload",
+            "name": name,
+            "fragments": fragments.len(),
+            "files": fragments.iter().map(|fragment| fragment.files.len()).sum::<usize>(),
+            "unique_field_lists": unique_field_lists(fragments),
+            "buffer_add_data_file_bytes": buffer_bytes,
+        })
+    );
+    for spec in specs() {
+        let built = Instant::now();
+        let batch = build_batch(fragments, spec)?;
+        let arrow_bytes = batch_memory(&batch);
+        let build_ns = built.elapsed().as_nanos();
+        if matches!(spec.mapping, Mapping::DictionaryList) {
+            println!(
+                "LEAF_JSON {}",
+                json!({
+                    "kind": "arm",
+                    "workload": name,
+                    "layout": match spec.layout { Layout::Flat => "flat", Layout::Nested => "nested" },
+                    "mapping": "arrow_dict",
+                    "physical_dictionary": spec.physical_dictionary,
+                    "skipped": "lance_schema_rejects_dictionary_of_lists",
+                    "encode_arrow_bytes": arrow_bytes,
+                    "encode_ns": build_ns,
+                })
+            );
+            continue;
+        }
+        let started = Instant::now();
+        let bytes = write_lance(&batch).await?;
+        let encode_ns = started.elapsed().as_nanos() + build_ns;
+        let encoded_bytes = bytes.len();
+        let (project_ns, projected_arrow_bytes, projected_rows) =
+            project(bytes.clone(), spec).await?;
+        for intern in [false, true] {
+            let (decoded, decode_ns, decoded_arrow_bytes) =
+                reconstruct(bytes.clone(), spec, intern).await?;
+            assert_eq!(decoded, fragments, "{}", spec.label());
+            println!(
+                "LEAF_JSON {}",
+                json!({
+                    "kind": "arm",
+                    "workload": name,
+                    "layout": match spec.layout { Layout::Flat => "flat", Layout::Nested => "nested" },
+                    "mapping": "list",
+                    "physical_dictionary": spec.physical_dictionary,
+                    "intern": intern,
+                    "encoded_bytes": encoded_bytes,
+                    "encode_arrow_bytes": arrow_bytes,
+                    "encode_ns": encode_ns,
+                    "decode_ns": decode_ns,
+                    "decode_arrow_bytes": decoded_arrow_bytes,
+                    "decoded_fragment_bytes": decoded.deep_size_of(),
+                    "project_ns": project_ns,
+                    "projected_arrow_bytes": projected_arrow_bytes,
+                    "projected_rows": projected_rows,
+                })
+            );
+        }
+    }
+    Ok(())
+}
+
+#[tokio::test]
+async fn flat_and_nested_leaves_round_trip_identical_fragments() {
+    let fragments = wide_fragments(4, 8, 2);
+    for spec in writable_specs() {
+        let (bytes, _, _) = encode_bytes(&fragments, spec).await.unwrap();
+        let (decoded, _, _) = reconstruct(bytes, spec, true).await.unwrap();
+        assert_eq!(decoded, fragments, "{}", spec.label());
+    }
+}
+
+#[test]
+fn dictionary_of_int_lists_is_not_a_lance_schema() {
+    let fragments = wide_fragments(1, 4, 0);
+    let spec = EncodeSpec {
+        layout: Layout::Flat,
+        mapping: Mapping::DictionaryList,
+        physical_dictionary: true,
+    };
+    let batch = encode_flat(&fragments, spec).unwrap();
+    let converted = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        LanceSchema::try_from(batch.schema().as_ref())
+    }));
+    if let Ok(Ok(_)) = converted {
+        panic!("dictionary of lists must not convert to a Lance schema");
+    }
+}
+
+#[ignore]
+#[tokio::test]
+async fn leaf_layouts_compare_encoded_size_and_decode() {
+    let fragment_count = env_u64("LEAF_F", 2000);
+    let columns = env_u64("LEAF_C", 100) as u32;
+    let adds = env_u64("LEAF_ADDS", 5);
+    let base = wide_fragments(fragment_count, columns, 0);
+    let after_adds = wide_fragments(fragment_count, columns, adds);
+    let timestamp_bump = with_timestamp(&after_adds);
+    println!(
+        "LEAF_JSON {}",
+        json!({
+            "kind": "config",
+            "records": "synthetic",
+            "storage": "in-memory",
+            "fragments": fragment_count,
+            "columns": columns,
+            "adds": adds,
+            "build": if cfg!(debug_assertions) { "debug" } else { "release" },
+        })
+    );
+    measure_workload("homogeneous_base", &base).await.unwrap();
+    measure_workload("after_adds", &after_adds).await.unwrap();
+    measure_workload("timestamp_bump", &timestamp_bump)
+        .await
+        .unwrap();
+}

--- a/rust/lance-table/src/fragment_metadata/mod.rs
+++ b/rust/lance-table/src/fragment_metadata/mod.rs
@@ -18,6 +18,11 @@ mod validation;
 #[cfg(any(test, feature = "test-util"))]
 pub mod support;
 
+#[cfg(test)]
+mod dict_decode_compare;
+#[cfg(test)]
+mod leaf_layout_compare;
+
 pub use commit::{TouchedFragments, ValidatedCommit, data_replacement};
 pub use layout::{MANIFEST_LAYOUT_FLAT, MANIFEST_LAYOUT_KEY, MANIFEST_LAYOUT_TREE, ManifestLayout};
 pub use node::{DEFAULT_MAX_LEAF_BYTES, DEFAULT_MAX_NODE_BYTES, FragmentMetadataTreeConfig};

--- a/rust/lance-table/src/fragment_metadata/mod.rs
+++ b/rust/lance-table/src/fragment_metadata/mod.rs
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+//! Immutable fragment metadata and buffered state changes.
+//!
+//! Native transactions own validation and rebase. This module prepares tree
+//! objects and a descriptor. The Version Manifest is the publication authority.
+
+pub mod action;
+mod bulk;
+pub mod commit;
+pub mod layout;
+pub mod node;
+pub mod store;
+pub mod tree;
+mod validation;
+
+#[cfg(any(test, feature = "test-util"))]
+pub mod support;
+
+pub use commit::{TouchedFragments, ValidatedCommit, data_replacement};
+pub use layout::{MANIFEST_LAYOUT_FLAT, MANIFEST_LAYOUT_KEY, MANIFEST_LAYOUT_TREE, ManifestLayout};
+pub use node::{DEFAULT_MAX_LEAF_BYTES, DEFAULT_MAX_NODE_BYTES, FragmentMetadataTreeConfig};
+pub use tree::{
+    BootstrapStats, CommitStats, FragmentMetadataTree, OffsetResolution, SnapshotPolicy,
+};

--- a/rust/lance-table/src/fragment_metadata/node.rs
+++ b/rust/lance-table/src/fragment_metadata/node.rs
@@ -1,0 +1,1089 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+//! Routing, accounting, and reduction of validated fragment actions.
+//!
+//! Node policies use encoded bytes because fragments and actions vary in size.
+//! Leaf encoding and object I/O live in `store`; recursive mutation lives in `tree`.
+
+use std::collections::BTreeMap;
+
+use prost::Message;
+
+use crate::format::Fragment;
+use crate::format::pb::{self, fragment_action::Action};
+use crate::fragment_metadata::action;
+use lance_core::{Error, Result};
+
+/// Default routing and leaf targets. These are independent writer policies.
+pub const DEFAULT_MAX_NODE_BYTES: u64 = 1024 * 1024;
+pub const DEFAULT_MAX_LEAF_BYTES: u64 = 1024 * 1024;
+
+/// Encoded-byte policy for immutable nodes and semantic buffers.
+#[derive(Debug, Clone)]
+pub struct FragmentMetadataTreeConfig {
+    /// Target encoded routing-plus-buffer body size. Routing grows after flushing.
+    pub max_node_bytes: u64,
+    /// Target encoded Lance leaf size. A single fragment may exceed this target.
+    pub max_leaf_bytes: u64,
+    /// Pending bytes at which a flush drains children whose batches amortize a
+    /// rewrite. Smaller batches stay buffered until `max_node_bytes` forces them.
+    pub semantic_buffer_bytes: u64,
+    /// Complete object limit, including root envelopes and singleton leaves.
+    pub hard_capacity_bytes: u64,
+    // A bounded fanout is useful for structural tests. Dataset writers grow by bytes.
+    pub(crate) max_children_per_node: u32,
+}
+
+impl Default for FragmentMetadataTreeConfig {
+    fn default() -> Self {
+        Self {
+            max_node_bytes: DEFAULT_MAX_NODE_BYTES,
+            max_leaf_bytes: DEFAULT_MAX_LEAF_BYTES,
+            semantic_buffer_bytes: 256 * 1024,
+            hard_capacity_bytes: 64 * 1024 * 1024,
+            max_children_per_node: u32::MAX,
+        }
+    }
+}
+
+impl FragmentMetadataTreeConfig {
+    pub fn validate(&self) -> Result<()> {
+        if self.max_node_bytes == 0
+            || self.max_leaf_bytes == 0
+            || self.semantic_buffer_bytes == 0
+            || self.hard_capacity_bytes == 0
+            || self.max_leaf_bytes > self.hard_capacity_bytes
+            || self.max_node_bytes > self.hard_capacity_bytes
+            || self.semantic_buffer_bytes > self.hard_capacity_bytes
+            || self.max_node_bytes > u64::MAX / 3
+            || self.max_leaf_bytes > u64::MAX / 3
+            || self.max_children_per_node < 2
+        {
+            return Err(Error::invalid_input(format!(
+                "fragment metadata tree config is invalid: max_node_bytes={}, \
+                 max_leaf_bytes={}, semantic_buffer_bytes={}, hard_capacity_bytes={}, \
+                 max_children_per_node={}",
+                self.max_node_bytes,
+                self.max_leaf_bytes,
+                self.semantic_buffer_bytes,
+                self.hard_capacity_bytes,
+                self.max_children_per_node
+            )));
+        }
+        Ok(())
+    }
+
+    #[cfg(any(test, feature = "test-util"))]
+    pub fn new(max_node_bytes: u64, max_children_per_node: u32) -> Self {
+        Self {
+            max_node_bytes,
+            max_leaf_bytes: max_node_bytes,
+            semantic_buffer_bytes: max_node_bytes,
+            max_children_per_node,
+            ..Self::default()
+        }
+    }
+
+    pub fn with_max_leaf_bytes(mut self, bytes: u64) -> Self {
+        self.max_leaf_bytes = bytes;
+        self
+    }
+    pub fn with_semantic_buffer_bytes(mut self, bytes: u64) -> Self {
+        self.semantic_buffer_bytes = bytes;
+        self
+    }
+    pub fn with_hard_capacity_bytes(mut self, bytes: u64) -> Self {
+        self.hard_capacity_bytes = bytes;
+        self
+    }
+    pub fn split_ceiling(&self) -> u64 {
+        self.max_node_bytes
+    }
+    pub fn split_piece_bytes(&self) -> u64 {
+        self.max_node_bytes / 2
+    }
+    pub fn merge_floor(&self) -> u64 {
+        self.max_node_bytes / 4
+    }
+    pub fn coalesce_ceiling(&self) -> u64 {
+        self.max_node_bytes * 3 / 5
+    }
+    pub fn leaf_split_ceiling(&self) -> u64 {
+        self.max_leaf_bytes
+    }
+    pub fn leaf_merge_floor(&self) -> u64 {
+        self.max_leaf_bytes / 4
+    }
+    pub fn leaf_coalesce_ceiling(&self) -> u64 {
+        self.max_leaf_bytes * 3 / 5
+    }
+}
+
+/// An internal node: child pivots (sorted by `min_key`, contiguous) + the
+/// ε-buffer. The buffer is kept in action_sequence (insertion) order in memory and sorted by
+/// `(key, action_sequence)` only when grouping for a flush.
+#[derive(Debug, Clone, Default)]
+pub struct InternalNode {
+    pub children: Vec<pb::FragmentMetadataChild>,
+    pub buffer: Vec<pb::FragmentMetadataMutation>,
+}
+
+/// Derived offsets into an immutable buffer. The wire representation stays a
+/// plain action sequence; a sparse lookup need not examine unrelated actions.
+#[derive(Debug, Clone)]
+pub(crate) struct BufferIndex {
+    offsets: Vec<(u64, usize)>,
+}
+
+impl BufferIndex {
+    pub(crate) fn new(buffer: &[pb::FragmentMetadataMutation]) -> Self {
+        let mut offsets: Vec<_> = buffer
+            .iter()
+            .enumerate()
+            .map(|(offset, action)| (action_key(action), offset))
+            .collect();
+        offsets.sort_unstable();
+        Self { offsets }
+    }
+
+    pub(crate) fn for_fragment(&self, id: u64) -> impl Iterator<Item = usize> + '_ {
+        let start = self.offsets.partition_point(|(key, _)| *key < id);
+        self.offsets[start..]
+            .iter()
+            .take_while(move |(key, _)| *key == id)
+            .map(|(_, offset)| *offset)
+    }
+}
+
+/// Fragment protobuf bytes, used to bound candidate encoding work and report amplification.
+pub fn fragment_logical_bytes(fragment: &Fragment) -> u64 {
+    pb::DataFragment::from(fragment).encoded_len() as u64
+}
+
+/// Fragment protobuf bytes before Lance encoding; this is not the leaf capacity metric.
+pub fn leaf_logical_bytes(fragments: &[Fragment]) -> u64 {
+    fragments.iter().map(fragment_logical_bytes).sum()
+}
+
+fn varint_bytes(mut value: u64) -> u64 {
+    let mut bytes = 1;
+    while value >= 0x80 {
+        value >>= 7;
+        bytes += 1;
+    }
+    bytes
+}
+
+fn repeated_message_bytes(message: &impl Message) -> u64 {
+    let payload_bytes = message.encoded_len() as u64;
+    1 + varint_bytes(payload_bytes) + payload_bytes
+}
+
+/// Logical byte size of an internal node = its exact encoded protobuf size.
+pub fn internal_logical_bytes(
+    children: &[pb::FragmentMetadataChild],
+    buffer: &[pb::FragmentMetadataMutation],
+) -> u64 {
+    children.iter().map(repeated_message_bytes).sum::<u64>()
+        + buffer.iter().map(repeated_message_bytes).sum::<u64>()
+}
+
+/// Whether an internal node violates its encoded-byte or fanout limit. This is
+/// the structural bound. A node over it must drain or split.
+pub fn internal_overflows(
+    children: &[pb::FragmentMetadataChild],
+    buffer: &[pb::FragmentMetadataMutation],
+    config: &FragmentMetadataTreeConfig,
+) -> bool {
+    children.len() as u32 > config.max_children_per_node
+        || internal_logical_bytes(children, buffer) >= config.split_ceiling()
+}
+
+/// Whether pending bytes exceed the semantic buffer. This is the soft bound.
+/// The writer drains children whose batches amortize a rewrite and keeps the
+/// rest buffered until structural pressure forces progress.
+pub fn buffer_pressured(
+    buffer: &[pb::FragmentMetadataMutation],
+    config: &FragmentMetadataTreeConfig,
+) -> bool {
+    internal_logical_bytes(&[], buffer) >= config.semantic_buffer_bytes
+}
+
+/// The target key of a buffered action (the fragment id it mutates).
+pub fn action_key(t: &pb::FragmentMetadataMutation) -> u64 {
+    t.action
+        .as_ref()
+        .and_then(action::target_frag_id)
+        .unwrap_or(0)
+}
+
+/// Index of the child owning `key`: the rightmost child whose `min_key` is at
+/// most `key`, and the first child for keys below every fence.
+///
+/// Routing invariant: sibling `min_key` values are the only fences. The last
+/// child's exclusive end is inherited from its parent (`2^32` at the root).
+/// Keys below the first fence belong to the first child, so an emptied
+/// node must be dropped rather than kept with `min_key = 0`.
+pub fn child_index_for(children: &[pb::FragmentMetadataChild], key: u64) -> usize {
+    match children.binary_search_by(|c| c.min_key.cmp(&key)) {
+        Ok(i) => i,
+        Err(0) => 0,
+        Err(i) => i - 1,
+    }
+}
+
+/// Pin the first child's fence to the node's lower bound. A rebuilt child list
+/// starts at its first stored key, but the range it owns starts where the
+/// parent says it does. That is 0 at the root and the parent's entry below it.
+pub fn fence(children: &mut [pb::FragmentMetadataChild], lower_bound: u64) {
+    if let Some(first) = children.first_mut() {
+        debug_assert!(lower_bound <= first.min_key);
+        first.min_key = lower_bound;
+    }
+}
+
+/// Exclusive end of the last child of a root. Fragment IDs are `u32`.
+pub const ROOT_EXCLUSIVE_END: u64 = 1u64 << 32;
+
+/// Exclusive end of `children[index]` inside a parent whose last child ends
+/// at `parent_end`.
+pub fn exclusive_end(children: &[pb::FragmentMetadataChild], index: usize, parent_end: u64) -> u64 {
+    children
+        .get(index + 1)
+        .map(|child| child.min_key)
+        .unwrap_or(parent_end)
+}
+
+/// Build a child reference for a leaf that has just been written.
+pub fn leaf_ref(
+    path: String,
+    fragments: &[Fragment],
+    object_size: u64,
+    materialized_through_action_sequence: u64,
+) -> Result<pb::FragmentMetadataChild> {
+    let total_rows = sum_aggregate_values(
+        fragments
+            .iter()
+            .map(|fragment| fragment.physical_rows.unwrap_or(0) as u64),
+        "total_rows",
+    )?;
+    // Counts are known by the writer invariant
+    // (`commit::require_known_counts`); a violation here means state
+    // bypassed validation.
+    let visible_rows = sum_aggregate_values(
+        fragments
+            .iter()
+            .map(|fragment| fragment.num_rows().unwrap_or(0) as u64),
+        "visible_rows",
+    )?;
+    Ok(pb::FragmentMetadataChild {
+        path,
+        base_id: None,
+        min_key: fragments.first().map(|f| f.id).unwrap_or(0),
+        num_keys: fragments.len() as u64,
+        height: 0,
+        num_children: 0,
+        total_rows,
+        object_size,
+        materialized_through_action_sequence,
+        visible_rows,
+    })
+}
+
+/// Build a child reference for an internal node that has just been written.
+pub fn internal_ref(
+    path: String,
+    children: &[pb::FragmentMetadataChild],
+    buffer: &[pb::FragmentMetadataMutation],
+    object_size: u64,
+) -> Result<pb::FragmentMetadataChild> {
+    let fragment_count_delta = sum_aggregate_deltas(
+        buffer.iter().map(|action| action.fragment_count_delta),
+        "fragment_count_delta",
+    )?;
+    let total_rows_delta = sum_aggregate_deltas(
+        buffer.iter().map(|action| action.total_rows_delta),
+        "total_rows_delta",
+    )?;
+    let num_keys = apply_aggregate_delta(
+        sum_aggregate_values(children.iter().map(|child| child.num_keys), "num_keys")?,
+        fragment_count_delta,
+        "num_keys",
+    )?;
+    let total_rows = apply_aggregate_delta(
+        sum_aggregate_values(children.iter().map(|child| child.total_rows), "total_rows")?,
+        total_rows_delta,
+        "total_rows",
+    )?;
+    let visible_rows_delta = sum_aggregate_deltas(
+        buffer.iter().map(|action| action.visible_rows_delta),
+        "visible_rows_delta",
+    )?;
+    let visible_rows = apply_aggregate_delta(
+        sum_aggregate_values(
+            children.iter().map(|child| child.visible_rows),
+            "visible_rows",
+        )?,
+        visible_rows_delta,
+        "visible_rows",
+    )?;
+    let height = children
+        .iter()
+        .map(|c| c.height)
+        .max()
+        .unwrap_or(0)
+        .checked_add(1)
+        .ok_or_else(|| super::validation::corrupt("Internal node height exceeds u32"))?;
+    Ok(pb::FragmentMetadataChild {
+        path,
+        base_id: None,
+        min_key: children.first().map(|c| c.min_key).unwrap_or(0),
+        num_keys,
+        height,
+        num_children: children.len() as u32,
+        total_rows,
+        object_size,
+        materialized_through_action_sequence: 0,
+        visible_rows,
+    })
+}
+
+pub(super) fn apply_aggregate_delta(base: u64, delta: i64, name: &str) -> Result<u64> {
+    if delta >= 0 {
+        base.checked_add(delta as u64).ok_or_else(|| {
+            Error::invalid_input(format!(
+                "fragment metadata tree {name} aggregate overflow: base={base}, delta={delta}"
+            ))
+        })
+    } else {
+        base.checked_sub(delta.unsigned_abs()).ok_or_else(|| {
+            Error::invalid_input(format!(
+                "fragment metadata tree {name} aggregate underflow: base={base}, delta={delta}"
+            ))
+        })
+    }
+}
+
+pub(super) fn sum_aggregate_deltas(
+    deltas: impl IntoIterator<Item = i64>,
+    name: &str,
+) -> Result<i64> {
+    deltas.into_iter().try_fold(0i64, |sum, delta| {
+        sum.checked_add(delta).ok_or_else(|| {
+            Error::invalid_input(format!(
+                "fragment metadata tree {name} overflow while summing: sum={sum}, delta={delta}"
+            ))
+        })
+    })
+}
+
+fn sum_aggregate_values(values: impl IntoIterator<Item = u64>, name: &str) -> Result<u64> {
+    values.into_iter().try_fold(0u64, |sum, value| {
+        sum.checked_add(value).ok_or_else(|| {
+            Error::invalid_input(format!(
+                "fragment metadata tree {name} overflow while summing: sum={sum}, value={value}"
+            ))
+        })
+    })
+}
+
+/// Is this child underflowing (a merge candidate)? Leaves underflow by bytes.
+/// Internal nodes must be sparse by both direct-child count and their exact
+/// encoded size so a hot ε-buffer is never merged as "small."
+pub fn is_underflow(
+    child: &pb::FragmentMetadataChild,
+    config: &FragmentMetadataTreeConfig,
+) -> bool {
+    if child.height == 0 {
+        child.object_size <= config.leaf_merge_floor()
+    } else {
+        child.num_children < (config.max_children_per_node / 4).max(1)
+            && child.object_size <= config.merge_floor()
+    }
+}
+
+/// Whether replay checks each mutation's count deltas against the record it
+/// changes. Storage paths verify. The reducer oracle and lowering compare
+/// records only, with deltas left unset.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub enum DeltaCheck {
+    Trust,
+    Verify,
+}
+
+/// Apply buffered mutations to an id-keyed fragment map in `(key, action_sequence)` order.
+/// `action_sequence` is assigned at commit time and only ever grows, so this
+/// order is the commit order per fragment wherever actions meet.
+pub fn apply_actions(
+    frags: &mut BTreeMap<u64, Fragment>,
+    actions: Vec<pb::FragmentMetadataMutation>,
+) -> Result<()> {
+    apply_mutations(frags, actions, DeltaCheck::Trust)
+}
+
+/// Apply mutations and reject any whose stored deltas differ from the change
+/// they make. The record before and after is in hand here, so this is where
+/// the format's exact-delta rule is enforced.
+pub fn apply_verified(
+    frags: &mut BTreeMap<u64, Fragment>,
+    actions: Vec<pb::FragmentMetadataMutation>,
+) -> Result<()> {
+    apply_mutations(frags, actions, DeltaCheck::Verify)
+}
+
+fn record_counts(fragment: Option<&Fragment>) -> (i64, i64, i64) {
+    fragment.map_or((0, 0, 0), |fragment| {
+        (
+            1,
+            fragment.physical_rows.unwrap_or(0) as i64,
+            fragment.num_rows().unwrap_or(0) as i64,
+        )
+    })
+}
+
+fn apply_mutations(
+    frags: &mut BTreeMap<u64, Fragment>,
+    mut actions: Vec<pb::FragmentMetadataMutation>,
+    check: DeltaCheck,
+) -> Result<()> {
+    actions.sort_unstable_by_key(|tagged| tagged.action_sequence);
+    if actions
+        .windows(2)
+        .any(|pair| pair[0].action_sequence == pair[1].action_sequence)
+    {
+        return Err(super::validation::corrupt(
+            "Duplicate action sequence number on a fragment replay path",
+        ));
+    }
+    for tagged in &actions {
+        super::validation::action(tagged.action.as_ref().ok_or_else(|| {
+            super::validation::corrupt(format!(
+                "Buffered action sequence number {} has no action",
+                tagged.action_sequence
+            ))
+        })?)?;
+    }
+    actions.sort_by_key(|t| (action_key(t), t.action_sequence));
+    for tagged in actions {
+        let key = action_key(&tagged);
+        let before = record_counts(frags.get(&key));
+        if let Some(action) = tagged.action {
+            apply_one(frags, action)?;
+        }
+        if check == DeltaCheck::Verify {
+            let after = record_counts(frags.get(&key));
+            let actual = (after.0 - before.0, after.1 - before.1, after.2 - before.2);
+            let stored = (
+                tagged.fragment_count_delta,
+                tagged.total_rows_delta,
+                tagged.visible_rows_delta,
+            );
+            if actual != stored {
+                return Err(super::validation::corrupt(format!(
+                    "Mutation action_sequence={} for fragment {key} stores fragment, row, and visible deltas {} {} {} but the record changed by {} {} {}",
+                    tagged.action_sequence,
+                    stored.0,
+                    stored.1,
+                    stored.2,
+                    actual.0,
+                    actual.1,
+                    actual.2
+                )));
+            }
+        }
+    }
+    Ok(())
+}
+
+fn apply_one(frags: &mut BTreeMap<u64, Fragment>, action: pb::FragmentAction) -> Result<()> {
+    let Some(action) = action.action else {
+        return Err(super::validation::corrupt(
+            "Buffered action has no recognized variant",
+        ));
+    };
+    match action {
+        Action::AddFragment(f) => {
+            let fragment = super::validation::fragment(f)?;
+            frags.insert(fragment.id, fragment);
+        }
+        Action::RemoveFragment(id) => {
+            frags.remove(&id);
+        }
+        Action::AddDataFile(a) => {
+            let file = crate::format::DataFile::try_from(
+                a.file
+                    .ok_or_else(|| Error::invalid_input("AddDataFile action missing file"))?,
+            )?;
+            let fragment = frags.get_mut(&a.frag_id).ok_or_else(|| {
+                Error::invalid_input(format!(
+                    "AddDataFile action targets missing frag_id={}",
+                    a.frag_id
+                ))
+            })?;
+            fragment.files.push(file);
+        }
+        Action::RemoveDataFile(a) => {
+            let fragment = frags.get_mut(&a.frag_id).ok_or_else(|| {
+                Error::invalid_input(format!(
+                    "RemoveDataFile action targets missing frag_id={}",
+                    a.frag_id
+                ))
+            })?;
+            fragment.files.retain(|f| f.path != a.path);
+        }
+        Action::ReplaceDataFile(a) => {
+            if a.expected_path.is_empty() || a.path.is_empty() {
+                return Err(Error::invalid_input(format!(
+                    "ReplaceDataFile for frag_id={} is missing expected_path or path",
+                    a.frag_id
+                )));
+            }
+            let fragment = frags.get_mut(&a.frag_id).ok_or_else(|| {
+                Error::invalid_input(format!(
+                    "ReplaceDataFile action targets missing frag_id={}",
+                    a.frag_id
+                ))
+            })?;
+            let matched = fragment
+                .files
+                .iter_mut()
+                .find(|file| file.path == a.expected_path)
+                .ok_or_else(|| {
+                    Error::internal(format!(
+                        "ReplaceDataFile for frag_id={} names data file {} which the fragment \
+                         no longer holds; commit-time validation must have seen a different \
+                         state",
+                        a.frag_id, a.expected_path
+                    ))
+                })?;
+            matched.path = a.path.clone();
+            matched.file_size_bytes = lance_io::utils::CachedFileSize::new(a.file_size_bytes);
+            matched.base_id = a.base_id;
+        }
+        Action::AddDeletionFile(a) => {
+            let deletion_file = a.deletion_file.ok_or_else(|| {
+                Error::invalid_input(format!(
+                    "AddDeletionFile action for frag_id={} is missing deletion_file",
+                    a.frag_id
+                ))
+            })?;
+            let fragment = frags.get_mut(&a.frag_id).ok_or_else(|| {
+                Error::invalid_input(format!(
+                    "AddDeletionFile action targets missing frag_id={}",
+                    a.frag_id
+                ))
+            })?;
+            let count = usize::try_from(deletion_file.num_deleted_rows)
+                .map_err(|_| super::validation::corrupt("Deleted row count exceeds usize"))?;
+            let mut file = crate::format::DeletionFile::try_from(deletion_file)?;
+            file.num_deleted_rows = Some(count);
+            fragment.deletion_file = Some(file);
+        }
+        Action::ClearDeletionFile(a) => {
+            let fragment = frags.get_mut(&a.frag_id).ok_or_else(|| {
+                Error::invalid_input(format!(
+                    "ClearDeletionFile action targets missing frag_id={}",
+                    a.frag_id
+                ))
+            })?;
+            fragment.deletion_file = None;
+        }
+    }
+    Ok(())
+}
+
+/// Normalize validated current-state actions, preserving each fragment's effect.
+///
+/// This is not a transaction validator: superseding a prefix is legal only
+/// after that prefix has been validated. Committed transaction history must
+/// retain the original actions. A run must also be a contiguous per-fragment
+/// segment of the action sequence number history; never normalize across an unapplied message
+/// held by another node.
+///
+/// The last whole-fragment reset establishes a known state, so its suffix can
+/// be evaluated once. Otherwise, deletion-file assignments form an independent
+/// last-writer-wins register, while file edits retain their order and first-path
+/// matching semantics. In particular, a path-changing replacement chain cannot
+/// be combined blindly: the second edit might match a different file slot.
+///
+/// Combined actions retain the last contributing action sequence number and the sum of aggregate
+/// deltas. If a sum cannot be represented, leave that run unchanged.
+pub fn squash_buffer(
+    buffer: Vec<pb::FragmentMetadataMutation>,
+) -> Vec<pb::FragmentMetadataMutation> {
+    let mut runs: BTreeMap<u64, Vec<pb::FragmentMetadataMutation>> = BTreeMap::new();
+    for tagged in buffer {
+        runs.entry(action_key(&tagged)).or_default().push(tagged);
+    }
+    let mut squashed = Vec::new();
+    for (key, mut run) in runs {
+        run.sort_by_key(|tagged| tagged.action_sequence);
+        if run.len() > 1 {
+            run = squash_run(key, run);
+        }
+        squashed.extend(run);
+    }
+    squashed.sort_by_key(|tagged| tagged.action_sequence);
+    squashed
+}
+
+fn combined(
+    run: &[pb::FragmentMetadataMutation],
+    action: Action,
+) -> Option<pb::FragmentMetadataMutation> {
+    Some(pb::FragmentMetadataMutation {
+        action_sequence: run.last()?.action_sequence,
+        action: Some(pb::FragmentAction {
+            action: Some(action),
+        }),
+        fragment_count_delta: run
+            .iter()
+            .try_fold(0i64, |sum, t| sum.checked_add(t.fragment_count_delta))?,
+        total_rows_delta: run
+            .iter()
+            .try_fold(0i64, |sum, t| sum.checked_add(t.total_rows_delta))?,
+        visible_rows_delta: run
+            .iter()
+            .try_fold(0i64, |sum, t| sum.checked_add(t.visible_rows_delta))?,
+    })
+}
+
+fn squash_run(
+    key: u64,
+    run: Vec<pb::FragmentMetadataMutation>,
+) -> Vec<pb::FragmentMetadataMutation> {
+    if run
+        .iter()
+        .any(|t| t.action.as_ref().and_then(|a| a.action.as_ref()).is_none())
+    {
+        return run;
+    }
+    if let Some(reset) = run.iter().rposition(|t| {
+        matches!(
+            t.action.as_ref().and_then(|a| a.action.as_ref()),
+            Some(Action::AddFragment(_)) | Some(Action::RemoveFragment(_))
+        )
+    }) {
+        let mut state = BTreeMap::new();
+        if apply_actions(&mut state, run[reset..].to_vec()).is_err() {
+            return run;
+        }
+        let action = match state.remove(&key) {
+            Some(fragment) => Action::AddFragment(pb::DataFragment::from(&fragment)),
+            None => Action::RemoveFragment(key),
+        };
+        return combined(&run, action).map_or(run, |t| vec![t]);
+    }
+
+    // File edits leave the deletion register and fragment existence unchanged.
+    // Its assignments therefore commute across those edits on validated input.
+    let mut deletion: Vec<pb::FragmentMetadataMutation> = Vec::new();
+    let mut files: Vec<pb::FragmentMetadataMutation> = Vec::with_capacity(run.len());
+    for tagged in &run {
+        let Some(next) = tagged.action.as_ref().and_then(|a| a.action.as_ref()) else {
+            return run;
+        };
+        if matches!(
+            next,
+            Action::AddDeletionFile(_) | Action::ClearDeletionFile(_)
+        ) {
+            deletion.push(tagged.clone());
+            continue;
+        }
+        let mut current = tagged.clone();
+        while let Some(action) = files.last().and_then(|prev| {
+            combine_file_pair(
+                prev.action.as_ref()?.action.as_ref()?,
+                current.action.as_ref()?.action.as_ref()?,
+            )
+        }) {
+            let start = files.len() - 1;
+            let pair = [files[start].clone(), current];
+            let Some(merged) = combined(&pair, action) else {
+                return run;
+            };
+            files.pop();
+            current = merged;
+        }
+        files.push(current);
+    }
+    if let Some(last) = deletion.last() {
+        let Some(action) = last.action.as_ref().and_then(|a| a.action.clone()) else {
+            return run;
+        };
+        let Some(merged) = combined(&deletion, action) else {
+            return run;
+        };
+        files.push(merged);
+    }
+    files.sort_by_key(|t| t.action_sequence);
+    files
+}
+
+/// Only identities valid for ordered lists with arbitrary path aliases belong
+/// here. Path uniqueness is not part of the storage action contract.
+fn combine_file_pair(first: &Action, second: &Action) -> Option<Action> {
+    match (first, second) {
+        (Action::RemoveDataFile(a), Action::RemoveDataFile(b)) if a.path == b.path => {
+            Some(Action::RemoveDataFile(b.clone()))
+        }
+        (Action::AddDataFile(a), Action::RemoveDataFile(b)) if a.file.as_ref()?.path == b.path => {
+            // The remove still has to delete any same-path files in the base.
+            Some(Action::RemoveDataFile(b.clone()))
+        }
+        (Action::ReplaceDataFile(a), Action::ReplaceDataFile(b))
+            if a.expected_path == a.path && a.expected_path == b.expected_path =>
+        {
+            // The first edit did not rename the slot, so both find the same
+            // first matching path, including when the base has duplicate paths.
+            Some(Action::ReplaceDataFile(pb::ReplaceDataFile {
+                frag_id: a.frag_id,
+                expected_path: a.expected_path.clone(),
+                path: b.path.clone(),
+                file_size_bytes: b.file_size_bytes,
+                base_id: b.base_id,
+            }))
+        }
+        _ => None,
+    }
+}
+
+/// Partition a buffer into one bucket per child by the routing fences. The
+/// returned vec has `children.len()` buckets; the buffer is consumed. Callers
+/// must not pass an empty `children` slice.
+pub fn partition_buffer_by_child(
+    children: &[pb::FragmentMetadataChild],
+    buffer: Vec<pb::FragmentMetadataMutation>,
+) -> Vec<Vec<pb::FragmentMetadataMutation>> {
+    let mut buckets: Vec<Vec<pb::FragmentMetadataMutation>> = vec![Vec::new(); children.len()];
+    for tagged in buffer {
+        let idx = child_index_for(children, action_key(&tagged));
+        buckets[idx].push(tagged);
+    }
+    buckets
+}
+
+/// Reject buckets that routing could only have produced from a corrupt node.
+/// A target outside the child's inherited range, or at or below its leaf
+/// watermark, is already applied or was never owned by this child.
+pub fn validate_routed(
+    children: &[pb::FragmentMetadataChild],
+    buckets: &[Vec<pb::FragmentMetadataMutation>],
+    parent_end: u64,
+) -> Result<()> {
+    for (index, (child, bucket)) in children.iter().zip(buckets).enumerate() {
+        let exclusive_end = exclusive_end(children, index, parent_end);
+        for tagged in bucket {
+            let target = action_key(tagged);
+            if target < child.min_key || target >= exclusive_end {
+                return Err(super::validation::corrupt(format!(
+                    "Mutation action_sequence={} targets fragment {target} outside [{}, {exclusive_end})",
+                    tagged.action_sequence, child.min_key
+                )));
+            }
+            if child.height == 0
+                && tagged.action_sequence <= child.materialized_through_action_sequence
+            {
+                return Err(super::validation::corrupt(format!(
+                    "Mutation action_sequence={} for fragment {target} is at or below the watermark {} of leaf {}",
+                    tagged.action_sequence, child.materialized_through_action_sequence, child.path
+                )));
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Sum of encoded bytes of a set of buffered actions.
+pub fn buffer_bytes(buffer: &[pb::FragmentMetadataMutation]) -> u64 {
+    buffer.iter().map(|t| t.encoded_len() as u64).sum()
+}
+
+/// Split an internal node's (children, buffer) into contiguous pieces targeting
+/// `piece_bytes` and at most `max_children_per_node` children each. The buffer
+/// follows its child by key range. A single indivisible child-plus-message unit
+/// may exceed the byte target, but never the original node's split ceiling.
+pub fn split_internal(
+    children: Vec<pb::FragmentMetadataChild>,
+    buffer: Vec<pb::FragmentMetadataMutation>,
+    piece_bytes: u64,
+    max_children_per_node: u32,
+) -> Vec<(
+    Vec<pb::FragmentMetadataChild>,
+    Vec<pb::FragmentMetadataMutation>,
+)> {
+    if children.is_empty() {
+        return vec![(children, buffer)];
+    }
+    let action_buckets = partition_buffer_by_child(&children, buffer);
+    let piece_bytes = piece_bytes.max(1);
+    let max_children_per_node = max_children_per_node.max(1) as usize;
+    let mut pieces = Vec::new();
+    let mut piece_children = Vec::new();
+    let mut piece_buffer = Vec::new();
+    let mut encoded_bytes = 0u64;
+
+    for (child, actions) in children.into_iter().zip(action_buckets) {
+        let unit_bytes = repeated_message_bytes(&child)
+            + actions.iter().map(repeated_message_bytes).sum::<u64>();
+        let exceeds_piece = !piece_children.is_empty()
+            && (piece_children.len() >= max_children_per_node
+                || encoded_bytes + unit_bytes > piece_bytes);
+        if exceeds_piece {
+            pieces.push((
+                std::mem::take(&mut piece_children),
+                std::mem::take(&mut piece_buffer),
+            ));
+            encoded_bytes = 0;
+        }
+        encoded_bytes += unit_bytes;
+        piece_children.push(child);
+        piece_buffer.extend(actions);
+    }
+    pieces.push((piece_children, piece_buffer));
+    // Greedy byte packing can leave one child at the right edge. Borrow the
+    // preceding range when both resulting nodes still fit the target; its
+    // messages must move with the routing fence, including inserts in gaps.
+    if pieces.len() > 1
+        && pieces
+            .last()
+            .is_some_and(|(children, _)| children.len() == 1)
+    {
+        let last = pieces.len() - 1;
+        let (before, after) = pieces.split_at_mut(last);
+        let (left_children, left_buffer) = &mut before[last - 1];
+        let (right_children, right_buffer) = &mut after[0];
+        if left_children.len() > 2 && max_children_per_node >= 2 {
+            let borrowed = &left_children[left_children.len() - 1];
+            let extra = repeated_message_bytes(borrowed)
+                + left_buffer
+                    .iter()
+                    .filter(|action| action_key(action) >= borrowed.min_key)
+                    .map(repeated_message_bytes)
+                    .sum::<u64>();
+            if internal_logical_bytes(right_children, right_buffer) + extra <= piece_bytes {
+                let fence = borrowed.min_key;
+                let (kept, moved): (Vec<_>, Vec<_>) = std::mem::take(left_buffer)
+                    .into_iter()
+                    .partition(|action| action_key(action) < fence);
+                *left_buffer = kept;
+                right_buffer.extend(moved);
+                right_children.insert(0, left_children.remove(left_children.len() - 1));
+            }
+        }
+    }
+    pieces
+}
+
+#[cfg(test)]
+mod tests {
+    mod reduction;
+    use super::*;
+    use crate::format::{DeletionFile, DeletionFileType};
+    use crate::fragment_metadata::support::{make_backfill_data_file, make_fragment};
+
+    fn tagged(action: pb::FragmentAction) -> pb::FragmentMetadataMutation {
+        pb::FragmentMetadataMutation {
+            action_sequence: 1,
+            action: Some(action),
+            fragment_count_delta: 0,
+            total_rows_delta: 0,
+            visible_rows_delta: 0,
+        }
+    }
+
+    fn child_ref(index: u64, object_size: u64, height: u32) -> pb::FragmentMetadataChild {
+        pb::FragmentMetadataChild {
+            path: format!("_bt/node/{index}.node"),
+            base_id: None,
+            min_key: index * 10,
+            num_keys: 10,
+            height,
+            num_children: u32::from(height > 0),
+            total_rows: 10,
+            object_size,
+            materialized_through_action_sequence: 0,
+            visible_rows: 10,
+        }
+    }
+
+    #[test]
+    fn internal_logical_bytes_matches_protobuf_encoding() {
+        let children = vec![child_ref(0, 1_000, 0), child_ref(1, 2_000, 0)];
+        let buffer = vec![
+            tagged(action::remove_fragment(3)),
+            tagged(action::add_data_file(7, &make_backfill_data_file(7, 0))),
+        ];
+        let encoded = pb::FragmentMetadataNode {
+            children: children.clone(),
+            buffer: buffer.clone(),
+        }
+        .encoded_len() as u64;
+
+        assert_eq!(internal_logical_bytes(&children, &buffer), encoded);
+    }
+
+    #[test]
+    fn split_internal_uses_parent_encoding_not_child_payload_sizes() {
+        let children = (0..8)
+            .map(|index| child_ref(index, 1024 * 1024, 0))
+            .collect();
+        let pieces = split_internal(children, Vec::new(), 1024, 4);
+
+        assert_eq!(pieces.len(), 2);
+        assert!(pieces.iter().all(|(children, _)| children.len() == 4));
+        assert!(
+            pieces
+                .iter()
+                .all(|(children, buffer)| internal_logical_bytes(children, buffer) <= 1024)
+        );
+    }
+
+    #[test]
+    fn split_internal_repairs_singleton_tail_with_its_gap_messages() {
+        let children = (0..7).map(|index| child_ref(index, 1, 0)).collect();
+        let buffer = vec![tagged(action::remove_fragment(55))];
+        let pieces = split_internal(children, buffer, 1024, 3);
+        assert_eq!(
+            pieces
+                .iter()
+                .map(|(children, _)| children.len())
+                .collect::<Vec<_>>(),
+            vec![3, 2, 2]
+        );
+        assert!(pieces[1].1.is_empty());
+        assert_eq!(action_key(&pieces[2].1[0]), 55);
+        assert_eq!(pieces[2].0[0].min_key, 50);
+        assert!(
+            pieces
+                .iter()
+                .all(|(children, buffer)| internal_logical_bytes(children, buffer) <= 1024)
+        );
+    }
+
+    #[test]
+    fn hot_internal_node_is_not_an_underflow_merge_candidate() {
+        let config = FragmentMetadataTreeConfig::new(1024, 16);
+        let mut child = child_ref(0, 512, 1);
+        child.num_children = 1;
+        assert!(!is_underflow(&child, &config));
+
+        child.object_size = 128;
+        assert!(is_underflow(&child, &config));
+    }
+
+    #[test]
+    fn internal_overflow_checks_encoded_bytes_and_fanout() {
+        let config = FragmentMetadataTreeConfig::new(256, 4);
+        let four_children: Vec<_> = (0..4).map(|index| child_ref(index, 1_000_000, 0)).collect();
+        assert!(!internal_overflows(&four_children, &[], &config));
+
+        let five_children: Vec<_> = (0..5).map(|index| child_ref(index, 1, 0)).collect();
+        assert!(internal_overflows(&five_children, &[], &config));
+
+        let hot_buffer: Vec<_> = (0..20)
+            .map(|fragment_id| tagged(action::remove_fragment(fragment_id)))
+            .collect();
+        assert!(internal_overflows(&four_children, &hot_buffer, &config));
+    }
+
+    #[test]
+    fn semantic_pressure_is_not_structural_overflow() {
+        let config = FragmentMetadataTreeConfig::new(4096, 4).with_semantic_buffer_bytes(64);
+        let children: Vec<_> = (0..4).map(|index| child_ref(index, 1024, 0)).collect();
+        let pending: Vec<_> = (0..20)
+            .map(|fragment_id| tagged(action::remove_fragment(fragment_id)))
+            .collect();
+        assert!(buffer_pressured(&pending, &config));
+        assert!(!internal_overflows(&children, &pending, &config));
+    }
+
+    #[test]
+    fn clear_deletion_file_action() {
+        let mut fragment = make_fragment(7);
+        fragment.deletion_file = Some(DeletionFile {
+            read_version: 3,
+            id: 11,
+            file_type: DeletionFileType::Bitmap,
+            num_deleted_rows: Some(1),
+            base_id: None,
+        });
+        let mut fragments = BTreeMap::from([(fragment.id, fragment)]);
+
+        apply_actions(&mut fragments, vec![tagged(action::clear_deletion_file(7))]).unwrap();
+
+        assert_eq!(fragments[&7].deletion_file, None);
+    }
+
+    #[test]
+    fn replace_data_file_swaps_the_named_file_only() {
+        use crate::fragment_metadata::support::make_replacement_data_file;
+
+        let fragment = make_fragment(7);
+        let expected_path = fragment.files[0].path.clone();
+        let mut fragments = BTreeMap::from([(fragment.id, fragment)]);
+        let replacement = make_replacement_data_file(7, 0);
+        apply_actions(
+            &mut fragments,
+            vec![tagged(action::replace_data_file(
+                7,
+                &expected_path,
+                &replacement,
+            ))],
+        )
+        .unwrap();
+        assert_eq!(fragments[&7].files.len(), 1);
+        assert_eq!(fragments[&7].files[0].path, replacement.path);
+
+        // The named file is gone: a storage invariant violation, not a user error.
+        let error = apply_actions(
+            &mut fragments,
+            vec![tagged(action::replace_data_file(
+                7,
+                &expected_path,
+                &replacement,
+            ))],
+        )
+        .unwrap_err();
+        assert!(matches!(error, Error::Internal { .. }), "{error}");
+    }
+
+    #[test]
+    fn mutation_actions_reject_missing_fragment() {
+        let deletion_file = pb::DeletionFile {
+            read_version: 3,
+            id: 11,
+            file_type: pb::deletion_file::DeletionFileType::Bitmap.into(),
+            num_deleted_rows: 1,
+            base_id: None,
+        };
+        let cases = [
+            (
+                "AddDataFile",
+                action::add_data_file(7, &make_backfill_data_file(7, 0)),
+            ),
+            (
+                "RemoveDataFile",
+                action::remove_data_file(7, "missing.lance"),
+            ),
+            (
+                "AddDeletionFile",
+                pb::FragmentAction {
+                    action: Some(Action::AddDeletionFile(pb::AddDeletionFile {
+                        frag_id: 7,
+                        deletion_file: Some(deletion_file),
+                    })),
+                },
+            ),
+        ];
+
+        for (action_name, action) in cases {
+            let error = apply_actions(&mut BTreeMap::new(), vec![tagged(action)]).unwrap_err();
+            assert!(matches!(error, Error::InvalidInput { .. }));
+            let message = error.to_string();
+            assert!(message.contains(action_name), "{message}");
+            assert!(message.contains("frag_id=7"), "{message}");
+        }
+    }
+}

--- a/rust/lance-table/src/fragment_metadata/node/tests/reduction.rs
+++ b/rust/lance-table/src/fragment_metadata/node/tests/reduction.rs
@@ -1,0 +1,282 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+use crate::format::pb::fragment_action::Action;
+use crate::format::{DataFile, DeletionFile, DeletionFileType, Fragment, pb};
+use crate::fragment_metadata::support::{make_backfill_data_file, make_fragment};
+use crate::fragment_metadata::{action, node};
+use proptest::prelude::*;
+use rand::{Rng, SeedableRng, rngs::SmallRng};
+use rstest::rstest;
+use std::collections::BTreeMap;
+use std::num::NonZeroU64;
+
+fn tagged(actions: Vec<pb::FragmentAction>) -> Vec<pb::FragmentMetadataMutation> {
+    actions
+        .into_iter()
+        .enumerate()
+        .map(|(i, action)| pb::FragmentMetadataMutation {
+            action_sequence: i as u64 + 1,
+            action: Some(action),
+            fragment_count_delta: 0,
+            total_rows_delta: 0,
+            visible_rows_delta: 0,
+        })
+        .collect()
+}
+
+fn equivalent(base: Fragment, actions: Vec<pb::FragmentAction>) {
+    let actions = tagged(actions);
+    let mut expected = BTreeMap::from([(base.id, base.clone())]);
+    node::apply_actions(&mut expected, actions.clone()).unwrap();
+    let normalized = node::squash_buffer(actions);
+    let mut actual = BTreeMap::from([(base.id, base)]);
+    node::apply_actions(&mut actual, normalized).unwrap();
+    assert_eq!(actual, expected);
+}
+
+#[rstest]
+#[case::descriptor_fields(false)]
+#[case::path_collision(true)]
+fn add_replace_preserves_first_match_and_descriptor(#[case] collision: bool) {
+    let mut base = make_fragment(7);
+    let mut added = make_backfill_data_file(7, 0);
+    if collision {
+        added.path = base.files[0].path.clone();
+    }
+    // Replacement must retain field/column mappings from the matched file,
+    // even when the replacement descriptor supplies different mappings.
+    base.physical_rows = Some(100);
+    let mut replacement = make_backfill_data_file(7, 9);
+    replacement.fields = added.fields.clone();
+    replacement.column_indices = vec![9].into();
+    equivalent(
+        base,
+        vec![
+            action::add_data_file(7, &added),
+            action::replace_data_file(7, &added.path, &replacement),
+        ],
+    );
+}
+
+#[test]
+fn replacement_chain_can_change_which_slot_matches() {
+    let mut base = make_fragment(7);
+    let second = make_backfill_data_file(7, 0);
+    let first_path = base.files[0].path.clone();
+    base.files.push(second.clone());
+    let final_file = make_backfill_data_file(7, 9);
+    equivalent(
+        base,
+        vec![
+            action::replace_data_file(7, &second.path, &make_fragment(7).files[0]),
+            action::replace_data_file(7, &first_path, &final_file),
+        ],
+    );
+}
+
+// Deliberately does not call node::apply_actions or any reducer function.
+// This is the ordered-vector storage specification, not transaction validation.
+fn reference_apply(state: &mut BTreeMap<u64, Fragment>, action: &pb::FragmentAction) {
+    match action.action.clone().unwrap() {
+        Action::AddFragment(f) => {
+            state.insert(f.id, Fragment::try_from(f).unwrap());
+        }
+        Action::RemoveFragment(id) => {
+            state.remove(&id);
+        }
+        Action::AddDataFile(a) => state
+            .get_mut(&a.frag_id)
+            .unwrap()
+            .files
+            .push(DataFile::try_from(a.file.unwrap()).unwrap()),
+        Action::RemoveDataFile(a) => state
+            .get_mut(&a.frag_id)
+            .unwrap()
+            .files
+            .retain(|f| f.path != a.path),
+        Action::ReplaceDataFile(a) => {
+            let file = state
+                .get_mut(&a.frag_id)
+                .unwrap()
+                .files
+                .iter_mut()
+                .find(|f| f.path == a.expected_path)
+                .unwrap();
+            file.path = a.path.clone();
+            file.file_size_bytes = lance_io::utils::CachedFileSize::new(a.file_size_bytes);
+            file.base_id = a.base_id;
+        }
+        Action::AddDeletionFile(a) => {
+            let encoded = a.deletion_file.unwrap();
+            let count = encoded.num_deleted_rows as usize;
+            let mut file = DeletionFile::try_from(encoded).unwrap();
+            file.num_deleted_rows = Some(count);
+            state.get_mut(&a.frag_id).unwrap().deletion_file = Some(file)
+        }
+        Action::ClearDeletionFile(a) => state.get_mut(&a.frag_id).unwrap().deletion_file = None,
+    }
+}
+
+fn random_action(
+    state: &BTreeMap<u64, Fragment>,
+    rng: &mut SmallRng,
+    step: u32,
+) -> pb::FragmentAction {
+    let id = [0, 7, 123_456_789, u32::MAX as u64][rng.random_range(0..4)];
+    let mut new_fragment = make_fragment(id);
+    new_fragment.physical_rows = Some(100);
+    if !state.contains_key(&id) {
+        return action::add_fragment(&new_fragment);
+    }
+    let fragment = &state[&id];
+    match rng.random_range(0..10) {
+        0 => action::add_fragment(&new_fragment),
+        1 => action::remove_fragment(id),
+        2 | 3 => {
+            let mut file = make_backfill_data_file(id, step);
+            // Aliases and non-default descriptor fields are intentional.
+            file.path = format!("alias-{}.lance", rng.random_range(0..4));
+            file.column_indices = vec![rng.random_range(0..16)].into();
+            action::add_data_file(id, &file)
+        }
+        4 | 5 if !fragment.files.is_empty() => {
+            let path = &fragment.files[rng.random_range(0..fragment.files.len())].path;
+            let mut file = make_backfill_data_file(id, step);
+            file.path = format!("alias-{}.lance", rng.random_range(0..4));
+            file.file_size_bytes = NonZeroU64::new(rng.random_range(1..5000)).into();
+            file.base_id = Some(rng.random_range(1..8));
+            action::replace_data_file(id, path, &file)
+        }
+        6 => action::remove_data_file(id, format!("alias-{}.lance", rng.random_range(0..4))),
+        7 | 8 => action::add_deletion_file(
+            id,
+            &DeletionFile {
+                read_version: step as u64 + 1,
+                id: step as u64,
+                file_type: DeletionFileType::Bitmap,
+                num_deleted_rows: Some(rng.random_range(0..100)),
+                base_id: None,
+            },
+        ),
+        _ => action::clear_deletion_file(id),
+    }
+}
+
+fn check_random_sequence(seed: u64, steps: usize) {
+    let mut rng = SmallRng::seed_from_u64(seed);
+    let base = BTreeMap::from([(7, make_fragment(7).with_physical_rows(100))]);
+    let mut expected = base.clone();
+    let mut pending = Vec::new();
+    let mut originals = Vec::new();
+    for step in 0..steps {
+        let action = random_action(&expected, &mut rng, step as u32);
+        reference_apply(&mut expected, &action);
+        let mut next = tagged(vec![action]).remove(0);
+        next.action_sequence = step as u64 + 1;
+        originals.push(next.clone());
+        pending.push(next);
+        // Each eight-action batch models one validated commit. Compare every
+        // snapshot, including the prefix after incremental normalization.
+        if step % 8 == 7 || step + 1 == steps {
+            pending = node::squash_buffer(pending);
+            let mut actual = base.clone();
+            node::apply_actions(&mut actual, pending.clone()).unwrap();
+            assert_eq!(actual, expected, "seed={seed}, step={step}");
+            let mut one_shot = base.clone();
+            node::apply_actions(&mut one_shot, node::squash_buffer(originals.clone())).unwrap();
+            assert_eq!(one_shot, expected, "one-shot seed={seed}, step={step}");
+            assert_eq!(
+                node::squash_buffer(pending.clone()),
+                pending,
+                "normal form idempotence"
+            );
+        }
+    }
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(128))]
+    #[test]
+    fn random_normalization(seed in any::<u64>(), steps in 1usize..257) {
+        check_random_sequence(seed, steps);
+    }
+}
+
+#[rstest]
+#[case::deletion_register(0)]
+#[case::whole_reset(1)]
+#[case::append_remove(2)]
+#[case::duplicate_remove(3)]
+#[case::same_path_replacement(4)]
+fn legal_reductions_preserve_aggregates(#[case] case: u8) {
+    let base = make_fragment(7);
+    let file = make_backfill_data_file(7, 0);
+    let deletion = DeletionFile {
+        read_version: 1,
+        id: 2,
+        file_type: DeletionFileType::Bitmap,
+        num_deleted_rows: Some(0),
+        base_id: None,
+    };
+    let actions = match case {
+        0 => vec![
+            action::add_deletion_file(7, &deletion),
+            action::add_data_file(7, &file),
+            action::clear_deletion_file(7),
+        ],
+        1 => vec![
+            action::add_data_file(7, &file),
+            action::add_fragment(&base),
+            action::add_data_file(7, &file),
+        ],
+        2 => vec![
+            action::add_data_file(7, &file),
+            action::remove_data_file(7, &file.path),
+        ],
+        3 => vec![
+            action::remove_data_file(7, &file.path),
+            action::remove_data_file(7, &file.path),
+        ],
+        _ => vec![
+            action::replace_data_file(7, &base.files[0].path, &base.files[0]),
+            action::replace_data_file(7, &base.files[0].path, &file),
+        ],
+    };
+    equivalent(base, actions.clone());
+    let mut input = tagged(actions);
+    for (i, action) in input.iter_mut().enumerate() {
+        action.fragment_count_delta = i as i64 - 1;
+        action.total_rows_delta = i as i64 * 10 - 5;
+        action.visible_rows_delta = i as i64 * 5 - 3;
+    }
+    let output = node::squash_buffer(input.clone());
+    assert!(output.len() < input.len());
+    assert_eq!(
+        input.iter().map(|t| t.fragment_count_delta).sum::<i64>(),
+        output.iter().map(|t| t.fragment_count_delta).sum::<i64>()
+    );
+    assert_eq!(
+        input.iter().map(|t| t.total_rows_delta).sum::<i64>(),
+        output.iter().map(|t| t.total_rows_delta).sum::<i64>()
+    );
+    assert_eq!(
+        input.iter().map(|t| t.visible_rows_delta).sum::<i64>(),
+        output.iter().map(|t| t.visible_rows_delta).sum::<i64>()
+    );
+    assert_eq!(
+        input.last().unwrap().action_sequence,
+        output.last().unwrap().action_sequence
+    );
+}
+
+#[test]
+fn unrepresentable_aggregate_keeps_original_run() {
+    let mut input = tagged(vec![
+        action::clear_deletion_file(7),
+        action::clear_deletion_file(7),
+    ]);
+    input[0].visible_rows_delta = i64::MAX;
+    input[1].visible_rows_delta = 1;
+    assert_eq!(node::squash_buffer(input.clone()), input);
+}

--- a/rust/lance-table/src/fragment_metadata/store.rs
+++ b/rust/lance-table/src/fragment_metadata/store.rs
@@ -1,0 +1,1353 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+//! Immutable protobuf routing nodes and columnar Lance leaves.
+//!
+//! Each fragment has a header containing its non-file metadata, followed by
+//! ordered data-file rows. File fields are separate columns for compression.
+//! Object paths are relative to the dataset root; every rewrite gets a new UUID.
+
+use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::ops::Range;
+use std::sync::{Arc, Mutex};
+
+use arrow_array::builder::{BinaryBuilder, Int32Builder, ListBuilder};
+use arrow_array::cast::AsArray;
+use arrow_array::types::UInt8Type;
+use arrow_array::types::{Int32Type, UInt32Type, UInt64Type};
+use arrow_array::{Array, RecordBatch, StringArray, UInt8Array, UInt32Array, UInt64Array};
+use arrow_schema::{DataType, Field as ArrowField, Schema as ArrowSchema};
+use futures::{FutureExt, TryStreamExt, future::BoxFuture};
+use prost::Message;
+
+use crate::format::pb;
+use crate::format::pb::fragment_action::Action;
+use crate::format::{DataFile, DataFileFieldInterner, Fragment, RowDatasetVersionMeta, RowIdMeta};
+use crate::fragment_metadata::node::{self, InternalNode};
+use lance_core::cache::LanceCache;
+use lance_core::datatypes::Schema as LanceSchema;
+use lance_core::{Error, Result};
+use lance_encoding::decoder::{DecoderPlugins, FilterExpression};
+use lance_file::reader::{FileReader, FileReaderOptions};
+use lance_file::version::ConcreteFileVersion;
+use lance_file::writer::FileWriterOptions;
+use lance_io::ReadBatchParams;
+use lance_io::object_reader::SmallReader;
+use lance_io::object_store::ObjectStore;
+use lance_io::scheduler::ScanScheduler;
+use lance_io::traits::Reader;
+use object_store::path::Path;
+use object_store::{GetOptions, ObjectStore as OSObjectStore, PutOptions, PutPayload};
+use uuid::Uuid;
+mod validation_reads;
+
+// Decode each leaf in batches of READ_BATCH_ROWS, with up to
+// READ_BATCH_READAHEAD decoder batches in flight for that leaf. A scan may
+// keep several leaves in flight separately.
+const READ_BATCH_ROWS: u32 = 16 * 1024;
+const READ_BATCH_READAHEAD: u32 = 16;
+
+/// A written node: its parent child reference plus the actual bytes written to
+/// storage (for write-amplification accounting).
+#[derive(Debug)]
+pub struct Written {
+    pub child_ref: pb::FragmentMetadataChild,
+    pub io_bytes: u64,
+}
+
+struct EncodedLeaf {
+    range: Range<usize>,
+    bytes: bytes::Bytes,
+}
+
+/// Reads and writes fragment metadata tree node files against an object store.
+#[derive(Clone)]
+pub struct NodeStore {
+    pub(super) object_store: Arc<ObjectStore>,
+    base: Path,
+    scheduler: Arc<ScanScheduler>,
+    cache: Arc<LanceCache>,
+    validation_reads: Option<Arc<validation_reads::ValidationReads>>,
+    pub(super) next_action_sequence: u64,
+    pub(super) hard_capacity_bytes: u64,
+    foreign_bases: HashMap<u32, ForeignBase>,
+    interner: Arc<Mutex<DataFileFieldInterner>>,
+}
+
+#[derive(Clone)]
+struct ForeignBase {
+    store: Arc<ObjectStore>,
+    base: Path,
+}
+
+impl NodeStore {
+    pub fn new(
+        object_store: Arc<ObjectStore>,
+        base: Path,
+        scheduler: Arc<ScanScheduler>,
+        cache: Arc<LanceCache>,
+    ) -> Self {
+        Self {
+            object_store,
+            base,
+            scheduler,
+            cache,
+            validation_reads: None,
+            next_action_sequence: u64::MAX,
+            hard_capacity_bytes: u64::MAX,
+            foreign_bases: HashMap::new(),
+            interner: Arc::new(Mutex::new(DataFileFieldInterner::default())),
+        }
+    }
+
+    pub(super) fn set_foreign_bases(
+        &mut self,
+        foreign_bases: HashMap<u32, (Arc<ObjectStore>, Path)>,
+    ) {
+        self.foreign_bases = foreign_bases
+            .into_iter()
+            .map(|(id, (store, base))| (id, ForeignBase { store, base }))
+            .collect();
+    }
+
+    pub(super) fn rebind(&mut self, object_store: Arc<ObjectStore>) {
+        self.scheduler = ScanScheduler::new(
+            object_store.clone(),
+            lance_io::scheduler::SchedulerConfig::max_bandwidth(&object_store),
+        );
+        self.object_store = object_store;
+        self.validation_reads = None;
+    }
+
+    pub(super) fn retain_validation_reads(&mut self) -> Result<()> {
+        self.validation_reads = Some(Arc::new(validation_reads::ValidationReads::new()?));
+        Ok(())
+    }
+
+    pub(super) fn clear_validation_reads(&mut self) {
+        self.validation_reads = None;
+    }
+
+    /// Write a leaf (sorted fragments) as a columnar Lance file.
+    ///
+    /// Each data file occupies one row. A fragment with no data files occupies
+    /// one marker row, and full non-file metadata is stored once per fragment.
+    /// Returns a leaf child reference plus actual bytes written.
+    pub async fn write_leaf(
+        &self,
+        fragments: &[Fragment],
+        materialized_through_action_sequence: u64,
+    ) -> Result<Written> {
+        let bytes = self.encode_leaf(fragments).await?;
+        self.write_encoded_leaf(fragments, bytes, materialized_through_action_sequence)
+            .await
+    }
+
+    /// Encode before publishing, splitting only when actual Lance bytes exceed
+    /// the target. A single fragment may exceed the target, but never the hard
+    /// object limit. Rejected encodings create no remote intermediate objects.
+    pub(super) async fn write_leaves(
+        &self,
+        fragments: &[Fragment],
+        watermark: u64,
+        config: &node::FragmentMetadataTreeConfig,
+    ) -> Result<Vec<Written>> {
+        let encoded = self.encoded_leaves(fragments, 0..fragments.len(), config);
+        futures::pin_mut!(encoded);
+        let mut output = Vec::new();
+        while let Some(leaf) = encoded.try_next().await? {
+            output.push(
+                self.write_encoded_leaf(&fragments[leaf.range], leaf.bytes, watermark)
+                    .await?,
+            );
+        }
+        Ok(output)
+    }
+
+    /// Pack adjacent bootstrap batches when their combined encoding fits. Keep
+    /// at most three targets of logical metadata in a candidate, except for an
+    /// indivisible fragment. Normal mutation splits retain their own headroom.
+    pub(super) async fn write_initial_leaves(
+        &self,
+        fragments: &[Fragment],
+        config: &node::FragmentMetadataTreeConfig,
+    ) -> Result<Vec<Written>> {
+        let mut pending: Option<EncodedLeaf> = None;
+        let mut output = Vec::new();
+        let mut start = 0;
+        while start < fragments.len() {
+            let mut end = start;
+            let mut logical_bytes = 0;
+            while end < fragments.len() && logical_bytes < config.max_leaf_bytes {
+                logical_bytes += node::fragment_logical_bytes(&fragments[end]);
+                end += 1;
+            }
+            let encoded = self.encoded_leaves(fragments, start..end, config);
+            futures::pin_mut!(encoded);
+            while let Some(leaf) = encoded.try_next().await? {
+                if let Some(previous) = pending.take() {
+                    let encoded_bytes = previous.bytes.len().checked_add(leaf.bytes.len());
+                    let range = previous.range.start..leaf.range.end;
+                    if encoded_bytes.is_some_and(|bytes| bytes as u64 <= config.max_leaf_bytes)
+                        && node::leaf_logical_bytes(&fragments[range.clone()])
+                            <= config.max_leaf_bytes * 3
+                    {
+                        let bytes = self.encode_leaf(&fragments[range.clone()]).await?;
+                        // Compression is not additive. The estimate only chooses
+                        // a candidate; its actual encoding decides admission.
+                        if bytes.len() as u64 <= config.max_leaf_bytes {
+                            pending = Some(EncodedLeaf { range, bytes });
+                            continue;
+                        }
+                    }
+                    output.push(
+                        self.write_encoded_leaf(&fragments[previous.range], previous.bytes, 0)
+                            .await?,
+                    );
+                }
+                pending = Some(leaf);
+            }
+            start = end;
+        }
+        if let Some(leaf) = pending {
+            output.push(
+                self.write_encoded_leaf(&fragments[leaf.range], leaf.bytes, 0)
+                    .await?,
+            );
+        }
+        Ok(output)
+    }
+
+    /// Read a columnar leaf back into a fragment list: each FRAGMENT header
+    /// row starts a fragment, its DATA_FILE rows follow.
+    pub fn read_leaf<'a>(
+        &'a self,
+        child: &'a pb::FragmentMetadataChild,
+    ) -> BoxFuture<'a, Result<Vec<Fragment>>> {
+        async move {
+            match &self.validation_reads {
+                Some(reads) => reads.read(self, child).await,
+                None => self.read_leaf_uncached(child).await,
+            }
+        }
+        .boxed()
+    }
+
+    /// Write an internal node (children + buffer) as a protobuf object.
+    pub async fn write_internal(
+        &self,
+        children: Vec<pb::FragmentMetadataChild>,
+        buffer: Vec<pb::FragmentMetadataMutation>,
+    ) -> Result<Written> {
+        let path = self.node_path();
+        let node = pb::FragmentMetadataNode {
+            children: children.clone(),
+            buffer,
+        };
+        let bytes = node.encode_to_vec();
+        let io_bytes = bytes.len() as u64;
+        self.object_store
+            .inner
+            .put_opts(
+                &self.resolve_path(path.as_ref())?,
+                PutPayload::from(bytes),
+                PutOptions::default(),
+            )
+            .await?;
+        Ok(Written {
+            child_ref: node::internal_ref(path.to_string(), &children, &node.buffer, io_bytes)?,
+            io_bytes,
+        })
+    }
+
+    /// Read an internal node.
+    pub async fn read_internal(&self, child: &pb::FragmentMetadataChild) -> Result<InternalNode> {
+        let (store, path) = self.resolve_child(child)?;
+        let bytes = store
+            .inner
+            .get_opts(&path, GetOptions::default())
+            .await?
+            .bytes()
+            .await?;
+        let object_size = bytes.len() as u64;
+        if object_size != child.object_size {
+            return Err(super::validation::corrupt(format!(
+                "Internal node {} has {object_size} bytes but its parent declares {}",
+                child.path, child.object_size,
+            )));
+        }
+        let mut node = pb::FragmentMetadataNode::decode(bytes)?;
+        super::validation::children(&node.children, self.next_action_sequence, child.min_key)?;
+        super::validation::buffer(&node.buffer, 1, self.next_action_sequence)?;
+        let summary = node::internal_ref(
+            child.path.clone(),
+            &node.children,
+            &node.buffer,
+            object_size,
+        )?;
+        if !derived_child_fields_match(&summary, child) {
+            return Err(super::validation::corrupt(format!(
+                "Internal node {} contents differ from its parent reference",
+                child.path
+            )));
+        }
+        // Inherited nodes belong to another dataset. Unset child and file
+        // refs take that dataset's base_id. External lineage has no base_id, so
+        // a source-relative path would bind to the wrong dataset.
+        if let Some(base_id) = child.base_id {
+            for descendant in &mut node.children {
+                if descendant.base_id.is_none() {
+                    descendant.base_id = Some(base_id);
+                }
+            }
+            let (store, base) = self.child_dataset(child)?;
+            preserve_inherited_refs(
+                &mut node.buffer,
+                SourceStore {
+                    object_store: store.as_ref(),
+                    base: &base,
+                    base_id,
+                },
+            )
+            .await?;
+        }
+        Ok(InternalNode {
+            children: node.children,
+            buffer: node.buffer,
+        })
+    }
+
+    /// Write an immutable root base without publishing a dataset version.
+    /// The caller must publish its reference through the Version Manifest.
+    pub async fn write_root_base(&self, root: &pb::FragmentMetadataRoot) -> Result<(String, u64)> {
+        let path = Path::from("_bt/base").join(format!("{}.root", Uuid::new_v4()));
+        let bytes = root.encode_to_vec();
+        let size = bytes.len() as u64;
+        self.object_store
+            .put(&self.resolve_path(path.as_ref())?, &bytes)
+            .await?;
+        Ok((path.to_string(), size))
+    }
+
+    /// Read a base named directly by a Version Manifest, without version lookup.
+    pub async fn read_root_base(&self, path: &str) -> Result<pb::FragmentMetadataRoot> {
+        let bytes = get_whole(&self.object_store, &self.resolve_path(path)?).await?;
+        Ok(pb::FragmentMetadataRoot::decode(bytes.as_ref())?)
+    }
+
+    pub(super) fn apply_verified(
+        &self,
+        fragments: &mut BTreeMap<u64, Fragment>,
+        actions: Vec<pb::FragmentMetadataMutation>,
+    ) -> Result<()> {
+        if actions.is_empty() {
+            return Ok(());
+        }
+        let touched: BTreeSet<u64> = actions.iter().map(node::action_key).collect();
+        node::apply_verified(fragments, actions)?;
+        let mut intern = self.lock_interner();
+        for id in touched {
+            if let Some(fragment) = fragments.get_mut(&id) {
+                intern_data_file_lists(&mut intern, fragment);
+            }
+        }
+        Ok(())
+    }
+
+    pub(super) fn share_data_file_lists<'a>(
+        &self,
+        fragments: impl IntoIterator<Item = &'a mut Fragment>,
+    ) {
+        let mut intern = self.lock_interner();
+        for fragment in fragments {
+            intern_data_file_lists(&mut intern, fragment);
+        }
+    }
+
+    pub(super) async fn encode_leaf(&self, fragments: &[Fragment]) -> Result<bytes::Bytes> {
+        let num_rows: usize = fragments.iter().map(|f| f.files.len() + 1).sum();
+        let mut row_kind = Vec::with_capacity(num_rows);
+        let mut frag_ids = Vec::with_capacity(num_rows);
+        let mut fragment_meta = BinaryBuilder::new();
+        let mut paths = Vec::with_capacity(num_rows);
+        let mut major = Vec::with_capacity(num_rows);
+        let mut minor = Vec::with_capacity(num_rows);
+        let mut sizes = Vec::with_capacity(num_rows);
+        let mut base_ids: Vec<Option<u32>> = Vec::with_capacity(num_rows);
+        let list_item = ArrowField::new("item", DataType::Int32, false);
+        let mut field_builder = ListBuilder::new(Int32Builder::new()).with_field(list_item.clone());
+        let mut col_builder = ListBuilder::new(Int32Builder::new()).with_field(list_item);
+
+        for f in fragments {
+            let mut header = pb::DataFragment::from(f);
+            header.files.clear();
+            row_kind.push(ROW_KIND_FRAGMENT);
+            frag_ids.push(f.id);
+            fragment_meta.append_value(header.encode_to_vec());
+            paths.push(String::new());
+            field_builder.append(true);
+            col_builder.append(true);
+            major.push(0);
+            minor.push(0);
+            sizes.push(0);
+            base_ids.push(None);
+            for data_file in &f.files {
+                row_kind.push(ROW_KIND_DATA_FILE);
+                frag_ids.push(f.id);
+                fragment_meta.append_null();
+                paths.push(data_file.path.clone());
+                for &field_id in data_file.fields.iter() {
+                    field_builder.values().append_value(field_id);
+                }
+                field_builder.append(true);
+                for &column_index in data_file.column_indices.iter() {
+                    col_builder.values().append_value(column_index);
+                }
+                col_builder.append(true);
+                major.push(data_file.file_major_version);
+                minor.push(data_file.file_minor_version);
+                sizes.push(
+                    data_file
+                        .file_size_bytes
+                        .get()
+                        .map(|size| size.get())
+                        .unwrap_or_default(),
+                );
+                base_ids.push(data_file.base_id);
+            }
+        }
+
+        let arrow_schema = leaf_arrow_schema();
+        let batch = RecordBatch::try_new(
+            arrow_schema.clone(),
+            vec![
+                Arc::new(UInt8Array::from(row_kind)),
+                Arc::new(UInt64Array::from(frag_ids)),
+                Arc::new(fragment_meta.finish()),
+                Arc::new(StringArray::from(paths)),
+                Arc::new(field_builder.finish()),
+                Arc::new(col_builder.finish()),
+                Arc::new(UInt32Array::from(major)),
+                Arc::new(UInt32Array::from(minor)),
+                Arc::new(UInt64Array::from(sizes)),
+                Arc::new(UInt32Array::from(base_ids)),
+            ],
+        )?;
+
+        let lance_schema = LanceSchema::try_from(arrow_schema.as_ref())?;
+        let memory = ObjectStore::memory();
+        let path = Path::from("encoded-leaf");
+        let writer = memory.create(&path).await?;
+        let mut file_writer = lance_file::versions::create_writer(
+            ConcreteFileVersion::V2_1,
+            writer,
+            lance_schema,
+            FileWriterOptions::default(),
+        )?;
+        file_writer.write_batch(&batch).await?;
+        file_writer.finish().await?;
+        get_whole(&memory, &path).await
+    }
+
+    async fn write_encoded_leaf(
+        &self,
+        fragments: &[Fragment],
+        bytes: bytes::Bytes,
+        materialized_through_action_sequence: u64,
+    ) -> Result<Written> {
+        let path = self.leaf_path();
+        let size = bytes.len() as u64;
+        self.object_store
+            .inner
+            .put_opts(
+                &self.resolve_path(path.as_ref())?,
+                bytes.into(),
+                PutOptions::default(),
+            )
+            .await?;
+        Ok(Written {
+            child_ref: node::leaf_ref(
+                path.to_string(),
+                fragments,
+                size,
+                materialized_through_action_sequence,
+            )?,
+            io_bytes: size,
+        })
+    }
+
+    fn encoded_leaves<'a>(
+        &'a self,
+        fragments: &'a [Fragment],
+        range: Range<usize>,
+        config: &'a node::FragmentMetadataTreeConfig,
+    ) -> impl futures::Stream<Item = Result<EncodedLeaf>> + 'a {
+        futures::stream::try_unfold(vec![range], move |mut pending| async move {
+            while let Some(range) = pending.pop() {
+                if range.is_empty() {
+                    continue;
+                }
+                let piece = &fragments[range.clone()];
+                let bytes = self.encode_leaf(piece).await?;
+                if bytes.len() as u64 > config.max_leaf_bytes && piece.len() > 1 {
+                    let middle = range.start + piece.len() / 2;
+                    pending.push(middle..range.end);
+                    pending.push(range.start..middle);
+                    continue;
+                }
+                if bytes.len() as u64 > config.hard_capacity_bytes {
+                    return Err(Error::invalid_input(format!(
+                        "fragment {} requires an encoded leaf of {} bytes, exceeding hard_capacity_bytes={}",
+                        piece[0].id,
+                        bytes.len(),
+                        config.hard_capacity_bytes
+                    )));
+                }
+                return Ok(Some((EncodedLeaf { range, bytes }, pending)));
+            }
+            Ok(None)
+        })
+    }
+
+    async fn read_leaf_uncached(&self, child: &pb::FragmentMetadataChild) -> Result<Vec<Fragment>> {
+        let (store, path) = self.resolve_child(child)?;
+        let object_size = usize::try_from(child.object_size).map_err(|_| {
+            Error::invalid_input(format!(
+                "leaf object_size does not fit usize: path={}, object_size={}",
+                child.path, child.object_size
+            ))
+        })?;
+        let object_reader = Arc::new(SmallReader::new(store.inner.clone(), path, 3, object_size));
+        let file_scheduler = self.scheduler.open_reader(object_reader.clone());
+        let reader = FileReader::try_open(
+            file_scheduler,
+            None,
+            Arc::<DecoderPlugins>::default(),
+            &self.cache,
+            FileReaderOptions::default(),
+        )
+        .await?;
+
+        // Opening the footer has already fetched the complete SmallReader
+        // object through the scheduler. Inspect those cached bytes, not a HEAD
+        // or a second GET, before trusting the reference's size.
+        let actual_size = object_reader.get_all().await?.len() as u64;
+        if actual_size != child.object_size {
+            return Err(super::validation::corrupt(format!(
+                "Leaf {} has {actual_size} bytes but its parent declares {}",
+                child.path, child.object_size,
+            )));
+        }
+
+        // A reference is untrusted until the leaf contents have been checked.
+        let mut fragments: Vec<Fragment> =
+            Vec::with_capacity(child.num_keys.min(READ_BATCH_ROWS as u64) as usize);
+        let mut stream = reader
+            .read_stream(
+                ReadBatchParams::RangeFull,
+                READ_BATCH_ROWS,
+                READ_BATCH_READAHEAD,
+                FilterExpression::no_filter(),
+            )
+            .await?;
+        while let Some(batch) = stream.try_next().await? {
+            if batch.schema().fields() != leaf_arrow_schema().fields() {
+                return Err(super::validation::corrupt(format!(
+                    "Leaf {} has an unexpected schema: {:?}",
+                    child.path,
+                    batch.schema()
+                )));
+            }
+            for (field, column) in batch.schema().fields().iter().zip(batch.columns()) {
+                if !field.is_nullable() && column.null_count() != 0 {
+                    return Err(super::validation::corrupt(format!(
+                        "Leaf {} has null values in {}",
+                        child.path,
+                        field.name()
+                    )));
+                }
+            }
+            let col = |name: &str| {
+                batch.column_by_name(name).ok_or_else(|| {
+                    Error::invalid_input(format!("leaf {} is missing column {name}", child.path))
+                })
+            };
+            let row_kinds = col("row_kind")?.as_primitive::<UInt8Type>();
+            let frag_ids = col("frag_id")?.as_primitive::<UInt64Type>();
+            let fragment_meta = col("fragment_meta")?.as_binary::<i32>();
+            let paths = col("path")?.as_string::<i32>();
+            let field_ids = col("field_ids")?.as_list::<i32>();
+            let col_indices = col("column_indices")?.as_list::<i32>();
+            let major = col("major_version")?.as_primitive::<UInt32Type>();
+            let minor = col("minor_version")?.as_primitive::<UInt32Type>();
+            let sizes = col("file_size_bytes")?.as_primitive::<UInt64Type>();
+            let base_ids = col("base_id")?.as_primitive::<UInt32Type>();
+
+            for row in 0..batch.num_rows() {
+                let fid = frag_ids.value(row);
+                if row_kinds.value(row) == ROW_KIND_FRAGMENT {
+                    if fragment_meta.is_null(row) {
+                        return Err(Error::invalid_input(format!(
+                            "leaf FRAGMENT row frag_id={fid} is missing fragment_meta"
+                        )));
+                    }
+                    let header = pb::DataFragment::decode(fragment_meta.value(row))?;
+                    let fragment = super::validation::fragment(header)?;
+                    if fragment.id != fid {
+                        return Err(Error::invalid_input(format!(
+                            "leaf FRAGMENT row frag_id={fid} does not match fragment_meta id={}",
+                            fragment.id
+                        )));
+                    }
+                    if !fragment.files.is_empty() {
+                        return Err(Error::invalid_input(format!(
+                            "leaf fragment_meta for frag_id={fid} unexpectedly contains {} data files",
+                            fragment.files.len()
+                        )));
+                    }
+                    // FRAGMENT rows carry fixed sentinels in the file columns.
+                    if !paths.value(row).is_empty()
+                        || !field_ids.value(row).is_empty()
+                        || !col_indices.value(row).is_empty()
+                        || major.value(row) != 0
+                        || minor.value(row) != 0
+                        || sizes.value(row) != 0
+                        || !base_ids.is_null(row)
+                    {
+                        return Err(super::validation::corrupt(format!(
+                            "Leaf {} FRAGMENT row for fragment {fid} has non sentinel file columns",
+                            child.path
+                        )));
+                    }
+                    if fragments.last().is_some_and(|previous| previous.id >= fid) {
+                        return Err(super::validation::corrupt(format!(
+                            "Leaf {} fragment ID {fid} is duplicated or out of order",
+                            child.path
+                        )));
+                    }
+                    fragments.push(fragment);
+                    continue;
+                }
+                if row_kinds.value(row) != ROW_KIND_DATA_FILE {
+                    return Err(super::validation::corrupt(format!(
+                        "Leaf {} has unknown row_kind={} at row {row}",
+                        child.path,
+                        row_kinds.value(row)
+                    )));
+                }
+                if !fragment_meta.is_null(row)
+                    || field_ids.value(row).null_count() != 0
+                    || col_indices.value(row).null_count() != 0
+                {
+                    return Err(super::validation::corrupt(format!(
+                        "Leaf {} has an invalid file row for fragment {fid}",
+                        child.path
+                    )));
+                }
+                let fields_array = field_ids.value(row);
+                let cols_array = col_indices.value(row);
+                let fields_values = fields_array.as_primitive::<Int32Type>().values();
+                let cols_values = cols_array.as_primitive::<Int32Type>().values();
+                let (fields, cols) = {
+                    let mut intern = self.lock_interner();
+                    (
+                        intern.intern_field_ids(fields_values),
+                        intern.intern_column_indices(cols_values),
+                    )
+                };
+                let base = (!base_ids.is_null(row)).then(|| base_ids.value(row));
+                // Metadata replay must preserve the stored numbers, including
+                // noncanonical pairs; decoding a data file is a separate step.
+                let df = DataFile {
+                    path: paths.value(row).to_string(),
+                    fields,
+                    column_indices: cols,
+                    file_major_version: major.value(row),
+                    file_minor_version: minor.value(row),
+                    file_size_bytes: lance_io::utils::CachedFileSize::new(sizes.value(row)),
+                    base_id: base,
+                };
+                let Some(fragment) = fragments.last_mut() else {
+                    return Err(Error::invalid_input(format!(
+                        "leaf DATA_FILE row frag_id={fid} precedes any FRAGMENT row"
+                    )));
+                };
+                if fragment.id != fid {
+                    return Err(Error::invalid_input(format!(
+                        "leaf DATA_FILE row frag_id={fid} does not follow its FRAGMENT row \
+                         (current fragment {})",
+                        fragment.id
+                    )));
+                }
+                fragment.files.push(df);
+            }
+        }
+        let mut summary = node::leaf_ref(
+            child.path.clone(),
+            &fragments,
+            child.object_size,
+            child.materialized_through_action_sequence,
+        )?;
+        // The fence comes from the parent and may sit below the first stored key.
+        if child.min_key > summary.min_key {
+            return Err(super::validation::corrupt(format!(
+                "Leaf {} fence {} is above its first fragment {}",
+                child.path, child.min_key, summary.min_key
+            )));
+        }
+        summary.min_key = child.min_key;
+        summary.base_id = child.base_id;
+        if summary.num_keys != child.num_keys
+            || summary.total_rows != child.total_rows
+            || summary.visible_rows != child.visible_rows
+            || summary.height != 0
+            || summary.num_children != 0
+        {
+            return Err(super::validation::corrupt(format!(
+                "Leaf {} contents differ from its parent reference",
+                child.path
+            )));
+        }
+        if let Some(base_id) = child.base_id {
+            let (store, base) = self.child_dataset(child)?;
+            preserve_inherited_fragments(
+                &mut fragments,
+                SourceStore {
+                    object_store: store.as_ref(),
+                    base: &base,
+                    base_id,
+                },
+            )
+            .await?;
+        }
+        Ok(fragments)
+    }
+
+    fn leaf_path(&self) -> Path {
+        Path::from("_bt/leaf").join(format!("{}.lance", Uuid::new_v4()))
+    }
+
+    fn node_path(&self) -> Path {
+        Path::from("_bt/node").join(format!("{}.node", Uuid::new_v4()))
+    }
+
+    fn resolve_path(&self, path: &str) -> Result<Path> {
+        self.resolve_under(&self.base, path)
+    }
+
+    fn resolve_child(&self, child: &pb::FragmentMetadataChild) -> Result<(Arc<ObjectStore>, Path)> {
+        let (store, base) = self.child_dataset(child)?;
+        Ok((store, self.resolve_under(&base, &child.path)?))
+    }
+
+    fn resolve_under(&self, base: &Path, path: &str) -> Result<Path> {
+        let relative = Path::parse(path).map_err(|error| {
+            super::validation::corrupt(format!("Invalid metadata path {path:?}: {error}"))
+        })?;
+        if !path.starts_with("_bt/") || path != relative.as_ref() {
+            return Err(super::validation::corrupt(format!(
+                "Metadata path {path:?} must be relative to _bt/"
+            )));
+        }
+        let mut resolved = base.clone();
+        resolved.extend(&relative);
+        Ok(resolved)
+    }
+
+    fn child_dataset(&self, child: &pb::FragmentMetadataChild) -> Result<(Arc<ObjectStore>, Path)> {
+        match child.base_id {
+            Some(id) => {
+                let foreign = self.foreign_bases.get(&id).ok_or_else(|| {
+                    super::validation::corrupt(format!(
+                        "Tree child {} names unknown base_id {id}",
+                        child.path
+                    ))
+                })?;
+                Ok((foreign.store.clone(), foreign.base.clone()))
+            }
+            None => Ok((self.object_store.clone(), self.base.clone())),
+        }
+    }
+
+    fn lock_interner(&self) -> std::sync::MutexGuard<'_, DataFileFieldInterner> {
+        self.interner
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
+}
+
+/// Fetch a whole object through the object-store trait, never through the
+/// local-filesystem fast path, so store wrappers (tracking, injected
+/// latency, caches) observe all metadata reads.
+pub async fn get_whole(object_store: &ObjectStore, path: &Path) -> Result<bytes::Bytes> {
+    let result = object_store
+        .inner
+        .get_opts(path, object_store::GetOptions::default())
+        .await?;
+    Ok(result.bytes().await?)
+}
+
+fn intern_data_file_lists(intern: &mut DataFileFieldInterner, fragment: &mut Fragment) {
+    for file in fragment.referenced_lance_files_mut() {
+        file.fields = intern.intern_field_ids(file.fields.as_ref());
+        file.column_indices = intern.intern_column_indices(file.column_indices.as_ref());
+    }
+}
+
+fn int_list_type() -> DataType {
+    DataType::List(Arc::new(ArrowField::new("item", DataType::Int32, false)))
+}
+
+/// A fragment header row; its DATA_FILE rows follow in file order.
+const ROW_KIND_FRAGMENT: u8 = 0;
+/// One data file of the most recent FRAGMENT row.
+const ROW_KIND_DATA_FILE: u8 = 1;
+
+/// Columnar leaf schema: a FRAGMENT header row per fragment, then one
+/// DATA_FILE row per data file with each `DataFile` field in its own column.
+fn leaf_arrow_schema() -> Arc<ArrowSchema> {
+    Arc::new(ArrowSchema::new(vec![
+        ArrowField::new("row_kind", DataType::UInt8, false),
+        ArrowField::new("frag_id", DataType::UInt64, false),
+        // FRAGMENT rows retain all metadata except the separately stored files.
+        ArrowField::new("fragment_meta", DataType::Binary, true),
+        // DATA_FILE rows only.
+        ArrowField::new("path", DataType::Utf8, false),
+        ArrowField::new("field_ids", int_list_type(), false),
+        ArrowField::new("column_indices", int_list_type(), false),
+        ArrowField::new("major_version", DataType::UInt32, false),
+        ArrowField::new("minor_version", DataType::UInt32, false),
+        ArrowField::new("file_size_bytes", DataType::UInt64, false), // 0 = unknown
+        // Absent means the file lives in the dataset that owns this leaf. A
+        // leaf inherited through a clone stamps its child reference's base_id
+        // on read, so the file still resolves against the source dataset.
+        ArrowField::new("base_id", DataType::UInt32, true),
+    ]))
+}
+
+/// Object store and dataset root that own inherited file and lineage references.
+#[derive(Clone, Copy)]
+pub struct SourceStore<'a> {
+    pub object_store: &'a ObjectStore,
+    pub base: &'a Path,
+    pub base_id: u32,
+}
+
+fn stamp_unset_base_id(fragment: &mut Fragment, base_id: u32) {
+    for file in fragment.referenced_lance_files_mut() {
+        if file.base_id.is_none() {
+            file.base_id = Some(base_id);
+        }
+    }
+    if let Some(deletion) = &mut fragment.deletion_file
+        && deletion.base_id.is_none()
+    {
+        deletion.base_id = Some(base_id);
+    }
+}
+
+async fn preserve_inherited_fragments(
+    fragments: &mut [Fragment],
+    source: SourceStore<'_>,
+) -> Result<()> {
+    for fragment in fragments.iter_mut() {
+        stamp_unset_base_id(fragment, source.base_id);
+    }
+    inline_external_lineage(source.object_store, source.base, fragments).await
+}
+
+/// Stamp unset file `base_id`s and inline source-relative lineage.
+pub async fn preserve_inherited_refs(
+    mutations: &mut [pb::FragmentMetadataMutation],
+    source: SourceStore<'_>,
+) -> Result<()> {
+    for tagged in mutations {
+        let Some(action) = tagged
+            .action
+            .as_mut()
+            .and_then(|action| action.action.as_mut())
+        else {
+            continue;
+        };
+        match action {
+            Action::AddFragment(encoded) => {
+                let mut fragment = Fragment::try_from(encoded.clone())?;
+                preserve_inherited_fragments(std::slice::from_mut(&mut fragment), source).await?;
+                *encoded = pb::DataFragment::from(&fragment);
+            }
+            Action::AddDataFile(value) => {
+                if let Some(file) = value.file.as_mut()
+                    && file.base_id.is_none()
+                {
+                    file.base_id = Some(source.base_id);
+                }
+            }
+            Action::AddDeletionFile(value) => {
+                if let Some(file) = value.deletion_file.as_mut()
+                    && file.base_id.is_none()
+                {
+                    file.base_id = Some(source.base_id);
+                }
+            }
+            Action::ReplaceDataFile(value) if value.base_id.is_none() => {
+                value.base_id = Some(source.base_id);
+            }
+            _ => {}
+        }
+    }
+    Ok(())
+}
+
+/// External lineage has no base_id. A source-relative path on a clone would
+/// bind to the destination dataset.
+pub async fn inline_external_lineage(
+    store: &ObjectStore,
+    base: &Path,
+    fragments: &mut [Fragment],
+) -> Result<()> {
+    async fn read_slice(
+        store: &ObjectStore,
+        base: &Path,
+        slice: &crate::format::ExternalFile,
+    ) -> Result<Vec<u8>> {
+        let start = usize::try_from(slice.offset).map_err(|_| {
+            Error::invalid_input(format!(
+                "lineage offset {} on {} exceeds usize",
+                slice.offset, slice.path
+            ))
+        })?;
+        let size = usize::try_from(slice.size).map_err(|_| {
+            Error::invalid_input(format!(
+                "lineage size {} on {} exceeds usize",
+                slice.size, slice.path
+            ))
+        })?;
+        let end = start.checked_add(size).ok_or_else(|| {
+            Error::invalid_input(format!(
+                "lineage byte range overflow on {} at offset {}",
+                slice.path, slice.offset
+            ))
+        })?;
+        let mut path = base.clone();
+        path.extend(&Path::parse(&slice.path)?);
+        Ok(store
+            .open(&path)
+            .await?
+            .get_range(start..end)
+            .await?
+            .to_vec())
+    }
+    for fragment in fragments {
+        if let Some(RowIdMeta::External(slice)) = &fragment.row_id_meta {
+            let bytes = read_slice(store, base, slice).await?;
+            fragment.row_id_meta = Some(RowIdMeta::Inline(bytes.into()));
+        }
+        for metadata in [
+            &mut fragment.created_at_version_meta,
+            &mut fragment.last_updated_at_version_meta,
+        ] {
+            if let Some(RowDatasetVersionMeta::External(slice)) = metadata.as_ref() {
+                let bytes = read_slice(store, base, slice).await?;
+                *metadata = Some(RowDatasetVersionMeta::Inline(bytes.into()));
+            }
+        }
+    }
+    Ok(())
+}
+
+fn derived_child_fields_match(
+    summary: &pb::FragmentMetadataChild,
+    child: &pb::FragmentMetadataChild,
+) -> bool {
+    summary.num_keys == child.num_keys
+        && summary.total_rows == child.total_rows
+        && summary.visible_rows == child.visible_rows
+        && summary.height == child.height
+        && summary.num_children == child.num_children
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use crate::format::{
+        DeletionFile, DeletionFileType, ExternalFile, RowDatasetVersionMeta, RowIdMeta,
+    };
+    use crate::fragment_metadata::action;
+    use crate::fragment_metadata::support::{
+        make_backfill_data_file, make_fragment, make_fragment_with_files,
+    };
+    use lance_core::utils::tempfile::TempObjDir;
+    use lance_io::scheduler::SchedulerConfig;
+    use object_store::ObjectStoreExt;
+    use rstest::rstest;
+
+    #[rstest]
+    #[case::historical_numbers(0, 3)]
+    #[case::unknown_numbers(17, 42)]
+    #[tokio::test]
+    async fn leaf_preserves_data_file_version_numbers(#[case] major: u32, #[case] minor: u32) {
+        let base = TempObjDir::default();
+        let store = test_store(base.clone());
+        let mut fragment = make_fragment(0);
+        fragment.files[0].file_major_version = major;
+        fragment.files[0].file_minor_version = minor;
+        let written = store.write_leaf(&[fragment.clone()], 0).await.unwrap();
+        assert_eq!(
+            store.read_leaf(&written.child_ref).await.unwrap(),
+            vec![fragment]
+        );
+    }
+
+    #[tokio::test]
+    async fn internal_read_rejects_an_understated_object_size() {
+        let base = TempObjDir::default();
+        let store = test_store(base.clone());
+        let children = (0..2)
+            .map(|id| {
+                node::leaf_ref(format!("_bt/leaf/{id}.lance"), &[make_fragment(id)], 1, 0).unwrap()
+            })
+            .collect();
+        let mut written = store.write_internal(children, Vec::new()).await.unwrap();
+        written.child_ref.object_size = 1;
+        let error = store.read_internal(&written.child_ref).await.unwrap_err();
+        assert!(matches!(error, Error::CorruptFile { .. }), "{error}");
+        assert!(error.to_string().contains("parent declares"), "{error}");
+    }
+
+    #[tokio::test]
+    async fn root_read_preserves_unknown_protobuf_fields_without_writer_limits() {
+        let base = TempObjDir::default();
+        let store = test_store(base.clone());
+        let mut bytes = pb::FragmentMetadataRoot::default().encode_to_vec();
+        bytes.extend_from_slice(&[0xa2, 0x06, 0x80, 0x01]);
+        bytes.extend_from_slice(&[0; 128]);
+        let path = "_bt/base/oversized.root";
+        store
+            .object_store
+            .put(&store.resolve_path(path).unwrap(), &bytes)
+            .await
+            .unwrap();
+        store.read_root_base(path).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn leaf_read_rejects_an_understated_object_size() {
+        let base = TempObjDir::default();
+        let store = test_store(base.clone());
+        let written = store.write_leaf(&[make_fragment(0)], 0).await.unwrap();
+        let path = store.resolve_path(&written.child_ref.path).unwrap();
+        let mut bytes = get_whole(&store.object_store, &path)
+            .await
+            .unwrap()
+            .to_vec();
+        bytes.push(0);
+        store.object_store.put(&path, &bytes).await.unwrap();
+        let error = store.read_leaf(&written.child_ref).await.unwrap_err();
+        assert!(matches!(error, Error::CorruptFile { .. }), "{error}");
+        assert!(error.to_string().contains("parent declares"), "{error}");
+    }
+
+    fn test_store(base: Path) -> NodeStore {
+        let object_store = Arc::new(ObjectStore::local());
+        let scheduler =
+            ScanScheduler::new(object_store.clone(), SchedulerConfig::default_for_testing());
+        NodeStore::new(
+            object_store,
+            base,
+            scheduler,
+            Arc::new(LanceCache::with_capacity(64 * 1024 * 1024)),
+        )
+    }
+
+    #[tokio::test]
+    async fn encoded_leaf_target_and_oversized_singleton_limit() {
+        let base = TempObjDir::default();
+        let store = test_store(base.clone());
+        let config = node::FragmentMetadataTreeConfig::new(4096, 8)
+            .with_max_leaf_bytes(8192)
+            .with_hard_capacity_bytes(4 * 1024 * 1024);
+        let fragments: Vec<_> = (0..256).map(make_fragment).collect();
+        let written = store.write_leaves(&fragments, 17, &config).await.unwrap();
+        assert!(written.len() > 1);
+        let mut read = Vec::new();
+        for leaf in &written {
+            assert!(leaf.io_bytes <= config.max_leaf_bytes || leaf.child_ref.num_keys == 1);
+            assert_eq!(leaf.child_ref.object_size, leaf.io_bytes);
+            assert_eq!(leaf.child_ref.materialized_through_action_sequence, 17);
+            read.extend(store.read_leaf(&leaf.child_ref).await.unwrap());
+        }
+        assert_eq!(read, fragments);
+
+        let wide = make_fragment_with_files(257, 4096);
+        let written = store
+            .write_leaves(std::slice::from_ref(&wide), 18, &config)
+            .await
+            .unwrap();
+        assert_eq!(written.len(), 1);
+        assert!(written[0].io_bytes > config.max_leaf_bytes);
+        assert_eq!(
+            store.read_leaf(&written[0].child_ref).await.unwrap(),
+            vec![wide.clone()]
+        );
+        let before = store
+            .object_store
+            .read_dir_all(&store.base.clone().join("_bt").join("leaf"), None)
+            .map_ok(|meta| meta.location)
+            .try_collect::<std::collections::BTreeSet<_>>()
+            .await
+            .unwrap();
+        let restricted = config.with_hard_capacity_bytes(16 * 1024);
+        let error = store
+            .write_leaves(&[wide], 19, &restricted)
+            .await
+            .unwrap_err();
+        assert!(matches!(error, Error::InvalidInput { .. }), "{error}");
+        assert!(error.to_string().contains("fragment 257"));
+        assert!(error.to_string().contains("hard_capacity_bytes=16384"));
+        assert_eq!(
+            store
+                .object_store
+                .read_dir_all(&store.base.clone().join("_bt").join("leaf"), None)
+                .map_ok(|meta| meta.location)
+                .try_collect::<std::collections::BTreeSet<_>>()
+                .await
+                .unwrap(),
+            before
+        );
+    }
+
+    #[tokio::test]
+    async fn leaf_round_trips_fragment_metadata_and_empty_fragment() {
+        let mut fragment = make_fragment(7);
+        fragment.deletion_file = Some(DeletionFile {
+            read_version: 3,
+            id: 11,
+            file_type: DeletionFileType::Bitmap,
+            num_deleted_rows: Some(1),
+            base_id: Some(2),
+        });
+        fragment.row_id_meta = Some(RowIdMeta::Inline(vec![1, 2, 3, 4].into()));
+        fragment.created_at_version_meta =
+            Some(RowDatasetVersionMeta::Inline(Arc::from([5, 6, 7])));
+        fragment.last_updated_at_version_meta =
+            Some(RowDatasetVersionMeta::Inline(Arc::from([8, 9, 10])));
+
+        let mut empty_fragment = Fragment::new(8);
+        empty_fragment.physical_rows = Some(12);
+        empty_fragment.row_id_meta = Some(RowIdMeta::Inline(vec![12, 13].into()));
+
+        let expected = vec![fragment, empty_fragment];
+        let tempdir = TempObjDir::default();
+        let store = test_store(tempdir.clone().join("fragment_metadata"));
+        let written = store.write_leaf(&expected, 0).await.unwrap();
+        let actual = store.read_leaf(&written.child_ref).await.unwrap();
+
+        assert_eq!(actual, expected);
+    }
+    #[tokio::test]
+    async fn validation_spill_preserves_known_zero_counts_and_relative_paths() {
+        let base = TempObjDir::default();
+        let mut store = test_store(base.clone());
+        let mut fragment = make_fragment(0);
+        fragment.physical_rows = Some(0);
+        fragment.deletion_file = Some(DeletionFile {
+            read_version: 1,
+            id: 1,
+            file_type: DeletionFileType::Bitmap,
+            num_deleted_rows: Some(0),
+            base_id: None,
+        });
+        let written = store
+            .write_leaf(std::slice::from_ref(&fragment), 0)
+            .await
+            .unwrap();
+        assert!(written.child_ref.path.starts_with("_bt/leaf/"));
+        assert!(!written.child_ref.path.contains("%2F"));
+        let path = store.resolve_path(&written.child_ref.path).unwrap();
+        assert!(store.object_store.inner.head(&path).await.is_ok());
+        store.retain_validation_reads().unwrap();
+        // First read populates scratch; the second decodes the scratch record.
+        for _ in 0..2 {
+            assert_eq!(
+                store.read_leaf(&written.child_ref).await.unwrap(),
+                vec![fragment.clone()]
+            );
+        }
+        for path in [
+            "../_bt/leaf/escape",
+            "/_bt/leaf/absolute",
+            "data/not-metadata",
+        ] {
+            assert!(store.resolve_path(path).is_err(), "{path}");
+        }
+    }
+
+    #[tokio::test]
+    async fn foreign_interior_buffer_inherits_dataset_on_file_refs() {
+        let base = TempObjDir::default();
+        let mut store = test_store(base.clone());
+        let children = (0..2)
+            .map(|id| {
+                node::leaf_ref(format!("_bt/leaf/{id}.lance"), &[make_fragment(id)], 1, 0).unwrap()
+            })
+            .collect();
+        let file = make_backfill_data_file(0, 0);
+        let mutation = pb::FragmentMetadataMutation {
+            action_sequence: 1,
+            action: Some(action::add_data_file(0, &file)),
+            fragment_count_delta: 0,
+            total_rows_delta: 0,
+            visible_rows_delta: 0,
+        };
+        let mut written = store
+            .write_internal(children, vec![mutation])
+            .await
+            .unwrap();
+        let object_store = store.object_store.clone();
+        let dataset_base = store.base.clone();
+        store.set_foreign_bases(HashMap::from([(7, (object_store, dataset_base))]));
+        written.child_ref.base_id = Some(7);
+        let node = store.read_internal(&written.child_ref).await.unwrap();
+        let Some(pb::fragment_action::Action::AddDataFile(add)) = node.buffer[0]
+            .action
+            .as_ref()
+            .and_then(|a| a.action.as_ref())
+        else {
+            panic!("expected AddDataFile");
+        };
+        assert_eq!(add.file.as_ref().and_then(|file| file.base_id), Some(7));
+    }
+
+    #[tokio::test]
+    async fn foreign_interior_buffer_inlines_add_fragment_lineage() {
+        let source_dir = TempObjDir::default();
+        let source = test_store(source_dir.clone());
+        source
+            .object_store
+            .put(
+                &source.resolve_path("_bt/lineage").unwrap(),
+                &[10, 11, 12, 13, 14],
+            )
+            .await
+            .unwrap();
+        let slice = ExternalFile {
+            path: "_bt/lineage".into(),
+            offset: 1,
+            size: 3,
+        };
+        let mut fragment = make_fragment(2);
+        fragment.row_id_meta = Some(RowIdMeta::External(slice.clone()));
+        fragment.created_at_version_meta = Some(RowDatasetVersionMeta::External(slice.clone()));
+        fragment.last_updated_at_version_meta = Some(RowDatasetVersionMeta::External(slice));
+        let mutation = pb::FragmentMetadataMutation {
+            action_sequence: 1,
+            action: Some(action::add_fragment(&fragment)),
+            fragment_count_delta: 1,
+            total_rows_delta: fragment.physical_rows.unwrap_or(0) as i64,
+            visible_rows_delta: fragment.num_rows().unwrap_or(0) as i64,
+        };
+        let children = (0..2)
+            .map(|id| {
+                node::leaf_ref(format!("_bt/leaf/{id}.lance"), &[make_fragment(id)], 1, 0).unwrap()
+            })
+            .collect();
+        let mut written = source
+            .write_internal(children, vec![mutation])
+            .await
+            .unwrap();
+        let dest_dir = TempObjDir::default();
+        let mut dest = test_store(dest_dir.clone());
+        dest.set_foreign_bases(HashMap::from([(
+            7,
+            (source.object_store.clone(), source.base.clone()),
+        )]));
+        written.child_ref.base_id = Some(7);
+        let node = dest.read_internal(&written.child_ref).await.unwrap();
+        let Some(pb::fragment_action::Action::AddFragment(encoded)) = node.buffer[0]
+            .action
+            .as_ref()
+            .and_then(|a| a.action.as_ref())
+        else {
+            panic!("expected AddFragment");
+        };
+        let read = Fragment::try_from(encoded.clone()).unwrap();
+        assert_eq!(
+            read.row_id_meta,
+            Some(RowIdMeta::Inline(vec![11, 12, 13].into()))
+        );
+        assert_eq!(
+            read.created_at_version_meta,
+            Some(RowDatasetVersionMeta::Inline(Arc::from([11, 12, 13])))
+        );
+        assert_eq!(read.files[0].base_id, Some(7));
+    }
+
+    #[tokio::test]
+    async fn leaf_reads_share_field_list_allocations_across_leaves() {
+        let base = TempObjDir::default();
+        let store = test_store(base.clone());
+        let first = store.write_leaf(&[make_fragment(0)], 0).await.unwrap();
+        let second = store.write_leaf(&[make_fragment(1)], 0).await.unwrap();
+        let a = store.read_leaf(&first.child_ref).await.unwrap();
+        let b = store.read_leaf(&second.child_ref).await.unwrap();
+        assert!(std::sync::Arc::ptr_eq(
+            &a[0].files[0].fields,
+            &b[0].files[0].fields
+        ));
+        assert!(std::sync::Arc::ptr_eq(
+            &a[0].files[0].column_indices,
+            &b[0].files[0].column_indices
+        ));
+    }
+
+    #[tokio::test]
+    async fn foreign_leaf_inlines_external_lineage() {
+        let source_dir = TempObjDir::default();
+        let source = test_store(source_dir.clone());
+        source
+            .object_store
+            .put(
+                &source.resolve_path("_bt/lineage").unwrap(),
+                &[10, 11, 12, 13, 14],
+            )
+            .await
+            .unwrap();
+        let slice = ExternalFile {
+            path: "_bt/lineage".into(),
+            offset: 1,
+            size: 3,
+        };
+        let mut fragment = make_fragment(0);
+        fragment.row_id_meta = Some(RowIdMeta::External(slice.clone()));
+        fragment.created_at_version_meta = Some(RowDatasetVersionMeta::External(slice.clone()));
+        fragment.last_updated_at_version_meta = Some(RowDatasetVersionMeta::External(slice));
+        let written = source
+            .write_leaf(std::slice::from_ref(&fragment), 0)
+            .await
+            .unwrap();
+
+        let dest_dir = TempObjDir::default();
+        let mut dest = test_store(dest_dir.clone());
+        dest.set_foreign_bases(HashMap::from([(
+            4,
+            (source.object_store.clone(), source.base.clone()),
+        )]));
+        let mut child = written.child_ref.clone();
+        child.base_id = Some(4);
+        let read = dest.read_leaf(&child).await.unwrap();
+        assert_eq!(
+            read[0].row_id_meta,
+            Some(RowIdMeta::Inline(vec![11, 12, 13].into()))
+        );
+        assert_eq!(
+            read[0].created_at_version_meta,
+            Some(RowDatasetVersionMeta::Inline(Arc::from([11, 12, 13])))
+        );
+        assert_eq!(
+            read[0].last_updated_at_version_meta,
+            read[0].created_at_version_meta
+        );
+        assert_eq!(read[0].files[0].base_id, Some(4));
+    }
+}

--- a/rust/lance-table/src/fragment_metadata/store/validation_reads.rs
+++ b/rust/lance-table/src/fragment_metadata/store/validation_reads.rs
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+//! Commit-scoped leaf reads retained on local scratch storage. The materializer
+//! reuses these reads, including untouched coalesce neighbors. Native validation
+//! can separately retain the complete Fragment set for global operations.
+
+use std::collections::BTreeMap;
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use lance_core::Result;
+use lance_core::utils::tempfile::TempDir;
+use prost::Message;
+use tokio::sync::{Mutex, OnceCell};
+use uuid::Uuid;
+
+use super::NodeStore;
+use crate::format::{Fragment, pb};
+
+pub(super) struct ValidationReads {
+    directory: TempDir,
+    leaves: Mutex<BTreeMap<String, Arc<OnceCell<PathBuf>>>>,
+}
+
+impl ValidationReads {
+    pub(super) fn new() -> Result<Self> {
+        Ok(Self {
+            directory: TempDir::try_new()?,
+            leaves: Mutex::new(BTreeMap::new()),
+        })
+    }
+
+    pub(super) async fn read(
+        &self,
+        store: &NodeStore,
+        child: &pb::FragmentMetadataChild,
+    ) -> Result<Vec<Fragment>> {
+        let cell = self
+            .leaves
+            .lock()
+            .await
+            .entry(child.path.clone())
+            .or_default()
+            .clone();
+        let mut loaded = None;
+        let path = cell
+            .get_or_try_init(|| async {
+                let fragments = store.read_leaf_uncached(child).await?;
+                let record = pb::Manifest {
+                    fragments: fragments.iter().map(Into::into).collect(),
+                    ..Default::default()
+                };
+                let path = self
+                    .directory
+                    .std_path()
+                    .join(format!("{}.pb", Uuid::new_v4()));
+                tokio::fs::write(&path, record.encode_to_vec()).await?;
+                loaded = Some(fragments);
+                Ok::<_, lance_core::Error>(path)
+            })
+            .await?;
+        if let Some(fragments) = loaded {
+            return Ok(fragments);
+        }
+        let bytes = tokio::fs::read(path).await?;
+        let record = pb::Manifest::decode(bytes.as_slice())?;
+        record
+            .fragments
+            .into_iter()
+            .map(crate::fragment_metadata::validation::fragment)
+            .collect()
+    }
+}

--- a/rust/lance-table/src/fragment_metadata/support.rs
+++ b/rust/lance-table/src/fragment_metadata/support.rs
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+//! Deterministic fragment metadata for tests. Data files are not written.
+
+use std::num::NonZero;
+
+use lance_file::version::ConcreteFileVersion;
+
+use crate::format::{DataFile, Fragment};
+
+const FILE_VERSION: ConcreteFileVersion = ConcreteFileVersion::V2_0;
+
+/// A realistic Lance data-file path `data/<50 chars>.lance` derived
+/// deterministically from `(id, salt)`. Matches Lance's real naming: first 3 of
+/// 16 UUID bytes → 24 binary chars, remaining 13 → 26 hex chars.
+pub fn data_file_path(id: u64, salt: u64) -> String {
+    // splitmix64-fill 16 pseudo-random-but-deterministic bytes (a synthetic UUID).
+    let mut bytes = [0u8; 16];
+    let mut state = id
+        .wrapping_mul(0x9E37_79B9_7F4A_7C15)
+        .wrapping_add(salt.wrapping_mul(0xD1B5_4A32_D192_ED03));
+    for chunk in bytes.chunks_mut(8) {
+        state = state.wrapping_add(0x9E37_79B9_7F4A_7C15);
+        let mut z = state;
+        z = (z ^ (z >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
+        z = (z ^ (z >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
+        z ^= z >> 31;
+        let n = chunk.len();
+        chunk.copy_from_slice(&z.to_le_bytes()[..n]);
+    }
+
+    let mut stem = String::with_capacity(50);
+    for &b in &bytes[..3] {
+        for i in (0..8).rev() {
+            stem.push(if (b >> i) & 1 == 1 { '1' } else { '0' });
+        }
+    }
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    for &b in &bytes[3..] {
+        stem.push(HEX[(b >> 4) as usize] as char);
+        stem.push(HEX[(b & 0xf) as usize] as char);
+    }
+    format!("data/{stem}.lance")
+}
+
+/// A base 1-row fragment with one two-column data file — the bootstrap table of
+/// N tiny fragments.
+pub fn make_fragment(id: u64) -> Fragment {
+    let mut fragment = Fragment::new(id).with_file(
+        data_file_path(id, 0),
+        vec![0, 1],
+        vec![0, 1],
+        FILE_VERSION,
+        NonZero::new(1024),
+    );
+    fragment.physical_rows = Some(1);
+    fragment
+}
+
+/// The data file that backfill round `col` attaches to `frag_id` (add-column):
+/// one new field in a new data file, as an embedding backfill would produce.
+pub fn make_backfill_data_file(frag_id: u64, col: u32) -> DataFile {
+    DataFile::new(
+        data_file_path(frag_id, col as u64 + 1),
+        vec![2 + col as i32],
+        vec![0],
+        FILE_VERSION,
+        NonZero::new(4096),
+        None,
+    )
+}
+
+/// The data file that data-replacement round `round` writes for `frag_id`:
+/// the same base columns in a fresh file, as an update or compaction rewrite
+/// would produce. Path salts start above every backfill salt so replacement
+/// paths never collide with add-column paths.
+pub fn make_replacement_data_file(frag_id: u64, round: u32) -> DataFile {
+    const REPLACEMENT_SALT_BASE: u64 = 1 << 32;
+    DataFile::new(
+        data_file_path(frag_id, REPLACEMENT_SALT_BASE + round as u64),
+        vec![0, 1],
+        vec![0, 1],
+        FILE_VERSION,
+        NonZero::new(1024),
+        None,
+    )
+}
+
+/// A fragment containing one base file and additional single-column files.
+pub fn make_fragment_with_files(id: u64, num_files: u32) -> Fragment {
+    let mut fragment = make_fragment(id);
+    for col in 0..num_files.saturating_sub(1) {
+        fragment.files.push(make_backfill_data_file(id, col));
+    }
+    fragment
+}

--- a/rust/lance-table/src/fragment_metadata/tree.rs
+++ b/rust/lance-table/src/fragment_metadata/tree.rs
@@ -1,0 +1,1607 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+//! Immutable routing with buffered fragment changes.
+//!
+//! Pressure drains the children whose pending bytes amortize a rewrite.
+//! Splits and coalesces transfer messages with their ranges. The Version
+//! Manifest publishes the prepared root after every dependency has been written.
+
+use std::borrow::Cow;
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet, VecDeque};
+use std::sync::{Arc, OnceLock};
+
+use futures::future::BoxFuture;
+use futures::stream::BoxStream;
+use futures::{Stream, StreamExt, TryStreamExt};
+
+use crate::format::Fragment;
+use crate::format::pb;
+use crate::fragment_metadata::commit::{self, TouchedFragments, ValidatedCommit};
+use crate::fragment_metadata::node::{
+    self, FragmentMetadataTreeConfig, InternalNode, apply_aggregate_delta, sum_aggregate_deltas,
+};
+use crate::fragment_metadata::store::NodeStore;
+use lance_core::cache::LanceCache;
+use lance_core::{Error, Result};
+use lance_io::object_store::ObjectStore;
+use lance_io::scheduler::ScanScheduler;
+use object_store::path::Path;
+use prost::Message;
+use roaring::RoaringBitmap;
+
+mod flush;
+mod publication;
+pub use publication::SnapshotPolicy;
+
+/// Accumulated write work over one commit (for stats / benchmark accounting).
+#[derive(Debug, Default, Clone, Copy)]
+struct WriteAcc {
+    io_bytes: u64,
+    flushes: u64,
+    splits: u64,
+    merges: u64,
+    /// Actions applied at leaves this commit.
+    materialized: u64,
+    /// Actions removed by same-key squashing this commit.
+    squashed: u64,
+    /// Deepest tree level at which a flush occurred this commit (0 = root only).
+    /// Values above 0 mean an interior ε-buffer drained.
+    max_flush_depth: u32,
+}
+
+impl WriteAcc {
+    fn add(&mut self, o: Self) {
+        self.io_bytes += o.io_bytes;
+        self.flushes += o.flushes;
+        self.splits += o.splits;
+        self.merges += o.merges;
+        self.materialized += o.materialized;
+        self.squashed += o.squashed;
+        self.max_flush_depth = self.max_flush_depth.max(o.max_flush_depth);
+    }
+}
+
+/// Result of flushing an internal node: (possibly split) children, residual
+/// buffer, and accumulated write work.
+type FlushResult = (
+    Vec<pb::FragmentMetadataChild>,
+    Vec<pb::FragmentMetadataMutation>,
+    WriteAcc,
+);
+/// Result of ingesting into a subtree: the child ref(s) that now represent it
+/// (>1 if it split), and accumulated write work.
+type IngestResult = (Vec<pb::FragmentMetadataChild>, WriteAcc);
+type BufferedChild = (pb::FragmentMetadataChild, Vec<pb::FragmentMetadataMutation>);
+
+/// Bytes/structure written while bootstrapping.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct BootstrapStats {
+    pub io_write_bytes: u64,
+    pub num_leaves: u64,
+    /// Root-to-leaf edge count; see [`FragmentMetadataTree::height`].
+    pub height: u32,
+}
+
+/// Result of one commit.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct CommitStats {
+    /// Compacted root, internal-node, and leaf bytes written by this commit.
+    pub tree_write_bytes: u64,
+    /// Inline or external roots prepared by this commit.
+    pub checkpoints: u64,
+    pub flushes: u64,
+    pub splits: u64,
+    pub merges: u64,
+    /// Root-to-leaf edge count; see [`FragmentMetadataTree::height`].
+    pub height: u32,
+    /// Deepest level flushed this commit (0 = root buffer only; ≥1 = cascaded
+    /// into internal nodes — the deep-flush regime).
+    pub max_flush_depth: u32,
+    /// Actions this commit staged into the root buffer.
+    pub messages_in: u64,
+    /// Actions that reached a leaf this commit (any commit's actions).
+    pub messages_materialized: u64,
+    /// Actions removed by same-key squashing this commit.
+    pub messages_squashed: u64,
+    /// Root buffer occupancy after the commit.
+    pub root_buffer_len: u64,
+}
+
+/// Tree size and occupancy statistics.
+#[derive(Debug, Default, Clone)]
+pub struct ShapeReport {
+    /// Root-to-leaf edge count; see [`FragmentMetadataTree::height`].
+    pub height: u32,
+    pub root_bytes: u64,
+    pub root_buffer_len: u64,
+    pub root_buffer_bytes: u64,
+    pub root_fanout: u32,
+    /// Encoded leaf object sizes from child references.
+    pub leaf_bytes: Vec<u64>,
+    /// Actual encoded Lance bytes used for the leaf-size policy.
+    pub leaf_object_bytes: Vec<u64>,
+    pub leaf_keys: Vec<u64>,
+    pub node_bytes: Vec<u64>,
+    pub node_fanouts: Vec<u32>,
+    pub node_buffer_lens: Vec<u64>,
+    pub node_buffer_bytes: Vec<u64>,
+}
+
+/// State of an in-order fragment walk: subtrees still to visit, each with
+/// the buffered actions routed to it, and fragments ready to yield.
+#[derive(Default)]
+struct FragmentWalk {
+    lower_bound: u64,
+    stack: Vec<BufferedChild>,
+    ready: VecDeque<Fragment>,
+    pending_error: Option<Error>,
+}
+
+/// Where the table's `offset`-th visible row lives.
+#[derive(Debug, Clone, PartialEq)]
+pub enum OffsetResolution {
+    /// The fragment holding the row and the visible-row offset within it.
+    Found(Box<Fragment>, u64),
+    /// The offset is at or past the table's visible row count.
+    BeyondEnd,
+}
+
+/// A writer session over a fragment metadata tree. Holds the root (child
+/// references, ε-buffer, and aggregates). Interior and leaf nodes are read on
+/// demand. A scan may prefetch several leaves.
+#[derive(Clone)]
+pub struct FragmentMetadataTree {
+    store: NodeStore,
+    config: FragmentMetadataTreeConfig,
+    version: u64,
+    children: Vec<pb::FragmentMetadataChild>,
+    buffer: Vec<pb::FragmentMetadataMutation>,
+    buffer_index: OnceLock<node::BufferIndex>,
+    next_action_sequence: u64,
+    total_fragments: u64,
+    total_rows: u64,
+    /// The next fragment id an append allocates; see `next_fragment_id`.
+    next_fragment_id: u64,
+    visible_rows: u64,
+    /// Transient selection of ordered bulk materialization for this commit.
+    force_flush: bool,
+    /// Exact descriptor this writer opened/prepared; derived, never persisted.
+    snapshot: Option<Box<pb::FragmentMetadataTree>>,
+}
+
+#[derive(Clone)]
+struct MutableState {
+    version: u64,
+    children: Vec<pb::FragmentMetadataChild>,
+    buffer: Vec<pb::FragmentMetadataMutation>,
+    next_action_sequence: u64,
+    total_fragments: u64,
+    total_rows: u64,
+
+    next_fragment_id: u64,
+    visible_rows: u64,
+}
+
+impl FragmentMetadataTree {
+    /// Bind an immutable snapshot to another handle for the same object namespace.
+    pub fn with_object_store(mut self, store: Arc<ObjectStore>) -> Self {
+        self.store.rebind(store);
+        self
+    }
+
+    pub fn set_foreign_bases(&mut self, foreign_bases: HashMap<u32, (Arc<ObjectStore>, Path)>) {
+        self.store.set_foreign_bases(foreign_bases);
+    }
+
+    async fn build(
+        mut store: NodeStore,
+        config: FragmentMetadataTreeConfig,
+        fragments: Vec<Fragment>,
+    ) -> Result<(Self, BootstrapStats)> {
+        config.validate()?;
+        store.hard_capacity_bytes = config.hard_capacity_bytes;
+        let mut io = 0u64;
+        let mut layer: Vec<pb::FragmentMetadataChild> = Vec::new();
+        let mut total_rows = 0u64;
+        let mut visible_rows = 0u64;
+        let mut next_fragment_id = 0u64;
+        let num_fragments = fragments.len() as u64;
+        for f in &fragments {
+            next_fragment_id = next_fragment_id.max(f.id.checked_add(1).ok_or_else(|| {
+                Error::invalid_input(format!("Fragment ID {} leaves no next ID", f.id))
+            })?);
+            commit::require_known_counts(f)?;
+            visible_rows = visible_rows
+                .checked_add(f.num_rows().unwrap_or(0) as u64)
+                .ok_or_else(|| {
+                    Error::invalid_input(format!("Visible row count overflow at fragment {}", f.id))
+                })?;
+            total_rows = total_rows
+                .checked_add(f.physical_rows.unwrap_or(0) as u64)
+                .ok_or_else(|| {
+                    Error::invalid_input(format!(
+                        "fragment metadata tree total_rows overflow while bootstrapping fragment id={}",
+                        f.id
+                    ))
+                })?;
+        }
+        for w in store.write_initial_leaves(&fragments, &config).await? {
+            io += w.io_bytes;
+            layer.push(w.child_ref);
+        }
+        let num_leaves = layer.len() as u64;
+        node::fence(&mut layer, 0);
+
+        // Byte pressure matters even below the configured fanout ceiling: a
+        // directory of long paths can overflow with very few children.
+        while node::internal_overflows(&layer, &[], &config) {
+            let previous_width = layer.len();
+            let mut next: Vec<pb::FragmentMetadataChild> = Vec::new();
+            let groups = node::split_internal(
+                layer,
+                Vec::new(),
+                config.split_piece_bytes(),
+                config.max_children_per_node,
+            );
+            if groups.len() >= previous_width {
+                return Err(Error::invalid_input(format!(
+                    "node budget {} cannot group two child references; widen the directory budget",
+                    config.max_node_bytes
+                )));
+            }
+            for (group, buffer) in groups {
+                let w = store.write_internal(group, buffer).await?;
+                io += w.io_bytes;
+                next.push(w.child_ref);
+            }
+            layer = next;
+        }
+        let height = layer.iter().map(|c| c.height).max().unwrap_or(0) + 1;
+
+        let tree = Self {
+            store,
+            config,
+            version: 1,
+            children: layer,
+            buffer: Vec::new(),
+            buffer_index: OnceLock::new(),
+            next_action_sequence: 1,
+            total_fragments: num_fragments,
+            total_rows,
+
+            next_fragment_id,
+            visible_rows,
+            force_flush: false,
+            snapshot: None,
+        };
+        Ok((
+            tree,
+            BootstrapStats {
+                io_write_bytes: io,
+                num_leaves,
+                height,
+            },
+        ))
+    }
+
+    /// Root-to-leaf edge count: one for a root over leaves, two with an
+    /// intervening routing level. An empty tree also reports one.
+    pub fn height(&self) -> u32 {
+        self.children.iter().map(|c| c.height).max().unwrap_or(0) + 1
+    }
+
+    /// Latest atomically published version held by this session.
+    pub fn version(&self) -> u64 {
+        self.version
+    }
+
+    /// Number of logical fragments, including buffered adds and removes.
+    ///
+    /// This reads root metadata only and performs no object-store IO.
+    pub fn count_fragments(&self) -> u64 {
+        self.total_fragments
+    }
+
+    /// Sum of physical rows across logical fragments.
+    ///
+    /// Admitted fragments have known counts. This reads root metadata only
+    /// and performs no object-store IO.
+    pub fn count_rows(&self) -> u64 {
+        self.total_rows
+    }
+
+    /// Visible rows (physical minus deleted) across the table. Exact by the
+    /// writer invariant on known counts. Root metadata only, no IO.
+    pub fn count_visible_rows(&self) -> u64 {
+        self.visible_rows
+    }
+
+    /// The next fragment id an append may allocate: zero on an empty table,
+    /// otherwise one above the largest id ever assigned, buffered adds
+    /// included. This is Lance's manifest allocation rule.
+    pub fn next_fragment_id(&self) -> u64 {
+        self.next_fragment_id
+    }
+
+    /// Number of actions currently buffered directly in the in-memory root.
+    pub fn root_buffer_len(&self) -> usize {
+        self.buffer.len()
+    }
+
+    /// Number of direct child references currently held by the in-memory root.
+    pub fn root_child_count(&self) -> usize {
+        self.children.len()
+    }
+
+    /// Encoded leaf sizes when the root points directly to leaves. Returns an
+    /// empty list when there is an intervening routing level.
+    pub fn leaf_object_sizes(&self) -> Vec<u64> {
+        self.children
+            .iter()
+            .filter(|child| child.height == 0)
+            .map(|child| child.object_size)
+            .collect()
+    }
+
+    /// Resolve one fragment by loading only the root-to-leaf path: at most
+    /// `height` reads on a compacted root.
+    ///
+    /// Routing follows sibling `min_key` fences (see [`node::child_index_for`]),
+    /// and buffered actions from every node on the path are applied with the
+    /// same action_sequence ordering as [`Self::materialize`].
+    pub async fn resolve_fragment(&self, frag_id: u64) -> Result<Option<Fragment>> {
+        let mut actions: Vec<pb::FragmentMetadataMutation> = self
+            .buffer_index
+            .get_or_init(|| node::BufferIndex::new(&self.buffer))
+            .for_fragment(frag_id)
+            .map(|offset| self.buffer[offset].clone())
+            .collect();
+        actions.sort_by_key(|t| t.action_sequence);
+        if let Some(reset) = actions.iter().rposition(|t| {
+            matches!(
+                t.action.as_ref().and_then(|a| a.action.as_ref()),
+                Some(pb::fragment_action::Action::AddFragment(_))
+                    | Some(pb::fragment_action::Action::RemoveFragment(_))
+            )
+        }) {
+            // Root messages for this key are newer than messages below them.
+            // A whole-state reset makes the older leaf state unnecessary. The
+            // prior record is unknown here, so deltas cannot be verified.
+            let mut fragments = BTreeMap::new();
+            node::apply_actions(&mut fragments, actions.split_off(reset))?;
+            self.store.share_data_file_lists(fragments.values_mut());
+            return Ok(fragments.remove(&frag_id));
+        }
+        let mut children = Cow::Borrowed(self.children.as_slice());
+        let mut fragment = None;
+
+        while !children.is_empty() {
+            let child = children[node::child_index_for(&children, frag_id)].clone();
+            if child.height == 0 {
+                node::validate_routed(
+                    std::slice::from_ref(&child),
+                    &[actions.clone()],
+                    node::ROOT_EXCLUSIVE_END,
+                )?;
+                fragment = self
+                    .store
+                    .read_leaf(&child)
+                    .await?
+                    .into_iter()
+                    .find(|candidate| candidate.id == frag_id);
+                break;
+            }
+
+            let internal = self.store.read_internal(&child).await?;
+            actions.extend(
+                internal
+                    .buffer
+                    .into_iter()
+                    .filter(|tagged| node::action_key(tagged) == frag_id),
+            );
+            children = Cow::Owned(internal.children);
+        }
+
+        let mut fragments = BTreeMap::new();
+        if let Some(fragment) = fragment {
+            fragments.insert(fragment.id, fragment);
+        }
+        self.replay_verified(&mut fragments, actions)?;
+        Ok(fragments.remove(&frag_id))
+    }
+
+    /// Resolve the current state of exactly `fragment_ids`, sharing path
+    /// reads across ids in the same subtree. This is the only read a commit
+    /// performs before publication: work is proportional to the touched
+    /// fragments and the tree height, never to the table.
+    pub async fn resolve_touched(&self, fragment_ids: &[u64]) -> Result<TouchedFragments> {
+        let ids: BTreeSet<u64> = fragment_ids.iter().copied().collect();
+        if ids.is_empty() {
+            return Ok(TouchedFragments::default());
+        }
+        let bitmap: Option<RoaringBitmap> = ids
+            .iter()
+            .map(|id| u32::try_from(*id).ok())
+            .collect::<Option<Vec<u32>>>()
+            .map(RoaringBitmap::from_iter);
+        let fragments = match bitmap {
+            Some(bitmap) => self
+                .resolve_fragments_concurrent(&bitmap, 8)
+                .await?
+                .into_iter()
+                .map(|fragment| (fragment.id, fragment))
+                .collect(),
+            None => {
+                let mut fragments = BTreeMap::new();
+                for id in &ids {
+                    if let Some(fragment) = self.resolve_fragment(*id).await? {
+                        fragments.insert(*id, fragment);
+                    }
+                }
+                fragments
+            }
+        };
+        Ok(TouchedFragments { ids, fragments })
+    }
+
+    /// Resolve a set of fragment ids while loading only the subtrees whose
+    /// routing range intersects the set.
+    ///
+    /// Pruning uses the routing fences, never a child's live `max_key`: a
+    /// buffered insert may sit above the child's live range and still belong
+    /// to it. Each covering node or leaf is loaded at most once. Leaf GETs
+    /// run with concurrency 1; use [`Self::resolve_fragments_concurrent`]
+    /// when the caller can overlap them.
+    pub async fn resolve_fragments(&self, fragment_ids: &RoaringBitmap) -> Result<Vec<Fragment>> {
+        self.resolve_fragments_concurrent(fragment_ids, 1).await
+    }
+
+    /// Same as [`Self::resolve_fragments`], overlapping covering leaf GETs.
+    pub async fn resolve_fragments_concurrent(
+        &self,
+        fragment_ids: &RoaringBitmap,
+        concurrency: usize,
+    ) -> Result<Vec<Fragment>> {
+        let mut leaves = Vec::new();
+        let mut actions = self
+            .buffer
+            .iter()
+            .filter(|tagged| bitmap_contains(fragment_ids, node::action_key(tagged)))
+            .cloned()
+            .collect();
+        self.collect_covering_leaves(
+            self.children.clone(),
+            0,
+            Some(node::ROOT_EXCLUSIVE_END),
+            fragment_ids,
+            &mut leaves,
+            &mut actions,
+        )
+        .await?;
+        let store = self.store.clone();
+        let mut fragments = futures::stream::iter(leaves)
+            .map(move |child| {
+                let store = store.clone();
+                async move { store.read_leaf(&child).await }
+            })
+            .buffered(concurrency.max(1))
+            .try_fold(BTreeMap::new(), |mut fragments, loaded| async move {
+                fragments.extend(
+                    loaded
+                        .into_iter()
+                        .filter(|fragment| bitmap_contains(fragment_ids, fragment.id))
+                        .map(|fragment| (fragment.id, fragment)),
+                );
+                Ok(fragments)
+            })
+            .await?;
+        self.replay_verified(&mut fragments, actions)?;
+        fragments.retain(|fragment_id, _| bitmap_contains(fragment_ids, *fragment_id));
+        Ok(fragments.into_values().collect())
+    }
+
+    /// Resolve which fragment holds the table's `offset`-th visible row and
+    /// the offset within that fragment, by descending subtree visible-row
+    /// totals: O(height) reads, never a stream from the first fragment.
+    ///
+    /// Totals are exact by the writer invariant on known counts. Buffered
+    /// actions above a child adjust its total and are applied when its leaf
+    /// is read, so the descent and a full stream agree.
+    pub async fn fragment_at_row_offset(&self, offset: u64) -> Result<OffsetResolution> {
+        if offset >= self.visible_rows {
+            return Ok(OffsetResolution::BeyondEnd);
+        }
+        let mut remaining = offset;
+        let mut children = self.children.clone();
+        let mut actions: Vec<pb::FragmentMetadataMutation> = self.buffer.clone();
+        loop {
+            if children.is_empty() {
+                // The whole table lives in buffered actions.
+                let mut fragments = BTreeMap::new();
+                self.replay_verified(&mut fragments, actions)?;
+                return Ok(walk_fragments(fragments.into_values(), remaining));
+            }
+            let buckets = node::partition_buffer_by_child(&children, actions);
+            node::validate_routed(&children, &buckets, node::ROOT_EXCLUSIVE_END)?;
+            let mut chosen = None;
+            for (child, bucket) in children.iter().zip(buckets) {
+                let delta = sum_aggregate_deltas(
+                    bucket.iter().map(|tagged| tagged.visible_rows_delta),
+                    "visible_rows_delta",
+                )?;
+                let adjusted = apply_aggregate_delta(child.visible_rows, delta, "visible_rows")?;
+                if remaining < adjusted {
+                    chosen = Some((child.clone(), bucket));
+                    break;
+                }
+                remaining -= adjusted;
+            }
+            let Some((child, bucket)) = chosen else {
+                // Totals said the offset is inside, but the walk fell off:
+                // an accounting bug, not a caller error.
+                return Err(Error::internal(format!(
+                    "row-offset descent exhausted children with {remaining} rows remaining"
+                )));
+            };
+            if child.height == 0 {
+                let mut fragments: BTreeMap<u64, Fragment> = self
+                    .store
+                    .read_leaf(&child)
+                    .await?
+                    .into_iter()
+                    .map(|fragment| (fragment.id, fragment))
+                    .collect();
+                self.replay_verified(&mut fragments, bucket)?;
+                return Ok(walk_fragments(fragments.into_values(), remaining));
+            }
+            let internal = self.store.read_internal(&child).await?;
+            actions = bucket;
+            actions.extend(internal.buffer);
+            children = internal.children;
+        }
+    }
+
+    /// Collect all leaf fragments and replay buffered actions in action sequence number order.
+    pub async fn materialize(&self) -> Result<Vec<Fragment>> {
+        let mut map: BTreeMap<u64, Fragment> = BTreeMap::new();
+        let mut actions: Vec<pb::FragmentMetadataMutation> = self.buffer.clone();
+        self.collect_subtree(self.children.clone(), &mut map, &mut actions)
+            .await?;
+        self.replay_verified(&mut map, actions)?;
+        Ok(map.into_values().collect())
+    }
+
+    /// Stream fragments in id order. This walk materializes one leaf at a
+    /// time. [`Self::fragment_stream_with_prefetch`] may keep several leaf
+    /// reads in flight.
+    pub fn iter_fragments(&self) -> impl Stream<Item = Result<Fragment>> + '_ {
+        futures::stream::try_unfold(self.start_walk_from(0), move |mut walk| async move {
+            let next = self.walk_next(&mut walk).await?;
+            Ok(next.map(|fragment| (fragment, walk)))
+        })
+    }
+
+    /// The same walk as [`Self::iter_fragments`], owning the tree so the
+    /// stream can outlive a borrow. This is the source a lazy scanner
+    /// consumes.
+    pub fn fragment_stream(self: Arc<Self>) -> BoxStream<'static, Result<Fragment>> {
+        self.fragment_stream_with_prefetch(1)
+    }
+
+    /// Stream fragments in increasing ID order, starting at `fragment_id`
+    /// inclusively. Routing skips earlier subtrees; holes and removed IDs are
+    /// omitted. The stream remains pinned to this tree's version.
+    ///
+    /// ```no_run
+    /// # use std::sync::Arc;
+    /// # use lance_table::fragment_metadata::FragmentMetadataTree;
+    /// # use futures::TryStreamExt;
+    /// # async fn example(tree: Arc<FragmentMetadataTree>) -> lance_core::Result<()> {
+    /// let mut stream = tree.fragment_stream_from(100);
+    /// while let Some(fragment) = stream.try_next().await? {
+    ///     assert!(fragment.id >= 100);
+    /// }
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn fragment_stream_from(
+        self: Arc<Self>,
+        fragment_id: u64,
+    ) -> BoxStream<'static, Result<Fragment>> {
+        let walk = self.start_walk_from(fragment_id);
+        futures::stream::try_unfold((self, walk), |(tree, mut walk)| async move {
+            let next = tree.walk_next(&mut walk).await?;
+            Ok(next.map(|fragment| (fragment, (tree, walk))))
+        })
+        .boxed()
+    }
+
+    /// Stream in ID order with at most `prefetch` leaf reads in flight, including
+    /// across routing-node boundaries. Zero selects one read at a time.
+    pub fn fragment_stream_with_prefetch(
+        self: Arc<Self>,
+        prefetch: usize,
+    ) -> BoxStream<'static, Result<Fragment>> {
+        if self.children.is_empty() {
+            return self.fragment_stream_from(0);
+        }
+        let walk = self.start_walk_from(0);
+        let store = self.store.clone();
+        futures::stream::try_unfold((self, walk), |(tree, mut walk)| async move {
+            let leaf = tree.walk_next_leaf(&mut walk).await?;
+            Ok(leaf.map(|leaf| (leaf, (tree, walk))))
+        })
+        .map_ok(move |(child, actions)| {
+            let store = store.clone();
+            async move {
+                let mut fragments: BTreeMap<u64, Fragment> = store
+                    .read_leaf(&child)
+                    .await?
+                    .into_iter()
+                    .map(|fragment| (fragment.id, fragment))
+                    .collect();
+                store.apply_verified(&mut fragments, actions)?;
+                Ok::<_, Error>(fragments)
+            }
+        })
+        .try_buffered(prefetch.max(1))
+        .map_ok(|state| futures::stream::iter(state.into_values().map(Ok)))
+        .try_flatten()
+        .boxed()
+    }
+
+    /// Fragment ids that still have a buffered action somewhere in the tree,
+    /// root included. Empty means every committed action has reached a leaf.
+    pub async fn buffered_action_keys(&self) -> Result<HashSet<u64>> {
+        let mut keys: HashSet<u64> = self.buffer.iter().map(node::action_key).collect();
+        let mut pending = self.children.clone();
+        while let Some(child) = pending.pop() {
+            if child.height == 0 {
+                continue;
+            }
+            let internal = self.store.read_internal(&child).await?;
+            keys.extend(internal.buffer.iter().map(node::action_key));
+            pending.extend(internal.children);
+        }
+        Ok(keys)
+    }
+
+    /// Walk the tree and collect `(height, logical_bytes)` for every internal node
+    /// (root included). Used to measure how full internal ε-buffers are — a node
+    /// near `B` is holding a big buffer, a node near its ref-only size is "cold".
+    pub async fn internal_node_sizes(&self) -> Result<Vec<(u32, u64)>> {
+        let mut out = vec![(
+            self.height(),
+            node::internal_logical_bytes(&self.children, &self.buffer),
+        )];
+        self.collect_internal_sizes(self.children.clone(), &mut out)
+            .await?;
+        Ok(out)
+    }
+
+    /// Structural health of the current tree: every internal node's fanout,
+    /// encoded bytes and buffer occupancy, every leaf's logical bytes and
+    /// key count, read from the object store (internal nodes only; leaf
+    /// sizes come from their refs).
+    pub async fn shape_report(&self) -> Result<ShapeReport> {
+        let root = self.compacted_root();
+        let mut report = ShapeReport {
+            height: self.height(),
+            root_bytes: root.encoded_len() as u64,
+            root_buffer_len: self.buffer.len() as u64,
+            root_buffer_bytes: node::buffer_bytes(&self.buffer),
+            root_fanout: self.children.len() as u32,
+            ..Default::default()
+        };
+        let mut stack: Vec<pb::FragmentMetadataChild> = self.children.clone();
+        while let Some(child) = stack.pop() {
+            if child.height == 0 {
+                report.leaf_bytes.push(child.object_size);
+                report.leaf_object_bytes.push(child.object_size);
+                report.leaf_keys.push(child.num_keys);
+                continue;
+            }
+            let node = self.store.read_internal(&child).await?;
+            report.node_bytes.push(child.object_size);
+            report.node_fanouts.push(node.children.len() as u32);
+            report.node_buffer_lens.push(node.buffer.len() as u64);
+            report
+                .node_buffer_bytes
+                .push(node::buffer_bytes(&node.buffer));
+            stack.extend(node.children);
+        }
+        Ok(report)
+    }
+
+    /// The leaf-watermark invariant: every action still buffered anywhere in
+    /// the tree must be newer than the leaf watermark it routes to. A
+    /// violation would mean a leaf claims to hold a change it never applied.
+    pub async fn verify_watermarks(&self) -> Result<()> {
+        // (action sequence number, routing key), gathered root first.
+        let mut pending: Vec<(u64, u64)> = self
+            .buffer
+            .iter()
+            .map(|tagged| (tagged.action_sequence, node::action_key(tagged)))
+            .collect();
+        let mut stack: Vec<pb::FragmentMetadataChild> = self.children.clone();
+        let mut leaves: Vec<pb::FragmentMetadataChild> = Vec::new();
+        while let Some(child) = stack.pop() {
+            if child.height == 0 {
+                leaves.push(child);
+                continue;
+            }
+            let internal = self.store.read_internal(&child).await?;
+            pending.extend(
+                internal
+                    .buffer
+                    .iter()
+                    .map(|tagged| (tagged.action_sequence, node::action_key(tagged))),
+            );
+            stack.extend(internal.children);
+        }
+        leaves.sort_by_key(|leaf| leaf.min_key);
+        for (action_sequence, key) in pending {
+            if leaves.is_empty() {
+                continue;
+            }
+            let leaf = &leaves[node::child_index_for(&leaves, key)];
+            if action_sequence <= leaf.materialized_through_action_sequence {
+                return Err(Error::invalid_input(format!(
+                    "buffered action action_sequence={action_sequence} for fragment {key} is at or below its \
+                     leaf's watermark {} (leaf {}): the leaf claims a change it cannot hold",
+                    leaf.materialized_through_action_sequence, leaf.path
+                )));
+            }
+        }
+        Ok(())
+    }
+
+    /// Read every node and leaf reachable from this root, proving the
+    /// published tree references no missing object. Returns the object count.
+    pub async fn verify_reachable(&self) -> Result<u64> {
+        let mut pending = self.children.clone();
+        let mut objects = 0u64;
+        while let Some(child) = pending.pop() {
+            objects += 1;
+            if child.height == 0 {
+                self.store.read_leaf(&child).await?;
+            } else {
+                pending.extend(self.store.read_internal(&child).await?.children);
+            }
+        }
+        Ok(objects)
+    }
+
+    fn mutable_state(&self) -> MutableState {
+        MutableState {
+            version: self.version,
+            children: self.children.clone(),
+            buffer: self.buffer.clone(),
+            next_action_sequence: self.next_action_sequence,
+            total_fragments: self.total_fragments,
+            total_rows: self.total_rows,
+
+            next_fragment_id: self.next_fragment_id,
+            visible_rows: self.visible_rows,
+        }
+    }
+
+    fn restore_mutable_state(&mut self, state: MutableState) {
+        self.buffer_index.take();
+        self.version = state.version;
+        self.children = state.children;
+        self.buffer = state.buffer;
+        self.next_action_sequence = state.next_action_sequence;
+        self.store.next_action_sequence = state.next_action_sequence;
+        self.total_fragments = state.total_fragments;
+
+        self.total_rows = state.total_rows;
+        self.next_fragment_id = state.next_fragment_id;
+        self.visible_rows = state.visible_rows;
+    }
+
+    /// Assign fresh action sequence numbers and move the in-memory root to
+    /// the next version: buffer, aggregates, id allocation, and table state.
+    fn stage_commit(
+        &mut self,
+        commit: &ValidatedCommit,
+        aggregate_deltas: Vec<commit::ActionDeltas>,
+    ) -> Result<Vec<pb::FragmentMetadataMutation>> {
+        let actions = &commit.fragment_actions;
+        let action_count = u64::try_from(actions.len()).map_err(|_| {
+            Error::invalid_input(format!(
+                "fragment metadata tree action count does not fit u64: {}",
+                actions.len()
+            ))
+        })?;
+        let next_action_sequence = self.next_action_sequence.checked_add(action_count).ok_or_else(|| {
+            Error::invalid_input(format!(
+                "fragment metadata tree action_sequence overflow: next_action_sequence={}, action_count={action_count}",
+                self.next_action_sequence
+            ))
+        })?;
+        let fragment_count_delta = sum_aggregate_deltas(
+            aggregate_deltas.iter().map(|deltas| deltas.fragment_count),
+            "fragment_count_delta",
+        )?;
+        let total_rows_delta = sum_aggregate_deltas(
+            aggregate_deltas.iter().map(|deltas| deltas.physical_rows),
+            "total_rows_delta",
+        )?;
+        let visible_rows_delta = sum_aggregate_deltas(
+            aggregate_deltas.iter().map(|deltas| deltas.visible_rows),
+            "visible_rows_delta",
+        )?;
+
+        let total_fragments = apply_aggregate_delta(
+            self.total_fragments,
+            fragment_count_delta,
+            "total_fragments",
+        )?;
+        let total_rows = apply_aggregate_delta(self.total_rows, total_rows_delta, "total_rows")?;
+        let visible_rows =
+            apply_aggregate_delta(self.visible_rows, visible_rows_delta, "visible_rows")?;
+
+        let mut tagged = Vec::with_capacity(actions.len());
+        for (offset, (action, deltas)) in actions.iter().zip(aggregate_deltas).enumerate() {
+            tagged.push(pb::FragmentMetadataMutation {
+                action_sequence: self.next_action_sequence + offset as u64,
+                action: Some(action.clone()),
+                fragment_count_delta: deltas.fragment_count,
+                total_rows_delta: deltas.physical_rows,
+                visible_rows_delta: deltas.visible_rows,
+            });
+        }
+        self.buffer_index.take();
+        self.buffer.extend(tagged.iter().cloned());
+        self.next_action_sequence = next_action_sequence;
+        self.store.next_action_sequence = next_action_sequence;
+        self.total_fragments = total_fragments;
+        self.total_rows = total_rows;
+        self.visible_rows = visible_rows;
+        self.version = self.version.checked_add(1).ok_or_else(|| {
+            Error::invalid_input("fragment metadata tree version counter exhausted")
+        })?;
+        for action in actions {
+            if let Some(pb::fragment_action::Action::AddFragment(fragment)) = &action.action {
+                self.next_fragment_id = self.next_fragment_id.max(fragment.id + 1);
+            }
+        }
+        if let Some(next) = commit.next_fragment_id {
+            if next < self.next_fragment_id || next > u64::from(u32::MAX) + 1 {
+                return Err(Error::invalid_input(format!(
+                    "Fragment ID frontier {next} must be between {} and 2^32",
+                    self.next_fragment_id
+                )));
+            }
+            self.next_fragment_id = next;
+        }
+        Ok(tagged)
+    }
+
+    /// The compacted root for the current in-memory state, publishing
+    /// `committed` as the version's history.
+    fn compacted_root(&self) -> pb::FragmentMetadataRoot {
+        pb::FragmentMetadataRoot {
+            children: self.children.clone(),
+            buffer: self.buffer.clone(),
+            next_action_sequence: self.next_action_sequence,
+        }
+    }
+
+    /// Flush the root buffer as far as it goes, then split, coalesce, and
+    /// shrink the root. Every touched node is copy-on-write, so nothing here
+    /// is visible until the root is published.
+    async fn rewrite_tree(&mut self) -> Result<WriteAcc> {
+        let mut acc = WriteAcc::default();
+
+        // Flush the root buffer down as far as it will go (root is depth 0).
+        let children = std::mem::take(&mut self.children);
+        let buffer = std::mem::take(&mut self.buffer);
+        let (children, buffer, a) = if self.force_flush {
+            let result = super::bulk::materialize(
+                &self.store,
+                &self.config,
+                children,
+                buffer,
+                self.next_action_sequence.saturating_sub(1),
+            )
+            .await?;
+            (
+                result.children,
+                Vec::new(),
+                WriteAcc {
+                    io_bytes: result.io_bytes,
+                    flushes: result.flushes,
+                    splits: result.splits,
+                    merges: result.merges,
+                    materialized: result.materialized,
+                    max_flush_depth: result.max_flush_depth,
+                    ..Default::default()
+                },
+            )
+        } else {
+            self.flush_internal(children, buffer, 0, 0).await?
+        };
+        acc.add(a);
+        self.children = children;
+        self.buffer = buffer;
+        node::fence(&mut self.children, 0);
+
+        // A childless root (an empty table grown by appends) cannot flush
+        // anywhere: materialize its buffer into the first leaves instead of
+        // splitting into a childless internal node.
+        if self.children.is_empty()
+            && (node::internal_overflows(&self.children, &self.buffer, &self.config)
+                || node::buffer_pressured(&self.buffer, &self.config))
+        {
+            let mut fragments = BTreeMap::new();
+            let actions = std::mem::take(&mut self.buffer);
+            self.replay_verified(&mut fragments, actions)?;
+            let fragments: Vec<Fragment> = fragments.into_values().collect();
+            let watermark = self.next_action_sequence.saturating_sub(1);
+            for w in self
+                .store
+                .write_leaves(&fragments, watermark, &self.config)
+                .await?
+            {
+                acc.io_bytes += w.io_bytes;
+                self.children.push(w.child_ref);
+            }
+        }
+
+        // A broad transaction can cross several heights at once. Keep lifting
+        // routing until the new root itself fits, not just its first children.
+        while node::internal_overflows(&self.children, &self.buffer, &self.config) {
+            let previous_width = self.children.len();
+            let pieces = node::split_internal(
+                std::mem::take(&mut self.children),
+                std::mem::take(&mut self.buffer),
+                self.config.split_piece_bytes(),
+                self.config.max_children_per_node,
+            );
+            if pieces.len() >= previous_width {
+                return Err(Error::invalid_input(format!(
+                    "node budget {} cannot reduce a root with {} children",
+                    self.config.max_node_bytes, previous_width
+                )));
+            }
+            let mut new_children = Vec::with_capacity(pieces.len());
+            for (ch, buf) in pieces {
+                let w = self.store.write_internal(ch, buf).await?;
+                acc.io_bytes += w.io_bytes;
+                new_children.push(w.child_ref);
+            }
+            self.children = new_children;
+            acc.splits += 1;
+        }
+
+        // Coalesce underflowing children (self-balancing on deletes).
+        if !self.force_flush {
+            let children = std::mem::take(&mut self.children);
+            let (children, a) = self.merge_small_children(children).await?;
+            acc.add(a);
+            self.children = children;
+        }
+
+        // Shrink: a root with a single internal child pulls that child up.
+        self.maybe_shrink_root().await?;
+        node::fence(&mut self.children, 0);
+        Ok(acc)
+    }
+
+    /// Flush an internal node's buffer to its children while it is pressured.
+    /// Only children whose pending batch amortizes a rewrite drain. Under
+    /// semantic pressure the rest keep buffering. Under structural pressure
+    /// the caller splits whatever routing still overflows. `depth` is this
+    /// node's level below the root, 0 for the root itself, and `lower_bound`
+    /// the range start its parent assigned. Returns the children, split if
+    /// needed, and the residual buffer.
+    fn flush_internal(
+        &self,
+        mut children: Vec<pb::FragmentMetadataChild>,
+        mut buffer: Vec<pb::FragmentMetadataMutation>,
+        depth: u32,
+        lower_bound: u64,
+    ) -> BoxFuture<'_, Result<FlushResult>> {
+        Box::pin(async move {
+            let mut acc = WriteAcc::default();
+            loop {
+                // A childless node has nowhere to flush; the caller turns the
+                // buffer into leaves instead.
+                if children.is_empty() {
+                    break;
+                }
+                let structural = node::internal_overflows(&children, &buffer, &self.config);
+                if !structural && !node::buffer_pressured(&buffer, &self.config) {
+                    break;
+                }
+                let pending = buffer.len();
+                let mut buckets = node::partition_buffer_by_child(&children, buffer);
+                node::validate_routed(&children, &buckets, node::ROOT_EXCLUSIVE_END)?;
+                let indices = flush::select_children(
+                    &children,
+                    &buckets,
+                    &self.config,
+                    self.store.object_store.io_parallelism(),
+                );
+                if indices.is_empty() {
+                    // Under semantic pressure no batch pays for its object yet,
+                    // so keep buffering. Under structural pressure a byte
+                    // overflow always leaves a bucket at or above the fair
+                    // share, so only routing or fanout remains and the caller
+                    // splits it.
+                    debug_assert!(
+                        !structural
+                            || pending == 0
+                            || children.len() as u32 > self.config.max_children_per_node
+                    );
+                    buffer = buckets.into_iter().flatten().collect();
+                    break;
+                }
+                let concurrency = indices.len();
+                let drains: Vec<_> = indices
+                    .into_iter()
+                    .map(|idx| {
+                        (
+                            idx,
+                            children[idx].clone(),
+                            std::mem::take(&mut buckets[idx]),
+                        )
+                    })
+                    .collect();
+                buffer = buckets.into_iter().flatten().collect();
+                let mut results: Vec<_> = futures::stream::iter(drains)
+                    .map(|(idx, child, actions)| async move {
+                        self.ingest(child, actions, depth)
+                            .await
+                            .map(|result| (idx, result))
+                    })
+                    .buffered(concurrency)
+                    .try_collect()
+                    .await?;
+                // Apply from the right so splits and removals keep earlier indices valid.
+                results.sort_unstable_by_key(|(idx, _)| std::cmp::Reverse(*idx));
+                for (idx, (new_refs, a)) in results {
+                    acc.add(a);
+                    acc.flushes += 1;
+                    acc.max_flush_depth = acc.max_flush_depth.max(depth);
+                    children.splice(idx..idx + 1, new_refs);
+                }
+            }
+            node::fence(&mut children, lower_bound);
+            Ok((children, buffer, acc))
+        })
+    }
+
+    /// Push `incoming` messages into the subtree rooted at `child` (at `depth`
+    /// below the root); apply at a leaf, recurse+buffer at an internal node;
+    /// split on overflow. Returns the child ref(s) that now represent the subtree.
+    fn ingest(
+        &self,
+        child: pb::FragmentMetadataChild,
+        incoming: Vec<pb::FragmentMetadataMutation>,
+        depth: u32,
+    ) -> BoxFuture<'_, Result<IngestResult>> {
+        Box::pin(async move {
+            let mut acc = WriteAcc::default();
+            if child.height == 0 {
+                // Leaf: apply messages, then split if it overflows.
+                let fragments = self.store.read_leaf(&child).await?;
+                let mut map: BTreeMap<u64, Fragment> =
+                    fragments.into_iter().map(|f| (f.id, f)).collect();
+                acc.materialized += incoming.len() as u64;
+                self.replay_verified(&mut map, incoming)?;
+                let new_frags: Vec<Fragment> = map.into_values().collect();
+
+                // A fully-emptied leaf is dropped from its parent. Keeping it would
+                // create a phantom child with min_key=0 that corrupts the
+                // sorted-by-min_key invariant `child_index_for` relies on.
+                if new_frags.is_empty() {
+                    return Ok((vec![], acc));
+                }
+                // The flush that reaches a leaf drained every buffer on its
+                // path for this range first, so the leaf now holds the
+                // result of every applicable action up to the action_sequence ceiling.
+                let watermark = self.next_action_sequence.saturating_sub(1);
+                let written = self
+                    .store
+                    .write_leaves(&new_frags, watermark, &self.config)
+                    .await?;
+                acc.splits += written.len().saturating_sub(1) as u64;
+                let mut refs: Vec<_> = written
+                    .into_iter()
+                    .map(|w| {
+                        acc.io_bytes += w.io_bytes;
+                        w.child_ref
+                    })
+                    .collect();
+                node::fence(&mut refs, child.min_key);
+                Ok((refs, acc))
+            } else {
+                // Internal: buffer, recurse-flush, split if it overflows.
+                let InternalNode {
+                    children,
+                    mut buffer,
+                } = self.store.read_internal(&child).await?;
+                buffer.extend(incoming);
+                let before = buffer.len();
+                buffer = node::squash_buffer(buffer);
+                acc.squashed += (before - buffer.len()) as u64;
+                // This node is one level deeper than the parent that flushed to it.
+                let (children, buffer, a) = self
+                    .flush_internal(children, buffer, depth + 1, child.min_key)
+                    .await?;
+                acc.add(a);
+                // Rebalance: coalesce any underflowing children before checking split.
+                let (children, a) = self.merge_small_children(children).await?;
+                acc.add(a);
+
+                // An internal node whose children all vanished is dropped too (same
+                // phantom-min_key=0 hazard as an empty leaf).
+                if children.is_empty() {
+                    return Ok((vec![], acc));
+                }
+                if node::internal_overflows(&children, &buffer, &self.config) {
+                    let mut refs = Vec::new();
+                    for (ch, buf) in node::split_internal(
+                        children,
+                        buffer,
+                        self.config.split_piece_bytes(),
+                        self.config.max_children_per_node,
+                    ) {
+                        let w = self.store.write_internal(ch, buf).await?;
+                        acc.io_bytes += w.io_bytes;
+                        refs.push(w.child_ref);
+                    }
+                    acc.splits += 1;
+                    node::fence(&mut refs, child.min_key);
+                    Ok((refs, acc))
+                } else {
+                    let w = self.store.write_internal(children, buffer).await?;
+                    acc.io_bytes += w.io_bytes;
+                    let mut refs = vec![w.child_ref];
+                    node::fence(&mut refs, child.min_key);
+                    Ok((refs, acc))
+                }
+            }
+        })
+    }
+
+    /// Coalesce runs of adjacent children when one underflows (leaf ≤ 0.25 B;
+    /// internal < max_children_per_node/4 children), bounded so the merged node stays valid
+    /// (leaves ≤ 0.6 B; internal ≤ max_children_per_node children). Reads/writes the merged
+    /// node(s). Leaves concat fragments; internal nodes concat children + buffers.
+    async fn merge_small_children(
+        &self,
+        children: Vec<pb::FragmentMetadataChild>,
+    ) -> Result<(Vec<pb::FragmentMetadataChild>, WriteAcc)> {
+        let mut acc = WriteAcc::default();
+        let mut out: Vec<pb::FragmentMetadataChild> = Vec::with_capacity(children.len());
+        let mut i = 0;
+        while i < children.len() {
+            if !node::is_underflow(&children[i], &self.config) {
+                out.push(children[i].clone());
+                i += 1;
+                continue;
+            }
+            // Grow a coalesce group with adjacent siblings, bounded by node kind.
+            let is_leaf = children[i].height == 0;
+            let mut group = vec![children[i].clone()];
+            let mut bytes = children[i].object_size;
+            let mut fan = children[i].num_children;
+            let mut j = i + 1;
+            while j < children.len() {
+                let c = &children[j];
+                let fits = if is_leaf {
+                    bytes + c.object_size <= self.config.leaf_coalesce_ceiling()
+                } else {
+                    fan + c.num_children <= self.config.max_children_per_node
+                        && bytes + c.object_size <= self.config.coalesce_ceiling()
+                };
+                if !fits {
+                    break;
+                }
+                bytes += c.object_size;
+                fan += c.num_children;
+                group.push(c.clone());
+                j += 1;
+            }
+            if group.len() == 1 {
+                out.extend(group);
+            } else {
+                let lower_bound = group[0].min_key;
+                let (mut merged, a) = self.coalesce(group).await?;
+                node::fence(&mut merged, lower_bound);
+                acc.add(a);
+                acc.merges += 1;
+                out.extend(merged);
+            }
+            i = j;
+        }
+        // A singleton at either edge needs its neighbor even when the normal
+        // soft coalesce ceiling would leave it alone. Rebalance the combined
+        // range under the hard node budget, keeping messages with their fences.
+        let mut repaired: Vec<pb::FragmentMetadataChild> = Vec::with_capacity(out.len());
+        let mut pending: VecDeque<_> = out.into();
+        while let Some(child) = pending.pop_front() {
+            if child.height == 0 || child.num_children > 1 {
+                repaired.push(child);
+                continue;
+            }
+            let pair = if let Some(right) = pending.pop_front() {
+                vec![child, right]
+            } else if let Some(left) = repaired.pop() {
+                vec![left, child]
+            } else {
+                // Its parent must provide a sibling or shrink this root.
+                repaired.push(child);
+                break;
+            };
+            let lower_bound = pair[0].min_key;
+            let mut children = Vec::new();
+            let mut buffer = Vec::new();
+            for sibling in pair {
+                let node = self.store.read_internal(&sibling).await?;
+                children.extend(node.children);
+                buffer.extend(node.buffer);
+            }
+            let (children, buffer, flushed) = self
+                .flush_internal(children, buffer, 0, lower_bound)
+                .await?;
+            acc.add(flushed);
+            let (children, coalesced) = Box::pin(self.merge_small_children(children)).await?;
+            acc.add(coalesced);
+            if children.is_empty() && buffer.is_empty() {
+                continue;
+            }
+            if node::internal_overflows(&children, &buffer, &self.config) {
+                // Occupancy repair may exceed the preferred half-full target.
+                // After draining hard pressure, split against the hard budget
+                // so a hot but valid range does not become a singleton again.
+                let pieces = node::split_internal(
+                    children,
+                    buffer,
+                    self.config.max_node_bytes - 1,
+                    self.config.max_children_per_node,
+                );
+                for (children, buffer) in pieces {
+                    if children.len() < 2 {
+                        return Err(Error::invalid_input(format!(
+                            "node budget {} cannot repair a singleton interior range",
+                            self.config.max_node_bytes
+                        )));
+                    }
+                    let written = self.store.write_internal(children, buffer).await?;
+                    acc.io_bytes += written.io_bytes;
+                    repaired.push(written.child_ref);
+                }
+            } else {
+                let written = self.store.write_internal(children, buffer).await?;
+                acc.io_bytes += written.io_bytes;
+                repaired.push(written.child_ref);
+                acc.merges += 1;
+            }
+        }
+        Ok((repaired, acc))
+    }
+
+    /// Combine an adjacent group of same-height children into one node.
+    async fn coalesce(
+        &self,
+        group: Vec<pb::FragmentMetadataChild>,
+    ) -> Result<(Vec<pb::FragmentMetadataChild>, WriteAcc)> {
+        let mut acc = WriteAcc::default();
+        if group[0].height == 0 {
+            let mut fragments: Vec<Fragment> = Vec::new();
+            for c in &group {
+                fragments.extend(self.store.read_leaf(c).await?);
+            }
+            fragments.sort_by_key(|f| f.id);
+            let watermark = group
+                .iter()
+                .map(|child| child.materialized_through_action_sequence)
+                .min()
+                .unwrap_or(0);
+            let written = self
+                .store
+                .write_leaves(&fragments, watermark, &self.config)
+                .await?;
+            let refs = written
+                .into_iter()
+                .map(|w| {
+                    acc.io_bytes += w.io_bytes;
+                    w.child_ref
+                })
+                .collect();
+            Ok((refs, acc))
+        } else {
+            let mut children: Vec<pb::FragmentMetadataChild> = Vec::new();
+            let mut buffer: Vec<pb::FragmentMetadataMutation> = Vec::new();
+            for c in &group {
+                let node = self.store.read_internal(c).await?;
+                children.extend(node.children);
+                buffer.extend(node.buffer);
+            }
+            // Joining parents exposes siblings that previously belonged to
+            // separate ranges; repair their occupancy before persisting them.
+            let (children, repaired) = Box::pin(self.merge_small_children(children)).await?;
+            acc.add(repaired);
+            let w = self.store.write_internal(children, buffer).await?;
+            acc.io_bytes += w.io_bytes;
+            Ok((vec![w.child_ref], acc))
+        }
+    }
+
+    /// Remove a routing level when its contents fit in the root. Multiple
+    /// children use the coalesce ceiling so growth and shrinkage have hysteresis.
+    async fn maybe_shrink_root(&mut self) -> Result<()> {
+        while !self.children.is_empty() && self.children[0].height > 0 {
+            if self.children.len() > 1 {
+                // Interior byte_size is the exact encoded children-plus-buffer
+                // body. Rule out a collapse without fetching every child.
+                let bytes = self.children.iter().try_fold(
+                    node::internal_logical_bytes(&[], &self.buffer),
+                    |bytes, child| bytes.checked_add(child.object_size),
+                );
+                if bytes.is_none_or(|bytes| bytes > self.config.coalesce_ceiling()) {
+                    break;
+                }
+            }
+            let mut children = Vec::new();
+            let mut buffer = self.buffer.clone();
+            for child in &self.children {
+                let node = self.store.read_internal(child).await?;
+                children.extend(node.children);
+                buffer.extend(node.buffer);
+            }
+            if node::internal_overflows(&children, &buffer, &self.config) {
+                break;
+            }
+            self.children = children;
+            self.buffer = buffer;
+            self.buffer_index.take();
+            node::fence(&mut self.children, 0);
+        }
+        Ok(())
+    }
+
+    /// Apply mutations and share repeated field mappings.
+    fn replay_verified(
+        &self,
+        fragments: &mut BTreeMap<u64, Fragment>,
+        actions: Vec<pb::FragmentMetadataMutation>,
+    ) -> Result<()> {
+        self.store.apply_verified(fragments, actions)
+    }
+
+    fn start_walk_from(&self, lower_bound: u64) -> FragmentWalk {
+        let mut walk = FragmentWalk {
+            lower_bound,
+            ..Default::default()
+        };
+        if self.children.is_empty() {
+            let mut fragments = BTreeMap::new();
+            match self.replay_verified(&mut fragments, self.buffer.clone()) {
+                Ok(()) => walk.ready.extend(fragments.into_values()),
+                Err(error) => walk.pending_error = Some(error),
+            }
+        } else {
+            let action_buckets =
+                node::partition_buffer_by_child(&self.children, self.buffer.clone());
+            if let Err(error) =
+                node::validate_routed(&self.children, &action_buckets, node::ROOT_EXCLUSIVE_END)
+            {
+                walk.pending_error = Some(error);
+                return walk;
+            }
+            let first = node::child_index_for(&self.children, lower_bound);
+            for (child, actions) in self
+                .children
+                .iter()
+                .cloned()
+                .zip(action_buckets)
+                .skip(first)
+                .rev()
+            {
+                walk.stack.push((child, actions));
+            }
+        }
+        walk
+    }
+
+    /// Advance an in-order walk by one fragment, reading one leaf at a time.
+    async fn walk_next(&self, walk: &mut FragmentWalk) -> Result<Option<Fragment>> {
+        if let Some(error) = walk.pending_error.take() {
+            return Err(error);
+        }
+        loop {
+            if let Some(fragment) = walk.ready.pop_front() {
+                if fragment.id < walk.lower_bound {
+                    continue;
+                }
+                return Ok(Some(fragment));
+            }
+            let Some((child, actions)) = self.walk_next_leaf(walk).await? else {
+                return Ok(None);
+            };
+            let mut fragments: BTreeMap<u64, Fragment> = self
+                .store
+                .read_leaf(&child)
+                .await?
+                .into_iter()
+                .map(|fragment| (fragment.id, fragment))
+                .collect();
+            self.replay_verified(&mut fragments, actions)?;
+            walk.ready.extend(fragments.into_values());
+        }
+    }
+
+    /// Traverse routing once, yielding leaves and their inherited actions in
+    /// order. Leaf I/O can then be prefetched without buffering the full table.
+    async fn walk_next_leaf(&self, walk: &mut FragmentWalk) -> Result<Option<BufferedChild>> {
+        while let Some((child, mut actions)) = walk.stack.pop() {
+            if child.height == 0 {
+                return Ok(Some((child, actions)));
+            }
+            let internal = self.store.read_internal(&child).await?;
+            actions.extend(internal.buffer);
+            if internal.children.is_empty() {
+                return Err(super::validation::corrupt(format!(
+                    "Interior {} has no children",
+                    child.path
+                )));
+            }
+            let action_buckets = node::partition_buffer_by_child(&internal.children, actions);
+            node::validate_routed(
+                &internal.children,
+                &action_buckets,
+                node::ROOT_EXCLUSIVE_END,
+            )?;
+            let first = node::child_index_for(&internal.children, walk.lower_bound);
+            for (child, actions) in internal
+                .children
+                .into_iter()
+                .zip(action_buckets)
+                .skip(first)
+                .rev()
+            {
+                walk.stack.push((child, actions));
+            }
+        }
+        Ok(None)
+    }
+
+    /// Read every leaf and every internal buffer below `children` into the
+    /// full-materialization accumulators. Table sized by definition; only
+    /// [`Self::materialize`] and the oracle tests use it.
+    fn collect_subtree<'a>(
+        &'a self,
+        children: Vec<pb::FragmentMetadataChild>,
+        frags: &'a mut BTreeMap<u64, Fragment>,
+        actions: &'a mut Vec<pb::FragmentMetadataMutation>,
+    ) -> BoxFuture<'a, Result<()>> {
+        Box::pin(async move {
+            for child in &children {
+                if child.height == 0 {
+                    for f in self.store.read_leaf(child).await? {
+                        frags.insert(f.id, f);
+                    }
+                } else {
+                    let node = self.store.read_internal(child).await?;
+                    actions.extend(node.buffer);
+                    self.collect_subtree(node.children, frags, actions).await?;
+                }
+            }
+            Ok(())
+        })
+    }
+
+    fn collect_covering_leaves<'a>(
+        &'a self,
+        children: Vec<pb::FragmentMetadataChild>,
+        lower_bound: u64,
+        upper_bound: Option<u64>,
+        fragment_ids: &'a RoaringBitmap,
+        leaves: &'a mut Vec<pb::FragmentMetadataChild>,
+        actions: &'a mut Vec<pb::FragmentMetadataMutation>,
+    ) -> BoxFuture<'a, Result<()>> {
+        Box::pin(async move {
+            for (index, child) in children.iter().enumerate() {
+                let child_lower_bound = if index == 0 {
+                    lower_bound
+                } else {
+                    child.min_key
+                };
+                let child_upper_bound = children
+                    .get(index + 1)
+                    .map(|next| next.min_key)
+                    .or(upper_bound);
+                if !bitmap_intersects_range(fragment_ids, child_lower_bound, child_upper_bound) {
+                    continue;
+                }
+                if child.height == 0 {
+                    leaves.push(child.clone());
+                } else {
+                    let internal = self.store.read_internal(child).await?;
+                    actions.extend(
+                        internal.buffer.into_iter().filter(|tagged| {
+                            bitmap_contains(fragment_ids, node::action_key(tagged))
+                        }),
+                    );
+                    self.collect_covering_leaves(
+                        internal.children,
+                        child_lower_bound,
+                        child_upper_bound,
+                        fragment_ids,
+                        leaves,
+                        actions,
+                    )
+                    .await?;
+                }
+            }
+            Ok(())
+        })
+    }
+
+    fn collect_internal_sizes<'a>(
+        &'a self,
+        children: Vec<pb::FragmentMetadataChild>,
+        out: &'a mut Vec<(u32, u64)>,
+    ) -> BoxFuture<'a, Result<()>> {
+        Box::pin(async move {
+            for c in &children {
+                if c.height > 0 {
+                    out.push((c.height, c.object_size));
+                    let node = self.store.read_internal(c).await?;
+                    self.collect_internal_sizes(node.children, out).await?;
+                }
+            }
+            Ok(())
+        })
+    }
+}
+
+fn walk_fragments(
+    fragments: impl IntoIterator<Item = Fragment>,
+    mut remaining: u64,
+) -> OffsetResolution {
+    for fragment in fragments {
+        // Counts are known by the writer invariant; a violation would have
+        // been rejected at commit.
+        let visible = fragment.num_rows().unwrap_or(0) as u64;
+        if remaining < visible {
+            return OffsetResolution::Found(Box::new(fragment), remaining);
+        }
+        remaining -= visible;
+    }
+    OffsetResolution::BeyondEnd
+}
+
+fn bitmap_contains(fragment_ids: &RoaringBitmap, fragment_id: u64) -> bool {
+    u32::try_from(fragment_id)
+        .map(|fragment_id| fragment_ids.contains(fragment_id))
+        .unwrap_or(false)
+}
+
+fn bitmap_intersects_range(
+    fragment_ids: &RoaringBitmap,
+    lower_bound: u64,
+    upper_bound: Option<u64>,
+) -> bool {
+    if upper_bound.is_some_and(|upper_bound| upper_bound <= lower_bound) {
+        return false;
+    }
+    let Ok(lower_bound) = u32::try_from(lower_bound) else {
+        return false;
+    };
+    let upper_bound = upper_bound
+        .and_then(|upper_bound| u32::try_from(upper_bound).ok())
+        .map(|upper_bound| upper_bound.saturating_sub(1))
+        .unwrap_or(u32::MAX);
+    lower_bound <= upper_bound && fragment_ids.range_cardinality(lower_bound..=upper_bound) > 0
+}
+
+#[cfg(test)]
+mod tests;

--- a/rust/lance-table/src/fragment_metadata/tree/flush.rs
+++ b/rust/lance-table/src/fragment_metadata/tree/flush.rs
@@ -1,0 +1,163 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+//! Bε drain policy: which children a pressured buffer drains, and how many at once.
+//!
+//! Qualified for root-to-leaf scatter. An interior child's drain recurses, so
+//! its object size understates the work below it. Deep tree amortization is a
+//! separate qualification behind the deep-writer gate.
+
+use crate::format::pb;
+use crate::fragment_metadata::node::{self, FragmentMetadataTreeConfig};
+
+// Drain at most eight children and 32 MiB of encoded child-object bytes
+// per batch. Decoded fragments and replacement buffers can use more memory.
+const MAX_CONCURRENT_LEAF_DRAINS: usize = 8;
+const MAX_BATCH_OBJECT_BYTES: u64 = 32 * 1024 * 1024;
+
+/// Soft-pressure target. Once pending edits reach this fraction of the
+/// child object's encoded size, further batching has diminishing value against
+/// the read and write of that object.
+const REWRITE_AMORTIZATION_DIVISOR: u64 = 16;
+
+/// Pending bytes a child must hold before draining it under semantic pressure.
+///
+/// The fair share of the node's remaining routing room guarantees progress by
+/// pigeonhole no later than structural pressure. The object fraction keeps a
+/// narrow directory from waiting on a share larger than a rewrite deserves.
+pub(super) fn amortization_gate(fair_share: u64, child: &pb::FragmentMetadataChild) -> u64 {
+    fair_share
+        .min(child.object_size / REWRITE_AMORTIZATION_DIVISOR)
+        .max(1)
+}
+
+pub(super) fn fair_share(
+    children: &[pb::FragmentMetadataChild],
+    config: &FragmentMetadataTreeConfig,
+) -> u64 {
+    let routing = node::internal_logical_bytes(children, &[]);
+    config.split_ceiling().saturating_sub(routing) / children.len().max(1) as u64
+}
+
+/// Children worth draining now, fullest first, bounded for one batch.
+///
+/// A byte overflow always leaves one bucket at or above the fair share by
+/// pigeonhole, so structural pressure needs no separate path here. When the
+/// result is empty only routing or fanout overflows, which the caller splits.
+pub(super) fn select_children(
+    children: &[pb::FragmentMetadataChild],
+    buckets: &[Vec<pb::FragmentMetadataMutation>],
+    config: &FragmentMetadataTreeConfig,
+    io_parallelism: usize,
+) -> Vec<usize> {
+    let fair_share = fair_share(children, config);
+    let mut ranked: Vec<_> = buckets
+        .iter()
+        .enumerate()
+        .map(|(idx, actions)| (node::internal_logical_bytes(&[], actions), idx))
+        .filter(|(bytes, _)| *bytes > 0)
+        .collect();
+    ranked.sort_unstable_by(|a, b| b.cmp(a));
+    let worthwhile = ranked
+        .iter()
+        .filter(|(bytes, idx)| *bytes >= amortization_gate(fair_share, &children[*idx]))
+        .map(|(_, idx)| *idx);
+    let limit = io_parallelism.clamp(1, MAX_CONCURRENT_LEAF_DRAINS);
+    let mut selected = Vec::with_capacity(limit);
+    let mut batch_bytes = 0;
+    for idx in worthwhile {
+        if !selected.is_empty()
+            && (children[idx].height > 0
+                || selected.len() >= limit
+                || batch_bytes + children[idx].object_size > MAX_BATCH_OBJECT_BYTES)
+        {
+            break;
+        }
+        selected.push(idx);
+        batch_bytes += children[idx].object_size;
+        // Interior drains recurse, so running them together would multiply the bound.
+        if children[idx].height > 0 {
+            break;
+        }
+    }
+    selected
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::fragment_metadata::action;
+    use rstest::rstest;
+
+    fn children(count: usize, height: u32, object_size: u64) -> Vec<pb::FragmentMetadataChild> {
+        vec![
+            pb::FragmentMetadataChild {
+                height,
+                object_size,
+                ..Default::default()
+            };
+            count
+        ]
+    }
+
+    fn bucket(id: u64, actions: usize) -> Vec<pb::FragmentMetadataMutation> {
+        vec![
+            pb::FragmentMetadataMutation {
+                action: Some(action::remove_fragment(id)),
+                ..Default::default()
+            };
+            actions
+        ]
+    }
+
+    #[rstest]
+    #[case::below_the_gate_waits(1, vec![])]
+    #[case::worthwhile_batches_drain_together(64, vec![9, 8, 7, 6, 5, 4, 3, 2])]
+    #[test]
+    fn selection_respects_the_gate_and_concurrency(
+        #[case] actions_per_child: usize,
+        #[case] expected: Vec<usize>,
+    ) {
+        let children = children(10, 0, 1024 * 1024);
+        let config = FragmentMetadataTreeConfig::default();
+        let buckets: Vec<_> = (0..10)
+            .map(|id| bucket(id, actions_per_child * (id as usize + 1) * 200))
+            .collect();
+        assert_eq!(select_children(&children, &buckets, &config, 8), expected);
+    }
+
+    #[test]
+    fn fair_share_binds_a_wide_directory() {
+        let children = children(256, 0, 1024 * 1024);
+        let config = FragmentMetadataTreeConfig::default();
+        let share = fair_share(&children, &config);
+        assert!(share < 1024 * 1024 / REWRITE_AMORTIZATION_DIVISOR);
+        assert_eq!(amortization_gate(share, &children[0]), share);
+        let narrow = children[..2].to_vec();
+        let share = fair_share(&narrow, &config);
+        assert_eq!(
+            amortization_gate(share, &narrow[0]),
+            1024 * 1024 / REWRITE_AMORTIZATION_DIVISOR
+        );
+    }
+
+    #[test]
+    fn interior_children_drain_alone_and_leaves_respect_the_store_limit() {
+        let config = FragmentMetadataTreeConfig::default();
+        let mut mixed = children(4, 0, 4096);
+        mixed[3].height = 1;
+        let buckets: Vec<_> = (0..4).map(|id| bucket(id, 4000)).collect();
+        assert_eq!(select_children(&mixed, &buckets, &config, 8), vec![3]);
+        let leaves = children(4, 0, 4096);
+        assert_eq!(select_children(&leaves, &buckets, &config, 2), vec![3, 2]);
+        assert!(select_children(&leaves, &vec![vec![]; 4], &config, 8).is_empty());
+    }
+
+    #[test]
+    fn selection_bounds_encoded_bytes_in_flight() {
+        let oversized = children(3, 0, MAX_BATCH_OBJECT_BYTES / 2 + 1);
+        let config = FragmentMetadataTreeConfig::default().with_hard_capacity_bytes(u64::MAX / 4);
+        let buckets: Vec<_> = (0..3).map(|id| bucket(id, 200_000)).collect();
+        assert_eq!(select_children(&oversized, &buckets, &config, 8), vec![2]);
+    }
+}

--- a/rust/lance-table/src/fragment_metadata/tree/publication.rs
+++ b/rust/lance-table/src/fragment_metadata/tree/publication.rs
@@ -1,0 +1,316 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+//! Prepare immutable tree objects for publication by an authoritative manifest.
+//! This path never writes a version-numbered root or races a second commit CAS.
+
+use super::*;
+use crate::format::pb::fragment_metadata_tree::Root;
+
+/// Publication byte budgets, independent of leaf and semantic-buffer budgets.
+#[derive(Debug, Clone, Copy)]
+pub struct SnapshotPolicy {
+    /// Embed root and descriptor only when their complete encoded contribution
+    /// to the Version Manifest fits this size. Zero disables embedding.
+    pub inline_root_bytes: usize,
+    /// Maximum encoded cumulative suffix. Zero writes an external root every commit.
+    pub max_suffix_bytes: usize,
+}
+
+impl Default for SnapshotPolicy {
+    fn default() -> Self {
+        Self {
+            inline_root_bytes: 64 * 1024,
+            max_suffix_bytes: 32 * 1024,
+        }
+    }
+}
+
+impl FragmentMetadataTree {
+    /// Resolve validation state while retaining complete leaf reads on local
+    /// scratch storage for a subsequent bulk materialization. Scratch is owned
+    /// by this writer and never referenced by a published snapshot.
+    pub async fn resolve_touched_for_bulk(&mut self, ids: &[u64]) -> Result<TouchedFragments> {
+        self.store.retain_validation_reads()?;
+        self.resolve_touched(ids).await
+    }
+
+    /// Immutable node paths required by this snapshot. Root bases and
+    /// mutations_since_root belong to the manifest descriptor.
+    pub async fn node_paths(&self) -> Result<Vec<String>> {
+        let mut pending = self.children.clone();
+        let mut paths = std::collections::BTreeSet::new();
+        while let Some(child) = pending.pop() {
+            if !paths.insert(child.path.clone()) {
+                return Err(Error::invalid_input(format!(
+                    "fragment metadata tree version {} repeats node {}",
+                    self.version, child.path
+                )));
+            }
+            if child.height > 0 {
+                pending.extend(self.store.read_internal(&child).await?.children);
+            }
+        }
+        Ok(paths.into_iter().collect())
+    }
+
+    /// Build immutable leaves and routing without publishing a version.
+    /// Publish the returned snapshot through the dataset's Version Manifest.
+    /// A failed publication leaves only unreachable immutable objects.
+    #[allow(clippy::too_many_arguments)]
+    pub async fn bootstrap_snapshot(
+        object_store: Arc<ObjectStore>,
+        base: Path,
+        scheduler: Arc<ScanScheduler>,
+        cache: Arc<LanceCache>,
+        config: FragmentMetadataTreeConfig,
+        mut fragments: Vec<Fragment>,
+        version: u64,
+        policy: SnapshotPolicy,
+    ) -> Result<(Self, pb::FragmentMetadataTree, BootstrapStats)> {
+        fragments.sort_by_key(|fragment| fragment.id);
+        if fragments.windows(2).any(|pair| pair[0].id == pair[1].id) {
+            return Err(Error::invalid_input(
+                "fragment metadata tree bootstrap contains duplicate fragment IDs",
+            ));
+        }
+        let store = NodeStore::new(object_store, base, scheduler, cache);
+        let (mut tree, mut stats) = Self::build(store, config, fragments).await?;
+        tree.version = version;
+        let (snapshot, bytes) = tree.checkpoint_snapshot(policy).await?;
+        tree.snapshot = Some(Box::new(snapshot.clone()));
+        stats.io_write_bytes += bytes;
+        Ok((tree, snapshot, stats))
+    }
+
+    /// Open fragment state using only a manifest descriptor and its named base.
+    /// `version` comes from that same authoritative manifest.
+    #[allow(clippy::too_many_arguments)]
+    pub async fn open_snapshot(
+        object_store: Arc<ObjectStore>,
+        base: Path,
+        scheduler: Arc<ScanScheduler>,
+        cache: Arc<LanceCache>,
+        snapshot: &pb::FragmentMetadataTree,
+        version: u64,
+        config: FragmentMetadataTreeConfig,
+        next_fragment_id: u64,
+    ) -> Result<Self> {
+        let mut store = NodeStore::new(object_store, base, scheduler, cache);
+        store.next_action_sequence = snapshot.next_action_sequence;
+        let root = match &snapshot.root {
+            Some(Root::InlineRoot(root)) if snapshot.mutations_since_root.is_empty() => {
+                root.clone()
+            }
+            Some(Root::InlineRoot(_)) => {
+                return Err(Error::invalid_input(format!(
+                    "fragment metadata tree version {version} has a suffix after an inline root"
+                )));
+            }
+            Some(Root::RootPath(path)) => store.read_root_base(path).await?,
+            None => {
+                return Err(Error::invalid_input(format!(
+                    "fragment metadata tree version {version} has no root base"
+                )));
+            }
+        };
+        let (base_fragments, base_rows, base_visible_rows) =
+            super::super::validation::root(&root, next_fragment_id)?;
+        store.hard_capacity_bytes = config.hard_capacity_bytes;
+        super::super::validation::buffer(
+            &snapshot.mutations_since_root,
+            root.next_action_sequence,
+            snapshot.next_action_sequence,
+        )?;
+        if next_fragment_id > u64::from(u32::MAX) + 1
+            || snapshot
+                .mutations_since_root
+                .iter()
+                .any(|tagged| node::action_key(tagged) >= next_fragment_id)
+        {
+            return Err(super::super::validation::corrupt(format!(
+                "Invalid snapshot allocation frontier at version {version}"
+            )));
+        }
+        if snapshot.next_action_sequence < root.next_action_sequence {
+            return Err(Error::invalid_input(format!(
+                "fragment metadata tree version {version} has next_action_sequence {} below the root's {}",
+                snapshot.next_action_sequence, root.next_action_sequence
+            )));
+        }
+        if snapshot.mutations_since_root.iter().any(|action| {
+            action.action_sequence < root.next_action_sequence
+                || action.action_sequence >= snapshot.next_action_sequence
+        }) {
+            return Err(Error::invalid_input(format!(
+                "fragment metadata tree version {version} mutations_since_root crosses its root action sequence frontier"
+            )));
+        }
+        let total_fragments = snapshot
+            .mutations_since_root
+            .iter()
+            .try_fold(base_fragments, |value, action| {
+                apply_aggregate_delta(value, action.fragment_count_delta, "Fragments")
+            })?;
+        let total_rows = snapshot
+            .mutations_since_root
+            .iter()
+            .try_fold(base_rows, |value, action| {
+                apply_aggregate_delta(value, action.total_rows_delta, "physical rows")
+            })?;
+        let visible_rows = snapshot
+            .mutations_since_root
+            .iter()
+            .try_fold(base_visible_rows, |value, action| {
+                apply_aggregate_delta(value, action.visible_rows_delta, "visible rows")
+            })?;
+        if visible_rows > total_rows {
+            return Err(super::super::validation::corrupt(format!(
+                "Derived visible rows {visible_rows} exceed physical rows {total_rows} at version {version}"
+            )));
+        }
+        let mut buffer = root.buffer;
+        buffer.extend(snapshot.mutations_since_root.iter().cloned());
+        config.validate()?;
+        Ok(Self {
+            store,
+            config,
+            version,
+            children: root.children,
+            buffer: node::squash_buffer(buffer),
+            buffer_index: OnceLock::new(),
+            next_action_sequence: snapshot.next_action_sequence,
+            total_fragments,
+            total_rows,
+            visible_rows,
+            next_fragment_id,
+            force_flush: false,
+            snapshot: Some(Box::new(snapshot.clone())),
+        })
+    }
+
+    /// Prepare a validated mutation for manifest publication. No version becomes
+    /// visible here. On failure, the in-memory tree is restored; objects already
+    /// written remain unreachable until normal retention GC removes them.
+    pub async fn prepare_snapshot(
+        &mut self,
+        commit: ValidatedCommit,
+        touched: &TouchedFragments,
+        previous_snapshot: &pb::FragmentMetadataTree,
+        policy: SnapshotPolicy,
+        bulk: bool,
+    ) -> Result<(pb::FragmentMetadataTree, CommitStats)> {
+        if self.snapshot.as_deref() != Some(previous_snapshot) {
+            return Err(Error::invalid_input(format!(
+                "fragment metadata tree version {} received a descriptor from another validation state",
+                self.version
+            )));
+        }
+        let deltas =
+            commit::aggregate_deltas(&commit.fragment_actions, touched, self.next_fragment_id)?;
+        let previous = self.mutable_state();
+        let result = self
+            .prepare_snapshot_inner(commit, deltas, previous_snapshot, policy, bulk)
+            .await;
+        self.force_flush = false;
+        self.store.clear_validation_reads();
+        if result.is_err() {
+            self.restore_mutable_state(previous);
+        }
+        if let Ok((snapshot, _)) = &result {
+            self.snapshot = Some(Box::new(snapshot.clone()));
+        }
+        result
+    }
+
+    async fn prepare_snapshot_inner(
+        &mut self,
+        commit: ValidatedCommit,
+        deltas: Vec<commit::ActionDeltas>,
+        previous: &pb::FragmentMetadataTree,
+        policy: SnapshotPolicy,
+        bulk: bool,
+    ) -> Result<(pb::FragmentMetadataTree, CommitStats)> {
+        let tagged = self.stage_commit(&commit, deltas)?;
+        let messages_in = tagged.len() as u64;
+        let before = self.buffer.len();
+        self.buffer = node::squash_buffer(std::mem::take(&mut self.buffer));
+        let squashed = before - self.buffer.len();
+        let mut suffix = previous.mutations_since_root.clone();
+        suffix.extend(tagged);
+        let suffix = node::squash_buffer(suffix);
+        if !bulk
+            && matches!(&previous.root, Some(Root::RootPath(_)))
+            && !node::internal_overflows(&self.children, &self.buffer, &self.config)
+            && node::internal_logical_bytes(&[], &suffix) <= policy.max_suffix_bytes as u64
+        {
+            return Ok((
+                self.snapshot_descriptor(previous.root.clone(), suffix),
+                CommitStats {
+                    messages_in,
+                    messages_squashed: squashed as u64,
+                    height: self.height(),
+                    root_buffer_len: self.buffer.len() as u64,
+                    ..Default::default()
+                },
+            ));
+        }
+        self.force_flush = bulk;
+        let acc = self.rewrite_tree().await?;
+        let (snapshot, bytes) = self.checkpoint_snapshot(policy).await?;
+        Ok((
+            snapshot,
+            CommitStats {
+                tree_write_bytes: acc.io_bytes + bytes,
+                messages_in,
+                messages_materialized: acc.materialized,
+                messages_squashed: squashed as u64 + acc.squashed,
+                flushes: acc.flushes,
+                splits: acc.splits,
+                merges: acc.merges,
+                max_flush_depth: acc.max_flush_depth,
+                height: self.height(),
+                root_buffer_len: self.buffer.len() as u64,
+                checkpoints: 1,
+            },
+        ))
+    }
+
+    fn snapshot_descriptor(
+        &self,
+        root: Option<Root>,
+        mutations_since_root: Vec<pb::FragmentMetadataMutation>,
+    ) -> pb::FragmentMetadataTree {
+        pb::FragmentMetadataTree {
+            root,
+            mutations_since_root,
+            next_action_sequence: self.next_action_sequence,
+        }
+    }
+
+    async fn checkpoint_snapshot(
+        &self,
+        policy: SnapshotPolicy,
+    ) -> Result<(pb::FragmentMetadataTree, u64)> {
+        let root = self.compacted_root();
+        if root.encoded_len() as u64 > self.config.hard_capacity_bytes {
+            return Err(Error::invalid_input(format!(
+                "fragment metadata root envelope requires {} encoded bytes, exceeding hard_capacity_bytes={}",
+                root.encoded_len(),
+                self.config.hard_capacity_bytes
+            )));
+        }
+        let mut snapshot = self.snapshot_descriptor(Some(Root::InlineRoot(root)), Vec::new());
+        if snapshot.encoded_len() <= policy.inline_root_bytes {
+            return Ok((snapshot, 0));
+        }
+        let Some(Root::InlineRoot(root)) = &snapshot.root else {
+            return Err(Error::internal(
+                "prepared fragment metadata snapshot has no inline root",
+            ));
+        };
+        let (path, bytes) = self.store.write_root_base(root).await?;
+        snapshot.root = Some(Root::RootPath(path));
+        Ok((snapshot, bytes))
+    }
+}

--- a/rust/lance-table/src/fragment_metadata/tree/tests.rs
+++ b/rust/lance-table/src/fragment_metadata/tree/tests.rs
@@ -1,0 +1,1058 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+use super::*;
+use crate::fragment_metadata::action;
+use crate::fragment_metadata::support::{
+    make_backfill_data_file, make_fragment, make_fragment_with_files, make_replacement_data_file,
+};
+use lance_io::object_store::{ObjectStoreParams, ObjectStoreRegistry};
+use lance_io::scheduler::SchedulerConfig;
+use lance_io::utils::failpoint::{FailOn, FailWhen, Failpoint, FailpointController};
+use lance_io::utils::tracking_store::IOTracker;
+use rand::{Rng, SeedableRng, rngs::SmallRng};
+use rstest::rstest;
+
+struct Fixture {
+    tree: FragmentMetadataTree,
+    config: FragmentMetadataTreeConfig,
+    snapshot: pb::FragmentMetadataTree,
+    store: Arc<ObjectStore>,
+    base: Path,
+    scheduler: Arc<ScanScheduler>,
+    io: IOTracker,
+}
+
+#[rstest]
+#[case::root_envelope(false)]
+#[case::child_object(true)]
+#[tokio::test]
+async fn snapshot_rejects_objects_over_its_hard_limit(#[case] oversized_child: bool) {
+    let fixture = Fixture::new(
+        2,
+        FragmentMetadataTreeConfig::default(),
+        SnapshotPolicy::default(),
+    )
+    .await;
+    let mut snapshot = fixture.snapshot.clone();
+    let Some(pb::fragment_metadata_tree::Root::InlineRoot(root)) = &mut snapshot.root else {
+        panic!("expected inline root");
+    };
+    if oversized_child {
+        root.children[0].object_size = 0;
+    } else {
+        root.next_action_sequence = 0;
+    }
+    let result = FragmentMetadataTree::open_snapshot(
+        fixture.store,
+        fixture.base,
+        fixture.scheduler,
+        Arc::new(LanceCache::with_capacity(0)),
+        &snapshot,
+        1,
+        fixture.config.clone(),
+        fixture.tree.next_fragment_id(),
+    )
+    .await;
+    let error = result
+        .err()
+        .expect("oversized snapshot must be rejected at open");
+    assert!(matches!(error, Error::CorruptFile { .. }), "{error}");
+    if oversized_child {
+        assert!(
+            error.to_string().contains("object_size") || error.to_string().contains("child"),
+            "{error}"
+        );
+    } else {
+        assert!(
+            error.to_string().contains("next_action_sequence"),
+            "{error}"
+        );
+    }
+}
+
+impl Fixture {
+    async fn new(count: u64, config: FragmentMetadataTreeConfig, policy: SnapshotPolicy) -> Self {
+        let io = IOTracker::default();
+        let (store, base) = ObjectStore::from_uri_and_params(
+            Arc::new(ObjectStoreRegistry::default()),
+            "memory://",
+            &ObjectStoreParams {
+                object_store_wrapper: Some(Arc::new(io.clone())),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+        let scheduler = ScanScheduler::new(store.clone(), SchedulerConfig::default_for_testing());
+        let (tree, snapshot, _) = FragmentMetadataTree::bootstrap_snapshot(
+            store.clone(),
+            base.clone(),
+            scheduler.clone(),
+            Arc::new(LanceCache::with_capacity(0)),
+            config.clone(),
+            (0..count).map(make_fragment).collect(),
+            1,
+            policy,
+        )
+        .await
+        .unwrap();
+        Self {
+            tree,
+            config,
+            snapshot,
+            store,
+            base,
+            scheduler,
+            io,
+        }
+    }
+
+    async fn open(
+        &self,
+        snapshot: &pb::FragmentMetadataTree,
+        version: u64,
+    ) -> FragmentMetadataTree {
+        FragmentMetadataTree::open_snapshot(
+            self.store.clone(),
+            self.base.clone(),
+            self.scheduler.clone(),
+            Arc::new(LanceCache::with_capacity(0)),
+            snapshot,
+            version,
+            self.config.clone(),
+            self.tree.next_fragment_id(),
+        )
+        .await
+        .unwrap()
+    }
+
+    async fn commit(
+        &mut self,
+        actions: Vec<pb::FragmentAction>,
+        policy: SnapshotPolicy,
+        bulk: bool,
+    ) -> CommitStats {
+        let ids: Vec<_> = actions.iter().filter_map(action::target_frag_id).collect();
+        let touched = if bulk {
+            self.tree.resolve_touched_for_bulk(&ids).await.unwrap()
+        } else {
+            self.tree.resolve_touched(&ids).await.unwrap()
+        };
+        let (snapshot, stats) = self
+            .tree
+            .prepare_snapshot(
+                ValidatedCommit::fragment_actions(actions),
+                &touched,
+                &self.snapshot,
+                policy,
+                bulk,
+            )
+            .await
+            .unwrap();
+        self.snapshot = snapshot;
+        stats
+    }
+}
+
+#[rstest]
+#[case::fragments("Fragments")]
+#[case::physical_rows("physical rows")]
+#[case::visible_rows("visible rows")]
+#[tokio::test]
+async fn snapshot_counts_are_checked_against_children_and_pending_changes(#[case] count: &str) {
+    let checkpoint = SnapshotPolicy {
+        inline_root_bytes: 0,
+        max_suffix_bytes: 0,
+    };
+    let mut fixture = Fixture::new(3, FragmentMetadataTreeConfig::default(), checkpoint).await;
+    fixture
+        .commit(vec![action::remove_fragment(0)], checkpoint, false)
+        .await;
+    assert_eq!(fixture.tree.root_buffer_len(), 1);
+    fixture
+        .commit(
+            vec![action::remove_fragment(1)],
+            SnapshotPolicy {
+                max_suffix_bytes: 1024,
+                ..checkpoint
+            },
+            false,
+        )
+        .await;
+    assert_eq!(fixture.snapshot.mutations_since_root.len(), 1);
+    let reopened = fixture.open(&fixture.snapshot, 3).await;
+    assert_eq!(
+        reopened.materialize().await.unwrap(),
+        vec![make_fragment(2)]
+    );
+
+    let mut snapshot = fixture.snapshot.clone();
+    match count {
+        "Fragments" => snapshot.mutations_since_root[0].fragment_count_delta = -999,
+        "physical rows" => snapshot.mutations_since_root[0].total_rows_delta = -999,
+        "visible rows" => snapshot.mutations_since_root[0].visible_rows_delta = -999,
+        _ => unreachable!(),
+    }
+    let error = FragmentMetadataTree::open_snapshot(
+        fixture.store,
+        fixture.base,
+        fixture.scheduler,
+        Arc::new(LanceCache::with_capacity(0)),
+        &snapshot,
+        3,
+        fixture.config.clone(),
+        fixture.tree.next_fragment_id(),
+    )
+    .await
+    .err()
+    .expect("snapshot totals must agree with the tree");
+    assert!(matches!(error, Error::InvalidInput { .. }), "{error}");
+    assert!(error.to_string().contains(count), "{error}");
+}
+
+#[rstest]
+#[case::buffered(17, false)]
+#[case::bulk(29, true)]
+#[tokio::test]
+async fn mutations_survive_routing_growth_and_historical_reads(
+    #[case] seed: u64,
+    #[case] bulk: bool,
+) {
+    let policy = SnapshotPolicy {
+        inline_root_bytes: 0,
+        max_suffix_bytes: 512,
+    };
+    let config = FragmentMetadataTreeConfig::new(512, u32::MAX).with_max_leaf_bytes(4096);
+    let mut fixture = Fixture::new(48, config, policy).await;
+    let initial = fixture.snapshot.clone();
+    let mut expected: BTreeMap<_, _> = (0..48).map(|id| (id, make_fragment(id))).collect();
+    let mut rng = SmallRng::seed_from_u64(seed);
+    let mut maximum_height = fixture.tree.height();
+    for round in 0..12 {
+        let mut changes = Vec::new();
+        for offset in 0..4 {
+            let id = 48 + round * 4 + offset;
+            let fragment = make_fragment(id);
+            changes.push(action::add_fragment(&fragment));
+            expected.insert(id, fragment);
+        }
+        let id = rng.random_range(0..48);
+        let mut fragment = make_fragment(id);
+        fragment.files[0].path = format!("round-{round}-{id}.lance");
+        changes.push(action::add_fragment(&fragment));
+        expected.insert(id, fragment);
+        fixture.commit(changes, policy, bulk).await;
+        maximum_height = maximum_height.max(fixture.tree.height());
+        assert_eq!(
+            fixture.tree.materialize().await.unwrap(),
+            expected.values().cloned().collect::<Vec<_>>()
+        );
+        fixture.tree.verify_watermarks().await.unwrap();
+        let reopened = fixture.open(&fixture.snapshot, round + 2).await;
+        assert_eq!(
+            reopened.materialize().await.unwrap(),
+            fixture.tree.materialize().await.unwrap()
+        );
+    }
+    assert!(
+        maximum_height >= 2,
+        "the fixture must cross an interior level"
+    );
+    let remove = expected
+        .keys()
+        .copied()
+        .filter(|id| *id != 7)
+        .map(action::remove_fragment)
+        .collect();
+    fixture.commit(remove, policy, true).await;
+    assert_eq!(fixture.tree.height(), 1);
+    assert_eq!(
+        fixture.tree.materialize().await.unwrap(),
+        vec![expected[&7].clone()]
+    );
+    let historical = fixture.open(&initial, 1).await;
+    assert_eq!(
+        historical.materialize().await.unwrap(),
+        (0..48).map(make_fragment).collect::<Vec<_>>()
+    );
+}
+
+#[tokio::test]
+async fn bulk_reuses_validation_leaf_reads_and_coalesces_across_parents() {
+    let policy = SnapshotPolicy {
+        inline_root_bytes: 0,
+        max_suffix_bytes: 0,
+    };
+    let config = FragmentMetadataTreeConfig::new(512, u32::MAX).with_max_leaf_bytes(4096);
+    let mut fixture = Fixture::new(64, config, policy).await;
+    let leaves = fixture.tree.shape_report().await.unwrap().leaf_keys.len();
+    assert!(fixture.tree.height() >= 2);
+    fixture.io.incremental_stats();
+    fixture
+        .commit((1..64).map(action::remove_fragment).collect(), policy, true)
+        .await;
+    let measured = fixture.io.incremental_stats();
+    let reads = measured
+        .requests
+        .iter()
+        .filter(|request| {
+            request.method.starts_with("get_") && request.path.as_ref().contains("_bt/leaf/")
+        })
+        .count();
+    assert_eq!(
+        reads, leaves,
+        "validation and materialization must share leaf reads: {measured:?}"
+    );
+    assert_eq!(fixture.tree.root_child_count(), 1);
+    assert_eq!(
+        measured.write_iops, 2,
+        "one replacement leaf and one root base"
+    );
+    assert_eq!(
+        fixture.tree.materialize().await.unwrap(),
+        vec![make_fragment(0)]
+    );
+}
+
+#[rstest]
+#[case::compacted(false, true)]
+#[case::buffered(true, true)]
+#[case::near_capacity(false, false)]
+#[tokio::test]
+async fn root_contracts_multiple_children_with_room_to_grow(
+    #[case] buffered: bool,
+    #[case] should_contract: bool,
+) {
+    let policy = SnapshotPolicy::default();
+    let mut fixture = Fixture::new(4, FragmentMetadataTreeConfig::default(), policy).await;
+    let mut leaves = Vec::new();
+    for id in 0..4 {
+        let written = fixture
+            .tree
+            .store
+            .write_leaves(&[make_fragment(id)], 0, &fixture.tree.config)
+            .await
+            .unwrap();
+        leaves.push(written.into_iter().next().unwrap().child_ref);
+    }
+    let mut expected: Vec<_> = (0..4).map(make_fragment).collect();
+    let mut child_buffer = Vec::new();
+    if buffered {
+        let old_path = expected[0].files[0].path.clone();
+        expected[0].files[0].path = "first-replacement.lance".into();
+        child_buffer.push(pb::FragmentMetadataMutation {
+            action_sequence: 1,
+            action: Some(action::replace_data_file(
+                0,
+                &old_path,
+                &expected[0].files[0],
+            )),
+            ..Default::default()
+        });
+        let old_path = expected[0].files[0].path.clone();
+        expected[0].files[0].path = "second-replacement.lance".into();
+        fixture.tree.buffer.push(pb::FragmentMetadataMutation {
+            action_sequence: 2,
+            action: Some(action::replace_data_file(
+                0,
+                &old_path,
+                &expected[0].files[0],
+            )),
+            ..Default::default()
+        });
+        fixture.tree.next_action_sequence = 3;
+        fixture.tree.store.next_action_sequence = 3;
+    }
+    let left = fixture
+        .tree
+        .store
+        .write_internal(leaves[..2].to_vec(), child_buffer)
+        .await
+        .unwrap();
+    let right = fixture
+        .tree
+        .store
+        .write_internal(leaves[2..].to_vec(), Vec::new())
+        .await
+        .unwrap();
+    fixture.tree.children = vec![left.child_ref, right.child_ref];
+    let collapsed_bytes = fixture
+        .tree
+        .children
+        .iter()
+        .map(|child| child.object_size)
+        .sum::<u64>()
+        + node::internal_logical_bytes(&[], &fixture.tree.buffer);
+    fixture.tree.config.max_node_bytes = if should_contract {
+        collapsed_bytes * 2
+    } else {
+        collapsed_bytes * 10 / 9
+    };
+    let mut historical = fixture.snapshot.clone();
+    historical.next_action_sequence = fixture.tree.next_action_sequence;
+    historical.root = Some(pb::fragment_metadata_tree::Root::InlineRoot(
+        fixture.tree.compacted_root(),
+    ));
+    assert_eq!(fixture.tree.height(), 2);
+    assert_eq!(
+        fixture.tree.resolve_fragment(0).await.unwrap(),
+        Some(expected[0].clone())
+    );
+
+    fixture.io.incremental_stats();
+    fixture.tree.maybe_shrink_root().await.unwrap();
+    let io = fixture.io.incremental_stats();
+    assert_eq!(fixture.tree.height(), if should_contract { 1 } else { 2 });
+    assert_eq!(io.write_iops, 0, "contraction must reuse the leaves");
+    assert!(
+        io.requests
+            .iter()
+            .all(|request| !request.path.as_ref().contains("_bt/leaf/"))
+    );
+    assert_eq!(fixture.tree.materialize().await.unwrap(), expected);
+    assert_eq!(
+        fixture.tree.resolve_fragment(0).await.unwrap(),
+        Some(expected[0].clone())
+    );
+    fixture.tree.verify_watermarks().await.unwrap();
+    let mut snapshot = historical.clone();
+    snapshot.root = Some(pb::fragment_metadata_tree::Root::InlineRoot(
+        fixture.tree.compacted_root(),
+    ));
+    let reopened = fixture.open(&snapshot, 1).await;
+    assert_eq!(reopened.materialize().await.unwrap(), expected);
+    let old = fixture.open(&historical, 1).await;
+    assert_eq!(old.height(), 2);
+    assert_eq!(old.materialize().await.unwrap(), expected);
+}
+
+#[tokio::test]
+async fn bootstrap_packs_compressed_batches_within_the_leaf_target() {
+    let config = FragmentMetadataTreeConfig::default();
+    let fixture = Fixture::new(0, config.clone(), SnapshotPolicy::default()).await;
+    let fragments: Vec<_> = (5_000_000..5_000_216)
+        .map(|id| make_fragment_with_files(id, 128))
+        .collect();
+    let encoded = fixture.tree.store.encode_leaf(&fragments).await.unwrap();
+    assert!(node::leaf_logical_bytes(&fragments) > config.max_leaf_bytes * 2);
+    assert!(encoded.len() as u64 <= config.max_leaf_bytes);
+    fixture.io.incremental_stats();
+    let (tree, stats) =
+        FragmentMetadataTree::build(fixture.tree.store, config.clone(), fragments.clone())
+            .await
+            .unwrap();
+    assert_eq!(
+        stats.num_leaves, 1,
+        "the complete encoding fits in one leaf"
+    );
+    assert_eq!(
+        fixture.io.incremental_stats().write_iops,
+        1,
+        "do not publish candidate leaves"
+    );
+    assert!(
+        tree.leaf_object_sizes()
+            .iter()
+            .all(|size| *size <= config.max_leaf_bytes)
+    );
+    assert_eq!(tree.materialize().await.unwrap(), fragments);
+}
+
+#[rstest]
+#[case::serial(1)]
+#[case::prefetched(4)]
+#[tokio::test]
+async fn deep_stream_honors_prefetch_and_preserves_order(#[case] prefetch: usize) {
+    let policy = SnapshotPolicy::default();
+    let config = FragmentMetadataTreeConfig::new(512, u32::MAX).with_max_leaf_bytes(4096);
+    let mut fixture = Fixture::new(64, config, policy).await;
+    let mut expected: Vec<_> = (0..64).map(make_fragment).collect();
+    let mut actions = Vec::new();
+    for fragment in expected.iter_mut().take(8) {
+        let file = crate::fragment_metadata::support::make_backfill_data_file(fragment.id, 0);
+        actions.push(action::add_data_file(fragment.id, &file));
+        fragment.files.push(file);
+    }
+    actions.push(action::remove_fragment(63));
+    actions.push(action::add_fragment(&make_fragment(64)));
+    expected[63] = make_fragment(64);
+    fixture.commit(actions, policy, false).await;
+    assert!(fixture.tree.height() >= 2);
+    let leaf_count = fixture.tree.shape_report().await.unwrap().leaf_keys.len();
+    let delayed = FailpointController::default();
+    delayed.set_get_latency(std::time::Duration::from_millis(2));
+    let io = IOTracker::default();
+    let mut store = fixture.store.as_ref().clone();
+    store.apply_wrapper(&delayed);
+    store.apply_wrapper(&io);
+    let tree = Arc::new(fixture.tree.with_object_store(Arc::new(store)));
+    let actual: Vec<_> = tree
+        .fragment_stream_with_prefetch(prefetch)
+        .try_collect()
+        .await
+        .unwrap();
+    assert_eq!(actual, expected);
+    let measured = io.incremental_stats();
+    assert_eq!(
+        measured
+            .requests
+            .iter()
+            .filter(|request| request.path.as_ref().contains("_bt/leaf/"))
+            .count(),
+        leaf_count,
+        "each leaf must be read once"
+    );
+    if prefetch == 1 {
+        assert_eq!(measured.num_stages, measured.read_iops);
+    } else {
+        assert!(
+            measured.num_stages < measured.read_iops,
+            "deep leaf reads must overlap: {measured:?}"
+        );
+    }
+}
+
+#[tokio::test]
+async fn failed_prepare_restores_frontiers_and_buffer() {
+    let policy = SnapshotPolicy::default();
+    let config = FragmentMetadataTreeConfig::new(1024, u32::MAX)
+        .with_max_leaf_bytes(4096)
+        .with_hard_capacity_bytes(8192);
+    let mut fixture = Fixture::new(2, config, policy).await;
+    let touched = fixture.tree.resolve_touched(&[9]).await.unwrap();
+    let error = fixture
+        .tree
+        .prepare_snapshot(
+            ValidatedCommit::fragment_actions(vec![action::add_fragment(
+                &make_fragment_with_files(9, 256),
+            )]),
+            &touched,
+            &fixture.snapshot,
+            policy,
+            true,
+        )
+        .await
+        .unwrap_err();
+    assert!(matches!(error, Error::InvalidInput { .. }), "{error}");
+    assert!(error.to_string().contains("hard_capacity_bytes"), "{error}");
+    assert_eq!(fixture.tree.version(), 1);
+    assert_eq!(fixture.tree.next_fragment_id(), 2);
+    assert_eq!(fixture.tree.root_buffer_len(), 0);
+    fixture
+        .commit(vec![action::add_fragment(&make_fragment(2))], policy, false)
+        .await;
+    assert_eq!(
+        fixture.tree.materialize().await.unwrap(),
+        (0..3).map(make_fragment).collect::<Vec<_>>()
+    );
+}
+
+#[rstest]
+#[case::rewrite(false, None)]
+#[case::split_and_remove(true, None)]
+#[case::failed_put(false, Some(FailWhen::Before))]
+#[case::lost_put_response(false, Some(FailWhen::After))]
+#[tokio::test]
+async fn sibling_leaf_drains_overlap_and_preserve_snapshots(
+    #[case] change_shape: bool,
+    #[case] failure: Option<FailWhen>,
+) {
+    let policy = SnapshotPolicy::default();
+    let config = FragmentMetadataTreeConfig::default()
+        .with_max_leaf_bytes(4096)
+        .with_semantic_buffer_bytes(1);
+    let mut fixture = Fixture::new(128, config, policy).await;
+    assert_eq!(fixture.tree.height(), 1);
+    assert!(fixture.tree.children.len() > 1);
+    let original = fixture.tree.materialize().await.unwrap();
+    let previous = fixture.snapshot.clone();
+    let mut expected = Vec::new();
+    let mut actions = Vec::new();
+    for fragment in &original {
+        let child = node::child_index_for(&fixture.tree.children, fragment.id);
+        if change_shape && child.is_multiple_of(2) {
+            actions.push(action::remove_fragment(fragment.id));
+        } else {
+            let replacement =
+                make_fragment_with_files(fragment.id, if change_shape { 16 } else { 2 });
+            actions.push(action::add_fragment(&replacement));
+            expected.push(replacement);
+        }
+    }
+    let ids: Vec<_> = original.iter().map(|fragment| fragment.id).collect();
+    let touched = fixture.tree.resolve_touched(&ids).await.unwrap();
+    let delayed = FailpointController::default();
+    delayed.set_get_latency(std::time::Duration::from_millis(2));
+    if let Some(when) = failure {
+        delayed.arm(Failpoint {
+            on: FailOn::Put,
+            when,
+            path_contains: "_bt/leaf/".into(),
+            nth: 2,
+        });
+    }
+    let io = IOTracker::default();
+    let mut store = fixture.store.as_ref().clone();
+    store.apply_wrapper(&delayed);
+    store.apply_wrapper(&io);
+    fixture.tree = fixture.tree.with_object_store(Arc::new(store));
+    let result = fixture
+        .tree
+        .prepare_snapshot(
+            ValidatedCommit::fragment_actions(actions.clone()),
+            &touched,
+            &previous,
+            policy,
+            false,
+        )
+        .await;
+    if failure.is_some() {
+        let error = result.unwrap_err();
+        assert!(matches!(error, Error::IO { .. }), "{error}");
+        assert!(delayed.tripped());
+        assert!(error.to_string().contains("failpoint"), "{error}");
+        assert_eq!(fixture.tree.version(), 1);
+        assert_eq!(fixture.tree.root_buffer_len(), 0);
+        assert_eq!(fixture.tree.materialize().await.unwrap(), original);
+        delayed.disarm();
+        fixture
+            .tree
+            .prepare_snapshot(
+                ValidatedCommit::fragment_actions(actions),
+                &touched,
+                &previous,
+                policy,
+                false,
+            )
+            .await
+            .unwrap();
+    } else {
+        let (_, stats) = result.unwrap();
+        assert!(stats.flushes > 1);
+        if change_shape {
+            assert!(stats.splits > 0);
+        }
+        let measured = io.incremental_stats();
+        assert!(
+            measured.num_stages < measured.read_iops + measured.write_iops,
+            "sibling drains must overlap: {measured:?}"
+        );
+    }
+    assert_eq!(fixture.tree.materialize().await.unwrap(), expected);
+    assert_eq!(
+        fixture
+            .open(&previous, 1)
+            .await
+            .materialize()
+            .await
+            .unwrap(),
+        original
+    );
+}
+
+#[rstest]
+#[case::buffered_inline(false, usize::MAX)]
+#[case::buffered_external(false, 0)]
+#[case::bulk_external(true, 0)]
+#[tokio::test]
+async fn aliased_file_actions_survive_pressure_and_checkpoint(
+    #[case] bulk: bool,
+    #[case] inline_root_bytes: usize,
+) {
+    let policy = SnapshotPolicy {
+        inline_root_bytes,
+        max_suffix_bytes: 256,
+    };
+    let config = FragmentMetadataTreeConfig::new(512, u32::MAX)
+        .with_max_leaf_bytes(4096)
+        .with_semantic_buffer_bytes(1);
+    let mut fixture = Fixture::new(32, config, policy).await;
+    assert!(fixture.tree.height() >= 2);
+    let mut expected: BTreeMap<_, _> = (0..32).map(|id| (id, make_fragment(id))).collect();
+    let mut fragment = make_fragment_with_files(7, 2);
+    fragment.files[0].path = "A".into();
+    fragment.files[1].path = "B".into();
+    fixture
+        .commit(vec![action::add_fragment(&fragment)], policy, bulk)
+        .await;
+    expected.insert(7, fragment.clone());
+    let historical = fixture.snapshot.clone();
+    let mut materialized = 0;
+    for (from, to) in [("B", "A"), ("A", "C")] {
+        let mut replacement = fragment.files[0].clone();
+        replacement.path = to.into();
+        // Replacement mapping and version are deliberately different: the
+        // action changes the first matching slot's location fields only.
+        replacement.fields = Arc::from([99]);
+        replacement.column_indices = Arc::from([9]);
+        replacement.file_major_version = 99;
+        let stats = fixture
+            .commit(
+                vec![action::replace_data_file(7, from, &replacement)],
+                policy,
+                bulk,
+            )
+            .await;
+        materialized += stats.messages_materialized;
+        let matched = fragment
+            .files
+            .iter_mut()
+            .find(|file| file.path == from)
+            .unwrap();
+        matched.path = to.into();
+        matched.file_size_bytes = replacement.file_size_bytes;
+        matched.base_id = replacement.base_id;
+        expected.insert(7, fragment.clone());
+        let reopened = fixture
+            .open(&fixture.snapshot, fixture.tree.version())
+            .await;
+        assert_eq!(
+            reopened.resolve_fragment(7).await.unwrap(),
+            Some(fragment.clone())
+        );
+        assert_eq!(
+            reopened.materialize().await.unwrap(),
+            expected.values().cloned().collect::<Vec<_>>()
+        );
+        assert_eq!(
+            reopened
+                .resolve_fragments(&RoaringBitmap::from_iter([7]))
+                .await
+                .unwrap(),
+            vec![fragment.clone()]
+        );
+        assert_eq!(
+            reopened.fragment_at_row_offset(7).await.unwrap(),
+            OffsetResolution::Found(Box::new(fragment.clone()), 0)
+        );
+        fixture.tree.verify_watermarks().await.unwrap();
+    }
+    assert_eq!(
+        fragment
+            .files
+            .iter()
+            .map(|file| file.path.as_str())
+            .collect::<Vec<_>>(),
+        ["C", "A"]
+    );
+    if !bulk {
+        assert_eq!(
+            materialized, 0,
+            "a chain below the amortization gate stays buffered"
+        );
+    }
+    fixture.commit(Vec::new(), policy, true).await;
+    assert_eq!(
+        fixture.tree.materialize().await.unwrap(),
+        expected.values().cloned().collect::<Vec<_>>()
+    );
+    let old = fixture.open(&historical, 2).await;
+    let old_fragment = old.resolve_fragment(7).await.unwrap().unwrap();
+    assert_eq!(
+        old_fragment
+            .files
+            .iter()
+            .map(|file| file.path.as_str())
+            .collect::<Vec<_>>(),
+        ["A", "B"]
+    );
+}
+
+#[tokio::test]
+async fn point_scatter_and_lower_bound_reads_use_the_same_state() {
+    let mut fixture = Fixture::new(
+        64,
+        FragmentMetadataTreeConfig::new(1024, u32::MAX).with_max_leaf_bytes(4096),
+        SnapshotPolicy::default(),
+    )
+    .await;
+    fixture
+        .commit(
+            vec![
+                action::remove_fragment(7),
+                action::add_fragment(&make_fragment(90)),
+            ],
+            SnapshotPolicy::default(),
+            false,
+        )
+        .await;
+    let bitmap = RoaringBitmap::from_iter([2, 7, 8, 63, 90]);
+    let selected = fixture.tree.resolve_fragments(&bitmap).await.unwrap();
+    assert_eq!(
+        selected
+            .iter()
+            .map(|fragment| fragment.id)
+            .collect::<Vec<_>>(),
+        vec![2, 8, 63, 90]
+    );
+    let tree = Arc::new(fixture.tree);
+    let from: Vec<_> = tree
+        .clone()
+        .fragment_stream_from(62)
+        .try_collect()
+        .await
+        .unwrap();
+    assert_eq!(
+        from.iter().map(|fragment| fragment.id).collect::<Vec<_>>(),
+        vec![62, 63, 90]
+    );
+    assert_eq!(tree.resolve_fragment(7).await.unwrap(), None);
+}
+
+#[tokio::test]
+async fn scattered_batches_wait_for_amortization_and_replay_in_order() {
+    const ROUNDS: u32 = 24;
+    let policy = SnapshotPolicy::default();
+    let config = FragmentMetadataTreeConfig::default()
+        .with_max_leaf_bytes(16 * 1024)
+        .with_semantic_buffer_bytes(1);
+    let mut fixture = Fixture::new(1024, config.clone(), policy).await;
+    assert_eq!(fixture.tree.height(), 1);
+    let leaves = fixture.tree.root_child_count();
+    assert!(leaves >= 8, "{leaves} leaves");
+    let original = fixture.tree.materialize().await.unwrap();
+    let historical = fixture.snapshot.clone();
+    let mut expected: BTreeMap<u64, Fragment> = original
+        .iter()
+        .map(|fragment| (fragment.id, fragment.clone()))
+        .collect();
+    let mut targets = Vec::with_capacity(leaves);
+    for child in 0..leaves {
+        let id = original
+            .iter()
+            .map(|fragment| fragment.id)
+            .find(|id| node::child_index_for(&fixture.tree.children, *id) == child)
+            .unwrap();
+        targets.push(id);
+    }
+    let chained = targets[leaves / 2];
+    let mut flushes = 0;
+    let mut deferred_rounds = 0;
+    for round in 0..ROUNDS {
+        let mut actions = Vec::new();
+        for &id in &targets {
+            let file = make_backfill_data_file(id, round);
+            actions.push(action::add_data_file(id, &file));
+            expected.get_mut(&id).unwrap().files.push(file);
+        }
+        let current = expected[&chained].files[0].path.clone();
+        let replacement = make_replacement_data_file(chained, round);
+        actions.push(action::replace_data_file(chained, &current, &replacement));
+        let slot = &mut expected.get_mut(&chained).unwrap().files[0];
+        slot.path = replacement.path.clone();
+        slot.file_size_bytes = replacement.file_size_bytes;
+        slot.base_id = replacement.base_id;
+
+        let stats = fixture.commit(actions, policy, false).await;
+        flushes += stats.flushes;
+        deferred_rounds += u64::from(stats.flushes == 0);
+        assert!(
+            !node::internal_overflows(&fixture.tree.children, &fixture.tree.buffer, &config),
+            "round {round}: the root must stay within its structural budget"
+        );
+        assert_eq!(
+            fixture.tree.materialize().await.unwrap(),
+            expected.values().cloned().collect::<Vec<_>>(),
+            "round {round}"
+        );
+        fixture.tree.verify_watermarks().await.unwrap();
+    }
+    assert!(
+        deferred_rounds > 0 && flushes >= leaves as u64,
+        "every leaf drained at least once and some rounds only buffered: \
+         flushes={flushes} deferred_rounds={deferred_rounds}"
+    );
+    assert!(
+        flushes <= (leaves as u64) * u64::from(ROUNDS) / 4,
+        "sub-gate batches must not rewrite a leaf every round: flushes={flushes} leaves={leaves}"
+    );
+    let reopened = fixture
+        .open(&fixture.snapshot, fixture.tree.version())
+        .await;
+    assert_eq!(
+        reopened.materialize().await.unwrap(),
+        expected.values().cloned().collect::<Vec<_>>()
+    );
+    let chained_fragment = reopened.resolve_fragment(chained).await.unwrap().unwrap();
+    assert_eq!(
+        chained_fragment.files[0].path,
+        make_replacement_data_file(chained, ROUNDS - 1).path
+    );
+    assert_eq!(
+        chained_fragment.files[0].fields,
+        original[0].files[0].fields
+    );
+    assert_eq!(chained_fragment.files.len(), 1 + ROUNDS as usize);
+    assert_eq!(
+        fixture
+            .open(&historical, 1)
+            .await
+            .materialize()
+            .await
+            .unwrap(),
+        original
+    );
+}
+
+#[rstest]
+#[case::inline_root_with_suffix("inline_root_with_suffix")]
+#[case::external_root_suffix_zero("external_root_suffix_zero")]
+#[case::root_buffer_zero("root_buffer_zero")]
+#[case::root_next_zero("root_next_zero")]
+#[tokio::test]
+async fn sequence_zero_is_rejected_on_open(#[case] shape: &str) {
+    let fixture = Fixture::new(
+        4,
+        FragmentMetadataTreeConfig::default(),
+        SnapshotPolicy::default(),
+    )
+    .await;
+    let pb::fragment_metadata_tree::Root::InlineRoot(root) = fixture.snapshot.root.clone().unwrap()
+    else {
+        panic!("expected inline root");
+    };
+    assert_eq!(root.next_action_sequence, 1, "bootstrap starts at 1");
+    assert_eq!(root.children[0].materialized_through_action_sequence, 0);
+    let zero = pb::FragmentMetadataMutation {
+        action_sequence: 0,
+        action: Some(action::remove_fragment(1)),
+        fragment_count_delta: -1,
+        total_rows_delta: -1,
+        visible_rows_delta: -1,
+    };
+    let mut snapshot = fixture.snapshot.clone();
+    match shape {
+        "inline_root_with_suffix" => {
+            snapshot.mutations_since_root = vec![zero];
+            snapshot.next_action_sequence = 1;
+        }
+        "external_root_suffix_zero" => {
+            let store = NodeStore::new(
+                fixture.store.clone(),
+                fixture.base.clone(),
+                fixture.scheduler.clone(),
+                Arc::new(LanceCache::with_capacity(0)),
+            );
+            let (path, _) = store.write_root_base(&root).await.unwrap();
+            snapshot.root = Some(pb::fragment_metadata_tree::Root::RootPath(path));
+            snapshot.mutations_since_root = vec![zero];
+            snapshot.next_action_sequence = 1;
+        }
+        "root_buffer_zero" => {
+            let mut root = root;
+            root.buffer = vec![zero];
+            snapshot.root = Some(pb::fragment_metadata_tree::Root::InlineRoot(root));
+        }
+        _ => {
+            let mut root = root;
+            root.next_action_sequence = 0;
+            snapshot.root = Some(pb::fragment_metadata_tree::Root::InlineRoot(root));
+            snapshot.next_action_sequence = 0;
+        }
+    }
+    let error = FragmentMetadataTree::open_snapshot(
+        fixture.store,
+        fixture.base,
+        fixture.scheduler,
+        Arc::new(LanceCache::with_capacity(0)),
+        &snapshot,
+        1,
+        fixture.config.clone(),
+        fixture.tree.next_fragment_id(),
+    )
+    .await
+    .err()
+    .expect("sequence 0 must not open");
+    assert!(
+        matches!(
+            error,
+            Error::CorruptFile { .. } | Error::InvalidInput { .. }
+        ),
+        "{error}"
+    );
+}
+
+#[tokio::test]
+async fn first_fences_follow_the_parent_not_the_first_stored_id() {
+    let policy = SnapshotPolicy::default();
+    let config = FragmentMetadataTreeConfig::new(512, u32::MAX)
+        .with_max_leaf_bytes(4096)
+        .with_semantic_buffer_bytes(1);
+    let mut fixture = Fixture::new(64, config, policy).await;
+    assert!(fixture.tree.height() >= 2);
+    assert_eq!(fixture.tree.children[0].min_key, 0);
+    let actions: Vec<_> = (0..6).map(action::remove_fragment).collect();
+    fixture.commit(actions, policy, false).await;
+    fixture.commit(Vec::new(), policy, true).await;
+    assert_eq!(fixture.tree.children[0].min_key, 0);
+    let reopened = fixture
+        .open(&fixture.snapshot, fixture.tree.version())
+        .await;
+    let fragments = reopened.materialize().await.unwrap();
+    assert_eq!(fragments[0].id, 6);
+    reopened.verify_watermarks().await.unwrap();
+    let mut snapshot = fixture.snapshot.clone();
+    if let Some(pb::fragment_metadata_tree::Root::InlineRoot(root)) = &mut snapshot.root {
+        root.children[0].min_key = 6;
+    } else {
+        panic!("expected inline root");
+    }
+    let error = FragmentMetadataTree::open_snapshot(
+        fixture.store.clone(),
+        fixture.base.clone(),
+        fixture.scheduler.clone(),
+        Arc::new(LanceCache::with_capacity(0)),
+        &snapshot,
+        fixture.tree.version(),
+        fixture.config.clone(),
+        fixture.tree.next_fragment_id(),
+    )
+    .await
+    .err()
+    .expect("a first fence above the parent's must not open");
+    assert!(matches!(error, Error::CorruptFile { .. }), "{error}");
+}
+
+#[rstest]
+#[case::point("point")]
+#[case::stream("stream")]
+#[case::offset("offset")]
+#[tokio::test]
+async fn mutation_at_or_below_its_leaf_watermark_is_rejected(#[case] read: &str) {
+    let policy = SnapshotPolicy::default();
+    let config = FragmentMetadataTreeConfig::default()
+        .with_max_leaf_bytes(4096)
+        .with_semantic_buffer_bytes(1);
+    let mut fixture = Fixture::new(64, config, policy).await;
+    let target = 40;
+    fixture
+        .commit(
+            vec![action::add_fragment(&make_fragment_with_files(target, 4))],
+            policy,
+            true,
+        )
+        .await;
+    let mut snapshot = fixture.snapshot.clone();
+    let Some(pb::fragment_metadata_tree::Root::InlineRoot(root)) = &mut snapshot.root else {
+        panic!("expected inline root");
+    };
+    let leaf = &root.children[node::child_index_for(&root.children, target)];
+    assert!(leaf.materialized_through_action_sequence >= 1);
+    root.buffer.push(pb::FragmentMetadataMutation {
+        action_sequence: leaf.materialized_through_action_sequence,
+        action: Some(action::clear_deletion_file(target)),
+        fragment_count_delta: 0,
+        total_rows_delta: 0,
+        visible_rows_delta: 0,
+    });
+    let tree = fixture.open(&snapshot, fixture.tree.version()).await;
+    let error = match read {
+        "point" => tree.resolve_fragment(target).await.err(),
+        "stream" => tree.iter_fragments().try_collect::<Vec<_>>().await.err(),
+        _ => tree.fragment_at_row_offset(target).await.err(),
+    }
+    .expect("a mutation at the watermark must not replay");
+    assert!(matches!(error, Error::CorruptFile { .. }), "{error}");
+    assert!(error.to_string().contains("watermark"), "{error}");
+}

--- a/rust/lance-table/src/fragment_metadata/validation.rs
+++ b/rust/lance-table/src/fragment_metadata/validation.rs
@@ -1,0 +1,237 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+//! Validate persisted metadata before routing or replay can discard information.
+
+use std::collections::BTreeSet;
+
+use lance_core::{Error, Result};
+
+use super::{action, node};
+use crate::format::{Fragment, pb};
+use pb::fragment_action::Action;
+
+pub(super) fn corrupt(message: impl Into<String>) -> Error {
+    Error::corrupt_file_named("Fragment metadata", message.into())
+}
+
+/// Counts in this format are always known, including zero. The shared flat
+/// protobuf conversion treats zero as a legacy unknown count.
+pub(super) fn fragment(encoded: pb::DataFragment) -> Result<Fragment> {
+    let rows = usize::try_from(encoded.physical_rows)
+        .map_err(|_| corrupt(format!("fragment {} row count exceeds usize", encoded.id)))?;
+    let deleted = encoded
+        .deletion_file
+        .as_ref()
+        .map(|file| file.num_deleted_rows);
+    if encoded.id > u64::from(u32::MAX)
+        || deleted.is_some_and(|count| count > encoded.physical_rows)
+    {
+        return Err(corrupt(format!(
+            "fragment {} has physical_rows={}, deleted_rows={deleted:?}",
+            encoded.id, encoded.physical_rows,
+        )));
+    }
+    let mut fragment = Fragment::try_from(encoded)?;
+    fragment.physical_rows = Some(rows);
+    if let Some(file) = &mut fragment.deletion_file {
+        file.num_deleted_rows = deleted.map(|count| count as usize);
+    }
+    Ok(fragment)
+}
+
+pub(super) fn action(encoded: &pb::FragmentAction) -> Result<u64> {
+    let id = action::target_frag_id(encoded)
+        .ok_or_else(|| corrupt("Buffered action has no recognized variant"))?;
+    if id > u64::from(u32::MAX) {
+        return Err(corrupt(format!(
+            "Buffered action Fragment ID {id} exceeds u32"
+        )));
+    }
+    match &encoded.action {
+        Some(Action::AddFragment(value)) => {
+            fragment(value.clone())?;
+        }
+        Some(Action::AddDataFile(value)) if value.file.is_none() => {
+            return Err(corrupt(format!(
+                "AddDataFile for fragment {id} has no file"
+            )));
+        }
+        Some(Action::ReplaceDataFile(value))
+            if value.expected_path.is_empty() || value.path.is_empty() =>
+        {
+            return Err(corrupt(format!(
+                "ReplaceDataFile for fragment {id} is missing expected_path or path"
+            )));
+        }
+        Some(Action::AddDeletionFile(value)) if value.deletion_file.is_none() => {
+            return Err(corrupt(format!(
+                "AddDeletionFile for fragment {id} has no file"
+            )));
+        }
+        _ => {}
+    }
+    Ok(id)
+}
+
+pub(super) fn buffer(
+    actions: &[pb::FragmentMetadataMutation],
+    first_action_sequence: u64,
+    next_action_sequence: u64,
+) -> Result<()> {
+    let mut seen = BTreeSet::new();
+    for tagged in actions {
+        if tagged.action_sequence < first_action_sequence
+            || tagged.action_sequence >= next_action_sequence
+            || !seen.insert(tagged.action_sequence)
+        {
+            return Err(corrupt(format!(
+                "Buffered action sequence number {} is duplicated or outside [{first_action_sequence}, {next_action_sequence})",
+                tagged.action_sequence,
+            )));
+        }
+        action(tagged.action.as_ref().ok_or_else(|| {
+            corrupt(format!(
+                "Buffered action sequence number {} has no action",
+                tagged.action_sequence
+            ))
+        })?)?;
+    }
+    Ok(())
+}
+
+/// `lower_bound` is the range start the parent assigned to this list. It is 0
+/// for the root and the parent's entry for an interior.
+pub(super) fn children(
+    children: &[pb::FragmentMetadataChild],
+    next_action_sequence: u64,
+    lower_bound: u64,
+) -> Result<()> {
+    let mut paths = BTreeSet::new();
+    for (index, child) in children.iter().enumerate() {
+        if (index == 0 && child.min_key != lower_bound)
+            || child.path.is_empty()
+            || !paths.insert(&child.path)
+            || child.min_key > u64::from(u32::MAX)
+            || child.object_size == 0
+            || child.visible_rows > child.total_rows
+            || child.height != children[0].height
+            || child.height == u32::MAX
+            || (child.height == 0
+                && (child.num_keys == 0
+                    || child.num_children != 0
+                    || child.materialized_through_action_sequence >= next_action_sequence))
+            || (child.height > 0
+                && (child.num_children < 2 || child.materialized_through_action_sequence != 0))
+            || (index > 0 && children[index - 1].min_key >= child.min_key)
+        {
+            return Err(corrupt(format!(
+                "Invalid child reference at position {index}: {child:?}"
+            )));
+        }
+    }
+    Ok(())
+}
+
+/// Validate the root and derive its fragment, physical-row and visible-row
+/// totals. `next_fragment_id` comes from the Version Manifest's high-water mark.
+pub(super) fn root(
+    root: &pb::FragmentMetadataRoot,
+    next_fragment_id: u64,
+) -> Result<(u64, u64, u64)> {
+    if root.next_action_sequence == 0 {
+        return Err(corrupt("Root next_action_sequence must be at least 1"));
+    }
+    children(&root.children, root.next_action_sequence, 0)?;
+    buffer(&root.buffer, 1, root.next_action_sequence)?;
+    let summary = node::internal_ref(String::new(), &root.children, &root.buffer, 0)?;
+    if summary.visible_rows > summary.total_rows {
+        return Err(corrupt(
+            "Root visible rows exceed physical rows derived from children and buffer",
+        ));
+    }
+    if next_fragment_id == 0 {
+        if !root.children.is_empty() || !root.buffer.is_empty() {
+            return Err(corrupt(
+                "Tree names fragment state but Manifest.max_fragment_id is absent",
+            ));
+        }
+    } else if root
+        .buffer
+        .iter()
+        .any(|tagged| node::action_key(tagged) >= next_fragment_id)
+    {
+        return Err(corrupt(format!(
+            "Root contains a fragment beyond allocation high-water mark {next_fragment_id}"
+        )));
+    }
+    Ok((summary.num_keys, summary.total_rows, summary.visible_rows))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rstest::rstest;
+
+    #[test]
+    fn rejects_height_overflow_without_panicking() {
+        let root = pb::FragmentMetadataRoot {
+            next_action_sequence: 1,
+            children: vec![pb::FragmentMetadataChild {
+                path: "_bt/node/overflow.node".into(),
+                height: u32::MAX,
+                num_children: 2,
+                object_size: 1,
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+        let error = super::root(&root, 1).unwrap_err();
+        assert!(matches!(error, Error::CorruptFile { .. }), "{error}");
+        assert!(error.to_string().contains("height"), "{error}");
+    }
+
+    #[rstest]
+    #[case::missing_payload(None)]
+    #[case::missing_variant(Some(pb::FragmentAction { action: None }))]
+    #[case::missing_file(Some(pb::FragmentAction { action: Some(Action::AddDataFile(pb::AddDataFile { frag_id: 1, file: None })) }))]
+    fn rejects_incomplete_actions(#[case] action: Option<pb::FragmentAction>) {
+        let error = buffer(
+            &[pb::FragmentMetadataMutation {
+                action_sequence: 1,
+                action,
+                ..Default::default()
+            }],
+            1,
+            2,
+        )
+        .unwrap_err();
+        assert!(matches!(error, Error::CorruptFile { .. }), "{error}");
+    }
+
+    #[test]
+    fn sequence_numbers_may_have_gaps_but_must_be_unique() {
+        let make = |action_sequence| pb::FragmentMetadataMutation {
+            action_sequence,
+            action: Some(action::remove_fragment(1)),
+            ..Default::default()
+        };
+        buffer(&[make(5), make(2)], 1, 6).unwrap();
+        for actions in [vec![make(2), make(2)], vec![make(0)], vec![make(6)]] {
+            let error = buffer(&actions, 1, 6).unwrap_err();
+            assert!(matches!(error, Error::CorruptFile { .. }), "{error}");
+            assert!(error.to_string().contains("action sequence number"));
+        }
+    }
+
+    #[test]
+    fn zero_is_a_known_row_count() {
+        let fragment = fragment(pb::DataFragment {
+            id: 1,
+            ..Default::default()
+        })
+        .unwrap();
+        assert_eq!(fragment.physical_rows, Some(0));
+        assert_eq!(fragment.num_rows(), Some(0));
+    }
+}

--- a/rust/lance-table/src/lib.rs
+++ b/rust/lance-table/src/lib.rs
@@ -3,6 +3,8 @@
 
 pub mod feature_flags;
 pub mod format;
+/// Immutable fragment metadata with buffered updates.
+pub mod fragment_metadata;
 pub mod io;
 pub mod rowids;
 pub mod system_index;

--- a/rust/lance/Cargo.toml
+++ b/rust/lance/Cargo.toml
@@ -105,6 +105,7 @@ pprof.workspace = true
 lzma-sys = { version = "0.1" }
 
 [dev-dependencies]
+lance-table = { workspace = true, features = ["test-util"] }
 lance-test-macros = { workspace = true }
 lance-datagen = { workspace = true }
 lance-datafusion = { workspace = true, features = ["datagen"] }

--- a/rust/lance/src/dataset.rs
+++ b/rust/lance/src/dataset.rs
@@ -30,8 +30,8 @@ use lance_file::versions as file_versions;
 use lance_index::{IndexType, progress::IndexBuildProgress};
 use lance_io::object_store::{
     ChainedWrappingObjectStore, LanceNamespaceStorageOptionsProvider, ObjectStore,
-    ObjectStoreParams, StorageOptions, StorageOptionsAccessor, StorageOptionsProvider,
-    WrappingObjectStore,
+    ObjectStoreParams, ObjectStoreRegistry, StorageOptions, StorageOptionsAccessor,
+    StorageOptionsProvider, WrappingObjectStore,
 };
 use lance_io::scheduler::{ScanScheduler, SchedulerConfig};
 use lance_io::utils::{
@@ -73,6 +73,10 @@ mod data_file;
 pub mod delta;
 pub mod files;
 pub mod fragment;
+pub mod fragment_metadata;
+pub mod fragment_source;
+mod lazy;
+pub use lazy::LazyDataset;
 mod hash_joiner;
 pub mod index;
 pub mod mem_wal;
@@ -249,6 +253,8 @@ pub struct Dataset {
     /// Object stores for additional base paths, normally shared across clones.
     /// Applying new object store wrappers starts a fresh cache scope.
     pub(crate) base_object_stores: BaseObjectStores,
+    /// Immutable external fragment state for this manifest version.
+    pub(crate) lazy_fragments: Option<Arc<fragment_source::LazyFragments>>,
 }
 
 /// The `OnceCell` coalesces concurrent first resolutions into one build.
@@ -555,25 +561,38 @@ impl Dataset {
     /// Check out the latest version of the dataset
     pub async fn checkout_latest(&mut self) -> Result<()> {
         let (manifest, manifest_location) = self.latest_manifest().await?;
-        self.set_manifest(manifest, manifest_location);
+        self.set_manifest(manifest, manifest_location).await?;
         Ok(())
     }
 
     /// Replace the manifest, refreshing derived state. Base stores are kept
     /// when `base_paths` is unchanged.
-    fn set_manifest(&mut self, manifest: Arc<Manifest>, manifest_location: ManifestLocation) {
+    async fn set_manifest(
+        &mut self,
+        manifest: Arc<Manifest>,
+        manifest_location: ManifestLocation,
+    ) -> Result<()> {
+        let mut replacement = self.clone();
         if manifest.base_paths != self.manifest.base_paths {
-            self.base_object_stores = Default::default();
+            replacement.base_object_stores = Default::default();
         }
-        self.manifest = manifest;
-        self.manifest_location = manifest_location;
-        self.fragment_bitmap = Arc::new(
-            self.manifest
+        replacement.manifest = manifest;
+        replacement.manifest_location = manifest_location;
+        replacement.lazy_fragments = None;
+        replacement.fragment_bitmap = Arc::new(
+            replacement
+                .manifest
                 .fragments
                 .iter()
                 .map(|f| f.id as u32)
                 .collect(),
         );
+        replacement = replacement.attach_fragment_source().await?;
+        if self.lazy_fragments.is_none() {
+            replacement.hydrate_fragments_for_maintenance().await?;
+        }
+        *self = replacement;
+        Ok(())
     }
 
     /// Check out the latest version of the branch
@@ -719,7 +738,7 @@ impl Dataset {
             )));
         }
 
-        Self::checkout_manifest(
+        let mut dataset = Self::checkout_manifest(
             self.object_store.clone(),
             new_location.path,
             new_location.uri,
@@ -730,7 +749,13 @@ impl Dataset {
             self.file_reader_options.clone(),
             self.store_params.as_deref().cloned(),
             self.base_store_params.clone(),
-        )
+        )?
+        .attach_fragment_source()
+        .await?;
+        if self.lazy_fragments.is_none() {
+            dataset.hydrate_fragments_for_maintenance().await?;
+        }
+        Ok(dataset)
     }
 
     pub(crate) async fn load_manifest(
@@ -929,7 +954,102 @@ impl Dataset {
             store_params: store_params.map(Box::new),
             base_store_params,
             base_object_stores: Default::default(),
+            lazy_fragments: None,
         })
+    }
+
+    pub(crate) fn with_prepared_tree(
+        mut self,
+        tree: lance_table::fragment_metadata::FragmentMetadataTree,
+    ) -> Self {
+        self.lazy_fragments = Some(Arc::new(fragment_source::LazyFragments::new(Arc::new(
+            tree,
+        ))));
+        self
+    }
+
+    pub(crate) async fn attach_fragment_source(self) -> Result<Self> {
+        if self.manifest.fragment_metadata.is_none() {
+            return Ok(self);
+        }
+        let mut tree = fragment_metadata::tree_from_manifest(
+            self.object_store.clone(),
+            self.base.clone(),
+            &self.manifest,
+        )
+        .await?;
+        tree.set_foreign_bases(self.tree_foreign_bases().await?);
+        Ok(self.with_prepared_tree(tree))
+    }
+
+    async fn tree_foreign_bases(
+        &self,
+    ) -> Result<std::collections::HashMap<u32, (Arc<ObjectStore>, Path)>> {
+        self.tree_foreign_bases_for(&self.manifest).await
+    }
+
+    pub(crate) async fn tree_foreign_bases_for(
+        &self,
+        manifest: &Manifest,
+    ) -> Result<std::collections::HashMap<u32, (Arc<ObjectStore>, Path)>> {
+        Self::resolve_tree_foreign_bases(
+            self.session.store_registry(),
+            &self.uri,
+            &self.object_store,
+            manifest,
+            Some(self),
+        )
+        .await
+    }
+
+    /// Resolve dataset-root bases named by `manifest`.
+    ///
+    /// Call this before writing a Version Manifest. A later failure would report
+    /// an error after that version is already visible.
+    pub(crate) async fn resolve_tree_foreign_bases(
+        registry: Arc<ObjectStoreRegistry>,
+        uri: &str,
+        store: &Arc<ObjectStore>,
+        manifest: &Manifest,
+        source: Option<&Self>,
+    ) -> Result<std::collections::HashMap<u32, (Arc<ObjectStore>, Path)>> {
+        let mut foreign = std::collections::HashMap::new();
+        for (id, base_path) in &manifest.base_paths {
+            if !base_path.is_dataset_root {
+                continue;
+            }
+            let path = base_path.extract_path(registry.clone())?;
+            let resolved = if base_path.path == uri || base_path.path.starts_with("memory:") {
+                store.clone()
+            } else if let Some(dataset) = source {
+                if dataset.manifest.base_paths.get(id) == Some(base_path) {
+                    dataset.base_object_store(*id).await?
+                } else {
+                    let params = dataset.store_params_for_base(Some(base_path));
+                    ObjectStore::from_uri_and_params(registry.clone(), &base_path.path, &params)
+                        .await?
+                        .0
+                }
+            } else {
+                ObjectStore::from_uri_and_params(
+                    registry.clone(),
+                    &base_path.path,
+                    &ObjectStoreParams::default(),
+                )
+                .await?
+                .0
+            };
+            foreign.insert(*id, (resolved, path));
+        }
+        Ok(foreign)
+    }
+
+    /// Where scans get fragments: the manifest list, or the fragment metadata tree.
+    pub fn fragment_source(&self) -> fragment_source::FragmentSource {
+        match &self.lazy_fragments {
+            Some(lazy) => fragment_source::FragmentSource::Lazy(lazy.clone()),
+            None => fragment_source::FragmentSource::Manifest(self.manifest.fragments.clone()),
+        }
     }
 
     /// Write to or Create a [Dataset] with a stream of [RecordBatch]s.
@@ -1657,6 +1777,29 @@ impl Dataset {
         write_config: &ManifestWriteConfig,
         commit_config: &CommitConfig,
     ) -> Result<()> {
+        if fragment_metadata::dataset_uses_fragment_metadata(&self.manifest) {
+            let mut committed = fragment_metadata::execute_commit(
+                fragment_metadata::CommitTarget {
+                    context: Some(Arc::new(self.clone())),
+                    materialize_fragments: self.lazy_fragments.is_none(),
+                    object_store: self.object_store.clone(),
+                    base_path: self.base.clone(),
+                    uri: self.uri.clone(),
+                    session: self.session.clone(),
+                    commit_handler: self.commit_handler.clone(),
+                },
+                commit_config,
+                &transaction,
+                None,
+                write_config,
+            )
+            .await?;
+            if self.lazy_fragments.is_none() {
+                committed.hydrate_fragments_for_maintenance().await?;
+            }
+            *self = committed;
+            return Ok(());
+        }
         let (manifest, manifest_location) = commit_transaction(
             self,
             self.object_store.as_ref(),
@@ -1670,7 +1813,8 @@ impl Dataset {
         )
         .await?;
 
-        self.set_manifest(Arc::new(manifest), manifest_location);
+        self.set_manifest(Arc::new(manifest), manifest_location)
+            .await?;
 
         Ok(())
     }
@@ -1700,6 +1844,10 @@ impl Dataset {
     }
 
     pub(crate) async fn count_all_rows(&self) -> Result<usize> {
+        if let Some(lazy) = &self.lazy_fragments {
+            return usize::try_from(lazy.tree().count_visible_rows())
+                .map_err(|_| Error::invalid_input("Visible row count does not fit usize"));
+        }
         let cnts = stream::iter(self.get_fragments())
             .map(|f| async move { f.count_rows(None).await })
             .buffer_unordered(16)
@@ -1715,6 +1863,7 @@ impl Dataset {
         row_indices: &[u64],
         projection: impl Into<ProjectionRequest>,
     ) -> Result<RecordBatch> {
+        self.fragment_source().materialized("take by row offset")?;
         take::take(self, row_indices, projection.into()).await
     }
 
@@ -1757,6 +1906,7 @@ impl Dataset {
         row_ids: &[u64],
         projection: impl Into<ProjectionRequest>,
     ) -> Result<RecordBatch> {
+        self.fragment_source().materialized("take by row id")?;
         Arc::new(self.clone())
             .take_builder(row_ids, projection)?
             .execute()
@@ -1856,7 +2006,7 @@ impl Dataset {
         row_indices: &[u64],
         column: impl AsRef<str>,
     ) -> Result<Vec<Option<BlobFile>>> {
-        let fragments = self.get_fragments();
+        let fragments = self.get_fragments_async().await?;
         let row_addrs = row_offsets_to_row_addresses(&fragments, row_indices).await?;
         blob::take_blobs_by_addresses(self, &row_addrs, column.as_ref()).await
     }
@@ -2037,6 +2187,10 @@ impl Dataset {
     }
 
     pub async fn count_deleted_rows(&self) -> Result<usize> {
+        if let Some(lazy) = &self.lazy_fragments {
+            return usize::try_from(lazy.tree().count_rows() - lazy.tree().count_visible_rows())
+                .map_err(|_| Error::invalid_input("Deleted row count does not fit usize"));
+        }
         futures::stream::iter(self.get_fragments())
             .map(|f| async move { f.count_deletions().await })
             .buffer_unordered(self.object_store.io_parallelism())
@@ -2059,6 +2213,16 @@ impl Dataset {
         cloned.base_object_stores = Default::default();
         if let Some(store_params) = store_params {
             cloned.store_params = Some(Box::new(store_params));
+        }
+        if let Some(lazy) = &cloned.lazy_fragments {
+            let tree = lazy
+                .tree()
+                .as_ref()
+                .clone()
+                .with_object_store(cloned.object_store.clone());
+            cloned.lazy_fragments = Some(Arc::new(fragment_source::LazyFragments::new(Arc::new(
+                tree,
+            ))));
         }
         cloned
     }
@@ -2111,6 +2275,16 @@ impl Dataset {
                     .collect(),
             )
         });
+        if let Some(lazy) = &cloned.lazy_fragments {
+            let tree = lazy
+                .tree()
+                .as_ref()
+                .clone()
+                .with_object_store(cloned.object_store.clone());
+            cloned.lazy_fragments = Some(Arc::new(fragment_source::LazyFragments::new(Arc::new(
+                tree,
+            ))));
+        }
         cloned
     }
 
@@ -2722,7 +2896,10 @@ impl Dataset {
     }
 
     pub fn count_fragments(&self) -> usize {
-        self.manifest.fragments.len()
+        self.lazy_fragments.as_ref().map_or_else(
+            || self.manifest.fragments.len(),
+            |lazy| lazy.tree().count_fragments() as usize,
+        )
     }
 
     /// Get the schema of the dataset
@@ -2741,7 +2918,8 @@ impl Dataset {
         Projection::full(self.clone())
     }
 
-    /// Get fragments.
+    /// Get all fragments. Ordinary dataset opens materialize external metadata
+    /// so this synchronous API retains its behavior across layouts.
     pub fn get_fragments(&self) -> Vec<FileFragment> {
         let dataset = Arc::new(self.clone());
         self.manifest
@@ -2751,14 +2929,111 @@ impl Dataset {
             .collect()
     }
 
+    /// Resolve every Fragment through its metadata backend. This explicitly
+    /// materializes the full list; use [`Self::fragment_source`] for streaming
+    /// or selective metadata access.
+    ///
+    /// ```
+    /// # use lance::{Dataset, Result};
+    /// # async fn example(dataset: &Dataset) -> Result<()> {
+    /// let fragments = dataset.get_fragments_async().await?;
+    /// assert_eq!(fragments.len(), dataset.count_fragments());
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn get_fragments_async(&self) -> Result<Vec<FileFragment>> {
+        let dataset = Arc::new(self.clone());
+        self.fragment_source()
+            .stream()
+            .map_ok(|fragment| FileFragment::new(dataset.clone(), fragment))
+            .try_collect()
+            .await
+    }
+
+    /// Populate metadata for APIs that require resident fragments. Install the
+    /// list and derived offsets together, after every metadata read succeeds.
+    pub(crate) async fn hydrate_fragments_for_maintenance(&mut self) -> Result<()> {
+        let Some(lazy) = &self.lazy_fragments else {
+            return Ok(());
+        };
+        let fragments: Vec<_> = lazy
+            .tree()
+            .clone()
+            .fragment_stream_with_prefetch(self.object_store.io_parallelism())
+            .try_collect()
+            .await?;
+        self.set_materialized_fragments(fragments);
+        Ok(())
+    }
+
+    pub(crate) fn set_materialized_fragments(&mut self, fragments: Vec<Fragment>) {
+        let bitmap = fragments
+            .iter()
+            .map(|fragment| fragment.id as u32)
+            .collect();
+        let mut manifest = self.manifest.as_ref().clone();
+        manifest.set_fragments(fragments);
+        self.manifest = Arc::new(manifest);
+        self.fragment_bitmap = Arc::new(bitmap);
+        self.lazy_fragments = None;
+    }
+
     /// Iterate over manifest fragments without allocating [`FileFragment`] wrappers.
     pub fn iter_fragments(&self) -> impl Iterator<Item = &Fragment> {
         self.manifest.fragments.iter()
     }
 
+    /// The fragments with these ids as [`FileFragment`]s, resolved through
+    /// the lazy source when the manifest list is not in memory. Reads are
+    /// proportional to the requested ids, never the table.
+    pub(crate) async fn file_fragments_for_ids(
+        &self,
+        fragment_ids: &[u64],
+    ) -> Result<Vec<FileFragment>> {
+        let dataset = Arc::new(self.clone());
+        if let Some(lazy) = &self.lazy_fragments {
+            let bitmap: RoaringBitmap = fragment_ids
+                .iter()
+                .map(|id| {
+                    u32::try_from(*id).map_err(|_| {
+                        Error::invalid_input(format!(
+                            "Fragment ID {id} exceeds Lance's u32 address space"
+                        ))
+                    })
+                })
+                .collect::<Result<_>>()?;
+            return Ok(lazy
+                .tree()
+                .resolve_fragments_concurrent(&bitmap, 8)
+                .await?
+                .into_iter()
+                .map(|fragment| FileFragment::new(dataset.clone(), fragment))
+                .collect());
+        }
+        Ok(self
+            .manifest
+            .fragments
+            .iter()
+            .filter(|fragment| fragment_ids.contains(&fragment.id))
+            .map(|fragment| FileFragment::new(dataset.clone(), fragment.clone()))
+            .collect())
+    }
+
     pub fn get_fragment(&self, fragment_id: usize) -> Option<FileFragment> {
         let metadata = self.find_fragment(fragment_id as u64)?.clone();
         Some(FileFragment::new(Arc::new(self.clone()), metadata))
+    }
+
+    /// Resolve a Fragment by its ID without loading unrelated metadata.
+    pub async fn get_fragment_async(&self, fragment_id: usize) -> Result<Option<FileFragment>> {
+        if let Some(lazy) = &self.lazy_fragments {
+            return Ok(lazy
+                .tree()
+                .resolve_fragment(fragment_id as u64)
+                .await?
+                .map(|metadata| FileFragment::new(Arc::new(self.clone()), metadata)));
+        }
+        Ok(self.get_fragment(fragment_id))
     }
 
     pub fn fragments(&self) -> &Arc<Vec<Fragment>> {
@@ -2916,7 +3191,22 @@ impl Dataset {
             .map(|addr| RowAddress::from(*addr).fragment_id())
             .dedup()
             .collect::<Vec<_>>();
-        let frags = self.get_frags_from_ordered_ids(&referenced_frag_ids);
+        let resolved = self
+            .file_fragments_for_ids(
+                &referenced_frag_ids
+                    .iter()
+                    .map(|id| u64::from(*id))
+                    .collect::<Vec<_>>(),
+            )
+            .await?;
+        let by_id: BTreeMap<_, _> = resolved
+            .into_iter()
+            .map(|fragment| (fragment.id(), fragment))
+            .collect();
+        let frags: Vec<_> = referenced_frag_ids
+            .iter()
+            .map(|id| by_id.get(&(*id as usize)))
+            .collect();
         let dv_futs = frags
             .iter()
             .map(|frag| {
@@ -3046,48 +3336,26 @@ impl Dataset {
     }
 
     pub async fn validate(&self) -> Result<()> {
-        // All fragments have unique ids
-        let id_counts =
-            self.manifest
-                .fragments
-                .iter()
-                .map(|f| f.id)
-                .fold(HashMap::new(), |mut acc, id| {
-                    *acc.entry(id).or_insert(0) += 1;
-                    acc
-                });
-        for (id, count) in id_counts {
-            if count > 1 {
-                return Err(Error::corrupt_file(
-                    self.base.clone(),
-                    format!(
-                        "Duplicate fragment id {} found in dataset {:?}",
-                        id, self.base
-                    ),
-                ));
-            }
-        }
-
-        // Fragments are sorted in increasing fragment id order
-        self.manifest
-            .fragments
-            .iter()
-            .map(|f| f.id)
-            .try_fold(0, |prev, id| {
-                if id < prev {
-                    Err(Error::corrupt_file(self.base.clone(), format!(
-                        "Fragment ids are not sorted in increasing fragment-id order. Found {} after {} in dataset {:?}",
-                        id, prev, self.base
-                    )))
+        let dataset = Arc::new(self.clone());
+        let mut previous_id = None;
+        self.fragment_source()
+            .stream()
+            .map_ok(move |fragment| {
+                let result = if previous_id.is_some_and(|id| fragment.id <= id) {
+                    Err(Error::corrupt_file(
+                        dataset.base.clone(),
+                        format!(
+                            "Fragment ids must be unique and increasing: {:?} followed by {}",
+                            previous_id, fragment.id
+                        ),
+                    ))
                 } else {
-                    Ok(id)
-                }
-            })?;
-
-        // All fragments have equal lengths
-        futures::stream::iter(self.get_fragments())
-            .map(|f| async move { f.validate().await })
-            .buffer_unordered(self.object_store.io_parallelism())
+                    Ok(FileFragment::new(dataset.clone(), fragment.clone()))
+                };
+                previous_id = Some(fragment.id);
+                async move { result?.validate().await }
+            })
+            .try_buffer_unordered(self.object_store.io_parallelism())
             .try_collect::<Vec<()>>()
             .await?;
 
@@ -3442,7 +3710,8 @@ impl Dataset {
     /// Collect all (relative_path, path) of the dataset files.
     async fn collect_paths(&self) -> Result<Vec<(String, Path)>> {
         let mut file_paths: Vec<(String, Path)> = Vec::new();
-        for fragment in self.manifest.fragments.iter() {
+        let mut fragments = self.fragment_source().stream();
+        while let Some(fragment) = fragments.try_next().await? {
             if let Some(RowIdMeta::External(external_file)) = &fragment.row_id_meta {
                 return Err(Error::internal(format!(
                     "External row_id_meta is not supported yet. external file path: {}",
@@ -3618,7 +3887,9 @@ pub(crate) fn load_new_transactions(dataset: &Dataset) -> NewTransactionResult<'
                 dataset.file_reader_options.clone(),
                 dataset.store_params.as_deref().cloned(),
                 dataset.base_store_params.clone(),
-            )
+            )?
+            .attach_fragment_source()
+            .await
         } else {
             // If we didn't get the latest manifest, we can still return the dataset
             // with the current manifest.
@@ -3738,7 +4009,7 @@ impl Dataset {
 
         // Write new data file to each fragment. Parallelism is done over columns,
         // so no parallelism done at this level.
-        let updated_fragments: Vec<Fragment> = stream::iter(self.get_fragments())
+        let updated_fragments: Vec<Fragment> = stream::iter(self.get_fragments_async().await?)
             .then(|f| {
                 let joiner = joiner.clone();
                 async move { f.merge(left_on, &joiner).await.map(|f| f.metadata) }

--- a/rust/lance/src/dataset/blob.rs
+++ b/rust/lance/src/dataset/blob.rs
@@ -4398,7 +4398,8 @@ async fn resolve_blob_read_location(
     }
 
     let frag = dataset
-        .get_fragment(frag_id as usize)
+        .get_fragment_async(frag_id as usize)
+        .await?
         .ok_or_else(|| Error::internal("Fragment not found".to_string()))?;
     let data_file = frag
         .data_file_for_field(blob_field_id)

--- a/rust/lance/src/dataset/builder.rs
+++ b/rust/lance/src/dataset/builder.rs
@@ -630,8 +630,30 @@ impl DatasetBuilder {
             .await
     }
 
-    #[instrument(skip_all)]
+    /// Load a dataset with resident metadata for the synchronous fragment APIs.
     pub async fn load(self) -> Result<Dataset> {
+        let mut dataset = self.load_unmaterialized().await?;
+        dataset.hydrate_fragments_for_maintenance().await?;
+        Ok(dataset)
+    }
+
+    /// Load metadata on demand. Use [`super::LazyDataset::into_dataset`] when
+    /// an operation needs the complete fragment list.
+    ///
+    /// ```
+    /// # use lance::{dataset::builder::DatasetBuilder, Result};
+    /// # async fn example(uri: &str) -> Result<()> {
+    /// let dataset = DatasetBuilder::from_uri(uri).load_lazy().await?;
+    /// let fragment = dataset.get_fragment(42).await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn load_lazy(self) -> Result<super::LazyDataset> {
+        Ok(super::LazyDataset::new(self.load_unmaterialized().await?))
+    }
+
+    #[instrument(skip_all)]
+    pub(crate) async fn load_unmaterialized(self) -> Result<Dataset> {
         let uri = self.table_uri.clone();
         let target_ref = self.version.clone();
         match self.load_impl().boxed().await {
@@ -804,7 +826,7 @@ impl DatasetBuilder {
             (base_path, table_uri)
         };
 
-        let dataset = Self::load_by_uri(
+        let dataset = Self::load_by_uri_unmaterialized(
             session,
             manifest,
             file_reader_options,
@@ -868,6 +890,36 @@ impl DatasetBuilder {
         store_params: Option<ObjectStoreParams>,
         base_store_params: Option<Arc<HashMap<String, ObjectStoreParams>>>,
     ) -> Result<Dataset> {
+        let mut dataset = Self::load_by_uri_unmaterialized(
+            session,
+            manifest,
+            file_reader_options,
+            table_uri,
+            version_number,
+            object_store,
+            base_path,
+            commit_handler,
+            store_params,
+            base_store_params,
+        )
+        .await?;
+        dataset.hydrate_fragments_for_maintenance().await?;
+        Ok(dataset)
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    async fn load_by_uri_unmaterialized(
+        session: Arc<Session>,
+        manifest: Option<Manifest>,
+        file_reader_options: Option<FileReaderOptions>,
+        table_uri: String,
+        version_number: Option<u64>,
+        object_store: Arc<ObjectStore>,
+        base_path: Path,
+        commit_handler: Arc<dyn CommitHandler>,
+        store_params: Option<ObjectStoreParams>,
+        base_store_params: Option<Arc<HashMap<String, ObjectStoreParams>>>,
+    ) -> Result<Dataset> {
         let (manifest, location) = if let Some(mut manifest) = manifest {
             ensure_can_read_manifest(&manifest)?;
             let location = commit_handler
@@ -879,37 +931,13 @@ impl DatasetBuilder {
             }
             (Arc::new(manifest), location)
         } else {
-            let manifest_location = match version_number {
-                Some(version) => {
-                    let target_manifest_result = commit_handler
-                        .resolve_version_location(&base_path, version, &object_store.inner)
-                        .await;
-                    // This may fail due to the uri is not the right branch
-                    // In this case we should try to load the latest version and checkout the right branch and version_number
-                    match target_manifest_result {
-                        Ok(manifest_location) => manifest_location,
-                        Err(e) => {
-                            if let Error::VersionNotFound { message: _ } = e {
-                                // If the version is not found, we need to try to load the latest version.
-                                commit_handler
-                                    .resolve_latest_location(&base_path, &object_store)
-                                    .await?
-                            } else {
-                                return Err(e);
-                            }
-                        }
-                    }
-                }
-                None => commit_handler
-                    .resolve_latest_location(&base_path, &object_store)
-                    .await
-                    .map_err(|e| match &e {
-                        Error::NotFound { .. } => {
-                            Error::dataset_not_found(base_path.to_string(), Box::new(e))
-                        }
-                        _ => e,
-                    })?,
-            };
+            let manifest_location = Self::resolve_manifest_location(
+                &commit_handler,
+                &base_path,
+                &object_store,
+                version_number,
+            )
+            .await?;
 
             let manifest = Dataset::get_manifest(
                 &object_store,
@@ -932,7 +960,49 @@ impl DatasetBuilder {
             file_reader_options,
             store_params,
             base_store_params,
-        )
+        )?
+        .attach_fragment_source()
+        .await
+    }
+
+    async fn resolve_manifest_location(
+        commit_handler: &Arc<dyn CommitHandler>,
+        base_path: &Path,
+        object_store: &Arc<ObjectStore>,
+        version_number: Option<u64>,
+    ) -> Result<lance_table::io::commit::ManifestLocation> {
+        let manifest_location = match version_number {
+            Some(version) => {
+                let target_manifest_result = commit_handler
+                    .resolve_version_location(base_path, version, &object_store.inner)
+                    .await;
+                // This may fail due to the uri is not the right branch
+                // In this case we should try to load the latest version and checkout the right branch and version_number
+                match target_manifest_result {
+                    Ok(manifest_location) => manifest_location,
+                    Err(e) => {
+                        if let Error::VersionNotFound { message: _ } = e {
+                            // If the version is not found, we need to try to load the latest version.
+                            commit_handler
+                                .resolve_latest_location(base_path, object_store)
+                                .await?
+                        } else {
+                            return Err(e);
+                        }
+                    }
+                }
+            }
+            None => commit_handler
+                .resolve_latest_location(base_path, object_store)
+                .await
+                .map_err(|e| match &e {
+                    Error::NotFound { .. } => {
+                        Error::dataset_not_found(base_path.to_string(), Box::new(e))
+                    }
+                    _ => e,
+                })?,
+        };
+        Ok(manifest_location)
     }
 }
 

--- a/rust/lance/src/dataset/cleanup.rs
+++ b/rust/lance/src/dataset/cleanup.rs
@@ -51,7 +51,7 @@ use lance_core::{
     },
 };
 use lance_table::{
-    format::{IndexMetadata, Manifest},
+    format::{Fragment, IndexMetadata, Manifest, pb},
     io::{
         commit::ManifestLocation,
         deletion::deletion_file_path,
@@ -61,6 +61,7 @@ use lance_table::{
 use object_store::ObjectMeta;
 use object_store::path::Path;
 use std::fmt::Debug;
+use std::sync::Arc;
 use std::{
     collections::{HashMap, HashSet},
     future,
@@ -77,6 +78,7 @@ struct ReferencedFiles {
     delete_paths: HashSet<Path>,
     tx_paths: HashSet<Path>,
     index_uuids: HashSet<String>,
+    metadata_paths: HashSet<Path>,
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
@@ -149,6 +151,9 @@ pub enum CleanupFileKind {
     /// logs to match the long-standing cleanup behavior.  Their bytes
     /// are still included in `bytes_removed`.
     TemporaryManifest,
+    /// Tree metadata contributes to bytes removed, but not data-file or
+    /// version counts.
+    FragmentMetadata,
 }
 
 impl CleanupCandidateFile {
@@ -197,7 +202,7 @@ impl RemovalStats {
             CleanupFileKind::Transaction => self.transaction_files_removed += 1,
             CleanupFileKind::Index => self.index_files_removed += 1,
             CleanupFileKind::Deletion => self.deletion_files_removed += 1,
-            CleanupFileKind::TemporaryManifest => {}
+            CleanupFileKind::TemporaryManifest | CleanupFileKind::FragmentMetadata => {}
         }
     }
 
@@ -583,6 +588,7 @@ impl<'a> CleanupTask<'a> {
             }
             Err(error) => return Err(error),
         };
+        let tree_files = self.inspect_tree(&manifest).await?;
         // Don't delete the latest version, even if it is old. Don't delete tagged versions,
         // regardless of age. Don't delete manifests if their version is newer than the dataset
         // version.  These are either in-progress or newly added since we started.
@@ -590,6 +596,14 @@ impl<'a> CleanupTask<'a> {
         let is_tagged = tagged_versions.contains(&manifest.version);
         let in_working_set = is_latest || !self.policy.should_clean(&manifest) || is_tagged;
         let mut inspection = inspection.lock().unwrap();
+        let files = if in_working_set {
+            &mut inspection.referenced_files
+        } else {
+            &mut inspection.verified_files
+        };
+        files.data_paths.extend(tree_files.data_paths);
+        files.delete_paths.extend(tree_files.delete_paths);
+        files.metadata_paths.extend(tree_files.metadata_paths);
 
         // Track tagged old versions in case we want to return a `CleanupError` later.
         // Only track tagged when it is old.
@@ -621,6 +635,64 @@ impl<'a> CleanupTask<'a> {
         Ok(())
     }
 
+    async fn inspect_tree(&self, manifest: &Manifest) -> Result<ReferencedFiles> {
+        let mut files = ReferencedFiles::default();
+        let Some(snapshot) = &manifest.fragment_metadata else {
+            return Ok(files);
+        };
+        let mut tree = super::fragment_metadata::tree_from_manifest(
+            self.dataset.object_store.clone(),
+            self.dataset.base.clone(),
+            manifest,
+        )
+        .await?;
+        tree.set_foreign_bases(self.dataset.tree_foreign_bases_for(manifest).await?);
+        let tree = Arc::new(tree);
+        let mut paths = tree.node_paths().await?;
+        if let Some(pb::fragment_metadata_tree::Root::RootPath(path)) = &snapshot.root {
+            paths.push(path.clone());
+        }
+        for path in paths {
+            files.metadata_paths.insert(Path::from(path));
+        }
+        let mut fragments = tree.fragment_stream();
+        while let Some(fragment) = fragments.try_next().await? {
+            self.record_fragment(&fragment, &mut files);
+        }
+        Ok(files)
+    }
+
+    fn record_fragment(&self, fragment: &Fragment, referenced_files: &mut ReferencedFiles) {
+        for file in fragment.referenced_lance_files() {
+            let full_data_path = self.dataset.data_dir().clone().join(file.path.as_str());
+            referenced_files
+                .data_paths
+                .insert(remove_prefix(&full_data_path, &self.dataset.base));
+        }
+        if let Some(lance_table::format::RowIdMeta::External(slice)) = &fragment.row_id_meta {
+            referenced_files
+                .metadata_paths
+                .insert(Path::from(slice.path.as_str()));
+        }
+        for metadata in [
+            &fragment.created_at_version_meta,
+            &fragment.last_updated_at_version_meta,
+        ] {
+            if let Some(lance_table::format::RowDatasetVersionMeta::External(slice)) = metadata {
+                referenced_files
+                    .metadata_paths
+                    .insert(Path::from(slice.path.as_str()));
+            }
+        }
+
+        if let Some(deletion_file) = &fragment.deletion_file {
+            let path = deletion_file_path(&self.dataset.base, fragment.id, deletion_file);
+            referenced_files
+                .delete_paths
+                .insert(remove_prefix(&path, &self.dataset.base));
+        }
+    }
+
     fn process_manifest(
         &self,
         manifest: &Manifest,
@@ -637,19 +709,7 @@ impl<'a> CleanupTask<'a> {
         };
 
         for fragment in manifest.fragments.iter() {
-            for file in fragment.referenced_lance_files() {
-                let full_data_path = self.dataset.data_dir().clone().join(file.path.as_str());
-                let relative_data_path = remove_prefix(&full_data_path, &self.dataset.base);
-                referenced_files.data_paths.insert(relative_data_path);
-            }
-            let delpath = fragment
-                .deletion_file
-                .as_ref()
-                .map(|delfile| deletion_file_path(&self.dataset.base, fragment.id, delfile));
-            if let Some(delpath) = delpath {
-                let relative_path = remove_prefix(&delpath, &self.dataset.base);
-                referenced_files.delete_paths.insert(relative_path);
-            }
+            self.record_fragment(fragment, referenced_files);
         }
         if let Some(relative_tx_path) = &manifest.transaction_file {
             referenced_files
@@ -745,6 +805,7 @@ impl<'a> CleanupTask<'a> {
             // the proof when the old manifests are removed by this cleanup pass.
             build_listing_stream(self.dataset.indices_dir(), None),
             build_listing_stream(self.dataset.deletions_dir(), unmodified_since),
+            build_listing_stream(self.dataset.base.clone().join("_bt"), None),
         ];
         let unreferenced_files = stream::iter(streams).flatten().boxed();
 
@@ -785,7 +846,7 @@ impl<'a> CleanupTask<'a> {
                     CleanupFileKind::Index => {
                         info!(target: TRACE_FILE_AUDIT, mode=mode, r#type=AUDIT_TYPE_INDEX, path = path_str);
                     }
-                    CleanupFileKind::Transaction | CleanupFileKind::TemporaryManifest => {}
+                    CleanupFileKind::Transaction | CleanupFileKind::TemporaryManifest | CleanupFileKind::FragmentMetadata => {}
                 }
             }
             cleanup_result
@@ -895,6 +956,38 @@ impl<'a> CleanupTask<'a> {
         let path = obj_meta.location;
         let relative_path = remove_prefix(&path, &self.dataset.base);
         let size_bytes = obj_meta.size;
+        if inspection
+            .referenced_files
+            .metadata_paths
+            .contains(&relative_path)
+        {
+            return Ok(None);
+        }
+        let maybe_in_progress = maybe_in_progress
+            && !inspection
+                .verified_files
+                .metadata_paths
+                .contains(&relative_path);
+        if relative_path.as_ref().starts_with("_bt/") {
+            let referenced = inspection
+                .referenced_files
+                .metadata_paths
+                .contains(&relative_path);
+            let verified = inspection
+                .verified_files
+                .metadata_paths
+                .contains(&relative_path);
+            return Ok(if !referenced && (!maybe_in_progress || verified) {
+                cleanup_file(
+                    path,
+                    CleanupFileKind::FragmentMetadata,
+                    !verified,
+                    size_bytes,
+                )
+            } else {
+                None
+            });
+        }
         if relative_path.as_ref().starts_with("_versions/.tmp") {
             // This is a temporary manifest file.
             //
@@ -1227,6 +1320,7 @@ impl<'a> CleanupTask<'a> {
                 .try_for_each_concurrent(self.dataset.object_store.io_parallelism(), |location| {
                     self.process_branch_referenced_manifests(
                         location,
+                        &branch_location.path,
                         *root_version_number,
                         &inspection,
                     )
@@ -1239,17 +1333,30 @@ impl<'a> CleanupTask<'a> {
     async fn process_branch_referenced_manifests(
         &self,
         location: ManifestLocation,
+        branch_base: &Path,
         referenced_version: u64,
         inspection: &Mutex<CleanupInspection>,
     ) -> Result<()> {
         let manifest =
             read_manifest(&self.dataset.object_store, &location.path, location.size).await?;
+        let mut fragments = if manifest.fragment_metadata.is_some() {
+            let mut tree = super::fragment_metadata::tree_from_manifest(
+                self.dataset.object_store.clone(),
+                branch_base.clone(),
+                &manifest,
+            )
+            .await?;
+            tree.set_foreign_bases(self.dataset.tree_foreign_bases_for(&manifest).await?);
+            Arc::new(tree).fragment_stream()
+        } else {
+            futures::stream::iter(manifest.fragments.as_ref().clone().into_iter().map(Ok)).boxed()
+        };
         let indexes =
             read_manifest_indexes(&self.dataset.object_store, &location, &manifest).await?;
-        let mut inspection = inspection.lock().unwrap();
         let mut is_referenced = false;
 
-        for fragment in manifest.fragments.iter() {
+        while let Some(fragment) = fragments.try_next().await? {
+            let mut inspection = inspection.lock().unwrap();
             for file in fragment.referenced_lance_files() {
                 if let Some(base_id) = file.base_id {
                     let base_path = manifest.base_paths.get(&base_id);
@@ -1297,6 +1404,7 @@ impl<'a> CleanupTask<'a> {
                 }
             }
         }
+        let mut inspection = inspection.lock().unwrap();
         for index in indexes {
             if let Some(base_id) = index.base_id {
                 let base_path = manifest.base_paths.get(&base_id);
@@ -2977,6 +3085,7 @@ mod tests {
         }
         task.process_branch_referenced_manifests(
             branch.manifest_location.clone(),
+            &branch.base,
             root_version,
             &inspection,
         )

--- a/rust/lance/src/dataset/fragment_metadata.rs
+++ b/rust/lance/src/dataset/fragment_metadata.rs
@@ -674,6 +674,8 @@ mod differential;
 mod gate_tests;
 #[cfg(test)]
 mod publication_tests;
+#[cfg(test)]
+mod scan_tests;
 
 #[cfg(test)]
 mod tests {

--- a/rust/lance/src/dataset/fragment_metadata.rs
+++ b/rust/lance/src/dataset/fragment_metadata.rs
@@ -1,0 +1,914 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+//! Fragment metadata trees behind the production commit entry point.
+//!
+//! `lance.manifest.layout=tree` selects this layout at creation. The Version
+//! Manifest owns schema, configuration, transaction identity, and the
+//! snapshot: an inline root, or `_bt/base/{uuid}.root` plus
+//! `mutations_since_root`. Transaction files are for conflict detection.
+//! Opening a named version reads that manifest and at most one external root.
+//!
+//! This layout is unstable. Use a disposable dataset. The format may change
+//! without keeping compatibility with earlier revisions.
+
+use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use lance_core::utils::backoff::SlotBackoff;
+
+use lance_core::cache::LanceCache;
+use lance_core::{Error, Result};
+use lance_io::object_store::ObjectStore;
+use lance_io::scheduler::{ScanScheduler, SchedulerConfig};
+use lance_table::format::{Fragment, Manifest, pb};
+use lance_table::fragment_metadata::store::NodeStore;
+use lance_table::fragment_metadata::{
+    FragmentMetadataTree, FragmentMetadataTreeConfig, ManifestLayout, TouchedFragments,
+    data_replacement,
+};
+use lance_table::io::commit::{
+    CommitConfig, CommitHandler, ManifestLocation, ManifestNamingScheme,
+};
+use object_store::path::Path;
+use prost::Message;
+
+use lance_select::RowAddrTreeMap;
+use lance_table::io::deletion::read_deletion_file;
+
+use super::Dataset;
+use super::transaction::{DataReplacementGroup, Operation, Transaction};
+use crate::io::commit::{cleanup_transaction_file, write_transaction_file};
+use crate::session::Session;
+mod native;
+mod publication;
+#[cfg(test)]
+mod test_support;
+pub(crate) use publication::tree_from_manifest;
+
+/// Encoded node-size budget in bytes, read from Overwrite config at create time.
+pub const MAX_NODE_BYTES_KEY: &str = "lance.fragment_metadata.max_node_bytes";
+/// Encoded leaf-size budget in bytes, read from Overwrite config at create time.
+pub const MAX_LEAF_BYTES_KEY: &str = "lance.fragment_metadata.max_leaf_bytes";
+
+/// Materialization policy for fragment metadata commits.
+#[derive(Debug, Clone, Copy, Default)]
+pub enum Materialization {
+    /// Retain validated changes in buffers and flush under byte pressure.
+    #[default]
+    Buffered,
+    /// Merge the complete fragment state into new leaves in one ordered pass.
+    Bulk,
+}
+
+/// Creation-time options for external fragment metadata.
+///
+/// Tree and publication budgets measure different objects. Flat manifests remain the default.
+///
+/// ```
+/// # use lance::dataset::fragment_metadata::FragmentMetadataOptions;
+/// # fn example() -> lance::Result<()> {
+/// let config = FragmentMetadataOptions::default().into_table_config()?;
+/// assert_eq!(config["lance.manifest.layout"], "tree");
+/// # Ok(())
+/// # }
+/// ```
+#[derive(Debug, Clone, Default)]
+pub struct FragmentMetadataOptions {
+    /// Encoded directory, leaf, buffer, and hard object byte budgets.
+    pub tree: FragmentMetadataTreeConfig,
+    /// Independent inline-descriptor and cumulative-suffix byte budgets.
+    pub publication: lance_table::fragment_metadata::SnapshotPolicy,
+    /// Buffered commits by default; use bulk for wide metadata rewrites.
+    pub materialization: Materialization,
+    /// Permit experimental writers with more than a root and one leaf level.
+    pub allow_deep_writer: bool,
+}
+
+impl FragmentMetadataOptions {
+    /// Validate and encode options for `Operation::Overwrite.config_upsert_values`.
+    /// Layout and structural budgets cannot change on an existing dataset.
+    pub fn into_table_config(self) -> Result<HashMap<String, String>> {
+        self.tree.validate()?;
+        Ok(HashMap::from([
+            (
+                lance_table::fragment_metadata::MANIFEST_LAYOUT_KEY.into(),
+                "tree".into(),
+            ),
+            (
+                MAX_NODE_BYTES_KEY.into(),
+                self.tree.max_node_bytes.to_string(),
+            ),
+            (
+                MAX_LEAF_BYTES_KEY.into(),
+                self.tree.max_leaf_bytes.to_string(),
+            ),
+            (
+                "lance.fragment_metadata.semantic_buffer_bytes".into(),
+                self.tree.semantic_buffer_bytes.to_string(),
+            ),
+            (
+                "lance.fragment_metadata.hard_capacity_bytes".into(),
+                self.tree.hard_capacity_bytes.to_string(),
+            ),
+            (
+                publication::INLINE_ROOT_BYTES_KEY.into(),
+                self.publication.inline_root_bytes.to_string(),
+            ),
+            (
+                publication::SUFFIX_BYTES_KEY.into(),
+                self.publication.max_suffix_bytes.to_string(),
+            ),
+            (
+                "lance.fragment_metadata.materialization".into(),
+                match self.materialization {
+                    Materialization::Buffered => "buffered",
+                    Materialization::Bulk => "bulk",
+                }
+                .into(),
+            ),
+            (
+                "lance.fragment_metadata.allow_deep_writer".into(),
+                self.allow_deep_writer.to_string(),
+            ),
+        ]))
+    }
+}
+
+/// Everything the fragment metadata commit path needs from `CommitBuilder::execute_inner`.
+#[derive(Clone)]
+pub(crate) struct CommitTarget {
+    pub context: Option<Arc<Dataset>>,
+    pub materialize_fragments: bool,
+    pub object_store: Arc<ObjectStore>,
+    pub base_path: Path,
+    pub uri: String,
+    pub session: Arc<Session>,
+    pub commit_handler: Arc<dyn CommitHandler>,
+}
+
+/// Whether `operation` is an Overwrite that selects the fragment metadata tree.
+///
+/// Rejects unknown layout values instead of ignoring them, so a typo cannot
+/// silently create a flat dataset.
+pub(crate) fn create_requested(operation: &Operation) -> Result<bool> {
+    if let Operation::Overwrite {
+        config_upsert_values: Some(config),
+        ..
+    } = operation
+    {
+        return Ok(ManifestLayout::from_config(config)? == ManifestLayout::Tree);
+    }
+    Ok(false)
+}
+
+/// Whether an opened manifest stores its fragment state in the tree.
+pub(crate) fn dataset_uses_fragment_metadata(manifest: &Manifest) -> bool {
+    manifest.fragment_metadata.is_some()
+}
+
+/// Bootstrap a fragment metadata tree from an Overwrite transaction.
+pub(crate) async fn execute_create(
+    target: CommitTarget,
+    transaction: &Transaction,
+    write_config: &super::ManifestWriteConfig,
+) -> Result<Dataset> {
+    let Operation::Overwrite {
+        config_upsert_values: Some(config_upsert),
+        ..
+    } = &transaction.operation
+    else {
+        return Err(Error::invalid_input(
+            "fragment metadata tree create requires an Overwrite operation with config_upsert_values",
+        ));
+    };
+    let tree_config = tree_config_from(config_upsert)?;
+    super::transaction::validate_operation(None, &transaction.operation)?;
+    // Keep create semantics (IDs, base paths, format inference, schema and
+    // feature flags) in the same authoritative builder as flat manifests.
+    let (mut manifest, _) =
+        transaction.build_manifest(None, Vec::new(), "", &write_config.to_build_config())?;
+    // The tree's writer invariant needs known counts. Production writers
+    // always produce them; converting older data computes a missing
+    // deletion count from its deletion vector, and refuses a missing
+    // physical count (computing that means reading data files, which is a
+    // migration, not a create).
+    let mut fragments = manifest.fragments.as_ref().clone();
+    for fragment in &mut fragments {
+        if let Some(deletion_file) = &mut fragment.deletion_file
+            && deletion_file.num_deleted_rows.is_none()
+        {
+            let deletion_vector = read_deletion_file(
+                fragment.id,
+                deletion_file,
+                &target.base_path,
+                &target.object_store,
+            )
+            .await?;
+            deletion_file.num_deleted_rows = Some(deletion_vector.len());
+        }
+    }
+    let transaction_file = if write_config.disable_transaction_file() {
+        None
+    } else {
+        Some(
+            write_transaction_file(
+                &target.object_store,
+                &target.base_path,
+                &pb::Transaction::from(transaction),
+            )
+            .await?,
+        )
+    };
+    manifest.set_fragments(Vec::new());
+    let policy = publication::policy(&manifest)?;
+    let bootstrap = FragmentMetadataTree::bootstrap_snapshot(
+        target.object_store.clone(),
+        target.base_path.clone(),
+        scheduler_for(&target.object_store),
+        Arc::new(LanceCache::with_capacity(0)),
+        tree_config,
+        fragments,
+        1,
+        policy,
+    )
+    .await;
+    match bootstrap {
+        Ok((tree, snapshot, _)) => {
+            publication::publish(
+                target,
+                tree,
+                manifest,
+                snapshot,
+                transaction_file,
+                Vec::new(),
+                write_config,
+                Some(transaction),
+            )
+            .await
+        }
+        Err(error) => {
+            if let Some(transaction_file) = transaction_file {
+                cleanup_transaction_file(
+                    &target.object_store,
+                    &target.base_path,
+                    &transaction_file,
+                )
+                .await;
+            }
+            Err(error)
+        }
+    }
+}
+
+/// Commit one production transaction against an existing fragment metadata tree.
+///
+/// `affected_rows` carries a delete or update's row-level intent, exactly as
+/// `CommitBuilder::with_affected_rows` does on the flat path; without it a
+/// same-fragment delete conflict cannot rebase and is rejected as retryable.
+pub(crate) async fn execute_commit(
+    target: CommitTarget,
+    commit_config: &CommitConfig,
+    transaction: &Transaction,
+    affected_rows: Option<&RowAddrTreeMap>,
+    write_config: &super::ManifestWriteConfig,
+) -> Result<Dataset> {
+    execute_commit_with_timeout(
+        target,
+        commit_config,
+        crate::io::commit::DEFAULT_COMMIT_RETRY_TIMEOUT,
+        transaction,
+        affected_rows,
+        write_config,
+    )
+    .await
+}
+
+/// Every CAS attempt uses the native conflict resolver and manifest builder.
+/// Only the resulting fragment changes are translated into tree mutations.
+pub(crate) async fn execute_commit_with_timeout(
+    target: CommitTarget,
+    commit_config: &CommitConfig,
+    retry_timeout: Duration,
+    transaction: &Transaction,
+    affected_rows: Option<&RowAddrTreeMap>,
+    write_config: &super::ManifestWriteConfig,
+) -> Result<Dataset> {
+    let attempts = commit_config.num_retries.max(1);
+    let start = Instant::now();
+    let mut backoff = SlotBackoff::default();
+    for attempt in 1..=attempts {
+        let mut dataset = publication::open_dataset(&target, None).await?;
+        lance_table::feature_flags::ensure_can_write_manifest(&dataset.manifest)?;
+        let lazy = dataset.lazy_fragments.as_ref().ok_or_else(|| {
+            Error::internal("opened fragment metadata dataset has no fragment source")
+        })?;
+        let mut tree = lazy.tree().as_ref().clone();
+        let previous_snapshot = publication::descriptor(&dataset.manifest)?;
+        // A retained handle is useful only for the exact state opened by this
+        // attempt. Rebase and retries must not carry stale fragment metadata.
+        if let Some(context) = target.context.as_ref().filter(|context| {
+            context.lazy_fragments.is_none()
+                && context.manifest.version == dataset.manifest.version
+                && context.manifest.fragment_metadata == dataset.manifest.fragment_metadata
+                && context.base == dataset.base
+                && Arc::ptr_eq(&context.object_store.inner, &dataset.object_store.inner)
+        }) {
+            let mut manifest = dataset.manifest.as_ref().clone();
+            manifest.fragments = context.manifest.fragments.clone();
+            dataset.manifest = Arc::new(manifest);
+            dataset.fragment_bitmap = context.fragment_bitmap.clone();
+            dataset.lazy_fragments = None;
+        }
+        if transaction.read_version > tree.version() {
+            return Err(Error::invalid_input(format!(
+                "Transaction read version {} exceeds current version {}",
+                transaction.read_version,
+                tree.version()
+            )));
+        }
+        let mut rebased = transaction.clone();
+        let strict_overwrite = matches!(transaction.operation, Operation::Overwrite { .. })
+            && commit_config.num_retries == 0;
+        if strict_overwrite && transaction.read_version != tree.version() {
+            return Err(Error::commit_conflict_source(
+                transaction.read_version + 1,
+                "Strict overwrite cannot rebase onto a newer version".into(),
+            ));
+        }
+        if transaction.read_version < tree.version()
+            && !(transaction.read_version == 0
+                && matches!(transaction.operation, Operation::Overwrite { .. }))
+        {
+            let mut resolver = crate::io::commit::conflict_resolver::TransactionRebase::try_new(
+                &dataset,
+                rebased,
+                affected_rows,
+            )
+            .await?;
+            for (version, other) in
+                publication::history(&target, transaction.read_version, tree.version()).await?
+            {
+                resolver.check_txn(&other, version)?;
+            }
+            rebased = resolver.finish(&dataset).await?;
+        }
+        let bulk = match dataset
+            .manifest
+            .config
+            .get("lance.fragment_metadata.materialization")
+            .map(String::as_str)
+        {
+            None | Some("buffered") => false,
+            Some("bulk") => true,
+            Some(value) => {
+                return Err(Error::invalid_input(format!(
+                    "lance.fragment_metadata.materialization must be buffered or bulk, got {value:?}"
+                )));
+            }
+        };
+        let prepared = native::prepare(
+            &dataset,
+            &mut tree,
+            &rebased,
+            transaction.read_version,
+            write_config,
+            bulk,
+        )
+        .await?;
+        let fragments = target
+            .materialize_fragments
+            .then(|| prepared.materialized_fragments(&dataset))
+            .flatten();
+        let policy = publication::policy(&prepared.manifest)?;
+        let transaction_file = if write_config.disable_transaction_file() {
+            None
+        } else {
+            Some(
+                write_transaction_file(
+                    &target.object_store,
+                    &target.base_path,
+                    &pb::Transaction::from(&rebased),
+                )
+                .await?,
+            )
+        };
+        let (snapshot, _) = tree
+            .prepare_snapshot(
+                prepared.changes,
+                &prepared.touched,
+                &previous_snapshot,
+                policy,
+                bulk,
+            )
+            .await?;
+        match publication::publish(
+            target.clone(),
+            tree,
+            prepared.manifest,
+            snapshot,
+            transaction_file,
+            prepared.indices,
+            write_config,
+            Some(&rebased),
+        )
+        .await
+        {
+            Ok(mut committed) => {
+                if let Some(fragments) = fragments {
+                    committed.set_materialized_fragments(fragments);
+                }
+                if !commit_config.skip_auto_cleanup {
+                    match super::cleanup::auto_cleanup_hook(&dataset, &committed.manifest).await {
+                        Ok(Some(stats)) => log::info!("Auto cleanup triggered: {stats:?}"),
+                        Err(error) => {
+                            log::error!("Error encountered during auto_cleanup_hook: {error}")
+                        }
+                        _ => {}
+                    }
+                }
+                return Ok(committed);
+            }
+            Err(Error::CommitConflict { .. }) if attempt < attempts => {
+                if attempt == 1 {
+                    backoff =
+                        backoff.with_unit(start.elapsed().as_millis().min(u32::MAX as u128) as u32);
+                }
+                if start.elapsed() >= retry_timeout {
+                    return Err(crate::io::commit::timeout_error(retry_timeout, attempt));
+                }
+                crate::io::commit::maybe_timeout(
+                    attempt,
+                    start,
+                    retry_timeout,
+                    tokio::time::sleep(backoff.next_backoff()),
+                )
+                .await?;
+            }
+            Err(error) => return Err(error),
+        }
+    }
+    Err(Error::internal(
+        "fragment metadata commit exhausted its nonempty attempt loop",
+    ))
+}
+
+/// Copy a source tree's dest-owned root into `manifest`, stamping inherited
+/// child and file references with `source_base_id`. Shared leaves stay in the
+/// source dataset.
+pub(crate) async fn clone_fragment_metadata(
+    dest_store: Arc<ObjectStore>,
+    dest_base: Path,
+    source_store: Arc<ObjectStore>,
+    source_base: Path,
+    source_base_id: u32,
+    manifest: &mut Manifest,
+) -> Result<()> {
+    let snapshot = publication::descriptor(manifest)?;
+    let source_nodes = NodeStore::new(
+        source_store.clone(),
+        source_base.clone(),
+        scheduler_for(&source_store),
+        Arc::new(LanceCache::with_capacity(0)),
+    );
+    let mut root = match &snapshot.root {
+        Some(pb::fragment_metadata_tree::Root::InlineRoot(root)) => root.clone(),
+        Some(pb::fragment_metadata_tree::Root::RootPath(path)) => {
+            source_nodes.read_root_base(path).await?
+        }
+        None => {
+            return Err(Error::invalid_input(
+                "cloned fragment metadata snapshot has no root",
+            ));
+        }
+    };
+    root.buffer
+        .extend(snapshot.mutations_since_root.iter().cloned());
+    root.next_action_sequence = snapshot.next_action_sequence;
+    for child in &mut root.children {
+        if child.base_id.is_none() {
+            child.base_id = Some(source_base_id);
+        }
+    }
+    lance_table::fragment_metadata::store::preserve_inherited_refs(
+        &mut root.buffer,
+        lance_table::fragment_metadata::store::SourceStore {
+            object_store: source_store.as_ref(),
+            base: &source_base,
+            base_id: source_base_id,
+        },
+    )
+    .await?;
+    let dest_nodes = NodeStore::new(
+        dest_store.clone(),
+        dest_base,
+        scheduler_for(&dest_store),
+        Arc::new(LanceCache::with_capacity(0)),
+    );
+    let (path, _) = dest_nodes.write_root_base(&root).await?;
+    manifest.fragment_metadata = Some(Arc::new(pb::FragmentMetadataTree {
+        root: Some(pb::fragment_metadata_tree::Root::RootPath(path)),
+        mutations_since_root: Vec::new(),
+        next_action_sequence: snapshot.next_action_sequence,
+    }));
+    Ok(())
+}
+
+/// Bootstrap dest-owned metadata from a complete fragment list. Used by deep
+/// clone after files have been copied into the destination dataset.
+pub(crate) async fn rebuild_fragment_metadata(
+    object_store: Arc<ObjectStore>,
+    base: Path,
+    manifest: &mut Manifest,
+) -> Result<()> {
+    let config = tree_config_from(&manifest.config)?;
+    let policy = publication::policy(manifest)?;
+    let fragments = std::mem::replace(&mut manifest.fragments, Arc::new(Vec::new()));
+    manifest.fragment_metadata = None;
+    let (tree, snapshot, _) = FragmentMetadataTree::bootstrap_snapshot(
+        object_store.clone(),
+        base,
+        scheduler_for(&object_store),
+        Arc::new(LanceCache::with_capacity(0)),
+        config,
+        Arc::unwrap_or_clone(fragments),
+        manifest.version,
+        policy,
+    )
+    .await?;
+    if tree.height() > 1
+        && manifest
+            .config
+            .get("lance.fragment_metadata.allow_deep_writer")
+            .map(String::as_str)
+            != Some("true")
+    {
+        return Err(Error::not_supported_source(
+            "cloned fragment metadata requires lance.fragment_metadata.allow_deep_writer=true"
+                .into(),
+        ));
+    }
+    manifest.fragment_metadata = Some(Arc::new(snapshot));
+    Ok(())
+}
+
+/// Copy external lineage slices into the destination-owned fragment record.
+/// These references have no base ID, so leaving a source-relative path in a
+/// clone would bind it to the wrong dataset.
+pub(crate) async fn inline_clone_lineage(
+    store: &ObjectStore,
+    base: &Path,
+    fragments: &mut [Fragment],
+) -> Result<()> {
+    lance_table::fragment_metadata::store::inline_external_lineage(store, base, fragments).await
+}
+
+/// Production DataReplacement, one group at a time against the touched
+/// state, after the transaction-wide rule that every replacement file in
+/// one transaction carries the same field set.
+fn replacement_actions(
+    replacements: &[DataReplacementGroup],
+    touched: &TouchedFragments,
+) -> Result<Vec<pb::FragmentAction>> {
+    let field_sets: HashSet<Vec<i32>> = replacements
+        .iter()
+        .map(|DataReplacementGroup(_, file)| file.fields.to_vec())
+        .collect();
+    if field_sets.len() > 1 {
+        return Err(Error::invalid_input(format!(
+            "All new data files must have the same fields, but found different \
+             fields: {field_sets:?}"
+        )));
+    }
+    let mut actions = Vec::with_capacity(replacements.len());
+    for DataReplacementGroup(fragment_id, file) in replacements {
+        actions.extend(data_replacement(
+            touched.get(*fragment_id),
+            *fragment_id,
+            file,
+        )?);
+    }
+    Ok(actions)
+}
+
+fn tree_config_from(config: &HashMap<String, String>) -> Result<FragmentMetadataTreeConfig> {
+    for (key, choices) in [
+        (
+            "lance.fragment_metadata.materialization",
+            ["buffered", "bulk"],
+        ),
+        (
+            "lance.fragment_metadata.allow_deep_writer",
+            ["false", "true"],
+        ),
+    ] {
+        if let Some(value) = config.get(key)
+            && !choices.contains(&value.as_str())
+        {
+            return Err(Error::invalid_input(format!(
+                "{key} must be one of {choices:?}, got {value:?}"
+            )));
+        }
+    }
+
+    for key in config
+        .keys()
+        .filter(|key| key.starts_with("lance.fragment_metadata."))
+    {
+        if !matches!(
+            key.as_str(),
+            MAX_NODE_BYTES_KEY
+                | MAX_LEAF_BYTES_KEY
+                | "lance.fragment_metadata.semantic_buffer_bytes"
+                | "lance.fragment_metadata.hard_capacity_bytes"
+                | "lance.fragment_metadata.inline_manifest_budget"
+                | "lance.fragment_metadata.publication_suffix_budget"
+                | "lance.fragment_metadata.materialization"
+                | "lance.fragment_metadata.allow_deep_writer"
+        ) {
+            return Err(Error::invalid_input(format!(
+                "Unknown fragment metadata setting {key}"
+            )));
+        }
+    }
+    fn parse(config: &HashMap<String, String>, key: &str) -> Result<Option<u64>> {
+        config
+            .get(key)
+            .map(|raw| {
+                raw.parse::<u64>().map_err(|_| {
+                    Error::invalid_input(format!("{key} must be an integer, got {raw:?}"))
+                })
+            })
+            .transpose()
+    }
+    // Opt-in policy defaults. Routing capacity, mutation batching, and encoded
+    // leaf locality are separate knobs; the byte limits determine growth.
+    let mut tree_config = FragmentMetadataTreeConfig::default();
+    if let Some(max_node_bytes) = parse(config, MAX_NODE_BYTES_KEY)? {
+        tree_config.max_node_bytes = max_node_bytes;
+    }
+    if let Some(max_leaf_bytes) = parse(config, MAX_LEAF_BYTES_KEY)? {
+        tree_config.max_leaf_bytes = max_leaf_bytes;
+    }
+    if let Some(bytes) = parse(config, "lance.fragment_metadata.semantic_buffer_bytes")? {
+        tree_config.semantic_buffer_bytes = bytes;
+    }
+    if let Some(bytes) = parse(config, "lance.fragment_metadata.hard_capacity_bytes")? {
+        tree_config.hard_capacity_bytes = bytes;
+    }
+    tree_config.validate()?;
+    Ok(tree_config)
+}
+
+fn scheduler_for(object_store: &Arc<ObjectStore>) -> Arc<ScanScheduler> {
+    ScanScheduler::new(
+        object_store.clone(),
+        SchedulerConfig::max_bandwidth(object_store),
+    )
+}
+
+#[cfg(test)]
+mod differential;
+#[cfg(test)]
+mod gate_tests;
+#[cfg(test)]
+mod publication_tests;
+
+#[cfg(test)]
+mod tests {
+    use super::test_support::Reader;
+    use super::*;
+    use crate::dataset::write::CommitBuilder;
+    use arrow_schema::{DataType, Field as ArrowField, Schema as ArrowSchema};
+    use futures::future::join_all;
+    use lance_core::datatypes::Schema;
+    use lance_table::format::pb as table_pb;
+    use lance_table::fragment_metadata::MANIFEST_LAYOUT_KEY;
+    use lance_table::fragment_metadata::support::{
+        make_backfill_data_file, make_fragment, make_replacement_data_file,
+    };
+
+    fn table_schema() -> Schema {
+        Schema::try_from(&ArrowSchema::new(vec![
+            ArrowField::new("id", DataType::Int64, false),
+            ArrowField::new("name", DataType::Utf8, false),
+        ]))
+        .unwrap()
+    }
+
+    fn fragment_metadata_config_upsert() -> HashMap<String, String> {
+        HashMap::from([
+            (
+                MANIFEST_LAYOUT_KEY.to_string(),
+                lance_table::fragment_metadata::MANIFEST_LAYOUT_TREE.to_string(),
+            ),
+            (MAX_NODE_BYTES_KEY.to_string(), (16 * 1024).to_string()),
+            (
+                "lance.fragment_metadata.allow_deep_writer".to_string(),
+                "true".to_string(),
+            ),
+        ])
+    }
+
+    fn create_transaction(n: u64, config: HashMap<String, String>) -> Transaction {
+        Transaction::new_from_version(
+            0,
+            Operation::Overwrite {
+                fragments: (0..n).map(make_fragment).collect(),
+                schema: table_schema(),
+                config_upsert_values: Some(config),
+                initial_bases: None,
+            },
+        )
+    }
+
+    async fn create_fragment_metadata_dataset(uri: &str, n: u64) -> Dataset {
+        CommitBuilder::new(uri)
+            .execute(create_transaction(n, fragment_metadata_config_upsert()))
+            .await
+            .unwrap()
+    }
+
+    #[tokio::test]
+    async fn create_reopen_and_resolve_through_commit_builder() {
+        let tempdir = tempfile::tempdir().unwrap();
+        let uri = tempdir.path().to_str().unwrap();
+        let dataset = create_fragment_metadata_dataset(uri, 500).await;
+        assert_eq!(dataset.manifest.version, 1);
+        assert!(dataset_uses_fragment_metadata(&dataset.manifest));
+        assert_eq!(dataset.schema().fields.len(), 2);
+
+        let reader = Reader::open_uri(uri).await.unwrap();
+        assert_eq!(reader.version(), 1);
+        assert_eq!(reader.count_fragments(), 500);
+        assert_eq!(reader.resolve_fragment(123).await.unwrap().unwrap().id, 123);
+
+        let opened = crate::dataset::builder::DatasetBuilder::from_uri(uri)
+            .load()
+            .await
+            .unwrap();
+        assert!(!opened.fragment_source().is_lazy());
+        assert_eq!(opened.fragments().len(), 500);
+        assert_eq!(opened.get_fragments().len(), 500);
+        assert_eq!(opened.get_fragment(123).unwrap().id(), 123);
+        let lazy = crate::dataset::builder::DatasetBuilder::from_uri(uri)
+            .load_lazy()
+            .await
+            .unwrap();
+        assert_eq!(lazy.count_fragments(), 500);
+        assert_eq!(lazy.get_fragment(123).await.unwrap().unwrap().id, 123);
+        assert_eq!(lazy.into_dataset().await.unwrap().fragments().len(), 500);
+        assert_eq!(opened.manifest.version, 1);
+    }
+
+    #[tokio::test]
+    async fn append_add_column_and_replace_commit_through_dataset_path() {
+        let tempdir = tempfile::tempdir().unwrap();
+        let uri = tempdir.path().to_str().unwrap();
+        let dataset = create_fragment_metadata_dataset(uri, 500).await;
+
+        let appended = CommitBuilder::new(Arc::new(dataset))
+            .execute(Transaction::new_from_version(
+                1,
+                Operation::Append {
+                    fragments: vec![make_fragment(500)],
+                },
+            ))
+            .await
+            .unwrap();
+        assert_eq!(appended.manifest.version, 2);
+
+        let add_column = CommitBuilder::new(Arc::new(appended))
+            .execute(Transaction::new_from_version(
+                2,
+                Operation::DataReplacement {
+                    replacements: (0..10)
+                        .map(|id| DataReplacementGroup(id, make_backfill_data_file(id, 0)))
+                        .collect(),
+                },
+            ))
+            .await
+            .unwrap();
+        assert_eq!(add_column.manifest.version, 3);
+
+        let replaced = CommitBuilder::new(Arc::new(add_column))
+            .execute(Transaction::new_from_version(
+                3,
+                Operation::DataReplacement {
+                    replacements: (0..10)
+                        .map(|id| DataReplacementGroup(id, make_replacement_data_file(id, 0)))
+                        .collect(),
+                },
+            ))
+            .await
+            .unwrap();
+        assert_eq!(replaced.manifest.version, 4);
+
+        let reader = Reader::open_uri(uri).await.unwrap();
+        assert_eq!(reader.count_fragments(), 501);
+        let touched = reader.resolve_fragment(3).await.unwrap().unwrap();
+        assert_eq!(touched.files.len(), 2);
+        assert_eq!(touched.files[0].path, make_replacement_data_file(3, 0).path);
+        assert_eq!(touched.files[1].path, make_backfill_data_file(3, 0).path);
+        let untouched = reader.resolve_fragment(400).await.unwrap().unwrap();
+        assert_eq!(untouched.files.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn production_transaction_file_stays_action_scale() {
+        let tempdir = tempfile::tempdir().unwrap();
+        let uri = tempdir.path().to_str().unwrap();
+        let dataset = create_fragment_metadata_dataset(uri, 2_000).await;
+
+        CommitBuilder::new(Arc::new(dataset))
+            .execute(Transaction::new_from_version(
+                1,
+                Operation::DataReplacement {
+                    replacements: (0..10)
+                        .map(|id| DataReplacementGroup(id, make_backfill_data_file(id, 0)))
+                        .collect(),
+                },
+            ))
+            .await
+            .unwrap();
+
+        let transactions_dir = std::fs::read_dir(tempdir.path().join("_transactions")).unwrap();
+        let mut backfill_transaction = None;
+        for entry in transactions_dir {
+            let entry = entry.unwrap();
+            let bytes = std::fs::read(entry.path()).unwrap();
+            let decoded = table_pb::Transaction::decode(bytes.as_slice()).unwrap();
+            if let Some(table_pb::transaction::Operation::DataReplacement(replacement)) =
+                decoded.operation
+            {
+                backfill_transaction = Some((bytes.len(), replacement.replacements.len()));
+            }
+        }
+        let (transaction_bytes, group_count) = backfill_transaction.unwrap();
+        assert_eq!(group_count, 10);
+        assert!(
+            transaction_bytes < 4 * 1024,
+            "10-group DataReplacement txn must stay action-scale at N=2000, \
+             got {transaction_bytes} bytes"
+        );
+    }
+
+    #[tokio::test]
+    async fn default_layout_still_flat_and_unknown_layout_rejected() {
+        let tempdir = tempfile::tempdir().unwrap();
+        let uri = tempdir.path().to_str().unwrap();
+        CommitBuilder::new(uri)
+            .execute(create_transaction(5, HashMap::new()))
+            .await
+            .unwrap();
+        assert!(
+            tempdir.path().join("_versions").exists(),
+            "default create must keep writing flat manifests"
+        );
+        assert!(!tempdir.path().join("_bt").exists());
+
+        let unknown_dir = tempfile::tempdir().unwrap();
+        let unknown_uri = unknown_dir.path().to_str().unwrap();
+        let error = CommitBuilder::new(unknown_uri)
+            .execute(create_transaction(
+                5,
+                HashMap::from([(MANIFEST_LAYOUT_KEY.to_string(), "tiered".to_string())]),
+            ))
+            .await
+            .unwrap_err();
+        assert!(error.to_string().contains("layout=\"tiered\""), "{error}");
+    }
+
+    #[tokio::test]
+    async fn concurrent_appends_leave_a_sane_tip() {
+        let tempdir = tempfile::tempdir().unwrap();
+        let uri = tempdir.path().to_str().unwrap();
+        create_fragment_metadata_dataset(uri, 100).await;
+
+        let outcomes = join_all((0..4u64).map(|writer| {
+            let uri = uri.to_string();
+            async move {
+                CommitBuilder::new(uri.as_str())
+                    .execute(Transaction::new_from_version(
+                        1,
+                        Operation::Append {
+                            fragments: vec![make_fragment(100 + writer)],
+                        },
+                    ))
+                    .await
+            }
+        }))
+        .await;
+
+        let successes = outcomes.iter().filter(|outcome| outcome.is_ok()).count();
+        assert!(successes >= 1, "at least one concurrent append must land");
+
+        let reader = Reader::open_uri(uri).await.unwrap();
+        assert_eq!(reader.version(), 1 + successes as u64);
+        assert_eq!(reader.count_fragments(), 100 + successes as u64);
+        for outcome in outcomes.into_iter().flatten() {
+            assert!(dataset_uses_fragment_metadata(&outcome.manifest));
+        }
+    }
+}

--- a/rust/lance/src/dataset/fragment_metadata.rs
+++ b/rust/lance/src/dataset/fragment_metadata.rs
@@ -676,6 +676,8 @@ mod gate_tests;
 mod publication_tests;
 #[cfg(test)]
 mod scan_tests;
+#[cfg(test)]
+mod wide_table_io;
 
 #[cfg(test)]
 mod tests {

--- a/rust/lance/src/dataset/fragment_metadata/differential.rs
+++ b/rust/lance/src/dataset/fragment_metadata/differential.rs
@@ -1,0 +1,442 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+//! Differential oracle: the same production `Transaction` committed through
+//! `CommitBuilder` against a flat dataset and a fragment metadata tree, then
+//! both logical states read back and compared. Flat Lance is the oracle.
+
+use std::collections::BTreeMap;
+
+use lance_core::datatypes::Schema;
+use lance_core::{Error, Result};
+use lance_file::version::LanceFileVersion;
+use lance_table::format::{DeletionFile, DeletionFileType, Fragment};
+use lance_table::fragment_metadata::support::{
+    make_backfill_data_file, make_fragment, make_replacement_data_file,
+};
+
+use super::MAX_NODE_BYTES_KEY;
+use super::test_support::{AddColumns, Reader, commit_target_for_uri, execute_add_columns};
+use crate::dataset::builder::DatasetBuilder;
+use crate::dataset::transaction::{DataReplacementGroup, Operation, Transaction};
+use crate::dataset::write::CommitBuilder;
+use lance_table::fragment_metadata::MANIFEST_LAYOUT_KEY;
+use lance_table::io::commit::CommitConfig;
+
+pub(super) fn table_schema() -> Schema {
+    use arrow_schema::{DataType, Field as ArrowField, Schema as ArrowSchema};
+    Schema::try_from(&ArrowSchema::new(vec![
+        ArrowField::new("id", DataType::Int64, false),
+        ArrowField::new("name", DataType::Utf8, false),
+    ]))
+    .unwrap()
+}
+
+/// Canonical logical state of a dataset, layout independent.
+#[derive(Debug, Clone, PartialEq)]
+pub(super) struct LogicalState {
+    pub version: u64,
+    pub schema: Schema,
+    pub fragments: BTreeMap<u64, Fragment>,
+}
+
+pub(super) struct Side {
+    pub uri: String,
+    _dir: tempfile::TempDir,
+}
+
+pub(super) struct Differential {
+    pub flat: Side,
+    pub fragment_metadata: Side,
+}
+
+pub(super) struct Outcome {
+    pub flat: Result<u64>,
+    pub fragment_metadata: Result<u64>,
+    /// `Some(true)` when both accepted and logical states are equal.
+    pub parity: Option<bool>,
+    /// The first divergence when both accepted and states differ.
+    pub diff: Option<String>,
+}
+
+impl Outcome {
+    pub fn both_accepted_and_equal(&self) -> bool {
+        self.flat.is_ok() && self.fragment_metadata.is_ok() && self.parity == Some(true)
+    }
+    pub fn both_rejected(&self) -> bool {
+        matches!((&self.flat, &self.fragment_metadata), (Err(flat), Err(tree)) if std::mem::discriminant(flat) == std::mem::discriminant(tree))
+    }
+}
+
+pub(super) fn error_category(error: &Error) -> String {
+    let text = error.to_string();
+    text.split(':').next().unwrap_or("").trim().to_string()
+}
+
+impl Differential {
+    pub async fn create(n: u64) -> Self {
+        Self::create_with_fragments((0..n).map(make_fragment).collect()).await
+    }
+
+    pub async fn create_with_fragments(fragments: Vec<Fragment>) -> Self {
+        let flat_dir = tempfile::tempdir().unwrap();
+        let fragment_metadata_dir = tempfile::tempdir().unwrap();
+        let flat = Side {
+            uri: flat_dir.path().to_str().unwrap().to_string(),
+            _dir: flat_dir,
+        };
+        let fragment_metadata = Side {
+            uri: fragment_metadata_dir.path().to_str().unwrap().to_string(),
+            _dir: fragment_metadata_dir,
+        };
+        CommitBuilder::new(flat.uri.as_str())
+            .execute(Transaction::new_from_version(
+                0,
+                Operation::Overwrite {
+                    fragments: fragments.clone(),
+                    schema: table_schema(),
+                    config_upsert_values: None,
+                    initial_bases: None,
+                },
+            ))
+            .await
+            .unwrap();
+        let config = std::collections::HashMap::from([
+            (
+                MANIFEST_LAYOUT_KEY.to_string(),
+                lance_table::fragment_metadata::MANIFEST_LAYOUT_TREE.to_string(),
+            ),
+            (MAX_NODE_BYTES_KEY.to_string(), (4 * 1024).to_string()),
+            (
+                super::MAX_LEAF_BYTES_KEY.to_string(),
+                (4 * 1024).to_string(),
+            ),
+            (
+                "lance.fragment_metadata.allow_deep_writer".to_string(),
+                "true".to_string(),
+            ),
+        ]);
+        CommitBuilder::new(fragment_metadata.uri.as_str())
+            .execute(Transaction::new_from_version(
+                0,
+                Operation::Overwrite {
+                    fragments,
+                    schema: table_schema(),
+                    config_upsert_values: Some(config),
+                    initial_bases: None,
+                },
+            ))
+            .await
+            .unwrap();
+        let this = Self {
+            flat,
+            fragment_metadata,
+        };
+        let diff = this.states_diff().await;
+        assert!(diff.is_none(), "bootstrap states differ: {diff:?}");
+        this
+    }
+
+    pub async fn flat_state(&self) -> LogicalState {
+        let dataset = DatasetBuilder::from_uri(&self.flat.uri)
+            .load()
+            .await
+            .unwrap();
+        LogicalState {
+            version: dataset.manifest.version,
+            schema: dataset.schema().clone(),
+            fragments: dataset
+                .fragments()
+                .iter()
+                .map(|fragment| (fragment.id, fragment.clone()))
+                .collect(),
+        }
+    }
+
+    pub async fn fragment_metadata_reader(&self) -> Reader {
+        Reader::open_uri(&self.fragment_metadata.uri).await.unwrap()
+    }
+
+    pub async fn fragment_metadata_state(&self) -> LogicalState {
+        let reader = self.fragment_metadata_reader().await;
+
+        LogicalState {
+            version: reader.version(),
+            schema: reader.schema().unwrap(),
+            fragments: reader
+                .materialize()
+                .await
+                .unwrap()
+                .into_iter()
+                .map(|fragment| (fragment.id, fragment))
+                .collect(),
+        }
+    }
+
+    /// `None` when both sides describe the same table, otherwise a
+    /// description of the first divergence found.
+    pub async fn states_diff(&self) -> Option<String> {
+        let flat = self.flat_state().await;
+        let fragment_metadata = self.fragment_metadata_state().await;
+        if flat.version != fragment_metadata.version {
+            return Some(format!(
+                "version differs: flat={} fragment_metadata={}",
+                flat.version, fragment_metadata.version
+            ));
+        }
+        if flat.schema != fragment_metadata.schema {
+            return Some(format!(
+                "schema differs:\nflat={:?}\nfragment_metadata={:?}",
+                flat.schema, fragment_metadata.schema
+            ));
+        }
+        if flat.fragments != fragment_metadata.fragments {
+            let flat_ids: Vec<_> = flat.fragments.keys().copied().collect();
+            let fragment_metadata_ids: Vec<_> =
+                fragment_metadata.fragments.keys().copied().collect();
+            if flat_ids != fragment_metadata_ids {
+                let only_flat: Vec<_> = flat_ids
+                    .iter()
+                    .filter(|id| !fragment_metadata.fragments.contains_key(id))
+                    .collect();
+                let only_fragment_metadata: Vec<_> = fragment_metadata_ids
+                    .iter()
+                    .filter(|id| !flat.fragments.contains_key(id))
+                    .collect();
+                return Some(format!(
+                    "fragment ids differ: only_flat={only_flat:?} only_fragment_metadata={only_fragment_metadata:?}"
+                ));
+            }
+            for (id, fragment) in &flat.fragments {
+                if fragment_metadata.fragments.get(id) != Some(fragment) {
+                    return Some(format!(
+                        "fragment {id} differs:\nflat={fragment:?}\nfragment_metadata={:?}",
+                        fragment_metadata.fragments.get(id)
+                    ));
+                }
+            }
+            return Some("fragments differ".to_string());
+        }
+        None
+    }
+
+    pub async fn states_equal(&self) -> bool {
+        self.states_diff().await.is_none()
+    }
+
+    /// Commit `operation` on both sides from `read_version`, record the row,
+    /// and compare logical states when both accepted.
+    pub async fn apply(&mut self, step: &str, read_version: u64, operation: Operation) -> Outcome {
+        let flat = CommitBuilder::new(self.flat.uri.as_str())
+            .execute(Transaction::new_from_version(
+                read_version,
+                operation.clone(),
+            ))
+            .await
+            .map(|dataset| dataset.manifest.version);
+        let fragment_metadata = CommitBuilder::new(self.fragment_metadata.uri.as_str())
+            .execute(Transaction::new_from_version(
+                read_version,
+                operation.clone(),
+            ))
+            .await
+            .map(|dataset| dataset.manifest.version);
+        self.record(step, flat, fragment_metadata).await
+    }
+
+    async fn record(
+        &mut self,
+        step: &str,
+        flat: Result<u64>,
+        fragment_metadata: Result<u64>,
+    ) -> Outcome {
+        let diff = if flat.is_ok() && fragment_metadata.is_ok() {
+            self.states_diff().await
+        } else {
+            None
+        };
+        let parity = if flat.is_ok() && fragment_metadata.is_ok() {
+            Some(diff.is_none())
+        } else {
+            None
+        };
+        let diff = diff.map(|difference| format!("{step}: {difference}"));
+        Outcome {
+            flat,
+            fragment_metadata,
+            parity,
+            diff,
+        }
+    }
+
+    /// Commit from each side's current tip.
+    pub async fn apply_latest(&mut self, step: &str, operation: Operation) -> Outcome {
+        let version = self.flat_state().await.version;
+        self.apply(step, version, operation).await
+    }
+}
+
+/// The schema flat Lance produces when add-column round `col` lands: the
+/// current schema merged with one Int32 field whose id follows the current
+/// max, which is the id `make_backfill_data_file(_, col)` writes.
+pub(super) fn schema_with_column(current: &Schema, col: u32) -> Schema {
+    use arrow_schema::{DataType, Field as ArrowField, Schema as ArrowSchema};
+    let added = ArrowSchema::new(vec![ArrowField::new(
+        format!("col{col}"),
+        DataType::Int32,
+        true,
+    )]);
+    let mut schema = current.merge(&added).unwrap();
+    schema.set_field_id(current.max_field_id());
+    assert_eq!(
+        schema.max_field_id(),
+        Some(2 + col as i32),
+        "backfill file field id must match the new schema field id"
+    );
+    schema
+}
+
+impl Differential {
+    pub async fn apply_add_columns(
+        &mut self,
+        step: &str,
+        read_version: u64,
+        ids: &[u64],
+        col: u32,
+    ) -> Outcome {
+        let base = {
+            let dataset = DatasetBuilder::from_uri(&self.flat.uri)
+                .with_version(read_version)
+                .load()
+                .await
+                .unwrap();
+            LogicalState {
+                version: dataset.manifest.version,
+                schema: dataset.schema().clone(),
+                fragments: dataset
+                    .fragments()
+                    .iter()
+                    .map(|fragment| (fragment.id, fragment.clone()))
+                    .collect(),
+            }
+        };
+        let schema = schema_with_column(&base.schema, col);
+        let merged_fragments: Vec<Fragment> = base
+            .fragments
+            .values()
+            .cloned()
+            .map(|mut fragment| {
+                if ids.contains(&fragment.id) {
+                    fragment
+                        .files
+                        .push(make_backfill_data_file(fragment.id, col));
+                }
+                fragment
+            })
+            .collect();
+        let flat = CommitBuilder::new(self.flat.uri.as_str())
+            .execute(Transaction::new_from_version(
+                read_version,
+                Operation::Merge {
+                    preserves_nullability: false,
+                    fragments: merged_fragments,
+                    schema: schema.clone(),
+                },
+            ))
+            .await
+            .map(|dataset| dataset.manifest.version);
+        let add_columns = AddColumns {
+            read_version,
+            schema,
+            replacements: ids
+                .iter()
+                .map(|id| DataReplacementGroup(*id, make_backfill_data_file(*id, col)))
+                .collect(),
+        };
+        let fragment_metadata = execute_add_columns(
+            commit_target_for_uri(&self.fragment_metadata.uri)
+                .await
+                .unwrap(),
+            &CommitConfig::default(),
+            &add_columns,
+        )
+        .await
+        .map(|dataset| dataset.manifest.version);
+        self.record(step, flat, fragment_metadata).await
+    }
+}
+
+pub(super) fn deletion_file(id: u64, read_version: u64) -> DeletionFile {
+    DeletionFile {
+        read_version,
+        id,
+        file_type: DeletionFileType::Bitmap,
+        num_deleted_rows: Some(1),
+        base_id: None,
+    }
+}
+
+pub(super) fn production_style_append(count: usize) -> Operation {
+    production_style_append_with_version(count, LanceFileVersion::V2_0)
+}
+
+/// The production writer emits fragments with id 0 and lets the commit
+/// assign real ids (`Transaction::fragments_with_ids`). Data files must
+/// carry the dataset's storage version, which an empty table defaults to
+/// the current stable version.
+pub(super) fn production_style_append_with_version(
+    count: usize,
+    version: LanceFileVersion,
+) -> Operation {
+    let (major, minor) = version.resolve().to_data_file_numbers();
+    Operation::Append {
+        fragments: (0..count)
+            .map(|index| {
+                let mut fragment = make_fragment(0);
+                fragment.id = 0;
+                fragment.physical_rows = Some(10);
+                fragment.files[0].path =
+                    format!("data/fresh-{index}-{}.lance", uuid::Uuid::new_v4());
+                fragment.files[0].file_major_version = major;
+                fragment.files[0].file_minor_version = minor;
+                fragment
+            })
+            .collect(),
+    }
+}
+
+pub(super) fn add_column(ids: impl IntoIterator<Item = u64>, col: u32) -> Operation {
+    Operation::DataReplacement {
+        replacements: ids
+            .into_iter()
+            .map(|id| DataReplacementGroup(id, make_backfill_data_file(id, col)))
+            .collect(),
+    }
+}
+
+pub(super) fn replace_base(ids: impl IntoIterator<Item = u64>, round: u32) -> Operation {
+    Operation::DataReplacement {
+        replacements: ids
+            .into_iter()
+            .map(|id| DataReplacementGroup(id, make_replacement_data_file(id, round)))
+            .collect(),
+    }
+}
+
+pub(super) fn delete_fragments(ids: impl IntoIterator<Item = u64>) -> Operation {
+    Operation::Delete {
+        updated_fragments: Vec::new(),
+        deleted_fragment_ids: ids.into_iter().collect(),
+        predicate: "true".to_string(),
+    }
+}
+
+pub(super) fn set_deletion_file(mut fragment: Fragment, file_id: u64) -> Operation {
+    let read_version = fragment.id;
+    fragment.deletion_file = Some(deletion_file(file_id, read_version));
+    Operation::Delete {
+        updated_fragments: vec![fragment],
+        deleted_fragment_ids: Vec::new(),
+        predicate: "id = 1".to_string(),
+    }
+}

--- a/rust/lance/src/dataset/fragment_metadata/gate_tests.rs
+++ b/rust/lance/src/dataset/fragment_metadata/gate_tests.rs
@@ -1,0 +1,996 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+//! Native transaction validation and conflict parity against flat manifests.
+
+use super::differential::{
+    Differential, add_column, delete_fragments, production_style_append,
+    production_style_append_with_version, replace_base, set_deletion_file,
+};
+use crate::dataset::transaction::{DataReplacementGroup, Operation, RewriteGroup, UpdateMode};
+use lance_core::Error;
+use lance_file::version::LanceFileVersion;
+use lance_table::format::DataFile;
+use lance_table::format::overlay::{DataOverlayFile, OverlayCoverage};
+use lance_table::fragment_metadata::support::{make_backfill_data_file, make_fragment};
+use std::num::NonZero;
+
+const N: u64 = 300;
+
+#[rstest::rstest]
+#[case::update_columns("update_columns")]
+#[case::update_rows("update_rows")]
+#[case::rewrite("rewrite")]
+#[case::overwrite("overwrite")]
+#[case::reserved_rewrite("reserved_rewrite")]
+#[tokio::test]
+async fn native_operation_results_match_flat(#[case] kind: &str) {
+    let mut diff = Differential::create(N).await;
+    let initial = diff.flat_state().await;
+    let mut old = vec![initial.fragments[&7].clone(), initial.fragments[&8].clone()];
+    let mut new = old.clone();
+    for fragment in &mut new {
+        fragment.files[0].path = format!("{kind}-{}.lance", fragment.id);
+    }
+    let operation = match kind {
+        "update_columns" => Operation::Update {
+            removed_fragment_ids: Vec::new(),
+            updated_fragments: new,
+            new_fragments: Vec::new(),
+            fields_modified: vec![0, 1],
+            compacted_sstables: Vec::new(),
+            fields_for_preserving_frag_bitmap: Vec::new(),
+            update_mode: Some(UpdateMode::RewriteColumns),
+            inserted_rows_filter: None,
+            updated_fragment_offsets: None,
+        },
+        "update_rows" => {
+            for fragment in &mut new {
+                fragment.id = 0;
+            }
+            Operation::Update {
+                removed_fragment_ids: vec![7, 8],
+                updated_fragments: Vec::new(),
+                new_fragments: new,
+                fields_modified: Vec::new(),
+                compacted_sstables: Vec::new(),
+                fields_for_preserving_frag_bitmap: Vec::new(),
+                update_mode: Some(UpdateMode::RewriteRows),
+                inserted_rows_filter: None,
+                updated_fragment_offsets: None,
+            }
+        }
+        "rewrite" | "reserved_rewrite" => {
+            if kind == "reserved_rewrite" {
+                let reserved = diff
+                    .apply_latest("reserve", Operation::ReserveFragments { num_fragments: 2 })
+                    .await;
+                assert!(
+                    reserved.both_accepted_and_equal(),
+                    "flat={:?} tree={:?}",
+                    reserved.flat,
+                    reserved.fragment_metadata
+                );
+                new[0].id = N;
+                new[1].id = N + 1;
+            } else {
+                for fragment in &mut new {
+                    fragment.id = 0;
+                }
+            }
+            Operation::Rewrite {
+                groups: vec![RewriteGroup {
+                    old_fragments: std::mem::take(&mut old),
+                    new_fragments: new,
+                }],
+                rewritten_indices: Vec::new(),
+                frag_reuse_index: None,
+            }
+        }
+        "overwrite" => {
+            for fragment in &mut new {
+                fragment.id = 0;
+            }
+            Operation::Overwrite {
+                fragments: new,
+                schema: initial.schema.clone(),
+                config_upsert_values: None,
+                initial_bases: None,
+            }
+        }
+        _ => unreachable!(),
+    };
+    let result = diff.apply_latest(kind, operation).await;
+    assert!(
+        result.both_accepted_and_equal(),
+        "flat={:?} tree={:?} diff={:?}",
+        result.flat,
+        result.fragment_metadata,
+        result.diff
+    );
+    let appended = diff
+        .apply_latest("append_after", production_style_append(3))
+        .await;
+    assert!(
+        appended.both_accepted_and_equal(),
+        "flat={:?} tree={:?} diff={:?}",
+        appended.flat,
+        appended.fragment_metadata,
+        appended.diff
+    );
+    let tree = diff.fragment_metadata_reader().await;
+    tree.tree.verify_watermarks().await.unwrap();
+}
+
+#[tokio::test]
+async fn replacement_validation_resolves_fields_before_aliased_paths() {
+    let mut fragment = make_fragment(0);
+    let mut backfill = make_backfill_data_file(0, 0);
+    backfill.path = fragment.files[0].path.clone();
+    fragment.files.push(backfill.clone());
+    let mut diff = Differential::create_with_fragments(vec![fragment]).await;
+    backfill.path = "replacement-of-second-occurrence.lance".to_string();
+    let result = diff
+        .apply_latest(
+            "replace_alias",
+            Operation::DataReplacement {
+                replacements: vec![DataReplacementGroup(0, backfill)],
+            },
+        )
+        .await;
+    assert!(
+        result.both_accepted_and_equal(),
+        "flat={:?}, tree={:?}, diff={:?}",
+        result.flat,
+        result.fragment_metadata,
+        result.diff
+    );
+    let mut stale = make_backfill_data_file(0, 0);
+    stale.path = "stale-replacement.lance".to_string();
+    let result = diff
+        .apply(
+            "stale_alias",
+            1,
+            Operation::DataReplacement {
+                replacements: vec![DataReplacementGroup(0, stale)],
+            },
+        )
+        .await;
+    assert!(
+        result.both_rejected(),
+        "Raw replacement intent must conflict even when storage used a whole Fragment SET: {:?}",
+        result.diff
+    );
+}
+
+#[rstest::rstest]
+#[case::fully_superseded(false)]
+#[case::partly_superseded(true)]
+#[tokio::test]
+async fn replacement_tombstones_overlays_like_flat(#[case] partial: bool) {
+    let mut fragment = make_fragment(0);
+    let mut overlay = fragment.files[0].clone();
+    overlay.path = "overlay.lance".to_string();
+    if partial {
+        overlay.fields = vec![0, 1, 2].into();
+        overlay.column_indices = vec![0, 1, 2].into();
+    }
+    fragment.overlays.push(DataOverlayFile {
+        data_file: overlay,
+        coverage: OverlayCoverage::Shared(std::sync::Arc::new([0].into_iter().collect())),
+        committed_version: 1,
+    });
+    let mut diff = Differential::create_with_fragments(vec![fragment]).await;
+    let result = diff
+        .apply_latest("replace_overlay_base", replace_base([0], 1))
+        .await;
+    assert!(
+        result.both_accepted_and_equal(),
+        "flat={:?}, tree={:?}, diff={:?}",
+        result.flat,
+        result.fragment_metadata,
+        result.diff
+    );
+    let state = diff.flat_state().await;
+    let overlays = &state.fragments[&0].overlays;
+    if partial {
+        assert_eq!(overlays[0].data_file.fields.as_ref(), &[-2, -2, 2]);
+    } else {
+        assert!(overlays.is_empty());
+    }
+}
+
+#[tokio::test]
+async fn add_then_replace_keeps_original_column_mapping_like_flat() {
+    let mut diff = Differential::create(N).await;
+    let first = diff.apply_latest("add_file", add_column([7], 0)).await;
+    assert!(first.both_accepted_and_equal(), "{:?}", first.diff);
+    let mut replacement = make_backfill_data_file(7, 0);
+    replacement.path = "replacement-with-different-column-mapping.lance".to_string();
+    replacement.column_indices = vec![9].into();
+    let second = diff
+        .apply_latest(
+            "replace_file",
+            Operation::DataReplacement {
+                replacements: vec![DataReplacementGroup(7, replacement)],
+            },
+        )
+        .await;
+    assert!(second.both_accepted_and_equal(), "{:?}", second.diff);
+    let current = diff.flat_state().await;
+    assert_eq!(current.fragments[&7].files[1].column_indices.as_ref(), &[0]);
+}
+
+/// Scattered ids that avoid the range the mixed stream deletes.
+fn scattered(round: u64, count: u64) -> Vec<u64> {
+    (0..count)
+        .map(|i| (i * 37 + round * 11) % N)
+        .filter(|id| !(100..140).contains(id))
+        .collect()
+}
+
+#[tokio::test]
+async fn semantic_matrix_matches_flat_through_leaf_application() {
+    let mut diff = Differential::create(N).await;
+
+    let steps: Vec<(&str, Operation)> = vec![
+        ("append_prod_ids", production_style_append(5)),
+        ("append_prod_ids", production_style_append(3)),
+        ("add_column_contiguous", add_column(0..10, 0)),
+        ("add_column_no_op_rejected", add_column(0..3, 0)),
+        ("add_column_scattered", add_column(scattered(0, 10), 1)),
+        ("replace_contiguous", replace_base(0..10, 0)),
+        ("replace_same_fragment_again", replace_base(0..10, 1)),
+        ("add_column_second_col_same_frags", add_column(0..10, 2)),
+        ("delete_whole_fragments", delete_fragments([7, 8, 9])),
+    ];
+    for (step, operation) in steps {
+        let outcome = diff.apply_latest(step, operation).await;
+        if step == "add_column_no_op_rejected" {
+            assert!(
+                outcome.both_rejected(),
+                "{step}: flat={:?} fragment_metadata={:?}",
+                outcome.flat.as_ref().err(),
+                outcome.fragment_metadata.as_ref().err()
+            );
+            continue;
+        }
+        assert!(
+            outcome.both_accepted_and_equal(),
+            "{step}: flat={:?} fragment_metadata={:?} diff={:?}",
+            outcome.flat.as_ref().err(),
+            outcome.fragment_metadata.as_ref().err(),
+            outcome.diff
+        );
+    }
+
+    let dv_target = N;
+    let flat_now = diff.flat_state().await;
+    let fragment = flat_now
+        .fragments
+        .get(&dv_target)
+        .unwrap_or_else(|| {
+            panic!(
+                "fragment {dv_target} missing on flat side; ids={:?}",
+                flat_now.fragments.keys().collect::<Vec<_>>()
+            )
+        })
+        .clone();
+    let outcome = diff
+        .apply_latest("add_deletion_file", set_deletion_file(fragment, 1))
+        .await;
+    assert!(
+        outcome.both_accepted_and_equal(),
+        "add_deletion_file: {:?}",
+        outcome.diff
+    );
+    let fragment = diff.flat_state().await.fragments[&dv_target].clone();
+    let outcome = diff
+        .apply_latest("replace_deletion_file", set_deletion_file(fragment, 2))
+        .await;
+    assert!(
+        outcome.both_accepted_and_equal(),
+        "replace_deletion_file: {:?}",
+        outcome.diff
+    );
+    let fragment = diff.flat_state().await.fragments[&5].clone();
+    let outcome = diff
+        .apply_latest(
+            "deletion_file_covering_all_rows_prunes",
+            set_deletion_file(fragment, 3),
+        )
+        .await;
+    assert!(
+        outcome.both_accepted_and_equal(),
+        "deletion_file_covering_all_rows_prunes: {:?}",
+        outcome.diff
+    );
+    assert!(!diff.flat_state().await.fragments.contains_key(&5));
+
+    for round in 0..40u64 {
+        let col = 3 + round as u32;
+        let live: Vec<u64> = diff.flat_state().await.fragments.keys().copied().collect();
+        let ids: Vec<u64> = (0..10)
+            .map(|i| live[((i * 37 + round * 11) % live.len() as u64) as usize])
+            .collect::<std::collections::BTreeSet<_>>()
+            .into_iter()
+            .collect();
+        let replace_ids: Vec<u64> = ids.iter().copied().take(4).collect();
+        let delete_id = *live
+            .iter()
+            .rev()
+            .find(|id| !ids.contains(id))
+            .expect("a live fragment outside the touched set");
+        let ops: Vec<(&str, Operation)> = vec![
+            ("mixed_append", production_style_append(2)),
+            ("mixed_add_column", add_column(ids.clone(), col)),
+            ("mixed_replace", replace_base(replace_ids, 2 + round as u32)),
+            ("mixed_delete", delete_fragments([delete_id])),
+        ];
+        for (step, operation) in ops {
+            let outcome = diff.apply_latest(step, operation).await;
+            assert!(
+                outcome.both_accepted_and_equal(),
+                "round {round} {step}: flat={:?} fragment_metadata={:?} diff={:?}",
+                outcome.flat.as_ref().err(),
+                outcome.fragment_metadata.as_ref().err(),
+                outcome.diff
+            );
+        }
+    }
+
+    let reader = diff.fragment_metadata_reader().await;
+    let buffered = reader.tree.buffered_action_keys().await.unwrap();
+    let state = diff.fragment_metadata_state().await;
+    let leaf_applied = state
+        .fragments
+        .keys()
+        .filter(|id| !buffered.contains(id))
+        .count();
+    assert!(
+        reader.tree.height() >= 2,
+        "stream must run against a multi-level tree, height={}",
+        reader.tree.height()
+    );
+    assert!(
+        leaf_applied > 0 && buffered.len() < state.fragments.len(),
+        "actions must have reached leaves: buffered={} fragments={}",
+        buffered.len(),
+        state.fragments.len()
+    );
+}
+
+async fn invalid_replacement_fails_its_own_commit(step: &str, operation: Operation) {
+    let mut diff = Differential::create(N).await;
+    let outcome = diff.apply_latest(step, operation).await;
+    assert!(
+        outcome.flat.is_err(),
+        "{step}: flat must reject at commit, got version {:?}",
+        outcome.flat
+    );
+    let mut later_failures = Vec::new();
+    for round in 0..12 {
+        let later = diff
+            .apply_latest(
+                &format!("{step}_later_append_{round}"),
+                production_style_append(1),
+            )
+            .await;
+        if let Err(error) = &later.fragment_metadata {
+            later_failures.push(format!("round {round}: {error}"));
+        }
+    }
+    assert!(
+        outcome.fragment_metadata.is_err(),
+        "{step}: fragment metadata tree accepted an invalid replacement at version {:?}; later commits failed: {:?}",
+        outcome.fragment_metadata,
+        later_failures
+    );
+    assert!(
+        later_failures.is_empty(),
+        "{step}: benign commits after a rejected replacement must succeed: {later_failures:?}"
+    );
+    assert!(diff.states_equal().await, "{step}: states diverged");
+}
+
+#[tokio::test]
+async fn replacement_of_missing_fragment_fails_its_own_commit() {
+    invalid_replacement_fails_its_own_commit("replace_missing_fragment", replace_base([9_999], 0))
+        .await;
+}
+
+#[tokio::test]
+async fn replacement_with_partial_field_overlap_fails_its_own_commit() {
+    let mut file = make_backfill_data_file(42, 0);
+    file = DataFile::new(
+        file.path.clone(),
+        vec![1, 99],
+        vec![0, 1],
+        lance_file::version::ConcreteFileVersion::from_data_file_numbers(
+            file.file_major_version,
+            file.file_minor_version,
+        )
+        .unwrap(),
+        NonZero::new(4096),
+        None,
+    );
+    invalid_replacement_fails_its_own_commit(
+        "replace_partial_overlap",
+        Operation::DataReplacement {
+            replacements: vec![DataReplacementGroup(42, file)],
+        },
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn replacement_with_no_matching_file_version_fails_its_own_commit() {
+    let (major, minor) = LanceFileVersion::V2_1.resolve().to_data_file_numbers();
+    let base = make_fragment(42).files[0].clone();
+    let file = DataFile::new(
+        "data/replacement-v21.lance",
+        vec![0, 1],
+        vec![0, 1],
+        lance_file::version::ConcreteFileVersion::from_data_file_numbers(major, minor).unwrap(),
+        NonZero::new(1024),
+        None,
+    );
+    assert_ne!(
+        base.file_major_version.max(base.file_minor_version),
+        u32::MAX
+    );
+    invalid_replacement_fails_its_own_commit(
+        "replace_no_matching_file_version",
+        Operation::DataReplacement {
+            replacements: vec![DataReplacementGroup(42, file)],
+        },
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn replacement_of_fragment_deleted_earlier_fails_its_own_commit() {
+    let mut diff = Differential::create(N).await;
+    let outcome = diff.apply_latest("delete_42", delete_fragments([42])).await;
+    assert!(outcome.both_accepted_and_equal());
+    let outcome = diff
+        .apply_latest("replace_deleted_42", replace_base([42], 0))
+        .await;
+    assert!(outcome.flat.is_err());
+    assert!(
+        outcome.fragment_metadata.is_err(),
+        "fragment metadata tree accepted a replacement of a fragment deleted at the previous version"
+    );
+}
+
+async fn conflict_pair(label: &str, a: Operation, b: Operation) -> (bool, bool, bool) {
+    let mut diff = Differential::create(N).await;
+    let base = diff.flat_state().await.version;
+    let first = diff.apply(&format!("{label}_A"), base, a).await;
+    assert!(
+        first.both_accepted_and_equal(),
+        "{label}: writer A must land: flat={:?} fragment_metadata={:?} diff={:?}",
+        first.flat.as_ref().err(),
+        first.fragment_metadata.as_ref().err(),
+        first.diff
+    );
+    let second = diff.apply(&format!("{label}_B"), base, b).await;
+    let parity = match (&second.flat, &second.fragment_metadata) {
+        (Ok(_), Ok(_)) => second.parity == Some(true),
+        (Err(_), Err(_)) => true,
+        _ => false,
+    };
+    (
+        second.flat.is_ok(),
+        second.fragment_metadata.is_ok(),
+        parity,
+    )
+}
+
+macro_rules! conflict_test {
+    ($name:ident, $csv:literal, $a:expr, $b:expr) => {
+        #[tokio::test]
+        async fn $name() {
+            let (flat_ok, fragment_metadata_ok, parity) =
+                conflict_pair(stringify!($name), $a, $b).await;
+            assert!(
+                parity,
+                "{}: flat_accepted={flat_ok} fragment_metadata_accepted={fragment_metadata_ok}",
+                stringify!($name)
+            );
+        }
+    };
+}
+
+conflict_test!(
+    conflict_append_vs_append,
+    "conflict-append-append.csv",
+    production_style_append(2),
+    production_style_append(2)
+);
+conflict_test!(
+    conflict_replace_f42_vs_replace_f42,
+    "conflict-replace-replace.csv",
+    replace_base([42], 0),
+    replace_base([42], 1)
+);
+conflict_test!(
+    conflict_replace_f42_vs_delete_f42,
+    "conflict-replace-delete.csv",
+    replace_base([42], 0),
+    delete_fragments([42])
+);
+conflict_test!(
+    conflict_delete_f42_vs_replace_f42,
+    "conflict-delete-replace.csv",
+    delete_fragments([42]),
+    replace_base([42], 0)
+);
+conflict_test!(
+    conflict_add_column_f42_vs_delete_f42,
+    "conflict-addcol-delete.csv",
+    add_column([42], 0),
+    delete_fragments([42])
+);
+conflict_test!(
+    conflict_delete_f42_vs_add_column_f42,
+    "conflict-delete-addcol.csv",
+    delete_fragments([42]),
+    add_column([42], 0)
+);
+conflict_test!(
+    conflict_add_column_f42_vs_add_column_f42_same_field,
+    "conflict-addcol-addcol-same.csv",
+    add_column([42], 0),
+    add_column([42], 0)
+);
+conflict_test!(
+    conflict_add_column_f42_vs_add_column_f42_other_field,
+    "conflict-addcol-addcol-other.csv",
+    add_column([42], 0),
+    add_column([42], 1)
+);
+conflict_test!(
+    conflict_deletion_file_f42_vs_delete_f42,
+    "conflict-dv-delete.csv",
+    set_deletion_file(make_fragment(42), 1),
+    delete_fragments([42])
+);
+conflict_test!(
+    conflict_delete_f42_vs_deletion_file_f42,
+    "conflict-delete-dv.csv",
+    delete_fragments([42]),
+    set_deletion_file(make_fragment(42), 1)
+);
+conflict_test!(
+    conflict_update_f42_vs_update_f99,
+    "conflict-replace-different.csv",
+    replace_base([42], 0),
+    replace_base([99], 0)
+);
+conflict_test!(
+    conflict_separate_subtrees,
+    "conflict-separate-subtrees.csv",
+    add_column([1, 2, 3], 0),
+    add_column([290, 291, 292], 0)
+);
+
+#[tokio::test]
+async fn append_with_id_zero_gets_fresh_id_and_keeps_fragment_zero() {
+    let mut diff = Differential::create(N).await;
+    let outcome = diff
+        .apply_latest("append_single_id_zero", production_style_append(1))
+        .await;
+    assert!(
+        outcome.both_accepted_and_equal(),
+        "flat={:?} fragment_metadata={:?} diff={:?}",
+        outcome.flat.as_ref().err(),
+        outcome.fragment_metadata.as_ref().err(),
+        outcome.diff
+    );
+    let state = diff.fragment_metadata_state().await;
+    assert_eq!(state.fragments.len(), N as usize + 1);
+    assert!(state.fragments.contains_key(&N), "fresh id must be max + 1");
+}
+
+#[tokio::test]
+async fn add_columns_updates_schema_and_files_atomically_like_flat() {
+    let mut diff = Differential::create(N).await;
+    let v1 = diff.flat_state().await.version;
+    let ids: Vec<u64> = (0..10).collect();
+    let outcome = diff.apply_add_columns("add_col0", v1, &ids, 0).await;
+    assert!(
+        outcome.both_accepted_and_equal(),
+        "add_col0: flat={:?} fragment_metadata={:?} diff={:?}",
+        outcome.flat.as_ref().err(),
+        outcome.fragment_metadata.as_ref().err(),
+        outcome.diff
+    );
+    let after = diff.fragment_metadata_state().await;
+    assert_eq!(after.schema.fields.len(), 3);
+    assert_eq!(after.fragments[&0].files.len(), 2);
+
+    let previous = crate::dataset::fragment_metadata::test_support::Reader::open_uri_at(
+        &diff.fragment_metadata.uri,
+        v1,
+    )
+    .await
+    .unwrap();
+    assert_eq!(previous.schema().unwrap().fields.len(), 2);
+    assert_eq!(
+        previous
+            .resolve_fragment(0)
+            .await
+            .unwrap()
+            .unwrap()
+            .files
+            .len(),
+        1
+    );
+
+    let v2 = diff.flat_state().await.version;
+    let scattered_ids = scattered(1, 10);
+    let outcome = diff
+        .apply_add_columns("add_col1", v2, &scattered_ids, 1)
+        .await;
+    assert!(
+        outcome.both_accepted_and_equal(),
+        "add_col1: {:?}",
+        outcome.diff
+    );
+    for round in 0..6 {
+        let outcome = diff
+            .apply_latest(
+                &format!("post_schema_append_{round}"),
+                production_style_append(1),
+            )
+            .await;
+        assert!(
+            outcome.both_accepted_and_equal(),
+            "append after schema change: {:?}",
+            outcome.diff
+        );
+    }
+    let reader = diff.fragment_metadata_reader().await;
+    assert!(reader.tree.verify_reachable().await.unwrap() > 0);
+    assert!(
+        diff.states_equal().await,
+        "schema and fragments must survive the fold"
+    );
+    assert_eq!(diff.fragment_metadata_state().await.schema.fields.len(), 4);
+}
+
+#[tokio::test]
+async fn add_columns_conflicts_match_flat() {
+    let mut diff = Differential::create(N).await;
+    let base = diff.flat_state().await.version;
+    let outcome = diff.apply("delete_42", base, delete_fragments([42])).await;
+    assert!(outcome.both_accepted_and_equal());
+    let outcome = diff
+        .apply_add_columns("stale_add_col_on_42", base, &[42, 43], 0)
+        .await;
+    assert!(
+        outcome.flat.is_err() && outcome.fragment_metadata.is_err(),
+        "stale add-column over a deleted target: flat={:?} fragment_metadata={:?}",
+        outcome.flat,
+        outcome.fragment_metadata
+    );
+
+    let base = diff.flat_state().await.version;
+    let outcome = diff.apply_add_columns("add_col0", base, &[1, 2], 0).await;
+    assert!(outcome.both_accepted_and_equal(), "{:?}", outcome.diff);
+    let outcome = diff
+        .apply(
+            "stale_append_after_schema_change",
+            base,
+            production_style_append(1),
+        )
+        .await;
+    assert!(
+        matches!(outcome.flat, Err(Error::RetryableCommitConflict { .. }))
+            && matches!(
+                outcome.fragment_metadata,
+                Err(Error::RetryableCommitConflict { .. })
+            ),
+        "stale append retries after a schema change on both sides: flat={:?} fragment_metadata={:?} diff={:?}",
+        outcome.flat.as_ref().err(),
+        outcome.fragment_metadata.as_ref().err(),
+        outcome.diff
+    );
+}
+
+#[tokio::test]
+async fn transaction_history_is_owned_by_version_manifest() {
+    let mut diff = Differential::create(N).await;
+    let mut rows = vec!["operation,transaction_file_bytes,manifest_bytes".to_string()];
+    for (step, operation) in [
+        ("replace_10", replace_base(0..10, 0)),
+        ("append_2", production_style_append(2)),
+        ("delete_3", delete_fragments([100, 101, 102])),
+    ] {
+        let expected_operation = operation.name().to_string();
+        let before: std::collections::HashSet<_> = std::fs::read_dir(
+            std::path::Path::new(&diff.fragment_metadata.uri).join("_transactions"),
+        )
+        .unwrap()
+        .map(|entry| entry.unwrap().path())
+        .collect();
+        let outcome = diff.apply_latest(step, operation).await;
+        assert!(
+            outcome.both_accepted_and_equal(),
+            "{step}: {:?}",
+            outcome.diff
+        );
+        let version = outcome.fragment_metadata.as_ref().unwrap();
+        let transaction_bytes: u64 = std::fs::read_dir(
+            std::path::Path::new(&diff.fragment_metadata.uri).join("_transactions"),
+        )
+        .unwrap()
+        .map(|entry| entry.unwrap().path())
+        .filter(|path| !before.contains(path))
+        .map(|path| std::fs::metadata(path).unwrap().len())
+        .sum();
+        let dataset =
+            crate::dataset::builder::DatasetBuilder::from_uri(&diff.fragment_metadata.uri)
+                .load()
+                .await
+                .unwrap();
+        assert_eq!(
+            dataset
+                .read_transaction()
+                .await
+                .unwrap()
+                .unwrap()
+                .operation
+                .name(),
+            expected_operation
+        );
+        assert_eq!(dataset.version().version, *version);
+        assert!(dataset.manifest.fragment_metadata.is_some());
+        assert!(
+            !std::path::Path::new(&diff.fragment_metadata.uri)
+                .join("_bt/root")
+                .exists()
+        );
+        let delta_bytes = std::fs::metadata(
+            std::path::Path::new(&diff.fragment_metadata.uri)
+                .join("_versions")
+                .join(dataset.manifest_location.path.filename().unwrap()),
+        )
+        .unwrap()
+        .len();
+        rows.push(format!("{step},{transaction_bytes},{delta_bytes}"));
+        assert!(transaction_bytes > 0 && delta_bytes > 0);
+    }
+    if let Ok(dir) = std::env::var("FRAGMENT_METADATA_OVERNIGHT_RESULTS") {
+        let mut text = rows.join("\n");
+        text.push('\n');
+        std::fs::write(
+            std::path::Path::new(&dir).join("txn-manifest-history.csv"),
+            text,
+        )
+        .unwrap();
+    }
+}
+
+#[tokio::test]
+async fn delete_with_missing_updated_fragment_matches_flat() {
+    let mut diff = Differential::create(N).await;
+    let outcome = diff.apply_latest("delete_42", delete_fragments([42])).await;
+    assert!(outcome.both_accepted_and_equal());
+    let mut ghost = make_fragment(42);
+    ghost.physical_rows = Some(10);
+    let outcome = diff
+        .apply_latest("update_missing_42", set_deletion_file(ghost, 1))
+        .await;
+    assert!(
+        outcome.both_accepted_and_equal() || outcome.both_rejected(),
+        "flat={:?} fragment_metadata={:?} diff={:?}",
+        outcome.flat.as_ref().err(),
+        outcome.fragment_metadata.as_ref().err(),
+        outcome.diff
+    );
+}
+
+#[tokio::test]
+async fn empty_dataset_bootstraps_and_grows_like_flat() {
+    let mut diff = Differential::create(0).await;
+    let storage_version = LanceFileVersion::default();
+    for round in 0..12 {
+        let outcome = diff
+            .apply_latest(
+                &format!("append_{round}"),
+                production_style_append_with_version(3, storage_version),
+            )
+            .await;
+        assert!(
+            outcome.both_accepted_and_equal(),
+            "round {round}: flat={:?} fragment_metadata={:?} diff={:?}",
+            outcome.flat.as_ref().err(),
+            outcome.fragment_metadata.as_ref().err(),
+            outcome.diff
+        );
+    }
+    assert_eq!(diff.fragment_metadata_state().await.fragments.len(), 36);
+}
+
+/// Writers A and B both read the same version; A lands; B commits stale.
+/// For every wired operation pair and key relation, flat and fragment
+/// metadata tree must agree on the verdict category (accept, retryable
+/// conflict, incompatible transaction, invalid input) and, when both
+/// accept, on the logical state.
+#[rstest::rstest]
+#[case::append_append(production_style_append(2), production_style_append(2))]
+#[case::append_delete(production_style_append(2), delete_fragments([42]))]
+#[case::append_replace(production_style_append(2), replace_base([42], 0))]
+#[case::append_add_column(production_style_append(2), add_column([42], 0))]
+#[case::delete_append(delete_fragments([42]), production_style_append(2))]
+#[case::delete_same(delete_fragments([42]), delete_fragments([42]))]
+#[case::delete_disjoint(delete_fragments([42]), delete_fragments([99]))]
+#[case::delete_dv_same(delete_fragments([42]), set_deletion_file(make_fragment(42), 1))]
+#[case::delete_dv_disjoint(delete_fragments([42]), set_deletion_file(make_fragment(99), 1))]
+#[case::delete_replace_same(delete_fragments([42]), replace_base([42], 0))]
+#[case::delete_replace_disjoint(delete_fragments([42]), replace_base([99], 0))]
+#[case::delete_add_column_same(delete_fragments([42]), add_column([42], 0))]
+#[case::delete_add_column_disjoint(delete_fragments([42]), add_column([99], 0))]
+#[case::dv_delete_same(set_deletion_file(make_fragment(42), 1), delete_fragments([42]))]
+#[case::dv_same(
+    set_deletion_file(make_fragment(42), 1),
+    set_deletion_file(make_fragment(42), 1)
+)]
+#[case::dv_disjoint(
+    set_deletion_file(make_fragment(42), 1),
+    set_deletion_file(make_fragment(99), 1)
+)]
+#[case::dv_replace_same(set_deletion_file(make_fragment(42), 1), replace_base([42], 0))]
+#[case::replace_append(replace_base([42], 0), production_style_append(2))]
+#[case::replace_delete_same(replace_base([42], 0), delete_fragments([42]))]
+#[case::replace_delete_disjoint(replace_base([42], 0), delete_fragments([99]))]
+#[case::replace_dv_same(replace_base([42], 0), set_deletion_file(make_fragment(42), 1))]
+#[case::replace_same_fragment_same_fields(replace_base([42], 0), replace_base([42], 1))]
+#[case::replace_disjoint_fragments(replace_base([42], 0), replace_base([99], 1))]
+#[case::replace_add_column_disjoint_fields(replace_base([42], 0), add_column([42], 0))]
+#[case::add_column_delete_same(add_column([42], 0), delete_fragments([42]))]
+#[case::add_column_replace_disjoint_fields(add_column([42], 0), replace_base([42], 0))]
+#[case::add_column_same_field(add_column([42], 0), add_column([43], 0))]
+#[case::add_column_other_field(add_column([42], 0), add_column([42], 1))]
+#[case::add_column_disjoint_fragments(add_column([42], 0), add_column([99], 0))]
+#[tokio::test]
+async fn conflict_matrix_matches_flat_for_every_wired_pair(
+    #[case] a: Operation,
+    #[case] b: Operation,
+) {
+    let mut diff = Differential::create(100).await;
+    let base = diff.flat_state().await.version;
+    let first = diff.apply("writer A", base, a).await;
+    assert!(
+        first.both_accepted_and_equal(),
+        "writer A must land: flat={:?} fragment_metadata={:?} diff={:?}",
+        first.flat.as_ref().err(),
+        first.fragment_metadata.as_ref().err(),
+        first.diff
+    );
+    let committed = diff.flat_state().await;
+    let second = diff.apply("stale writer B", base, b).await;
+    let flat_verdict = second
+        .flat
+        .as_ref()
+        .err()
+        .map(super::differential::error_category);
+    let fragment_metadata_verdict = second
+        .fragment_metadata
+        .as_ref()
+        .err()
+        .map(super::differential::error_category);
+    assert_eq!(flat_verdict, fragment_metadata_verdict, "{:?}", second.diff);
+    match (&second.flat, &second.fragment_metadata) {
+        (Ok(_), Ok(_)) => assert_eq!(second.parity, Some(true), "{:?}", second.diff),
+        (Err(_), Err(_)) => {
+            assert_eq!(
+                diff.flat_state().await,
+                committed,
+                "Flat rejection changed state"
+            );
+            assert_eq!(
+                diff.fragment_metadata_state().await,
+                committed,
+                "Tree rejection changed state"
+            );
+        }
+        _ => panic!(
+            "Writer verdicts differ: flat={:?}, fragment_metadata={:?}",
+            second.flat, second.fragment_metadata
+        ),
+    }
+}
+
+#[tokio::test]
+async fn stale_index_coverage_uses_the_original_read_version() {
+    use lance_table::system_index::mem_wal::{
+        CompactedSsTable, MEM_WAL_INDEX_NAME, MemWalIndexDetails, load_mem_wal_index_details,
+        new_mem_wal_index_meta,
+    };
+    let mut diff = Differential::create(2).await;
+    let shard = uuid::Uuid::new_v4();
+    let wal = new_mem_wal_index_meta(
+        1,
+        MemWalIndexDetails {
+            compacted_sstables: vec![CompactedSsTable::new(shard, 5)],
+            ..Default::default()
+        },
+    )
+    .unwrap();
+    let outcome = diff
+        .apply_latest(
+            "wal",
+            Operation::CreateIndex {
+                new_indices: vec![wal],
+                removed_indices: Vec::new(),
+            },
+        )
+        .await;
+    assert!(outcome.both_accepted_and_equal(), "{:?}", outcome.diff);
+    let read_version = diff.flat_state().await.version;
+    let outcome = diff
+        .apply_latest(
+            "append",
+            Operation::Append {
+                fragments: vec![make_fragment(0)],
+            },
+        )
+        .await;
+    assert!(outcome.both_accepted_and_equal(), "{:?}", outcome.diff);
+    let index = lance_table::format::IndexMetadata {
+        uuid: uuid::Uuid::new_v4(),
+        name: "id_idx".into(),
+        fields: vec![0],
+        covering_fields: Vec::new(),
+        dataset_version: read_version,
+        fragment_bitmap: Some([0, 1].into_iter().collect()),
+        index_details: Some(std::sync::Arc::new(prost_types::Any {
+            type_url: "type.googleapis.com/lance.index.BTreeIndexDetails".into(),
+            value: Vec::new(),
+        })),
+        index_version: 0,
+        created_at: None,
+        base_id: None,
+        files: Some(Vec::new()),
+    };
+    let outcome = diff
+        .apply(
+            "index_after_append",
+            read_version,
+            Operation::CreateIndex {
+                new_indices: vec![index],
+                removed_indices: Vec::new(),
+            },
+        )
+        .await;
+    assert!(
+        outcome.both_accepted_and_equal(),
+        "flat={:?}, tree={:?}, diff={:?}",
+        outcome.flat,
+        outcome.fragment_metadata,
+        outcome.diff
+    );
+    let mut details = Vec::new();
+    for uri in [&diff.flat.uri, &diff.fragment_metadata.uri] {
+        let dataset = crate::Dataset::open(uri).await.unwrap();
+        let indices = crate::index::load_all_indices(&dataset).await.unwrap();
+        let wal = indices
+            .iter()
+            .find(|index| index.name == MEM_WAL_INDEX_NAME)
+            .unwrap();
+        details.push(load_mem_wal_index_details(wal.clone()).unwrap());
+    }
+    assert_eq!(details[0], details[1]);
+    let catchup = details[0]
+        .index_catchup
+        .iter()
+        .find(|entry| entry.index_name == "id_idx")
+        .unwrap();
+    assert_eq!(
+        catchup.caught_up_generations,
+        vec![CompactedSsTable::new(shard, 5)]
+    );
+}

--- a/rust/lance/src/dataset/fragment_metadata/native.rs
+++ b/rust/lance/src/dataset/fragment_metadata/native.rs
@@ -1,0 +1,435 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+//! Compile authoritative Lance transaction results into fragment storage changes.
+
+use std::collections::BTreeSet;
+use std::sync::Arc;
+
+use lance_core::{Error, Result};
+use lance_table::format::{Fragment, IndexMetadata, Manifest};
+use lance_table::fragment_metadata::{
+    FragmentMetadataTree, TouchedFragments, ValidatedCommit, action,
+};
+
+use super::super::transaction::{Operation, Transaction, validate_operation};
+use super::super::{Dataset, ManifestWriteConfig};
+use crate::index::load_all_indices;
+use crate::io::commit::{
+    check_column_indices, check_storage_version, fix_schema, migrate_indices, migrate_manifest,
+};
+use lance_table::system_index::mem_wal::MEM_WAL_INDEX_NAME;
+use lance_table::transaction::ReadVersionState;
+
+pub(super) struct PreparedOperation {
+    pub manifest: Manifest,
+    pub indices: Vec<IndexMetadata>,
+    pub touched: TouchedFragments,
+    pub changes: ValidatedCommit,
+    fragments: Arc<Vec<Fragment>>,
+    complete: bool,
+}
+
+impl PreparedOperation {
+    pub fn materialized_fragments(&self, dataset: &Dataset) -> Option<Vec<Fragment>> {
+        if self.complete {
+            let mut fragments = self.fragments.as_ref().clone();
+            fragments.sort_unstable_by_key(|fragment| fragment.id);
+            return Some(fragments);
+        }
+        if dataset.lazy_fragments.is_some() {
+            return None;
+        }
+        let mut replacements = self.fragments.as_ref().clone();
+        replacements.sort_unstable_by_key(|fragment| fragment.id);
+        let mut replacements = replacements.into_iter().peekable();
+        let mut fragments = Vec::with_capacity(dataset.manifest.fragments.len());
+        for old in dataset.manifest.fragments.iter() {
+            while let Some(fragment) = replacements.next_if(|fragment| fragment.id < old.id) {
+                fragments.push(fragment);
+            }
+            if let Some(fragment) = replacements.next_if(|fragment| fragment.id == old.id) {
+                fragments.push(fragment);
+            } else if !self.touched.ids.contains(&old.id) {
+                fragments.push(old.clone());
+            }
+        }
+        fragments.extend(replacements);
+        Some(fragments)
+    }
+}
+
+/// A partial manifest is an attempt-local input to the ordinary builder, never
+/// a snapshot. Global transformations require the complete list. Index retention
+/// needs only evidence that a generation still covers a live, untouched fragment.
+pub(super) async fn prepare(
+    dataset: &Dataset,
+    tree: &mut FragmentMetadataTree,
+    transaction: &Transaction,
+    original_read_version: u64,
+    config: &ManifestWriteConfig,
+    bulk: bool,
+) -> Result<PreparedOperation> {
+    let mut indices = load_all_indices(dataset).await?.as_ref().clone();
+    // Coverage is proved against the transaction's original read version. A
+    // sparse manifest cannot prove that an index covers every live fragment.
+    let read_state = if indices.iter().any(|index| index.name == MEM_WAL_INDEX_NAME) {
+        let mut read_dataset = if original_read_version == 0 {
+            dataset.clone()
+        } else {
+            dataset.checkout_version(original_read_version).await?
+        };
+        read_dataset.hydrate_fragments_for_maintenance().await?;
+        let read_indices = load_all_indices(&read_dataset).await?;
+        Some((read_dataset, read_indices))
+    } else {
+        None
+    };
+    validate_allocation(tree.next_fragment_id(), &transaction.operation)?;
+    let selected_ids: Option<Vec<u64>> = match &transaction.operation {
+        Operation::Append { fragments } => Some(
+            fragments
+                .iter()
+                .filter(|fragment| fragment.id != 0)
+                .map(|fragment| fragment.id)
+                .collect(),
+        ),
+        Operation::ReserveFragments { .. } => Some(Vec::new()),
+        Operation::DataReplacement { replacements } => {
+            Some(replacements.iter().map(|group| group.0).collect())
+        }
+        Operation::Delete {
+            updated_fragments,
+            deleted_fragment_ids,
+            ..
+        } => Some(
+            updated_fragments
+                .iter()
+                .map(|fragment| fragment.id)
+                .chain(deleted_fragment_ids.iter().copied())
+                .collect(),
+        ),
+        Operation::Update {
+            updated_fragments,
+            removed_fragment_ids,
+            new_fragments,
+            ..
+        } => Some(
+            updated_fragments
+                .iter()
+                .map(|fragment| fragment.id)
+                .chain(removed_fragment_ids.iter().copied())
+                .chain(
+                    new_fragments
+                        .iter()
+                        .filter(|fragment| fragment.id != 0)
+                        .map(|fragment| fragment.id),
+                )
+                .collect(),
+        ),
+        Operation::Rewrite { groups, .. } => Some(
+            groups
+                .iter()
+                .flat_map(|group| {
+                    group
+                        .old_fragments
+                        .iter()
+                        .chain(
+                            group
+                                .new_fragments
+                                .iter()
+                                .filter(|fragment| fragment.id != 0),
+                        )
+                        .map(|fragment| fragment.id)
+                })
+                .collect(),
+        ),
+        Operation::DataOverlay { groups } => {
+            Some(groups.iter().map(|group| group.fragment_id).collect())
+        }
+        Operation::Clone { .. } => {
+            return Err(Error::not_supported_source(
+                format!(
+                    "fragment metadata tree cannot publish {} through this commit path",
+                    transaction.operation.name()
+                )
+                .into(),
+            ));
+        }
+        _ => None,
+    };
+    let complete = selected_ids.is_none();
+    let mut touched = if complete {
+        if bulk {
+            tree.resolve_touched_for_bulk(&[]).await?;
+        }
+        let fragments = if dataset.lazy_fragments.is_none() {
+            dataset.manifest.fragments.as_ref().clone()
+        } else {
+            tree.materialize().await?
+        };
+        TouchedFragments {
+            ids: fragments.iter().map(|fragment| fragment.id).collect(),
+            fragments: fragments
+                .into_iter()
+                .map(|fragment| (fragment.id, fragment))
+                .collect(),
+        }
+    } else {
+        let ids = selected_ids.unwrap_or_default();
+        resolve_touched(dataset, tree, &ids, bulk).await?
+    };
+    if !complete
+        && matches!(
+            transaction.operation,
+            Operation::Delete { .. } | Operation::Update { .. }
+        )
+    {
+        // Native retention distinguishes empty/nonempty index generations. One
+        // unchanged live record per bitmap preserves that decision without
+        // enumerating all fragment metadata on every indexed mutation. A fully
+        // stale bitmap may require checking all its candidates to prove absence.
+        for index in &indices {
+            let Some(bitmap) = &index.fragment_bitmap else {
+                continue;
+            };
+            if touched
+                .fragments
+                .keys()
+                .any(|id| !touched.ids.contains(id) && bitmap.contains(*id as u32))
+            {
+                continue;
+            }
+            let mut candidates = bitmap
+                .iter()
+                .map(u64::from)
+                .filter(|id| !touched.ids.contains(id));
+            let mut batch_size = 1;
+            loop {
+                let ids: Vec<_> = candidates.by_ref().take(batch_size).collect();
+                batch_size = 64;
+                if ids.is_empty() {
+                    break;
+                }
+                let resolved = resolve_touched(dataset, tree, &ids, bulk).await?;
+                if let Some((id, fragment)) = resolved.fragments.into_iter().next() {
+                    touched.fragments.insert(id, fragment);
+                    break;
+                }
+            }
+        }
+        touched.ids.extend(touched.fragments.keys().copied());
+    }
+    let mut current = dataset.manifest.as_ref().clone();
+    current.set_fragments(touched.fragments.values().cloned().collect());
+    validate_operation(Some(&current), &transaction.operation)?;
+    let (mut manifest, prepared_indices) =
+        if let Operation::Restore { version } = transaction.operation {
+            let (mut restored, indices) = Transaction::restore_old_manifest(
+                &dataset.object_store,
+                dataset.commit_handler.as_ref(),
+                &dataset.base,
+                version,
+                &config.to_build_config(),
+                "",
+                &current,
+            )
+            .await?;
+            if restored.fragment_metadata.is_some() {
+                restored.fragments = Arc::new(
+                    super::tree_from_manifest(
+                        dataset.object_store.clone(),
+                        dataset.base.clone(),
+                        &restored,
+                    )
+                    .await?
+                    .materialize()
+                    .await?,
+                );
+            }
+            restored.version = current.version + 1;
+            (restored, indices)
+        } else {
+            transaction.build_manifest_with_read_version(
+                Some(&current),
+                indices,
+                "",
+                &config.to_build_config(),
+                read_state
+                    .as_ref()
+                    .map(|(dataset, indices)| ReadVersionState {
+                        manifest: dataset.manifest.as_ref(),
+                        indices: indices.as_slice(),
+                    }),
+            )?
+        };
+    indices = prepared_indices;
+    super::tree_config_from(&manifest.config)?;
+    super::publication::policy(&manifest)?;
+    // Byte targets are writer policy and may change. The layout and the hard
+    // capacity are properties of the objects already written.
+    for key in [
+        lance_table::fragment_metadata::MANIFEST_LAYOUT_KEY,
+        "lance.fragment_metadata.hard_capacity_bytes",
+    ] {
+        if manifest.config.get(key) != current.config.get(key) {
+            return Err(Error::invalid_input(format!(
+                "fragment metadata setting {key} cannot change from {:?} to {:?}; it is fixed when the metadata tree is created, so rebuild the metadata tree to change it",
+                current.config.get(key),
+                manifest.config.get(key)
+            )));
+        }
+    }
+
+    // Untouched lazy Fragments may still require these reader capabilities.
+    // The ordinary builder sees only the selected state in the sparse case.
+    if !complete {
+        manifest.reader_feature_flags |= current.reader_feature_flags;
+        manifest.writer_feature_flags |= current.writer_feature_flags;
+    }
+    migrate_manifest(dataset, &mut manifest, current.writer_version.is_none()).await?;
+    fix_schema(&mut manifest)?;
+    check_storage_version(&mut manifest)?;
+    check_column_indices(&manifest)?;
+    let recovered_coverage = migrate_indices(dataset, &mut indices).await?;
+    Transaction::withdraw_coverage_invalidated_after_build(
+        &mut indices,
+        &recovered_coverage,
+        manifest.version,
+    )?;
+
+    let final_ids: BTreeSet<_> = manifest
+        .fragments
+        .iter()
+        .map(|fragment| fragment.id)
+        .collect();
+    if complete {
+        // A complete enumeration also resolves absence, including previously
+        // reserved IDs that an authoritative Rewrite or Merge now introduces.
+        touched.ids.extend(final_ids.iter().copied());
+    }
+    let mut actions: Vec<_> = touched
+        .fragments
+        .keys()
+        .filter(|id| !final_ids.contains(id))
+        .copied()
+        .map(action::remove_fragment)
+        .collect();
+    actions.extend(
+        manifest
+            .fragments
+            .iter()
+            .filter(|fragment| touched.get(fragment.id) != Some(*fragment))
+            .map(action::add_fragment),
+    );
+    // Preserve compact location changes when they exactly produce the native
+    // result. The reducer is never responsible for validating a transaction.
+    if let Operation::DataReplacement { replacements } = &transaction.operation
+        && let Ok(compact) = super::replacement_actions(replacements, &touched)
+    {
+        let mut result = touched.fragments.clone();
+        let messages = compact
+            .iter()
+            .enumerate()
+            .map(
+                |(action_sequence, action)| lance_table::format::pb::FragmentMetadataMutation {
+                    action_sequence: action_sequence as u64 + 1,
+                    action: Some(action.clone()),
+                    ..Default::default()
+                },
+            )
+            .collect();
+        if lance_table::fragment_metadata::node::apply_actions(&mut result, messages).is_ok()
+            && result.values().eq(manifest.fragments.iter())
+        {
+            actions = compact;
+        }
+    }
+    let fragments = std::mem::replace(&mut manifest.fragments, Arc::new(Vec::new()));
+    let next_fragment_id = super::publication::next_fragment_id(&manifest);
+    Ok(PreparedOperation {
+        manifest,
+        indices,
+        touched,
+        fragments,
+        complete,
+        changes: ValidatedCommit {
+            fragment_actions: actions,
+            next_fragment_id: Some(next_fragment_id),
+        },
+    })
+}
+
+async fn resolve_touched(
+    dataset: &Dataset,
+    tree: &mut FragmentMetadataTree,
+    ids: &[u64],
+    bulk: bool,
+) -> Result<TouchedFragments> {
+    if dataset.lazy_fragments.is_none() {
+        let ids: BTreeSet<u64> = ids.iter().copied().collect();
+        let fragments = ids
+            .iter()
+            .filter_map(|id| {
+                dataset
+                    .manifest
+                    .fragments
+                    .binary_search_by_key(id, |fragment| fragment.id)
+                    .ok()
+                    .map(|index| (*id, dataset.manifest.fragments[index].clone()))
+            })
+            .collect();
+        Ok(TouchedFragments { ids, fragments })
+    } else if bulk {
+        tree.resolve_touched_for_bulk(ids).await
+    } else {
+        tree.resolve_touched(ids).await
+    }
+}
+
+fn validate_allocation(next_id: u64, operation: &Operation) -> Result<()> {
+    let new_fragments: Vec<_> = match operation {
+        Operation::Append { fragments } | Operation::Overwrite { fragments, .. } => {
+            fragments.iter().collect()
+        }
+        Operation::Update { new_fragments, .. } => new_fragments.iter().collect(),
+        Operation::Rewrite { groups, .. } => groups
+            .iter()
+            .flat_map(|group| group.new_fragments.iter())
+            .collect(),
+        Operation::ReserveFragments { num_fragments } => {
+            if next_id
+                .checked_add(u64::from(*num_fragments))
+                .is_none_or(|end| end > u64::from(u32::MAX) + 1)
+            {
+                return Err(Error::invalid_input(
+                    "Fragment ID allocation exceeds Lance's u32 address space",
+                ));
+            }
+            return Ok(());
+        }
+        _ => return Ok(()),
+    };
+    let start = next_id;
+    let allocated = if matches!(operation, Operation::Overwrite { .. }) {
+        new_fragments.len()
+    } else {
+        new_fragments
+            .iter()
+            .filter(|fragment| fragment.id == 0)
+            .count()
+    } as u64;
+    if (!matches!(operation, Operation::Overwrite { .. })
+        && new_fragments
+            .iter()
+            .any(|fragment| fragment.id > u64::from(u32::MAX)))
+        || start
+            .checked_add(allocated)
+            .is_none_or(|end| end > u64::from(u32::MAX) + 1)
+    {
+        return Err(Error::invalid_input(
+            "Fragment ID allocation exceeds Lance's u32 address space",
+        ));
+    }
+    Ok(())
+}

--- a/rust/lance/src/dataset/fragment_metadata/publication.rs
+++ b/rust/lance/src/dataset/fragment_metadata/publication.rs
@@ -1,0 +1,309 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+//! The Version Manifest is the only publication authority. Tree objects are
+//! immutable dependencies; raw transaction records are used only for conflicts.
+
+use super::*;
+use lance_io::object_store::ObjectStoreRegistry;
+use lance_table::fragment_metadata::SnapshotPolicy;
+use lance_table::io::commit::CommitError;
+use lance_table::io::manifest::read_manifest;
+
+pub(super) const INLINE_ROOT_BYTES_KEY: &str = "lance.fragment_metadata.inline_manifest_budget";
+pub(super) const SUFFIX_BYTES_KEY: &str = "lance.fragment_metadata.publication_suffix_budget";
+
+#[allow(clippy::too_many_arguments)]
+pub(super) async fn publish(
+    target: CommitTarget,
+    mut tree: FragmentMetadataTree,
+    mut manifest: Manifest,
+    snapshot: pb::FragmentMetadataTree,
+    transaction_file: Option<String>,
+    indices: Vec<lance_table::format::IndexMetadata>,
+    write_config: &super::super::ManifestWriteConfig,
+    transaction: Option<&Transaction>,
+) -> Result<Dataset> {
+    let allow_deep = match manifest
+        .config
+        .get("lance.fragment_metadata.allow_deep_writer")
+        .map(String::as_str)
+    {
+        None | Some("false") => false,
+        Some("true") => true,
+        Some(value) => {
+            return Err(Error::invalid_input(format!(
+                "lance.fragment_metadata.allow_deep_writer must be true or false, got {value:?}"
+            )));
+        }
+    };
+    if tree.height() > 1 && !allow_deep {
+        return Err(Error::not_supported_source(format!(
+            "fragment metadata writer prepared {} levels; recursive Bε routing remains experimental and requires lance.fragment_metadata.allow_deep_writer=true",
+            tree.height() + 1).into()));
+    }
+    // Resolve dataset-root stores before writing the Version Manifest.
+    // A later failure would report an error after the version is already visible.
+    let foreign_bases = Dataset::resolve_tree_foreign_bases(
+        target.session.store_registry(),
+        &target.uri,
+        &target.object_store,
+        &manifest,
+        target.context.as_deref(),
+    )
+    .await?;
+    manifest.version = tree.version();
+    if tree.count_visible_rows() < tree.count_rows() {
+        manifest.reader_feature_flags |= lance_table::feature_flags::FLAG_DELETION_FILES;
+    }
+    manifest.max_fragment_id = tree
+        .next_fragment_id()
+        .checked_sub(1)
+        .map(|id| {
+            u32::try_from(id).map_err(|_| {
+                Error::invalid_input(format!(
+                    "Fragment ID {id} exceeds Lance's u32 address space"
+                ))
+            })
+        })
+        .transpose()?;
+    manifest.fragment_metadata = Some(Arc::new(snapshot));
+    manifest.transaction_file = transaction_file;
+    manifest.transaction_section = None;
+    let location = super::super::write_manifest_file(
+        &target.object_store,
+        target.commit_handler.as_ref(),
+        &target.base_path,
+        &mut manifest,
+        (!indices.is_empty()).then_some(indices),
+        write_config,
+        ManifestNamingScheme::V2,
+        transaction
+            .map(pb::Transaction::from)
+            .filter(|tx| tx.encoded_len() <= crate::io::commit::MAX_INLINE_TRANSACTION_BYTES)
+            .map(lance_table::format::Transaction::from),
+        transaction.is_none_or(|tx| {
+            lance_table::format::operation_may_change_schema(&pb::Transaction::from(tx))
+        }),
+    )
+    .await;
+    let location = match location {
+        Ok(location) => location,
+        Err(error) => {
+            // Use the same outcome verification and handler policy as flat
+            // commits. An unavailable readback must not look safe to retry.
+            let was_conflict = matches!(error, CommitError::CommitConflict);
+            let error = match error {
+                CommitError::CommitConflict => Error::commit_conflict_source(
+                    manifest.version,
+                    "Another writer published this Version Manifest".into(),
+                ),
+                CommitError::OtherError(error) => error,
+            };
+            let outcome = if let Some(transaction) = transaction {
+                crate::io::commit::verify_commit_outcome(
+                    &target.object_store,
+                    target.commit_handler.as_ref(),
+                    &target.base_path,
+                    manifest.version,
+                    transaction,
+                )
+                .await
+            } else {
+                crate::io::commit::CommitOutcome::Unknown
+            };
+            match outcome {
+                crate::io::commit::CommitOutcome::Ours {
+                    manifest: published,
+                    location,
+                } if published.fragment_metadata == manifest.fragment_metadata => {
+                    if !was_conflict && target.commit_handler.propagate_commit_error_after_success()
+                    {
+                        return Err(error);
+                    }
+                    manifest = *published;
+                    location
+                }
+                crate::io::commit::CommitOutcome::Unknown => {
+                    return Err(Error::commit_status_unknown_source(
+                        manifest.version,
+                        Box::new(error),
+                    ));
+                }
+                _ => return Err(error),
+            }
+        }
+    };
+    let dataset = Dataset::checkout_manifest(
+        target.object_store,
+        target.base_path,
+        target.uri,
+        Arc::new(manifest),
+        location,
+        target.session,
+        target.commit_handler,
+        target
+            .context
+            .as_ref()
+            .and_then(|dataset| dataset.file_reader_options.clone()),
+        target
+            .context
+            .as_ref()
+            .and_then(|dataset| dataset.store_params.as_deref().cloned()),
+        target
+            .context
+            .as_ref()
+            .and_then(|dataset| dataset.base_store_params.clone()),
+    )?;
+    tree.set_foreign_bases(foreign_bases);
+    Ok(dataset.with_prepared_tree(tree))
+}
+
+pub(super) async fn open_dataset(target: &CommitTarget, version: Option<u64>) -> Result<Dataset> {
+    let (manifest, location) = read_version(
+        &target.object_store,
+        &target.base_path,
+        target.commit_handler.as_ref(),
+        version,
+    )
+    .await?;
+    Dataset::checkout_manifest(
+        target.object_store.clone(),
+        target.base_path.clone(),
+        target.uri.clone(),
+        Arc::new(manifest),
+        location,
+        target.session.clone(),
+        target.commit_handler.clone(),
+        target
+            .context
+            .as_ref()
+            .and_then(|dataset| dataset.file_reader_options.clone()),
+        target
+            .context
+            .as_ref()
+            .and_then(|dataset| dataset.store_params.as_deref().cloned()),
+        target
+            .context
+            .as_ref()
+            .and_then(|dataset| dataset.base_store_params.clone()),
+    )?
+    .attach_fragment_source()
+    .await
+}
+
+pub async fn tree_from_manifest(
+    store: Arc<ObjectStore>,
+    base: Path,
+    manifest: &Manifest,
+) -> Result<FragmentMetadataTree> {
+    let snapshot = descriptor(manifest)?;
+    let mut tree = FragmentMetadataTree::open_snapshot(
+        store.clone(),
+        base,
+        scheduler_for(&store),
+        Arc::new(LanceCache::with_capacity(0)),
+        &snapshot,
+        manifest.version,
+        super::tree_config_from(&manifest.config)?,
+        next_fragment_id(manifest),
+    )
+    .await?;
+    tree.set_foreign_bases(foreign_bases_from_manifest(&store, manifest)?);
+    Ok(tree)
+}
+
+pub(super) async fn history(
+    target: &CommitTarget,
+    since: u64,
+    through: u64,
+) -> Result<Vec<(u64, Transaction)>> {
+    let mut history = Vec::new();
+    for version in since + 1..=through {
+        let (manifest, location) = read_version(
+            &target.object_store,
+            &target.base_path,
+            target.commit_handler.as_ref(),
+            Some(version),
+        )
+        .await?;
+        let transaction = crate::io::commit::read_manifest_transaction(
+            &target.object_store,
+            &target.base_path,
+            &manifest,
+            &location,
+        )
+        .await?
+        .ok_or_else(|| {
+            Error::invalid_input(format!(
+                "Version {version} has no transaction history; cannot rebase"
+            ))
+        })?;
+        history.push((version, transaction));
+    }
+    Ok(history)
+}
+
+pub(super) async fn read_version(
+    store: &ObjectStore,
+    base: &Path,
+    handler: &dyn CommitHandler,
+    version: Option<u64>,
+) -> Result<(Manifest, ManifestLocation)> {
+    let location = match version {
+        Some(version) => {
+            handler
+                .resolve_version_location(base, version, &store.inner)
+                .await?
+        }
+        None => handler.resolve_latest_location(base, store).await?,
+    };
+    let manifest = read_manifest(store, &location.path, location.size).await?;
+    Ok((manifest, location))
+}
+
+pub(super) fn policy(manifest: &Manifest) -> Result<SnapshotPolicy> {
+    let defaults = SnapshotPolicy::default();
+    let parse = |key: &str, default| {
+        manifest.config.get(key).map_or(Ok(default), |value| {
+            value.parse::<usize>().map_err(|_| {
+                Error::invalid_input(format!("{key} must be a byte count, got {value:?}"))
+            })
+        })
+    };
+    Ok(SnapshotPolicy {
+        inline_root_bytes: parse(INLINE_ROOT_BYTES_KEY, defaults.inline_root_bytes)?,
+        max_suffix_bytes: parse(SUFFIX_BYTES_KEY, defaults.max_suffix_bytes)?,
+    })
+}
+
+pub(super) fn descriptor(manifest: &Manifest) -> Result<pb::FragmentMetadataTree> {
+    let snapshot = manifest.fragment_metadata.as_ref().ok_or_else(|| {
+        Error::invalid_input(format!(
+            "fragment metadata tree version {} has no descriptor",
+            manifest.version
+        ))
+    })?;
+    Ok(snapshot.as_ref().clone())
+}
+
+/// The next allocatable fragment id, from the manifest's high-water mark.
+pub(super) fn next_fragment_id(manifest: &Manifest) -> u64 {
+    manifest.max_fragment_id.map_or(0, |id| u64::from(id) + 1)
+}
+
+fn foreign_bases_from_manifest(
+    store: &Arc<ObjectStore>,
+    manifest: &Manifest,
+) -> Result<HashMap<u32, (Arc<ObjectStore>, Path)>> {
+    let registry = Arc::new(ObjectStoreRegistry::default());
+    let mut foreign = HashMap::new();
+    for (id, base_path) in &manifest.base_paths {
+        if !base_path.is_dataset_root {
+            continue;
+        }
+        let path = base_path.extract_path(registry.clone())?;
+        foreign.insert(*id, (store.clone(), path));
+    }
+    Ok(foreign)
+}

--- a/rust/lance/src/dataset/fragment_metadata/publication_tests.rs
+++ b/rust/lance/src/dataset/fragment_metadata/publication_tests.rs
@@ -1,0 +1,1316 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+use super::publication::{descriptor, read_version};
+use super::test_support::open_tree;
+use super::*;
+use futures::TryStreamExt;
+use lance_io::object_store::{ObjectStoreParams, ObjectStoreRegistry, WrappingObjectStore};
+use lance_io::utils::failpoint::{FailOn, FailWhen, Failpoint, FailpointController};
+use lance_io::utils::tracking_store::IOTracker;
+use lance_table::format::BasePath;
+use lance_table::fragment_metadata::MANIFEST_LAYOUT_KEY;
+use lance_table::fragment_metadata::support::{make_fragment, make_replacement_data_file};
+use lance_table::io::commit::{
+    CommitError, CommitHandler, ConditionalPutCommitHandler, ManifestLocation, ManifestWriter,
+};
+use object_store::ObjectStoreExt;
+use prost::Message;
+use rstest::rstest;
+
+async fn fixture(bulk: bool) -> (CommitTarget, FailpointController, Dataset) {
+    let failpoints = FailpointController::default();
+    let params = ObjectStoreParams {
+        object_store_wrapper: Some(Arc::new(failpoints.clone())),
+        ..Default::default()
+    };
+    let (object_store, base_path) = ObjectStore::from_uri_and_params(
+        Arc::new(ObjectStoreRegistry::default()),
+        "memory://",
+        &params,
+    )
+    .await
+    .unwrap();
+    let target = CommitTarget {
+        context: None,
+        materialize_fragments: false,
+        object_store,
+        base_path,
+        uri: "memory://".to_string(),
+        session: Arc::new(Session::default()),
+        commit_handler: Arc::new(ConditionalPutCommitHandler),
+    };
+    let config = HashMap::from([
+        (MANIFEST_LAYOUT_KEY.to_string(), "tree".to_string()),
+        (MAX_NODE_BYTES_KEY.to_string(), "65536".to_string()),
+        (MAX_LEAF_BYTES_KEY.to_string(), "32768".to_string()),
+        (
+            publication::INLINE_ROOT_BYTES_KEY.to_string(),
+            "0".to_string(),
+        ),
+        (
+            publication::SUFFIX_BYTES_KEY.to_string(),
+            "2048".to_string(),
+        ),
+        (
+            "lance.fragment_metadata.materialization".to_string(),
+            if bulk { "bulk" } else { "buffered" }.to_string(),
+        ),
+    ]);
+    let transaction = Transaction::new_from_version(
+        0,
+        Operation::Overwrite {
+            schema: differential::table_schema(),
+            fragments: (0..512).map(make_fragment).collect(),
+            config_upsert_values: Some(config),
+            initial_bases: None,
+        },
+    );
+    let dataset = execute_create(
+        target.clone(),
+        &transaction,
+        &crate::dataset::ManifestWriteConfig::default(),
+    )
+    .await
+    .unwrap();
+    (target, failpoints, dataset)
+}
+
+fn replacement(version: u64) -> Transaction {
+    Transaction::new_from_version(
+        version,
+        Operation::DataReplacement {
+            replacements: vec![DataReplacementGroup(
+                7,
+                make_replacement_data_file(7, version.try_into().unwrap()),
+            )],
+        },
+    )
+}
+
+#[tokio::test]
+async fn hydration_overlaps_leaf_reads_and_keeps_state_on_failure() {
+    let (mut target, failpoints, original) = fixture(false).await;
+    target.base_path = target.base_path.join("hydration");
+    target.uri = "memory:///hydration".to_string();
+    let io = IOTracker::default();
+    let mut store = target.object_store.as_ref().clone();
+    store.apply_wrapper(&io);
+    target.object_store = Arc::new(store);
+    let mut config = original.manifest.config.clone();
+    config.insert(MAX_LEAF_BYTES_KEY.to_string(), "4096".to_string());
+    let expected: Vec<_> = (0..128).map(make_fragment).collect();
+    execute_create(
+        target.clone(),
+        &Transaction::new_from_version(
+            0,
+            Operation::Overwrite {
+                schema: differential::table_schema(),
+                fragments: expected.clone(),
+                config_upsert_values: Some(config),
+                initial_bases: None,
+            },
+        ),
+        &Default::default(),
+    )
+    .await
+    .unwrap();
+    let mut dataset = publication::open_dataset(&target, Some(1)).await.unwrap();
+    let leaves = dataset
+        .lazy_fragments
+        .as_ref()
+        .unwrap()
+        .tree()
+        .leaf_object_sizes()
+        .len();
+    assert!(leaves > 1);
+    let manifest = dataset.manifest.clone();
+    let bitmap = dataset.fragment_bitmap.clone();
+    let leaf = target
+        .object_store
+        .inner
+        .list(Some(&target.base_path.join("_bt").join("leaf")))
+        .try_next()
+        .await
+        .unwrap()
+        .unwrap()
+        .location;
+    let bytes = target
+        .object_store
+        .inner
+        .get(&leaf)
+        .await
+        .unwrap()
+        .bytes()
+        .await
+        .unwrap();
+    target.object_store.inner.delete(&leaf).await.unwrap();
+    let error = dataset
+        .hydrate_fragments_for_maintenance()
+        .await
+        .unwrap_err();
+    assert!(
+        matches!(error, Error::IO { .. } | Error::NotFound { .. }),
+        "{error:?}"
+    );
+    assert!(error.to_string().contains(leaf.as_ref()), "{error}");
+    assert!(Arc::ptr_eq(&dataset.manifest, &manifest));
+    assert!(Arc::ptr_eq(&dataset.fragment_bitmap, &bitmap));
+    assert!(dataset.lazy_fragments.is_some());
+    target
+        .object_store
+        .inner
+        .put(&leaf, bytes.into())
+        .await
+        .unwrap();
+    failpoints.set_get_latency(std::time::Duration::from_millis(2));
+    io.incremental_stats();
+    dataset.hydrate_fragments_for_maintenance().await.unwrap();
+    assert_eq!(dataset.manifest.fragments.as_ref(), &expected);
+    assert!(dataset.lazy_fragments.is_none());
+    let measured = io.incremental_stats();
+    assert!(measured.num_stages < measured.read_iops, "{measured:?}");
+}
+
+#[rstest]
+#[case::append("append")]
+#[case::replace("replace")]
+#[case::delete("delete")]
+#[case::overwrite("overwrite")]
+#[case::lazy("lazy")]
+#[tokio::test]
+async fn retained_commit_reuses_current_metadata(#[case] operation: &str) {
+    let (mut target, _, _) = fixture(false).await;
+    let io = IOTracker::default();
+    let mut store = target.object_store.as_ref().clone();
+    store.apply_wrapper(&io);
+    target.object_store = Arc::new(store);
+    let mut initial = publication::open_dataset(&target, None).await.unwrap();
+    initial.hydrate_fragments_for_maintenance().await.unwrap();
+    let initial = Arc::new(initial);
+    let original = initial.manifest.fragments.clone();
+    let transaction = match operation {
+        "append" => Transaction::new_from_version(1, differential::production_style_append(2)),
+        "delete" => Transaction::new_from_version(1, differential::delete_fragments([7, 300])),
+        "overwrite" => Transaction::new_from_version(
+            1,
+            Operation::Overwrite {
+                schema: differential::table_schema(),
+                fragments: vec![make_fragment(0), make_fragment(0)],
+                config_upsert_values: None,
+                initial_bases: None,
+            },
+        ),
+        "replace" | "lazy" => Transaction::new_from_version(
+            1,
+            Operation::DataReplacement {
+                replacements: [7, 128, 300, 500]
+                    .into_iter()
+                    .map(|id| DataReplacementGroup(id, make_replacement_data_file(id, 1)))
+                    .collect(),
+            },
+        ),
+        _ => unreachable!(),
+    };
+    let builder = crate::dataset::write::CommitBuilder::new(initial.clone());
+    io.incremental_stats();
+    let committed = if operation == "lazy" {
+        let lazy = builder.execute_lazy(transaction).await.unwrap();
+        let reads = io.incremental_stats();
+        assert!(
+            reads
+                .requests
+                .iter()
+                .all(|request| !request.path.as_ref().contains("_bt/leaf/")),
+            "{reads:?}"
+        );
+        let dataset = lazy.into_dataset().await.unwrap();
+        assert!(io.incremental_stats().read_iops > 0);
+        dataset
+    } else {
+        let committed = builder.execute(transaction).await.unwrap();
+        let reads = io.incremental_stats();
+        assert!(
+            reads.requests.iter().all(|request| {
+                !request.method.starts_with("get_") || !request.path.as_ref().contains("_bt/leaf/")
+            }),
+            "{reads:?}"
+        );
+        committed
+    };
+    let (fresh, _) = open_tree(&target, None).await.unwrap();
+    assert_eq!(
+        committed.manifest.fragments.as_ref(),
+        &fresh.materialize().await.unwrap()
+    );
+    assert_eq!(
+        committed.fragment_bitmap.len(),
+        committed.manifest.fragments.len() as u64
+    );
+    let (historic, _) = open_tree(&target, Some(1)).await.unwrap();
+    assert_eq!(
+        historic.materialize().await.unwrap(),
+        original.as_ref().clone()
+    );
+    assert_eq!(initial.manifest.fragments, original);
+}
+
+#[tokio::test]
+async fn retained_commit_rebases_without_reusing_stale_metadata() {
+    let (mut target, _, _) = fixture(false).await;
+    let io = IOTracker::default();
+    let mut store = target.object_store.as_ref().clone();
+    store.apply_wrapper(&io);
+    target.object_store = Arc::new(store);
+    let mut original = publication::open_dataset(&target, None).await.unwrap();
+    original.hydrate_fragments_for_maintenance().await.unwrap();
+    let original = Arc::new(original);
+    let other = crate::dataset::write::CommitBuilder::new(original.clone())
+        .execute(Transaction::new_from_version(
+            1,
+            differential::production_style_append(2),
+        ))
+        .await
+        .unwrap();
+    io.incremental_stats();
+    let committed = crate::dataset::write::CommitBuilder::new(original.clone())
+        .execute(replacement(1))
+        .await
+        .unwrap();
+    assert_eq!(committed.version_id(), 3);
+    assert_eq!(
+        committed.manifest.fragments.len(),
+        other.manifest.fragments.len()
+    );
+    assert_eq!(
+        committed.manifest.fragments.last(),
+        other.manifest.fragments.last()
+    );
+    let reads = io.incremental_stats();
+    assert!(
+        reads.requests.iter().any(|request| {
+            request.method.starts_with("get_") && request.path.as_ref().contains("_bt/leaf/")
+        }),
+        "{reads:?}"
+    );
+    let (fresh, _) = open_tree(&target, None).await.unwrap();
+    assert_eq!(
+        committed.manifest.fragments.as_ref(),
+        &fresh.materialize().await.unwrap()
+    );
+    assert_eq!(original.version_id(), 1);
+}
+
+#[rstest]
+#[case::descriptor("descriptor")]
+#[case::base("base")]
+#[case::object_store("object_store")]
+#[tokio::test]
+async fn retained_metadata_requires_matching_identity(#[case] mismatch: &str) {
+    let (mut target, _, _) = fixture(false).await;
+    let io = IOTracker::default();
+    let mut store = target.object_store.as_ref().clone();
+    store.apply_wrapper(&io);
+    target.object_store = Arc::new(store);
+    let mut context = publication::open_dataset(&target, None).await.unwrap();
+    context.hydrate_fragments_for_maintenance().await.unwrap();
+    match mismatch {
+        "descriptor" => Arc::make_mut(&mut context.manifest).fragment_metadata = None,
+        "base" => context.base = Path::from("another_dataset"),
+        "object_store" => context.object_store = Arc::new(ObjectStore::memory()),
+        _ => unreachable!(),
+    }
+    target.context = Some(Arc::new(context));
+    target.materialize_fragments = true;
+    io.incremental_stats();
+    let mut committed = execute_commit(
+        target.clone(),
+        &Default::default(),
+        &replacement(1),
+        None,
+        &Default::default(),
+    )
+    .await
+    .unwrap();
+    committed.hydrate_fragments_for_maintenance().await.unwrap();
+    let measured = io.incremental_stats();
+    assert!(
+        measured.requests.iter().any(|request| {
+            request.method.starts_with("get_") && request.path.as_ref().contains("_bt/leaf/")
+        }),
+        "{measured:?}"
+    );
+    let (fresh, _) = open_tree(&target, None).await.unwrap();
+    assert_eq!(
+        committed.manifest.fragments.as_ref(),
+        &fresh.materialize().await.unwrap()
+    );
+}
+
+#[derive(Debug)]
+struct ConcurrentPublication(tokio::sync::Barrier);
+
+#[async_trait::async_trait]
+impl CommitHandler for ConcurrentPublication {
+    async fn commit(
+        &self,
+        manifest: &mut lance_table::format::Manifest,
+        indices: Option<Vec<lance_table::format::IndexMetadata>>,
+        base_path: &Path,
+        object_store: &ObjectStore,
+        manifest_writer: ManifestWriter,
+        naming_scheme: ManifestNamingScheme,
+        transaction: Option<lance_table::format::Transaction>,
+    ) -> std::result::Result<ManifestLocation, CommitError> {
+        if manifest.version == 2 {
+            self.0.wait().await;
+        }
+        ConditionalPutCommitHandler
+            .commit(
+                manifest,
+                indices,
+                base_path,
+                object_store,
+                manifest_writer,
+                naming_scheme,
+                transaction,
+            )
+            .await
+    }
+}
+
+#[tokio::test]
+async fn retained_commit_retries_after_concurrent_publication() {
+    let (mut target, _, _) = fixture(false).await;
+    target.commit_handler = Arc::new(ConcurrentPublication(tokio::sync::Barrier::new(2)));
+    let mut initial = publication::open_dataset(&target, None).await.unwrap();
+    initial.hydrate_fragments_for_maintenance().await.unwrap();
+    let initial = Arc::new(initial);
+    let append = crate::dataset::write::CommitBuilder::new(initial.clone())
+        .with_skip_auto_cleanup(true)
+        .execute(Transaction::new_from_version(
+            1,
+            differential::production_style_append(2),
+        ));
+    let replace = crate::dataset::write::CommitBuilder::new(initial.clone())
+        .with_skip_auto_cleanup(true)
+        .execute(replacement(1));
+    let (append, replace) = tokio::time::timeout(std::time::Duration::from_secs(2), async {
+        tokio::join!(append, replace)
+    })
+    .await
+    .unwrap();
+    let append = append.unwrap();
+    let replace = replace.unwrap();
+    assert_ne!(append.version_id(), replace.version_id());
+    for committed in [&append, &replace] {
+        let (fresh, _) = open_tree(&target, Some(committed.version_id()))
+            .await
+            .unwrap();
+        assert_eq!(
+            committed.manifest.fragments.as_ref(),
+            &fresh.materialize().await.unwrap()
+        );
+    }
+    let latest = if append.version_id() == 3 {
+        append
+    } else {
+        replace
+    };
+    assert_eq!(latest.manifest.fragments.len(), 514);
+    assert_eq!(
+        latest.manifest.fragments[7].files[0].path,
+        make_replacement_data_file(7, 1).path
+    );
+    assert_eq!(initial.version_id(), 1);
+    assert_eq!(initial.manifest.fragments[7], make_fragment(7));
+}
+
+#[rstest]
+#[case::leaf_before("_bt/leaf/", FailWhen::Before, false)]
+#[case::leaf_after("_bt/leaf/", FailWhen::After, false)]
+#[case::base_before("_bt/base/", FailWhen::Before, false)]
+#[case::base_after("_bt/base/", FailWhen::After, false)]
+#[case::manifest_before("_versions/", FailWhen::Before, false)]
+#[case::manifest_response_lost("_versions/", FailWhen::After, true)]
+#[tokio::test]
+async fn publication_failure_preserves_snapshot_and_retry(
+    #[case] path: &str,
+    #[case] when: FailWhen,
+    #[case] published: bool,
+) {
+    let (mut target, failpoints, mut initial) = fixture(true).await;
+    initial.hydrate_fragments_for_maintenance().await.unwrap();
+    target.context = Some(Arc::new(initial.clone()));
+    target.materialize_fragments = true;
+    let original = initial
+        .fragment_source()
+        .stream()
+        .try_collect::<Vec<_>>()
+        .await
+        .unwrap();
+    let transaction = replacement(1);
+    failpoints.arm(Failpoint {
+        on: FailOn::Put,
+        when,
+        path_contains: path.to_string(),
+        nth: 1,
+    });
+    let result = execute_commit(
+        target.clone(),
+        &CommitConfig::default(),
+        &transaction,
+        None,
+        &crate::dataset::ManifestWriteConfig::default(),
+    )
+    .await;
+    assert!(failpoints.tripped(), "Failpoint {path} did not execute");
+    failpoints.disarm();
+    assert_eq!(
+        result.is_ok(),
+        published,
+        "{path}: {:?}",
+        result.as_ref().err()
+    );
+    let (latest, _) = open_tree(&target, None).await.unwrap();
+    assert_eq!(latest.version(), if published { 2 } else { 1 });
+    let (historic, _) = open_tree(&target, Some(1)).await.unwrap();
+    assert_eq!(historic.materialize().await.unwrap(), original);
+    let committed = if published {
+        result.unwrap()
+    } else {
+        execute_commit(
+            target.clone(),
+            &CommitConfig::default(),
+            &transaction,
+            None,
+            &crate::dataset::ManifestWriteConfig::default(),
+        )
+        .await
+        .unwrap()
+    };
+    assert_eq!(committed.manifest.version, 2);
+    assert_eq!(
+        committed.read_transaction().await.unwrap().unwrap().uuid,
+        transaction.uuid
+    );
+    assert_ne!(
+        committed
+            .fragment_source()
+            .stream()
+            .try_collect::<Vec<_>>()
+            .await
+            .unwrap(),
+        original
+    );
+    let roots = target
+        .object_store
+        .list(Some(target.base_path.clone().join("_bt").join("root")))
+        .try_collect::<Vec<_>>()
+        .await
+        .unwrap();
+    assert!(
+        roots.is_empty(),
+        "A second snapshot authority was published"
+    );
+}
+
+#[tokio::test]
+async fn suffix_pressure_writes_external_roots_and_historical_versions_open() {
+    let (target, _, _) = fixture(false).await;
+    let mut bases = std::collections::BTreeSet::new();
+    let mut has_suffix = false;
+    let mut states = Vec::new();
+    for version in 1..=40 {
+        if version > 1 {
+            execute_commit(
+                target.clone(),
+                &CommitConfig::default(),
+                &replacement(version - 1),
+                None,
+                &crate::dataset::ManifestWriteConfig::default(),
+            )
+            .await
+            .unwrap();
+        }
+        let (tree, manifest) = open_tree(&target, Some(version)).await.unwrap();
+        let snapshot = descriptor(&manifest).unwrap();
+        let Some(pb::fragment_metadata_tree::Root::RootPath(path)) = snapshot.root else {
+            panic!("expected external root");
+        };
+        bases.insert(path);
+        has_suffix |= !snapshot.mutations_since_root.is_empty();
+        assert!(
+            pb::FragmentMetadataNode {
+                children: Vec::new(),
+                buffer: snapshot.mutations_since_root
+            }
+            .encoded_len()
+                <= 2048
+        );
+        states.push(tree.resolve_fragment(7).await.unwrap());
+    }
+    assert!(has_suffix);
+    // Repeated replacement can reduce to one message, so force distinct IDs
+    // until the bounded cumulative suffix writes a new external root.
+    for version in 41..=80 {
+        let transaction = Transaction::new_from_version(
+            version - 1,
+            Operation::DataReplacement {
+                replacements: vec![DataReplacementGroup(
+                    version,
+                    make_replacement_data_file(version, 1),
+                )],
+            },
+        );
+        execute_commit(
+            target.clone(),
+            &CommitConfig::default(),
+            &transaction,
+            None,
+            &crate::dataset::ManifestWriteConfig::default(),
+        )
+        .await
+        .unwrap();
+        let (manifest, _) = read_version(
+            &target.object_store,
+            &target.base_path,
+            target.commit_handler.as_ref(),
+            Some(version),
+        )
+        .await
+        .unwrap();
+        if let Some(pb::fragment_metadata_tree::Root::RootPath(path)) =
+            descriptor(&manifest).unwrap().root
+        {
+            bases.insert(path);
+        }
+    }
+    assert!(
+        bases.len() > 1,
+        "suffix pressure never wrote a second external root"
+    );
+    for (index, state) in states.into_iter().enumerate() {
+        let (tree, _) = open_tree(&target, Some(index as u64 + 1)).await.unwrap();
+        assert_eq!(tree.resolve_fragment(7).await.unwrap(), state);
+    }
+}
+
+#[tokio::test]
+async fn cleanup_traces_retained_tree_and_removes_abandoned_base() {
+    let (target, _, initial) = fixture(true).await;
+    let old_snapshot = descriptor(&initial.manifest).unwrap();
+    let latest = execute_commit(
+        target.clone(),
+        &CommitConfig::default(),
+        &replacement(1),
+        None,
+        &crate::dataset::ManifestWriteConfig::default(),
+    )
+    .await
+    .unwrap();
+    let orphan = target
+        .base_path
+        .clone()
+        .join("_bt")
+        .join("base")
+        .join("abandoned.root");
+    target
+        .object_store
+        .put(&orphan, b"unpublished")
+        .await
+        .unwrap();
+    let policy = super::super::cleanup::CleanupPolicy {
+        before_version: Some(2),
+        delete_unverified: true,
+        ..Default::default()
+    };
+    super::super::cleanup::cleanup_old_versions(&latest, policy)
+        .await
+        .unwrap();
+    assert!(target.object_store.inner.head(&orphan).await.is_err());
+    if let Some(pb::fragment_metadata_tree::Root::RootPath(path)) = old_snapshot.root {
+        assert!(
+            target
+                .object_store
+                .inner
+                .head(&Path::from_iter(
+                    target.base_path.parts().chain(Path::from(path).parts())
+                ))
+                .await
+                .is_err()
+        );
+    }
+    let (tree, _) = open_tree(&target, Some(2)).await.unwrap();
+    assert_eq!(tree.count_fragments(), 512);
+    assert!(tree.resolve_fragment(7).await.unwrap().is_some());
+    assert_eq!(tree.materialize().await.unwrap().len(), 512);
+    assert!(open_tree(&target, Some(1)).await.is_err());
+}
+
+#[tokio::test]
+async fn deep_writer_requires_its_own_experimental_gate() {
+    let (target, _, dataset) = fixture(false).await;
+    let mut config = dataset.manifest.config.clone();
+    config.insert(MAX_NODE_BYTES_KEY.to_string(), "512".to_string());
+    config.insert(MAX_LEAF_BYTES_KEY.to_string(), "1024".to_string());
+    let isolated = CommitTarget {
+        base_path: target.base_path.clone().join("deep-gate"),
+        ..target
+    };
+    let transaction = Transaction::new_from_version(
+        0,
+        Operation::Overwrite {
+            fragments: (0..128).map(make_fragment).collect(),
+            schema: differential::table_schema(),
+            config_upsert_values: Some(config),
+            initial_bases: None,
+        },
+    );
+    let error = execute_create(
+        isolated.clone(),
+        &transaction,
+        &crate::dataset::ManifestWriteConfig::default(),
+    )
+    .await
+    .unwrap_err();
+    assert!(matches!(error, Error::NotSupported { .. }), "{error}");
+    assert!(error.to_string().contains("allow_deep_writer"));
+    assert!(
+        read_version(
+            &isolated.object_store,
+            &isolated.base_path,
+            isolated.commit_handler.as_ref(),
+            None
+        )
+        .await
+        .is_err()
+    );
+}
+
+#[tokio::test]
+async fn named_manifest_open_has_no_history_or_list_fanout() {
+    let (mut target, _, _) = fixture(false).await;
+    for version in 1..=12 {
+        execute_commit(
+            target.clone(),
+            &CommitConfig::default(),
+            &replacement(version),
+            None,
+            &crate::dataset::ManifestWriteConfig::default(),
+        )
+        .await
+        .unwrap();
+    }
+    let tracker = IOTracker::default();
+    let mut store = (*target.object_store).clone();
+    store.inner = tracker.wrap("", store.inner);
+    target.object_store = Arc::new(store);
+    let (tree, _) = open_tree(&target, Some(13)).await.unwrap();
+    let io = tracker.incremental_stats();
+    assert!(
+        io.requests
+            .iter()
+            .all(|request| !request.method.starts_with("list")),
+        "{io:?}"
+    );
+    let gets: Vec<_> = io
+        .requests
+        .iter()
+        .filter(|request| request.method.starts_with("get_"))
+        .collect();
+    // Conditional manifest resolution adds a HEAD, represented by get_opts
+    // with zero bytes. Named-version open reads the manifest and at most one root.
+    assert!(gets.len() <= 3, "{io:?}");
+    assert!(
+        io.requests
+            .iter()
+            .all(|request| !request.path.as_ref().contains("_transactions/")),
+        "{io:?}"
+    );
+    assert!(tree.resolve_fragment(7).await.unwrap().is_some());
+    let io = tracker.incremental_stats();
+    assert!(
+        io.read_iops <= 1,
+        "point lookup issued more than one leaf GET: {io:?}"
+    );
+}
+
+#[tokio::test]
+async fn checkout_latest_refreshes_the_fragment_source_atomically() {
+    let (target, failpoints, mut original) = fixture(false).await;
+    let old = original
+        .fragment_source()
+        .stream()
+        .try_collect::<Vec<_>>()
+        .await
+        .unwrap();
+    let latest = execute_commit(
+        target,
+        &CommitConfig::default(),
+        &replacement(1),
+        None,
+        &crate::dataset::ManifestWriteConfig::default(),
+    )
+    .await
+    .unwrap();
+    failpoints.arm(Failpoint {
+        on: FailOn::Get,
+        when: FailWhen::Before,
+        path_contains: "_bt/base/".to_string(),
+        nth: 1,
+    });
+    assert!(original.checkout_latest().await.is_err());
+    assert!(failpoints.tripped());
+    assert_eq!(original.manifest.version, 1);
+    assert_eq!(
+        original
+            .fragment_source()
+            .stream()
+            .try_collect::<Vec<_>>()
+            .await
+            .unwrap(),
+        old
+    );
+    failpoints.disarm();
+    original.checkout_latest().await.unwrap();
+    assert_eq!(original.manifest.version, 2);
+    let current = original
+        .fragment_source()
+        .stream()
+        .try_collect::<Vec<_>>()
+        .await
+        .unwrap();
+    assert_ne!(current, old);
+    assert_eq!(
+        current,
+        latest
+            .fragment_source()
+            .stream()
+            .try_collect::<Vec<_>>()
+            .await
+            .unwrap()
+    );
+}
+
+#[tokio::test]
+async fn indexed_local_delete_resolves_only_touched_leaf_and_retention_witness() {
+    let (mut target, _, original) = fixture(false).await;
+    target.base_path = target.base_path.join("indexed-local");
+    target.uri = "memory:///indexed-local".to_string();
+    let mut config = original.manifest.config.clone();
+    config.insert(MAX_LEAF_BYTES_KEY.to_string(), "8192".to_string());
+    let initial = execute_create(
+        target.clone(),
+        &Transaction::new_from_version(
+            0,
+            Operation::Overwrite {
+                schema: differential::table_schema(),
+                fragments: (0..4096).map(make_fragment).collect(),
+                config_upsert_values: Some(config),
+                initial_bases: None,
+            },
+        ),
+        &Default::default(),
+    )
+    .await
+    .unwrap();
+    let leaves = initial
+        .lazy_fragments
+        .as_ref()
+        .unwrap()
+        .tree()
+        .shape_report()
+        .await
+        .unwrap()
+        .leaf_keys
+        .len();
+    assert!(leaves > 4);
+    let index = lance_table::format::IndexMetadata {
+        covering_fields: Vec::new(),
+        uuid: uuid::Uuid::new_v4(),
+        fields: vec![0],
+        name: "id_idx".to_string(),
+        dataset_version: 1,
+        fragment_bitmap: Some((0..4096).collect()),
+        index_details: Some(Arc::new(prost_types::Any {
+            type_url: "type.googleapis.com/lance.index.BTreeIndexDetails".to_string(),
+            value: Vec::new(),
+        })),
+        index_version: 0,
+        created_at: None,
+        base_id: None,
+        files: Some(Vec::new()),
+    };
+    let indexed = execute_commit(
+        target.clone(),
+        &Default::default(),
+        &Transaction::new_from_version(
+            1,
+            Operation::CreateIndex {
+                new_indices: vec![index.clone()],
+                removed_indices: Vec::new(),
+            },
+        ),
+        None,
+        &Default::default(),
+    )
+    .await
+    .unwrap();
+    let index = crate::index::load_all_indices(&indexed).await.unwrap()[0].clone();
+    let io = IOTracker::default();
+    let mut store = target.object_store.as_ref().clone();
+    store.inner = io.wrap("", store.inner.clone());
+    target.object_store = Arc::new(store);
+    let deleted = execute_commit(
+        target,
+        &Default::default(),
+        &Transaction::new_from_version(
+            2,
+            Operation::Delete {
+                updated_fragments: Vec::new(),
+                deleted_fragment_ids: vec![4095],
+                predicate: "id = 4095".to_string(),
+            },
+        ),
+        None,
+        &Default::default(),
+    )
+    .await
+    .unwrap();
+    let measured = io.incremental_stats();
+    let leaf_gets = measured
+        .requests
+        .iter()
+        .filter(|request| {
+            request.method.starts_with("get_") && request.path.as_ref().contains("_bt/leaf/")
+        })
+        .count();
+    assert_eq!(
+        leaf_gets, 2,
+        "one touched leaf and one live index-retention witness"
+    );
+    assert_eq!(deleted.count_fragments(), 4095);
+    assert_eq!(
+        crate::index::load_all_indices(&deleted)
+            .await
+            .unwrap()
+            .as_slice(),
+        &[index]
+    );
+}
+
+#[tokio::test]
+async fn allocation_frontier_rejects_exhaustion_without_publication() {
+    let (target, _, original) = fixture(false).await;
+    let reserved = execute_commit(
+        target.clone(),
+        &Default::default(),
+        &Transaction::new_from_version(
+            1,
+            Operation::ReserveFragments {
+                num_fragments: u32::MAX - 511,
+            },
+        ),
+        None,
+        &Default::default(),
+    )
+    .await
+    .unwrap();
+    assert_eq!(reserved.manifest.max_fragment_id, Some(u32::MAX));
+    assert_eq!(
+        reserved
+            .lazy_fragments
+            .as_ref()
+            .unwrap()
+            .tree()
+            .next_fragment_id(),
+        u64::from(u32::MAX) + 1
+    );
+    for operation in [
+        Operation::Append {
+            fragments: vec![make_fragment(0)],
+        },
+        Operation::ReserveFragments { num_fragments: 1 },
+    ] {
+        let error = execute_commit(
+            target.clone(),
+            &Default::default(),
+            &Transaction::new_from_version(2, operation),
+            None,
+            &Default::default(),
+        )
+        .await
+        .unwrap_err();
+        assert!(matches!(error, Error::InvalidInput { .. }), "{error}");
+        assert!(error.to_string().contains("u32 address space"));
+    }
+    let latest = publication::open_dataset(&target, None).await.unwrap();
+    assert_eq!(latest.version().version, 2);
+    assert_eq!(latest.count_fragments(), original.count_fragments());
+}
+
+#[tokio::test]
+async fn shallow_clone_stamps_source_tree_references() {
+    let (_target, _, mut original) = fixture(false).await;
+    let cloned = original
+        .shallow_clone("memory:///clone", 1, None)
+        .await
+        .unwrap();
+    let snapshot = cloned.manifest.fragment_metadata.as_ref().unwrap();
+    let Some(pb::fragment_metadata_tree::Root::RootPath(root_path)) = &snapshot.root else {
+        panic!("clone must own a dest root");
+    };
+    assert!(root_path.starts_with("_bt/"));
+    let tree = tree_from_manifest(
+        cloned.object_store.clone(),
+        cloned.base.clone(),
+        &cloned.manifest,
+    )
+    .await
+    .unwrap();
+    assert!(
+        tree.node_paths()
+            .await
+            .unwrap()
+            .iter()
+            .all(|path| path.starts_with("_bt/"))
+    );
+    let source_id = cloned
+        .manifest
+        .base_paths
+        .iter()
+        .find(|(_, base)| base.path.contains("memory:"))
+        .map(|(id, _)| *id)
+        .expect("clone must retain a source BasePath");
+    let cloned_root = cloned
+        .object_store
+        .inner
+        .get(&Path::from_iter(
+            cloned
+                .base
+                .parts()
+                .chain(Path::from(root_path.as_str()).parts()),
+        ))
+        .await
+        .unwrap()
+        .bytes()
+        .await
+        .unwrap();
+    let root = pb::FragmentMetadataRoot::decode(cloned_root.as_ref()).unwrap();
+    assert!(
+        root.children
+            .iter()
+            .all(|child| child.base_id == Some(source_id)),
+        "{:?}",
+        root.children
+    );
+    let fragments = tree.materialize().await.unwrap();
+    assert_eq!(fragments.len(), 512);
+    assert!(
+        fragments
+            .iter()
+            .all(|fragment| fragment.files.iter().all(|file| file.base_id.is_some()))
+    );
+}
+
+#[tokio::test]
+async fn config_update_after_memory_clone_keeps_fragment_count() {
+    let (_target, _, mut original) = fixture(false).await;
+    let mut cloned = original
+        .shallow_clone("memory:///clone-commit", 1, None)
+        .await
+        .unwrap();
+    cloned
+        .update_config([("app.note", "after-clone")])
+        .await
+        .unwrap();
+    assert_eq!(cloned.count_fragments(), 512);
+}
+
+#[rstest]
+#[tokio::test]
+async fn structural_settings_require_rebuild_but_byte_targets_may_change(
+    #[values(
+        ("lance.fragment_metadata.hard_capacity_bytes", "134217728"),
+        ("lance.manifest.layout", "flat")
+    )]
+    change: (&str, &str),
+) {
+    let (key, value) = change;
+    let (target, _, mut dataset) = fixture(false).await;
+    dataset
+        .update_config([("lance.fragment_metadata.semantic_buffer_bytes", "4096")])
+        .await
+        .unwrap();
+    assert_eq!(dataset.version().version, 2);
+    let error = dataset.update_config([(key, value)]).await.unwrap_err();
+    assert!(matches!(error, Error::InvalidInput { .. }));
+    assert!(error.to_string().contains(key));
+    assert!(error.to_string().contains("rebuild"));
+    assert_eq!(dataset.version().version, 2);
+    assert_eq!(
+        read_version(
+            &target.object_store,
+            &target.base_path,
+            target.commit_handler.as_ref(),
+            None
+        )
+        .await
+        .unwrap()
+        .0
+        .version,
+        2
+    );
+    dataset
+        .update_config([("app.note", "allowed")])
+        .await
+        .unwrap();
+    assert_eq!(
+        dataset.manifest.config.get("app.note").map(String::as_str),
+        Some("allowed")
+    );
+}
+
+#[test]
+fn native_leaf_and_buffer_budgets_do_not_follow_directory_override() {
+    let original = tree_config_from(&HashMap::new()).unwrap();
+    let changed = tree_config_from(&HashMap::from([(
+        MAX_NODE_BYTES_KEY.to_string(),
+        "65536".to_string(),
+    )]))
+    .unwrap();
+    assert_ne!(changed.max_node_bytes, original.max_node_bytes);
+    assert_eq!(changed.max_leaf_bytes, original.max_leaf_bytes);
+    assert_eq!(
+        changed.semantic_buffer_bytes,
+        original.semantic_buffer_bytes
+    );
+}
+
+#[rstest]
+#[case("lance.fragment_metadata.max_root_delta_tail", "4")]
+#[case("lance.fragment_metadata.max_children_per_node", "16")]
+#[case("lance.fragment_metadata.materialization", "force_flush")]
+#[case("lance.fragment_metadata.allow_deep_writer", "yes")]
+#[test]
+fn invalid_metadata_settings_are_rejected(#[case] key: &str, #[case] value: &str) {
+    let error = tree_config_from(&HashMap::from([(key.into(), value.into())])).unwrap_err();
+    assert!(matches!(error, Error::InvalidInput { .. }));
+    assert!(error.to_string().contains(key));
+}
+
+#[tokio::test]
+async fn inline_history_survives_a_lost_publish_response() {
+    let (target, failpoints, _) = fixture(true).await;
+    let config = crate::dataset::ManifestWriteConfig::default().with_transaction_file_disabled();
+    let transaction = replacement(1);
+    failpoints.arm(Failpoint {
+        on: FailOn::Put,
+        when: FailWhen::After,
+        path_contains: "_versions/".into(),
+        nth: 1,
+    });
+    let committed = execute_commit(
+        target.clone(),
+        &Default::default(),
+        &transaction,
+        None,
+        &config,
+    )
+    .await
+    .unwrap();
+    assert!(failpoints.tripped());
+    assert!(committed.manifest.transaction_file.is_none());
+    assert_eq!(
+        committed.read_transaction().await.unwrap().unwrap().uuid,
+        transaction.uuid
+    );
+    let history = publication::history(&target, 1, 2).await.unwrap();
+    assert_eq!(history[0].1.uuid, transaction.uuid);
+}
+
+#[tokio::test]
+async fn clone_inlines_external_lineage_slices_from_the_source() {
+    let store = ObjectStore::memory();
+    let base = Path::from("source");
+    store
+        .put(
+            &base.clone().join("_bt").join("lineage"),
+            &[0, 1, 2, 3, 4, 5],
+        )
+        .await
+        .unwrap();
+    let slice = lance_table::format::ExternalFile {
+        path: "_bt/lineage".into(),
+        offset: 2,
+        size: 3,
+    };
+    let mut fragments = vec![make_fragment(0)];
+    fragments[0].row_id_meta = Some(lance_table::format::RowIdMeta::External(slice.clone()));
+    fragments[0].created_at_version_meta = Some(
+        lance_table::format::RowDatasetVersionMeta::External(slice.clone()),
+    );
+    fragments[0].last_updated_at_version_meta =
+        Some(lance_table::format::RowDatasetVersionMeta::External(slice));
+    inline_clone_lineage(&store, &base, &mut fragments)
+        .await
+        .unwrap();
+    assert_eq!(
+        fragments[0].row_id_meta,
+        Some(lance_table::format::RowIdMeta::Inline(vec![2, 3, 4].into()))
+    );
+    assert_eq!(
+        fragments[0].created_at_version_meta,
+        Some(lance_table::format::RowDatasetVersionMeta::Inline(
+            Arc::from([2, 3, 4])
+        ))
+    );
+    assert_eq!(
+        fragments[0].last_updated_at_version_meta,
+        fragments[0].created_at_version_meta
+    );
+}
+
+#[rstest]
+#[case::temporarily_hidden(false)]
+#[case::verification_outage(true)]
+#[tokio::test]
+async fn ambiguous_publication_uses_native_verification(#[case] outage: bool) {
+    let (mut target, _, _) = fixture(false).await;
+    let handler = Arc::new(crate::utils::test::AmbiguousCommitHandler::default());
+    handler.fail_next(crate::utils::test::AmbiguousFailure::LandAndError);
+    if outage {
+        handler
+            .fail_resolve
+            .store(true, std::sync::atomic::Ordering::SeqCst);
+    } else {
+        handler.fail_next_resolves_with_not_found(2);
+    }
+    target.commit_handler = handler.clone();
+    let result = execute_commit(
+        target.clone(),
+        &Default::default(),
+        &replacement(1),
+        None,
+        &Default::default(),
+    )
+    .await;
+    if outage {
+        let error = result.unwrap_err();
+        assert!(error.is_commit_status_unknown(), "{error}");
+    } else {
+        assert_eq!(result.unwrap().version_id(), 2);
+    }
+    handler
+        .fail_resolve
+        .store(false, std::sync::atomic::Ordering::SeqCst);
+    let (tree, manifest) = open_tree(&target, Some(2)).await.unwrap();
+    assert_eq!(tree.version(), 2);
+    assert!(manifest.transaction_file.is_some());
+}
+
+#[derive(Debug)]
+struct ReleaseErrorLock;
+
+#[async_trait::async_trait]
+impl lance_table::io::commit::CommitLease for ReleaseErrorLock {
+    async fn release(
+        &self,
+        success: bool,
+    ) -> std::result::Result<(), lance_table::io::commit::CommitError> {
+        if success {
+            Err(lance_table::io::commit::CommitError::OtherError(Error::io(
+                "lease release failed",
+            )))
+        } else {
+            Ok(())
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl lance_table::io::commit::CommitLock for ReleaseErrorLock {
+    type Lease = Self;
+    async fn lock(
+        &self,
+        _version: u64,
+    ) -> std::result::Result<Self, lance_table::io::commit::CommitError> {
+        Ok(Self)
+    }
+}
+
+#[tokio::test]
+async fn published_commit_preserves_custom_handler_release_errors() {
+    let (mut target, _, _) = fixture(false).await;
+    target.commit_handler = Arc::new(ReleaseErrorLock);
+    let error = execute_commit(
+        target.clone(),
+        &Default::default(),
+        &replacement(1),
+        None,
+        &Default::default(),
+    )
+    .await
+    .unwrap_err();
+    assert!(
+        error.to_string().contains("lease release failed"),
+        "{error}"
+    );
+    assert_eq!(open_tree(&target, Some(2)).await.unwrap().0.version(), 2);
+}
+
+#[tokio::test]
+async fn detached_creation_is_rejected_before_publication() {
+    let dir = tempfile::tempdir().unwrap();
+    let uri = dir.path().to_str().unwrap();
+    let error = crate::dataset::write::CommitBuilder::new(uri)
+        .with_detached(true)
+        .execute(Transaction::new_from_version(
+            0,
+            Operation::Overwrite {
+                fragments: vec![make_fragment(0)],
+                schema: super::differential::table_schema(),
+                config_upsert_values: Some(
+                    FragmentMetadataOptions::default()
+                        .into_table_config()
+                        .unwrap(),
+                ),
+                initial_bases: None,
+            },
+        ))
+        .await
+        .unwrap_err();
+    assert!(matches!(error, Error::NotSupported { .. }), "{error}");
+    assert!(!dir.path().join("_versions").exists());
+    assert!(!dir.path().join("_bt").exists());
+}
+
+#[tokio::test]
+async fn unknown_dataset_root_base_does_not_publish_a_version() {
+    let dir = tempfile::tempdir().unwrap();
+    let uri = dir.path().to_str().unwrap();
+    let error = crate::dataset::write::CommitBuilder::new(uri)
+        .execute(Transaction::new_from_version(
+            0,
+            Operation::Overwrite {
+                fragments: vec![make_fragment(0)],
+                schema: super::differential::table_schema(),
+                config_upsert_values: Some(
+                    FragmentMetadataOptions::default()
+                        .into_table_config()
+                        .unwrap(),
+                ),
+                initial_bases: Some(vec![BasePath::new(
+                    1,
+                    "noscheme://nowhere".into(),
+                    None,
+                    true,
+                )]),
+            },
+        ))
+        .await
+        .unwrap_err();
+    assert!(error.to_string().contains("Unknown scheme"), "{error}");
+    assert!(!dir.path().join("_versions").exists());
+}

--- a/rust/lance/src/dataset/fragment_metadata/scan_tests.rs
+++ b/rust/lance/src/dataset/fragment_metadata/scan_tests.rs
@@ -1,0 +1,1069 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+//! One real Lance scan through the lazy fragment source, compared against
+//! the same data in a flat dataset, plus the bounds a lazily opened table
+//! must keep at scale.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use arrow_array::{Int32Array, RecordBatch, RecordBatchIterator, StringArray};
+use arrow_schema::{DataType, Field, Schema as ArrowSchema};
+use datafusion::common::stats::Precision;
+use datafusion::physical_plan::ExecutionPlan;
+use futures::TryStreamExt;
+use lance_file::version::LanceFileVersion;
+use lance_index::{IndexType, scalar::ScalarIndexParams};
+use lance_io::object_store::ObjectStoreParams;
+use lance_io::utils::tracking_store::IOTracker;
+use lance_table::format::overlay::{DataOverlayFile, OverlayCoverage};
+use lance_table::format::pb::{fragment_action::Action, fragment_metadata_tree::Root};
+use lance_table::fragment_metadata::support::make_fragment;
+use rstest::rstest;
+
+use super::MAX_NODE_BYTES_KEY;
+use crate::dataset::builder::DatasetBuilder;
+use crate::dataset::optimize::{CompactionOptions, compact_files};
+use crate::dataset::transaction::{DataOverlayGroup, Operation, Transaction};
+use crate::dataset::write::CommitBuilder;
+use crate::dataset::write::update::UpdateBuilder;
+use crate::dataset::{Dataset, NewColumnTransform, ReadParams, WriteMode, WriteParams};
+use crate::dataset::{MergeInsertBuilder, WhenMatched, WhenNotMatched};
+use crate::index::DatasetIndexExt;
+use crate::io::exec::{LanceScanConfig, LanceScanExec};
+use lance_table::fragment_metadata::MANIFEST_LAYOUT_KEY;
+
+fn rows(start: i32, count: i32) -> RecordBatch {
+    let schema = Arc::new(ArrowSchema::new(vec![
+        Field::new("id", DataType::Int32, false),
+        Field::new("name", DataType::Utf8, false),
+    ]));
+    RecordBatch::try_new(
+        schema,
+        vec![
+            Arc::new(Int32Array::from_iter_values(start..start + count)),
+            Arc::new(StringArray::from_iter_values(
+                (start..start + count).map(|i| format!("row-{i}")),
+            )),
+        ],
+    )
+    .unwrap()
+}
+
+async fn write_flat(uri: &str, start: i32, count: i32, mode: WriteMode) -> Dataset {
+    let batch = rows(start, count);
+    let reader = RecordBatchIterator::new(vec![Ok(batch.clone())], batch.schema());
+    Dataset::write(
+        reader,
+        uri,
+        Some(WriteParams {
+            max_rows_per_file: 10,
+            max_rows_per_group: 10,
+            mode,
+            ..Default::default()
+        }),
+    )
+    .await
+    .unwrap()
+}
+
+/// Copy the flat dataset's data and deletion files next to the tree layout so
+/// both datasets read the same bytes.
+fn copy_dir(from: &std::path::Path, to: &std::path::Path) {
+    if !from.exists() {
+        return;
+    }
+    std::fs::create_dir_all(to).unwrap();
+    for entry in std::fs::read_dir(from).unwrap() {
+        let entry = entry.unwrap();
+        let target = to.join(entry.file_name());
+        if entry.file_type().unwrap().is_dir() {
+            copy_dir(&entry.path(), &target);
+        } else {
+            std::fs::copy(entry.path(), target).unwrap();
+        }
+    }
+}
+
+#[rstest]
+#[case::inline(64 * 1024)]
+#[case::external(0)]
+#[tokio::test]
+async fn column_replacement_reuses_metadata_leaves(#[case] inline_root_bytes: usize) {
+    let flat_dir = tempfile::tempdir().unwrap();
+    let tree_dir = tempfile::tempdir().unwrap();
+    let mut flat = write_flat(flat_dir.path().to_str().unwrap(), 0, 20, WriteMode::Create).await;
+    flat.add_columns(
+        NewColumnTransform::SqlExpressions(vec![("double_id".into(), "id * 2".into())]),
+        None,
+        None,
+    )
+    .await
+    .unwrap();
+    copy_dir(&flat_dir.path().join("data"), &tree_dir.path().join("data"));
+    let options = super::FragmentMetadataOptions {
+        publication: lance_table::fragment_metadata::SnapshotPolicy {
+            inline_root_bytes,
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+    let dataset = CommitBuilder::new(tree_dir.path().to_str().unwrap())
+        .execute(Transaction::new_from_version(
+            0,
+            Operation::Overwrite {
+                fragments: flat.fragments().to_vec(),
+                schema: flat.schema().clone(),
+                config_upsert_values: Some(options.into_table_config().unwrap()),
+                initial_bases: None,
+            },
+        ))
+        .await
+        .unwrap();
+    let old = dataset.get_fragment(0).unwrap().metadata().clone();
+    assert_eq!(old.files.len(), 2);
+    assert_eq!(dataset.fragments().len(), 2);
+    let schema = lance_core::datatypes::Schema {
+        fields: vec![dataset.schema().field("double_id").unwrap().clone()],
+        metadata: Default::default(),
+    };
+    let batch =
+        arrow_array::record_batch!(("double_id", Int32, [0, 3, 6, 9, 12, 15, 18, 21, 24, 27]))
+            .unwrap();
+    let replacement = dataset
+        .get_fragment(0)
+        .unwrap()
+        .write_columns(futures::stream::iter([Ok(batch)]), &schema)
+        .await
+        .unwrap();
+    let replacement_path = replacement.1.path.clone();
+    let before = super::publication::descriptor(&dataset.manifest).unwrap();
+    let leaf_count = std::fs::read_dir(tree_dir.path().join("_bt/leaf"))
+        .unwrap()
+        .count();
+    let updated = CommitBuilder::new(Arc::new(dataset.clone()))
+        .execute(Transaction::new_from_version(
+            dataset.version_id(),
+            Operation::DataReplacement {
+                replacements: vec![replacement],
+            },
+        ))
+        .await
+        .unwrap();
+    let after = super::publication::descriptor(&updated.manifest).unwrap();
+    let pending = match (&before.root, &after.root) {
+        (Some(Root::InlineRoot(old)), Some(Root::InlineRoot(new))) => {
+            assert_eq!(old.children, new.children);
+            &new.buffer
+        }
+        (Some(Root::RootPath(old)), Some(Root::RootPath(new))) => {
+            assert_eq!(old, new);
+            &after.mutations_since_root
+        }
+        _ => panic!("replacement should keep the same publication layout"),
+    };
+    assert_eq!(pending.len(), 1);
+    assert!(matches!(
+        pending[0].action.as_ref().unwrap().action,
+        Some(Action::ReplaceDataFile(_))
+    ));
+    assert_eq!(
+        std::fs::read_dir(tree_dir.path().join("_bt/leaf"))
+            .unwrap()
+            .count(),
+        leaf_count
+    );
+    let current = updated.get_fragment(0).unwrap().metadata().clone();
+    assert_eq!(current.files[0], old.files[0]);
+    assert_eq!(current.files[1].path, replacement_path);
+    assert_eq!(current.files[1].fields, old.files[1].fields);
+    assert_eq!(current.files[1].column_indices, old.files[1].column_indices);
+    assert_eq!(updated.fragments()[1], dataset.fragments()[1]);
+    assert_eq!(
+        updated
+            .count_rows(Some("id < 10 AND double_id != id * 3".into()))
+            .await
+            .unwrap(),
+        0
+    );
+    assert_eq!(
+        updated
+            .count_rows(Some("id >= 10 AND double_id != id * 2".into()))
+            .await
+            .unwrap(),
+        0
+    );
+    let historical = DatasetBuilder::from_uri(tree_dir.path().to_str().unwrap())
+        .with_version(dataset.version_id())
+        .load()
+        .await
+        .unwrap();
+    assert_eq!(
+        historical
+            .count_rows(Some("double_id != id * 2".into()))
+            .await
+            .unwrap(),
+        0
+    );
+}
+
+/// A fragment metadata dataset holding exactly the flat dataset's fragments, over copies
+/// of its files.
+async fn mirror_into_fragment_metadata(
+    flat: &Dataset,
+    flat_dir: &std::path::Path,
+    fragment_metadata_uri: &str,
+    materialization: &str,
+) {
+    for sub in ["data", "_deletions"] {
+        copy_dir(
+            &flat_dir.join(sub),
+            &std::path::Path::new(fragment_metadata_uri).join(sub),
+        );
+    }
+    let config = HashMap::from([
+        (
+            MANIFEST_LAYOUT_KEY.to_string(),
+            lance_table::fragment_metadata::MANIFEST_LAYOUT_TREE.to_string(),
+        ),
+        (MAX_NODE_BYTES_KEY.to_string(), (2 * 1024).to_string()),
+        (
+            "lance.fragment_metadata.allow_deep_writer".to_string(),
+            "true".to_string(),
+        ),
+        (
+            "lance.fragment_metadata.materialization".to_string(),
+            materialization.to_string(),
+        ),
+    ]);
+    let mut fragments = flat.fragments().to_vec();
+    if flat.manifest.uses_stable_row_ids() {
+        for fragment in &mut fragments {
+            fragment.row_id_meta = None;
+            fragment.created_at_version_meta = None;
+            fragment.last_updated_at_version_meta = None;
+        }
+    }
+    let dataset = CommitBuilder::new(fragment_metadata_uri)
+        .use_stable_row_ids(flat.manifest.uses_stable_row_ids())
+        .with_storage_format(
+            flat.manifest
+                .data_storage_format
+                .lance_file_format()
+                .to_selector(),
+        )
+        .execute(Transaction::new_from_version(
+            0,
+            Operation::Overwrite {
+                fragments: Vec::new(),
+                schema: flat.schema().clone(),
+                config_upsert_values: Some(config),
+                initial_bases: None,
+            },
+        ))
+        .await
+        .unwrap();
+    let deletions: HashMap<_, _> = fragments
+        .iter()
+        .filter_map(|fragment| {
+            fragment
+                .deletion_file
+                .clone()
+                .map(|deletion| (fragment.id, deletion))
+        })
+        .collect();
+    for fragment in &mut fragments {
+        fragment.deletion_file = None;
+    }
+    let dataset = CommitBuilder::new(Arc::new(dataset))
+        .execute(Transaction::new_from_version(
+            1,
+            Operation::Append { fragments },
+        ))
+        .await
+        .unwrap();
+    let updated_fragments: Vec<_> = dataset
+        .fragments()
+        .iter()
+        .filter_map(|fragment| {
+            deletions.get(&fragment.id).map(|deletion| {
+                let mut fragment = fragment.clone();
+                fragment.deletion_file = Some(deletion.clone());
+                fragment
+            })
+        })
+        .collect();
+    if !updated_fragments.is_empty() {
+        CommitBuilder::new(Arc::new(dataset))
+            .execute(Transaction::new_from_version(
+                2,
+                Operation::Delete {
+                    updated_fragments,
+                    deleted_fragment_ids: Vec::new(),
+                    predicate: "fixture".into(),
+                },
+            ))
+            .await
+            .unwrap();
+    }
+}
+
+async fn scan_sorted(
+    dataset: &Dataset,
+    columns: Option<&[&str]>,
+    filter: Option<&str>,
+) -> Vec<String> {
+    let mut scanner = dataset.scan();
+    if let Some(columns) = columns {
+        scanner.project(columns).unwrap();
+    }
+    if let Some(filter) = filter {
+        scanner.filter(filter).unwrap();
+    }
+    let batches = scanner
+        .try_into_stream()
+        .await
+        .unwrap()
+        .try_collect::<Vec<_>>()
+        .await
+        .unwrap();
+    let mut lines = Vec::new();
+    for batch in batches {
+        for row in 0..batch.num_rows() {
+            let mut cells = Vec::new();
+            for column in batch.columns() {
+                cells.push(arrow_cast::display::array_value_to_string(column, row).unwrap());
+            }
+            lines.push(cells.join("|"));
+        }
+    }
+    lines.sort();
+    lines
+}
+
+#[rstest]
+#[tokio::test]
+async fn legacy_data_files_stream_through_lazy_metadata(#[values(true, false)] ordered: bool) {
+    let flat_dir = tempfile::tempdir().unwrap();
+    let tree_dir = tempfile::tempdir().unwrap();
+    let batch = rows(0, 60);
+    let mut flat = Dataset::write(
+        RecordBatchIterator::new(vec![Ok(batch.clone())], batch.schema()),
+        flat_dir.path().to_str().unwrap(),
+        Some(WriteParams {
+            max_rows_per_file: 10,
+            max_rows_per_group: 10,
+            data_storage_version: Some(LanceFileVersion::Legacy),
+            ..Default::default()
+        }),
+    )
+    .await
+    .unwrap();
+    flat.delete("id < 5").await.unwrap();
+    mirror_into_fragment_metadata(
+        &flat,
+        flat_dir.path(),
+        tree_dir.path().to_str().unwrap(),
+        "buffered",
+    )
+    .await;
+    let tree = DatasetBuilder::from_uri(tree_dir.path().to_str().unwrap())
+        .load_unmaterialized()
+        .await
+        .unwrap();
+    assert!(tree.fragment_source().is_lazy());
+    assert_eq!(tree.fragment_source().row_count().unwrap().get(), 55);
+    assert_eq!(tree.count_rows(None).await.unwrap(), 55);
+    assert_eq!(tree.count_deleted_rows().await.unwrap(), 5);
+    assert_eq!(
+        tree.filter_deleted_ids(&[0, 5, 1_u64 << 32]).await.unwrap(),
+        vec![5, 1_u64 << 32]
+    );
+    tree.validate().await.unwrap();
+    for retain_deleted in [false, true] {
+        let plan = LanceScanExec::new(
+            Arc::new(tree.clone()),
+            tree.fragment_source(),
+            None,
+            Arc::new(tree.schema().clone()),
+            LanceScanConfig {
+                with_make_deletions_null: retain_deleted,
+                ..Default::default()
+            },
+        );
+        assert_eq!(
+            plan.partition_statistics(None).unwrap().num_rows,
+            if retain_deleted {
+                Precision::Absent
+            } else {
+                Precision::Exact(55)
+            }
+        );
+    }
+    let batch = tree
+        .scan()
+        .scan_in_order(ordered)
+        .try_into_batch()
+        .await
+        .unwrap();
+    assert_eq!(batch.num_rows(), 55);
+    assert_eq!(
+        scan_sorted(&tree, None, None).await,
+        scan_sorted(&flat, None, None).await
+    );
+    let fragments = tree.get_fragments_async().await.unwrap();
+    let missing = &fragments.last().unwrap().metadata().files[0].path;
+    std::fs::remove_file(tree_dir.path().join("data").join(missing)).unwrap();
+    let reopened = DatasetBuilder::from_uri(tree_dir.path().to_str().unwrap())
+        .load_unmaterialized()
+        .await
+        .unwrap();
+    let error = reopened.validate().await.unwrap_err();
+    assert!(matches!(error, lance_core::Error::NotFound { .. }));
+    assert!(error.to_string().contains(missing));
+}
+
+#[rstest]
+#[tokio::test]
+async fn native_clone_rows_and_branch_retention(#[values("shallow", "deep", "branch")] mode: &str) {
+    let flat_dir = tempfile::tempdir().unwrap();
+    let source_dir = tempfile::tempdir().unwrap();
+    let clone_dir = tempfile::tempdir().unwrap();
+    let flat = write_flat(flat_dir.path().to_str().unwrap(), 0, 60, WriteMode::Create).await;
+    mirror_into_fragment_metadata(
+        &flat,
+        flat_dir.path(),
+        source_dir.path().to_str().unwrap(),
+        "bulk",
+    )
+    .await;
+    let mut source = Dataset::open(source_dir.path().to_str().unwrap())
+        .await
+        .unwrap();
+    let original_fragment = source.get_fragments_async().await.unwrap()[0]
+        .metadata()
+        .clone();
+    let mut overlay_file = original_fragment.files[0].clone();
+    overlay_file.path = "clone-overlay.lance".to_string();
+    source
+        .object_store
+        .copy(
+            &source
+                .base
+                .clone()
+                .join("data")
+                .join(original_fragment.files[0].path.as_str()),
+            &source
+                .base
+                .clone()
+                .join("data")
+                .join(overlay_file.path.as_str()),
+        )
+        .await
+        .unwrap();
+    source = CommitBuilder::new(Arc::new(source.clone()))
+        .execute(Transaction::new_from_version(
+            source.version().version,
+            Operation::DataOverlay {
+                groups: vec![DataOverlayGroup {
+                    fragment_id: original_fragment.id,
+                    overlays: vec![DataOverlayFile {
+                        data_file: overlay_file,
+                        coverage: OverlayCoverage::Shared(Arc::new((0..10).collect())),
+                        committed_version: 0,
+                    }],
+                }],
+            },
+        ))
+        .await
+        .unwrap();
+    source.delete("id < 5").await.unwrap();
+    let original = scan_sorted(&source, None, None).await;
+    assert_eq!(original.len(), 55);
+    let version = source.version().version;
+    let mut cloned = match mode {
+        "shallow" => source
+            .shallow_clone(clone_dir.path().to_str().unwrap(), version, None)
+            .await
+            .unwrap(),
+        "deep" => source
+            .deep_clone(clone_dir.path().to_str().unwrap(), version, None)
+            .await
+            .unwrap(),
+        "branch" => source
+            .create_branch("metadata-test", version, None)
+            .await
+            .unwrap(),
+        _ => unreachable!(),
+    };
+    assert!(cloned.manifest.fragment_metadata.is_some());
+    assert_eq!(scan_sorted(&cloned, None, None).await, original);
+    let clone_version = cloned.version().version;
+    cloned.delete("id >= 55").await.unwrap();
+    assert_eq!(cloned.count_rows(None).await.unwrap(), 50);
+    assert_eq!(scan_sorted(&source, None, None).await, original);
+    assert_eq!(
+        scan_sorted(
+            &cloned.checkout_version(clone_version).await.unwrap(),
+            None,
+            None
+        )
+        .await,
+        original
+    );
+    source.delete("id >= 5").await.unwrap();
+    if mode != "shallow" {
+        crate::dataset::cleanup::cleanup_old_versions(
+            &source,
+            crate::dataset::cleanup::CleanupPolicy {
+                before_version: Some(source.version().version),
+                delete_unverified: true,
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+        assert_eq!(scan_sorted(&cloned, None, None).await.len(), 50);
+    }
+    let reopened = Dataset::open(cloned.uri()).await.unwrap();
+    assert_eq!(scan_sorted(&reopened, None, None).await.len(), 50);
+}
+
+#[rstest]
+#[tokio::test]
+async fn native_row_mutations_and_compaction_match_flat(
+    #[values(false, true)] stable_ids: bool,
+    #[values("buffered", "bulk")] materialization: &str,
+    #[values(false, true)] indexed: bool,
+) {
+    let flat_dir = tempfile::tempdir().unwrap();
+    let fragment_metadata_dir = tempfile::tempdir().unwrap();
+    let flat_uri = flat_dir.path().to_str().unwrap();
+    let fragment_metadata_uri = fragment_metadata_dir.path().to_str().unwrap();
+    let batch = rows(0, 60);
+    let flat = Dataset::write(
+        RecordBatchIterator::new(vec![Ok(batch.clone())], batch.schema()),
+        flat_uri,
+        Some(WriteParams {
+            max_rows_per_file: 10,
+            max_rows_per_group: 10,
+            enable_stable_row_ids: stable_ids,
+            ..Default::default()
+        }),
+    )
+    .await
+    .unwrap();
+    mirror_into_fragment_metadata(
+        &flat,
+        flat_dir.path(),
+        fragment_metadata_uri,
+        materialization,
+    )
+    .await;
+    let fragment_metadata = DatasetBuilder::from_uri(fragment_metadata_uri)
+        .load_unmaterialized()
+        .await
+        .unwrap();
+    assert_eq!(
+        fragment_metadata.manifest.next_row_id,
+        flat.manifest.next_row_id
+    );
+    let initial = scan_sorted(&flat, None, None).await;
+    let mut results = Vec::new();
+    for mut dataset in [flat, fragment_metadata] {
+        let initial_version = dataset.version_id();
+        if indexed {
+            dataset
+                .create_index(
+                    &["id"],
+                    IndexType::Scalar,
+                    Some("id_idx".to_string()),
+                    &ScalarIndexParams::default(),
+                    true,
+                )
+                .await
+                .unwrap();
+            let indices = dataset.load_indices().await.unwrap();
+            assert_eq!(indices[0].fragment_bitmap.as_ref().unwrap().len(), 6);
+            assert_eq!(scan_sorted(&dataset, None, Some("id >= 55")).await.len(), 5);
+        }
+        let update = UpdateBuilder::new(Arc::new(dataset))
+            .update_where("id >= 15 AND id < 25")
+            .unwrap()
+            .set("name", "'updated-' || cast(id as string)")
+            .unwrap()
+            .build()
+            .unwrap()
+            .execute()
+            .await
+            .unwrap();
+        assert_eq!(update.rows_updated, 10);
+        let after_update = scan_sorted(&update.new_dataset, None, None).await;
+        assert_eq!(after_update.len(), 60);
+        let source = rows(55, 10);
+        let (merged, stats) =
+            MergeInsertBuilder::try_new(update.new_dataset.clone(), vec!["id".to_string()])
+                .unwrap()
+                .when_matched(WhenMatched::UpdateAll)
+                .when_not_matched(WhenNotMatched::InsertAll)
+                .try_build()
+                .unwrap()
+                .execute_reader(RecordBatchIterator::new(
+                    vec![Ok(source.clone())],
+                    source.schema(),
+                ))
+                .await
+                .unwrap();
+        assert_eq!(stats.num_inserted_rows, 5);
+        assert_eq!(stats.num_updated_rows, 5);
+        if indexed {
+            assert_eq!(scan_sorted(&merged, None, Some("id >= 55")).await.len(), 10);
+        }
+        let before_compaction = scan_sorted(&merged, None, None).await;
+        let metadata = merged
+            .fragment_source()
+            .stream()
+            .try_collect::<Vec<_>>()
+            .await
+            .unwrap();
+        assert_eq!(
+            metadata
+                .iter()
+                .map(|fragment| fragment.num_rows().unwrap())
+                .sum::<usize>(),
+            65,
+            "Merged metadata row count for {}",
+            merged.uri()
+        );
+        assert_eq!(
+            before_compaction.len(),
+            65,
+            "Merged rows for {}: {before_compaction:?}",
+            merged.uri()
+        );
+        let mut compacted = merged.as_ref().clone();
+        let metrics = compact_files(
+            &mut compacted,
+            CompactionOptions {
+                target_rows_per_fragment: 20,
+                materialize_deletions: true,
+                ..Default::default()
+            },
+            None,
+        )
+        .await
+        .unwrap();
+        assert!(metrics.fragments_removed > 0);
+        let after_compaction = scan_sorted(&compacted, None, None).await;
+        let mut index_coverage = Vec::new();
+        for index in compacted.load_indices().await.unwrap().iter() {
+            // Independent compaction tasks can assign different physical IDs.
+            // Compare the actual indexed rows rather than those allocation labels.
+            let bitmap = index.fragment_bitmap.as_ref().unwrap();
+            let mut covered_ids = Vec::new();
+            let fragments = compacted.get_fragments_async().await.unwrap();
+            for fragment in fragments
+                .iter()
+                .filter(|fragment| bitmap.contains(fragment.id() as u32))
+            {
+                let batch = fragment
+                    .scan()
+                    .project(&["id"])
+                    .unwrap()
+                    .try_into_batch()
+                    .await
+                    .unwrap();
+                covered_ids.extend(
+                    batch
+                        .column_by_name("id")
+                        .unwrap()
+                        .as_any()
+                        .downcast_ref::<Int32Array>()
+                        .unwrap()
+                        .values()
+                        .iter()
+                        .copied(),
+                );
+            }
+            covered_ids.sort_unstable();
+            assert!(!covered_ids.is_empty());
+            index_coverage.push((
+                index.name.clone(),
+                index.fields.clone(),
+                covered_ids,
+                index.dataset_version - initial_version,
+            ));
+        }
+        assert_eq!(before_compaction, after_compaction);
+        assert_eq!(
+            scan_sorted(
+                &compacted.checkout_version(initial_version).await.unwrap(),
+                None,
+                None
+            )
+            .await,
+            initial
+        );
+        assert_eq!(compacted.count_rows(None).await.unwrap(), 65);
+        compacted
+            .add_columns(
+                NewColumnTransform::SqlExpressions(vec![(
+                    "double_id".to_string(),
+                    "id * 2".to_string(),
+                )]),
+                None,
+                None,
+            )
+            .await
+            .unwrap();
+        assert_eq!(compacted.count_rows(None).await.unwrap(), 65);
+        assert_eq!(
+            compacted
+                .count_rows(Some("double_id != id * 2".to_string()))
+                .await
+                .unwrap(),
+            0
+        );
+        let backfilled = scan_sorted(&compacted, None, None).await;
+        let maximum_id = compacted.manifest.max_fragment_id;
+        let mut restored = compacted.checkout_version(initial_version).await.unwrap();
+        restored.restore().await.unwrap();
+        assert_eq!(scan_sorted(&restored, None, None).await, initial);
+        assert_eq!(restored.manifest.max_fragment_id, maximum_id);
+        results.push((after_update, after_compaction, backfilled, index_coverage));
+    }
+    assert_eq!(results[0], results[1]);
+}
+
+#[tokio::test]
+async fn lazy_scan_matches_flat_scan_on_real_files() {
+    let flat_dir = tempfile::tempdir().unwrap();
+    let fragment_metadata_dir = tempfile::tempdir().unwrap();
+    let flat_uri = flat_dir.path().to_str().unwrap();
+    let fragment_metadata_uri = fragment_metadata_dir.path().to_str().unwrap();
+
+    write_flat(flat_uri, 0, 35, WriteMode::Create).await;
+    write_flat(flat_uri, 35, 23, WriteMode::Append).await;
+    let mut flat = Dataset::open(flat_uri).await.unwrap();
+    flat.delete("id = 3 OR id = 40").await.unwrap();
+    assert!(flat.fragments().len() >= 6, "want a multi-fragment table");
+
+    mirror_into_fragment_metadata(&flat, flat_dir.path(), fragment_metadata_uri, "buffered").await;
+
+    let fragment_metadata = DatasetBuilder::from_uri(fragment_metadata_uri)
+        .load_unmaterialized()
+        .await
+        .unwrap();
+    assert!(
+        fragment_metadata.fragment_source().is_lazy(),
+        "fragment metadata open must not materialize fragments"
+    );
+    assert!(
+        fragment_metadata.fragments().is_empty(),
+        "the manifest list stays empty"
+    );
+    // The lazy table plans through the ordinary modern read path.
+    let plan = fragment_metadata.scan().explain_plan(true).await.unwrap();
+    assert!(
+        plan.contains("LanceRead"),
+        "expected the modern read path, got:\n{plan}"
+    );
+
+    for (columns, filter) in [
+        (None, None),
+        (Some(["name"].as_slice()), None),
+        (None, Some("id > 5 AND id < 50")),
+        (Some(["id"].as_slice()), Some("id % 7 = 0")),
+    ] {
+        let expected = scan_sorted(&flat, columns, filter).await;
+        let actual = scan_sorted(&fragment_metadata, columns, filter).await;
+        assert_eq!(actual, expected, "columns={columns:?} filter={filter:?}");
+        assert!(!expected.is_empty());
+    }
+    assert_eq!(
+        fragment_metadata.count_rows(None).await.unwrap(),
+        flat.count_rows(None).await.unwrap()
+    );
+    assert_eq!(
+        fragment_metadata
+            .count_rows(Some("id < 10".into()))
+            .await
+            .unwrap(),
+        flat.count_rows(Some("id < 10".into())).await.unwrap()
+    );
+    let error = fragment_metadata
+        .take(&[0, 1], flat.schema().clone())
+        .await
+        .unwrap_err();
+    assert!(
+        error.to_string().contains("complete fragment list"),
+        "{error}"
+    );
+}
+
+#[tokio::test]
+async fn lazy_open_and_first_fragment_stay_bounded() {
+    let n = 1024;
+    let dir = tempfile::tempdir().unwrap();
+    let uri = dir.path().to_str().unwrap();
+    let schema = lance_core::datatypes::Schema::try_from(&ArrowSchema::new(vec![
+        Field::new("id", DataType::Int64, false),
+        Field::new("name", DataType::Utf8, false),
+    ]))
+    .unwrap();
+    let config = HashMap::from([
+        (
+            MANIFEST_LAYOUT_KEY.to_string(),
+            lance_table::fragment_metadata::MANIFEST_LAYOUT_TREE.to_string(),
+        ),
+        (MAX_NODE_BYTES_KEY.to_string(), (256 * 1024).to_string()),
+        (
+            "lance.fragment_metadata.allow_deep_writer".to_string(),
+            "true".to_string(),
+        ),
+    ]);
+    {
+        CommitBuilder::new(uri)
+            .execute(Transaction::new_from_version(
+                0,
+                Operation::Overwrite {
+                    fragments: (0..n).map(make_fragment).collect(),
+                    schema,
+                    config_upsert_values: Some(config),
+                    initial_bases: None,
+                },
+            ))
+            .await
+            .unwrap();
+    }
+
+    let io = IOTracker::default();
+    let params = ReadParams {
+        store_options: Some(ObjectStoreParams {
+            object_store_wrapper: Some(Arc::new(io.clone())),
+            ..Default::default()
+        }),
+        ..Default::default()
+    };
+    let dataset = DatasetBuilder::from_uri(uri)
+        .with_read_params(params)
+        .load_unmaterialized()
+        .await
+        .unwrap();
+    let open_reads = io.incremental_stats().read_iops;
+    assert!(dataset.fragment_source().is_lazy());
+
+    let mut stream = dataset.fragment_source().stream();
+    let first = stream.try_next().await.unwrap().unwrap();
+    let first_reads = io.incremental_stats().read_iops;
+    assert_eq!(first.id, 0);
+    assert!(
+        open_reads <= 4,
+        "open must read the root chain only, read {open_reads} objects"
+    );
+    assert!(
+        first_reads <= 8,
+        "first fragment must arrive after one root-to-leaf path, read {first_reads} objects"
+    );
+
+    let mut count = 0u64;
+    while let Some(fragment) = stream.try_next().await.unwrap() {
+        count += 1;
+        assert!(fragment.id > 0);
+    }
+    assert_eq!(count + 1, n);
+}
+
+/// Delete against Delete on the same fragment must classify and rebase
+/// exactly as flat Lance does through `DeleteBuilder`. Flat merges disjoint
+/// row deletions on the same fragment, rejects overlapping ones as retryable
+/// at the rebase step (then succeeds on retry by re-scanning), and removes a
+/// fragment whose rows are all gone.
+async fn delete_pair(
+    flat_predicate_a: &str,
+    predicate_b: &str,
+) -> (
+    crate::Result<u64>,
+    crate::Result<u64>,
+    Vec<String>,
+    Vec<String>,
+) {
+    use crate::dataset::write::delete::DeleteBuilder;
+    let flat_dir = tempfile::tempdir().unwrap();
+    let fragment_metadata_dir = tempfile::tempdir().unwrap();
+    let flat_uri = flat_dir.path().to_str().unwrap();
+    let fragment_metadata_uri = fragment_metadata_dir.path().to_str().unwrap();
+    write_flat(flat_uri, 0, 40, WriteMode::Create).await;
+    let flat = Dataset::open(flat_uri).await.unwrap();
+    mirror_into_fragment_metadata(&flat, flat_dir.path(), fragment_metadata_uri, "buffered").await;
+
+    let run = |uri: String| {
+        let a = flat_predicate_a.to_string();
+        let b = predicate_b.to_string();
+        async move {
+            // Both writers hold the same version, then commit in turn with
+            // zero conflict retries so the rebase itself is what we observe,
+            // not a retry that re-scans.
+            let stale_a = Arc::new(Dataset::open(&uri).await.unwrap());
+            let stale_b = Arc::new(Dataset::open(&uri).await.unwrap());
+            let first = DeleteBuilder::new(stale_a, &a)
+                .conflict_retries(0)
+                .execute()
+                .await
+                .map(|result| result.new_dataset.manifest.version);
+            let second = DeleteBuilder::new(stale_b, &b)
+                .conflict_retries(0)
+                .execute()
+                .await
+                .map(|result| result.new_dataset.manifest.version);
+            (first, second)
+        }
+    };
+    let (flat_first, flat_second) = run(flat_uri.to_string()).await;
+    assert!(flat_first.is_ok(), "{flat_first:?}");
+    let (fragment_metadata_first, fragment_metadata_second) =
+        run(fragment_metadata_uri.to_string()).await;
+    assert!(
+        fragment_metadata_first.is_ok(),
+        "{fragment_metadata_first:?}"
+    );
+
+    let flat_state = scan_sorted(&Dataset::open(flat_uri).await.unwrap(), None, None).await;
+    let fragment_metadata_state = scan_sorted(
+        &DatasetBuilder::from_uri(fragment_metadata_uri)
+            .load_unmaterialized()
+            .await
+            .unwrap(),
+        None,
+        None,
+    )
+    .await;
+    (
+        flat_second,
+        fragment_metadata_second,
+        flat_state,
+        fragment_metadata_state,
+    )
+}
+
+fn same_verdict(flat: &crate::Result<u64>, fragment_metadata: &crate::Result<u64>) -> bool {
+    match (flat, fragment_metadata) {
+        (Ok(_), Ok(_)) => true,
+        (Err(flat), Err(fragment_metadata)) => {
+            super::differential::error_category(flat)
+                == super::differential::error_category(fragment_metadata)
+        }
+        _ => false,
+    }
+}
+
+#[tokio::test]
+async fn delete_delete_same_fragment_disjoint_rows_rebases_like_flat() {
+    let (flat, fragment_metadata, flat_state, fragment_metadata_state) =
+        delete_pair("id = 1", "id = 3").await;
+    assert!(flat.is_ok(), "flat merges disjoint deletes: {flat:?}");
+    assert!(
+        same_verdict(&flat, &fragment_metadata),
+        "flat={flat:?} fragment_metadata={fragment_metadata:?}"
+    );
+    assert_eq!(fragment_metadata_state, flat_state);
+    assert_eq!(flat_state.len(), 38);
+}
+
+#[tokio::test]
+async fn delete_delete_same_fragment_overlapping_rows_conflicts_like_flat() {
+    let (flat, fragment_metadata, flat_state, fragment_metadata_state) =
+        delete_pair("id = 1 OR id = 2", "id = 2").await;
+    assert!(
+        flat.is_err(),
+        "flat rejects overlapping row deletes: {flat:?}"
+    );
+    assert!(
+        same_verdict(&flat, &fragment_metadata),
+        "flat={flat:?} fragment_metadata={fragment_metadata:?}"
+    );
+    assert_eq!(fragment_metadata_state, flat_state);
+}
+
+#[tokio::test]
+async fn delete_delete_covering_all_rows_removes_fragment_like_flat() {
+    // Fragment 0 holds ids 0..10; together the two deletes cover it entirely.
+    let (flat, fragment_metadata, flat_state, fragment_metadata_state) =
+        delete_pair("id < 5", "id >= 5 AND id < 10").await;
+    assert!(flat.is_ok(), "{flat:?}");
+    assert!(
+        same_verdict(&flat, &fragment_metadata),
+        "flat={flat:?} fragment_metadata={fragment_metadata:?}"
+    );
+    assert_eq!(fragment_metadata_state, flat_state);
+    assert_eq!(flat_state.len(), 30);
+}
+
+#[tokio::test]
+async fn stale_delete_after_whole_fragment_removal_conflicts_like_flat() {
+    // Writer A removes fragment 0 outright; B's stale delete touches it.
+    let (flat, fragment_metadata, flat_state, fragment_metadata_state) =
+        delete_pair("id < 10", "id = 3").await;
+    assert!(
+        same_verdict(&flat, &fragment_metadata),
+        "flat={flat:?} fragment_metadata={fragment_metadata:?}"
+    );
+    assert_eq!(fragment_metadata_state, flat_state);
+}
+
+#[tokio::test]
+async fn public_lazy_handle_scans_commits_and_materializes_offsets() {
+    let flat_dir = tempfile::tempdir().unwrap();
+    let tree_dir = tempfile::tempdir().unwrap();
+    let flat = write_flat(flat_dir.path().to_str().unwrap(), 0, 40, WriteMode::Create).await;
+    let uri = tree_dir.path().to_str().unwrap();
+    mirror_into_fragment_metadata(&flat, flat_dir.path(), uri, "buffered").await;
+    let lazy = DatasetBuilder::from_uri(uri).load_lazy().await.unwrap();
+    assert_eq!(lazy.count_rows(None).await.unwrap(), 40);
+    assert_eq!(lazy.count_rows(Some("id >= 15".into())).await.unwrap(), 25);
+    assert_eq!(lazy.scan().try_into_batch().await.unwrap().num_rows(), 40);
+    let fragments = lazy.get_fragments(&[3, 0, 3]).await.unwrap();
+    assert_eq!(
+        fragments.iter().map(|f| f.id).collect::<Vec<_>>(),
+        vec![0, 3]
+    );
+    let committed = lazy
+        .commit(Transaction::new_from_version(
+            lazy.version_id(),
+            Operation::Delete {
+                updated_fragments: Vec::new(),
+                deleted_fragment_ids: vec![1],
+                predicate: "fixture".into(),
+            },
+        ))
+        .await
+        .unwrap();
+    assert_eq!(committed.count_rows(None).await.unwrap(), 30);
+    assert_eq!(lazy.count_rows(None).await.unwrap(), 40);
+    assert_eq!(
+        committed
+            .checkout_version(lazy.version_id())
+            .await
+            .unwrap()
+            .count_rows(None)
+            .await
+            .unwrap(),
+        40
+    );
+    let dataset = committed.into_dataset().await.unwrap();
+    let rows = dataset
+        .take(&[0, 10, 29], dataset.schema().clone())
+        .await
+        .unwrap();
+    assert_eq!(rows.num_rows(), 3);
+    assert_eq!(
+        rows.column(0)
+            .as_any()
+            .downcast_ref::<Int32Array>()
+            .unwrap()
+            .values()
+            .as_ref(),
+        &[0, 20, 39]
+    );
+}

--- a/rust/lance/src/dataset/fragment_metadata/test_support.rs
+++ b/rust/lance/src/dataset/fragment_metadata/test_support.rs
@@ -1,0 +1,167 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+//! Test-only entry points over the fragment metadata commit path: opening a
+//! tree at a version, a lazy reader session, and a Merge commit that adds
+//! columns.
+
+use std::sync::Arc;
+
+use lance_core::Result;
+use lance_core::datatypes::Schema;
+use lance_io::object_store::ObjectStore;
+use lance_table::format::{Fragment, Manifest, pb};
+use lance_table::fragment_metadata::{FragmentMetadataTree, TouchedFragments};
+use lance_table::io::commit::{CommitConfig, ConditionalPutCommitHandler, commit_handler_from_url};
+
+use super::publication::{read_version, tree_from_manifest};
+use super::{CommitTarget, execute_commit, replacement_actions};
+use crate::dataset::transaction::{DataReplacementGroup, Operation, Transaction};
+use crate::dataset::{Dataset, ManifestWriteConfig};
+use crate::session::Session;
+
+pub(super) async fn open_tree(
+    target: &CommitTarget,
+    version: Option<u64>,
+) -> Result<(FragmentMetadataTree, Manifest)> {
+    let (manifest, _) = read_version(
+        &target.object_store,
+        &target.base_path,
+        target.commit_handler.as_ref(),
+        version,
+    )
+    .await?;
+    let tree = tree_from_manifest(
+        target.object_store.clone(),
+        target.base_path.clone(),
+        &manifest,
+    )
+    .await?;
+    Ok((tree, manifest))
+}
+
+/// Build a commit target for a dataset uri the way `CommitBuilder` does.
+pub(super) async fn commit_target_for_uri(uri: &str) -> Result<CommitTarget> {
+    let session = Arc::new(Session::default());
+    let (object_store, base_path) =
+        ObjectStore::from_uri_and_params(session.store_registry(), uri, &Default::default())
+            .await?;
+    let commit_handler = commit_handler_from_url(uri, &None).await?;
+    Ok(CommitTarget {
+        context: None,
+        materialize_fragments: false,
+        object_store,
+        base_path,
+        uri: uri.to_string(),
+        session,
+        commit_handler,
+    })
+}
+
+/// A new table schema plus the data files that back the new fields,
+/// published as `Operation::Merge`.
+pub(super) struct AddColumns {
+    pub read_version: u64,
+    pub schema: Schema,
+    pub replacements: Vec<DataReplacementGroup>,
+}
+
+pub(super) async fn execute_add_columns(
+    target: CommitTarget,
+    commit_config: &CommitConfig,
+    add_columns: &AddColumns,
+) -> Result<Dataset> {
+    let (tree, _) = open_tree(&target, Some(add_columns.read_version)).await?;
+    let fragments = tree.materialize().await?;
+    let touched = TouchedFragments {
+        ids: fragments.iter().map(|fragment| fragment.id).collect(),
+        fragments: fragments
+            .into_iter()
+            .map(|fragment| (fragment.id, fragment))
+            .collect(),
+    };
+    let actions = replacement_actions(&add_columns.replacements, &touched)?;
+    let mut fragments = touched.fragments;
+    let messages = actions
+        .into_iter()
+        .enumerate()
+        .map(|(action_sequence, action)| pb::FragmentMetadataMutation {
+            action_sequence: action_sequence as u64 + 1,
+            action: Some(action),
+            ..Default::default()
+        })
+        .collect();
+    lance_table::fragment_metadata::node::apply_actions(&mut fragments, messages)?;
+    let transaction = Transaction::new_from_version(
+        add_columns.read_version,
+        Operation::Merge {
+            fragments: fragments.into_values().collect(),
+            schema: add_columns.schema.clone(),
+            preserves_nullability: false,
+        },
+    );
+    execute_commit(
+        target,
+        commit_config,
+        &transaction,
+        None,
+        &ManifestWriteConfig::default(),
+    )
+    .await
+}
+
+/// Lazy metadata session. The named Version Manifest and its immutable root
+/// base determine state; selective resolution reads only the necessary paths.
+pub(super) struct Reader {
+    pub(super) tree: FragmentMetadataTree,
+    schema: Schema,
+}
+
+impl Reader {
+    /// Open the latest version from a dataset uri, resolving the object store
+    /// the same way the commit path does.
+    pub async fn open_uri(uri: &str) -> Result<Self> {
+        Self::open_uri_version(uri, None).await
+    }
+
+    /// Open a specific published version from a dataset uri.
+    pub async fn open_uri_at(uri: &str, version: u64) -> Result<Self> {
+        Self::open_uri_version(uri, Some(version)).await
+    }
+
+    async fn open_uri_version(uri: &str, version: Option<u64>) -> Result<Self> {
+        let session = Arc::new(Session::default());
+        let (object_store, base) =
+            ObjectStore::from_uri_and_params(session.store_registry(), uri, &Default::default())
+                .await?;
+        let (manifest, _) =
+            read_version(&object_store, &base, &ConditionalPutCommitHandler, version).await?;
+        let tree = tree_from_manifest(object_store, base, &manifest).await?;
+        Ok(Self {
+            tree,
+            schema: manifest.schema,
+        })
+    }
+
+    /// The table schema stored with this version.
+    pub fn schema(&self) -> Result<Schema> {
+        Ok(self.schema.clone())
+    }
+
+    pub fn version(&self) -> u64 {
+        self.tree.version()
+    }
+
+    pub fn count_fragments(&self) -> u64 {
+        self.tree.count_fragments()
+    }
+
+    pub async fn resolve_fragment(&self, fragment_id: u64) -> Result<Option<Fragment>> {
+        self.tree.resolve_fragment(fragment_id).await
+    }
+
+    /// Materialize the full fragment list, for benchmarks and global checks.
+    pub async fn materialize(&self) -> Result<Vec<Fragment>> {
+        self.tree.materialize().await
+    }
+}

--- a/rust/lance/src/dataset/fragment_metadata/wide_table_io.rs
+++ b/rust/lance/src/dataset/fragment_metadata/wide_table_io.rs
@@ -1,0 +1,506 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+//! Local-disk measurement of wide-table metadata growth.
+//!
+//! Merge arms commit `Operation::Merge` with an updated schema, the path
+//! add_columns uses. The replace arm commits `Operation::DataReplacement` with
+//! file replacements only. It does not publish schema. That arm is a
+//! metadata-only experiment, not add_columns. Routing add_columns through
+//! DataReplacement remains an investigation, including schema publication and
+//! validation.
+//!
+//! Synthetic fragment records, no 2048-row data files. Reports local I/O and
+//! on-disk metadata sizes, not S3 and not dataset-open heap of a real table.
+//! Ignored: run with `--ignored --nocapture`.
+//!
+//! Env: `WIDE_F` fragments (default 2000), `WIDE_C` columns (50),
+//! `WIDE_ADDS` rounds (5). `WIDE_F=20000 WIDE_C=500 WIDE_ADDS=5` is the RFC
+//! shape.
+
+// The measurements are the deliverable of this ignored harness, read from
+// `--nocapture` output rather than asserted.
+#![allow(clippy::print_stdout)]
+
+use std::collections::HashMap;
+use std::num::NonZero;
+use std::path::Path;
+use std::sync::Arc;
+use std::time::Instant;
+
+use arrow_schema::{DataType, Field as ArrowField, Schema as ArrowSchema};
+use lance_core::datatypes::Schema;
+use lance_file::version::ConcreteFileVersion;
+use lance_io::object_store::ObjectStoreParams;
+use lance_io::utils::tracking_store::{IOTracker, IoStats};
+use lance_table::format::{DataFile, Fragment, pb};
+use lance_table::fragment_metadata::support::data_file_path;
+use lance_table::fragment_metadata::{MANIFEST_LAYOUT_KEY, MANIFEST_LAYOUT_TREE};
+use prost::Message;
+
+use super::{MAX_LEAF_BYTES_KEY, MAX_NODE_BYTES_KEY};
+use crate::dataset::Dataset;
+use crate::dataset::builder::DatasetBuilder;
+use crate::dataset::transaction::{DataReplacementGroup, Operation, Transaction};
+use crate::dataset::write::CommitBuilder;
+use crate::session::Session;
+
+const FILE_VERSION: ConcreteFileVersion = ConcreteFileVersion::V2_0;
+
+fn env_u64(name: &str, default: u64) -> u64 {
+    std::env::var(name)
+        .ok()
+        .and_then(|value| value.parse().ok())
+        .unwrap_or(default)
+}
+
+fn wide_schema(cols: u32) -> Schema {
+    Schema::try_from(&ArrowSchema::new(
+        (0..cols)
+            .map(|i| ArrowField::new(format!("c{i}"), DataType::Int32, true))
+            .collect::<Vec<_>>(),
+    ))
+    .unwrap()
+}
+
+fn wide_fragment(id: u64, fields: Arc<[i32]>, indices: Arc<[i32]>) -> Fragment {
+    let mut fragment = Fragment::new(id);
+    fragment.physical_rows = Some(2048);
+    fragment.files.push(DataFile {
+        path: data_file_path(id, 0),
+        fields,
+        column_indices: indices,
+        file_major_version: 2,
+        file_minor_version: 0,
+        file_size_bytes: NonZero::new(4096).into(),
+        base_id: None,
+    });
+    fragment
+}
+
+fn backfill_file(frag_id: u64, field_id: i32) -> DataFile {
+    DataFile::new(
+        data_file_path(frag_id, field_id as u64),
+        vec![field_id],
+        vec![0],
+        FILE_VERSION,
+        NonZero::new(4096),
+        None,
+    )
+}
+
+fn tree_config() -> HashMap<String, String> {
+    let node_bytes = env_u64("WIDE_NODE_BYTES", 1024 * 1024);
+    HashMap::from([
+        (
+            MANIFEST_LAYOUT_KEY.to_string(),
+            MANIFEST_LAYOUT_TREE.to_string(),
+        ),
+        (MAX_NODE_BYTES_KEY.to_string(), node_bytes.to_string()),
+        (MAX_LEAF_BYTES_KEY.to_string(), (1024 * 1024).to_string()),
+        (
+            "lance.fragment_metadata.semantic_buffer_bytes".to_string(),
+            node_bytes.to_string(),
+        ),
+        (
+            "lance.fragment_metadata.hard_capacity_bytes".to_string(),
+            (256 * 1024 * 1024).to_string(),
+        ),
+        (
+            "lance.fragment_metadata.allow_deep_writer".to_string(),
+            "true".to_string(),
+        ),
+        (
+            "lance.fragment_metadata.materialization".to_string(),
+            "buffered".to_string(),
+        ),
+    ])
+}
+
+fn dir_bytes(path: &Path) -> u64 {
+    if !path.exists() {
+        return 0;
+    }
+    let mut total = 0;
+    let mut stack = vec![path.to_path_buf()];
+    while let Some(dir) = stack.pop() {
+        let Ok(entries) = std::fs::read_dir(&dir) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_dir() {
+                stack.push(path);
+            } else if let Ok(meta) = entry.metadata() {
+                total += meta.len();
+            }
+        }
+    }
+    total
+}
+
+struct Disk {
+    versions: u64,
+    transactions: u64,
+    tree: u64,
+}
+
+impl Disk {
+    fn of(root: &Path) -> Self {
+        Self {
+            versions: dir_bytes(&root.join("_versions")),
+            transactions: dir_bytes(&root.join("_transactions")),
+            tree: dir_bytes(&root.join("_bt")),
+        }
+    }
+
+    fn metadata(&self) -> u64 {
+        self.versions + self.transactions + self.tree
+    }
+
+    fn fmt(&self) -> String {
+        format!(
+            "versions={:.2} MiB  txn={:.2} MiB  _bt={:.2} MiB  total={:.2} MiB",
+            mib(self.versions),
+            mib(self.transactions),
+            mib(self.tree),
+            mib(self.metadata())
+        )
+    }
+}
+
+fn mib(bytes: u64) -> f64 {
+    bytes as f64 / (1024.0 * 1024.0)
+}
+
+fn fmt_io(stats: &IoStats) -> String {
+    format!(
+        "r={}/{}  w={}/{}  ({:.2} MiB read, {:.2} MiB write)",
+        stats.read_iops,
+        stats.read_bytes,
+        stats.write_iops,
+        stats.written_bytes,
+        mib(stats.read_bytes),
+        mib(stats.written_bytes)
+    )
+}
+
+fn latest_manifest_bytes(root: &Path) -> u64 {
+    let dir = root.join("_versions");
+    let Ok(entries) = std::fs::read_dir(&dir) else {
+        return 0;
+    };
+    let mut best: Option<(u64, u64)> = None;
+    for entry in entries.flatten() {
+        let name = entry.file_name();
+        let name = name.to_string_lossy();
+        let Some(stem) = name.strip_suffix(".manifest") else {
+            continue;
+        };
+        let Ok(version) = stem.parse::<u64>() else {
+            continue;
+        };
+        let Ok(meta) = entry.metadata() else {
+            continue;
+        };
+        if best.is_none_or(|(v, _)| version >= v) {
+            best = Some((version, meta.len()));
+        }
+    }
+    best.map(|(_, bytes)| bytes).unwrap_or(0)
+}
+
+fn leaf_gets(stats: &IoStats) -> u64 {
+    stats
+        .requests
+        .iter()
+        .filter(|request| {
+            request.path.as_ref().contains("_bt/leaf/") && request.method.starts_with("get_")
+        })
+        .count() as u64
+}
+
+async fn create_dataset(
+    uri: &str,
+    fragments: Vec<Fragment>,
+    schema: Schema,
+    tree: bool,
+) -> Dataset {
+    let config = if tree { Some(tree_config()) } else { None };
+    CommitBuilder::new(uri)
+        .with_skip_auto_cleanup(true)
+        .execute(Transaction::new_from_version(
+            0,
+            Operation::Overwrite {
+                fragments,
+                schema,
+                config_upsert_values: config,
+                initial_bases: None,
+            },
+        ))
+        .await
+        .unwrap()
+}
+
+async fn open_tracked(uri: &str, tracker: &IOTracker) -> Dataset {
+    let params = ObjectStoreParams {
+        object_store_wrapper: Some(Arc::new(tracker.clone())),
+        ..Default::default()
+    };
+    DatasetBuilder::from_uri(uri)
+        .with_store_params(params)
+        .with_session(Arc::new(Session::default()))
+        .load()
+        .await
+        .unwrap()
+}
+
+/// `into_dataset` hydrates; keep the lazy handle for checkout that must not.
+async fn open_lazy_tracked(uri: &str, tracker: &IOTracker) -> crate::dataset::LazyDataset {
+    let params = ObjectStoreParams {
+        object_store_wrapper: Some(Arc::new(tracker.clone())),
+        ..Default::default()
+    };
+    DatasetBuilder::from_uri(uri)
+        .with_store_params(params)
+        .with_session(Arc::new(Session::default()))
+        .load_lazy()
+        .await
+        .unwrap()
+}
+
+/// Updated schema plus one backfill file per fragment. This is the add_columns path.
+fn merge_add(fragments: &[Fragment], schema: Schema, field_id: i32) -> Operation {
+    Operation::Merge {
+        preserves_nullability: false,
+        schema,
+        fragments: fragments
+            .iter()
+            .map(|fragment| {
+                let mut fragment = fragment.clone();
+                fragment.files.push(backfill_file(fragment.id, field_id));
+                fragment
+            })
+            .collect(),
+    }
+}
+
+/// File replacements only. No schema. Not add_columns.
+fn replacement_add(n: u64, field_id: i32) -> Operation {
+    Operation::DataReplacement {
+        replacements: (0..n)
+            .map(|id| DataReplacementGroup(id, backfill_file(id, field_id)))
+            .collect(),
+    }
+}
+
+struct LayoutRun {
+    name: &'static str,
+    uri: String,
+    root: std::path::PathBuf,
+    dataset: Dataset,
+}
+
+async fn run_adds(
+    run: &mut LayoutRun,
+    mut merge_fragments: Option<Vec<Fragment>>,
+    n: u64,
+    start_cols: u32,
+    adds: u32,
+) {
+    let use_merge = merge_fragments.is_some();
+    println!(
+        "\n== {}  merge={}  F={n} start_C={start_cols} adds={adds} ==",
+        run.name, use_merge
+    );
+    let bootstrap = Disk::of(&run.root);
+    println!("  after create: {}", bootstrap.fmt());
+
+    let reader_tracker = IOTracker::default();
+    let mut eager = open_tracked(&run.uri, &reader_tracker).await;
+    let eager_open = reader_tracker.incremental_stats();
+    println!("  eager open:   {}", fmt_io(&eager_open));
+    println!("  eager open leaf GETs: {}", leaf_gets(&eager_open));
+
+    let lazy_tracker = IOTracker::default();
+    let mut lazy = open_lazy_tracked(&run.uri, &lazy_tracker).await;
+    let lazy_open = lazy_tracker.incremental_stats();
+    println!("  lazy open:    {}", fmt_io(&lazy_open));
+    println!("  lazy open leaf GETs:  {}", leaf_gets(&lazy_open));
+
+    let mut prev_disk = bootstrap;
+
+    for round in 0..adds {
+        let field_id = start_cols as i32 + round as i32;
+        let schema = wide_schema(start_cols + round + 1);
+        let op = if let Some(fragments) = merge_fragments.as_ref() {
+            merge_add(fragments, schema, field_id)
+        } else {
+            replacement_add(n, field_id)
+        };
+        let t0 = Instant::now();
+        run.dataset = CommitBuilder::new(Arc::new(run.dataset.clone()))
+            .with_skip_auto_cleanup(true)
+            .execute(Transaction::new_from_version(
+                run.dataset.manifest.version,
+                op,
+            ))
+            .await
+            .unwrap();
+        let commit_ms = t0.elapsed().as_secs_f64() * 1000.0;
+        if let Some(fragments) = merge_fragments.as_mut() {
+            for fragment in fragments.iter_mut() {
+                fragment.files.push(backfill_file(fragment.id, field_id));
+            }
+        }
+        let disk = Disk::of(&run.root);
+        let wrote = disk.metadata().saturating_sub(prev_disk.metadata());
+        let latest = latest_manifest_bytes(&run.root);
+        println!(
+            "  add {round}: {commit_ms:.0} ms  wrote {:.2} MiB  latest_manifest={:.2} MiB  ({})",
+            mib(wrote),
+            mib(latest),
+            disk.fmt()
+        );
+
+        let t1 = Instant::now();
+        eager.checkout_latest().await.unwrap();
+        let eager_refresh = reader_tracker.incremental_stats();
+        let eager_ms = t1.elapsed().as_secs_f64() * 1000.0;
+        println!(
+            "    eager checkout_latest: {eager_ms:.0} ms  {}  leaf GETs={}",
+            fmt_io(&eager_refresh),
+            leaf_gets(&eager_refresh)
+        );
+
+        let t2 = Instant::now();
+        lazy = lazy
+            .checkout_version(run.dataset.manifest.version)
+            .await
+            .unwrap();
+        let lazy_refresh = lazy_tracker.incremental_stats();
+        let lazy_ms = t2.elapsed().as_secs_f64() * 1000.0;
+        println!(
+            "    lazy  checkout:         {lazy_ms:.0} ms  {}  leaf GETs={}",
+            fmt_io(&lazy_refresh),
+            leaf_gets(&lazy_refresh)
+        );
+        println!(
+            "WIDE_JSON {{\"arm\":\"{}\",\"round\":{round},\"commit_ms\":{commit_ms:.1},\"wrote_bytes\":{wrote},\"latest_manifest_bytes\":{latest},\"eager_ms\":{eager_ms:.1},\"eager_read_bytes\":{},\"eager_leaf_gets\":{},\"lazy_ms\":{lazy_ms:.1},\"lazy_read_bytes\":{},\"lazy_leaf_gets\":{},\"versions_bytes\":{},\"txn_bytes\":{},\"bt_bytes\":{}}}",
+            run.name,
+            eager_refresh.read_bytes,
+            leaf_gets(&eager_refresh),
+            lazy_refresh.read_bytes,
+            leaf_gets(&lazy_refresh),
+            disk.versions,
+            disk.transactions,
+            disk.tree
+        );
+
+        prev_disk = disk;
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+#[ignore]
+async fn wide_table_add_columns_io() {
+    let n = env_u64("WIDE_F", 2_000);
+    let cols = env_u64("WIDE_C", 50) as u32;
+    let adds = env_u64("WIDE_ADDS", 5) as u32;
+    assert!(n > 0 && cols > 0 && adds > 0);
+
+    let field_ids: Arc<[i32]> = (0..cols as i32).collect::<Vec<_>>().into();
+    let indices: Arc<[i32]> = vec![0i32; cols as usize].into();
+    let fragments: Vec<Fragment> = (0..n)
+        .map(|id| wide_fragment(id, field_ids.clone(), indices.clone()))
+        .collect();
+    let schema = wide_schema(cols);
+
+    let sample_file = backfill_file(0, cols as i32);
+    let sample_frag = fragments[0].clone();
+    println!(
+        "encoded DataFile (1 field) = {} B  encoded bootstrap fragment = {} B  F={n} C={cols}",
+        pb::DataFile::from(&sample_file).encoded_len(),
+        pb::DataFragment::from(&sample_frag).encoded_len()
+    );
+    let descriptor_only: usize = (0..n)
+        .map(|id| pb::DataFile::from(&backfill_file(id, cols as i32)).encoded_len())
+        .sum();
+
+    let arms = std::env::var("WIDE_ARMS").unwrap_or_else(|_| "flat,merge,replace".into());
+    let run_flat = arms.split(',').any(|a| a == "flat");
+    let run_merge = arms.split(',').any(|a| a == "merge");
+    let run_replace = arms.split(',').any(|a| a == "replace");
+    println!(
+        "node/buffer bytes = {}",
+        env_u64("WIDE_NODE_BYTES", 1024 * 1024)
+    );
+
+    let tmp = tempfile::tempdir().unwrap();
+    if run_flat {
+        let flat_root = tmp.path().join("flat");
+        std::fs::create_dir_all(&flat_root).unwrap();
+        let t0 = Instant::now();
+        let flat = create_dataset(
+            flat_root.to_str().unwrap(),
+            fragments.clone(),
+            schema.clone(),
+            false,
+        )
+        .await;
+        println!("flat create: {:.1}s", t0.elapsed().as_secs_f64());
+        let mut flat = LayoutRun {
+            name: "flat Merge",
+            uri: flat_root.to_str().unwrap().to_string(),
+            root: flat_root,
+            dataset: flat,
+        };
+        run_adds(&mut flat, Some(fragments.clone()), n, cols, adds).await;
+    }
+    if run_merge {
+        let tree_merge_root = tmp.path().join("tree_merge");
+        std::fs::create_dir_all(&tree_merge_root).unwrap();
+        let t1 = Instant::now();
+        let tree_merge = create_dataset(
+            tree_merge_root.to_str().unwrap(),
+            fragments.clone(),
+            schema.clone(),
+            true,
+        )
+        .await;
+        println!(
+            "tree create (merge arm): {:.1}s",
+            t1.elapsed().as_secs_f64()
+        );
+        let mut tree_merge = LayoutRun {
+            name: "tree Merge",
+            uri: tree_merge_root.to_str().unwrap().to_string(),
+            root: tree_merge_root,
+            dataset: tree_merge,
+        };
+        run_adds(&mut tree_merge, Some(fragments.clone()), n, cols, adds).await;
+    }
+    if run_replace {
+        let tree_replace_root = tmp.path().join("tree_replace");
+        std::fs::create_dir_all(&tree_replace_root).unwrap();
+        let t2 = Instant::now();
+        let tree_replace =
+            create_dataset(tree_replace_root.to_str().unwrap(), fragments, schema, true).await;
+        println!(
+            "tree create (replace arm): {:.1}s",
+            t2.elapsed().as_secs_f64()
+        );
+        let mut tree_replace = LayoutRun {
+            name: "tree DataReplacement, metadata-only",
+            uri: tree_replace_root.to_str().unwrap().to_string(),
+            root: tree_replace_root,
+            dataset: tree_replace,
+        };
+        run_adds(&mut tree_replace, None, n, cols, adds).await;
+    }
+
+    println!(
+        "descriptor-only estimate: {:.2} MiB. Sum of encoded DataFile protobufs for F one-field files. No routing, leaves, or publication.",
+        mib(descriptor_only as u64)
+    );
+}

--- a/rust/lance/src/dataset/fragment_source.rs
+++ b/rust/lance/src/dataset/fragment_source.rs
@@ -1,0 +1,144 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+//! Where a scan gets its fragments.
+//!
+//! A flat manifest holds the whole fragment list in memory. A fragment
+//! metadata tree yields fragments leaf by leaf, so a scan can start before
+//! the metadata for the last fragment has been read. Plan nodes that can
+//! consume a stream take a [`FragmentSource`]; plan nodes that need the
+//! complete list ask for [`FragmentSource::materialized`] and refuse a lazy
+//! source rather than materializing it behind the caller's back.
+
+use std::sync::Arc;
+
+use futures::StreamExt;
+use futures::stream::BoxStream;
+use lance_core::{Error, Result};
+use lance_table::format::Fragment;
+use lance_table::fragment_metadata::FragmentMetadataTree;
+
+/// Fragments served from a fragment metadata tree, in id order. Hydration
+/// prefetches up to the store's I/O parallelism in leaves. A streaming scan
+/// keeps a bounded number of leaf reads in flight.
+pub struct LazyFragments {
+    tree: Arc<FragmentMetadataTree>,
+}
+
+impl std::fmt::Debug for LazyFragments {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "LazyFragments({:?})",
+            FragmentMetadataTreeDebug(&self.tree)
+        )
+    }
+}
+
+impl LazyFragments {
+    pub fn new(tree: Arc<FragmentMetadataTree>) -> Self {
+        Self { tree }
+    }
+
+    pub fn tree(&self) -> &Arc<FragmentMetadataTree> {
+        &self.tree
+    }
+}
+
+impl std::fmt::Debug for FragmentMetadataTreeDebug<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "FragmentMetadataTree(version={})", self.0.version())
+    }
+}
+struct FragmentMetadataTreeDebug<'a>(&'a FragmentMetadataTree);
+
+#[derive(Clone)]
+pub enum FragmentSource {
+    /// The manifest's fragment list, already in memory.
+    Manifest(Arc<Vec<Fragment>>),
+    /// A stream from the fragment metadata tree.
+    Lazy(Arc<LazyFragments>),
+}
+
+impl std::fmt::Debug for FragmentSource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Manifest(fragments) => write!(f, "Manifest({} fragments)", fragments.len()),
+            Self::Lazy(lazy) => write!(f, "Lazy({:?})", FragmentMetadataTreeDebug(lazy.tree())),
+        }
+    }
+}
+
+impl From<Arc<Vec<Fragment>>> for FragmentSource {
+    fn from(fragments: Arc<Vec<Fragment>>) -> Self {
+        Self::Manifest(fragments)
+    }
+}
+
+impl From<Vec<Fragment>> for FragmentSource {
+    fn from(fragments: Vec<Fragment>) -> Self {
+        Self::Manifest(Arc::new(fragments))
+    }
+}
+
+impl FragmentSource {
+    pub fn is_lazy(&self) -> bool {
+        matches!(self, Self::Lazy(_))
+    }
+
+    /// Fragments in id order. Manifest clones one fragment per yield from the
+    /// shared `Arc`, not a second full `Vec` before the first item.
+    pub fn stream(&self) -> BoxStream<'static, Result<Fragment>> {
+        match self {
+            Self::Manifest(fragments) => {
+                let fragments = Arc::clone(fragments);
+                futures::stream::iter(0..fragments.len())
+                    .map(move |idx| Ok(fragments[idx].clone()))
+                    .boxed()
+            }
+            Self::Lazy(lazy) => lazy.tree.clone().fragment_stream(),
+        }
+    }
+
+    /// The complete list, for plan nodes that need random access. A lazy
+    /// source refuses instead of collecting: the caller must plan through the
+    /// streaming scan or gain an explicit full-list path.
+    pub fn materialized(&self, purpose: &str) -> Result<Arc<Vec<Fragment>>> {
+        match self {
+            Self::Manifest(fragments) => Ok(fragments.clone()),
+            Self::Lazy(_) => Err(Error::not_supported_source(
+                format!("{purpose} needs the complete fragment list, which a lazily loaded fragment metadata dataset does not hold in memory yet")
+                    .into(),
+            )),
+        }
+    }
+
+    /// Visible row count. A flat source may lack legacy statistics; a tree
+    /// admits only known counts and maintains exact visible-row aggregates.
+    pub fn row_count(&self) -> Option<FragmentRowCount> {
+        match self {
+            Self::Manifest(fragments) => {
+                let sum: Option<usize> = fragments.iter().map(Fragment::num_rows).sum();
+                sum.map(FragmentRowCount::Exact)
+            }
+            Self::Lazy(lazy) => usize::try_from(lazy.tree.count_visible_rows())
+                .ok()
+                .map(FragmentRowCount::Exact),
+        }
+    }
+}
+
+/// Row count from a fragment source, with how precise the value is.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum FragmentRowCount {
+    Exact(usize),
+    Inexact(usize),
+}
+
+impl FragmentRowCount {
+    pub fn get(self) -> usize {
+        match self {
+            Self::Exact(n) | Self::Inexact(n) => n,
+        }
+    }
+}

--- a/rust/lance/src/dataset/lazy.rs
+++ b/rust/lance/src/dataset/lazy.rs
@@ -1,0 +1,137 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+use std::sync::Arc;
+
+use futures::{StreamExt, stream::BoxStream};
+use lance_core::{Result, datatypes::Schema};
+use lance_table::format::Fragment;
+
+use super::{Dataset, refs::Ref, scanner::Scanner, transaction::Transaction, write::CommitBuilder};
+
+/// A dataset whose fragment metadata is read on demand.
+///
+/// This handle provides streaming metadata, scans without indices, and native
+/// transactions. Convert with [`Self::into_dataset`] for APIs that need resident
+/// fragments, including index construction and synchronous fragment access.
+///
+/// ```
+/// # use lance::{dataset::builder::DatasetBuilder, Result};
+/// # use futures::TryStreamExt;
+/// # async fn example(uri: &str) -> Result<()> {
+/// let dataset = DatasetBuilder::from_uri(uri).load_lazy().await?;
+/// let mut fragments = dataset.fragments_from(100);
+/// while let Some(fragment) = fragments.try_next().await? {
+///     assert!(fragment.id >= 100);
+/// }
+/// # Ok(())
+/// # }
+/// ```
+#[derive(Clone)]
+pub struct LazyDataset {
+    dataset: Dataset,
+}
+
+impl LazyDataset {
+    pub(crate) fn new(dataset: Dataset) -> Self {
+        Self { dataset }
+    }
+
+    /// Schema of this snapshot; no metadata objects are read.
+    pub fn schema(&self) -> &Schema {
+        self.dataset.schema()
+    }
+
+    /// Published version number of this snapshot.
+    pub fn version_id(&self) -> u64 {
+        self.dataset.version_id()
+    }
+
+    /// Number of live fragments, including buffered changes.
+    pub fn count_fragments(&self) -> usize {
+        self.dataset.count_fragments()
+    }
+
+    /// Count visible rows; an absent filter uses metadata aggregates.
+    pub async fn count_rows(&self, filter: Option<String>) -> Result<usize> {
+        if let Some(filter) = filter {
+            let mut scanner = self.scan();
+            scanner
+                .filter(&filter)?
+                .project::<String>(&[])?
+                .with_row_id();
+            Ok(scanner.count_rows().await? as usize)
+        } else {
+            self.dataset.count_all_rows().await
+        }
+    }
+
+    /// Resolve one fragment. Deleted and unallocated IDs return `None`.
+    pub async fn get_fragment(&self, id: u64) -> Result<Option<Fragment>> {
+        if let Some(lazy) = &self.dataset.lazy_fragments {
+            lazy.tree().resolve_fragment(id).await
+        } else {
+            Ok(self
+                .dataset
+                .manifest
+                .fragments
+                .iter()
+                .find(|f| f.id == id)
+                .cloned())
+        }
+    }
+
+    /// Resolve distinct live IDs in ascending order, sharing leaf reads.
+    pub async fn get_fragments(&self, ids: &[u64]) -> Result<Vec<Fragment>> {
+        Ok(self
+            .dataset
+            .file_fragments_for_ids(ids)
+            .await?
+            .into_iter()
+            .map(|fragment| fragment.metadata().clone())
+            .collect())
+    }
+
+    /// Stream fragments in ID order, starting at an inclusive lower bound.
+    pub fn fragments_from(&self, id: u64) -> BoxStream<'static, Result<Fragment>> {
+        if let Some(lazy) = &self.dataset.lazy_fragments {
+            lazy.tree().clone().fragment_stream_from(id)
+        } else {
+            let fragments = self.dataset.manifest.fragments.clone();
+            let start = fragments.partition_point(|fragment| fragment.id < id);
+            futures::stream::iter(start..fragments.len())
+                .map(move |index| Ok(fragments[index].clone()))
+                .boxed()
+        }
+    }
+
+    /// Start a streaming scan without indices. Indexed plans require
+    /// [`Self::into_dataset`] to prepare the complete live-fragment bitmap.
+    pub fn scan(&self) -> Scanner {
+        let mut scanner = self.dataset.scan();
+        scanner.use_index(false).use_scalar_index(false);
+        scanner
+    }
+
+    /// Open another published snapshot with metadata loaded on demand.
+    pub async fn checkout_version(&self, version: impl Into<Ref>) -> Result<Self> {
+        Ok(Self::new(self.dataset.checkout_version(version).await?))
+    }
+
+    /// Commit a native transaction with the standard retry policy.
+    ///
+    /// The returned snapshot keeps fragment metadata lazy. The original handle
+    /// remains pinned to its version if publication succeeds or fails.
+    pub async fn commit(&self, transaction: Transaction) -> Result<Self> {
+        CommitBuilder::new(Arc::new(self.dataset.clone()))
+            .execute_lazy(transaction)
+            .await
+    }
+
+    /// Read all fragment metadata and return a regular dataset. A failed read
+    /// leaves other handles to this snapshot usable.
+    pub async fn into_dataset(mut self) -> Result<Dataset> {
+        self.dataset.hydrate_fragments_for_maintenance().await?;
+        Ok(self.dataset)
+    }
+}

--- a/rust/lance/src/dataset/optimize.rs
+++ b/rust/lance/src/dataset/optimize.rs
@@ -103,7 +103,7 @@ use crate::Dataset;
 use crate::Result;
 use crate::dataset::utils::CapturedRowIds;
 use crate::index::{DatasetIndexExt, DatasetIndexInternalExt, index_is_usable, load_all_indices};
-use crate::io::commit::{DEFAULT_COMMIT_RETRY_TIMEOUT, commit_transaction, migrate_fragments};
+use crate::io::commit::migrate_fragments;
 use arrow::array::AsArray;
 use arrow::datatypes::{UInt8Type, UInt32Type, UInt64Type};
 use arrow_array::builder::{LargeBinaryBuilder, PrimitiveBuilder, StringBuilder};
@@ -762,7 +762,7 @@ impl CompactionPlanner for DefaultCompactionPlanner {
 
         // get_fragments should be returning fragments in sorted order (by id)
         // and fragment ids should be unique
-        let fragments = dataset.get_fragments();
+        let fragments = dataset.get_fragments_async().await?;
 
         debug_assert!(
             fragments.windows(2).all(|w| w[0].id() < w[1].id()),
@@ -2266,25 +2266,18 @@ async fn reserve_fragment_ids(
         None,
     );
 
-    let (manifest, _) = commit_transaction(
-        dataset,
-        dataset.object_store.as_ref(),
-        dataset.commit_handler.as_ref(),
-        &transaction,
-        &Default::default(),
-        &Default::default(),
-        DEFAULT_COMMIT_RETRY_TIMEOUT,
-        dataset.manifest_location.naming_scheme,
-        None,
-    )
-    .await?;
+    let mut committed = dataset.clone();
+    committed
+        .apply_commit(transaction, &Default::default(), &Default::default())
+        .await?;
+    let manifest = &committed.manifest;
 
     // Need +1 since max_fragment_id is inclusive in this case and ranges are exclusive
-    let new_max_exclusive = manifest.max_fragment_id.unwrap_or(0) + 1;
-    let reserved_ids = (new_max_exclusive - fragments.len() as u32)..(new_max_exclusive);
+    let new_max_exclusive = u64::from(manifest.max_fragment_id.unwrap_or(0)) + 1;
+    let reserved_ids = (new_max_exclusive - fragments.len() as u64)..new_max_exclusive;
 
     for (fragment, new_id) in fragments.zip(reserved_ids) {
-        fragment.id = new_id as u64;
+        fragment.id = new_id;
     }
 
     Ok(())

--- a/rust/lance/src/dataset/rowids.rs
+++ b/rust/lance/src/dataset/rowids.rs
@@ -112,7 +112,7 @@ pub(crate) async fn translate_addr_treemap_to_row_ids(
 ) -> Result<RowAddrTreeMap> {
     let mut row_ids = RowAddrTreeMap::new();
     for (fragment_id, selection) in addrs.iter() {
-        let Some(file_fragment) = dataset.get_fragment(*fragment_id as usize) else {
+        let Some(file_fragment) = dataset.get_fragment_async(*fragment_id as usize).await? else {
             continue;
         };
         let sequence = load_row_id_sequence(dataset, file_fragment.metadata()).await?;
@@ -211,7 +211,7 @@ async fn row_addrs_to_row_ids_impl(
 
     let mut ids: Vec<Option<u64>> = vec![None; addrs.len()];
     for (fragment_id, positions) in positions_by_fragment {
-        let Some(fragment) = dataset.get_fragment(fragment_id as usize) else {
+        let Some(fragment) = dataset.get_fragment_async(fragment_id as usize).await? else {
             continue;
         };
         let sequence = load_row_id_sequence(dataset, fragment.metadata()).await?;
@@ -241,13 +241,10 @@ async fn row_addrs_to_row_ids_impl(
 /// keyed by the fragment's content; the index is keyed by manifest generation
 /// and cannot stand in for it.
 async fn load_row_id_index(dataset: &Dataset) -> Result<RowIdIndex> {
-    // A `for` loop rather than `map`: a closure returning a future that borrows
-    // its argument trips the higher-ranked lifetime check on the outer future.
-    let mut loads = Vec::with_capacity(dataset.manifest.fragments.len());
-    for fragment in dataset.manifest.fragments.iter() {
-        loads.push(read_fragment_row_id_index(dataset, fragment));
-    }
-    let fragment_indices: Vec<FragmentRowIdIndex> = futures::stream::iter(loads)
+    let fragment_indices: Vec<FragmentRowIdIndex> = dataset
+        .fragment_source()
+        .stream()
+        .map(|fragment| async move { read_fragment_row_id_index(dataset, &fragment?).await })
         .buffer_unordered(dataset.object_store.io_parallelism())
         .try_collect()
         .await?;
@@ -306,6 +303,32 @@ mod test {
             false,
         )]));
         RecordBatch::try_new(schema, vec![Arc::new(Int32Array::from_iter_values(values))]).unwrap()
+    }
+
+    #[tokio::test]
+    async fn row_id_index_propagates_missing_deletion_file() {
+        let batch = sequence_batch(0..10);
+        let mut dataset = Dataset::write(
+            RecordBatchIterator::new(vec![Ok(batch.clone())], batch.schema()),
+            "memory://",
+            Some(WriteParams {
+                enable_stable_row_ids: true,
+                ..Default::default()
+            }),
+        )
+        .await
+        .unwrap();
+        dataset.delete("id < 2").await.unwrap();
+        let fragment = &dataset.manifest.fragments[0];
+        let path = lance_table::io::deletion::deletion_file_path(
+            &dataset.base,
+            fragment.id,
+            fragment.deletion_file.as_ref().unwrap(),
+        );
+        dataset.object_store.delete(&path).await.unwrap();
+        let error = load_row_id_index(&dataset).await.unwrap_err();
+        assert!(matches!(error, Error::NotFound { .. }), "{error}");
+        assert!(error.to_string().contains(path.filename().unwrap()));
     }
 
     #[tokio::test]

--- a/rust/lance/src/dataset/scanner.rs
+++ b/rust/lance/src/dataset/scanner.rs
@@ -94,6 +94,7 @@ use tracing::{Span, info_span, instrument};
 use uuid::Uuid;
 
 use super::Dataset;
+use super::fragment_source::FragmentSource;
 use super::versions;
 use crate::dataset::overlay::{collect_overlay_stale_rows_for_segment, overlaid_fragments};
 use crate::dataset::row_offsets_to_row_addresses;
@@ -1388,13 +1389,21 @@ impl Scanner {
     pub fn new(dataset: Arc<Dataset>) -> Self {
         let projection_plan = ProjectionPlan::full(dataset.clone()).unwrap();
         let file_reader_options = dataset.file_reader_options.clone();
+        // Late materialization takes deferred columns by row id through the
+        // manifest fragment list. A lazily loaded fragment metadata table has
+        // no such list yet, so every projected column is read in the scan itself.
+        let materialization_style = if dataset.lazy_fragments.is_some() {
+            MaterializationStyle::AllEarly
+        } else {
+            MaterializationStyle::Heuristic
+        };
         let mut scanner = Self {
             dataset,
             projection_plan,
             blob_handling: BlobHandling::default(),
             prefilter: false,
             external_row_mask: None,
-            materialization_style: MaterializationStyle::Heuristic,
+            materialization_style,
             filter: LanceFilter::default(),
             full_text_query: None,
             batch_size: None,
@@ -2944,10 +2953,14 @@ impl Scanner {
             // This tests if any of the fragments are missing the physical_rows property (old style)
             // If they are then we cannot use scalar indices
             if filter_plan.index_query.is_some() {
+                let dataset_fragments = self
+                    .dataset
+                    .fragment_source()
+                    .materialized("scalar index planning")?;
                 let fragments = if let Some(fragments) = self.fragments.as_ref() {
                     fragments
                 } else {
-                    self.dataset.fragments()
+                    dataset_fragments.as_ref()
                 };
                 let mut has_missing_row_count = false;
                 for frag in fragments {
@@ -3096,6 +3109,15 @@ impl Scanner {
         log::trace!("creating scanner plan");
         self.validate_options()?;
 
+        if self.dataset.lazy_fragments.is_some()
+            && (self.full_text_query.is_some()
+                || self.nearest.as_ref().is_some_and(|query| query.use_index))
+        {
+            return Err(Error::not_supported(
+                "Indexed search requires a materialized Dataset; call LazyDataset::into_dataset",
+            ));
+        }
+
         let full_text_query = match &self.full_text_query {
             Some(query) => Some(self.resolve_full_text_search_query(query).await?),
             None => None,
@@ -3117,6 +3139,12 @@ impl Scanner {
         let mut filter_plan = self
             .create_filter_plan(use_scalar_index, query_filter, fts_document_granularity)
             .await?;
+
+        if self.dataset.lazy_fragments.is_some() && filter_plan.expr_filter_plan.has_index_query() {
+            return Err(Error::not_supported(
+                "Indexed scan requires a materialized Dataset; call LazyDataset::into_dataset",
+            ));
+        }
 
         let mut use_limit_node = true;
         // Source: either a (K|A)NN search, full text search, or a (full|indexed) scan
@@ -3325,7 +3353,10 @@ impl Scanner {
         scan_range: Option<Range<u64>>,
         is_prefilter: bool,
     ) -> Result<PlannedFilteredScan> {
-        let fragments = fragments.unwrap_or(self.dataset.fragments().clone());
+        let fragments = match fragments {
+            Some(fragments) => FragmentSource::Manifest(fragments),
+            None => self.dataset.fragment_source(),
+        };
         let mut filter_pushed_down = false;
 
         let plan: Arc<dyn ExecutionPlan> = if filter_plan.has_index_query() {
@@ -3334,6 +3365,7 @@ impl Scanner {
                     "Cannot include deleted rows in a scalar indexed scan".into(),
                 ));
             }
+            let fragments = fragments.materialized("scalar indexed scan")?;
             self.scalar_indexed_scan(projection, filter_plan, fragments)
                 .await
         } else if !is_prefilter
@@ -3673,6 +3705,9 @@ impl Scanner {
             }
             TakeOperation::RowAddrs(addrs) => self.row_addrs_as_take_input(addrs).await,
             TakeOperation::RowOffsets(offsets) => {
+                self.dataset
+                    .fragment_source()
+                    .materialized("take by row offset")?;
                 let mut addrs =
                     row_offsets_to_row_addresses(&self.dataset.get_fragments(), &offsets).await?;
                 addrs.retain(|addr| *addr != RowAddress::TOMBSTONE_ROW);
@@ -5672,7 +5707,7 @@ impl Scanner {
                 false,
                 false,
                 vector_scan_projection,
-                Arc::new(fallback_fragments),
+                Arc::new(fallback_fragments).into(),
                 // Can't pushdown limit/offset in an ANN search
                 None,
                 // We are re-ordering anyways, so no need to get data in a deterministic order.
@@ -6190,9 +6225,9 @@ impl Scanner {
         projection: Arc<Schema>,
     ) -> Arc<dyn ExecutionPlan> {
         let fragments = if let Some(fragment) = self.fragments.as_ref() {
-            Arc::new(fragment.clone())
+            FragmentSource::Manifest(Arc::new(fragment.clone()))
         } else {
-            self.dataset.fragments().clone()
+            self.dataset.fragment_source()
         };
         let ordered = if self.ordering.is_some() || self.nearest.is_some() {
             // If we are sorting the results there is no need to scan in order
@@ -6222,11 +6257,11 @@ impl Scanner {
         with_row_created_at_version: bool,
         with_make_deletions_null: bool,
         projection: Arc<Schema>,
-        fragments: Arc<Vec<Fragment>>,
+        fragments: FragmentSource,
         range: Option<Range<u64>>,
         ordered: bool,
     ) -> Arc<dyn ExecutionPlan> {
-        log::trace!("scan_fragments covered {} fragments", fragments.len());
+        log::trace!("scan_fragments covered {:?}", fragments);
         let config = LanceScanConfig {
             batch_size: self.get_batch_size(),
             batch_readahead: self.batch_readahead,
@@ -6273,7 +6308,9 @@ impl Scanner {
         let fragments = if let Some(fragment) = self.fragments.as_ref() {
             Arc::new(fragment.clone())
         } else {
-            self.dataset.fragments().clone()
+            self.dataset
+                .fragment_source()
+                .materialized("pushdown scan")?
         };
 
         Ok(Arc::new(LancePushdownScanExec::try_new(

--- a/rust/lance/src/dataset/schema_evolution.rs
+++ b/rust/lance/src/dataset/schema_evolution.rs
@@ -451,7 +451,7 @@ pub(super) async fn add_columns(
             dataset,
             transforms,
             read_columns,
-            &dataset.get_fragments(),
+            &dataset.get_fragments_async().await?,
             batch_size,
         )
         .await?;
@@ -937,7 +937,7 @@ pub(super) async fn alter_columns(
         };
         let mapper = Box::new(mapper);
 
-        let source_fragments = dataset.get_fragments();
+        let source_fragments = dataset.get_fragments_async().await?;
         let original_file_counts = source_fragments
             .iter()
             .map(|fragment| (fragment.id() as u64, fragment.metadata.files.len()))

--- a/rust/lance/src/dataset/tests/dataset_io.rs
+++ b/rust/lance/src/dataset/tests/dataset_io.rs
@@ -1934,7 +1934,7 @@ async fn test_deep_clone_rejects_unsupported_writer_before_copying() {
 
     let mut unsupported_manifest = source.manifest.as_ref().clone();
     unsupported_manifest.version += 1;
-    unsupported_manifest.writer_feature_flags |= feature_flags::FLAG_UNKNOWN << 1;
+    unsupported_manifest.writer_feature_flags |= 1u64 << 63; // An unassigned writer capability.
     write_manifest_file(
         source.object_store.as_ref(),
         source.commit_handler.as_ref(),
@@ -1982,7 +1982,7 @@ async fn test_shallow_clone_rejects_unsupported_writer_before_writing_target() {
 
     let mut unsupported_manifest = source.manifest.as_ref().clone();
     unsupported_manifest.version += 1;
-    unsupported_manifest.writer_feature_flags |= feature_flags::FLAG_UNKNOWN << 1;
+    unsupported_manifest.writer_feature_flags |= 1u64 << 63; // An unassigned writer capability.
     write_manifest_file(
         source.object_store.as_ref(),
         source.commit_handler.as_ref(),

--- a/rust/lance/src/dataset/utils.rs
+++ b/rust/lance/src/dataset/utils.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright The Lance Authors
 
-use crate::Result;
+use crate::{Dataset, Result};
 use arrow_array::{ArrayRef, RecordBatch, UInt64Array};
 use arrow_schema::{
     DataType, Field as ArrowField, Schema as ArrowSchema, SchemaRef as ArrowSchemaRef,
@@ -15,11 +15,62 @@ use lance_arrow::json::{
     has_arrow_json_fields, has_json_fields, lance_json_to_arrow_json,
 };
 use lance_core::ROW_ID;
+use lance_table::format::Fragment;
 use lance_table::rowids::{RowIdIndex, RowIdSequence};
 use roaring::RoaringTreemap;
 use std::borrow::Cow;
+use std::collections::BTreeMap;
 use std::sync::Arc;
 use std::sync::mpsc::Receiver;
+
+/// Apply physical-row deletions only to referenced Fragments, resolving through
+/// the dataset metadata source so update and merge-insert share identical behavior.
+pub async fn apply_deletions(
+    dataset: &Dataset,
+    removed_row_ids: &RoaringTreemap,
+) -> Result<(Vec<Fragment>, Vec<u64>)> {
+    let bitmaps = Arc::new(removed_row_ids.bitmaps().collect::<BTreeMap<_, _>>());
+
+    enum FragmentChange {
+        Unchanged,
+        Modified(Box<Fragment>),
+        Removed(u64),
+    }
+
+    let mut updated_fragments = Vec::new();
+    let mut removed_fragments = Vec::new();
+
+    let fragment_ids: Vec<_> = bitmaps.keys().map(|id| u64::from(*id)).collect();
+    let mut stream = futures::stream::iter(dataset.file_fragments_for_ids(&fragment_ids).await?)
+        .map(move |fragment| {
+            let bitmaps_ref = bitmaps.clone();
+            async move {
+                let fragment_id = fragment.id();
+                if let Some(bitmap) = bitmaps_ref.get(&(fragment_id as u32)) {
+                    match fragment.extend_deletions(*bitmap).await {
+                        Ok(Some(new_fragment)) => {
+                            Ok(FragmentChange::Modified(Box::new(new_fragment.metadata)))
+                        }
+                        Ok(None) => Ok(FragmentChange::Removed(fragment_id as u64)),
+                        Err(e) => Err(e),
+                    }
+                } else {
+                    Ok(FragmentChange::Unchanged)
+                }
+            }
+        })
+        .buffer_unordered(dataset.object_store.io_parallelism());
+
+    while let Some(res) = stream.next().await.transpose()? {
+        match res {
+            FragmentChange::Unchanged => {}
+            FragmentChange::Modified(fragment) => updated_fragments.push(*fragment),
+            FragmentChange::Removed(fragment_id) => removed_fragments.push(fragment_id),
+        }
+    }
+
+    Ok((updated_fragments, removed_fragments))
+}
 
 fn extract_row_ids(
     row_ids: &mut CapturedRowIds,

--- a/rust/lance/src/dataset/versions/mod.rs
+++ b/rust/lance/src/dataset/versions/mod.rs
@@ -59,7 +59,7 @@ use crate::io::exec::{
 pub fn create_scan_stream(
     version: ConcreteFileVersion,
     dataset: Arc<Dataset>,
-    fragments: Arc<Vec<Fragment>>,
+    fragments: impl Into<super::fragment_source::FragmentSource>,
     offsets: Option<Range<u64>>,
     projection: Arc<Schema>,
     config: LanceScanConfig,

--- a/rust/lance/src/dataset/write/commit.rs
+++ b/rust/lance/src/dataset/write/commit.rs
@@ -28,6 +28,7 @@ use crate::{
 
 use super::{WriteDestination, resolve_commit_handler};
 use crate::dataset::branch_location::BranchLocation;
+use crate::dataset::fragment_metadata;
 use crate::dataset::transaction::validate_operation;
 use lance_core::utils::tracing::{DATASET_COMMITTED_EVENT, TRACE_DATASET_EVENTS};
 use tracing::info;
@@ -275,6 +276,26 @@ impl<'a> CommitBuilder<'a> {
     }
 
     pub async fn execute(self, transaction: Transaction) -> Result<Dataset> {
+        let mut dataset = self.execute_with_fragments(transaction, true).await?;
+        dataset.hydrate_fragments_for_maintenance().await?;
+        Ok(dataset)
+    }
+
+    /// Commit and return a handle that reads fragment metadata on demand.
+    pub async fn execute_lazy(
+        self,
+        transaction: Transaction,
+    ) -> Result<crate::dataset::LazyDataset> {
+        Ok(crate::dataset::LazyDataset::new(
+            self.execute_with_fragments(transaction, false).await?,
+        ))
+    }
+
+    async fn execute_with_fragments(
+        self,
+        transaction: Transaction,
+        materialize_fragments: bool,
+    ) -> Result<Dataset> {
         let timeout = self.timeout;
         if let Some(t) = timeout
             && t.is_zero()
@@ -286,7 +307,7 @@ impl<'a> CommitBuilder<'a> {
         // Box the inner future so wrapping it in `tokio::time::Timeout` does
         // not deepen the future type — downstream `async fn`s that await
         // `execute` otherwise hit the compiler's layout-query depth limit.
-        let fut = Box::pin(self.execute_inner(transaction));
+        let fut = Box::pin(self.execute_inner(transaction, materialize_fragments));
         match timeout {
             Some(t) => match tokio::time::timeout(t, fut).await {
                 Ok(res) => res,
@@ -300,7 +321,11 @@ impl<'a> CommitBuilder<'a> {
         }
     }
 
-    async fn execute_inner(self, transaction: Transaction) -> Result<Dataset> {
+    async fn execute_inner(
+        self,
+        transaction: Transaction,
+        materialize_fragments: bool,
+    ) -> Result<Dataset> {
         let session = self
             .session
             .or_else(|| self.dest.dataset().map(|ds| ds.session.clone()))
@@ -362,7 +387,7 @@ impl<'a> CommitBuilder<'a> {
                     builder = builder.with_version(transaction.read_version)
                 }
 
-                match builder.load().await {
+                match builder.load_unmaterialized().await {
                     Ok(dataset) => WriteDestination::Dataset(Arc::new(dataset)),
                     Err(Error::DatasetNotFound { .. } | Error::NotFound { .. }) => {
                         WriteDestination::Uri(uri)
@@ -371,6 +396,91 @@ impl<'a> CommitBuilder<'a> {
                 }
             }
         };
+
+        let use_stable_row_ids = if self.migration_next_row_id.is_some() {
+            true
+        } else if let Some(ds) = dest.dataset() {
+            ds.manifest.uses_stable_row_ids()
+        } else {
+            self.use_stable_row_ids.unwrap_or(false)
+        };
+        // Validate storage format matches existing dataset
+        if let Some(ds) = dest.dataset()
+            && let Some(storage_format) = self.storage_format
+        {
+            let passed_storage_format = DataStorageFormat::new(storage_format);
+            if ds.manifest.data_storage_format != passed_storage_format
+                && !matches!(transaction.operation, Operation::Overwrite { .. })
+            {
+                return Err(Error::invalid_input_source(format!(
+                    "Storage format mismatch. Existing dataset uses {:?}, but new data uses {:?}",
+                    ds.manifest.data_storage_format,
+                    passed_storage_format
+                ).into()));
+            }
+        }
+
+        let manifest_config = ManifestWriteConfig {
+            use_stable_row_ids,
+            storage_format: self.storage_format.map(DataStorageFormat::new),
+            migration_next_row_id: self.migration_next_row_id,
+            ..Default::default()
+        };
+
+        // Route the selected metadata backend through the same Version Manifest handler.
+        let fragment_metadata_target = || fragment_metadata::CommitTarget {
+            context: dest.dataset().map(|dataset| Arc::new(dataset.clone())),
+            materialize_fragments,
+            object_store: object_store.clone(),
+            base_path: base_path.clone(),
+            uri: match &self.dest {
+                WriteDestination::Dataset(dataset) => dataset.uri().to_string(),
+                WriteDestination::Uri(uri) => uri.to_string(),
+            },
+            session: session.clone(),
+            commit_handler: commit_handler.clone(),
+        };
+        match &dest {
+            WriteDestination::Dataset(dataset) => {
+                if fragment_metadata::dataset_uses_fragment_metadata(&dataset.manifest) {
+                    if self.detached {
+                        return Err(Error::not_supported_source(
+                            "Detached fragment metadata publication is not implemented".into(),
+                        ));
+                    }
+                    return fragment_metadata::execute_commit_with_timeout(
+                        fragment_metadata_target(),
+                        &self.commit_config,
+                        self.retry_timeout,
+                        &transaction,
+                        self.affected_rows.as_ref(),
+                        &manifest_config,
+                    )
+                    .await;
+                }
+                if fragment_metadata::create_requested(&transaction.operation)? {
+                    return Err(Error::invalid_input(
+                        "cannot overwrite an existing flat-manifest dataset with \
+                         lance.manifest.layout=tree; tree layout is selected at create time",
+                    ));
+                }
+            }
+            WriteDestination::Uri(_) => {
+                if fragment_metadata::create_requested(&transaction.operation)? {
+                    if self.detached {
+                        return Err(Error::not_supported_source(
+                            "Detached fragment metadata publication is not implemented".into(),
+                        ));
+                    }
+                    return fragment_metadata::execute_create(
+                        fragment_metadata_target(),
+                        &transaction,
+                        &manifest_config,
+                    )
+                    .await;
+                }
+            }
+        }
 
         if dest.dataset().is_none()
             && !matches!(
@@ -406,38 +516,6 @@ impl<'a> CommitBuilder<'a> {
             ManifestNamingScheme::V2
         } else {
             ManifestNamingScheme::V1
-        };
-
-        let use_stable_row_ids = if self.migration_next_row_id.is_some() {
-            // Migration activation always enables stable row IDs regardless of
-            // the current dataset state.
-            true
-        } else if let Some(ds) = dest.dataset() {
-            ds.manifest.uses_stable_row_ids()
-        } else {
-            self.use_stable_row_ids.unwrap_or(false)
-        };
-        // Validate storage format matches existing dataset
-        if let Some(ds) = dest.dataset()
-            && let Some(storage_format) = self.storage_format
-        {
-            let passed_storage_format = DataStorageFormat::new(storage_format);
-            if ds.manifest.data_storage_format != passed_storage_format
-                && !matches!(transaction.operation, Operation::Overwrite { .. })
-            {
-                return Err(Error::invalid_input_source(format!(
-                    "Storage format mismatch. Existing dataset uses {:?}, but new data uses {:?}",
-                    ds.manifest.data_storage_format,
-                    passed_storage_format
-                ).into()));
-            }
-        }
-
-        let manifest_config = ManifestWriteConfig {
-            use_stable_row_ids,
-            storage_format: self.storage_format.map(DataStorageFormat::new),
-            migration_next_row_id: self.migration_next_row_id,
-            ..Default::default()
         };
 
         let (manifest, manifest_location) = if let Some(dataset) = dest.dataset() {
@@ -502,22 +580,22 @@ impl<'a> CommitBuilder<'a> {
         );
 
         let fragment_bitmap = Arc::new(manifest.fragments.iter().map(|f| f.id as u32).collect());
-
-        match &self.dest {
+        let dataset = match &self.dest {
             WriteDestination::Dataset(dataset) => {
                 let base_object_stores = if manifest.base_paths == dataset.manifest.base_paths {
                     dataset.base_object_stores.clone()
                 } else {
                     Default::default()
                 };
-                Ok(Dataset {
+                Dataset {
+                    lazy_fragments: None,
                     manifest: Arc::new(manifest),
                     manifest_location,
                     session,
                     fragment_bitmap,
                     base_object_stores,
                     ..dataset.as_ref().clone()
-                })
+                }
             }
             WriteDestination::Uri(uri) => {
                 let refs = Refs::new(
@@ -530,7 +608,8 @@ impl<'a> CommitBuilder<'a> {
                     },
                 );
 
-                Ok(Dataset {
+                Dataset {
+                    lazy_fragments: None,
                     object_store,
                     base: base_path,
                     uri: uri.to_string(),
@@ -546,9 +625,10 @@ impl<'a> CommitBuilder<'a> {
                     store_params: self.store_params.clone().map(Box::new),
                     base_store_params: None,
                     base_object_stores: Default::default(),
-                })
+                }
             }
-        }
+        };
+        dataset.attach_fragment_source().await
     }
 
     /// Commit a set of transactions as a single new version.

--- a/rust/lance/src/dataset/write/delete.rs
+++ b/rust/lance/src/dataset/write/delete.rs
@@ -64,7 +64,11 @@ async fn apply_deletions(
     let mut updated_fragments = Vec::new();
     let mut removed_fragments = Vec::new();
 
-    let mut stream = futures::stream::iter(dataset.get_fragments())
+    // Only the fragments with matched rows change; fetch exactly those, which
+    // a lazily loaded fragment metadata table resolves through the tree.
+    let touched_ids: Vec<u64> = bitmaps.keys().map(|id| *id as u64).collect();
+    let touched_fragments = dataset.file_fragments_for_ids(&touched_ids).await?;
+    let mut stream = futures::stream::iter(touched_fragments)
         .map(move |fragment| {
             let bitmaps_ref = bitmaps.clone();
             async move {
@@ -295,13 +299,19 @@ impl RetryExecutor for DeleteJob {
                     filter_expr,
                     Expr::Literal(ScalarValue::Boolean(Some(true)), _)
                 ) {
-                    // Predicate evaluated to true - delete all fragments
-                    let fragments = self.dataset.get_fragments();
-                    let num_deleted_rows: u64 = fragments
-                        .iter()
-                        .map(|f| f.metadata.num_rows().unwrap_or(0) as u64)
-                        .sum();
-                    let deleted_fragment_ids = fragments.iter().map(|f| f.id() as u64).collect();
+                    // Predicate evaluated to true - delete all fragments.
+                    // Stream the source so a lazily loaded table never holds
+                    // the whole list.
+                    let (deleted_fragment_ids, num_deleted_rows) = self
+                        .dataset
+                        .fragment_source()
+                        .stream()
+                        .try_fold((Vec::new(), 0u64), |(mut ids, rows), fragment| async move {
+                            ids.push(fragment.id);
+                            let fragment_rows = fragment.num_rows().unwrap_or(0) as u64;
+                            Ok((ids, rows + fragment_rows))
+                        })
+                        .await?;
 
                     // When deleting everything, we don't have specific row addresses,
                     // so better not to emit affected rows.

--- a/rust/lance/src/dataset/write/merge_insert.rs
+++ b/rust/lance/src/dataset/write/merge_insert.rs
@@ -135,7 +135,7 @@ use roaring::{RoaringBitmap, RoaringTreemap};
 use snafu::ResultExt;
 use std::collections::HashMap;
 use std::{
-    collections::{BTreeMap, HashSet},
+    collections::HashSet,
     iter::Peekable,
     sync::{
         Arc, Mutex,
@@ -1926,7 +1926,8 @@ impl MergeInsertJob {
             match frag_id.first() {
                 Some(ScalarValue::UInt64(Some(frag_id))) => {
                     let frag_id = *frag_id;
-                    let Some(fragment) = dataset.get_fragment(frag_id as usize) else {
+                    let Some(fragment) = dataset.file_fragments_for_ids(&[frag_id]).await?.pop()
+                    else {
                         error!(
                             fragment_id = frag_id,
                             dataset_uri = %dataset.uri(),
@@ -2788,7 +2789,7 @@ impl MergeInsertJob {
             let removed_row_addrs = RoaringTreemap::from_iter(removed_row_addr_vec);
 
             let (updated_fragments, removed_fragment_ids) =
-                Self::apply_deletions(&self.dataset, &removed_row_addrs).await?;
+                crate::dataset::utils::apply_deletions(&self.dataset, &removed_row_addrs).await?;
 
             let operation = Operation::Update {
                 removed_fragment_ids,
@@ -2926,7 +2927,8 @@ impl MergeInsertJob {
                 }
             };
 
-            let deletions_result = Self::apply_deletions(&self.dataset, &removed_row_addrs).await;
+            let deletions_result =
+                crate::dataset::utils::apply_deletions(&self.dataset, &removed_row_addrs).await;
             let (old_fragments, removed_fragment_ids) = match deletions_result {
                 Ok(v) => v,
                 Err(e) => {
@@ -2976,53 +2978,6 @@ impl MergeInsertJob {
             stats,
             inserted_rows_filter: None, // not implemented for v1
         })
-    }
-
-    // Delete a batch of rows by id, returns the fragments modified and the fragments removed
-    async fn apply_deletions(
-        dataset: &Dataset,
-        removed_row_ids: &RoaringTreemap,
-    ) -> Result<(Vec<Fragment>, Vec<u64>)> {
-        let bitmaps = Arc::new(removed_row_ids.bitmaps().collect::<BTreeMap<_, _>>());
-
-        enum FragmentChange {
-            Unchanged,
-            Modified(Box<Fragment>),
-            Removed(u64),
-        }
-
-        let mut updated_fragments = Vec::new();
-        let mut removed_fragments = Vec::new();
-
-        let mut stream = futures::stream::iter(dataset.get_fragments())
-            .map(move |fragment| {
-                let bitmaps_ref = bitmaps.clone();
-                async move {
-                    let fragment_id = fragment.id();
-                    if let Some(bitmap) = bitmaps_ref.get(&(fragment_id as u32)) {
-                        match fragment.extend_deletions(*bitmap).await {
-                            Ok(Some(new_fragment)) => {
-                                Ok(FragmentChange::Modified(Box::new(new_fragment.metadata)))
-                            }
-                            Ok(None) => Ok(FragmentChange::Removed(fragment_id as u64)),
-                            Err(e) => Err(e),
-                        }
-                    } else {
-                        Ok(FragmentChange::Unchanged)
-                    }
-                }
-            })
-            .buffer_unordered(dataset.object_store.io_parallelism());
-
-        while let Some(res) = stream.next().await.transpose()? {
-            match res {
-                FragmentChange::Unchanged => {}
-                FragmentChange::Modified(fragment) => updated_fragments.push(*fragment),
-                FragmentChange::Removed(fragment_id) => removed_fragments.push(fragment_id),
-            }
-        }
-
-        Ok((updated_fragments, removed_fragments))
     }
 
     /// Generate the execution plan and return it as a formatted string for debugging.
@@ -13211,7 +13166,7 @@ MergeInsert: on=[id], when_matched=DoNothing, when_not_matched=InsertAll, when_n
     /// Tests that apply_deletions correctly handles an error when applying the row deletions.
     #[tokio::test]
     async fn test_apply_deletions_invalid_row_address() {
-        use super::exec::apply_deletions;
+        use crate::dataset::utils::apply_deletions;
         use roaring::RoaringTreemap;
 
         let test_uri = "memory://test_apply_deletions_error.lance";

--- a/rust/lance/src/dataset/write/merge_insert/exec.rs
+++ b/rust/lance/src/dataset/write/merge_insert/exec.rs
@@ -5,20 +5,13 @@ mod delete;
 mod in_place;
 mod write;
 
-use std::collections::BTreeMap;
-use std::sync::Arc;
-
 use datafusion::physical_plan::metrics::{Count, ExecutionPlanMetricsSet, MetricBuilder};
-use futures::StreamExt;
-use lance_table::format::Fragment;
-use roaring::RoaringTreemap;
 
 pub use delete::DeleteOnlyMergeInsertExec;
 pub use in_place::InPlaceMergeInsertExec;
 pub use write::FullSchemaMergeInsertExec;
 
 use super::MergeStats;
-use crate::Dataset;
 
 pub(super) struct MergeInsertMetrics {
     pub num_inserted_rows: Count,
@@ -61,50 +54,4 @@ impl MergeInsertMetrics {
             num_skipped_duplicates,
         }
     }
-}
-
-pub(super) async fn apply_deletions(
-    dataset: &Dataset,
-    removed_row_addrs: &RoaringTreemap,
-) -> crate::Result<(Vec<Fragment>, Vec<u64>)> {
-    let bitmaps = Arc::new(removed_row_addrs.bitmaps().collect::<BTreeMap<_, _>>());
-
-    enum FragmentChange {
-        Unchanged,
-        Modified(Box<Fragment>),
-        Removed(u64),
-    }
-
-    let mut updated_fragments = Vec::new();
-    let mut removed_fragments = Vec::new();
-
-    let mut stream = futures::stream::iter(dataset.get_fragments())
-        .map(move |fragment| {
-            let bitmaps_ref = bitmaps.clone();
-            async move {
-                let fragment_id = fragment.id();
-                if let Some(bitmap) = bitmaps_ref.get(&(fragment_id as u32)) {
-                    match fragment.extend_deletions(*bitmap).await {
-                        Ok(Some(new_fragment)) => {
-                            Ok(FragmentChange::Modified(Box::new(new_fragment.metadata)))
-                        }
-                        Ok(None) => Ok(FragmentChange::Removed(fragment_id as u64)),
-                        Err(e) => Err(e),
-                    }
-                } else {
-                    Ok(FragmentChange::Unchanged)
-                }
-            }
-        })
-        .buffer_unordered(dataset.object_store.io_parallelism());
-
-    while let Some(res) = stream.next().await.transpose()? {
-        match res {
-            FragmentChange::Unchanged => {}
-            FragmentChange::Modified(fragment) => updated_fragments.push(*fragment),
-            FragmentChange::Removed(fragment_id) => removed_fragments.push(fragment_id),
-        }
-    }
-
-    Ok((updated_fragments, removed_fragments))
 }

--- a/rust/lance/src/dataset/write/merge_insert/exec/delete.rs
+++ b/rust/lance/src/dataset/write/merge_insert/exec/delete.rs
@@ -30,7 +30,8 @@ use crate::dataset::write::merge_insert::{
     create_duplicate_row_error, resolve_target_bases,
 };
 
-use super::{MergeInsertMetrics, apply_deletions};
+use super::MergeInsertMetrics;
+use crate::dataset::utils::apply_deletions;
 
 /// Specialized physical execution node for delete-only merge insert operations.
 ///

--- a/rust/lance/src/dataset/write/merge_insert/exec/write.rs
+++ b/rust/lance/src/dataset/write/merge_insert/exec/write.rs
@@ -51,7 +51,7 @@ use crate::{
     },
 };
 
-use super::apply_deletions;
+use crate::dataset::utils::apply_deletions;
 
 /// Shared state for merge insert operations to simplify lock management
 struct MergeState {

--- a/rust/lance/src/dataset/write/update.rs
+++ b/rust/lance/src/dataset/write/update.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: Copyright The Lance Authors
 
-use std::collections::{BTreeMap, HashMap, HashSet};
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -33,7 +33,6 @@ use lance_core::{ROW_ADDR_FIELD, ROW_ID_FIELD, ROW_OFFSET_FIELD};
 use lance_datafusion::expr::safe_coerce_scalar;
 use lance_select::RowAddrTreeMap;
 use lance_table::format::{Fragment, RowIdMeta};
-use roaring::RoaringTreemap;
 use snafu::ResultExt;
 
 /// Collect a field id and all of its descendant field ids (pre-order). A struct
@@ -480,7 +479,8 @@ impl UpdateJob {
         // Apply deletions
         let row_id_index = get_row_id_index(&self.dataset).await?;
         let row_addrs = removed_row_ids.row_addrs(row_id_index.as_deref())?;
-        let deletions_result = self.apply_deletions(&row_addrs).await;
+        let deletions_result =
+            crate::dataset::utils::apply_deletions(&self.dataset, &row_addrs).await;
         let (old_fragments, removed_fragment_ids) = match deletions_result {
             Ok(v) => v,
             Err(e) => {
@@ -592,55 +592,6 @@ impl UpdateJob {
             batch = batch.replace_column_by_name(column.as_str(), new_values)?;
         }
         Ok(batch)
-    }
-
-    /// Use previous found rows ids to delete rows from existing fragments.
-    ///
-    /// Returns the set of modified fragments and removed fragments, if any.
-    async fn apply_deletions(
-        &self,
-        removed_row_addrs: &RoaringTreemap,
-    ) -> Result<(Vec<Fragment>, Vec<u64>)> {
-        let bitmaps = Arc::new(removed_row_addrs.bitmaps().collect::<BTreeMap<_, _>>());
-
-        enum FragmentChange {
-            Unchanged,
-            Modified(Box<Fragment>),
-            Removed(u64),
-        }
-
-        let mut updated_fragments = Vec::new();
-        let mut removed_fragments = Vec::new();
-
-        let mut stream = futures::stream::iter(self.dataset.get_fragments())
-            .map(move |fragment| {
-                let bitmaps_ref = bitmaps.clone();
-                async move {
-                    let fragment_id = fragment.id();
-                    if let Some(bitmap) = bitmaps_ref.get(&(fragment_id as u32)) {
-                        match fragment.extend_deletions(*bitmap).await {
-                            Ok(Some(new_fragment)) => {
-                                Ok(FragmentChange::Modified(Box::new(new_fragment.metadata)))
-                            }
-                            Ok(None) => Ok(FragmentChange::Removed(fragment_id as u64)),
-                            Err(e) => Err(e),
-                        }
-                    } else {
-                        Ok(FragmentChange::Unchanged)
-                    }
-                }
-            })
-            .buffer_unordered(self.dataset.object_store.io_parallelism());
-
-        while let Some(res) = stream.next().await.transpose()? {
-            match res {
-                FragmentChange::Unchanged => {}
-                FragmentChange::Modified(fragment) => updated_fragments.push(*fragment),
-                FragmentChange::Removed(fragment_id) => removed_fragments.push(fragment_id),
-            }
-        }
-
-        Ok((updated_fragments, removed_fragments))
     }
 }
 
@@ -1969,7 +1920,7 @@ mod tests {
             .count()
     }
 
-    /// Site 4 in PR #6320: when `UpdateJob::apply_deletions` fails after the new
+    /// Site 4 in PR #6320: when `apply_deletions` fails after the new
     /// rewrite fragments have been written, those new data files must be cleaned up.
     #[tokio::test]
     async fn test_update_cleans_up_data_on_apply_deletions_failure() {

--- a/rust/lance/src/index/create.rs
+++ b/rust/lance/src/index/create.rs
@@ -155,6 +155,7 @@ impl<'a> CreateIndexBuilder<'a> {
 
     #[instrument(skip_all)]
     pub async fn execute_uncommitted(&mut self) -> Result<IndexMetadata> {
+        self.dataset.hydrate_fragments_for_maintenance().await?;
         self.execute_uncommitted_impl().await
     }
 
@@ -624,6 +625,7 @@ impl<'a> CreateIndexBuilder<'a> {
 
     #[instrument(skip_all)]
     async fn execute(mut self) -> Result<IndexMetadata> {
+        self.dataset.hydrate_fragments_for_maintenance().await?;
         // Multi-segment FM-Index path: when num_segments > 1, build one segment
         // per fragment group and commit them all atomically.
         if let Some(num_segments) = self.fmindex_num_segments()

--- a/rust/lance/src/io/commit.rs
+++ b/rust/lance/src/io/commit.rs
@@ -136,7 +136,7 @@ pub(crate) async fn read_transaction_file(
 /// have NOT landed (see [`verify_commit_outcome`]): a landed manifest
 /// references its transaction file by path, so deleting it would corrupt the
 /// version.
-async fn cleanup_transaction_file(
+pub(crate) async fn cleanup_transaction_file(
     object_store: &ObjectStore,
     base_path: &Path,
     transaction_file: &str,
@@ -169,7 +169,7 @@ async fn cleanup_transaction_file(
 
 /// Who owns the manifest at a version, checked after a failed commit attempt.
 #[derive(Debug)]
-enum CommitOutcome {
+pub(crate) enum CommitOutcome {
     /// The manifest at the version is the one this attempt wrote: the commit
     /// actually landed even though the store reported a failure (e.g. the
     /// response to a successful conditional PUT was lost and an internal
@@ -199,7 +199,7 @@ const COMMIT_VERIFICATION_ATTEMPTS: u32 = 3;
 ///
 /// Never returns an error. Read failures and non-definitive not-found results
 /// are retried briefly, then collapse to [`CommitOutcome::Unknown`].
-async fn verify_commit_outcome(
+pub(crate) async fn verify_commit_outcome(
     object_store: &ObjectStore,
     commit_handler: &dyn CommitHandler,
     base_path: &Path,
@@ -270,7 +270,7 @@ async fn verify_commit_outcome(
     }
 }
 
-async fn read_manifest_transaction(
+pub(crate) async fn read_manifest_transaction(
     object_store: &ObjectStore,
     base_path: &Path,
     manifest: &Manifest,
@@ -386,7 +386,12 @@ async fn do_commit_new_dataset(
         )
         .await?;
         ensure_can_write_manifest(&source_manifest)?;
-        Some((source_store, source_manifest_location, source_manifest))
+        Some((
+            source_store,
+            source_manifest_location,
+            source_manifest,
+            source_base_path,
+        ))
     } else {
         None
     };
@@ -405,7 +410,7 @@ async fn do_commit_new_dataset(
             branch_name,
             ..
         },
-        Some((source_store, source_manifest_location, source_manifest)),
+        Some((source_store, source_manifest_location, source_manifest, source_base_path)),
     ) = (&transaction.operation, clone_source)
     {
         if *is_shallow {
@@ -415,13 +420,24 @@ async fn do_commit_new_dataset(
                 .max()
                 .map(|id| *id + 1)
                 .unwrap_or(0);
-            let new_manifest = source_manifest.shallow_clone(
+            let mut new_manifest = source_manifest.shallow_clone(
                 ref_name.clone(),
                 ref_path.clone(),
                 new_base_id,
                 branch_name.clone(),
                 transaction_file.clone(),
             );
+            if new_manifest.fragment_metadata.is_some() {
+                crate::dataset::fragment_metadata::clone_fragment_metadata(
+                    Arc::new(object_store.clone()),
+                    base_path.clone(),
+                    Arc::new(source_store.clone()),
+                    source_base_path,
+                    new_base_id,
+                    &mut new_manifest,
+                )
+                .await?;
+            }
 
             let updated_indices = if let Some(index_section_pos) = source_manifest.index_section {
                 let reader = source_store.open(&source_manifest_location.path).await?;
@@ -459,6 +475,37 @@ async fn do_commit_new_dataset(
                 }
             }
             new_manifest.fragments = Arc::new(new_frags);
+
+            if new_manifest.fragment_metadata.is_some() {
+                let tree = crate::dataset::fragment_metadata::tree_from_manifest(
+                    Arc::new(source_store.clone()),
+                    source_base_path.clone(),
+                    &source_manifest,
+                )
+                .await?;
+                let mut fragments = tree.materialize().await?;
+                crate::dataset::fragment_metadata::inline_clone_lineage(
+                    source_store,
+                    &source_base_path,
+                    &mut fragments,
+                )
+                .await?;
+                for fragment in &mut fragments {
+                    for file in fragment.referenced_lance_files_mut() {
+                        file.base_id = None;
+                    }
+                    if let Some(deletion) = fragment.deletion_file.as_mut() {
+                        deletion.base_id = None;
+                    }
+                }
+                new_manifest.set_fragments(fragments);
+                crate::dataset::fragment_metadata::rebuild_fragment_metadata(
+                    Arc::new(object_store.clone()),
+                    base_path.clone(),
+                    &mut new_manifest,
+                )
+                .await?;
+            }
 
             // Indices: keep metadata but normalize base to local
             let mut updated_indices = Vec::new();
@@ -672,7 +719,7 @@ pub fn manifest_needs_migration(manifest: &Manifest, indices: &[IndexMetadata]) 
 ///
 /// Fields such as `physical_rows` and `num_deleted_rows` may not have been
 /// in older datasets. To bring these old manifests up-to-date, we add them here.
-async fn migrate_manifest(
+pub(crate) async fn migrate_manifest(
     dataset: &Dataset,
     manifest: &mut Manifest,
     recompute_stats: bool,
@@ -692,7 +739,7 @@ async fn migrate_manifest(
     Ok(())
 }
 
-fn check_storage_version(manifest: &mut Manifest) -> Result<()> {
+pub(crate) fn check_storage_version(manifest: &mut Manifest) -> Result<()> {
     crate::dataset::versions::check_manifest_storage_version(manifest)
 }
 
@@ -716,14 +763,14 @@ fn check_fragment_ids(manifest: &Manifest) -> Result<()> {
     Ok(())
 }
 
-fn check_column_indices(manifest: &Manifest) -> Result<()> {
+pub(crate) fn check_column_indices(manifest: &Manifest) -> Result<()> {
     crate::dataset::versions::validate_column_indices(manifest)
 }
 
 /// Fix schema in case of duplicate field ids.
 ///
 /// See test dataset v0.10.5/corrupt_schema
-fn fix_schema(manifest: &mut Manifest) -> Result<()> {
+pub(crate) fn fix_schema(manifest: &mut Manifest) -> Result<()> {
     // We can short-circuit if there is only one file per fragment or no fragments.
     if manifest.fragments.iter().all(|f| f.files.len() <= 1) {
         return Ok(());
@@ -937,7 +984,10 @@ fn must_recalculate_fragment_bitmap(
 /// the only changes here that alter what an index covers, and the caller has to
 /// withdraw MemWAL catch-up for them: this runs after the coverage derivation,
 /// and it keeps the segment's UUID.
-async fn migrate_indices(dataset: &Dataset, indices: &mut [IndexMetadata]) -> Result<Vec<String>> {
+pub(crate) async fn migrate_indices(
+    dataset: &Dataset,
+    indices: &mut [IndexMetadata],
+) -> Result<Vec<String>> {
     infer_missing_vector_details(dataset, indices).await;
     let mut recovered_coverage = Vec::new();
     let needs_recalculating = match detect_overlapping_fragments(indices) {

--- a/rust/lance/src/io/commit/conflict_resolver.rs
+++ b/rust/lance/src/io/commit/conflict_resolver.rs
@@ -1860,15 +1860,14 @@ impl<'a> TransactionRebase<'a> {
                     .collect::<Vec<_>>();
                 // We are rewriting the deletion files on the *current* dataset.
                 let files_to_rewrite = dataset
-                    .fragments()
-                    .as_slice()
-                    .iter()
-                    .filter_map(|fragment| {
-                        if fragments_ids_to_rewrite.contains(&fragment.id) {
-                            Some((fragment.id, fragment.deletion_file.clone()))
-                        } else {
-                            None
-                        }
+                    .file_fragments_for_ids(&fragments_ids_to_rewrite)
+                    .await?
+                    .into_iter()
+                    .map(|fragment| {
+                        (
+                            fragment.metadata().id,
+                            fragment.metadata().deletion_file.clone(),
+                        )
                     })
                     .collect::<Vec<_>>();
                 let existing_deletion_vecs = futures::stream::iter(files_to_rewrite)
@@ -2034,11 +2033,8 @@ impl<'a> TransactionRebase<'a> {
         }
 
         for (fragment_id, coverage) in coverage_by_fragment {
-            let Some(current_fragment) = dataset
-                .fragments()
-                .as_slice()
-                .iter()
-                .find(|f| f.id == fragment_id)
+            let fragments = dataset.file_fragments_for_ids(&[fragment_id]).await?;
+            let Some(current_fragment) = fragments.first().map(|fragment| fragment.metadata())
             else {
                 // The fragment is gone entirely; the overlay is orphaned.
                 return Err(crate::Error::retryable_commit_conflict_source(
@@ -2295,13 +2291,10 @@ async fn initial_fragments_for_rebase(
     };
 
     Ok(dataset
-        .fragments()
-        .iter()
-        .filter(|fragment| {
-            // Check if the fragment is modified by the transaction.
-            modified_fragment_ids.contains(&fragment.id)
-        })
-        .map(|fragment| (fragment.id, (fragment.clone(), false)))
+        .file_fragments_for_ids(&modified_fragment_ids.iter().copied().collect::<Vec<_>>())
+        .await?
+        .into_iter()
+        .map(|fragment| (fragment.metadata().id, (fragment.metadata().clone(), false)))
         .collect())
 }
 

--- a/rust/lance/src/io/exec/filtered_read.rs
+++ b/rust/lance/src/io/exec/filtered_read.rs
@@ -240,6 +240,16 @@ impl ScopedFragmentRead {
     }
 }
 
+/// Cross-fragment state of a streaming plan: the running logical offset for
+/// `scan_range_before_filter`, the next read priority, and whether planning
+/// is past the requested range.
+#[derive(Debug, Default)]
+struct StreamingPlanCursor {
+    range_offset: u64,
+    next_priority: u32,
+    done: bool,
+}
+
 /// A fragment with all of its metadata loaded
 #[derive(Debug, Clone)]
 struct LoadedFragment {
@@ -899,27 +909,12 @@ impl FilteredReadStream {
             let fragment_id = fragment.fragment.id() as u32;
             if let Some(to_read) = fragments_to_read.get(&fragment_id) {
                 if !to_read.is_empty() {
-                    // Resolve filter for this fragment
-                    let filter = if let Some(evaluated_index) = evaluated_index {
-                        if evaluated_index.applicable_fragments.contains(fragment_id) {
-                            let r = &evaluated_index.index_result;
-                            // `Exact` results don't need a recheck. `AtLeast`
-                            // results can also skip recheck when the
-                            // skip/take pushdown is in play (we only read the
-                            // guaranteed-match ranges in that case).
-                            let can_skip_recheck = r.is_exact()
-                                || (r.is_at_least() && scan_planned_with_limit_pushed_down);
-                            if can_skip_recheck {
-                                options.refine_filter.clone()
-                            } else {
-                                options.full_filter.clone()
-                            }
-                        } else {
-                            options.full_filter.clone()
-                        }
-                    } else {
-                        options.full_filter.clone()
-                    };
+                    let filter = Self::fragment_filter(
+                        evaluated_index,
+                        fragment_id,
+                        scan_planned_with_limit_pushed_down,
+                        options,
+                    );
 
                     if let Some(f) = filter {
                         filters.insert(fragment_id, Arc::new(f));
@@ -953,6 +948,156 @@ impl FilteredReadStream {
             filters,
             scan_range_after_filter,
         }
+    }
+
+    /// Create a stream that plans and reads fragments as a fragment source
+    /// yields them, never holding the complete list. Used for lazily loaded
+    /// fragment metadata tables. The first batch can be produced before the
+    /// source is exhausted.
+    async fn try_new_streaming(
+        dataset: Arc<Dataset>,
+        fragments: BoxStream<'static, lance_core::Result<Fragment>>,
+        options: FilteredReadOptions,
+        metrics: &ExecutionPlanMetricsSet,
+        evaluated_index: Option<Arc<EvaluatedIndex>>,
+        materialization_context: Arc<BlobMaterializationContext>,
+    ) -> DataFusionResult<Self> {
+        let global_metrics = Arc::new(FilteredReadGlobalMetrics::new(metrics));
+        let threading_mode = options.threading_mode;
+        let io_parallelism = dataset.object_store.io_parallelism();
+        let fragment_readahead = options
+            .fragment_readahead
+            .unwrap_or_else(|| (*DEFAULT_FRAGMENT_READAHEAD).unwrap_or(io_parallelism * 2))
+            .max(1);
+        let output_schema = public_blob_v2_binary_projection_schema(&options.projection);
+        let scheduler_config = if let Some(io_buffer_size_bytes) = options
+            .io_buffer_size_bytes
+            .or_else(get_default_io_buffer_size_override)
+        {
+            SchedulerConfig::new(io_buffer_size_bytes)
+        } else {
+            SchedulerConfig::max_bandwidth(dataset.object_store.as_ref())
+        };
+        let scan_scheduler = ScanScheduler::new(dataset.object_store.clone(), scheduler_config);
+        // Never pushed into planning on this path; the execution-side hard
+        // range applies it, and pull-based planning stops once it completes.
+        let scan_range_after_filter = options.scan_range_after_filter.clone();
+        let fragment_soft_limit = scan_range_after_filter.as_ref().map(|range| range.end);
+
+        let default_batch_size = options.batch_size.unwrap_or_else(|| {
+            get_default_batch_size().unwrap_or_else(|| {
+                std::cmp::max(
+                    dataset.object_store.as_ref().block_size() / 4,
+                    BATCH_SIZE_FALLBACK,
+                )
+            }) as u32
+        });
+        let projection = Arc::new(options.projection.clone());
+        let with_deleted_rows = options.with_deleted_rows;
+
+        let load_dataset = dataset.clone();
+        let loaded = fragments
+            .map(move |fragment| {
+                let dataset = load_dataset.clone();
+                async move { Self::load_fragment(dataset, fragment?, with_deleted_rows, None).await }
+            })
+            // Ordered readahead: logical offsets depend on fragment order.
+            .buffered(io_parallelism);
+
+        let options_for_plan = options;
+        let scan_scheduler_for_plan = scan_scheduler.clone();
+        let scoped = loaded
+            .scan(
+                StreamingPlanCursor::default(),
+                move |cursor, loaded: lance_core::Result<LoadedFragment>| {
+                    let next = match loaded {
+                        Err(error) => Some(Err(error)),
+                        Ok(loaded) => {
+                            if cursor.done {
+                                None
+                            } else {
+                                let planned = Self::plan_one_fragment(
+                                    &loaded,
+                                    &evaluated_index,
+                                    &options_for_plan,
+                                    cursor,
+                                );
+                                match planned {
+                                    None if cursor.done => None,
+                                    None => Some(Ok(None)),
+                                    Some((ranges, filter)) => {
+                                        let priority = cursor.next_priority;
+                                        cursor.next_priority += 1;
+                                        Some(Ok(Some(ScopedFragmentRead {
+                                            fragment: loaded.fragment.clone(),
+                                            ranges,
+                                            projection: projection.clone(),
+                                            with_deleted_rows,
+                                            batch_size: default_batch_size,
+                                            file_reader_options: options_for_plan
+                                                .file_reader_options
+                                                .clone(),
+                                            physical_filter: filter.as_ref().and_then(|filter| {
+                                                options_for_plan.physical_filter(filter)
+                                            }),
+                                            filter,
+                                            priority,
+                                            scan_scheduler: scan_scheduler_for_plan.clone(),
+                                        })))
+                                    }
+                                }
+                            }
+                        }
+                    };
+                    std::future::ready(next)
+                },
+            )
+            .try_filter_map(|scoped| std::future::ready(Ok(scoped)));
+
+        let read_dataset = dataset;
+        let global_metrics_clone = global_metrics.clone();
+        let fragment_streams = scoped
+            .map(move |scoped_result| match scoped_result {
+                Ok(scoped_fragment) => {
+                    let metrics = global_metrics_clone.clone();
+                    let dataset = read_dataset.clone();
+                    let materialization_context = materialization_context.clone();
+                    SpawnedTask::spawn(
+                        Self::read_fragment(
+                            dataset,
+                            scoped_fragment,
+                            metrics,
+                            fragment_soft_limit,
+                            materialization_context,
+                            true,
+                        )
+                        .in_current_span(),
+                    )
+                    .map(|thread_result| {
+                        thread_result.map_err(|error| {
+                            Error::internal(format!("Fragment read task failed: {error}"))
+                        })?
+                    })
+                    .boxed()
+                }
+                Err(error) => std::future::ready(Err(error)).boxed(),
+            })
+            .buffered(fragment_readahead);
+        let task_stream = fragment_streams.try_flatten().boxed();
+
+        Ok(Self {
+            output_schema,
+            task_stream: Arc::new(AsyncMutex::new(task_stream)),
+            scan_scheduler,
+            metrics: global_metrics,
+            active_partitions_counter: Arc::new(AtomicUsize::new(0)),
+            threading_mode,
+            scan_range_after_filter,
+            // Unknown up front on a streaming plan. Only the take-shaped
+            // consolidation heuristic reads these, and zero disables it.
+            touched_fragments: 0,
+            planned_rows: 0,
+        })
     }
 
     /// Handles are constructed here, I/O-free, only for the fragments the
@@ -1007,6 +1152,93 @@ impl FilteredReadStream {
         }
 
         scoped_fragments
+    }
+
+    /// Which filter one fragment's read must apply, given how the index
+    /// covered it. `Exact` results don't need a recheck; `AtLeast` results
+    /// can also skip it when the skip/take pushdown is in play (only the
+    /// guaranteed-match ranges are read in that case).
+    fn fragment_filter(
+        evaluated_index: &Option<Arc<EvaluatedIndex>>,
+        fragment_id: u32,
+        limit_pushed_down: bool,
+        options: &FilteredReadOptions,
+    ) -> Option<Expr> {
+        if let Some(evaluated_index) = evaluated_index {
+            if evaluated_index.applicable_fragments.contains(fragment_id) {
+                let r = &evaluated_index.index_result;
+                let can_skip_recheck = r.is_exact() || (r.is_at_least() && limit_pushed_down);
+                if can_skip_recheck {
+                    options.refine_filter.clone()
+                } else {
+                    options.full_filter.clone()
+                }
+            } else {
+                options.full_filter.clone()
+            }
+        } else {
+            options.full_filter.clone()
+        }
+    }
+
+    /// Plan one fragment as the fragment stream yields it.
+    ///
+    /// This is the streaming counterpart of one [`Self::plan_scan`] loop
+    /// iteration, built on the same range and index primitives. It never
+    /// pushes `scan_range_after_filter` into the plan: the execution-side
+    /// hard range handles skip/take, and because the task stream is pulled,
+    /// planning stops on its own once that range completes. `cursor` carries
+    /// the only cross-fragment state, the logical offset for
+    /// `scan_range_before_filter`.
+    fn plan_one_fragment(
+        loaded: &LoadedFragment,
+        evaluated_index: &Option<Arc<EvaluatedIndex>>,
+        options: &FilteredReadOptions,
+        cursor: &mut StreamingPlanCursor,
+    ) -> Option<(Vec<Range<u64>>, Option<Expr>)> {
+        if let Some(range_before_filter) = &options.scan_range_before_filter
+            && cursor.range_offset >= range_before_filter.end
+        {
+            cursor.done = true;
+            return None;
+        }
+        let mut to_read = Self::full_frag_range(loaded.num_physical_rows, &loaded.deletion_vector);
+        if let Some(range_before_filter) = &options.scan_range_before_filter {
+            let range_start = cursor.range_offset;
+            let range_end = if options.with_deleted_rows {
+                cursor.range_offset += loaded.num_physical_rows;
+                range_start + loaded.num_physical_rows
+            } else {
+                cursor.range_offset += loaded.num_logical_rows;
+                range_start + loaded.num_logical_rows
+            };
+            to_read = Self::trim_ranges(to_read, range_start..range_end, range_before_filter);
+            if to_read.is_empty() {
+                return None;
+            }
+        }
+        let mut planned = BTreeMap::new();
+        let mut unused_push_down = BTreeMap::new();
+        let (mut to_skip, mut to_take) = (0u64, u64::MAX);
+        Self::apply_index_to_fragment(
+            evaluated_index,
+            &loaded.fragment,
+            &loaded.row_id_sequence,
+            loaded.index_upper_ranges.clone(),
+            to_read,
+            &mut to_skip,
+            &mut to_take,
+            &mut planned,
+            &mut unused_push_down,
+            options.only_indexed_fragments,
+        );
+        let fragment_id = loaded.fragment.id() as u32;
+        let ranges = planned.remove(&fragment_id).unwrap_or_default();
+        if ranges.is_empty() {
+            return None;
+        }
+        let filter = Self::fragment_filter(evaluated_index, fragment_id, false, options);
+        Some((ranges, filter))
     }
 
     /// Apply index to a fragment and apply skip/take to matched ranges if possible
@@ -2405,6 +2637,23 @@ impl FilteredReadExec {
         })
     }
 
+    /// Run the index input plan, if any, to the mask the planner applies
+    /// per fragment.
+    async fn evaluate_index(
+        index_input: Option<&Arc<dyn ExecutionPlan>>,
+        partition: usize,
+        ctx: Arc<TaskContext>,
+    ) -> Result<Option<EvaluatedIndex>> {
+        let Some(index_input) = index_input else {
+            return Ok(None);
+        };
+        let mut index_search = index_input.execute(partition, ctx)?;
+        let index_search_result = index_search.next().await.ok_or_else(|| {
+            Error::internal("Index search did not yield any results".to_string())
+        })??;
+        Ok(Some(EvaluatedIndex::try_from_arrow(&index_search_result)?))
+    }
+
     /// Get or create the internal plan
     async fn get_or_create_plan_impl<'a>(
         plan_cell: &'a OnceCell<FilteredReadInternalPlan>,
@@ -2571,6 +2820,34 @@ impl FilteredReadExec {
             let mut running_stream = running_stream_lock.lock().await;
             let inner = if let Some(running_stream) = &*running_stream {
                 running_stream.get_stream(&metrics, partition)
+            } else if dataset.fragment_source().is_lazy() && options.fragments.is_none() {
+                // A lazily loaded table plans fragment by fragment as the
+                // source yields them; the complete-plan path below would
+                // read an empty manifest list.
+                let mut evaluated_index =
+                    Self::evaluate_index(index_input.as_ref(), partition, context.clone())
+                        .await
+                        .map_err(|e| DataFusionError::External(e.into()))?;
+                if let Some(block) = options
+                    .overlay_block
+                    .as_ref()
+                    .and_then(|mask| mask.block_list())
+                {
+                    evaluated_index = evaluated_index.map(|index| index.without_rows(block));
+                }
+                let source_stream = dataset.fragment_source().stream();
+                let new_running_stream = FilteredReadStream::try_new_streaming(
+                    dataset,
+                    source_stream,
+                    options,
+                    &metrics,
+                    evaluated_index.map(Arc::new),
+                    materialization_context,
+                )
+                .await?;
+                let first_stream = new_running_stream.get_stream(&metrics, partition);
+                *running_stream = Some(new_running_stream);
+                first_stream
             } else {
                 let plan = Self::get_or_create_plan_impl(
                     &plan_cell,
@@ -3167,7 +3444,7 @@ impl DisplayAs for FilteredReadExec {
                         .fragments
                         .as_ref()
                         .map(|f| f.len())
-                        .unwrap_or(self.dataset.fragments().len()),
+                        .unwrap_or(self.dataset.count_fragments()),
                     self.options.scan_range_before_filter,
                     self.options.scan_range_after_filter,
                     self.options.projection.with_row_id,
@@ -3194,7 +3471,7 @@ impl DisplayAs for FilteredReadExec {
                         .fragments
                         .as_ref()
                         .map(|f| f.len())
-                        .unwrap_or(self.dataset.fragments().len()),
+                        .unwrap_or(self.dataset.count_fragments()),
                     self.options.scan_range_before_filter,
                     self.options.scan_range_after_filter,
                     self.options.projection.with_row_id,
@@ -3252,6 +3529,16 @@ impl ExecutionPlan for FilteredReadExec {
                 num_rows: source.plan.partition_statistics(partition)?.num_rows,
                 ..Statistics::new_unknown(self.schema().as_ref())
             }));
+        }
+        if self.options.fragments.is_none() && self.dataset.fragment_source().is_lazy() {
+            let mut statistics = Statistics::new_unknown(&self.schema());
+            statistics.num_rows = self
+                .dataset
+                .fragment_source()
+                .row_count()
+                .map(|count| Precision::Inexact(count.get()))
+                .unwrap_or(Precision::Absent);
+            return Ok(Arc::new(statistics));
         }
         let fragments = self
             .options

--- a/rust/lance/src/io/exec/scan.rs
+++ b/rust/lance/src/io/exec/scan.rs
@@ -26,17 +26,16 @@ use lance_arrow::SchemaExt;
 use lance_core::utils::tokio::get_num_compute_intensive_cpus;
 use lance_core::utils::tracing::StreamTracingExt;
 use lance_core::{
-    Error, ROW_ADDR_FIELD, ROW_CREATED_AT_VERSION_FIELD, ROW_ID_FIELD,
-    ROW_LAST_UPDATED_AT_VERSION_FIELD,
+    ROW_ADDR_FIELD, ROW_CREATED_AT_VERSION_FIELD, ROW_ID_FIELD, ROW_LAST_UPDATED_AT_VERSION_FIELD,
 };
 use lance_file::reader::FileReaderOptions;
 use lance_io::scheduler::{ScanScheduler, SchedulerConfig};
-use lance_table::format::Fragment;
 use log::debug;
 use tracing::Instrument;
 
 use crate::dataset::Dataset;
 use crate::dataset::fragment::{FileFragment, FragReadConfig, FragmentReader};
+use crate::dataset::fragment_source::{FragmentRowCount, FragmentSource};
 use crate::dataset::scanner::{
     BATCH_SIZE_FALLBACK, DEFAULT_FRAGMENT_READAHEAD, DEFAULT_IO_BUFFER_SIZE,
     LEGACY_DEFAULT_FRAGMENT_READAHEAD,
@@ -161,7 +160,7 @@ impl LanceStream {
     #[allow(clippy::too_many_arguments)]
     pub fn try_new(
         dataset: Arc<Dataset>,
-        fragments: Arc<Vec<Fragment>>,
+        fragments: impl Into<FragmentSource>,
         offsets: Option<Range<u64>>,
         projection: Arc<Schema>,
         config: LanceScanConfig,
@@ -177,13 +176,14 @@ impl LanceStream {
     #[allow(clippy::too_many_arguments)]
     pub fn try_new_v2(
         dataset: Arc<Dataset>,
-        fragments: Arc<Vec<Fragment>>,
+        fragments: impl Into<FragmentSource>,
         offsets: Option<Range<u64>>,
         projection: Arc<Schema>,
         config: LanceScanConfig,
         metrics: &ExecutionPlanMetricsSet,
         partition: usize,
     ) -> Result<Self> {
+        let fragments = fragments.into();
         let scan_metrics = ScanMetrics::new(metrics, partition);
         let timer = scan_metrics.baseline_metrics.elapsed_compute().timer();
         let materialize_blob_v2_binary =
@@ -240,55 +240,41 @@ impl LanceStream {
             frag_parallelism
         );
 
+        // Fragments arrive as a stream so a lazily loaded table starts
+        // reading after its first leaf, not after its last. An offset range
+        // is resolved by walking that same stream in order.
+        let fragment_dataset = dataset.clone();
         let mut file_fragments = fragments
-            .iter()
-            .map(|fragment| FileFragment::new(dataset.clone(), fragment.clone()))
-            .map(|fragment| FragmentWithRange {
-                fragment,
+            .stream()
+            .map_ok(move |fragment| FragmentWithRange {
+                fragment: FileFragment::new(fragment_dataset.clone(), fragment),
                 range: None,
             })
-            .collect::<Vec<_>>();
+            .map_err(DataFusionError::from)
+            .boxed();
 
         if let Some(offsets) = offsets {
-            let mut rows_to_skip = offsets.start;
-            let mut rows_to_take = offsets.end - offsets.start;
-            let mut filtered_fragments = Vec::with_capacity(file_fragments.len());
-
-            let mut frags_iter = file_fragments.into_iter();
-            while rows_to_take > 0 {
-                if let Some(next_frag) = frags_iter.next() {
-                    let num_rows_in_frag = next_frag
-                        .fragment
-                        .count_rows(None)
-                        // count_rows should be a fast operation in v2 files
-                        .now_or_never()
-                        .ok_or(Error::internal(
-                            "Encountered fragment without row count metadata in v2 file"
-                                .to_string(),
-                        ))??;
-                    if rows_to_skip >= num_rows_in_frag as u64 {
-                        rows_to_skip -= num_rows_in_frag as u64;
-                    } else {
-                        let rows_to_take_in_frag =
-                            (num_rows_in_frag as u64 - rows_to_skip).min(rows_to_take);
-                        let range =
-                            Some(rows_to_skip as u32..(rows_to_skip + rows_to_take_in_frag) as u32);
-                        filtered_fragments.push(FragmentWithRange {
-                            fragment: next_frag.fragment,
-                            range,
-                        });
-                        rows_to_skip = 0;
-                        rows_to_take -= rows_to_take_in_frag;
+            file_fragments = stream::try_unfold(
+                (file_fragments, offsets.start, offsets.end - offsets.start),
+                |(mut fragments, mut skip, mut remaining)| async move {
+                    while remaining > 0 {
+                        let Some(mut fragment) = fragments.try_next().await? else {
+                            return Ok(None);
+                        };
+                        let rows = fragment.fragment.count_rows(None).await? as u64;
+                        if skip >= rows {
+                            skip -= rows;
+                            continue;
+                        }
+                        let take = (rows - skip).min(remaining);
+                        fragment.range = Some(skip as u32..(skip + take) as u32);
+                        remaining -= take;
+                        return Ok(Some((fragment, (fragments, 0, remaining))));
                     }
-                } else {
-                    log::warn!(
-                        "Ran out of fragments before we were done scanning for range: {:?}",
-                        offsets
-                    );
-                    rows_to_take = 0;
-                }
-            }
-            file_fragments = filtered_fragments;
+                    Ok(None)
+                },
+            )
+            .boxed();
         }
 
         let scan_scheduler = ScanScheduler::new(
@@ -304,8 +290,10 @@ impl LanceStream {
             config.materialization_readahead_bytes,
         );
         let config_for_stream = config.clone();
-        let batches = stream::iter(file_fragments.into_iter().enumerate())
+        let batches = file_fragments
+            .enumerate()
             .map(move |(priority, file_fragment)| {
+                let file_fragment = file_fragment?;
                 let project_schema = project_schema.clone();
                 let scan_scheduler = scan_scheduler.clone();
                 let config = config_for_stream.clone();
@@ -417,13 +405,14 @@ impl LanceStream {
     #[allow(clippy::too_many_arguments)]
     pub fn try_new_v1(
         dataset: Arc<Dataset>,
-        fragments: Arc<Vec<Fragment>>,
+        fragments: impl Into<FragmentSource>,
         _offsets: Option<Range<u64>>,
         projection: Arc<Schema>,
         config: LanceScanConfig,
         metrics: &ExecutionPlanMetricsSet,
         partition: usize,
     ) -> Result<Self> {
+        let fragments = fragments.into();
         let scan_metrics = ScanMetrics::new(metrics, partition);
         let timer = scan_metrics.baseline_metrics.elapsed_compute().timer();
         let project_schema = projection.clone();
@@ -440,30 +429,31 @@ impl LanceStream {
         );
 
         let file_fragments = fragments
-            .iter()
-            .map(|fragment| FileFragment::new(dataset.clone(), fragment.clone()))
-            .collect::<Vec<_>>();
+            .stream()
+            .map_ok(move |fragment| FileFragment::new(dataset.clone(), fragment))
+            .map_err(DataFusionError::from);
 
         let batches = if config.ordered_output {
-            let readers = buffered_fragment_opens(
-                stream::iter(file_fragments),
-                fragment_readahead,
-                move |file_fragment| {
-                    open_file(
-                        file_fragment,
-                        project_schema.clone(),
-                        FragReadConfig::default()
-                            .with_row_id(config.with_row_id)
-                            .with_row_address(config.with_row_address)
-                            .with_row_last_updated_at_version(
-                                config.with_row_last_updated_at_version,
-                            )
-                            .with_row_created_at_version(config.with_row_created_at_version),
-                        config.with_make_deletions_null,
-                        None,
-                    )
-                },
-            );
+            let readers =
+                buffered_fragment_opens(file_fragments, fragment_readahead, move |file_fragment| {
+                    let project_schema = project_schema.clone();
+                    async move {
+                        open_file(
+                            file_fragment?,
+                            project_schema,
+                            FragReadConfig::default()
+                                .with_row_id(config.with_row_id)
+                                .with_row_address(config.with_row_address)
+                                .with_row_last_updated_at_version(
+                                    config.with_row_last_updated_at_version,
+                                )
+                                .with_row_created_at_version(config.with_row_created_at_version),
+                            config.with_make_deletions_null,
+                            None,
+                        )
+                        .await
+                    }
+                });
             let tasks = readers.and_then(move |reader| async move {
                 reader
                     .read_all(config.batch_size as u32)
@@ -479,25 +469,26 @@ impl LanceStream {
                 .stream_in_current_span()
                 .boxed()
         } else {
-            let readers = buffered_fragment_opens(
-                stream::iter(file_fragments),
-                fragment_readahead,
-                move |file_fragment| {
-                    open_file(
-                        file_fragment,
-                        project_schema.clone(),
-                        FragReadConfig::default()
-                            .with_row_id(config.with_row_id)
-                            .with_row_address(config.with_row_address)
-                            .with_row_last_updated_at_version(
-                                config.with_row_last_updated_at_version,
-                            )
-                            .with_row_created_at_version(config.with_row_created_at_version),
-                        config.with_make_deletions_null,
-                        None,
-                    )
-                },
-            );
+            let readers =
+                buffered_fragment_opens(file_fragments, fragment_readahead, move |file_fragment| {
+                    let project_schema = project_schema.clone();
+                    async move {
+                        open_file(
+                            file_fragment?,
+                            project_schema,
+                            FragReadConfig::default()
+                                .with_row_id(config.with_row_id)
+                                .with_row_address(config.with_row_address)
+                                .with_row_last_updated_at_version(
+                                    config.with_row_last_updated_at_version,
+                                )
+                                .with_row_created_at_version(config.with_row_created_at_version),
+                            config.with_make_deletions_null,
+                            None,
+                        )
+                        .await
+                    }
+                });
             let tasks = readers.and_then(move |reader| async move {
                 reader
                     .read_all(config.batch_size as u32)
@@ -609,7 +600,7 @@ impl Default for LanceScanConfig {
 #[derive(Debug)]
 pub struct LanceScanExec {
     dataset: Arc<Dataset>,
-    fragments: Arc<Vec<Fragment>>,
+    fragments: FragmentSource,
     range: Option<Range<u64>>,
     projection: Arc<Schema>,
     output_schema: Arc<ArrowSchema>,
@@ -660,7 +651,7 @@ impl LanceScanExec {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         dataset: Arc<Dataset>,
-        fragments: Arc<Vec<Fragment>>,
+        fragments: impl Into<FragmentSource>,
         range: Option<Range<u64>>,
         projection: Arc<Schema>,
         config: LanceScanConfig,
@@ -697,7 +688,7 @@ impl LanceScanExec {
         ));
         Self {
             dataset,
-            fragments,
+            fragments: fragments.into(),
             range,
             projection,
             output_schema,
@@ -712,8 +703,8 @@ impl LanceScanExec {
         &self.dataset
     }
 
-    /// Get the fragments for this scan.
-    pub fn fragments(&self) -> &Arc<Vec<Fragment>> {
+    /// Where this scan gets its fragments.
+    pub fn fragments(&self) -> &FragmentSource {
         &self.fragments
     }
 
@@ -789,20 +780,15 @@ impl ExecutionPlan for LanceScanExec {
     }
 
     fn partition_statistics(&self, _partition: Option<usize>) -> Result<Arc<Statistics>> {
-        // Some fragments from older datasets might have the row count stats missing.
-        let (row_count, is_exact) =
-            self.fragments
-                .iter()
-                .fold(
-                    (0, true),
-                    |(row_count, is_exact), fragment| match fragment.num_rows() {
-                        Some(num_rows) => (row_count + num_rows, is_exact),
-                        None => (row_count, false),
-                    },
-                );
-        let num_rows = match is_exact {
-            true => Precision::Exact(row_count),
-            false => Precision::Absent,
+        // Visible counts are not the output cardinality when deleted rows are
+        // retained with null row IDs. Do not advertise an exact smaller count.
+        if self.config.with_make_deletions_null {
+            return Ok(Arc::new(Statistics::new_unknown(self.schema().as_ref())));
+        }
+        let num_rows = match self.fragments.row_count() {
+            Some(FragmentRowCount::Exact(row_count)) => Precision::Exact(row_count),
+            Some(FragmentRowCount::Inexact(row_count)) => Precision::Inexact(row_count),
+            None => Precision::Absent,
         };
 
         Ok(Arc::new(Statistics {


### PR DESCRIPTION
Prototype implementation of the fragment metadata tree in #9060.

Stores fragment metadata in immutable leaves and buffers updates so small commits can reuse most of the tree. Includes native commits, lazy metadata reads, same-store clone and cleanup support, and benchmark harnesses.

Enable it at creation with `lance.manifest.layout=tree`. Flat manifests remain the default.

Opening this for feedback and for people to try their workloads, especially append and backfill alongside readers. Please share your fragment count, files per fragment, update pattern, and columns being read.

A few limitations:

* `add_columns` still uses `Merge` and replaces full fragment records. Column-level metadata isolation is not implemented.
* Cross-store clones still need verification.
* Writers beyond a root and one leaf level require `lance.fragment_metadata.allow_deep_writer=true`.

Use disposable datasets. The format is experimental and may change. Earlier S3 numbers are from the previous prototype.

Validation: workspace checks passed at each implementation commit. Formatting, clippy, and the `lance-table`, `lance-io`, and `lance --lib` test suites passed at the tip.